### PR TITLE
The Cancel button, in the Recruid dialog, remains its translated text…

### DIFF
--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -505,6 +505,8 @@ Troop Dialog::RecruitMonster( const Monster & monster0, uint32_t available, cons
                 buttonOk.draw();
             }
 
+            buttonCancel.draw();
+
             if ( buttonMax.isEnabled() || max == 0 )
                 buttonMax.draw();
             if ( buttonMin.isEnabled() )


### PR DESCRIPTION
… after the monster change.

The Cancel button does not lose its translation text after a change to its non-upgraded part.

fixes #6311 
fixed #5966 