### PR TITLE
Death Wave spell animation fix (Battlefield)

### DIFF
--- a/src/fheroes2/battle/battle_animation.cpp
+++ b/src/fheroes2/battle/battle_animation.cpp
@@ -142,6 +142,8 @@ AnimationReference::AnimationReference( int monsterID )
     // Taking damage
     appendFrames( _wince, Bin_Info::MonsterAnimInfo::WINCE_UP );
     appendFrames( _wince, Bin_Info::MonsterAnimInfo::WINCE_END ); // TODO: play it back together for now
+    appendFrames( _winceUp, Bin_Info::MonsterAnimInfo::WINCE_UP );
+    appendFrames( _winceDown, Bin_Info::MonsterAnimInfo::WINCE_END );
     appendFrames( _death, Bin_Info::MonsterAnimInfo::DEATH );
 
     // Idle animations
@@ -279,6 +281,10 @@ const std::vector<int> & AnimationReference::getAnimationVector( int animState )
         return _ranged[Monster_Info::BOTTOM].start;
     case Monster_Info::RANG_BOT_END:
         return _ranged[Monster_Info::BOTTOM].end;
+    case Monster_Info::WNCE_UP:
+        return _winceUp;
+    case Monster_Info::WNCE_DOWN:
+        return _winceDown;
     case Monster_Info::WNCE:
         return _wince;
     case Monster_Info::KILL:
@@ -358,6 +364,12 @@ std::vector<int> AnimationReference::getAnimationOffset( int animState ) const
         break;
     case Monster_Info::RANG_BOT_END:
         offset.resize( _ranged[Monster_Info::BOTTOM].end.size(), 0 );
+        break;
+    case Monster_Info::WNCE_UP:
+        offset.resize( _winceUp.size(), 0 );
+        break;
+    case Monster_Info::WNCE_DOWN:
+        offset.resize( _winceDown.size(), 0 );
         break;
     case Monster_Info::WNCE:
         offset.resize( _wince.size(), 0 );

--- a/src/fheroes2/battle/battle_animation.h
+++ b/src/fheroes2/battle/battle_animation.h
@@ -103,6 +103,8 @@ protected:
     std::vector<int> _moveLastTile;
     std::vector<int> _moveOneTile;
     monsterReturnAnim _flying;
+    std::vector<int> _winceUp;
+    std::vector<int> _winceDown;
     std::vector<int> _wince;
     std::vector<int> _death;
     monsterReturnAnim _melee[3];

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3363,18 +3363,17 @@ void Battle::Interface::SetHeroAnimationReactionToTroopDeath( const int32_t deat
     if ( deathColor == Color::UNUSED ) {
         return;
     }
-    else {
-        const bool attackersTurn = ( deathColor == arena.GetArmy2Color() );
-        OpponentSprite * attackingHero = attackersTurn ? opponent1 : opponent2;
-        OpponentSprite * defendingHero = attackersTurn ? opponent2 : opponent1;
-        // 60% of joyful animation
-        if ( attackingHero && Rand::Get( 1, 5 ) < 4 ) {
-            attackingHero->SetAnimation( OP_JOY );
-        }
-        // 80% of sorrow animation otherwise
-        else if ( defendingHero && Rand::Get( 1, 5 ) < 5 ) {
-            defendingHero->SetAnimation( OP_SORROW );
-        }
+
+    const bool attackersTurn = ( deathColor == arena.GetArmy2Color() );
+    OpponentSprite * attackingHero = attackersTurn ? opponent1 : opponent2;
+    OpponentSprite * defendingHero = attackersTurn ? opponent2 : opponent1;
+    // 60% of joyful animation
+    if ( attackingHero && Rand::Get( 1, 5 ) < 4 ) {
+        attackingHero->SetAnimation( OP_JOY );
+    }
+    // 80% of sorrow animation otherwise
+    else if ( defendingHero && Rand::Get( 1, 5 ) < 5 ) {
+        defendingHero->SetAnimation( OP_SORROW );
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -5145,7 +5145,9 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( int32_t dst, const Targ
 fheroes2::Point CalculateSpellPosition( const Battle::Unit & target, int spellICN, const fheroes2::Sprite & spellSprite )
 {
     const fheroes2::Rect & pos = target.GetRectPosition();
-    const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
+
+    // Get the sprite for the first frame, so its center not shift if the creature is animating (instead of target.GetFrame()).
+    const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.animation.firstFrame() );
 
     // Bottom-left corner (default) position with spell offset applied
     fheroes2::Point result( pos.x + spellSprite.x(), pos.y + pos.height + cellYOffset + spellSprite.y() );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4740,6 +4740,10 @@ void Battle::Interface::RedrawActionDeathWaveSpell( const int32_t strength )
     _currentUnit = nullptr;
     cursor.SetThemes( Cursor::WAR_POINTER );
 
+    // Reset the idle animation for all troops and redraw the '_mainSurface'.
+    ResetIdleTroopAnimation();
+    RedrawPartialFinish();
+
     fheroes2::Rect area = GetArea();
     // Cut out the battle log image so we don't use it in the death wave effect.
     area.height -= 36;
@@ -4824,6 +4828,10 @@ void Battle::Interface::RedrawActionHolyShoutSpell( const int strength )
     LocalEvent & le = LocalEvent::Get();
 
     cursor.SetThemes( Cursor::WAR_POINTER );
+
+    // Reset the idle animation for all troops and redraw the '_mainSurface'.
+    ResetIdleTroopAnimation();
+    RedrawPartialFinish();
 
     const fheroes2::Image original( _mainSurface );
     fheroes2::Image blurred = fheroes2::CreateBlurredImage( _mainSurface, strength );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -5183,6 +5183,16 @@ fheroes2::Point CalculateSpellPosition( const Battle::Unit & target, int spellIC
         // bottom center point
         result.x += pos.width / 2;
         break;
+    case ICN::REDDEATH:
+        // Position shifts for the Death Row spell to be closer to OG.
+        result.x += pos.width / 2 + ( target.isReflect() ? 26 : -4 );
+        result.y -= pos.height - 4;
+        break;
+    case ICN::MAGIC08:
+        // Position shifts for the Holy Shout spell to be closer to OG.
+        result.x += pos.width / 2 + ( target.isReflect() ? 12 : 0 );
+        result.y += unitSprite.y() / 2 - 1;
+        break;
     default:
         // center point of the unit
         result.x += pos.width / 2;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4834,9 +4834,12 @@ void Battle::Interface::RedrawActionHolyShoutSpell( const int strength )
     RedrawPartialFinish();
 
     const fheroes2::Image original( _mainSurface );
-    fheroes2::Image blurred = fheroes2::CreateBlurredImage( _mainSurface, strength );
-    // Make the spell effect darker by setting its 'transform' layer.
-    fheroes2::ApplyTransform( blurred, 0, 0, blurred.width(), blurred.height(), 4 );
+    fheroes2::Image blurred = fheroes2::CreateBlurredImage( _mainSurface, 3 );
+
+    // Make the spell effect more dark-red.
+    fheroes2::Image blurredRed( blurred );
+    fheroes2::ApplyPalette( blurredRed, PAL::GetPalette( PAL::PaletteType::RED ) );
+    fheroes2::AlphaBlit( blurredRed, blurred, static_cast<uint8_t>( 10 * strength ) );
 
     _currentUnit = nullptr;
     AudioManager::PlaySound( M82::MASSCURS );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -5187,8 +5187,8 @@ fheroes2::Point CalculateSpellPosition( const Battle::Unit & target, int spellIC
         result.x += pos.width / 2;
         break;
     case ICN::REDDEATH:
-        // Position shifts for the Death Row spell to be closer to OG.
-        result.x += pos.width / 2 + ( target.isReflect() ? 26 : -4 );
+        // Shift spell sprite position for wide ceature to its head.
+        result.x += pos.width / 2 + ( target.isReflect() ? 1 - spellSprite.width() - 2 * spellSprite.x() - pos.width / 8 : pos.width / 8 );
         result.y -= pos.height - 4;
         break;
     case ICN::MAGIC08:

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -5264,7 +5264,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const TargetsInfo & tar
 
             if ( frame < maxFrame ) {
                 for ( const auto & target : targets ) {
-                    if ( target.defender && target.damage ) {
+                    if ( target.defender ) {
                         const bool reflect = ( isReflectICN && target.defender->isReflect() );
                         const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( icn, frame );
                         const fheroes2::Point & pos = CalculateSpellPosition( *target.defender, icn, spellSprite );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3360,8 +3360,11 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
 
 void Battle::Interface::SetHeroAnimationReactionToTroopDeath( const int32_t deathColor )
 {
-    if ( deathColor != Color::UNUSED ) {
-        const bool attackersTurn = deathColor == arena.GetArmy2Color();
+    if ( deathColor == Color::UNUSED ) {
+        return;
+    }
+    else {
+        const bool attackersTurn = ( deathColor == arena.GetArmy2Color() );
         OpponentSprite * attackingHero = attackersTurn ? opponent1 : opponent2;
         OpponentSprite * defendingHero = attackersTurn ? opponent2 : opponent1;
         // 60% of joyful animation
@@ -3772,8 +3775,9 @@ void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, const T
 
                 ++damagedMonsters;
                 totalDamage += it->damage;
-                if ( maximumDamage < it->damage )
+                if ( maximumDamage < it->damage ) {
                     maximumDamage = it->damage;
+                }
             }
         }
 
@@ -3784,7 +3788,6 @@ void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, const T
         case Spell::DEATHWAVE:
             RedrawTargetsWithFrameAnimation( targets, ICN::REDDEATH, M82::UNKNOWN, true );
             break;
-
         case Spell::HOLYWORD:
         case Spell::HOLYSHOUT:
             RedrawTargetsWithFrameAnimation( targets, ICN::MAGIC08, M82::UNKNOWN, true );
@@ -4770,7 +4773,8 @@ void Battle::Interface::RedrawActionDeathWaveSpell( const int32_t strength )
         CheckGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
-            fheroes2::Blit( fheroes2::CreateDeathWaveEffect( copy, position, waveLength, deathWaveCurve ), _mainSurface );
+            // TODO: instead of rendering the whole frame for the wave effect we should render only the area where the effect is active.
+            fheroes2::Blit( fheroes2::CreateDeathWaveEffect( copy, position, deathWaveCurve ), _mainSurface );
             RedrawPartialFinish();
 
             position += 5;
@@ -5304,7 +5308,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const TargetsInfo & tar
                     if ( !target.defender->isValid() ) {
                         target.defender->IncreaseAnimFrame( false );
 
-                        // If the death animation is still in process then set isDefenderAnimatimg to false.
+                        // If the death animation is still in process then set isDefenderAnimating to false.
                         isDefenderAnimating |= !target.defender->isFinishAnimFrame();
                     }
                     else if ( target.damage ) {
@@ -5322,7 +5326,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const TargetsInfo & tar
                             target.defender->SwitchAnimation( Monster_Info::STATIC );
                         }
 
-                        // If not all damaged (and not killed) units are set to STATIC animation then set isDefenderAnimatimg to false.
+                        // If not all damaged (and not killed) units are set to STATIC animation then set isDefenderAnimating to false.
                         isDefenderAnimating |= !( target.defender->GetAnimationState() == Monster_Info::STATIC );
                     }
                 }
@@ -5332,8 +5336,8 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const TargetsInfo & tar
         }
     }
 
-    if ( wnce && !mirrorImages.empty() ) {
-        // Fade away animation for destroyed mirror images
+    if ( !mirrorImages.empty() ) {
+        // Fade away animation for destroyed mirror images.
         RedrawActionRemoveMirrorImage( mirrorImages );
     }
 }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4826,7 +4826,9 @@ void Battle::Interface::RedrawActionHolyShoutSpell( const int strength )
     cursor.SetThemes( Cursor::WAR_POINTER );
 
     const fheroes2::Image original( _mainSurface );
-    const fheroes2::Image blurred = fheroes2::CreateBlurredImage( _mainSurface, strength );
+    fheroes2::Image blurred = fheroes2::CreateBlurredImage( _mainSurface, strength );
+    // Make the spell effect darker by setting its 'transform' layer.
+    fheroes2::ApplyTransform( blurred, 0, 0, blurred.width(), blurred.height(), 4 );
 
     _currentUnit = nullptr;
     AudioManager::PlaySound( M82::MASSCURS );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -332,7 +332,7 @@ namespace Battle
         void RedrawActionColdRingSpell( int32_t, const TargetsInfo & );
         void RedrawActionElementalStormSpell( const TargetsInfo & );
         void RedrawActionArmageddonSpell();
-        void RedrawActionHolyShoutSpell( const int strength );
+        void RedrawActionHolyShoutSpell( const uint8_t strength );
         void RedrawActionResurrectSpell( Unit &, const Spell & );
         void RedrawActionDeathWaveSpell( const int strength );
         void RedrawActionLightningBoltSpell( const Unit & );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -332,9 +332,9 @@ namespace Battle
         void RedrawActionColdRingSpell( int32_t, const TargetsInfo & );
         void RedrawActionElementalStormSpell( const TargetsInfo & );
         void RedrawActionArmageddonSpell();
-        void RedrawActionHolyShoutSpell( const TargetsInfo & targets, int strength );
+        void RedrawActionHolyShoutSpell( const int strength );
         void RedrawActionResurrectSpell( Unit &, const Spell & );
-        void RedrawActionDeathWaveSpell( const TargetsInfo & targets, int strength );
+        void RedrawActionDeathWaveSpell( const int strength );
         void RedrawActionLightningBoltSpell( const Unit & );
         void RedrawActionChainLightningSpell( const TargetsInfo & );
         void RedrawLightningOnTargets( const std::vector<fheroes2::Point> & points, const fheroes2::Rect & drawRoi ); // helper function
@@ -351,6 +351,7 @@ namespace Battle
         void ResetIdleTroopAnimation() const;
         void UpdateContourColor();
         void CheckGlobalEvents( LocalEvent & );
+        void SetHeroAnimationReactionToTroopDeath( const int32_t deathColor );
 
         void ProcessingHeroDialogResult( int, Actions & );
 

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -247,8 +247,8 @@ namespace fheroes2
         const std::vector<int32_t>::const_iterator endX = deathWaveCurve.end() - ( x > width ? x - width : 0 );
 
         for ( ; pntX != endX; ++pntX, ++outImageX, ++inImageX ) {
-            const uint8_t * outImageYEnd = outImageX + ( height + *pntX ) * width;
-            const uint8_t * inImageY = inImageX - ( *pntX + 1 ) * width;
+            const uint8_t * outImageYEnd = outImageX + static_cast<int64_t>( height + *pntX ) * width;
+            const uint8_t * inImageY = inImageX - static_cast<int64_t>( *pntX + 1 ) * width;
 
             // A loop to shift all horizontal pixels vertically.
             uint8_t * outImageY = outImageX;

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -22,8 +22,8 @@
 
 #include <chrono>
 #include <cmath>
-#include <cstdlib>
 #include <cstddef>
+#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <deque>

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -234,7 +234,7 @@ namespace fheroes2
 
         const int32_t width = in.width();
         // If the death wave curve is outside of the battlefield - return the original image.
-        if ( x < 0 || ( x - waveWidth ) >= width || !deathWaveCurve.size() )
+        if ( x < 0 || ( x - waveWidth ) >= width || deathWaveCurve.empty() )
             return out;
 
         const int32_t height = in.height();

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -23,6 +23,7 @@
 #include <chrono>
 #include <cmath>
 #include <cstdlib>
+#include <cstddef>
 #include <cstring>
 #include <ctime>
 #include <deque>

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -31,6 +31,7 @@
 #include <utility>
 
 #include "localevent.h"
+#include "logging.h"
 #include "screen.h"
 #include "settings.h"
 #include "system.h"
@@ -233,7 +234,7 @@ namespace fheroes2
 
         const int32_t width = in.width();
         // If the death wave curve is outside of the battlefield - return the original image.
-        if ( x < 0 || ( x - waveWidth ) >= width )
+        if ( x < 0 || ( x - waveWidth ) >= width || !deathWaveCurve.size() )
             return out;
 
         const int32_t height = in.height();
@@ -248,6 +249,12 @@ namespace fheroes2
         const std::vector<int32_t>::const_iterator endX = deathWaveCurve.end() - ( x > width ? x - width : 0 );
 
         for ( ; pntX != endX; ++pntX, ++outImageX, ++inImageX ) {
+            // The death curve should have only negative values and should not be higher, than the height of 'in' image.
+            if ( ( *pntX >= 0 ) || ( *pntX <= -height ) ) {
+                DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Death Wave curve is out of range (" << -height << ", 0): " << *pntX )
+                continue;
+            }
+
             const uint8_t * outImageYEnd = outImageX + static_cast<ptrdiff_t>( height + *pntX ) * width;
             const uint8_t * inImageY = inImageX - static_cast<ptrdiff_t>( *pntX + 1 ) * width;
 

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -28,12 +28,10 @@
 #include <cstring>
 #include <ctime>
 #include <deque>
-#include <ostream>
 #include <string>
 #include <utility>
 
 #include "localevent.h"
-#include "logging.h"
 #include "screen.h"
 #include "settings.h"
 #include "system.h"

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -247,8 +247,8 @@ namespace fheroes2
         const std::vector<int32_t>::const_iterator endX = deathWaveCurve.end() - ( x > width ? x - width : 0 );
 
         for ( ; pntX != endX; ++pntX, ++outImageX, ++inImageX ) {
-            const uint8_t * outImageYEnd = outImageX + static_cast<int64_t>( height + *pntX ) * width;
-            const uint8_t * inImageY = inImageX - static_cast<int64_t>( *pntX + 1 ) * width;
+            const uint8_t * outImageYEnd = outImageX + static_cast<ptrdiff_t>( height + *pntX ) * width;
+            const uint8_t * inImageY = inImageX - static_cast<ptrdiff_t>( *pntX + 1 ) * width;
 
             // A loop to shift all horizontal pixels vertically.
             uint8_t * outImageY = outImageX;

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -20,6 +20,7 @@
 
 #include "ui_tool.h"
 
+#include <cassert>
 #include <chrono>
 #include <cmath>
 #include <cstddef>
@@ -226,7 +227,7 @@ namespace fheroes2
         }
     }
 
-    Image CreateDeathWaveEffect( const Image & in, const int32_t x, const int32_t waveWidth, const std::vector<int32_t> & deathWaveCurve )
+    Image CreateDeathWaveEffect( const Image & in, const int32_t x, const std::vector<int32_t> & deathWaveCurve )
     {
         if ( in.empty() )
             return Image();
@@ -234,6 +235,8 @@ namespace fheroes2
         Image out = in;
 
         const int32_t width = in.width();
+        const int32_t waveWidth = static_cast<int32_t>( deathWaveCurve.size() );
+
         // If the death wave curve is outside of the battlefield - return the original image.
         if ( x < 0 || ( x - waveWidth ) >= width || deathWaveCurve.empty() )
             return out;
@@ -252,7 +255,7 @@ namespace fheroes2
         for ( ; pntX != endX; ++pntX, ++outImageX, ++inImageX ) {
             // The death curve should have only negative values and should not be higher, than the height of 'in' image.
             if ( ( *pntX >= 0 ) || ( *pntX <= -height ) ) {
-                DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Death Wave curve is out of range (" << -height << ", 0): " << *pntX )
+                assert( 0 );
                 continue;
             }
 

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -223,7 +223,7 @@ namespace fheroes2
         }
     }
 
-    Image CreateDeathWaveEffect( const Image & in, int32_t x, int32_t waveWidth, int32_t waveHeight )
+    Image CreateDeathWaveEffect( const Image & in, const int32_t x, const int32_t waveWidth, const std::vector<int32_t> & deathWaveCurve )
     {
         if ( in.empty() )
             return Image();
@@ -231,43 +231,37 @@ namespace fheroes2
         Image out = in;
 
         const int32_t width = in.width();
-        const int32_t height = in.height();
-
-        if ( x + waveWidth < 0 || x - waveWidth >= width )
+        // If the death wave curve is outside of the battlefield - return the original image.
+        if ( x < 0 || ( x - waveWidth ) >= width )
             return out;
 
-        const int32_t startX = ( x > waveWidth ) ? x - waveWidth : 0;
-        const int32_t endX = ( x + waveWidth < width ) ? x + waveWidth : width;
+        const int32_t height = in.height();
 
-        const double pi = std::acos( -1 );
-        const double waveLimit = waveWidth / pi;
+        // Set the image horizontal offset from where to draw the wave.
+        const int32_t offsetX = x < waveWidth ? 0 : x - waveWidth;
+        uint8_t * outImageX = out.image() + offsetX;
+        const uint8_t * inImageX = in.image() + offsetX;
 
-        uint8_t * outImageX = out.image() + startX;
-        uint8_t * outTransformX = out.transform() + startX;
+        // Set pointers to the start and the end of the death wave curve.
+        std::vector<int32_t>::const_iterator pntX = deathWaveCurve.begin() + ( x < waveWidth ? waveWidth - x : 0 );
+        const std::vector<int32_t>::const_iterator endX = deathWaveCurve.end() - ( x > width ? x - width : 0 );
 
-        const uint8_t * inImageX = in.image() + startX;
-        const uint8_t * inTransformX = in.transform() + startX;
+        for ( ; pntX != endX; ++pntX, ++outImageX, ++inImageX ) {
+            const uint8_t * outImageYEnd = outImageX + ( height + *pntX ) * width;
+            const uint8_t * inImageY = inImageX - ( *pntX + 1 ) * width;
 
-        for ( int32_t posX = startX; posX < endX; ++posX, ++outImageX, ++outTransformX, ++inImageX, ++inTransformX ) {
-            const int32_t waveX = posX - x;
-
-            const int32_t offsetY = static_cast<int32_t>( waveHeight * ( ( waveX < waveLimit ) ? tan( waveX / waveLimit ) / 2 : sin( waveX / waveLimit ) ) );
-
-            const int32_t offsetOut = offsetY >= 0 ? offsetY * width : 0;
-            const int32_t offsetOutEnd = offsetY >= 0 ? ( height - 1 - offsetY ) * width : ( height - 1 + offsetY ) * width;
-
-            uint8_t * outImageY = outImageX + offsetOut;
-            uint8_t * outTransformY = outTransformX + offsetOut;
-            const uint8_t * outImageYEnd = outImageX + offsetOutEnd;
-
-            const int32_t offsetIn = offsetY >= 0 ? 0 : -offsetY * width;
-
-            const uint8_t * inImageY = inImageX + offsetIn;
-            const uint8_t * inTransformY = inTransformX + offsetIn;
-
-            for ( ; outImageY != outImageYEnd; outImageY += width, outTransformY += width, inImageY += width, inTransformY += width ) {
+            // A loop to shift all horizontal pixels vertically.
+            uint8_t * outImageY = outImageX;
+            for ( ; outImageY != outImageYEnd; outImageY += width ) {
+                inImageY += width;
                 *outImageY = *inImageY;
-                *outTransformY = *inTransformY;
+            }
+
+            // Flip the image under the death wave to create a distortion effect.
+            for ( int32_t i = 0; i > *pntX; --i ) {
+                *outImageY = *inImageY;
+                outImageY += width;
+                inImageY -= width;
             }
         }
 

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -27,6 +27,7 @@
 #include <cstring>
 #include <ctime>
 #include <deque>
+#include <ostream>
 #include <string>
 #include <utility>
 

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <vector>
 
 #include "image.h"
 #include "math_base.h"

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -108,7 +108,7 @@ namespace fheroes2
         const bool isOriginalEvilInterface;
     };
 
-    Image CreateDeathWaveEffect( const Image & in, int32_t x, int32_t waveWidth, int32_t waveHeight );
+    Image CreateDeathWaveEffect( const Image & in, const int32_t x, const int32_t waveWidth, const std::vector<int32_t> & deathWaveCurve );
 
     Image CreateRippleEffect( const Image & in, int32_t frameId, double scaleX = 0.05, double waveFrequency = 20.0 );
 

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -109,7 +109,7 @@ namespace fheroes2
         const bool isOriginalEvilInterface;
     };
 
-    Image CreateDeathWaveEffect( const Image & in, const int32_t x, const int32_t waveWidth, const std::vector<int32_t> & deathWaveCurve );
+    Image CreateDeathWaveEffect( const Image & in, const int32_t x, const std::vector<int32_t> & deathWaveCurve );
 
     Image CreateRippleEffect( const Image & in, int32_t frameId, double scaleX = 0.05, double waveFrequency = 20.0 );
 

--- a/src/fheroes2/monster/monster_anim.h
+++ b/src/fheroes2/monster/monster_anim.h
@@ -61,6 +61,8 @@ namespace Monster_Info
         RANG_FRONT_END,
         RANG_BOT,
         RANG_BOT_END,
+        WNCE_UP,
+        WNCE_DOWN,
         WNCE, // combined UP and RETURN anim
         KILL,
         INVALID


### PR DESCRIPTION
Close #5701 and close #1041.
Relates to #1229.

Redone the animation sequence for Death Wave, Death Ripple, Holy Word and Holy Shout shout.
Now the flame animation (after the spell animation) is made only after applying damage from the spell. And during this flame animation the death animation and the wince animation is applied to the corresponding creatures.
To do this I had to make a copy of part of the code from `RedrawActionWincesKills` method. :(
To reduce the size of this duplication a new (small) method was made.

fheroes2 Death Death Ripple and Death Wave animations:

https://user-images.githubusercontent.com/113276641/206888610-90a2e068-487d-49cc-9e8a-469f80a587c5.mp4

Original game Death Ripple and Death Wave animations:

https://user-images.githubusercontent.com/113276641/206887219-44e3a4c3-8a93-4f9e-b54c-9c91eb0d64a4.mp4

<details><summary>fheroes2 Holy Word and Holy Shout animation:</summary>

https://user-images.githubusercontent.com/113276641/207246675-ed7064b1-1e7a-4606-82ae-378b12baf6a2.mp4

https://user-images.githubusercontent.com/113276641/207246687-81fa1b97-fc39-40ce-99d9-09cfb551d7ad.mp4

</details>

<details><summary>Original game Holy Word and Holy Shout animation:</summary>

https://user-images.githubusercontent.com/113276641/207246918-7dad4d13-04c6-4487-916b-559976be864d.mp4

https://user-images.githubusercontent.com/113276641/207246934-e32ef987-9709-4a4a-b963-47db28756617.mp4

</details>