### PR TITLE
Add links to download the ARM64 Linux build, distinguish the archive names between x86-64 and ARM64

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -14,7 +14,7 @@ jobs:
           env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_WITH_SDL1: ON }
           package_name: fheroes2_ubuntu_x86-64_SDL1.zip
           package_files: fheroes2 LICENSE script/linux/install_sdl_1.sh download_demo_version.sh extract_homm2_resources.sh changelog.txt README.txt files/lang/*.mo files/data/*.h2d
-          release_name: Ubuntu (Linux) build with SDL1 (latest commit)
+          release_name: Ubuntu x86-64 (Linux) build with SDL1 (latest commit)
           release_tag: fheroes2-linux-sdl1_dev
         - name: Linux x86-64 SDL1 Debug
           os: ubuntu-latest
@@ -26,7 +26,7 @@ jobs:
           env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON }
           package_name: fheroes2_ubuntu_x86-64_SDL2.zip
           package_files: fheroes2 LICENSE script/linux/install_sdl_2.sh download_demo_version.sh extract_homm2_resources.sh changelog.txt README.txt files/lang/*.mo files/data/*.h2d
-          release_name: Ubuntu (Linux) build with SDL2 (latest commit)
+          release_name: Ubuntu x86-64 (Linux) build with SDL2 (latest commit)
           release_tag: fheroes2-linux-sdl2_dev
         - name: Linux x86-64 SDL2 Debug
           os: ubuntu-latest

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -8,27 +8,27 @@ jobs:
     strategy:
       matrix:
         config:
-        - name: Linux SDL1 Release
+        - name: Linux x86-64 SDL1 Release
           os: ubuntu-latest
           dependencies: libsdl1.2-dev libsdl-mixer1.2-dev gettext
           env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_WITH_SDL1: ON }
-          package_name: fheroes2_ubuntu_SDL1.zip
+          package_name: fheroes2_ubuntu_x86-64_SDL1.zip
           package_files: fheroes2 LICENSE script/linux/install_sdl_1.sh download_demo_version.sh extract_homm2_resources.sh changelog.txt README.txt files/lang/*.mo files/data/*.h2d
           release_name: Ubuntu (Linux) build with SDL1 (latest commit)
           release_tag: fheroes2-linux-sdl1_dev
-        - name: Linux SDL1 Debug
+        - name: Linux x86-64 SDL1 Debug
           os: ubuntu-latest
           dependencies: libsdl1.2-dev libsdl-mixer1.2-dev gettext
           env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_WITH_SDL1: ON, FHEROES2_WITH_DEBUG: ON, FHEROES2_WITH_ASAN: ON }
-        - name: Linux SDL2 Release
+        - name: Linux x86-64 SDL2 Release
           os: ubuntu-latest
           dependencies: libsdl2-dev libsdl2-mixer-dev gettext
           env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON }
-          package_name: fheroes2_ubuntu_SDL2.zip
+          package_name: fheroes2_ubuntu_x86-64_SDL2.zip
           package_files: fheroes2 LICENSE script/linux/install_sdl_2.sh download_demo_version.sh extract_homm2_resources.sh changelog.txt README.txt files/lang/*.mo files/data/*.h2d
           release_name: Ubuntu (Linux) build with SDL2 (latest commit)
           release_tag: fheroes2-linux-sdl2_dev
-        - name: Linux SDL2 Debug
+        - name: Linux x86-64 SDL2 Debug
           os: ubuntu-latest
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
           env: { FHEROES2_STRICT_COMPILATION: ON, FHEROES2_WITH_TOOLS: ON, FHEROES2_WITH_IMAGE: ON, FHEROES2_WITH_DEBUG: ON, FHEROES2_WITH_TSAN: ON }

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -218,8 +218,13 @@ You have to copy the subdirectories `ANIM`, `DATA`, `MAPS` and `MUSIC` from the 
 ### Linux ZIP archive
 
 * Download one of the following Linux ZIP archives:<br>
-  [**SDL2 (recommended)**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_ubuntu_SDL2.zip) or<br>
-  [**SDL1**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_ubuntu_SDL1.zip).
+  * **Linux x64-64**:<br>
+  [**SDL2 (recommended)**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_ubuntu_x86-64_SDL2.zip) or<br>
+  [**SDL1**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_ubuntu_x86-64_SDL1.zip)
+
+  * **Linux ARM64**:<br>
+  [**SDL2 (recommended)**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_ubuntu_arm64_SDL2.zip) or<br>
+  [**SDL1**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_ubuntu_arm64_SDL1.zip)
 
 * After downloading the ZIP archive, extract it to a suitable directory of your choice. Then you will need to install the SDL libraries
   required to run the game. The installation procedure depends on the Linux distribution you are using:
@@ -286,8 +291,10 @@ You can download the precompiled binaries of the latest commit (snapshot) for
 [**SDL1**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-osx-sdl1_dev)
 ),
 **Ubuntu** (
-[**SDL2**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-linux-sdl2_dev) and
-[**SDL1**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-linux-sdl1_dev)
+[**x86-64 SDL2**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-linux-sdl2_dev),
+[**x86-64 SDL1**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-linux-sdl1_dev),
+[**ARM64 SDL2**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-linux-arm-sdl2_dev) and
+[**ARM64 SDL1**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-linux-arm-sdl1_dev)
 ),
 [**Android**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-android),
 [**PlayStation Vita**](https://github.com/ihhub/fheroes2/releases/tag/fheroes2-psv-sdl2_dev) and

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -217,7 +217,8 @@ You have to copy the subdirectories `ANIM`, `DATA`, `MAPS` and `MUSIC` from the 
 <a name="linux-zip-archive"></a>
 ### Linux ZIP archive
 
-* Download one of the following Linux ZIP archives:<br>
+* Download one of the following Linux ZIP archives:
+
   * **Linux x64-64**:<br>
   [**SDL2 (recommended)**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_ubuntu_x86-64_SDL2.zip) or<br>
   [**SDL1**](https://github.com/ihhub/fheroes2/releases/latest/download/fheroes2_ubuntu_x86-64_SDL1.zip)


### PR DESCRIPTION
Because now we have ARM64 builds.

Hi @ihhub could you please postpone the release creation until this PR will be merged since the names of x86-64 linux ZIP archives have been changed?