### PR TITLE
Do not stop object animation during AI turn

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1701,7 +1701,8 @@ namespace AI
 
             const std::vector<Game::DelayType> delayTypes = { Game::CURRENT_AI_DELAY, Game::MAPS_DELAY };
 
-            while ( LocalEvent::Get().HandleEvents( !hideAIMovements && Game::isDelayNeeded( delayTypes ) ) ) {
+            LocalEvent & le = LocalEvent::Get();
+            while ( le.HandleEvents( !hideAIMovements && Game::isDelayNeeded( delayTypes ) ) ) {
 #if defined( WITH_DEBUG )
                 if ( HotKeyPressEvent( Game::HotKeyEvent::TRANSFER_CONTROL_TO_AI ) && Players::Get( hero.GetColor() )->isAIAutoControlMode() ) {
                     if ( fheroes2::showMessage( fheroes2::Text( _( "Warning" ), fheroes2::FontType::normalYellow() ),
@@ -1783,7 +1784,7 @@ namespace AI
                 }
 
                 if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
-                    // will be animated in hero loop
+                    // Update Adventure Map objects' animation.
                     uint32_t & frame = Game::MapsAnimationFrame();
                     ++frame;
                     gameArea.SetRedraw();

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1779,7 +1779,7 @@ namespace AI
                         }
                     }
 
-                    basicInterface.SetRedraw( Interface::REDRAW_GAMEAREA );
+                    gameArea.SetRedraw();
                 }
 
                 if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1699,7 +1699,7 @@ namespace AI
             const bool hideAIMovements = ( conf.AIMoveSpeed() == 0 );
             const bool noMovementAnimation = ( conf.AIMoveSpeed() == 10 );
 
-            const std::vector<Game::DelayType> delayTypes = { Game::CURRENT_AI_DELAY };
+            const std::vector<Game::DelayType> delayTypes = { Game::CURRENT_AI_DELAY, Game::MAPS_DELAY };
 
             while ( LocalEvent::Get().HandleEvents( !hideAIMovements && Game::isDelayNeeded( delayTypes ) ) ) {
 #if defined( WITH_DEBUG )
@@ -1779,14 +1779,19 @@ namespace AI
                         }
                     }
 
-                    basicInterface.Redraw( Interface::REDRAW_GAMEAREA );
-                    fheroes2::Display::instance().render();
+                    basicInterface.SetRedraw( Interface::REDRAW_GAMEAREA );
                 }
 
                 if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
                     // will be animated in hero loop
                     uint32_t & frame = Game::MapsAnimationFrame();
                     ++frame;
+                    gameArea.SetRedraw();
+                }
+
+                if ( basicInterface.NeedRedraw() ) {
+                    basicInterface.Redraw();
+                    fheroes2::Display::instance().render();
                 }
             }
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -252,7 +252,7 @@ namespace AI
         std::map<int32_t, double> _neutralMonsterStrengthCache;
 
         void CastleTurn( Castle & castle, bool defensive );
-        bool HeroesTurn( VecHeroes & heroes );
+        bool HeroesTurn( VecHeroes & heroes, const uint32_t startProgressValue, const uint32_t endProgressValue );
 
         double getHunterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -37,11 +37,13 @@
 #include "artifact.h"
 #include "castle.h"
 #include "color.h"
+#include "game_interface.h"
 #include "game_over.h"
 #include "game_static.h"
 #include "gamedefs.h"
 #include "ground.h"
 #include "heroes.h"
+#include "interface_status.h"
 #include "kingdom.h"
 #include "logging.h"
 #include "luck.h"
@@ -1742,7 +1744,7 @@ namespace AI
         }
     }
 
-    bool Normal::HeroesTurn( VecHeroes & heroes )
+    bool Normal::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressValue, const uint32_t endProgressValue )
     {
         if ( heroes.empty() ) {
             // No heroes so we indicate that all heroes moved.
@@ -1759,6 +1761,8 @@ namespace AI
 
         const int monsterStrengthMultiplierCount = 2;
         const double monsterStrengthMultipliers[monsterStrengthMultiplierCount] = { ARMY_ADVANTAGE_MEDIUM, ARMY_ADVANTAGE_SMALL };
+
+        Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
 
         while ( !availableHeroes.empty() ) {
             Heroes * bestHero = availableHeroes.front().hero;
@@ -1860,12 +1864,20 @@ namespace AI
 
             _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
             _pathfinder.setSpellPointReserve( 0.5 );
+
+            // The size of heroes can be increased if a new hero is released from Jail.
+            const size_t maxHeroCount = std::max( heroes.size(), availableHeroes.size() );
+            const size_t progressValue = ( endProgressValue - startProgressValue ) * ( maxHeroCount - availableHeroes.size() ) / maxHeroCount + startProgressValue;
+
+            status.RedrawStatusIfNeeded( static_cast<uint32_t>( progressValue ) );
         }
 
         const bool allHeroesMoved = availableHeroes.empty();
 
         _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
         _pathfinder.setSpellPointReserve( 0.5 );
+
+        status.RedrawStatusIfNeeded( endProgressValue );
 
         return allHeroesMoved;
     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1867,9 +1867,13 @@ namespace AI
 
             // The size of heroes can be increased if a new hero is released from Jail.
             const size_t maxHeroCount = std::max( heroes.size(), availableHeroes.size() );
-            const size_t progressValue = ( endProgressValue - startProgressValue ) * ( maxHeroCount - availableHeroes.size() ) / maxHeroCount + startProgressValue;
 
-            status.RedrawStatusIfNeeded( static_cast<uint32_t>( progressValue ) );
+            if ( maxHeroCount > 0 ) {
+                // At least one hero still exist in the kingdom.
+                const size_t progressValue = ( endProgressValue - startProgressValue ) * ( maxHeroCount - availableHeroes.size() ) / maxHeroCount + startProgressValue;
+
+                status.RedrawStatusIfNeeded( static_cast<uint32_t>( progressValue ) );
+            }
         }
 
         const bool allHeroesMoved = availableHeroes.empty();

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1872,7 +1872,7 @@ namespace AI
                 // At least one hero still exist in the kingdom.
                 const size_t progressValue = ( endProgressValue - startProgressValue ) * ( maxHeroCount - availableHeroes.size() ) / maxHeroCount + startProgressValue;
 
-                status.RedrawStatusIfNeeded( static_cast<uint32_t>( progressValue ) );
+                status.DrawAITurnProgress( static_cast<uint32_t>( progressValue ) );
             }
         }
 
@@ -1881,7 +1881,7 @@ namespace AI
         _pathfinder.setArmyStrengthMultiplier( originalMonsterStrengthMultiplier );
         _pathfinder.setSpellPointReserve( 0.5 );
 
-        status.RedrawStatusIfNeeded( endProgressValue );
+        status.DrawAITurnProgress( endProgressValue );
 
         return allHeroesMoved;
     }

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -414,7 +414,7 @@ namespace AI
 
         // reset indicator
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
-        status.RedrawTurnProgress( 0 );
+        status.SetToRedrawTurnProgress( 0 );
 
         AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
@@ -536,7 +536,7 @@ namespace AI
 
         DEBUG_LOG( DBG_AI, DBG_TRACE, Color::String( myColor ) << " found " << _mapObjects.size() << " valid objects" )
 
-        status.RedrawTurnProgress( 1 );
+        status.SetToRedrawTurnProgress( 1 );
 
         uint32_t progressStatus = 6;
 
@@ -553,21 +553,21 @@ namespace AI
             setHeroRoles( heroes );
 
             if ( progressStatus == 6 ) {
-                status.RedrawTurnProgress( 6 );
+                status.SetToRedrawTurnProgress( 6 );
                 ++progressStatus;
             }
             else {
-                status.RedrawTurnProgress( 8 );
+                status.SetToRedrawTurnProgress( 8 );
             }
 
             castlesInDanger = findCastlesInDanger( castles, enemyArmies, myColor );
             sortedCastleList = getSortedCastleList( castles, castlesInDanger );
 
             if ( progressStatus == 7 ) {
-                status.RedrawTurnProgress( 7 );
+                status.SetToRedrawTurnProgress( 7 );
             }
             else {
-                status.RedrawTurnProgress( 8 );
+                status.SetToRedrawTurnProgress( 8 );
             }
 
             const bool moreTaskForHeroes = HeroesTurn( heroes );
@@ -579,7 +579,7 @@ namespace AI
             ++availableHeroCount;
         }
 
-        status.RedrawTurnProgress( 9 );
+        status.SetToRedrawTurnProgress( 9 );
 
         // sync up castle list (if conquered new ones during the turn)
         if ( castles.size() != sortedCastleList.size() ) {

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -414,7 +414,7 @@ namespace AI
 
         // reset indicator
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
-        status.RedrawStatusIfNeeded( 0 );
+        status.DrawAITurnProgress( 0 );
 
         AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
@@ -537,7 +537,7 @@ namespace AI
         DEBUG_LOG( DBG_AI, DBG_TRACE, Color::String( myColor ) << " found " << _mapObjects.size() << " valid objects" )
 
         uint32_t progressStatus = 1;
-        status.RedrawStatusIfNeeded( progressStatus );
+        status.DrawAITurnProgress( progressStatus );
 
         std::vector<AICastle> sortedCastleList;
         std::set<int> castlesInDanger;
@@ -561,7 +561,7 @@ namespace AI
 
             if ( progressStatus == 1 ) {
                 progressStatus = 8;
-                status.RedrawStatusIfNeeded( progressStatus );
+                status.DrawAITurnProgress( progressStatus );
             }
 
             // Step 4. Buy new heroes, adjust roles, sort heroes based on priority or strength
@@ -571,7 +571,7 @@ namespace AI
             ++availableHeroCount;
         }
 
-        status.RedrawStatusIfNeeded( 9 );
+        status.DrawAITurnProgress( 9 );
 
         // sync up castle list (if conquered new ones during the turn)
         if ( castles.size() != sortedCastleList.size() ) {
@@ -586,7 +586,7 @@ namespace AI
             }
         }
 
-        status.RedrawStatusIfNeeded( 10 );
+        status.DrawAITurnProgress( 10 );
     }
 
     bool Normal::purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, int32_t availableHeroCount,

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -955,7 +955,6 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
             fastScrollRepeatCount = 0;
         }
 
-        const fheroes2::Rect displayArea( 0, 0, display.width(), display.height() );
         const bool isHiddenInterface = conf.isHideInterfaceEnabled();
         const bool prevIsCursorOverButtons = isCursorOverButtons;
         isCursorOverButtons = false;
@@ -968,6 +967,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
             }
 
             // if the hero is currently moving, pressing any mouse button should stop him
+            const fheroes2::Rect displayArea{ 0, 0, display.width(), display.height() };
             if ( le.MouseClickLeft( displayArea ) || le.MousePressRight( displayArea ) ) {
                 stopHero = true;
             }

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -475,20 +475,18 @@ void Interface::StatusWindow::TimerEventProcessing()
 
 void Interface::StatusWindow::RedrawStatusIfNeeded( const uint32_t progressValue )
 {
+    // Process events if any before rendering a frame. For instance, updating a mouse cursor position.
+    LocalEvent::Get().HandleEvents( false );
+
     turn_progress = progressValue;
 
     interface.Redraw( REDRAW_STATUS );
 
     if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
-        // Process events if any before rendering a frame. For instance, updating a mouse cursor position.
-        LocalEvent::Get().HandleEvents( false );
-
         uint32_t & frame = Game::MapsAnimationFrame();
         ++frame;
 
-        interface.GetGameArea().SetRedraw();
-
-        interface.Redraw();
+        interface.Redraw( REDRAW_GAMEAREA );
         fheroes2::Display::instance().render();
     }
 }

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -472,7 +472,7 @@ void Interface::StatusWindow::TimerEventProcessing()
     SetRedraw();
 }
 
-void Interface::StatusWindow::RedrawStatusIfNeeded( const uint32_t progressValue )
+void Interface::StatusWindow::DrawAITurnProgress( const uint32_t progressValue )
 {
     // Process events if any before rendering a frame. For instance, updating a mouse cursor position.
     LocalEvent::Get().HandleEvents( false );

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -36,7 +36,6 @@
 #include "heroes.h"
 #include "icn.h"
 #include "image.h"
-#include "interface_gamearea.h"
 #include "interface_status.h"
 #include "kingdom.h"
 #include "localevent.h"

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -36,6 +36,7 @@
 #include "heroes.h"
 #include "icn.h"
 #include "image.h"
+#include "interface_gamearea.h"
 #include "interface_status.h"
 #include "kingdom.h"
 #include "localevent.h"

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -470,10 +470,9 @@ void Interface::StatusWindow::TimerEventProcessing()
     SetRedraw();
 }
 
-void Interface::StatusWindow::RedrawTurnProgress( uint32_t v )
+void Interface::StatusWindow::SetToRedrawTurnProgress( const uint32_t progressValue )
 {
-    turn_progress = v;
+    turn_progress = progressValue;
 
     interface.Redraw( REDRAW_STATUS );
-    fheroes2::Display::instance().render( GetArea() );
 }

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -29,6 +29,8 @@
 #include "castle.h"
 #include "color.h"
 #include "dialog.h"
+#include "game.h"
+#include "game_delays.h"
 #include "game_interface.h"
 #include "gamedefs.h"
 #include "heroes.h"
@@ -470,9 +472,22 @@ void Interface::StatusWindow::TimerEventProcessing()
     SetRedraw();
 }
 
-void Interface::StatusWindow::SetToRedrawTurnProgress( const uint32_t progressValue )
+void Interface::StatusWindow::RedrawStatusIfNeeded( const uint32_t progressValue )
 {
     turn_progress = progressValue;
 
     interface.Redraw( REDRAW_STATUS );
+
+    if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+        // Process events if any before rendering a frame. For instance, updating a mouse cursor position.
+        LocalEvent::Get().HandleEvents( false );
+
+        uint32_t & frame = Game::MapsAnimationFrame();
+        ++frame;
+
+        interface.GetGameArea().SetRedraw();
+
+        interface.Redraw();
+        fheroes2::Display::instance().render();
+    }
 }

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -63,7 +63,7 @@ namespace Interface
 
         void SetState( const StatusType status );
         void SetResource( int, uint32_t );
-        void RedrawTurnProgress( uint32_t );
+        void SetToRedrawTurnProgress( const uint32_t progressValue );
         void QueueEventProcessing();
         void TimerEventProcessing();
 

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -63,7 +63,7 @@ namespace Interface
 
         void SetState( const StatusType status );
         void SetResource( int, uint32_t );
-        void RedrawStatusIfNeeded( const uint32_t progressValue );
+        void DrawAITurnProgress( const uint32_t progressValue );
         void QueueEventProcessing();
         void TimerEventProcessing();
 

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -63,7 +63,7 @@ namespace Interface
 
         void SetState( const StatusType status );
         void SetResource( int, uint32_t );
-        void SetToRedrawTurnProgress( const uint32_t progressValue );
+        void RedrawStatusIfNeeded( const uint32_t progressValue );
         void QueueEventProcessing();
         void TimerEventProcessing();
 


### PR DESCRIPTION
If AI movement is not shown or AI heroes are hidden by fog Adventure Map is not updated so all objects become frozen. The changes allow to continue animation of objects for such cases.

Progress bar for AI turn is updated based on heroes' turns. It also renders when Adventure Map objects require an update so we do not waste time for rendering a frame just to indicate some progress and then few nanoseconds later we do the same.