### PR TITLE
Display the amount of gold in the diplomacy dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -711,6 +711,9 @@ int Dialog::ArmyJoinWithCost( const Troop & troop, const uint32_t join, const ui
     posy += text.h() + 40;
     fheroes2::Blit( sprite, display, pos.x + ( pos.width - sprite.width() ) / 2, posy );
 
+    const fheroes2::Text goldText( std::to_string( gold ), fheroes2::FontType::smallWhite() );
+    goldText.draw( pos.x + ( pos.width - goldText.width() ) / 2, posy + sprite.height() + 5, display );
+
     fheroes2::ButtonGroup btnGroup( pos, buttons );
     btnGroup.draw();
 


### PR DESCRIPTION
fix #6323

Looks like the regression after #5671.

![join](https://user-images.githubusercontent.com/32623900/206320760-53c96fc9-cf69-4243-a7da-07e838f1b56e.jpg)
