### PR TITLE
Reduce priority for bottles in sea for AI

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -333,8 +333,10 @@ namespace
         case MP2::OBJ_TREEKNOWLEDGE:
             if ( !hero.isVisited( tile ) ) {
                 const ResourceCount & rc = tile.QuantityResourceCount();
-                if ( !rc.isValid() || kingdom.AllowPayment( Funds( rc ) ) )
+                // If the payment is required do not waste all resources from the kingdom. Use them wisely.
+                if ( !rc.isValid() || kingdom.AllowPayment( Funds( rc ) * 5 ) ) {
                     return true;
+                }
             }
             break;
 
@@ -369,7 +371,7 @@ namespace
             break;
         }
 
-        // accept army
+        // Get a free army.
         case MP2::OBJ_WATCHTOWER:
         case MP2::OBJ_EXCAVATION:
         case MP2::OBJ_CAVE:
@@ -847,6 +849,11 @@ namespace AI
             return 1000.0 * art.getArtifactValue();
         }
         else if ( MP2::isPickupObject( objectType ) ) {
+            if ( objectType == MP2::OBJ_BOTTLE ) {
+                // A bottle is useless to AI as it contains only a message.
+                return 0;
+            }
+
             return 850.0;
         }
         else if ( MP2::isCaptureObject( objectType ) && MP2::isQuantityObject( objectType ) ) {
@@ -1129,6 +1136,11 @@ namespace AI
             return std::max( tile.QuantityGold(), 1000U );
         }
         else if ( MP2::isPickupObject( objectType ) ) {
+            if ( objectType == MP2::OBJ_BOTTLE ) {
+                // A bottle is useless to AI as it contains only a message.
+                return 0;
+            }
+
             return anotherFriendlyHeroPresent ? 100.0 : 500.0;
         }
         else if ( MP2::isCaptureObject( objectType ) && MP2::isQuantityObject( objectType ) ) {
@@ -1393,6 +1405,11 @@ namespace AI
             return 1000.0 * art.getArtifactValue();
         }
         else if ( MP2::isPickupObject( objectType ) ) {
+            if ( objectType == MP2::OBJ_BOTTLE ) {
+                // A bottle is useless to AI as it contains only a message.
+                return 0;
+            }
+
             return twoTiles;
         }
         else if ( MP2::isCaptureObject( objectType ) && MP2::isQuantityObject( objectType ) ) {


### PR DESCRIPTION
Plus AI heroes shouldn't waste last resources for a level up in Tree of Knowledge.