### PR TITLE
Fix incorrect cursor shadow position at the creature's turn start

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2343,6 +2343,9 @@ void Battle::Interface::HumanTurn( const Unit & b, Actions & a )
     Cursor & cursor = Cursor::Get();
     LocalEvent & le = LocalEvent::Get();
 
+    // Reset the cursor position to avoid forcing the cursor shadow to be drawn at the last position of the previous turn.
+    index_pos = -1;
+
     cursor.SetThemes( Cursor::WAR_POINTER );
     _currentUnit = &b;
     humanturn_redraw = false;


### PR DESCRIPTION
close #5831