### PR TITLE
Fixed redraw difficulty info after click

### DIFF
--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -320,6 +320,7 @@ namespace
                     levelCursor.setPosition( coordDifficulty[index].x, coordDifficulty[index].y );
                     levelCursor.redraw();
                     Game::saveDifficulty( index );
+                    RedrawDifficultyInfo( pointDifficultyInfo );
                     playersInfo.RedrawInfo( false );
                     ratingRoi = RedrawRatingInfo( rectPanel.getPosition(), rectPanel.width );
                     buttonOk.draw();


### PR DESCRIPTION
After click on difficulty buttons no more displaying info about difficulty. This commit is fix it.