### PR TITLE
Add the ability to set the maximum text width for each icon in settings dialogs

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -203,37 +203,42 @@ namespace
         }
 
         const fheroes2::Sprite & speedIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, speedIcnIndex );
-        fheroes2::drawOption( areas[0], speedIcon, _( "Speed" ), str, THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[0], speedIcon, _( "Speed" ), str, fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const bool isShowArmyOrderEnabled = conf.BattleShowArmyOrder();
         const fheroes2::Sprite & armyOrderIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowArmyOrderEnabled ? 4 : 3 );
-        fheroes2::drawOption( areas[1], armyOrderIcon, _( "Army Order" ), isShowArmyOrderEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[1], armyOrderIcon, _( "Army Order" ), isShowArmyOrderEnabled ? _( "On" ) : _( "Off" ),
+                              fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const bool isBattleAudoSpellCastEnabled = conf.BattleAutoSpellcast();
         const fheroes2::Sprite & battleAutoSpellCastIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isBattleAudoSpellCastEnabled ? 7 : 6 );
-        fheroes2::drawOption( areas[2], battleAutoSpellCastIcon, _( "Auto Spell Casting" ), isBattleAudoSpellCastEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[2], battleAutoSpellCastIcon, _( "Auto Spell Casting" ), isBattleAudoSpellCastEnabled ? _( "On" ) : _( "Off" ),
+                              fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const bool isShowBattleGridEnabled = conf.BattleShowGrid();
         const fheroes2::Sprite & battleGridIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowBattleGridEnabled ? 9 : 8 );
-        fheroes2::drawOption( areas[3], battleGridIcon, _( "Grid" ), isShowBattleGridEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[3], battleGridIcon, _( "Grid" ), isShowBattleGridEnabled ? _( "On" ) : _( "Off" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const bool isShowMoveShadowEnabled = conf.BattleShowMoveShadow();
         const fheroes2::Sprite & moveShadowIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowMoveShadowEnabled ? 11 : 10 );
-        fheroes2::drawOption( areas[4], moveShadowIcon, _( "Shadow Movement" ), isShowMoveShadowEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[4], moveShadowIcon, _( "Shadow Movement" ), isShowMoveShadowEnabled ? _( "On" ) : _( "Off" ),
+                              fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const bool isShowMouseShadowEnabled = conf.BattleShowMouseShadow();
         const fheroes2::Sprite & mouseShadowIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowMouseShadowEnabled ? 13 : 12 );
-        fheroes2::drawOption( areas[5], mouseShadowIcon, _( "Shadow Cursor" ), isShowMouseShadowEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[5], mouseShadowIcon, _( "Shadow Cursor" ), isShowMouseShadowEnabled ? _( "On" ) : _( "Off" ),
+                              fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
-        fheroes2::drawOption( areas[6], audioSettingsIcon, _( "Audio" ), _( "Settings" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[6], audioSettingsIcon, _( "Audio" ), _( "Settings" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );
-        fheroes2::drawOption( areas[7], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[7], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const bool isShowBattleDamageInfoEnabled = conf.isBattleShowDamageInfoEnabled();
         const fheroes2::Sprite & damageInfoIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowBattleDamageInfoEnabled ? 4 : 3 );
-        fheroes2::drawOption( areas[8], damageInfoIcon, _( "Damage Info" ), isShowBattleDamageInfoEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( areas[8], damageInfoIcon, _( "Damage Info" ), isShowBattleDamageInfoEnabled ? _( "On" ) : _( "Off" ),
+                              fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 
     DialogAction openBattleOptionDialog( bool & saveConfiguration )

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -185,7 +185,7 @@ namespace
         Close
     };
 
-    void RedrawBattleSettings( const std::vector<fheroes2::Rect> & areas )
+    void RedrawBattleSettings( const std::vector<fheroes2::Rect> & areas, const int32_t iconTextMaxWidth )
     {
         assert( areas.size() == 9 );
 
@@ -203,37 +203,37 @@ namespace
         }
 
         const fheroes2::Sprite & speedIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, speedIcnIndex );
-        fheroes2::drawOption( areas[0], speedIcon, _( "Speed" ), str );
+        fheroes2::drawOption( areas[0], speedIcon, _( "Speed" ), str, iconTextMaxWidth );
 
         const bool isShowArmyOrderEnabled = conf.BattleShowArmyOrder();
         const fheroes2::Sprite & armyOrderIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowArmyOrderEnabled ? 4 : 3 );
-        fheroes2::drawOption( areas[1], armyOrderIcon, _( "Army Order" ), isShowArmyOrderEnabled ? _( "On" ) : _( "Off" ) );
+        fheroes2::drawOption( areas[1], armyOrderIcon, _( "Army Order" ), isShowArmyOrderEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
 
         const bool isBattleAudoSpellCastEnabled = conf.BattleAutoSpellcast();
         const fheroes2::Sprite & battleAutoSpellCastIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isBattleAudoSpellCastEnabled ? 7 : 6 );
-        fheroes2::drawOption( areas[2], battleAutoSpellCastIcon, _( "Auto Spell Casting" ), isBattleAudoSpellCastEnabled ? _( "On" ) : _( "Off" ) );
+        fheroes2::drawOption( areas[2], battleAutoSpellCastIcon, _( "Auto Spell Casting" ), isBattleAudoSpellCastEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
 
         const bool isShowBattleGridEnabled = conf.BattleShowGrid();
         const fheroes2::Sprite & battleGridIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowBattleGridEnabled ? 9 : 8 );
-        fheroes2::drawOption( areas[3], battleGridIcon, _( "Grid" ), isShowBattleGridEnabled ? _( "On" ) : _( "Off" ) );
+        fheroes2::drawOption( areas[3], battleGridIcon, _( "Grid" ), isShowBattleGridEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
 
         const bool isShowMoveShadowEnabled = conf.BattleShowMoveShadow();
         const fheroes2::Sprite & moveShadowIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowMoveShadowEnabled ? 11 : 10 );
-        fheroes2::drawOption( areas[4], moveShadowIcon, _( "Shadow Movement" ), isShowMoveShadowEnabled ? _( "On" ) : _( "Off" ) );
+        fheroes2::drawOption( areas[4], moveShadowIcon, _( "Shadow Movement" ), isShowMoveShadowEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
 
         const bool isShowMouseShadowEnabled = conf.BattleShowMouseShadow();
         const fheroes2::Sprite & mouseShadowIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowMouseShadowEnabled ? 13 : 12 );
-        fheroes2::drawOption( areas[5], mouseShadowIcon, _( "Shadow Cursor" ), isShowMouseShadowEnabled ? _( "On" ) : _( "Off" ) );
+        fheroes2::drawOption( areas[5], mouseShadowIcon, _( "Shadow Cursor" ), isShowMouseShadowEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
 
         const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
-        fheroes2::drawOption( areas[6], audioSettingsIcon, _( "Audio" ), _( "Settings" ) );
+        fheroes2::drawOption( areas[6], audioSettingsIcon, _( "Audio" ), _( "Settings" ), iconTextMaxWidth );
 
         const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );
-        fheroes2::drawOption( areas[7], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ) );
+        fheroes2::drawOption( areas[7], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), iconTextMaxWidth );
 
         const bool isShowBattleDamageInfoEnabled = conf.isBattleShowDamageInfoEnabled();
         const fheroes2::Sprite & damageInfoIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowBattleDamageInfoEnabled ? 4 : 3 );
-        fheroes2::drawOption( areas[8], damageInfoIcon, _( "Damage Info" ), isShowBattleDamageInfoEnabled ? _( "On" ) : _( "Off" ) );
+        fheroes2::drawOption( areas[8], damageInfoIcon, _( "Damage Info" ), isShowBattleDamageInfoEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
     }
 
     DialogAction openBattleOptionDialog( bool & saveConfiguration )
@@ -266,6 +266,7 @@ namespace
 
         const fheroes2::Point optionOffset( 36 + pos_rt.x, 47 + pos_rt.y );
         const fheroes2::Point optionStep( 92, 110 );
+        const int32_t iconTextMaxWidth = optionStep.x - 5;
 
         std::vector<fheroes2::Rect> optionAreas;
         optionAreas.reserve( 9 );
@@ -280,7 +281,7 @@ namespace
         fheroes2::Button buttonOkay( buttonOffset.x, buttonOffset.y, isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0, 1 );
         buttonOkay.draw();
 
-        RedrawBattleSettings( optionAreas );
+        RedrawBattleSettings( optionAreas, iconTextMaxWidth );
 
         display.render();
 
@@ -378,7 +379,7 @@ namespace
 
             if ( redrawScreen ) {
                 fheroes2::Blit( dialog, display, pos_rt.x, pos_rt.y );
-                RedrawBattleSettings( optionAreas );
+                RedrawBattleSettings( optionAreas, iconTextMaxWidth );
                 display.render();
 
                 saveConfiguration = true;

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -185,7 +185,7 @@ namespace
         Close
     };
 
-    void RedrawBattleSettings( const std::vector<fheroes2::Rect> & areas, const int32_t iconTextMaxWidth )
+    void RedrawBattleSettings( const std::vector<fheroes2::Rect> & areas )
     {
         assert( areas.size() == 9 );
 
@@ -203,37 +203,37 @@ namespace
         }
 
         const fheroes2::Sprite & speedIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, speedIcnIndex );
-        fheroes2::drawOption( areas[0], speedIcon, _( "Speed" ), str, iconTextMaxWidth );
+        fheroes2::drawOption( areas[0], speedIcon, _( "Speed" ), str, THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         const bool isShowArmyOrderEnabled = conf.BattleShowArmyOrder();
         const fheroes2::Sprite & armyOrderIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowArmyOrderEnabled ? 4 : 3 );
-        fheroes2::drawOption( areas[1], armyOrderIcon, _( "Army Order" ), isShowArmyOrderEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
+        fheroes2::drawOption( areas[1], armyOrderIcon, _( "Army Order" ), isShowArmyOrderEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         const bool isBattleAudoSpellCastEnabled = conf.BattleAutoSpellcast();
         const fheroes2::Sprite & battleAutoSpellCastIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isBattleAudoSpellCastEnabled ? 7 : 6 );
-        fheroes2::drawOption( areas[2], battleAutoSpellCastIcon, _( "Auto Spell Casting" ), isBattleAudoSpellCastEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
+        fheroes2::drawOption( areas[2], battleAutoSpellCastIcon, _( "Auto Spell Casting" ), isBattleAudoSpellCastEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         const bool isShowBattleGridEnabled = conf.BattleShowGrid();
         const fheroes2::Sprite & battleGridIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowBattleGridEnabled ? 9 : 8 );
-        fheroes2::drawOption( areas[3], battleGridIcon, _( "Grid" ), isShowBattleGridEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
+        fheroes2::drawOption( areas[3], battleGridIcon, _( "Grid" ), isShowBattleGridEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         const bool isShowMoveShadowEnabled = conf.BattleShowMoveShadow();
         const fheroes2::Sprite & moveShadowIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowMoveShadowEnabled ? 11 : 10 );
-        fheroes2::drawOption( areas[4], moveShadowIcon, _( "Shadow Movement" ), isShowMoveShadowEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
+        fheroes2::drawOption( areas[4], moveShadowIcon, _( "Shadow Movement" ), isShowMoveShadowEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         const bool isShowMouseShadowEnabled = conf.BattleShowMouseShadow();
         const fheroes2::Sprite & mouseShadowIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowMouseShadowEnabled ? 13 : 12 );
-        fheroes2::drawOption( areas[5], mouseShadowIcon, _( "Shadow Cursor" ), isShowMouseShadowEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
+        fheroes2::drawOption( areas[5], mouseShadowIcon, _( "Shadow Cursor" ), isShowMouseShadowEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
-        fheroes2::drawOption( areas[6], audioSettingsIcon, _( "Audio" ), _( "Settings" ), iconTextMaxWidth );
+        fheroes2::drawOption( areas[6], audioSettingsIcon, _( "Audio" ), _( "Settings" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );
-        fheroes2::drawOption( areas[7], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), iconTextMaxWidth );
+        fheroes2::drawOption( areas[7], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         const bool isShowBattleDamageInfoEnabled = conf.isBattleShowDamageInfoEnabled();
         const fheroes2::Sprite & damageInfoIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowBattleDamageInfoEnabled ? 4 : 3 );
-        fheroes2::drawOption( areas[8], damageInfoIcon, _( "Damage Info" ), isShowBattleDamageInfoEnabled ? _( "On" ) : _( "Off" ), iconTextMaxWidth );
+        fheroes2::drawOption( areas[8], damageInfoIcon, _( "Damage Info" ), isShowBattleDamageInfoEnabled ? _( "On" ) : _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
     }
 
     DialogAction openBattleOptionDialog( bool & saveConfiguration )
@@ -266,7 +266,6 @@ namespace
 
         const fheroes2::Point optionOffset( 36 + pos_rt.x, 47 + pos_rt.y );
         const fheroes2::Point optionStep( 92, 110 );
-        const int32_t iconTextMaxWidth = optionStep.x - 5;
 
         std::vector<fheroes2::Rect> optionAreas;
         optionAreas.reserve( 9 );
@@ -281,7 +280,7 @@ namespace
         fheroes2::Button buttonOkay( buttonOffset.x, buttonOffset.y, isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0, 1 );
         buttonOkay.draw();
 
-        RedrawBattleSettings( optionAreas, iconTextMaxWidth );
+        RedrawBattleSettings( optionAreas );
 
         display.render();
 
@@ -379,7 +378,7 @@ namespace
 
             if ( redrawScreen ) {
                 fheroes2::Blit( dialog, display, pos_rt.x, pos_rt.y );
-                RedrawBattleSettings( optionAreas, iconTextMaxWidth );
+                RedrawBattleSettings( optionAreas );
                 display.render();
 
                 saveConfiguration = true;

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -20,7 +20,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -45,7 +44,7 @@
 
 namespace
 {
-    void drawDialog( const std::vector<fheroes2::Rect> & rects, const int32_t iconTextMaxWidth )
+    void drawDialog( const std::vector<fheroes2::Rect> & rects )
     {
         assert( rects.size() == 4 );
 
@@ -61,7 +60,7 @@ namespace
             value = _( "off" );
         }
 
-        fheroes2::drawOption( rects[0], musicVolumeIcon, _( "Music" ), value, iconTextMaxWidth );
+        fheroes2::drawOption( rects[0], musicVolumeIcon, _( "Music" ), value, TWO_ELEMENT_ROW_TEXT_WIDTH );
 
         // Sound volume.
         const fheroes2::Sprite & soundVolumeOption = fheroes2::AGG::GetICN( ICN::SPANEL, Audio::isValid() ? 3 : 2 );
@@ -72,7 +71,7 @@ namespace
             value = _( "off" );
         }
 
-        fheroes2::drawOption( rects[1], soundVolumeOption, _( "Effects" ), value, iconTextMaxWidth );
+        fheroes2::drawOption( rects[1], soundVolumeOption, _( "Effects" ), value, TWO_ELEMENT_ROW_TEXT_WIDTH );
 
         // Music Type.
         const MusicSource musicType = conf.MusicType();
@@ -87,7 +86,7 @@ namespace
             value = _( "External" );
         }
 
-        fheroes2::drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value, iconTextMaxWidth );
+        fheroes2::drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value, TWO_ELEMENT_ROW_TEXT_WIDTH );
 
         // 3D Audio.
         const bool is3DAudioEnabled = conf.is3DAudioEnabled();
@@ -99,7 +98,7 @@ namespace
             value = _( "Off" );
         }
 
-        fheroes2::drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value, iconTextMaxWidth );
+        fheroes2::drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value, TWO_ELEMENT_ROW_TEXT_WIDTH );
     }
 }
 
@@ -130,7 +129,6 @@ namespace Dialog
         const fheroes2::Sprite & optionSprite = fheroes2::AGG::GetICN( ICN::SPANEL, 0 );
         const fheroes2::Point optionOffset( 69 + dialogArea.x, 47 + dialogArea.y );
         const fheroes2::Point optionStep( 118, 110 );
-        const int32_t iconTextMaxWidth = optionStep.x - 5;
 
         std::vector<fheroes2::Rect> roi;
         roi.reserve( 4 );
@@ -144,7 +142,7 @@ namespace Dialog
         const fheroes2::Rect & musicTypeRoi = roi[2];
         const fheroes2::Rect & audio3D = roi[3];
 
-        drawDialog( roi, iconTextMaxWidth );
+        drawDialog( roi );
 
         const fheroes2::Point buttonOffset( 112 + dialogArea.x, 252 + dialogArea.y );
         fheroes2::Button buttonOkay( buttonOffset.x, buttonOffset.y, isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0, 1 );
@@ -242,7 +240,7 @@ namespace Dialog
             if ( saveMusicVolume || saveSoundVolume || saveMusicType ) {
                 // redraw
                 fheroes2::Blit( dialog, display, dialogArea.x, dialogArea.y );
-                drawDialog( roi, iconTextMaxWidth );
+                drawDialog( roi );
                 buttonOkay.draw();
                 display.render();
 

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -60,7 +60,7 @@ namespace
             value = _( "off" );
         }
 
-        fheroes2::drawOption( rects[0], musicVolumeIcon, _( "Music" ), value, TWO_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[0], musicVolumeIcon, _( "Music" ), value, fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
 
         // Sound volume.
         const fheroes2::Sprite & soundVolumeOption = fheroes2::AGG::GetICN( ICN::SPANEL, Audio::isValid() ? 3 : 2 );
@@ -71,7 +71,7 @@ namespace
             value = _( "off" );
         }
 
-        fheroes2::drawOption( rects[1], soundVolumeOption, _( "Effects" ), value, TWO_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[1], soundVolumeOption, _( "Effects" ), value, fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
 
         // Music Type.
         const MusicSource musicType = conf.MusicType();
@@ -86,7 +86,7 @@ namespace
             value = _( "External" );
         }
 
-        fheroes2::drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value, TWO_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value, fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
 
         // 3D Audio.
         const bool is3DAudioEnabled = conf.is3DAudioEnabled();
@@ -98,7 +98,7 @@ namespace
             value = _( "Off" );
         }
 
-        fheroes2::drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value, TWO_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value, fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
     }
 }
 

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -20,6 +20,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -44,7 +44,7 @@
 
 namespace
 {
-    void drawDialog( const std::vector<fheroes2::Rect> & rects )
+    void drawDialog( const std::vector<fheroes2::Rect> & rects, const int32_t iconTextMaxWidth )
     {
         assert( rects.size() == 4 );
 
@@ -60,7 +60,7 @@ namespace
             value = _( "off" );
         }
 
-        fheroes2::drawOption( rects[0], musicVolumeIcon, _( "Music" ), value );
+        fheroes2::drawOption( rects[0], musicVolumeIcon, _( "Music" ), value, iconTextMaxWidth );
 
         // Sound volume.
         const fheroes2::Sprite & soundVolumeOption = fheroes2::AGG::GetICN( ICN::SPANEL, Audio::isValid() ? 3 : 2 );
@@ -71,7 +71,7 @@ namespace
             value = _( "off" );
         }
 
-        fheroes2::drawOption( rects[1], soundVolumeOption, _( "Effects" ), value );
+        fheroes2::drawOption( rects[1], soundVolumeOption, _( "Effects" ), value, iconTextMaxWidth );
 
         // Music Type.
         const MusicSource musicType = conf.MusicType();
@@ -86,7 +86,7 @@ namespace
             value = _( "External" );
         }
 
-        fheroes2::drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value );
+        fheroes2::drawOption( rects[2], musicTypeIcon, _( "Music Type" ), value, iconTextMaxWidth );
 
         // 3D Audio.
         const bool is3DAudioEnabled = conf.is3DAudioEnabled();
@@ -98,7 +98,7 @@ namespace
             value = _( "Off" );
         }
 
-        fheroes2::drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value );
+        fheroes2::drawOption( rects[3], interfaceStateIcon, _( "3D Audio" ), value, iconTextMaxWidth );
     }
 }
 
@@ -129,6 +129,7 @@ namespace Dialog
         const fheroes2::Sprite & optionSprite = fheroes2::AGG::GetICN( ICN::SPANEL, 0 );
         const fheroes2::Point optionOffset( 69 + dialogArea.x, 47 + dialogArea.y );
         const fheroes2::Point optionStep( 118, 110 );
+        const int32_t iconTextMaxWidth = optionStep.x - 5;
 
         std::vector<fheroes2::Rect> roi;
         roi.reserve( 4 );
@@ -142,7 +143,7 @@ namespace Dialog
         const fheroes2::Rect & musicTypeRoi = roi[2];
         const fheroes2::Rect & audio3D = roi[3];
 
-        drawDialog( roi );
+        drawDialog( roi, iconTextMaxWidth );
 
         const fheroes2::Point buttonOffset( 112 + dialogArea.x, 252 + dialogArea.y );
         fheroes2::Button buttonOkay( buttonOffset.x, buttonOffset.y, isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0, 1 );
@@ -240,7 +241,7 @@ namespace Dialog
             if ( saveMusicVolume || saveSoundVolume || saveMusicType ) {
                 // redraw
                 fheroes2::Blit( dialog, display, dialogArea.x, dialogArea.y );
-                drawDialog( roi );
+                drawDialog( roi, iconTextMaxWidth );
                 buttonOkay.draw();
                 display.render();
 

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -50,6 +50,7 @@ namespace
 
     const fheroes2::Point optionOffset{ 36, 47 };
     const int32_t optionWindowSize{ 65 };
+    const int32_t iconTextMaxWidth = offsetBetweenOptions.width - 5;
 
     const fheroes2::Rect languageRoi{ optionOffset.x, optionOffset.y, optionWindowSize, optionWindowSize };
     const fheroes2::Rect graphicsRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y, optionWindowSize, optionWindowSize };
@@ -64,41 +65,41 @@ namespace
         const fheroes2::SupportedLanguage currentLanguage = fheroes2::getLanguageFromAbbreviation( Settings::Get().getGameLanguage() );
         fheroes2::LanguageSwitcher languageSwitcher( currentLanguage );
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 18 ), _( "Language" ), fheroes2::getLanguageName( currentLanguage ) );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 18 ), _( "Language" ), fheroes2::getLanguageName( currentLanguage ), iconTextMaxWidth );
     }
 
     void drawGraphics( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 15 ), _( "Graphics" ), _( "Settings" ) );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 15 ), _( "Graphics" ), _( "Settings" ), iconTextMaxWidth );
     }
 
     void drawAudioOptions( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ) );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ), iconTextMaxWidth );
     }
 
     void drawHotKeyOptions( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 5 ), _( "Hot Keys" ), _( "Configure" ) );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 5 ), _( "Hot Keys" ), _( "Configure" ), iconTextMaxWidth );
     }
 
     void drawCursorTypeOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isMonochromeCursorEnabled() ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ) );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ), iconTextMaxWidth );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ) );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ), iconTextMaxWidth );
         }
     }
 
     void drawTextSupportModeOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isTextSupportModeEnabled() ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ) );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ), iconTextMaxWidth );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ) );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ), iconTextMaxWidth );
         }
     }
 

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -65,41 +65,43 @@ namespace
         fheroes2::LanguageSwitcher languageSwitcher( currentLanguage );
 
         fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 18 ), _( "Language" ), fheroes2::getLanguageName( currentLanguage ),
-                              THREE_ELEMENT_ROW_TEXT_WIDTH );
+                              fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 
     void drawGraphics( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 15 ), _( "Graphics" ), _( "Settings" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 15 ), _( "Graphics" ), _( "Settings" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 
     void drawAudioOptions( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 
     void drawHotKeyOptions( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 5 ), _( "Hot Keys" ), _( "Configure" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 5 ), _( "Hot Keys" ), _( "Configure" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 
     void drawCursorTypeOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isMonochromeCursorEnabled() ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ),
+                                  fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ),
+                                  fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
     }
 
     void drawTextSupportModeOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isTextSupportModeEnabled() ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
     }
 

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -50,7 +50,6 @@ namespace
 
     const fheroes2::Point optionOffset{ 36, 47 };
     const int32_t optionWindowSize{ 65 };
-    const int32_t iconTextMaxWidth = offsetBetweenOptions.width - 5;
 
     const fheroes2::Rect languageRoi{ optionOffset.x, optionOffset.y, optionWindowSize, optionWindowSize };
     const fheroes2::Rect graphicsRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y, optionWindowSize, optionWindowSize };
@@ -65,41 +64,42 @@ namespace
         const fheroes2::SupportedLanguage currentLanguage = fheroes2::getLanguageFromAbbreviation( Settings::Get().getGameLanguage() );
         fheroes2::LanguageSwitcher languageSwitcher( currentLanguage );
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 18 ), _( "Language" ), fheroes2::getLanguageName( currentLanguage ), iconTextMaxWidth );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 18 ), _( "Language" ), fheroes2::getLanguageName( currentLanguage ),
+                              THREE_ELEMENT_ROW_TEXT_WIDTH );
     }
 
     void drawGraphics( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 15 ), _( "Graphics" ), _( "Settings" ), iconTextMaxWidth );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 15 ), _( "Graphics" ), _( "Settings" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
     }
 
     void drawAudioOptions( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ), iconTextMaxWidth );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
     }
 
     void drawHotKeyOptions( const fheroes2::Rect & optionRoi )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 5 ), _( "Hot Keys" ), _( "Configure" ), iconTextMaxWidth );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 5 ), _( "Hot Keys" ), _( "Configure" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
     }
 
     void drawCursorTypeOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isMonochromeCursorEnabled() ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ), iconTextMaxWidth );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ), iconTextMaxWidth );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
         }
     }
 
     void drawTextSupportModeOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isTextSupportModeEnabled() ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ), iconTextMaxWidth );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ), iconTextMaxWidth );
+            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
         }
     }
 

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -55,7 +55,6 @@ namespace
     const fheroes2::Size offsetBetweenOptions{ 118, 110 };
     const fheroes2::Point optionOffset{ 69, 47 };
     const int32_t optionWindowSize{ 65 };
-    const int32_t iconTextMaxWidth = offsetBetweenOptions.width - 5;
 
     const fheroes2::Rect resolutionRoi{ optionOffset.x, optionOffset.y, optionWindowSize, optionWindowSize };
     const fheroes2::Rect modeRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y, optionWindowSize, optionWindowSize };
@@ -68,7 +67,7 @@ namespace
         std::string resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );
 
         fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().isEvilInterfaceEnabled() ? 17 : 16 ), _( "Resolution" ),
-                              std::move( resolutionName ), iconTextMaxWidth );
+                              std::move( resolutionName ), TWO_ELEMENT_ROW_TEXT_WIDTH );
     }
 
     void drawMode( const fheroes2::Rect & optionRoi )
@@ -79,10 +78,10 @@ namespace
             fheroes2::Sprite icon = originalIcon;
             fheroes2::Resize( originalIcon, 6, 6, 53, 53, icon, 2, 2, 61, 61 );
 
-            fheroes2::drawOption( optionRoi, icon, _( "window|Mode" ), _( "Fullscreen" ), iconTextMaxWidth );
+            fheroes2::drawOption( optionRoi, icon, _( "window|Mode" ), _( "Fullscreen" ), TWO_ELEMENT_ROW_TEXT_WIDTH );
         }
         else {
-            fheroes2::drawOption( optionRoi, originalIcon, _( "window|Mode" ), _( "Windowed" ), iconTextMaxWidth );
+            fheroes2::drawOption( optionRoi, originalIcon, _( "window|Mode" ), _( "Windowed" ), TWO_ELEMENT_ROW_TEXT_WIDTH );
         }
     }
 
@@ -91,7 +90,7 @@ namespace
         const bool isVSyncEnabled = Settings::Get().isVSyncEnabled();
 
         fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on" ) : _( "off" ),
-                              iconTextMaxWidth );
+                              TWO_ELEMENT_ROW_TEXT_WIDTH );
     }
 
     void drawSystemInfo( const fheroes2::Rect & optionRoi )
@@ -108,7 +107,7 @@ namespace
         }
         info.draw( ( image.width() - info.width() ) / 2, ( image.height() - info.height() ) / 2, image );
 
-        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on" ) : _( "off" ), iconTextMaxWidth );
+        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on" ) : _( "off" ), TWO_ELEMENT_ROW_TEXT_WIDTH );
     }
 
     SelectedWindow showConfigurationWindow()

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -67,7 +67,7 @@ namespace
         std::string resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );
 
         fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().isEvilInterfaceEnabled() ? 17 : 16 ), _( "Resolution" ),
-                              std::move( resolutionName ), TWO_ELEMENT_ROW_TEXT_WIDTH );
+                              std::move( resolutionName ), fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
     }
 
     void drawMode( const fheroes2::Rect & optionRoi )
@@ -78,10 +78,10 @@ namespace
             fheroes2::Sprite icon = originalIcon;
             fheroes2::Resize( originalIcon, 6, 6, 53, 53, icon, 2, 2, 61, 61 );
 
-            fheroes2::drawOption( optionRoi, icon, _( "window|Mode" ), _( "Fullscreen" ), TWO_ELEMENT_ROW_TEXT_WIDTH );
+            fheroes2::drawOption( optionRoi, icon, _( "window|Mode" ), _( "Fullscreen" ), fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
         }
         else {
-            fheroes2::drawOption( optionRoi, originalIcon, _( "window|Mode" ), _( "Windowed" ), TWO_ELEMENT_ROW_TEXT_WIDTH );
+            fheroes2::drawOption( optionRoi, originalIcon, _( "window|Mode" ), _( "Windowed" ), fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
         }
     }
 
@@ -90,7 +90,7 @@ namespace
         const bool isVSyncEnabled = Settings::Get().isVSyncEnabled();
 
         fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on" ) : _( "off" ),
-                              TWO_ELEMENT_ROW_TEXT_WIDTH );
+                              fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
     }
 
     void drawSystemInfo( const fheroes2::Rect & optionRoi )
@@ -107,7 +107,7 @@ namespace
         }
         info.draw( ( image.width() - info.width() ) / 2, ( image.height() - info.height() ) / 2, image );
 
-        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on" ) : _( "off" ), TWO_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on" ) : _( "off" ), fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
     }
 
     SelectedWindow showConfigurationWindow()

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -55,6 +55,7 @@ namespace
     const fheroes2::Size offsetBetweenOptions{ 118, 110 };
     const fheroes2::Point optionOffset{ 69, 47 };
     const int32_t optionWindowSize{ 65 };
+    const int32_t iconTextMaxWidth = offsetBetweenOptions.width - 5;
 
     const fheroes2::Rect resolutionRoi{ optionOffset.x, optionOffset.y, optionWindowSize, optionWindowSize };
     const fheroes2::Rect modeRoi{ optionOffset.x + offsetBetweenOptions.width, optionOffset.y, optionWindowSize, optionWindowSize };
@@ -67,7 +68,7 @@ namespace
         std::string resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );
 
         fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().isEvilInterfaceEnabled() ? 17 : 16 ), _( "Resolution" ),
-                              std::move( resolutionName ) );
+                              std::move( resolutionName ), iconTextMaxWidth );
     }
 
     void drawMode( const fheroes2::Rect & optionRoi )
@@ -78,10 +79,10 @@ namespace
             fheroes2::Sprite icon = originalIcon;
             fheroes2::Resize( originalIcon, 6, 6, 53, 53, icon, 2, 2, 61, 61 );
 
-            fheroes2::drawOption( optionRoi, icon, _( "window|Mode" ), _( "Fullscreen" ) );
+            fheroes2::drawOption( optionRoi, icon, _( "window|Mode" ), _( "Fullscreen" ), iconTextMaxWidth );
         }
         else {
-            fheroes2::drawOption( optionRoi, originalIcon, _( "window|Mode" ), _( "Windowed" ) );
+            fheroes2::drawOption( optionRoi, originalIcon, _( "window|Mode" ), _( "Windowed" ), iconTextMaxWidth );
         }
     }
 
@@ -89,7 +90,7 @@ namespace
     {
         const bool isVSyncEnabled = Settings::Get().isVSyncEnabled();
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on" ) : _( "off" ) );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on" ) : _( "off" ), iconTextMaxWidth );
     }
 
     void drawSystemInfo( const fheroes2::Rect & optionRoi )
@@ -106,7 +107,7 @@ namespace
         }
         info.draw( ( image.width() - info.width() ) / 2, ( image.height() - info.height() ) / 2, image );
 
-        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on" ) : _( "off" ) );
+        fheroes2::drawOption( optionRoi, image, _( "System Info" ), isSystemInfoDisplayed ? _( "on" ) : _( "off" ), iconTextMaxWidth );
     }
 
     SelectedWindow showConfigurationWindow()

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -90,7 +90,8 @@ namespace
     {
         const bool isVSyncEnabled = Settings::Get().isVSyncEnabled();
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on" ) : _( "off" ), iconTextMaxWidth );
+        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "on" ) : _( "off" ),
+                              iconTextMaxWidth );
     }
 
     void drawSystemInfo( const fheroes2::Rect & optionRoi )

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -65,16 +65,17 @@ namespace
 
         // Audio settings.
         const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
-        fheroes2::drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "Settings" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "Settings" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         // Hot keys.
         const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );
-        fheroes2::drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         // Cursor Type.
         const bool isMonoCursor = Settings::Get().isMonochromeCursorEnabled();
         const fheroes2::Sprite & cursorTypeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isMonoCursor ? 20 : 21 );
-        fheroes2::drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ),
+                              fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         // Hero's movement speed.
         const int heroSpeed = conf.HeroesMoveSpeed();
@@ -95,7 +96,7 @@ namespace
             value = std::to_string( heroSpeed );
         }
 
-        fheroes2::drawOption( rects[3], heroSpeedIcon, _( "Hero Speed" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[3], heroSpeedIcon, _( "Hero Speed" ), value, fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         // AI's movement speed.
         const int aiSpeed = conf.AIMoveSpeed();
@@ -118,7 +119,7 @@ namespace
             value = std::to_string( aiSpeed );
         }
 
-        fheroes2::drawOption( rects[4], aiSpeedIcon, _( "Enemy Speed" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[4], aiSpeedIcon, _( "Enemy Speed" ), value, fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         // Scrolling speed.
         const int scrollSpeed = conf.ScrollSpeed();
@@ -155,7 +156,7 @@ namespace
         assert( scrollSpeedIconIcn != ICN::UNKNOWN );
 
         const fheroes2::Sprite & scrollSpeedIcon = fheroes2::AGG::GetICN( scrollSpeedIconIcn, scrollSpeedIconId );
-        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), scrollSpeedName, THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), scrollSpeedName, fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         // Interface theme.
         const bool isEvilInterface = conf.isEvilInterfaceEnabled();
@@ -167,7 +168,7 @@ namespace
             value = _( "Good" );
         }
 
-        fheroes2::drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value, fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         // Interface show/hide state.
         const bool isHiddenInterface = conf.isHideInterfaceEnabled();
@@ -180,7 +181,7 @@ namespace
             value = _( "Show" );
         }
 
-        fheroes2::drawOption( rects[7], interfaceStateIcon, _( "Interface" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
+        fheroes2::drawOption( rects[7], interfaceStateIcon, _( "Interface" ), value, fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         // Auto-battles.
         if ( conf.BattleAutoResolve() ) {
@@ -188,11 +189,11 @@ namespace
             value = spellcast ? _( "Auto Resolve" ) : _( "Auto, No Spells" );
 
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, spellcast ? 7 : 6 );
-            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
+            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), value, fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
         else {
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 18 );
-            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "autoBattle|Manual" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
+            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "autoBattle|Manual" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
     }
 

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -57,7 +57,7 @@ namespace
         Close
     };
 
-    void drawDialog( const std::vector<fheroes2::Rect> & rects )
+    void drawDialog( const std::vector<fheroes2::Rect> & rects, const int32_t iconTextMaxWidth )
     {
         assert( rects.size() == 9 );
 
@@ -65,16 +65,16 @@ namespace
 
         // Audio settings.
         const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
-        fheroes2::drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "Settings" ) );
+        fheroes2::drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "Settings" ), iconTextMaxWidth );
 
         // Hot keys.
         const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );
-        fheroes2::drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ) );
+        fheroes2::drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), iconTextMaxWidth );
 
         // Cursor Type.
         const bool isMonoCursor = Settings::Get().isMonochromeCursorEnabled();
         const fheroes2::Sprite & cursorTypeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isMonoCursor ? 20 : 21 );
-        fheroes2::drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ) );
+        fheroes2::drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ), iconTextMaxWidth );
 
         // Hero's movement speed.
         const int heroSpeed = conf.HeroesMoveSpeed();
@@ -95,7 +95,7 @@ namespace
             value = std::to_string( heroSpeed );
         }
 
-        fheroes2::drawOption( rects[3], heroSpeedIcon, _( "Hero Speed" ), value );
+        fheroes2::drawOption( rects[3], heroSpeedIcon, _( "Hero Speed" ), value, iconTextMaxWidth );
 
         // AI's movement speed.
         const int aiSpeed = conf.AIMoveSpeed();
@@ -118,7 +118,7 @@ namespace
             value = std::to_string( aiSpeed );
         }
 
-        fheroes2::drawOption( rects[4], aiSpeedIcon, _( "Enemy Speed" ), value );
+        fheroes2::drawOption( rects[4], aiSpeedIcon, _( "Enemy Speed" ), value, iconTextMaxWidth );
 
         // Scrolling speed.
         const int scrollSpeed = conf.ScrollSpeed();
@@ -155,7 +155,7 @@ namespace
         assert( scrollSpeedIconIcn != ICN::UNKNOWN );
 
         const fheroes2::Sprite & scrollSpeedIcon = fheroes2::AGG::GetICN( scrollSpeedIconIcn, scrollSpeedIconId );
-        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), scrollSpeedName );
+        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), scrollSpeedName, iconTextMaxWidth );
 
         // Interface theme.
         const bool isEvilInterface = conf.isEvilInterfaceEnabled();
@@ -167,7 +167,7 @@ namespace
             value = _( "Good" );
         }
 
-        fheroes2::drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value );
+        fheroes2::drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value, iconTextMaxWidth );
 
         // Interface show/hide state.
         const bool isHiddenInterface = conf.isHideInterfaceEnabled();
@@ -180,7 +180,7 @@ namespace
             value = _( "Show" );
         }
 
-        fheroes2::drawOption( rects[7], interfaceStateIcon, _( "Interface" ), value );
+        fheroes2::drawOption( rects[7], interfaceStateIcon, _( "Interface" ), value, iconTextMaxWidth );
 
         // Auto-battles.
         if ( conf.BattleAutoResolve() ) {
@@ -188,11 +188,11 @@ namespace
             value = spellcast ? _( "Auto Resolve" ) : _( "Auto, No Spells" );
 
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, spellcast ? 7 : 6 );
-            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), value );
+            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), value, iconTextMaxWidth );
         }
         else {
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 18 );
-            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "autoBattle|Manual" ) );
+            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "autoBattle|Manual" ), iconTextMaxWidth );
         }
     }
 
@@ -221,6 +221,7 @@ namespace
         const fheroes2::Sprite & optionSprite = fheroes2::AGG::GetICN( ICN::SPANEL, 0 );
         const fheroes2::Point optionOffset( 36 + dialogArea.x, 47 + dialogArea.y );
         const fheroes2::Point optionStep( 92, 110 );
+        const int32_t iconTextMaxWidth = optionStep.x - 5;
 
         std::vector<fheroes2::Rect> roi;
 
@@ -240,7 +241,7 @@ namespace
         const fheroes2::Rect & interfaceStateRoi = roi[7];
         const fheroes2::Rect & battleResolveRoi = roi[8];
 
-        drawDialog( roi );
+        drawDialog( roi, iconTextMaxWidth );
 
         const fheroes2::Point buttonOffset( 112 + dialogArea.x, 362 + dialogArea.y );
         fheroes2::Button buttonOkay( buttonOffset.x, buttonOffset.y, isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0, 1 );
@@ -384,7 +385,7 @@ namespace
             if ( saveHeroSpeed || saveAISpeed || saveScrollSpeed || saveAutoBattle ) {
                 // redraw
                 fheroes2::Blit( dialog, display, dialogArea.x, dialogArea.y );
-                drawDialog( roi );
+                drawDialog( roi, iconTextMaxWidth );
                 buttonOkay.draw();
                 display.render();
 

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -57,7 +57,7 @@ namespace
         Close
     };
 
-    void drawDialog( const std::vector<fheroes2::Rect> & rects, const int32_t iconTextMaxWidth )
+    void drawDialog( const std::vector<fheroes2::Rect> & rects )
     {
         assert( rects.size() == 9 );
 
@@ -65,16 +65,16 @@ namespace
 
         // Audio settings.
         const fheroes2::Sprite & audioSettingsIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 1 );
-        fheroes2::drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "Settings" ), iconTextMaxWidth );
+        fheroes2::drawOption( rects[0], audioSettingsIcon, _( "Audio" ), _( "Settings" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         // Hot keys.
         const fheroes2::Sprite & hotkeysIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, 5 );
-        fheroes2::drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), iconTextMaxWidth );
+        fheroes2::drawOption( rects[1], hotkeysIcon, _( "Hot Keys" ), _( "Configure" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         // Cursor Type.
         const bool isMonoCursor = Settings::Get().isMonochromeCursorEnabled();
         const fheroes2::Sprite & cursorTypeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isMonoCursor ? 20 : 21 );
-        fheroes2::drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ), iconTextMaxWidth );
+        fheroes2::drawOption( rects[2], cursorTypeIcon, _( "Mouse Cursor" ), isMonoCursor ? _( "Black & White" ) : _( "Color" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         // Hero's movement speed.
         const int heroSpeed = conf.HeroesMoveSpeed();
@@ -95,7 +95,7 @@ namespace
             value = std::to_string( heroSpeed );
         }
 
-        fheroes2::drawOption( rects[3], heroSpeedIcon, _( "Hero Speed" ), value, iconTextMaxWidth );
+        fheroes2::drawOption( rects[3], heroSpeedIcon, _( "Hero Speed" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         // AI's movement speed.
         const int aiSpeed = conf.AIMoveSpeed();
@@ -118,7 +118,7 @@ namespace
             value = std::to_string( aiSpeed );
         }
 
-        fheroes2::drawOption( rects[4], aiSpeedIcon, _( "Enemy Speed" ), value, iconTextMaxWidth );
+        fheroes2::drawOption( rects[4], aiSpeedIcon, _( "Enemy Speed" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         // Scrolling speed.
         const int scrollSpeed = conf.ScrollSpeed();
@@ -155,7 +155,7 @@ namespace
         assert( scrollSpeedIconIcn != ICN::UNKNOWN );
 
         const fheroes2::Sprite & scrollSpeedIcon = fheroes2::AGG::GetICN( scrollSpeedIconIcn, scrollSpeedIconId );
-        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), scrollSpeedName, iconTextMaxWidth );
+        fheroes2::drawOption( rects[5], scrollSpeedIcon, _( "Scroll Speed" ), scrollSpeedName, THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         // Interface theme.
         const bool isEvilInterface = conf.isEvilInterfaceEnabled();
@@ -167,7 +167,7 @@ namespace
             value = _( "Good" );
         }
 
-        fheroes2::drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value, iconTextMaxWidth );
+        fheroes2::drawOption( rects[6], interfaceThemeIcon, _( "Interface Type" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         // Interface show/hide state.
         const bool isHiddenInterface = conf.isHideInterfaceEnabled();
@@ -180,7 +180,7 @@ namespace
             value = _( "Show" );
         }
 
-        fheroes2::drawOption( rects[7], interfaceStateIcon, _( "Interface" ), value, iconTextMaxWidth );
+        fheroes2::drawOption( rects[7], interfaceStateIcon, _( "Interface" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
 
         // Auto-battles.
         if ( conf.BattleAutoResolve() ) {
@@ -188,11 +188,11 @@ namespace
             value = spellcast ? _( "Auto Resolve" ) : _( "Auto, No Spells" );
 
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, spellcast ? 7 : 6 );
-            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), value, iconTextMaxWidth );
+            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), value, THREE_ELEMENT_ROW_TEXT_WIDTH );
         }
         else {
             const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 18 );
-            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "autoBattle|Manual" ), iconTextMaxWidth );
+            fheroes2::drawOption( rects[8], autoBattleIcon, _( "Battles" ), _( "autoBattle|Manual" ), THREE_ELEMENT_ROW_TEXT_WIDTH );
         }
     }
 
@@ -221,7 +221,6 @@ namespace
         const fheroes2::Sprite & optionSprite = fheroes2::AGG::GetICN( ICN::SPANEL, 0 );
         const fheroes2::Point optionOffset( 36 + dialogArea.x, 47 + dialogArea.y );
         const fheroes2::Point optionStep( 92, 110 );
-        const int32_t iconTextMaxWidth = optionStep.x - 5;
 
         std::vector<fheroes2::Rect> roi;
 
@@ -241,7 +240,7 @@ namespace
         const fheroes2::Rect & interfaceStateRoi = roi[7];
         const fheroes2::Rect & battleResolveRoi = roi[8];
 
-        drawDialog( roi, iconTextMaxWidth );
+        drawDialog( roi );
 
         const fheroes2::Point buttonOffset( 112 + dialogArea.x, 362 + dialogArea.y );
         fheroes2::Button buttonOkay( buttonOffset.x, buttonOffset.y, isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0, 1 );
@@ -385,7 +384,7 @@ namespace
             if ( saveHeroSpeed || saveAISpeed || saveScrollSpeed || saveAutoBattle ) {
                 // redraw
                 fheroes2::Blit( dialog, display, dialogArea.x, dialogArea.y );
-                drawDialog( roi, iconTextMaxWidth );
+                drawDialog( roi );
                 buttonOkay.draw();
                 display.render();
 

--- a/src/fheroes2/gui/ui_option_item.cpp
+++ b/src/fheroes2/gui/ui_option_item.cpp
@@ -29,23 +29,24 @@
 
 namespace
 {
-    const fheroes2::Point textOffset{ 11, 12 };
-    const int32_t nameOffset = 6;
+    const int32_t textVerticalOffset = 12;
+    const int32_t nameVerticalOffset = 6;
 }
 
 namespace fheroes2
 {
-    void drawOption( const Rect & optionRoi, const Sprite & icon, std::string titleText, std::string valueText )
+    void drawOption( const Rect & optionRoi, const Sprite & icon, std::string titleText, std::string valueText, const int32_t textMaxWidth )
     {
         Display & display = Display::instance();
 
         const Text title( std::move( titleText ), FontType::smallWhite() );
         const Text name( std::move( valueText ), FontType::smallWhite() );
 
-        const int32_t textMaxWidth = 87;
+        // Calculate the text field left border position to horizontally align the text to the icon center.
+        const int32_t textHorizontalOffset = optionRoi.x + ( icon.width() - textMaxWidth ) / 2;
 
-        title.draw( optionRoi.x - textOffset.x, optionRoi.y - textOffset.y + title.height() - title.height( textMaxWidth ), textMaxWidth, display );
-        name.draw( optionRoi.x - textOffset.x, optionRoi.y + optionRoi.height + nameOffset, textMaxWidth, display );
+        title.draw( textHorizontalOffset, optionRoi.y - textVerticalOffset + title.height() - title.height( textMaxWidth ), textMaxWidth, display );
+        name.draw( textHorizontalOffset, optionRoi.y + optionRoi.height + nameVerticalOffset, textMaxWidth, display );
 
         Blit( icon, 0, 0, display, optionRoi.x, optionRoi.y, icon.width(), icon.height() );
     }

--- a/src/fheroes2/gui/ui_option_item.h
+++ b/src/fheroes2/gui/ui_option_item.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #include "math_base.h"

--- a/src/fheroes2/gui/ui_option_item.h
+++ b/src/fheroes2/gui/ui_option_item.h
@@ -25,6 +25,12 @@
 
 #include "math_base.h"
 
+enum : int32_t
+{
+    TWO_ELEMENT_ROW_TEXT_WIDTH = 113,
+    THREE_ELEMENT_ROW_TEXT_WIDTH = 87
+};
+
 namespace fheroes2
 {
     class Sprite;

--- a/src/fheroes2/gui/ui_option_item.h
+++ b/src/fheroes2/gui/ui_option_item.h
@@ -25,14 +25,14 @@
 
 #include "math_base.h"
 
-enum : int32_t
-{
-    TWO_ELEMENT_ROW_TEXT_WIDTH = 113,
-    THREE_ELEMENT_ROW_TEXT_WIDTH = 87
-};
-
 namespace fheroes2
 {
+    enum UiOptionTextWidth : int32_t
+    {
+        TWO_ELEMENTS_ROW = 113,
+        THREE_ELEMENTS_ROW = 87
+    };
+
     class Sprite;
 
     void drawOption( const Rect & optionRoi, const Sprite & icon, std::string titleText, std::string valueText, const int32_t textMaxWidth );

--- a/src/fheroes2/gui/ui_option_item.h
+++ b/src/fheroes2/gui/ui_option_item.h
@@ -28,5 +28,5 @@ namespace fheroes2
 {
     class Sprite;
 
-    void drawOption( const Rect & optionRoi, const Sprite & icon, std::string titleText, std::string valueText );
+    void drawOption( const Rect & optionRoi, const Sprite & icon, std::string titleText, std::string valueText, const int32_t textMaxWidth );
 }


### PR DESCRIPTION
The settings dialogs have different spacing between elements: in audio and graphics settings there is more space than in other configuration dialogs. So for these two dialogs the maximum text width can be set higher to allow use of longer phrases (especially for translations).
This PR adds the ability to set per element (per icon) the maximum text width for configuration dialogs. In this PR maximum width is set to `( distance_between_elements - 5px )`.