### PR TITLE
Fix extra frame rendering for status update during AI turn

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1796,6 +1796,14 @@ namespace AI
                         }
                     }
 
+                    if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+                        // Update Adventure Map objects' animation.
+                        uint32_t & frame = Game::MapsAnimationFrame();
+                        ++frame;
+
+                        gameArea.SetRedraw();
+                    }
+
                     basicInterface.Redraw( Interface::REDRAW_GAMEAREA );
 
                     // If this assertion blows up it means that we are holding a RedrawLocker lock for rendering which should not happen.

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1798,8 +1798,6 @@ namespace AI
                     if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
                         // Update Adventure Map objects' animation.
                         Game::updateAdventureMapAnimationIndex();
-
-                        gameArea.SetRedraw();
                     }
 
                     basicInterface.Redraw( Interface::REDRAW_GAMEAREA );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1722,9 +1722,7 @@ namespace AI
                     break;
                 }
 
-                const bool hideHeroAnimation = ( hideAIMovements || !AIHeroesShowAnimation( hero, colors ) );
-
-                if ( hideHeroAnimation ) {
+                if ( hideAIMovements || !AIHeroesShowAnimation( hero, colors ) ) {
                     hero.Move( true );
                     recenterNeeded = true;
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1729,8 +1729,7 @@ namespace AI
                     // Render a frame only if there is a need to show one.
                     if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
                         // Update Adventure Map objects' animation.
-                        uint32_t & frame = Game::MapsAnimationFrame();
-                        ++frame;
+                        Game::updateAdventureMapAnimationIndex();
 
                         basicInterface.Redraw( Interface::REDRAW_GAMEAREA );
 
@@ -1798,8 +1797,7 @@ namespace AI
 
                     if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
                         // Update Adventure Map objects' animation.
-                        uint32_t & frame = Game::MapsAnimationFrame();
-                        ++frame;
+                        Game::updateAdventureMapAnimationIndex();
 
                         gameArea.SetRedraw();
                     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1783,6 +1783,8 @@ namespace AI
 
         Interface::StatusWindow & status = Interface::Basic::Get().GetStatusWindow();
 
+        uint32_t currentProgressValue = startProgressValue;
+
         while ( !availableHeroes.empty() ) {
             Heroes * bestHero = availableHeroes.front().hero;
             double maxPriority = 0;
@@ -1890,8 +1892,10 @@ namespace AI
             if ( maxHeroCount > 0 ) {
                 // At least one hero still exist in the kingdom.
                 const size_t progressValue = ( endProgressValue - startProgressValue ) * ( maxHeroCount - availableHeroes.size() ) / maxHeroCount + startProgressValue;
-
-                status.DrawAITurnProgress( static_cast<uint32_t>( progressValue ) );
+                if ( currentProgressValue < progressValue ) {
+                    currentProgressValue = static_cast<uint32_t>( progressValue );
+                    status.DrawAITurnProgress( currentProgressValue );
+                }
             }
         }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -215,9 +215,14 @@ void Game::Init()
     Game::HotKeysLoad( Settings::GetLastFile( "", "fheroes2.key" ) );
 }
 
-uint32_t & Game::MapsAnimationFrame()
+uint32_t Game::getAdventureMapAnimationIndex()
 {
     return maps_animation_frame;
+}
+
+void Game::updateAdventureMapAnimationIndex()
+{
+    ++maps_animation_frame;
 }
 
 // play environment sounds from the game area in focus

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -97,7 +97,11 @@ namespace Game
     int GetKingdomColors();
     int GetActualKingdomColors();
     void DialogPlayers( int color, std::string );
-    uint32_t & MapsAnimationFrame();
+
+    uint32_t getAdventureMapAnimationIndex();
+
+    void updateAdventureMapAnimationIndex();
+
     uint32_t GetRating();
     uint32_t GetGameOverScores();
     uint32_t GetLostTownDays();

--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -252,8 +252,7 @@ int32_t Interface::Basic::GetDimensionDoorDestination( const int32_t from, const
         }
 
         if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
-            uint32_t & frame = Game::MapsAnimationFrame();
-            ++frame;
+            Game::updateAdventureMapAnimationIndex();
 
             Redraw( REDRAW_GAMEAREA );
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1164,6 +1164,10 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
 
         if ( NeedRedraw() ) {
             Redraw();
+
+            // If this assertion blows up it means that we are holding a RedrawLocker lock for rendering which should not happen.
+            assert( GetRedrawMask() == 0 );
+
             display.render();
         }
     }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1152,8 +1152,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
 
         // map objects animation
         if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
-            uint32_t & frame = Game::MapsAnimationFrame();
-            ++frame;
+            Game::updateAdventureMapAnimationIndex();
             gameArea.SetRedraw();
         }
 

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -482,8 +482,7 @@ void Interface::StatusWindow::DrawAITurnProgress( const uint32_t progressValue )
     interface.SetRedraw( REDRAW_STATUS );
 
     if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
-        uint32_t & frame = Game::MapsAnimationFrame();
-        ++frame;
+        Game::updateAdventureMapAnimationIndex();
 
         interface.Redraw( REDRAW_GAMEAREA );
         fheroes2::Display::instance().render();

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -479,7 +479,7 @@ void Interface::StatusWindow::DrawAITurnProgress( const uint32_t progressValue )
 
     turn_progress = progressValue;
 
-    interface.Redraw( REDRAW_STATUS );
+    interface.SetRedraw( REDRAW_STATUS );
 
     if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
         uint32_t & frame = Game::MapsAnimationFrame();

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3164,8 +3164,7 @@ void ActionToHutMagi( Heroes & hero, const MP2::MapObjectType objectType, int32_
                 while ( le.HandleEvents( Game::isDelayNeeded( { Game::MAPS_DELAY } ) ) && delay < 7 ) {
                     if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
                         ++delay;
-                        uint32_t & frame = Game::MapsAnimationFrame();
-                        ++frame;
+                        Game::updateAdventureMapAnimationIndex();
                         I.Redraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
                     }
                 }

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -532,7 +532,7 @@ std::vector<std::pair<fheroes2::Point, fheroes2::Sprite>> Heroes::getHeroSprites
 
     int flagFrameID = sprite_index;
     if ( !isMoveEnabled() ) {
-        flagFrameID = isShipMaster() ? 0 : Game::MapsAnimationFrame();
+        flagFrameID = isShipMaster() ? 0 : Game::getAdventureMapAnimationIndex();
     }
 
     fheroes2::Point offset;

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -532,7 +532,7 @@ std::vector<std::pair<fheroes2::Point, fheroes2::Sprite>> Heroes::getHeroSprites
 
     int flagFrameID = sprite_index;
     if ( !isMoveEnabled() ) {
-        flagFrameID = isShipMaster() ? 0 : Game::getAdventureMapAnimationIndex();
+        flagFrameID = isShipMaster() ? 0 : static_cast<int>( Game::getAdventureMapAnimationIndex() );
     }
 
     fheroes2::Point offset;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1301,7 +1301,7 @@ void Maps::Tiles::renderAddonObject( fheroes2::Image & output, const Interface::
 
     area.BlitOnTile( output, sprite, sprite.x(), sprite.y(), offset, false, alphaValue );
 
-    const uint32_t animationIndex = ICN::AnimationFrame( icn, addon.index, Game::MapsAnimationFrame() );
+    const uint32_t animationIndex = ICN::AnimationFrame( icn, addon.index, Game::getAdventureMapAnimationIndex() );
     if ( animationIndex > 0 ) {
         const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( icn, animationIndex );
 
@@ -1334,7 +1334,7 @@ void Maps::Tiles::renderMainObject( fheroes2::Image & output, const Interface::G
 
     // Render possible animation image.
     // TODO: quantity2 is used in absolutely incorrect way! Fix all the logic for it. As of now (quantity2 != 0) expression is used only for Magic Garden.
-    const uint32_t mainObjectAnimationIndex = ICN::AnimationFrame( mainObjectIcn, objectIndex, Game::MapsAnimationFrame(), quantity2 != 0 );
+    const uint32_t mainObjectAnimationIndex = ICN::AnimationFrame( mainObjectIcn, objectIndex, Game::getAdventureMapAnimationIndex(), quantity2 != 0 );
     if ( mainObjectAnimationIndex > 0 ) {
         const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( mainObjectIcn, mainObjectAnimationIndex );
 
@@ -1516,7 +1516,7 @@ void Maps::Tiles::redrawTopLayerExtraObjects( fheroes2::Image & dst, const bool 
     if ( renderFlyingGhosts ) {
         // This sprite is bigger than TILEWIDTH but rendering is correct for heroes and boats.
         // TODO: consider adding this sprite as a part of an addon.
-        const fheroes2::Sprite & image = fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::MapsAnimationFrame() % 15 );
+        const fheroes2::Sprite & image = fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::getAdventureMapAnimationIndex() % 15 );
 
         const uint8_t alphaValue = area.getObjectAlphaValue( uniq );
 
@@ -2303,7 +2303,7 @@ std::pair<uint32_t, uint32_t> Maps::Tiles::GetMonsterSpriteIndices( const Tiles 
     else {
         const fheroes2::Point & mp = Maps::GetPoint( tileIndex );
         const std::array<uint8_t, 15> & monsterAnimationSequence = fheroes2::getMonsterAnimationSequence();
-        spriteIndices.second = monsterIndex * 9 + 1 + monsterAnimationSequence[( Game::MapsAnimationFrame() + mp.x * mp.y ) % monsterAnimationSequence.size()];
+        spriteIndices.second = monsterIndex * 9 + 1 + monsterAnimationSequence[( Game::getAdventureMapAnimationIndex() + mp.x * mp.y ) % monsterAnimationSequence.size()];
     }
     return spriteIndices;
 }


### PR DESCRIPTION
This is a leftover code and regression from #6319 which was forgotten to be addressed:
- do not update progress status for AI if it isn't changed. Every movement for hero was updating the status bar
- remove one extra frame rendering upon calling `DrawAITurnProgress()` method
- code cleanup to avoid weird reference increment code