### PR TITLE
Fix forced IDLE animation after switching to STATIC animation. (Battlefield)

### DIFF
--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1615,6 +1615,12 @@ bool Battle::Unit::isHaveDamage() const
 bool Battle::Unit::SwitchAnimation( int rule, bool reverse )
 {
     animation.switchAnimation( rule, reverse );
+
+    if ( rule == Monster_Info::STATIC ) {
+        // Reset the delay before switching to the 'IDLE' animation from 'STATIC'.
+        checkIdleDelay();
+    }
+
     return animation.isValid();
 }
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1614,12 +1614,12 @@ bool Battle::Unit::isHaveDamage() const
 
 bool Battle::Unit::SwitchAnimation( int rule, bool reverse )
 {
-    animation.switchAnimation( rule, reverse );
-
-    if ( rule == Monster_Info::STATIC ) {
+    if ( rule == Monster_Info::STATIC && GetAnimationState() != Monster_Info::IDLE ) {
         // Reset the delay before switching to the 'IDLE' animation from 'STATIC'.
         checkIdleDelay();
     }
+
+    animation.switchAnimation( rule, reverse );
 
     return animation.isValid();
 }


### PR DESCRIPTION
close #6399

It seems that the problem was that while creature does its non `STATIC`/`IDLE` animation (attack, wince, moving) the delay till the next `IDLE` animation passes and after switching to `STATIC` animation the game automatically switches the creature to `IDLE` animation. So the creature could start its `IDLE` animation after wince, instead if `STATIC`, which changes to attack animation in the middle of `IDLE`.