### PR TITLE
Fix idle animation stops (Battlefield)

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1280,6 +1280,8 @@ void Battle::Interface::RedrawPartialStart()
 {
     RedrawCover();
     RedrawArmies();
+    // Animate idle for all troops on the battlefield with every redraw start.
+    IdleTroopsAnimation();
 }
 
 void Battle::Interface::RedrawPartialFinish()


### PR DESCRIPTION
Close #1229
Continue idle troop animation with every 'RedrawPartialStart'.
<details><summary>The creatures continue using idle animation while catapult attacks. ▼</summary>

https://user-images.githubusercontent.com/113276641/206894036-04656850-5f91-4f1f-8c44-b15d89704816.mp4

</details>
Also some methods do a screen copy before performing an animation and uses it during the whole animation.
This methods should change the animation from 'IDLE' to 'STATIC' themselves.
For the Death Wave spell I'll try to fix it in #6344 