### PR TITLE
Avoid using memory on heap for rendering methods

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -790,7 +790,7 @@ namespace fheroes2
         const uint8_t * gamePalette = getGamePalette();
 
         if ( flip ) {
-            const int32_t offsetInY = inY * widthIn + widthIn - 1 - inX;
+            const int32_t offsetInY = inY * widthIn + inX + width - 1;
             const uint8_t * imageInY = in.image() + offsetInY;
             const uint8_t * transformInY = in.transform() + offsetInY;
 
@@ -993,7 +993,7 @@ namespace fheroes2
         const int32_t widthOut = out.width();
 
         if ( flip ) {
-            const int32_t offsetInY = inY * widthIn + widthIn - 1 - inX;
+            const int32_t offsetInY = inY * widthIn + inX + width - 1;
             const uint8_t * imageInY = in.image() + offsetInY;
             const uint8_t * transformInY = in.transform() + offsetInY;
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1242,7 +1242,7 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
     // Some addons must be rendered after the main object on the tile. This applies for flags.
     // Since this method is called intensively during rendering we have to avoid memory allocation on heap.
     const size_t maxPostRenderAddons = 16;
-    std::array<const TilesAddon *, maxPostRenderAddons> postRenderingAddon;
+    std::array<const TilesAddon *, maxPostRenderAddons> postRenderingAddon{ nullptr };
     size_t postRenderAddonCount = 0;
 
     for ( const TilesAddon & addon : addons_level1 ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1242,7 +1242,7 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
     // Some addons must be rendered after the main object on the tile. This applies for flags.
     // Since this method is called intensively during rendering we have to avoid memory allocation on heap.
     const size_t maxPostRenderAddons = 16;
-    std::array<const TilesAddon *, maxPostRenderAddons> postRenderingAddon{ nullptr };
+    std::array<const TilesAddon *, maxPostRenderAddons> postRenderingAddon{};
     size_t postRenderAddonCount = 0;
 
     for ( const TilesAddon & addon : addons_level1 ) {


### PR DESCRIPTION
`redrawBottomLayerObjects()` method is called a lot of times while rendering a frame of Adventure Map. Using a container based on heap memory is not an optimal from performance point of view approach.

Also fix incorrect logic for `Blit()` and `AlphaBlit()` functions where we might read invalid data.

relates to #5716