### PR TITLE
Install the latest Microsoft Visual C++ Redistributable package using Inno Setup

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -44,18 +44,21 @@ jobs:
         shell: bash
     steps:
     - uses: actions/checkout@v3
-    - name: Install dependencies and cygwin
+    - name: Install dependencies
       run: |
         script/windows/install_packages.bat
-        choco.exe install cygwin cyg-get -y
-        cyg-get.bat make libiconv libunistring5 gettext-devel
+    - name: Install MSYS2 tools
+      run: |
+        C:\msys64\usr\bin\pacman.exe -S --noconfirm --noprogressbar gettext-devel
+      shell: cmd
     - name: Download MSVC Redistributable package
       run: |
-        $ErrorActionPreference = "Stop"
-        [void](New-Item -Path ".vcredist" -ItemType "directory")
-        # This should be a permanent link
-        Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.${{ matrix.config.platform }}.exe" -OutFile ".vcredist\vcredist.exe"
-      shell: pwsh
+        mkdir .vcredist && ^
+        C:\msys64\usr\bin\wget.exe -O .vcredist/vcredist.exe "%VCREDIST_URL%"
+      shell: cmd
+      env:
+        # Permalink URL from https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
+        VCREDIST_URL: https://aka.ms/vs/17/release/vc_redist.${{ matrix.config.platform }}.exe
     - uses: microsoft/setup-msbuild@v1
     - name: Generate version information
       run: |
@@ -71,7 +74,8 @@ jobs:
         MSBuild.exe bin2txt-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
     - name: Generate translations
       run: |
-        C:\tools\cygwin\bin\bash.exe -l -eo pipefail -c ^"cd ""$GITHUB_WORKSPACE""; make -C files/lang -j 2^"
+        set PATH=C:\msys64\usr\bin;%PATH%
+        C:\msys64\usr\bin\make.exe -C files/lang -j 2
       shell: cmd
     - name: Create Inno Setup package
       run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -49,6 +49,13 @@ jobs:
         script/windows/install_packages.bat
         choco.exe install cygwin cyg-get -y
         cyg-get.bat make libiconv libunistring5 gettext-devel
+    - name: Download MSVC Redistributable package
+      run: |
+        $ErrorActionPreference = "Stop"
+        [void](New-Item -Path ".vcredist" -ItemType "directory")
+        # This should be a permanent link
+        Invoke-WebRequest -Uri "https://aka.ms/vs/17/release/vc_redist.${{ matrix.config.platform }}.exe" -OutFile ".vcredist\vcredist.exe"
+      shell: pwsh
     - uses: microsoft/setup-msbuild@v1
     - name: Generate version information
       run: |

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -59,10 +59,16 @@ jobs:
       env:
         # Permalink URL from https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
         VCREDIST_URL: https://aka.ms/vs/17/release/vc_redist.${{ matrix.config.platform }}.exe
-    - uses: microsoft/setup-msbuild@v1
+    - name: Verify MSVC Redistributable package
+      run: |
+        "%SIGNTOOL_DIR%\signtool.exe" verify /v /d /all /pa /r "Microsoft Root Certificate Authority" .vcredist\vcredist.exe
+      shell: cmd
+      env:
+        SIGNTOOL_DIR: C:\Program Files (x86)\Windows Kits\10\bin\x64
     - name: Generate version information
       run: |
         echo "FHEROES2_APP_VERSION=$(cat version.txt)" >> "$GITHUB_ENV"
+    - uses: microsoft/setup-msbuild@v1
     - name: Build
       run: |
         MSBuild.exe fheroes2-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}

--- a/docs/README.txt
+++ b/docs/README.txt
@@ -24,6 +24,16 @@ As an alternative to the previous step, you can manually copy the subdirectories
 'DATA', 'MAPS' and 'MUSIC' (some of them may be missing depending on the version of the
 original game) from the original game directory to the fheroes2 installation directory.
 
+If you are running fheroes2 on Windows and see complaints about missing DLLs, then you
+may need to install the Microsoft Visual C++ redistributable package. You can download
+it using the following URLs:
+
+https://aka.ms/vs/17/release/vc_redist.x86.exe - for 32-bit x86 fheroes2 builds;
+https://aka.ms/vs/17/release/vc_redist.x64.exe - for 64-bit x64 fheroes2 builds.
+
+Or you can install the game using the installer, in this case, this package will be
+installed automatically.
+
 --- License ---
 This project is under GNU General Public License v2.0. Refer to file LICENSE for more
 details.

--- a/script/windows/fheroes2.iss
+++ b/script/windows/fheroes2.iss
@@ -34,24 +34,33 @@ Source: "..\..\files\data\*.h2d"; DestDir: "{app}\files\data"
 #if DeployConfName == 'SDL2'
 Source: "..\..\files\soundfonts\*.*"; DestDir: "{app}\files\soundfonts"
 #endif
+Source: "..\..\.vcredist\vcredist.exe"; DestDir: "{tmp}"
 
 [Tasks]
-Name: desktopicon; Description: "Desktop shortcut"
+Name: desktopicon; Description: "{cm:DesktopIconTaskDescription}"
 
 [Icons]
-Name: "{group}\fheroes2"; Filename: "{app}\{#AppName}.exe"; WorkingDir: "{app}"
-Name: "{group}\Download the demo version of the original HoMM2"; Filename: "{app}\download_demo_version.bat"; WorkingDir: "{app}"
-Name: "{group}\Extract game resources from the original distribution of HoMM2"; Filename: "{app}\extract_homm2_resources.bat"; WorkingDir: "{app}"
-Name: "{group}\Resource extraction toolset"; Filename: "{app}\resource_extraction_toolset.bat"; WorkingDir: "{app}"
-Name: "{group}\Game data files"; Filename: %WINDIR%\explorer.exe; Parameters: """%APPDATA%\{#AppName}"""
-Name: "{group}\Uninstall"; Filename: "{uninstallexe}"
-Name: "{autodesktop}\fheroes2"; Filename: "{app}\{#AppName}.exe"; WorkingDir: "{app}"; Tasks: desktopicon
+Name: "{group}\{#AppName}"; Filename: "{app}\{#AppName}.exe"; WorkingDir: "{app}"
+Name: "{group}\{cm:DownloadDemoVersionIconName}"; Filename: "{app}\download_demo_version.bat"; WorkingDir: "{app}"
+Name: "{group}\{cm:ExtractResourcesIconName}"; Filename: "{app}\extract_homm2_resources.bat"; WorkingDir: "{app}"
+Name: "{group}\{cm:ResourceExtractionToolsetIconName}"; Filename: "{app}\resource_extraction_toolset.bat"; WorkingDir: "{app}"
+Name: "{group}\{cm:GameDataFilesIconName}"; Filename: %WINDIR%\explorer.exe; Parameters: """%APPDATA%\{#AppName}"""
+Name: "{group}\{cm:UninstallIconName}"; Filename: "{uninstallexe}"
+Name: "{autodesktop}\{#AppName}"; Filename: "{app}\{#AppName}.exe"; WorkingDir: "{app}"; Tasks: desktopicon
 
 [Run]
 Filename: "{app}\extract_homm2_resources.bat"; Flags: runascurrentuser; Check: UseResourcesFromOriginalGame
 Filename: "{app}\download_demo_version.bat"; Flags: runascurrentuser; Check: UseResourcesFromDemoVersion
+Filename: "{tmp}\vcredist.exe"; Parameters: "/install /quiet /norestart"; StatusMsg: "{cm:VCRedistRunStatusMsg}"
 
 [CustomMessages]
+DesktopIconTaskDescription=Desktop shortcut
+DownloadDemoVersionIconName=Download the demo version of the original HoMM2
+ExtractResourcesIconName=Extract game resources from the original distribution of HoMM2
+ResourceExtractionToolsetIconName=Resource extraction toolset
+GameDataFilesIconName=Game data files
+UninstallIconName=Uninstall
+VCRedistRunStatusMsg=Installing the Visual C++ Redistributable package...
 ResourcesSettingsPageCaption=Game Resources Settings
 ResourcesSettingsPageDescription=Configure the source of the original game's resources
 UseResourcesFromOriginalGameRadioButtonCaption=Use resources from the original game

--- a/script/windows/fheroes2.iss
+++ b/script/windows/fheroes2.iss
@@ -18,6 +18,8 @@ OutputDir={#BuildDir}
 #if Platform == 'x64'
 ArchitecturesInstallIn64BitMode=x64
 #endif
+; Do not request a system reboot when vcredist.exe queues up some DLLs to replace their older versions on the next reboot
+RestartIfNeededByRun=no
 
 [Files]
 Source: "{#BuildDir}\{#AppName}.exe"; DestDir: "{app}"; Flags: ignoreversion


### PR DESCRIPTION
Related to #6276

I also switched this workflow from Cygwin to the pre-installed MSYS2, this somewhat accelerated the build - from 6-8 minutes to 4-6 minutes.

I have a few notes though:

1. ~We download the redistributable package installer [from the MS website](https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170) via a permalink without any verification. Hash verification is useless here, because we don't control "the other side" and I suspect that there will be silent regular updates for that package, but maybe we can use at least the digital signature verification. We can try to figure this out.~ Implemented the mandatory signature verification using the `signtool.exe`.
2. ~When `vcredist.exe` updates libraries in `SYSTEM32`, Inno Setup detects this and suggests to reboot the system. I can turn it off, but I'm not sure that I need to do this. @ihhub what do you think?~ Turned it off. 
3. Currently Inno Setup always runs the `vcredist.exe` in the quiet mode (no GUI, no questions), and this is on purpose - if we will ask the average user "Do you want to install blah-blah-blah package?", he will say "what package?...", so this question is mostly useless. But we can offer `vcredist` installation as an option, if someone brings arguments that it's better this way.