### PR TITLE
Do not draw multiple frames of Adventure Map

### DIFF
--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -47,6 +47,7 @@ Interface::Basic::Basic()
     , statusWindow( *this )
     , controlPanel( *this )
     , redraw( 0 )
+    , _lockRedraw( false )
 {
     Reset();
 }
@@ -112,6 +113,11 @@ Interface::Basic & Interface::Basic::Get()
 
 void Interface::Basic::Redraw( const uint32_t force /* = 0 */ )
 {
+    if ( _lockRedraw ) {
+        SetRedraw( force );
+        return;
+    }
+
     const Settings & conf = Settings::Get();
 
     const uint32_t combinedRedraw = redraw | force;

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -80,6 +80,26 @@ namespace Interface
     class Basic
     {
     public:
+        // This class is used to lock rendering of Basic class. This is useful when we have to generate only a single frame.
+        // Use this class ONLY when you are going to call rendering after all other operations.
+        class RedrawLocker
+        {
+        public:
+            RedrawLocker( Basic & basic )
+                : _basic( basic )
+            {
+                _basic._lockRedraw = true;
+            }
+
+            ~RedrawLocker()
+            {
+                _basic._lockRedraw = false;
+            }
+
+        private:
+            Basic & _basic;
+        };
+
         static Basic & Get();
 
         bool NeedRedraw() const
@@ -212,6 +232,8 @@ namespace Interface
         ControlPanel controlPanel;
 
         uint32_t redraw;
+
+        bool _lockRedraw;
     };
 }
 

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -85,7 +85,7 @@ namespace Interface
         class RedrawLocker
         {
         public:
-            RedrawLocker( Basic & basic )
+            explicit RedrawLocker( Basic & basic )
                 : _basic( basic )
             {
                 _basic._lockRedraw = true;

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -91,6 +91,12 @@ namespace Interface
                 _basic._lockRedraw = true;
             }
 
+            RedrawLocker( const RedrawLocker & ) = delete;
+            RedrawLocker( RedrawLocker && ) = delete;
+
+            RedrawLocker & operator=( const RedrawLocker & ) = delete;
+            RedrawLocker & operator=( RedrawLocker && ) = delete;
+
             ~RedrawLocker()
             {
                 _basic._lockRedraw = false;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1064,10 +1064,15 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                     if ( resetHeroSprite ) {
                         hero->SetSpriteIndex( heroAnimationSpriteId - 1 );
                     }
+
                     if ( hero->isMoveEnabled() ) {
                         if ( hero->Move( 10 == conf.HeroesMoveSpeed() ) ) {
+                            // Do not generate a frame as we are going to do it later.
+                            Interface::Basic::RedrawLocker redrawLocker( Interface::Basic::Get() );
+
                             gameArea.SetCenter( hero->GetCenter() );
                             ResetFocus( GameFocus::HEROES );
+
                             RedrawFocus();
 
                             if ( stopHero ) {
@@ -1079,6 +1084,9 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                         else {
                             const fheroes2::Point movement( hero->MovementDirection() );
                             if ( movement != fheroes2::Point() ) { // don't waste resources for no movement
+                                // Do not generate a frame as we are going to do it later.
+                                Interface::Basic::RedrawLocker redrawLocker( Interface::Basic::Get() );
+
                                 const int32_t heroMovementSkipValue = Game::HumanHeroAnimSkip();
 
                                 heroAnimationOffset = movement;

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -494,6 +494,9 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
                 populateHeroObjectInfo( tileUnfit, tile.GetHeroes() );
 
+                // Update object type as it could be an object under the hero.
+                objectType = tile.GetObject( false );
+
                 break;
             }
 
@@ -531,10 +534,6 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
             default:
                 break;
-            }
-
-            if ( objectType == MP2::OBJ_HEROES ) {
-                objectType = tile.GetObject( false );
             }
 
             switch ( objectType ) {


### PR DESCRIPTION
We were generating but not rendering multiple frames of Adventure Map while a hero was moving. This was a waste of resources by doing nothing from the perspective of players. This change is not ideal as I wanted to avoid making heavy changes. Also the change should potentially reduce fluctuations in FPS as these "extra" frames were rendered only when a hero moves to another tile.

Looks like we have exactly the same problem for Adventure Map rendering like we did for localevent: too many useless rendering calls. To prove it I cite a message from Discord about performance drop on PS Vita:
```
30% is just during map scrolling. Performance drop during hero movement on the world map is closer to 50%-55%
```
which means that we really do something extra while a hero is moving.