### PR TITLE
The newly allocated channels have a default volume of MIX_MAX_VOLUME

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -825,7 +825,7 @@ void Mixer::SetChannels( const int num )
     }
 
     if ( isMuted ) {
-        savedMixerVolumes.resize( static_cast<size_t>( mixerChannelCount ), 0 );
+        savedMixerVolumes.resize( static_cast<size_t>( mixerChannelCount ), MIX_MAX_VOLUME );
 
         Mix_Volume( -1, 0 );
     }


### PR DESCRIPTION
As mentioned in the [documentation](https://wiki.libsdl.org/SDL_mixer/Mix_Volume), the default volume for the newly allocated channels is `MIX_MAX_VOLUME`. We should remember the correct volume for the newly allocated channels when audio is muted, otherwise there is a discrepancy in behavior when audio is muted and when it is not muted.

There was the correct logic initially, but it was changed for some reason in #5486.