### PR TITLE
Fix incorrect resource placements on certain maps

### DIFF
--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -23,6 +23,7 @@
 
 #include <cstdint>
 #include <list>
+#include <ostream>
 #include <utility>
 
 #include "army_troop.h"
@@ -598,7 +599,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
             break;
         default:
             // Some maps have broken resources being put which ideally we need to correct. Let's make them 0 Wood.
-            ERROR_LOG( "Tile " << _index << " contains unknown resource type. Tileset " << objectTileset << ", object index " << objectIndex )
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Tile " << _index << " contains unknown resource type. Tileset " << objectTileset << ", object index " << objectIndex )
             resourceType = Resource::WOOD;
             count = 0;
             break;

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -22,6 +22,8 @@
  ***************************************************************************/
 
 #include <cstdint>
+#include <list>
+#include <utility>
 
 #include "army_troop.h"
 #include "artifact.h"

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -28,6 +28,7 @@
 #include "army_troop.h"
 #include "artifact.h"
 #include "color.h"
+#include "logging.h"
 #include "maps_tiles.h"
 #include "monster.h"
 #include "mp2.h"
@@ -597,6 +598,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
             break;
         default:
             // Some maps have broken resources being put which ideally we need to correct. Let's make them 0 Wood.
+            ERROR_LOG( "Tile " << _index << " contains unknown resource type. Tileset " << objectTileset << ", object index " << objectIndex )
             resourceType = Resource::WOOD;
             count = 0;
             break;


### PR DESCRIPTION
close #6393

This change must be thoughtfully tested on many maps to make sure that we don't break anything. The test scope should be done on maps with "bad" resources as well as any normal resources.