### PR TITLE
ScenarioInfo window: all difficulty texts remain after difficulty is …

### DIFF
--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -320,9 +320,11 @@ namespace
                     levelCursor.setPosition( coordDifficulty[index].x, coordDifficulty[index].y );
                     levelCursor.redraw();
                     Game::saveDifficulty( index );
+                    RedrawDifficultyInfo( pointDifficultyInfo );
                     playersInfo.RedrawInfo( false );
                     ratingRoi = RedrawRatingInfo( rectPanel.getPosition(), rectPanel.width );
                     buttonOk.draw();
+                    buttonCancel.draw();
                     display.render();
                 }
                 // playersInfo


### PR DESCRIPTION
…changed

ScenarioInfo window displays difficulty text after a difficulty is changed. Also, the Cancel button does not change its language.

Fixes #6295 