### PR TITLE
Make an option to toggle screen scaling type

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -658,8 +658,8 @@ namespace
 
             if ( width_ != VITA_FULLSCREEN_WIDTH || height_ != VITA_FULLSCREEN_HEIGHT ) {
                 if ( isFullScreen ) {
-                    vita2d_texture_set_filters( _texBuffer, isLinearScaling() ? SCE_GXM_TEXTURE_FILTER_LINEAR : SCE_GXM_TEXTURE_FILTER_POINT,
-                                                isLinearScaling() ? SCE_GXM_TEXTURE_FILTER_LINEAR : SCE_GXM_TEXTURE_FILTER_POINT );
+                    vita2d_texture_set_filters( _texBuffer, isNearestScaling() ? SCE_GXM_TEXTURE_FILTER_POINT : SCE_GXM_TEXTURE_FILTER_LINEAR,
+                                                isNearestScaling() ? SCE_GXM_TEXTURE_FILTER_POINT : SCE_GXM_TEXTURE_FILTER_LINEAR );
                     if ( ( static_cast<float>( VITA_FULLSCREEN_WIDTH ) / VITA_FULLSCREEN_HEIGHT ) >= ( static_cast<float>( width_ ) / height_ ) ) {
                         const float scale = static_cast<float>( VITA_FULLSCREEN_HEIGHT ) / height_;
                         _destRect.width = static_cast<int32_t>( static_cast<float>( width_ ) * scale );
@@ -1199,7 +1199,7 @@ namespace
                 return false;
             }
 
-            if ( SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, ( isLinearScaling() ? "linear" : " nearest" ) ) == SDL_FALSE ) {
+            if ( SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, ( isNearestScaling() ? " nearest" : "linear" ) ) == SDL_FALSE ) {
                 ERROR_LOG( "Failed to set a linear scale hint for rendering." )
             }
 

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -658,7 +658,8 @@ namespace
 
             if ( width_ != VITA_FULLSCREEN_WIDTH || height_ != VITA_FULLSCREEN_HEIGHT ) {
                 if ( isFullScreen ) {
-                    vita2d_texture_set_filters( _texBuffer, SCE_GXM_TEXTURE_FILTER_LINEAR, SCE_GXM_TEXTURE_FILTER_LINEAR );
+                    vita2d_texture_set_filters( _texBuffer, isLinearScaling() ? SCE_GXM_TEXTURE_FILTER_LINEAR : SCE_GXM_TEXTURE_FILTER_POINT,
+                                                isLinearScaling() ? SCE_GXM_TEXTURE_FILTER_LINEAR : SCE_GXM_TEXTURE_FILTER_POINT );
                     if ( ( static_cast<float>( VITA_FULLSCREEN_WIDTH ) / VITA_FULLSCREEN_HEIGHT ) >= ( static_cast<float>( width_ ) / height_ ) ) {
                         const float scale = static_cast<float>( VITA_FULLSCREEN_HEIGHT ) / height_;
                         _destRect.width = static_cast<int32_t>( static_cast<float>( width_ ) * scale );
@@ -1198,7 +1199,7 @@ namespace
                 return false;
             }
 
-            if ( SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, "linear" ) == SDL_FALSE ) {
+            if ( SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, ( isLinearScaling() ? "linear" : " nearest" ) ) == SDL_FALSE ) {
                 ERROR_LOG( "Failed to set a linear scale hint for rendering." )
             }
 

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1199,7 +1199,7 @@ namespace
                 return false;
             }
 
-            if ( SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, ( isNearestScaling() ? " nearest" : "linear" ) ) == SDL_FALSE ) {
+            if ( SDL_SetHint( SDL_HINT_RENDER_SCALE_QUALITY, ( isNearestScaling() ? "nearest" : "linear" ) ) == SDL_FALSE ) {
                 ERROR_LOG( "Failed to set a linear scale hint for rendering." )
             }
 

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -81,6 +81,16 @@ namespace fheroes2
             // Do nothing.
         }
 
+        void setLinearScaling( const bool enable )
+        {
+            _linearScaling = enable;
+        }
+
+        bool isLinearScaling() const
+        {
+            return _linearScaling;
+        }
+
     protected:
         BaseRenderEngine()
             : _isFullScreen( false )
@@ -118,6 +128,8 @@ namespace fheroes2
 
     private:
         bool _isFullScreen;
+
+        bool _linearScaling;
     };
 
     class Display : public Image

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -81,19 +81,20 @@ namespace fheroes2
             // Do nothing.
         }
 
-        void setLinearScaling( const bool enable )
+        void setNearestScaling( const bool enable )
         {
-            _linearScaling = enable;
+            _nearestScaling = enable;
         }
 
-        bool isLinearScaling() const
+        bool isNearestScaling() const
         {
-            return _linearScaling;
+            return _nearestScaling;
         }
 
     protected:
         BaseRenderEngine()
             : _isFullScreen( false )
+            , _nearestScaling( false )
         {
             // Do nothing.
         }
@@ -129,7 +130,7 @@ namespace fheroes2
     private:
         bool _isFullScreen;
 
-        bool _linearScaling;
+        bool _nearestScaling;
     };
 
     class Display : public Image

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -482,7 +482,7 @@ std::string Settings::String() const
     os << std::endl << "# enable cursor software rendering" << std::endl;
     os << "cursor soft rendering = " << ( _optGlobal.Modes( GLOBAL_CURSOR_SOFT_EMULATION ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# scaling type: nearest or linear (default)" << std::endl;
+    os << std::endl << "# scaling type: nearest or linear (set by default)" << std::endl;
     os << "screen scaling type = " << ( _optGlobal.Modes( GLOBAL_SCREEN_NEAREST_SCALING ) ? "linear" : "nearest" ) << std::endl;
 
     return os.str();

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -337,7 +337,7 @@ bool Settings::Read( const std::string & filePath )
     }
 
     if ( config.Exists( "screen scaling type" ) ) {
-        setAutoSaveAtBeginningOfTurn( config.StrParams( "screen scaling type" ) == "linear" );
+        setScreenLinearScaling( config.StrParams( "screen scaling type" ) == "linear" );
     }
 
     return true;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -79,7 +79,7 @@ namespace
         GLOBAL_BATTLE_AUTO_RESOLVE = 0x04000000,
         GLOBAL_BATTLE_AUTO_SPELLCAST = 0x08000000,
         GLOBAL_AUTO_SAVE_AT_BEGINNING_OF_TURN = 0x10000000,
-        GLOBAL_SCREEN_LINEAR_SCALING = 0x20000000
+        GLOBAL_SCREEN_NEAREST_SCALING = 0x20000000
     };
 }
 
@@ -114,8 +114,6 @@ Settings::Settings()
     _optGlobal.SetModes( GLOBAL_BATTLE_SHOW_MOUSE_SHADOW );
     _optGlobal.SetModes( GLOBAL_BATTLE_SHOW_MOVE_SHADOW );
     _optGlobal.SetModes( GLOBAL_BATTLE_AUTO_SPELLCAST );
-
-    _optGlobal.SetModes( GLOBAL_SCREEN_LINEAR_SCALING );
 
     if ( System::isHandheldDevice() ) {
         // Due to the nature of handheld devices having small screens in general it is good to make fullscreen option by default.
@@ -339,7 +337,7 @@ bool Settings::Read( const std::string & filePath )
     }
 
     if ( config.Exists( "screen scaling type" ) ) {
-        setScreenLinearScaling( config.StrParams( "screen scaling type" ) == "linear" );
+        setNearestLinearScaling( config.StrParams( "screen scaling type" ) == "nearest" );
     }
 
     return true;
@@ -484,8 +482,8 @@ std::string Settings::String() const
     os << std::endl << "# enable cursor software rendering" << std::endl;
     os << "cursor soft rendering = " << ( _optGlobal.Modes( GLOBAL_CURSOR_SOFT_EMULATION ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# scaling type: nearest (default) or linear" << std::endl;
-    os << "screen scaling type = " << ( _optGlobal.Modes( GLOBAL_SCREEN_LINEAR_SCALING ) ? "linear" : "nearest" ) << std::endl;
+    os << std::endl << "# scaling type: nearest or linear (default)" << std::endl;
+    os << "screen scaling type = " << ( _optGlobal.Modes( GLOBAL_SCREEN_NEAREST_SCALING ) ? "linear" : "nearest" ) << std::endl;
 
     return os.str();
 }
@@ -789,15 +787,15 @@ void Settings::setEvilInterface( const bool enable )
     }
 }
 
-void Settings::setScreenLinearScaling( const bool enable )
+void Settings::setNearestLinearScaling( const bool enable )
 {
     if ( enable ) {
-        _optGlobal.SetModes( GLOBAL_SCREEN_LINEAR_SCALING );
-        fheroes2::engine().setLinearScaling( true );
+        _optGlobal.SetModes( GLOBAL_SCREEN_NEAREST_SCALING );
+        fheroes2::engine().setNearestScaling( true );
     }
     else {
-        _optGlobal.ResetModes( GLOBAL_SCREEN_LINEAR_SCALING );
-        fheroes2::engine().setLinearScaling( false );
+        _optGlobal.ResetModes( GLOBAL_SCREEN_NEAREST_SCALING );
+        fheroes2::engine().setNearestScaling( false );
     }
 }
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -78,7 +78,8 @@ namespace
         GLOBAL_BATTLE_SHOW_MOVE_SHADOW = 0x02000000,
         GLOBAL_BATTLE_AUTO_RESOLVE = 0x04000000,
         GLOBAL_BATTLE_AUTO_SPELLCAST = 0x08000000,
-        GLOBAL_AUTO_SAVE_AT_BEGINNING_OF_TURN = 0x10000000
+        GLOBAL_AUTO_SAVE_AT_BEGINNING_OF_TURN = 0x10000000,
+        GLOBAL_SCREEN_LINEAR_SCALING = 0x20000000
     };
 }
 
@@ -335,6 +336,10 @@ bool Settings::Read( const std::string & filePath )
         }
     }
 
+    if ( config.Exists( "screen scaling type" ) ) {
+        setAutoSaveAtBeginningOfTurn( config.StrParams( "screen scaling type" ) == "linear" );
+    }
+
     return true;
 }
 
@@ -476,6 +481,9 @@ std::string Settings::String() const
 
     os << std::endl << "# enable cursor software rendering" << std::endl;
     os << "cursor soft rendering = " << ( _optGlobal.Modes( GLOBAL_CURSOR_SOFT_EMULATION ) ? "on" : "off" ) << std::endl;
+
+    os << std::endl << "# scaling type: nearest (default) or linear" << std::endl;
+    os << "screen scaling type = " << ( _optGlobal.Modes( GLOBAL_SCREEN_LINEAR_SCALING ) ? "linear" : "nearest" ) << std::endl;
 
     return os.str();
 }
@@ -776,6 +784,18 @@ void Settings::setEvilInterface( const bool enable )
     }
     else {
         _optGlobal.ResetModes( GLOBAL_EVIL_INTERFACE );
+    }
+}
+
+void Settings::setScreenLinearScaling( const bool enable )
+{
+    if ( enable ) {
+        _optGlobal.SetModes( GLOBAL_SCREEN_LINEAR_SCALING );
+        fheroes2::engine().setLinearScaling( true );
+    }
+    else {
+        _optGlobal.ResetModes( GLOBAL_SCREEN_LINEAR_SCALING );
+        fheroes2::engine().setLinearScaling( false );
     }
 }
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -483,7 +483,7 @@ std::string Settings::String() const
     os << "cursor soft rendering = " << ( _optGlobal.Modes( GLOBAL_CURSOR_SOFT_EMULATION ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# scaling type: nearest or linear (set by default)" << std::endl;
-    os << "screen scaling type = " << ( _optGlobal.Modes( GLOBAL_SCREEN_NEAREST_SCALING ) ? "linear" : "nearest" ) << std::endl;
+    os << "screen scaling type = " << ( _optGlobal.Modes( GLOBAL_SCREEN_NEAREST_SCALING ) ? "nearest" : "linear" ) << std::endl;
 
     return os.str();
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -115,6 +115,8 @@ Settings::Settings()
     _optGlobal.SetModes( GLOBAL_BATTLE_SHOW_MOVE_SHADOW );
     _optGlobal.SetModes( GLOBAL_BATTLE_AUTO_SPELLCAST );
 
+    _optGlobal.SetModes( GLOBAL_SCREEN_LINEAR_SCALING );
+
     if ( System::isHandheldDevice() ) {
         // Due to the nature of handheld devices having small screens in general it is good to make fullscreen option by default.
         _optGlobal.SetModes( GLOBAL_FULLSCREEN );

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -245,6 +245,7 @@ public:
     void setBattleDamageInfo( const bool enable );
     void setHideInterface( const bool enable );
     void setEvilInterface( const bool enable );
+    void setScreenLinearScaling( const bool enable );
 
     void SetSoundVolume( int v );
     void SetMusicVolume( int v );

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -245,7 +245,7 @@ public:
     void setBattleDamageInfo( const bool enable );
     void setHideInterface( const bool enable );
     void setEvilInterface( const bool enable );
-    void setScreenLinearScaling( const bool enable );
+    void setNearestLinearScaling( const bool enable );
 
     void SetSoundVolume( int v );
     void SetMusicVolume( int v );


### PR DESCRIPTION
With introduction of "fake" full screen mode for Windows it is visible that the picture is blurred with linear mode. To cover needs of everyone we are adding a new configuration option to choose pixelated image or blurred. By default it is linear.

relates to #5373
relates to #2238
relates to #4946