### PR TITLE
Implement the infrastructure to apply campaign bonuses and awards to a specific hero, multiple campaign-related fixes

### DIFF
--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -29,10 +29,12 @@
 #include "artifact.h"
 #include "campaign_scenariodata.h"
 #include "dir.h"
+#include "game.h"
 #include "maps_fileinfo.h"
 #include "monster.h"
 #include "race.h"
 #include "resource.h"
+#include "save_format_version.h"
 #include "serialize.h"
 #include "settings.h"
 #include "skill.h"
@@ -202,7 +204,7 @@ namespace
         case 6:
             bonus.emplace_back( Campaign::ScenarioBonusData::RESOURCES, Resource::SULFUR, 10 );
             bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::POWER_AXE, 1 );
-            bonus.emplace_back( Campaign::ScenarioBonusData::SPELL, Spell::ANIMATEDEAD, 1 );
+            bonus.emplace_back( Campaign::ScenarioBonusData::ARTIFACT, Artifact::SPELL_SCROLL, 1, Spell::ANIMATEDEAD );
             break;
         case 7:
             bonus.emplace_back( Campaign::ScenarioBonusData::SPELL, Spell::VIEWHEROES, 1 );
@@ -337,7 +339,35 @@ namespace
         return bonus;
     }
 
-    const char * getArtifactCampaignName( const int32_t artifactId )
+    const char * getSpellCampaignName( const int32_t spellId )
+    {
+        switch ( spellId ) {
+        case Spell::ANIMATEDEAD:
+            return _( "campaignBonus|Animate Dead" );
+        case Spell::CHAINLIGHTNING:
+            return _( "campaignBonus|Chain Lightning" );
+        case Spell::FIREBLAST:
+            return _( "campaignBonus|Fireblast" );
+        case Spell::MASSCURSE:
+            return _( "campaignBonus|Mass Curse" );
+        case Spell::MASSHASTE:
+            return _( "campaignBonus|Mass Haste" );
+        case Spell::MIRRORIMAGE:
+            return _( "campaignBonus|Mirror Image" );
+        case Spell::RESURRECT:
+            return _( "campaignBonus|Resurrect" );
+        case Spell::STEELSKIN:
+            return _( "campaignBonus|Steelskin" );
+        case Spell::SUMMONEELEMENT:
+            return _( "campaignBonus|Summon Earth" );
+        case Spell::VIEWHEROES:
+            return _( "campaignBonus|View Heroes" );
+        default:
+            return Spell( spellId ).GetName();
+        }
+    }
+
+    const char * getArtifactCampaignName( const int32_t artifactId, const int32_t spellId )
     {
         switch ( artifactId ) {
         case Artifact::BALLISTA:
@@ -384,6 +414,8 @@ namespace
             return _( "campaignBonus|Traveler's Boots" );
         case Artifact::WHITE_PEARL:
             return _( "campaignBonus|White Pearl" );
+        case Artifact::SPELL_SCROLL:
+            return getSpellCampaignName( spellId );
         default:
             return Artifact( artifactId ).GetName();
         }
@@ -581,34 +613,6 @@ namespace
         }
     }
 
-    const char * getSpellCampaignName( const int32_t spellId )
-    {
-        switch ( spellId ) {
-        case Spell::ANIMATEDEAD:
-            return _( "campaignBonus|Animate Dead" );
-        case Spell::CHAINLIGHTNING:
-            return _( "campaignBonus|Chain Lightning" );
-        case Spell::FIREBLAST:
-            return _( "campaignBonus|Fireblast" );
-        case Spell::MASSCURSE:
-            return _( "campaignBonus|Mass Curse" );
-        case Spell::MASSHASTE:
-            return _( "campaignBonus|Mass Haste" );
-        case Spell::MIRRORIMAGE:
-            return _( "campaignBonus|Mirror Image" );
-        case Spell::RESURRECT:
-            return _( "campaignBonus|Resurrect" );
-        case Spell::STEELSKIN:
-            return _( "campaignBonus|Steelskin" );
-        case Spell::SUMMONEELEMENT:
-            return _( "campaignBonus|Summon Earth" );
-        case Spell::VIEWHEROES:
-            return _( "campaignBonus|View Heroes" );
-        default:
-            return Spell( spellId ).GetName();
-        }
-    }
-
     bool tryGetMatchingFile( const std::string & fileName, std::string & matchingFilePath )
     {
         static const auto fileNameToPath = []() {
@@ -651,12 +655,21 @@ namespace Campaign
         : _type( 0 )
         , _subType( 0 )
         , _amount( 0 )
+        , _spellId( Spell::NONE )
     {}
 
     ScenarioBonusData::ScenarioBonusData( const int32_t type, const int32_t subType, const int32_t amount )
         : _type( type )
         , _subType( subType )
         , _amount( amount )
+        , _spellId( Spell::NONE )
+    {}
+
+    ScenarioBonusData::ScenarioBonusData( const int32_t type, const int32_t subType, const int32_t amount, const int32_t spellId )
+        : _type( type )
+        , _subType( subType )
+        , _amount( amount )
+        , _spellId( spellId )
     {}
 
     std::string ScenarioBonusData::getName() const
@@ -665,7 +678,7 @@ namespace Campaign
 
         switch ( _type ) {
         case ScenarioBonusData::ARTIFACT:
-            objectName = getArtifactCampaignName( _subType );
+            objectName = getArtifactCampaignName( _subType, _spellId );
             break;
         case ScenarioBonusData::RESOURCES:
             objectName = std::to_string( _amount ) + " " + Resource::String( _subType );
@@ -776,12 +789,22 @@ namespace Campaign
 
     StreamBase & operator<<( StreamBase & msg, const Campaign::ScenarioBonusData & data )
     {
-        return msg << data._type << data._subType << data._amount;
+        return msg << data._type << data._subType << data._amount << data._spellId;
     }
 
     StreamBase & operator>>( StreamBase & msg, Campaign::ScenarioBonusData & data )
     {
-        return msg >> data._type >> data._subType >> data._amount;
+        msg >> data._type >> data._subType >> data._amount;
+
+        static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE5_1000_RELEASE, "Remove the check below." );
+        if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE5_1000_RELEASE ) {
+            data._spellId = Spell::NONE;
+        }
+        else {
+            msg >> data._spellId;
+        }
+
+        return msg;
     }
 
     ScenarioData::ScenarioData( const ScenarioInfoId & scenarioInfo, std::vector<ScenarioInfoId> && nextScenarios, const std::string & fileName,

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -655,21 +655,21 @@ namespace Campaign
         : _type( 0 )
         , _subType( 0 )
         , _amount( 0 )
-        , _spellId( Spell::NONE )
+        , _artifactSpellId( Spell::NONE )
     {}
 
     ScenarioBonusData::ScenarioBonusData( const int32_t type, const int32_t subType, const int32_t amount )
         : _type( type )
         , _subType( subType )
         , _amount( amount )
-        , _spellId( Spell::NONE )
+        , _artifactSpellId( Spell::NONE )
     {}
 
     ScenarioBonusData::ScenarioBonusData( const int32_t type, const int32_t subType, const int32_t amount, const int32_t spellId )
         : _type( type )
         , _subType( subType )
         , _amount( amount )
-        , _spellId( spellId )
+        , _artifactSpellId( spellId )
     {}
 
     std::string ScenarioBonusData::getName() const
@@ -678,7 +678,7 @@ namespace Campaign
 
         switch ( _type ) {
         case ScenarioBonusData::ARTIFACT:
-            objectName = getArtifactCampaignName( _subType, _spellId );
+            objectName = getArtifactCampaignName( _subType, _artifactSpellId );
             break;
         case ScenarioBonusData::RESOURCES:
             objectName = std::to_string( _amount ) + " " + Resource::String( _subType );
@@ -789,7 +789,7 @@ namespace Campaign
 
     StreamBase & operator<<( StreamBase & msg, const Campaign::ScenarioBonusData & data )
     {
-        return msg << data._type << data._subType << data._amount << data._spellId;
+        return msg << data._type << data._subType << data._amount << data._artifactSpellId;
     }
 
     StreamBase & operator>>( StreamBase & msg, Campaign::ScenarioBonusData & data )
@@ -798,10 +798,10 @@ namespace Campaign
 
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE5_1000_RELEASE, "Remove the check below." );
         if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE5_1000_RELEASE ) {
-            data._spellId = Spell::NONE;
+            data._artifactSpellId = Spell::NONE;
         }
         else {
-            msg >> data._spellId;
+            msg >> data._artifactSpellId;
         }
 
         return msg;

--- a/src/fheroes2/campaign/campaign_scenariodata.h
+++ b/src/fheroes2/campaign/campaign_scenariodata.h
@@ -103,7 +103,7 @@ namespace Campaign
         int32_t _type;
         int32_t _subType;
         int32_t _amount;
-        int32_t _spellId; // Spell ID of a spell scroll
+        int32_t _artifactSpellId; // Spell ID of a spell scroll
 
         ScenarioBonusData();
         ScenarioBonusData( const int32_t type, const int32_t subType, const int32_t amount );

--- a/src/fheroes2/campaign/campaign_scenariodata.h
+++ b/src/fheroes2/campaign/campaign_scenariodata.h
@@ -103,9 +103,11 @@ namespace Campaign
         int32_t _type;
         int32_t _subType;
         int32_t _amount;
+        int32_t _spellId; // Spell ID of a spell scroll
 
         ScenarioBonusData();
         ScenarioBonusData( const int32_t type, const int32_t subType, const int32_t amount );
+        ScenarioBonusData( const int32_t type, const int32_t subType, const int32_t amount, const int32_t spellId );
 
         friend StreamBase & operator<<( StreamBase & msg, const ScenarioBonusData & data );
         friend StreamBase & operator>>( StreamBase & msg, ScenarioBonusData & data );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -630,7 +630,6 @@ namespace
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
-                    hero->SpellBookActivate();
                     hero->AppendSpellToBook( scenarioBonus._subType, true );
                 }
 
@@ -706,7 +705,6 @@ namespace
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
-                    hero->SpellBookActivate();
                     hero->AppendSpellToBook( awards[i]._subType, true );
                 }
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -530,7 +530,7 @@ namespace
         }
     }
 
-    Heroes * getHeroForScenarioBonusOrCampaignAwards( const Campaign::ScenarioInfoId & scenarioInfoId, const Kingdom & kingdom )
+    Heroes * getHeroToApplyBonusOrAwards( const Campaign::ScenarioInfoId & scenarioInfoId, const Kingdom & kingdom )
     {
         static const std::map<std::pair<int, int>, int> targetHeroes = { // Defender
                                                                          { { Campaign::ROLAND_CAMPAIGN, 5 }, Heroes::HALTON },
@@ -588,7 +588,7 @@ namespace
 
                 break;
             case Campaign::ScenarioBonusData::ARTIFACT: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -598,7 +598,7 @@ namespace
                 break;
             }
             case Campaign::ScenarioBonusData::TROOP: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -608,7 +608,7 @@ namespace
                 break;
             }
             case Campaign::ScenarioBonusData::SPELL: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -623,7 +623,7 @@ namespace
 
                 break;
             case Campaign::ScenarioBonusData::STARTING_RACE_AND_ARMY: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -633,7 +633,7 @@ namespace
                 break;
             }
             case Campaign::ScenarioBonusData::SKILL_PRIMARY: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -645,7 +645,7 @@ namespace
                 break;
             }
             case Campaign::ScenarioBonusData::SKILL_SECONDARY: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -674,7 +674,7 @@ namespace
 
             switch ( awards[i]._type ) {
             case Campaign::CampaignAwardData::TYPE_GET_ARTIFACT: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( currentScenarioInfoId, humanKingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( currentScenarioInfoId, humanKingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -684,7 +684,7 @@ namespace
                 break;
             }
             case Campaign::CampaignAwardData::TYPE_GET_SPELL: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( currentScenarioInfoId, humanKingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( currentScenarioInfoId, humanKingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -711,7 +711,7 @@ namespace
 
                 break;
             case Campaign::CampaignAwardData::TYPE_CARRY_OVER_FORCES: {
-                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( currentScenarioInfoId, humanKingdom );
+                Heroes * hero = getHeroToApplyBonusOrAwards( currentScenarioInfoId, humanKingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -537,8 +537,6 @@ namespace
                                                                              { { Campaign::ROLAND_CAMPAIGN, 9 }, Heroes::ROLAND },
                                                                              // Apocalypse
                                                                              { { Campaign::ARCHIBALD_CAMPAIGN, 10 }, Heroes::ARCHIBALD },
-                                                                             // King and Country
-                                                                             { { Campaign::VOYAGE_HOME_CAMPAIGN, 2 }, Heroes::GALLAVANT },
                                                                              // Blood is Thicker
                                                                              { { Campaign::VOYAGE_HOME_CAMPAIGN, 3 }, Heroes::GALLAVANT } };
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -610,7 +610,13 @@ namespace
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
-                    hero->PickupArtifact( Artifact( scenarioBonus._subType ) );
+                    Artifact artifact( scenarioBonus._subType );
+
+                    if ( artifact == Artifact::SPELL_SCROLL ) {
+                        artifact.SetSpell( scenarioBonus._spellId );
+                    }
+
+                    hero->PickupArtifact( artifact );
                 }
 
                 break;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -538,6 +538,10 @@ namespace
                                                                          { { Campaign::ROLAND_CAMPAIGN, 9 }, Heroes::ROLAND },
                                                                          // Apocalypse
                                                                          { { Campaign::ARCHIBALD_CAMPAIGN, 10 }, Heroes::ARCHIBALD },
+                                                                         // The Wayward Son, Rogar the Barbarian
+                                                                         { { Campaign::DESCENDANTS_CAMPAIGN, 2 }, Heroes::ERGON },
+                                                                         // The Epic Battle, Jarkonas VI the Wizard
+                                                                         { { Campaign::DESCENDANTS_CAMPAIGN, 7 }, Heroes::ELDERIAN },
                                                                          // King and Country
                                                                          { { Campaign::VOYAGE_HOME_CAMPAIGN, 2 }, Heroes::GALLAVANT },
                                                                          // Blood is Thicker
@@ -608,6 +612,7 @@ namespace
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
+                    hero->SpellBookActivate();
                     hero->AppendSpellToBook( scenarioBonus._subType, true );
                 }
 
@@ -684,6 +689,7 @@ namespace
                 Heroes * hero = getHeroForCampaignAwards( currentScenarioInfoId, humanKingdom );
                 assert( hero != nullptr );
 
+                hero->SpellBookActivate();
                 hero->AppendSpellToBook( awards[i]._subType, true );
 
                 break;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -530,6 +530,53 @@ namespace
         }
     }
 
+    Heroes * getHeroForScenarioBonus( const Campaign::ScenarioInfoId & scenarioInfoId, const Kingdom & kingdom )
+    {
+        // The "special" kingdom heroes may have the ID of another hero, but a custom name and portrait,
+        // so the search should be performed by the portrait ID
+        auto findHero = [&kingdom]( const int targetHeroId ) -> Heroes * {
+            for ( Heroes * hero : kingdom.GetHeroes() ) {
+                assert( hero != nullptr );
+
+                if ( hero->getPortraitId() == targetHeroId ) {
+                    return hero;
+                }
+            }
+
+            return nullptr;
+        };
+
+        switch ( scenarioInfoId.campaignId ) {
+        case Campaign::VOYAGE_HOME_CAMPAIGN:
+            switch ( scenarioInfoId.scenarioId ) {
+            // King and Country
+            case 2:
+            // Blood is Thicker
+            case 3: {
+                Heroes * hero = findHero( Heroes::GALLAVANT );
+                if ( hero ) {
+                    return hero;
+                }
+
+                DEBUG_LOG( DBG_GAME, DBG_WARN,
+                           "the hero to whom the bonus should be applied has not been found"
+                               << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
+
+                break;
+            }
+            default:
+                break;
+            }
+
+            break;
+        default:
+            break;
+        }
+
+        // By default, the scenario bonus is applied to the best hero of the kingdom
+        return kingdom.GetBestHero();
+    }
+
     void SetScenarioBonus( const Campaign::ScenarioInfoId & scenarioInfoId, const Campaign::ScenarioBonusData & scenarioBonus )
     {
         const Players & sortedPlayers = Settings::Get().GetPlayers();
@@ -538,64 +585,93 @@ namespace
                 continue;
             }
 
-            if ( !player->isControlHuman() )
+            if ( !player->isControlHuman() ) {
                 continue;
+            }
 
             Kingdom & kingdom = world.GetKingdom( player->GetColor() );
-            Heroes * bestHero = kingdom.GetBestHero();
 
             switch ( scenarioBonus._type ) {
             case Campaign::ScenarioBonusData::RESOURCES:
                 kingdom.AddFundsResource( Funds( scenarioBonus._subType, scenarioBonus._amount ) );
+
                 break;
             case Campaign::ScenarioBonusData::ARTIFACT: {
-                assert( bestHero != nullptr );
-                if ( bestHero != nullptr ) {
-                    bestHero->PickupArtifact( Artifact( scenarioBonus._subType ) );
+                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                assert( hero != nullptr );
+
+                if ( hero != nullptr ) {
+                    hero->PickupArtifact( Artifact( scenarioBonus._subType ) );
                 }
+
                 break;
             }
-            case Campaign::ScenarioBonusData::TROOP:
-                assert( bestHero != nullptr );
-                if ( bestHero != nullptr ) {
-                    bestHero->GetArmy().JoinTroop( Troop( Monster( scenarioBonus._subType ), scenarioBonus._amount ) );
+            case Campaign::ScenarioBonusData::TROOP: {
+                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                assert( hero != nullptr );
+
+                if ( hero != nullptr ) {
+                    hero->GetArmy().JoinTroop( Troop( Monster( scenarioBonus._subType ), scenarioBonus._amount ) );
                 }
+
                 break;
+            }
             case Campaign::ScenarioBonusData::SPELL: {
                 KingdomHeroes & heroes = kingdom.GetHeroes();
                 assert( !heroes.empty() );
+
                 if ( !heroes.empty() ) {
                     // TODO: make sure that the correct hero receives the spell. Right now it's a semi-hacky way to do this.
                     heroes.back()->AppendSpellToBook( scenarioBonus._subType, true );
                 }
+
                 break;
             }
             case Campaign::ScenarioBonusData::STARTING_RACE:
                 Players::SetPlayerRace( player->GetColor(), scenarioBonus._subType );
+
                 break;
-            case Campaign::ScenarioBonusData::STARTING_RACE_AND_ARMY:
-                assert( bestHero != nullptr );
-                if ( bestHero != nullptr ) {
-                    setHeroAndArmyBonus( bestHero, scenarioInfoId );
+            case Campaign::ScenarioBonusData::STARTING_RACE_AND_ARMY: {
+                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                assert( hero != nullptr );
+
+                if ( hero != nullptr ) {
+                    setHeroAndArmyBonus( hero, scenarioInfoId );
                 }
+
                 break;
-            case Campaign::ScenarioBonusData::SKILL_PRIMARY:
-                assert( bestHero != nullptr );
-                if ( bestHero != nullptr ) {
+            }
+            case Campaign::ScenarioBonusData::SKILL_PRIMARY: {
+                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                assert( hero != nullptr );
+
+                if ( hero != nullptr ) {
                     for ( int32_t i = 0; i < scenarioBonus._amount; ++i )
-                        bestHero->IncreasePrimarySkill( scenarioBonus._subType );
+                        hero->IncreasePrimarySkill( scenarioBonus._subType );
                 }
+
                 break;
-            case Campaign::ScenarioBonusData::SKILL_SECONDARY:
-                assert( bestHero != nullptr );
-                if ( bestHero != nullptr ) {
-                    bestHero->LearnSkill( Skill::Secondary( scenarioBonus._subType, scenarioBonus._amount ) );
+            }
+            case Campaign::ScenarioBonusData::SKILL_SECONDARY: {
+                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                assert( hero != nullptr );
+
+                if ( hero != nullptr ) {
+                    hero->LearnSkill( Skill::Secondary( scenarioBonus._subType, scenarioBonus._amount ) );
                 }
+
                 break;
+            }
             default:
                 assert( 0 );
             }
         }
+    }
+
+    Heroes * getHeroForCampaignAwards( const Campaign::ScenarioInfoId & /* scenarioInfoId */, const Kingdom & kingdom )
+    {
+        // By default, campaign awards are awarded to the best hero of the kingdom
+        return kingdom.GetBestHero();
     }
 
     // apply only the ones that are applied at the start (artifact, spell, carry-over troops)
@@ -610,28 +686,46 @@ namespace
                 continue;
 
             switch ( awards[i]._type ) {
-            case Campaign::CampaignAwardData::TYPE_GET_ARTIFACT:
-                humanKingdom.GetBestHero()->PickupArtifact( Artifact( awards[i]._subType ) );
+            case Campaign::CampaignAwardData::TYPE_GET_ARTIFACT: {
+                Heroes * hero = getHeroForCampaignAwards( currentScenarioInfoId, humanKingdom );
+                assert( hero != nullptr );
+
+                hero->PickupArtifact( Artifact( awards[i]._subType ) );
+
                 break;
-            case Campaign::CampaignAwardData::TYPE_GET_SPELL:
-                humanKingdom.GetBestHero()->AppendSpellToBook( awards[i]._subType, true );
+            }
+            case Campaign::CampaignAwardData::TYPE_GET_SPELL: {
+                Heroes * hero = getHeroForCampaignAwards( currentScenarioInfoId, humanKingdom );
+                assert( hero != nullptr );
+
+                hero->AppendSpellToBook( awards[i]._subType, true );
+
                 break;
+            }
             case Campaign::CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO:
                 for ( const Player * player : sortedPlayers ) {
                     Kingdom & kingdom = world.GetKingdom( player->GetColor() );
                     const KingdomHeroes & heroes = kingdom.GetHeroes();
 
                     for ( size_t j = 0; j < heroes.size(); ++j ) {
+                        assert( heroes[j] != nullptr );
+
                         if ( heroes[j]->GetID() == awards[i]._subType ) {
                             heroes[j]->SetFreeman( Battle::RESULT_LOSS );
                             break;
                         }
                     }
                 }
+
                 break;
-            case Campaign::CampaignAwardData::TYPE_CARRY_OVER_FORCES:
-                replaceArmy( humanKingdom.GetBestHero()->GetArmy(), Campaign::CampaignSaveData::Get().getCarryOverTroops() );
+            case Campaign::CampaignAwardData::TYPE_CARRY_OVER_FORCES: {
+                Heroes * hero = getHeroForCampaignAwards( currentScenarioInfoId, humanKingdom );
+                assert( hero != nullptr );
+
+                replaceArmy( hero->GetArmy(), Campaign::CampaignSaveData::Get().getCarryOverTroops() );
+
                 break;
+            }
             default:
                 break;
             }

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -536,6 +536,8 @@ namespace
                                                                          { { Campaign::ROLAND_CAMPAIGN, 5 }, Heroes::HALTON },
                                                                          // Final Justice
                                                                          { { Campaign::ROLAND_CAMPAIGN, 9 }, Heroes::ROLAND },
+                                                                         // Apocalypse
+                                                                         { { Campaign::ARCHIBALD_CAMPAIGN, 10 }, Heroes::ARCHIBALD },
                                                                          // King and Country
                                                                          { { Campaign::VOYAGE_HOME_CAMPAIGN, 2 }, Heroes::GALLAVANT },
                                                                          // Blood is Thicker

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -613,7 +613,7 @@ namespace
                     Artifact artifact( scenarioBonus._subType );
 
                     if ( artifact == Artifact::SPELL_SCROLL ) {
-                        artifact.SetSpell( scenarioBonus._spellId );
+                        artifact.SetSpell( scenarioBonus._artifactSpellId );
                     }
 
                     hero->PickupArtifact( artifact );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -555,6 +555,22 @@ namespace
         };
 
         switch ( scenarioInfoId.campaignId ) {
+        case Campaign::ROLAND_CAMPAIGN:
+            switch ( scenarioInfoId.scenarioId ) {
+            // Defender
+            case 5: {
+                Heroes * hero = findHero( Heroes::HALTON );
+                if ( hero ) {
+                    return hero;
+                }
+
+                break;
+            }
+            default:
+                break;
+            }
+
+            break;
         case Campaign::VOYAGE_HOME_CAMPAIGN:
             switch ( scenarioInfoId.scenarioId ) {
             // King and Country
@@ -621,12 +637,11 @@ namespace
                 break;
             }
             case Campaign::ScenarioBonusData::SPELL: {
-                KingdomHeroes & heroes = kingdom.GetHeroes();
-                assert( !heroes.empty() );
+                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                assert( hero != nullptr );
 
-                if ( !heroes.empty() ) {
-                    // TODO: make sure that the correct hero receives the spell. Right now it's a semi-hacky way to do this.
-                    heroes.back()->AppendSpellToBook( scenarioBonus._subType, true );
+                if ( hero != nullptr ) {
+                    hero->AppendSpellToBook( scenarioBonus._subType, true );
                 }
 
                 break;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -530,7 +530,7 @@ namespace
         }
     }
 
-    Heroes * getHeroForScenarioBonus( const Campaign::ScenarioInfoId & scenarioInfoId, const Kingdom & kingdom )
+    Heroes * getHeroForScenarioBonusOrCampaignAwards( const Campaign::ScenarioInfoId & scenarioInfoId, const Kingdom & kingdom )
     {
         static const std::map<std::pair<int, int>, int> targetHeroes = { // Defender
                                                                          { { Campaign::ROLAND_CAMPAIGN, 5 }, Heroes::HALTON },
@@ -560,11 +560,11 @@ namespace
             }
 
             DEBUG_LOG( DBG_GAME, DBG_WARN,
-                       "the hero to whom the bonus should be applied has not been found"
+                       "the hero to whom bonuses or awards should be applied has not been found"
                            << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
         }
 
-        // By default, the scenario bonus is applied to the best hero of the kingdom
+        // By default, bonuses and awards are applied to the best hero of the kingdom
         return kingdom.GetBestHero();
     }
 
@@ -588,7 +588,7 @@ namespace
 
                 break;
             case Campaign::ScenarioBonusData::ARTIFACT: {
-                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -598,7 +598,7 @@ namespace
                 break;
             }
             case Campaign::ScenarioBonusData::TROOP: {
-                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -608,7 +608,7 @@ namespace
                 break;
             }
             case Campaign::ScenarioBonusData::SPELL: {
-                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -623,7 +623,7 @@ namespace
 
                 break;
             case Campaign::ScenarioBonusData::STARTING_RACE_AND_ARMY: {
-                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -633,18 +633,19 @@ namespace
                 break;
             }
             case Campaign::ScenarioBonusData::SKILL_PRIMARY: {
-                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
-                    for ( int32_t i = 0; i < scenarioBonus._amount; ++i )
+                    for ( int32_t i = 0; i < scenarioBonus._amount; ++i ) {
                         hero->IncreasePrimarySkill( scenarioBonus._subType );
+                    }
                 }
 
                 break;
             }
             case Campaign::ScenarioBonusData::SKILL_SECONDARY: {
-                Heroes * hero = getHeroForScenarioBonus( scenarioInfoId, kingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( scenarioInfoId, kingdom );
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
@@ -659,12 +660,6 @@ namespace
         }
     }
 
-    Heroes * getHeroForCampaignAwards( const Campaign::ScenarioInfoId & /* scenarioInfoId */, const Kingdom & kingdom )
-    {
-        // By default, campaign awards are awarded to the best hero of the kingdom
-        return kingdom.GetBestHero();
-    }
-
     // apply only the ones that are applied at the start (artifact, spell, carry-over troops)
     // the rest will be applied based on the situation required
     void applyObtainedCampaignAwards( const Campaign::ScenarioInfoId & currentScenarioInfoId, const std::vector<Campaign::CampaignAwardData> & awards )
@@ -673,24 +668,29 @@ namespace
         Kingdom & humanKingdom = world.GetKingdom( Players::HumanColors() );
 
         for ( size_t i = 0; i < awards.size(); ++i ) {
-            if ( currentScenarioInfoId.scenarioId < awards[i]._startScenarioID )
+            if ( currentScenarioInfoId.scenarioId < awards[i]._startScenarioID ) {
                 continue;
+            }
 
             switch ( awards[i]._type ) {
             case Campaign::CampaignAwardData::TYPE_GET_ARTIFACT: {
-                Heroes * hero = getHeroForCampaignAwards( currentScenarioInfoId, humanKingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( currentScenarioInfoId, humanKingdom );
                 assert( hero != nullptr );
 
-                hero->PickupArtifact( Artifact( awards[i]._subType ) );
+                if ( hero != nullptr ) {
+                    hero->PickupArtifact( Artifact( awards[i]._subType ) );
+                }
 
                 break;
             }
             case Campaign::CampaignAwardData::TYPE_GET_SPELL: {
-                Heroes * hero = getHeroForCampaignAwards( currentScenarioInfoId, humanKingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( currentScenarioInfoId, humanKingdom );
                 assert( hero != nullptr );
 
-                hero->SpellBookActivate();
-                hero->AppendSpellToBook( awards[i]._subType, true );
+                if ( hero != nullptr ) {
+                    hero->SpellBookActivate();
+                    hero->AppendSpellToBook( awards[i]._subType, true );
+                }
 
                 break;
             }
@@ -711,10 +711,12 @@ namespace
 
                 break;
             case Campaign::CampaignAwardData::TYPE_CARRY_OVER_FORCES: {
-                Heroes * hero = getHeroForCampaignAwards( currentScenarioInfoId, humanKingdom );
+                Heroes * hero = getHeroForScenarioBonusOrCampaignAwards( currentScenarioInfoId, humanKingdom );
                 assert( hero != nullptr );
 
-                replaceArmy( hero->GetArmy(), Campaign::CampaignSaveData::Get().getCarryOverTroops() );
+                if ( hero != nullptr ) {
+                    replaceArmy( hero->GetArmy(), Campaign::CampaignSaveData::Get().getCarryOverTroops() );
+                }
 
                 break;
             }

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -532,65 +532,28 @@ namespace
 
     Heroes * getHeroForScenarioBonus( const Campaign::ScenarioInfoId & scenarioInfoId, const Kingdom & kingdom )
     {
-        // The "special" kingdom heroes may have the ID of another hero, but a custom name and portrait,
-        // so the search should be performed by the portrait ID
-        auto findHero = [&scenarioInfoId, &kingdom]( const int targetHeroId ) -> Heroes * {
+        static const std::map<std::pair<int, int>, int> targetHeroes = { // Defender
+                                                                         { { Campaign::ROLAND_CAMPAIGN, 5 }, Heroes::HALTON },
+                                                                         // King and Country
+                                                                         { { Campaign::VOYAGE_HOME_CAMPAIGN, 2 }, Heroes::GALLAVANT },
+                                                                         // Blood is Thicker
+                                                                         { { Campaign::VOYAGE_HOME_CAMPAIGN, 3 }, Heroes::GALLAVANT } };
+
+        const auto iter = targetHeroes.find( { scenarioInfoId.campaignId, scenarioInfoId.scenarioId } );
+        if ( iter != targetHeroes.end() ) {
+            // The "special" kingdom heroes may have the ID of another hero, but a custom name and portrait,
+            // so the search should be performed by the portrait ID
             for ( Heroes * hero : kingdom.GetHeroes() ) {
                 assert( hero != nullptr );
 
-                if ( hero->getPortraitId() == targetHeroId ) {
+                if ( hero->getPortraitId() == iter->second ) {
                     return hero;
                 }
             }
 
-#ifdef WITH_DEBUG
             DEBUG_LOG( DBG_GAME, DBG_WARN,
                        "the hero to whom the bonus should be applied has not been found"
                            << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
-#else
-            (void)scenarioInfoId;
-#endif
-
-            return nullptr;
-        };
-
-        switch ( scenarioInfoId.campaignId ) {
-        case Campaign::ROLAND_CAMPAIGN:
-            switch ( scenarioInfoId.scenarioId ) {
-            // Defender
-            case 5: {
-                Heroes * hero = findHero( Heroes::HALTON );
-                if ( hero ) {
-                    return hero;
-                }
-
-                break;
-            }
-            default:
-                break;
-            }
-
-            break;
-        case Campaign::VOYAGE_HOME_CAMPAIGN:
-            switch ( scenarioInfoId.scenarioId ) {
-            // King and Country
-            case 2:
-            // Blood is Thicker
-            case 3: {
-                Heroes * hero = findHero( Heroes::GALLAVANT );
-                if ( hero ) {
-                    return hero;
-                }
-
-                break;
-            }
-            default:
-                break;
-            }
-
-            break;
-        default:
-            break;
         }
 
         // By default, the scenario bonus is applied to the best hero of the kingdom

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -543,9 +543,13 @@ namespace
                 }
             }
 
+#ifdef WITH_DEBUG
             DEBUG_LOG( DBG_GAME, DBG_WARN,
                        "the hero to whom the bonus should be applied has not been found"
                            << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
+#else
+            (void)scenarioInfoId;
+#endif
 
             return nullptr;
         };

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -532,36 +532,56 @@ namespace
 
     Heroes * getHeroToApplyBonusOrAwards( const Campaign::ScenarioInfoId & scenarioInfoId, const Kingdom & kingdom )
     {
-        static const std::map<std::pair<int, int>, int> targetHeroes = { // Defender
-                                                                         { { Campaign::ROLAND_CAMPAIGN, 5 }, Heroes::HALTON },
-                                                                         // Final Justice
-                                                                         { { Campaign::ROLAND_CAMPAIGN, 9 }, Heroes::ROLAND },
-                                                                         // Apocalypse
-                                                                         { { Campaign::ARCHIBALD_CAMPAIGN, 10 }, Heroes::ARCHIBALD },
-                                                                         // The Wayward Son, Rogar the Barbarian
-                                                                         { { Campaign::DESCENDANTS_CAMPAIGN, 2 }, Heroes::ERGON },
-                                                                         // The Epic Battle, Jarkonas VI the Wizard
-                                                                         { { Campaign::DESCENDANTS_CAMPAIGN, 7 }, Heroes::ELDERIAN },
-                                                                         // King and Country
-                                                                         { { Campaign::VOYAGE_HOME_CAMPAIGN, 2 }, Heroes::GALLAVANT },
-                                                                         // Blood is Thicker
-                                                                         { { Campaign::VOYAGE_HOME_CAMPAIGN, 3 }, Heroes::GALLAVANT } };
+        {
+            static const std::map<std::pair<int, int>, int> targetHeroes = { // Final Justice
+                                                                             { { Campaign::ROLAND_CAMPAIGN, 9 }, Heroes::ROLAND },
+                                                                             // Apocalypse
+                                                                             { { Campaign::ARCHIBALD_CAMPAIGN, 10 }, Heroes::ARCHIBALD },
+                                                                             // King and Country
+                                                                             { { Campaign::VOYAGE_HOME_CAMPAIGN, 2 }, Heroes::GALLAVANT },
+                                                                             // Blood is Thicker
+                                                                             { { Campaign::VOYAGE_HOME_CAMPAIGN, 3 }, Heroes::GALLAVANT } };
 
-        const auto iter = targetHeroes.find( { scenarioInfoId.campaignId, scenarioInfoId.scenarioId } );
-        if ( iter != targetHeroes.end() ) {
-            // The "special" kingdom heroes may have the ID of another hero, but a custom name and portrait,
-            // so the search should be performed by the portrait ID
-            for ( Heroes * hero : kingdom.GetHeroes() ) {
-                assert( hero != nullptr );
+            const auto iter = targetHeroes.find( { scenarioInfoId.campaignId, scenarioInfoId.scenarioId } );
+            if ( iter != targetHeroes.end() ) {
+                // The "special" kingdom heroes may have the ID of another hero, but a custom name and portrait,
+                // so the search should be performed by the portrait ID
+                for ( Heroes * hero : kingdom.GetHeroes() ) {
+                    assert( hero != nullptr );
 
-                if ( hero->getPortraitId() == iter->second ) {
-                    return hero;
+                    if ( hero->getPortraitId() == iter->second ) {
+                        return hero;
+                    }
                 }
-            }
 
-            DEBUG_LOG( DBG_GAME, DBG_WARN,
-                       "the hero to whom bonuses or awards should be applied has not been found"
-                           << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
+                DEBUG_LOG( DBG_GAME, DBG_WARN,
+                           "the hero to whom bonuses or awards should be applied has not been found"
+                               << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
+            }
+        }
+
+        {
+            static const std::map<std::pair<int, int>, int> targetRaces = { // Defender
+                                                                            { { Campaign::ROLAND_CAMPAIGN, 5 }, Race::SORC },
+                                                                            // The Wayward Son
+                                                                            { { Campaign::DESCENDANTS_CAMPAIGN, 2 }, Race::SORC },
+                                                                            // The Epic Battle
+                                                                            { { Campaign::DESCENDANTS_CAMPAIGN, 7 }, Race::SORC } };
+
+            const auto iter = targetRaces.find( { scenarioInfoId.campaignId, scenarioInfoId.scenarioId } );
+            if ( iter != targetRaces.end() ) {
+                for ( Heroes * hero : kingdom.GetHeroes() ) {
+                    assert( hero != nullptr );
+
+                    if ( hero->GetRace() == iter->second ) {
+                        return hero;
+                    }
+                }
+
+                DEBUG_LOG( DBG_GAME, DBG_WARN,
+                           "the hero to whom bonuses or awards should be applied has not been found"
+                               << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
+            }
         }
 
         // By default, bonuses and awards are applied to the best hero of the kingdom

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -534,6 +534,8 @@ namespace
     {
         static const std::map<std::pair<int, int>, int> targetHeroes = { // Defender
                                                                          { { Campaign::ROLAND_CAMPAIGN, 5 }, Heroes::HALTON },
+                                                                         // Final Justice
+                                                                         { { Campaign::ROLAND_CAMPAIGN, 9 }, Heroes::ROLAND },
                                                                          // King and Country
                                                                          { { Campaign::VOYAGE_HOME_CAMPAIGN, 2 }, Heroes::GALLAVANT },
                                                                          // Blood is Thicker

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -696,7 +696,7 @@ namespace
             }
             case Campaign::CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO:
                 for ( const Player * player : sortedPlayers ) {
-                    Kingdom & kingdom = world.GetKingdom( player->GetColor() );
+                    const Kingdom & kingdom = world.GetKingdom( player->GetColor() );
                     const KingdomHeroes & heroes = kingdom.GetHeroes();
 
                     for ( size_t j = 0; j < heroes.size(); ++j ) {

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -534,7 +534,7 @@ namespace
     {
         // The "special" kingdom heroes may have the ID of another hero, but a custom name and portrait,
         // so the search should be performed by the portrait ID
-        auto findHero = [&kingdom]( const int targetHeroId ) -> Heroes * {
+        auto findHero = [&scenarioInfoId, &kingdom]( const int targetHeroId ) -> Heroes * {
             for ( Heroes * hero : kingdom.GetHeroes() ) {
                 assert( hero != nullptr );
 
@@ -542,6 +542,10 @@ namespace
                     return hero;
                 }
             }
+
+            DEBUG_LOG( DBG_GAME, DBG_WARN,
+                       "the hero to whom the bonus should be applied has not been found"
+                           << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
 
             return nullptr;
         };
@@ -557,10 +561,6 @@ namespace
                 if ( hero ) {
                     return hero;
                 }
-
-                DEBUG_LOG( DBG_GAME, DBG_WARN,
-                           "the hero to whom the bonus should be applied has not been found"
-                               << ", campaign id: " << scenarioInfoId.campaignId << ", scenario id: " << scenarioInfoId.scenarioId )
 
                 break;
             }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -809,7 +809,7 @@ void Interface::GameArea::SetRedraw() const
 fheroes2::Image Interface::GameArea::GenerateUltimateArtifactAreaSurface( const int32_t index, const fheroes2::Point & offset )
 {
     if ( !Maps::isValidAbsIndex( index ) ) {
-        DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Ultimate artifact is not found on index " << index )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Ultimate artifact is not found on index " << index )
         return fheroes2::Image();
     }
 

--- a/src/fheroes2/gui/ui_campaign.cpp
+++ b/src/fheroes2/gui/ui_campaign.cpp
@@ -74,7 +74,7 @@ namespace fheroes2
             Artifact artifact( bonusData._subType );
 
             if ( artifact == Artifact::SPELL_SCROLL ) {
-                artifact.SetSpell( bonusData._spellId );
+                artifact.SetSpell( bonusData._artifactSpellId );
             }
 
             const ArtifactDialogElement artifactUI( artifact );

--- a/src/fheroes2/gui/ui_campaign.cpp
+++ b/src/fheroes2/gui/ui_campaign.cpp
@@ -71,7 +71,12 @@ namespace fheroes2
     {
         switch ( bonusData._type ) {
         case Campaign::ScenarioBonusData::ARTIFACT: {
-            const Artifact artifact( bonusData._subType );
+            Artifact artifact( bonusData._subType );
+
+            if ( artifact == Artifact::SPELL_SCROLL ) {
+                artifact.SetSpell( bonusData._spellId );
+            }
+
             const ArtifactDialogElement artifactUI( artifact );
             const TextDialogElement artifactDescriptionUI( std::make_shared<Text>( artifact.GetDescription(), FontType::normalWhite() ) );
 

--- a/src/fheroes2/gui/ui_castle.cpp
+++ b/src/fheroes2/gui/ui_castle.cpp
@@ -191,7 +191,7 @@ namespace fheroes2
             break;
         default:
             assert( 0 );
-            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "unknown race" )
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown race" )
         }
 
         const Sprite & castleImage = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, icnIndex );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -192,13 +192,12 @@ Heroes::Heroes()
     , _aiRole( Role::HUNTER )
 {}
 
-Heroes::Heroes( int heroID, int race, int initialLevel )
+Heroes::Heroes( const int heroID, const int race, const int initialExperience )
     : Heroes( heroID, race )
 {
-    // level 1 is technically regarded as 0, so reduce the initial level by 1
-    experience = GetExperienceFromLevel( initialLevel - 1 );
+    experience = initialExperience;
 
-    for ( int i = 1; i < initialLevel; ++i ) {
+    for ( int i = 1; i < GetLevel(); ++i ) {
         LevelUp( false, true );
     }
 }
@@ -1715,27 +1714,27 @@ void AllHeroes::Init()
     for ( uint32_t hid = Heroes::ZOM; hid <= Heroes::CELIA; ++hid )
         push_back( new Heroes( hid, Race::NECR ) );
 
-    // from campain
-    push_back( new Heroes( Heroes::ROLAND, Race::WZRD, 5 ) );
-    push_back( new Heroes( Heroes::CORLAGON, Race::KNGT, 5 ) );
-    push_back( new Heroes( Heroes::ELIZA, Race::SORC, 5 ) );
-    push_back( new Heroes( Heroes::ARCHIBALD, Race::WRLK, 5 ) );
-    push_back( new Heroes( Heroes::HALTON, Race::KNGT, 5 ) );
-    push_back( new Heroes( Heroes::BAX, Race::NECR, 5 ) );
+    // SW campaign
+    push_back( new Heroes( Heroes::ROLAND, Race::WZRD, 5000 ) );
+    push_back( new Heroes( Heroes::CORLAGON, Race::KNGT, 5000 ) );
+    push_back( new Heroes( Heroes::ELIZA, Race::SORC, 5000 ) );
+    push_back( new Heroes( Heroes::ARCHIBALD, Race::WRLK, 5000 ) );
+    push_back( new Heroes( Heroes::HALTON, Race::KNGT, 5000 ) );
+    push_back( new Heroes( Heroes::BAX, Race::NECR, 5000 ) );
 
-    // loyalty version
+    // PoL
     if ( Settings::Get().isCurrentMapPriceOfLoyalty() ) {
-        push_back( new Heroes( Heroes::SOLMYR, Race::WZRD, 5 ) );
-        push_back( new Heroes( Heroes::DAINWIN, Race::WRLK, 5 ) );
-        push_back( new Heroes( Heroes::MOG, Race::NECR, 5 ) );
-        push_back( new Heroes( Heroes::UNCLEIVAN, Race::BARB, 5 ) );
-        push_back( new Heroes( Heroes::JOSEPH, Race::WZRD, 5 ) );
-        push_back( new Heroes( Heroes::GALLAVANT, Race::KNGT, 5 ) );
-        push_back( new Heroes( Heroes::ELDERIAN, Race::WRLK, 5 ) );
-        push_back( new Heroes( Heroes::CEALLACH, Race::KNGT, 5 ) );
-        push_back( new Heroes( Heroes::DRAKONIA, Race::WZRD, 5 ) );
-        push_back( new Heroes( Heroes::MARTINE, Race::SORC, 5 ) );
-        push_back( new Heroes( Heroes::JARKONAS, Race::BARB, 5 ) );
+        push_back( new Heroes( Heroes::SOLMYR, Race::WZRD, 5000 ) );
+        push_back( new Heroes( Heroes::DAINWIN, Race::WRLK, 5000 ) );
+        push_back( new Heroes( Heroes::MOG, Race::NECR, 5000 ) );
+        push_back( new Heroes( Heroes::UNCLEIVAN, Race::BARB, 5000 ) );
+        push_back( new Heroes( Heroes::JOSEPH, Race::WZRD, 5000 ) );
+        push_back( new Heroes( Heroes::GALLAVANT, Race::KNGT, 5000 ) );
+        push_back( new Heroes( Heroes::ELDERIAN, Race::WRLK, 5000 ) );
+        push_back( new Heroes( Heroes::CEALLACH, Race::KNGT, 5000 ) );
+        push_back( new Heroes( Heroes::DRAKONIA, Race::WZRD, 5000 ) );
+        push_back( new Heroes( Heroes::MARTINE, Race::SORC, 5000 ) );
+        push_back( new Heroes( Heroes::JARKONAS, Race::BARB, 5000 ) );
     }
     else {
         // for non-PoL maps, just add unknown heroes instead in place of the PoL-specific ones

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -192,14 +192,10 @@ Heroes::Heroes()
     , _aiRole( Role::HUNTER )
 {}
 
-Heroes::Heroes( const int heroID, const int race, const int initialExperience )
+Heroes::Heroes( const int heroID, const int race, const uint32_t additionalExperience )
     : Heroes( heroID, race )
 {
-    experience = initialExperience;
-
-    for ( int i = 1; i < GetLevel(); ++i ) {
-        LevelUp( false, true );
-    }
+    IncreaseExperience( additionalExperience, true );
 }
 
 Heroes::Heroes( int heroid, int rc )
@@ -992,7 +988,7 @@ bool Heroes::PickupArtifact( const Artifact & art )
     return true;
 }
 
-void Heroes::IncreaseExperience( const uint32_t amount, const bool autoselect )
+void Heroes::IncreaseExperience( const uint32_t amount, const bool autoselect /* = false */ )
 {
     int oldLevel = GetLevelFromExperience( experience );
     int newLevel = GetLevelFromExperience( experience + amount );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -733,7 +733,6 @@ bool Heroes::Recruit( const Castle & castle )
     }
 
     if ( castle.GetLevelMageGuild() ) {
-        // learn spells
         castle.MageGuildEducateHero( *this );
     }
 
@@ -744,34 +743,29 @@ bool Heroes::Recruit( const Castle & castle )
 
 void Heroes::ActionNewDay()
 {
-    // recovery move points
     move_point = GetMaxMovePoints();
 
-    // replenish spell points
-    ReplenishSpellPoints();
+    if ( world.CountDay() > 1 ) {
+        ReplenishSpellPoints();
+    }
 
-    // remove day visit object
     visit_object.remove_if( Visit::isDayLife );
 
-    // new day, new capacities
     ResetModes( SAVEMP );
 }
 
 void Heroes::ActionNewWeek()
 {
-    // remove week visit object
     visit_object.remove_if( Visit::isWeekLife );
 }
 
 void Heroes::ActionNewMonth()
 {
-    // remove month visit object
     visit_object.remove_if( Visit::isMonthLife );
 }
 
 void Heroes::ActionAfterBattle()
 {
-    // remove month visit object
     visit_object.remove_if( Visit::isBattleLife );
 
     SetModes( ACTION );

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -267,7 +267,7 @@ public:
 
     Heroes();
     Heroes( int heroid, int rc );
-    Heroes( int heroID, int race, int initialLevel );
+    Heroes( const int heroID, const int race, const int initialExperience );
     Heroes( const Heroes & ) = delete;
 
     ~Heroes() override = default;

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -517,6 +517,11 @@ public:
         return Heroes::GetPortrait( portrait, type );
     }
 
+    int getPortraitId() const
+    {
+        return portrait;
+    }
+
     static int GetLevelFromExperience( uint32_t );
     static uint32_t GetExperienceFromLevel( int );
 
@@ -589,8 +594,11 @@ private:
 
     Army army;
 
-    int hid; /* hero id */
-    int portrait; /* hero id */
+    // Hero ID
+    int hid;
+    // Corresponds to the ID of the hero whose portrait is applied. Usually equal to the
+    // ID of this hero, unless a custom portrait is applied.
+    int portrait;
     int _race;
     int save_maps_object;
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -267,7 +267,7 @@ public:
 
     Heroes();
     Heroes( int heroid, int rc );
-    Heroes( const int heroID, const int race, const int initialExperience );
+    Heroes( const int heroID, const int race, const uint32_t additionalExperience );
     Heroes( const Heroes & ) = delete;
 
     ~Heroes() override = default;

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -686,7 +686,7 @@ Funds Kingdom::GetIncome( int type /* INCOME_ALL */ ) const
     return getHandicapDependentIncome( totalIncome, player->getHandicapStatus() );
 }
 
-Heroes * Kingdom::GetBestHero()
+Heroes * Kingdom::GetBestHero() const
 {
     return !heroes.empty() ? *std::max_element( heroes.begin(), heroes.end(), HeroesStrongestArmy ) : nullptr;
 }

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -91,7 +91,7 @@ public:
 
     void appendSurrenderedHero( Heroes & hero );
 
-    Heroes * GetBestHero();
+    Heroes * GetBestHero() const;
 
     Monster GetStrongestMonster() const;
 

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -29,6 +29,7 @@ enum SaveFileFormat : uint16_t
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
     // 10000 value must be used for 1.0 release so all version before it should have lower than this value.
+    FORMAT_VERSION_PRE5_1000_RELEASE = 9964,
     FORMAT_VERSION_PRE4_1000_RELEASE = 9963,
     FORMAT_VERSION_PRE3_1000_RELEASE = 9962,
     FORMAT_VERSION_PRE2_1000_RELEASE = 9961,
@@ -39,5 +40,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_0919_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE4_1000_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE5_1000_RELEASE
 };

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -267,7 +267,7 @@ bool Settings::Read( const std::string & filePath )
             video_mode.height = GetInt( height );
         }
         else {
-            DEBUG_LOG( DBG_ENGINE, DBG_WARN, "unknown video mode: " << value )
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown video mode: " << value )
         }
     }
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -122,7 +122,7 @@ bool World::LoadMapMP2( const std::string & filename )
 
     StreamFile fs;
     if ( !fs.open( filename, "rb" ) ) {
-        DEBUG_LOG( DBG_GAME | DBG_ENGINE, DBG_WARN, "file not found " << filename.c_str() )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "file not found " << filename.c_str() )
         return false;
     }
 


### PR DESCRIPTION
fix #6027

Currently (before this PR) campaign bonuses and awards are applied to the "best hero of the kingdom", which usually means "hero with the most powerful army". This PR introduces some sort of "infrastructure" to set the specific hero to get these bonuses & awards (with the fallback to the old behavior if no hero specified or found). After a quick run through the campaigns I found the following places (and fixed these places in this PR):

* Roland's campaign, mission "Defender" - there are two heroes, and Sorceress should get the bonus spell;
* Roland's campaign, mission "Final Justice" - there are multiple heroes, and Roland should get the bonus artifact, as well as army from "The Gauntlet";
* Archibald's campaign, mission "Apocalypse" - there are multiple heroes, and Archibald should get the bonus artifact, as well as army from the previous mission;
* Descendants campaign, mission "The Wayward Son" - there are multiple heroes, and Sorceress should get the bonus;
* Descendants campaign, mission "The Epic Battle" - there are multiple heroes, and Sorceress should get the bonus;
* Voyage Home campaign, mission "Blood is Thicker" - there are two heroes, and Gallavant should get the bonus skill.

Maybe there are another places, and maybe I missed something regarding the missions listed above. Hi @LeHerosInconnu, @Branikolog what do you think?