### PR TITLE
Disable Trade button in Marketplace when appropriate

### DIFF
--- a/src/fheroes2/dialog/dialog_marketplace.cpp
+++ b/src/fheroes2/dialog/dialog_marketplace.cpp
@@ -424,6 +424,7 @@ void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
 
     buttonGift.draw();
     buttonExit.draw();
+    buttonTrade.disable();
     display.render();
 
     LocalEvent & le = LocalEvent::Get();


### PR DESCRIPTION
The problem was that the `buttonTrade` was always interpreted as `isEnabled()`.

Fix #6369 