### PR TITLE
[#5240] Adjusted "Battlefield Casualties" vertical position of MonsterLines.

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -576,7 +576,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     text.Blit( pos_rt.x + ( pos_rt.width - text.w() ) / 2, pos_rt.y + 285 );
 
     if ( killed1.isValid() )
-        Army::drawSingleDetailedMonsterLine( killed1, pos_rt.x + 25, pos_rt.y + 303, 270 );
+        Army::drawSingleDetailedMonsterLine( killed1, pos_rt.x + 25, pos_rt.y + 308, 270 );
     else {
         text.Set( _( "None" ), Font::SMALL );
         text.Blit( pos_rt.x + ( pos_rt.width - text.w() ) / 2, pos_rt.y + 300 );
@@ -587,7 +587,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     text.Blit( pos_rt.x + ( pos_rt.width - text.w() ) / 2, pos_rt.y + 345 );
 
     if ( killed2.isValid() )
-        Army::drawSingleDetailedMonsterLine( killed2, pos_rt.x + 25, pos_rt.y + 363, 270 );
+        Army::drawSingleDetailedMonsterLine( killed2, pos_rt.x + 25, pos_rt.y + 368, 270 );
     else {
         text.Set( _( "None" ), Font::SMALL );
         text.Blit( pos_rt.x + ( pos_rt.width - text.w() ) / 2, pos_rt.y + 360 );


### PR DESCRIPTION
![Heroes2_308_368](https://user-images.githubusercontent.com/117003547/208266724-1efd2f3c-c5b9-4172-a645-e6c6b7b0dc7c.png)
Added enough slack for neither the attacker's nor defender's row of monsters to ever vertically overlap with either text label. This is probably as good as it gets without shuffling the other labels around.