### PR TITLE
Optimize multiple places for rendering

### DIFF
--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -62,8 +62,8 @@ namespace fheroes2
 
     bool TimeDelay::isPassed( const uint64_t delayMs ) const
     {
-        const std::chrono::duration<double> time = std::chrono::steady_clock::now() - _prevTime;
-        const uint64_t passedMs = static_cast<uint64_t>( time.count() * 1000 + 0.5 );
+        const auto time = std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() - _prevTime );
+        const uint64_t passedMs = time.count();
         return passedMs >= delayMs;
     }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -69,13 +69,10 @@
 #include "ui_tool.h"
 #include "world.h"
 
-namespace Battle
-{
-    Arena * arena = nullptr;
-}
-
 namespace
 {
+    Battle::Arena * arena = nullptr;
+
     // Compute a new seed from a list of actions, so random actions happen differently depending on user inputs
     uint32_t UpdateRandomSeed( const uint32_t seed, const Battle::Actions & actions )
     {
@@ -396,9 +393,11 @@ Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const
         _interface->fullRedraw();
         display.render();
 
-        // Wait for the end of M82::PREBATTL playback
-        while ( LocalEvent::Get().HandleEvents() && Mixer::isPlaying( -1 ) )
-            ;
+        // Wait for the end of M82::PREBATTL playback. Make sure that we check the music status first as HandleEvents() call is not instant.
+        LocalEvent & le = LocalEvent::Get();
+        while ( Mixer::isPlaying( -1 ) && le.HandleEvents() ) {
+            // Do nothing.
+        }
     }
 }
 
@@ -1271,16 +1270,6 @@ Battle::Force & Battle::Arena::getEnemyForce( const int color ) const
 Battle::Force & Battle::Arena::GetCurrentForce() const
 {
     return getForce( current_color );
-}
-
-int Battle::Arena::GetICNCovr() const
-{
-    return icn_covr;
-}
-
-uint32_t Battle::Arena::GetCurrentTurn() const
-{
-    return current_turn;
 }
 
 Battle::Result & Battle::Arena::GetResult()

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -100,7 +100,11 @@ namespace Battle
         bool AutoBattleInProgress() const;
         bool CanToggleAutoBattle() const;
 
-        uint32_t GetCurrentTurn() const;
+        uint32_t GetCurrentTurn() const
+        {
+            return current_turn;
+        }
+
         Result & GetResult();
 
         const HeroBase * getCommander( const int color ) const;
@@ -172,7 +176,11 @@ namespace Battle
         void ApplyActionSpellDefaults( Command &, const Spell & );
 
         bool IsShootingPenalty( const Unit &, const Unit & ) const;
-        int GetICNCovr() const;
+
+        int GetICNCovr() const
+        {
+            return icn_covr;
+        }
 
         uint32_t GetCastleTargetValue( int ) const;
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2990,25 +2990,26 @@ void Battle::Interface::AnimateUnitWithDelay( Unit & unit, uint32_t delay )
         return;
     }
 
+    // Render the first frame before waiting any delay.
+    Redraw();
+    unit.IncreaseAnimFrame();
+
+    // Reset the delay to wait till the next frame.
+    Game::AnimateResetDelay( Game::DelayType::CUSTOM_DELAY );
+
     LocalEvent & le = LocalEvent::Get();
     const uint64_t frameDelay = ( unit.animation.animationLength() > 0 ) ? delay / unit.animation.animationLength() : 0;
-
-    // Immediately indicate that the delay has passed to render first frame immediately.
-    Game::passCustomAnimationDelay( frameDelay );
-    // Make sure that the first run is passed immediately.
-    assert( !Game::isCustomDelayNeeded( frameDelay ) );
 
     while ( le.HandleEvents( Game::isCustomDelayNeeded( frameDelay ) ) ) {
         CheckGlobalEvents( le );
 
         if ( Game::validateCustomAnimationDelay( frameDelay ) ) {
-            Redraw();
-
             if ( unit.isFinishAnimFrame() ) {
                 // We have reached the end of animation.
                 break;
             }
 
+            Redraw();
             unit.IncreaseAnimFrame();
         }
     }
@@ -3019,21 +3020,22 @@ void Battle::Interface::AnimateOpponents( OpponentSprite * target )
     if ( target == nullptr || target->isFinishFrame() ) // nothing to animate
         return;
 
-    // Immediately indicate that the delay has passed to render first frame immediately.
-    Game::passAnimationDelay( Game::BATTLE_OPPONENTS_DELAY );
-    // Make sure that the first run is passed immediately.
-    assert( !Game::isDelayNeeded( { Game::BATTLE_OPPONENTS_DELAY } ) );
+    // Render the first frame before waiting any delay.
+    Redraw();
+    target->IncreaseAnimFrame();
+
+    // Reset the delay to wait till the next frame.
+    Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
 
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_OPPONENTS_DELAY } ) ) ) {
         if ( Game::validateAnimationDelay( Game::BATTLE_OPPONENTS_DELAY ) ) {
-            Redraw();
-
             if ( target->isFinishFrame() ) {
                 // We have reached the end of animation.
                 break;
             }
 
+            Redraw();
             target->IncreaseAnimFrame();
         }
     }
@@ -3044,23 +3046,24 @@ void Battle::Interface::RedrawTroopDefaultDelay( Unit & unit )
     if ( unit.isFinishAnimFrame() ) // nothing to animate
         return;
 
-    // Immediately indicate that the delay has passed to render first frame immediately.
-    Game::passAnimationDelay( Game::BATTLE_FRAME_DELAY );
-    // Make sure that the first run is passed immediately.
-    assert( !Game::isDelayNeeded( { Game::BATTLE_FRAME_DELAY } ) );
+    // Render the first frame before waiting any delay.
+    Redraw();
+    unit.IncreaseAnimFrame();
+
+    // Reset the delay to wait till the next frame.
+    Game::AnimateResetDelay( Game::DelayType::BATTLE_FRAME_DELAY );
 
     LocalEvent & le = LocalEvent::Get();
-    while ( le.HandleEvents( false ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_FRAME_DELAY } ) ) ) {
         CheckGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::BATTLE_FRAME_DELAY ) ) {
-            Redraw();
-
             if ( unit.isFinishAnimFrame() ) {
                 // We have reached the end of animation.
                 break;
             }
 
+            Redraw();
             unit.IncreaseAnimFrame();
         }
     }
@@ -4783,6 +4786,9 @@ void Battle::Interface::RedrawActionResurrectSpell( Unit & target, const Spell &
         // Restore direction of the creature, since it could be killed when it was reflected.
         target.UpdateDirection();
 
+        Redraw();
+        target.IncreaseAnimFrame();
+
         Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
 
         LocalEvent & le = LocalEvent::Get();
@@ -4790,13 +4796,12 @@ void Battle::Interface::RedrawActionResurrectSpell( Unit & target, const Spell &
             CheckGlobalEvents( le );
 
             if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
-                Redraw();
-
                 if ( target.isFinishAnimFrame() ) {
                     // We have reached the end of animation.
                     break;
                 }
 
+                Redraw();
                 target.IncreaseAnimFrame();
             }
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3588,6 +3588,9 @@ void Battle::Interface::RedrawActionFly( Unit & unit, const Position & pos )
         return;
     }
 
+    // Reset the delay to wait till the next frame.
+    Game::AnimateResetDelay( Game::DelayType::CUSTOM_DELAY );
+
     const fheroes2::Point destPos = unit.GetRectPosition().getPosition();
     fheroes2::Point targetPos = Board::GetCell( destIndex )->GetPos().getPosition();
 
@@ -3635,9 +3638,6 @@ void Battle::Interface::RedrawActionFly( Unit & unit, const Position & pos )
 
     unit.SwitchAnimation( Monster_Info::FLY_UP );
     AudioManager::PlaySound( unit.M82Tkof() );
-
-    // Reset the delay to wait till the next frame.
-    Game::AnimateResetDelay( Game::DelayType::CUSTOM_DELAY );
 
     // Take off animation should have the same between frame delay as the movement animation.
     AnimateUnitWithDelay( unit, frameDelay * static_cast<uint32_t>( unit.animation.animationLength() ) / movementFrames );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4580,8 +4580,8 @@ void Battle::Interface::RedrawLightningOnTargets( const std::vector<fheroes2::Po
             }
         }
 
-        while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) &&
-                ( ( isHorizontalBolt && roi.width < drawRoi.width ) || ( !isHorizontalBolt && roi.height < drawRoi.height ) ) ) {
+        while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) )
+                && ( ( isHorizontalBolt && roi.width < drawRoi.width ) || ( !isHorizontalBolt && roi.height < drawRoi.height ) ) ) {
             if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
                 if ( isHorizontalBolt ) {
                     if ( isForwardDirection ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2992,7 +2992,6 @@ void Battle::Interface::AnimateUnitWithDelay( Unit & unit, uint32_t delay )
 
     // Render the first frame before waiting any delay.
     Redraw();
-    unit.IncreaseAnimFrame();
 
     // Reset the delay to wait till the next frame.
     Game::AnimateResetDelay( Game::DelayType::CUSTOM_DELAY );
@@ -3009,8 +3008,8 @@ void Battle::Interface::AnimateUnitWithDelay( Unit & unit, uint32_t delay )
                 break;
             }
 
-            Redraw();
             unit.IncreaseAnimFrame();
+            Redraw();
         }
     }
 }
@@ -3022,7 +3021,6 @@ void Battle::Interface::AnimateOpponents( OpponentSprite * target )
 
     // Render the first frame before waiting any delay.
     Redraw();
-    target->IncreaseAnimFrame();
 
     // Reset the delay to wait till the next frame.
     Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
@@ -3035,8 +3033,8 @@ void Battle::Interface::AnimateOpponents( OpponentSprite * target )
                 break;
             }
 
-            Redraw();
             target->IncreaseAnimFrame();
+            Redraw();
         }
     }
 }
@@ -3048,7 +3046,6 @@ void Battle::Interface::RedrawTroopDefaultDelay( Unit & unit )
 
     // Render the first frame before waiting any delay.
     Redraw();
-    unit.IncreaseAnimFrame();
 
     // Reset the delay to wait till the next frame.
     Game::AnimateResetDelay( Game::DelayType::BATTLE_FRAME_DELAY );
@@ -3063,8 +3060,8 @@ void Battle::Interface::RedrawTroopDefaultDelay( Unit & unit )
                 break;
             }
 
-            Redraw();
             unit.IncreaseAnimFrame();
+            Redraw();
         }
     }
 }
@@ -4929,7 +4926,6 @@ void Battle::Interface::RedrawActionDeathWaveSpell( const int32_t strength )
 
     AudioManager::PlaySound( M82::MNRDEATH );
 
-    int32_t position = 0;
     while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && position < area.width + waveLength ) {
         CheckGlobalEvents( le );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2990,12 +2990,6 @@ void Battle::Interface::AnimateUnitWithDelay( Unit & unit, uint32_t delay )
         return;
     }
 
-    // Render the first frame before waiting any delay.
-    Redraw();
-
-    // Reset the delay to wait till the next frame.
-    Game::AnimateResetDelay( Game::DelayType::CUSTOM_DELAY );
-
     LocalEvent & le = LocalEvent::Get();
     const uint64_t frameDelay = ( unit.animation.animationLength() > 0 ) ? delay / unit.animation.animationLength() : 0;
 
@@ -3003,13 +2997,14 @@ void Battle::Interface::AnimateUnitWithDelay( Unit & unit, uint32_t delay )
         CheckGlobalEvents( le );
 
         if ( Game::validateCustomAnimationDelay( frameDelay ) ) {
+            Redraw();
+
             if ( unit.isFinishAnimFrame() ) {
                 // We have reached the end of animation.
                 break;
             }
 
             unit.IncreaseAnimFrame();
-            Redraw();
         }
     }
 }
@@ -3019,22 +3014,18 @@ void Battle::Interface::AnimateOpponents( OpponentSprite * target )
     if ( target == nullptr || target->isFinishFrame() ) // nothing to animate
         return;
 
-    // Render the first frame before waiting any delay.
-    Redraw();
-
-    // Reset the delay to wait till the next frame.
-    Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
-
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_OPPONENTS_DELAY } ) ) ) {
         if ( Game::validateAnimationDelay( Game::BATTLE_OPPONENTS_DELAY ) ) {
+            // Render the first frame before waiting any delay.
+            Redraw();
+
             if ( target->isFinishFrame() ) {
                 // We have reached the end of animation.
                 break;
             }
 
             target->IncreaseAnimFrame();
-            Redraw();
         }
     }
 }
@@ -3044,24 +3035,19 @@ void Battle::Interface::RedrawTroopDefaultDelay( Unit & unit )
     if ( unit.isFinishAnimFrame() ) // nothing to animate
         return;
 
-    // Render the first frame before waiting any delay.
-    Redraw();
-
-    // Reset the delay to wait till the next frame.
-    Game::AnimateResetDelay( Game::DelayType::BATTLE_FRAME_DELAY );
-
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_FRAME_DELAY } ) ) ) {
         CheckGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::BATTLE_FRAME_DELAY ) ) {
+            Redraw();
+
             if ( unit.isFinishAnimFrame() ) {
                 // We have reached the end of animation.
                 break;
             }
 
             unit.IncreaseAnimFrame();
-            Redraw();
         }
     }
 }
@@ -3180,6 +3166,9 @@ void Battle::Interface::RedrawActionAttackPart1( Unit & attacker, Unit & defende
 
         // redraw archer attack animation
         if ( attacker.SwitchAnimation( Monster_Info::RANG_TOP + direction * 2 ) ) {
+            // Reset the delay to wait till the next frame.
+            Game::AnimateResetDelay( Game::DelayType::CUSTOM_DELAY );
+
             AnimateUnitWithDelay( attacker, Game::ApplyBattleSpeed( attacker.animation.getShootingSpeed() ) );
         }
 
@@ -3199,6 +3188,9 @@ void Battle::Interface::RedrawActionAttackPart1( Unit & attacker, Unit & defende
 
         // redraw melee attack animation
         if ( attacker.SwitchAnimation( attackAnim ) ) {
+            // Reset the delay to wait till the next frame.
+            Game::AnimateResetDelay( Game::DelayType::BATTLE_FRAME_DELAY );
+
             RedrawTroopDefaultDelay( attacker );
         }
     }
@@ -3220,6 +3212,10 @@ void Battle::Interface::RedrawActionAttackPart2( Unit & attacker, const TargetsI
 
     // targets damage animation
     RedrawActionWincesKills( targets, &attacker );
+
+    // Reset the delay to wait till the next frame.
+    Game::AnimateResetDelay( Game::DelayType::BATTLE_FRAME_DELAY );
+
     RedrawTroopDefaultDelay( attacker );
 
     attacker.SwitchAnimation( Monster_Info::STATIC );
@@ -3451,6 +3447,9 @@ void Battle::Interface::RedrawActionMove( Unit & unit, const Indexes & path )
     unit.SwitchAnimation( Monster_Info::MOVING );
     const uint32_t movementFrames = static_cast<uint32_t>( unit.animation.animationLength() );
 
+    // Reset the delay to wait till the next frame.
+    Game::AnimateResetDelay( Game::DelayType::CUSTOM_DELAY );
+
     // Slowed flying creature has to fly off.
     if ( canFly ) {
         // If a flying creature has to cross the bridge during its path we have to open it before the creature flyes up.
@@ -3635,6 +3634,10 @@ void Battle::Interface::RedrawActionFly( Unit & unit, const Position & pos )
 
     unit.SwitchAnimation( Monster_Info::FLY_UP );
     AudioManager::PlaySound( unit.M82Tkof() );
+
+    // Reset the delay to wait till the next frame.
+    Game::AnimateResetDelay( Game::DelayType::CUSTOM_DELAY );
+
     // Take off animation should have the same between frame delay as the movement animation.
     AnimateUnitWithDelay( unit, frameDelay * static_cast<uint32_t>( unit.animation.animationLength() ) / movementFrames );
 
@@ -3728,6 +3731,9 @@ void Battle::Interface::RedrawActionSpellCastPart1( const Spell & spell, int32_t
     if ( caster ) {
         OpponentSprite * opponent = caster->GetColor() == arena.GetArmy1Color() ? opponent1 : opponent2;
         if ( opponent ) {
+            // Reset the delay to wait till the next frame.
+            Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
+
             opponent->SetAnimation( spell.isApplyWithoutFocusObject() ? OP_CAST_MASS : OP_CAST_UP );
             AnimateOpponents( opponent );
         }
@@ -3878,6 +3884,9 @@ void Battle::Interface::RedrawActionSpellCastPart1( const Spell & spell, int32_t
     if ( caster ) {
         OpponentSprite * opponent = caster->GetColor() == arena.GetArmy1Color() ? opponent1 : opponent2;
         if ( opponent ) {
+            // Reset the delay to wait till the next frame.
+            Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
+
             opponent->SetAnimation( ( target != nullptr ) ? OP_CAST_UP_RETURN : OP_CAST_MASS_RETURN );
             AnimateOpponents( opponent );
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3268,6 +3268,11 @@ void Battle::Interface::RedrawActionAttackPart2( Unit & attacker, const TargetsI
 
 void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Unit * attacker /* = nullptr */ )
 {
+    // Reset the delay to wait till the next frame.
+    if ( !Game::isDelayNeeded( { Game::DelayType::BATTLE_FRAME_DELAY } ) ) {
+        Game::AnimateResetDelay( Game::DelayType::BATTLE_FRAME_DELAY );
+    }
+
     LocalEvent & le = LocalEvent::Get();
 
     // targets damage animation

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -109,7 +109,10 @@ namespace Battle
 
         fheroes2::Point GetCastPosition() const;
         void Redraw( fheroes2::Image & dst ) const;
-        void Update();
+
+        // Return true is animation state was changed.
+        bool updateAnimationState();
+
         void SetAnimation( int rule );
         void IncreaseAnimFrame( bool loop = false );
 

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -243,7 +243,7 @@ void Castle::OpenWell()
     display.render();
 
     LocalEvent & le = LocalEvent::Get();
-    while ( le.HandleEvents() ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::CASTLE_UNIT_DELAY } ) ) ) {
         le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
 
         le.MousePressLeft( buttonMax.area() ) ? buttonMax.drawOnPress() : buttonMax.drawOnRelease();

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -220,10 +220,10 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
     LocalEvent & le = LocalEvent::Get();
     int result = Dialog::ZERO;
 
-    display.render();
+    display.render( restorer.rect() );
 
     // dialog menu loop
-    while ( le.HandleEvents() ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::CASTLE_UNIT_DELAY } ) ) ) {
         if ( flags & BUTTONS ) {
             if ( buttonUpgrade.isEnabled() )
                 le.MousePressLeft( buttonUpgrade.area() ) ? buttonUpgrade.drawOnPress() : buttonUpgrade.drawOnRelease();
@@ -288,7 +288,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
                 if ( buttonExit.isEnabled() )
                     buttonExit.draw();
 
-                display.render();
+                display.render( restorer.rect() );
             }
         }
         else {

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -613,7 +613,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile, const bool ignoreHeroOnTile )
 
     outputInTextSupportMode( tile, name_object );
 
-    display.render();
+    display.render( restorer.rect() );
 
     // quick info loop
     while ( le.HandleEvents() && le.MousePressRight() )
@@ -621,7 +621,7 @@ void Dialog::QuickInfo( const Maps::Tiles & tile, const bool ignoreHeroOnTile )
 
     // restore background
     restorer.restore();
-    display.render();
+    display.render( restorer.rect() );
 }
 
 void Dialog::QuickInfo( const Castle & castle, const fheroes2::Point & position /* = {} */, const bool showOnRadar /* = false */,

--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -362,7 +362,7 @@ Troop Dialog::RecruitMonster( const Monster & monster0, uint32_t available, cons
     monsterSwitchLeft.draw();
     monsterSwitchRight.draw();
 
-    display.render();
+    display.render( back.rect() );
 
     std::vector<Monster> upgrades = { monster0 };
     while ( upgrades.back().GetDowngrade() != upgrades.back() ) {
@@ -528,7 +528,7 @@ Troop Dialog::RecruitMonster( const Monster & monster0, uint32_t available, cons
             monsterSwitchLeft.draw();
             monsterSwitchRight.draw();
 
-            display.render();
+            display.render( back.rect() );
         }
 
         if ( buttonOk.isEnabled() && ( le.MouseClickLeft( buttonOk.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) ) )
@@ -541,7 +541,7 @@ Troop Dialog::RecruitMonster( const Monster & monster0, uint32_t available, cons
     }
 
     back.restore();
-    display.render();
+    display.render( back.rect() );
 
     return Troop( monster, result );
 }

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -715,6 +715,11 @@ void Game::ShowCredits()
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
+    // Immediately indicate that the delay has passed to render first frame immediately.
+    Game::passCustomAnimationDelay( animationDelay );
+    // Make sure that the first run is passed immediately.
+    assert( !Game::isCustomDelayNeeded( animationDelay ) );
+
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents( Game::isCustomDelayNeeded( animationDelay ) ) ) {
         if ( le.KeyPress() || le.MouseClickLeft() || le.MouseClickMiddle() || le.MouseClickRight() )

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -157,7 +157,15 @@ bool Game::validateAnimationDelay( const DelayType delayType )
 
 void Game::passAnimationDelay( const DelayType delayType )
 {
+    assert( delayType != Game::DelayType::CUSTOM_DELAY );
+
     delays[delayType].pass();
+}
+
+void Game::passCustomAnimationDelay( const uint64_t delayMs )
+{
+    delays[Game::DelayType::CUSTOM_DELAY].setDelay( delayMs );
+    delays[Game::DelayType::CUSTOM_DELAY].pass();
 }
 
 void Game::UpdateGameSpeed()

--- a/src/fheroes2/game/game_delays.h
+++ b/src/fheroes2/game/game_delays.h
@@ -70,8 +70,11 @@ namespace Game
     // If custom delay (DelayType::CUSTOM_DELAY) is passed reset it and return true. Otherwise return false.
     bool validateCustomAnimationDelay( const uint64_t delayMs );
 
-    // Explicitly pass delay. Useful for loops when first iterator must pass.
+    // Explicitly pass delay. Useful for loops when first iterator must pass. DelayType::CUSTOM_DELAY must not be passed!
     void passAnimationDelay( const DelayType delayType );
+
+    // Explicitly pass custom delay. Useful for loops when first iterator must pass.
+    void passCustomAnimationDelay( const uint64_t delayMs );
 
     void AnimateResetDelay( const DelayType delayType );
     void UpdateGameSpeed();

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -281,7 +281,7 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
     }
 
     LocalEvent & le = LocalEvent::Get();
-    while ( le.HandleEvents() ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::MAPS_DELAY } ) ) ) {
         le.MousePressLeft( buttonOtherHighScore.area() ) ? buttonOtherHighScore.drawOnPress() : buttonOtherHighScore.drawOnRelease();
         le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
 

--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -216,7 +216,7 @@ int32_t Interface::Basic::GetDimensionDoorDestination( const int32_t from, const
     LocalEvent & le = LocalEvent::Get();
     int32_t returnValue = -1;
 
-    while ( le.HandleEvents() ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::MAPS_DELAY } ) ) ) {
         const fheroes2::Point & mp = le.GetMouseCursor();
 
         if ( radarRect & mp ) {

--- a/src/fheroes2/game/game_logo.cpp
+++ b/src/fheroes2/game/game_logo.cpp
@@ -20,6 +20,7 @@
 
 #include "game_logo.h"
 
+#include <cassert>
 #include <cstdint>
 
 #include "game_delays.h"
@@ -53,6 +54,11 @@ void fheroes2::showTeamInfo()
 
     uint8_t alpha = 250;
     const uint64_t animationDelay = 40;
+
+    // Immediately indicate that the delay has passed to render first frame immediately.
+    Game::passCustomAnimationDelay( animationDelay );
+    // Make sure that the first run is passed immediately.
+    assert( !Game::isCustomDelayNeeded( animationDelay ) );
 
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents( Game::isCustomDelayNeeded( animationDelay ) ) && alpha > 20 ) {

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -292,6 +292,11 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
     Cursor::Get().setVideoPlaybackCursor();
 
+    // Immediately indicate that the delay has passed to render first frame immediately.
+    Game::passCustomAnimationDelay( customDelay );
+    // Make sure that the first run is passed immediately.
+    assert( !Game::isCustomDelayNeeded( customDelay ) );
+
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents( Game::isCustomDelayNeeded( customDelay ) ) ) {
         if ( le.MouseClickLeft( campaignRoi[0] ) || HotKeyPressEvent( HotKeyEvent::CAMPAIGN_ROLAND ) ) {
@@ -391,6 +396,11 @@ fheroes2::GameMode Game::NewPriceOfLoyaltyCampaign()
 
     fheroes2::GameMode gameChoice = fheroes2::GameMode::NEW_CAMPAIGN_SELECTION;
     uint64_t customDelay = 0;
+
+    // Immediately indicate that the delay has passed to render first frame immediately.
+    Game::passCustomAnimationDelay( customDelay );
+    // Make sure that the first run is passed immediately.
+    assert( !Game::isCustomDelayNeeded( customDelay ) );
 
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents( highlightCampaignId < videos.size() ? Game::isCustomDelayNeeded( customDelay ) : true ) ) {

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <array>
+#include <cassert>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -18,6 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <ostream>
@@ -132,7 +133,9 @@ namespace Video
 
         bool isFrameReady = false;
 
-        Game::passAnimationDelay( Game::CUSTOM_DELAY );
+        Game::passCustomAnimationDelay( delay );
+        // Make sure that the first run is passed immediately.
+        assert( !Game::isCustomDelayNeeded( delay ) );
 
         bool userMadeAction = false;
 

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -1047,7 +1047,7 @@ void Interface::GameArea::runSingleObjectAnimation( const std::shared_ptr<BaseOb
     fheroes2::Display & display = fheroes2::Display::instance();
     Interface::Basic & basicInterface = Interface::Basic::Get();
 
-    while ( le.HandleEvents() && !info->isAnimationCompleted() ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::HEROES_PICKUP_DELAY } ) ) && !info->isAnimationCompleted() ) {
         if ( Game::validateAnimationDelay( Game::HEROES_PICKUP_DELAY ) ) {
             basicInterface.Redraw( Interface::REDRAW_GAMEAREA );
             display.render();

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -328,13 +328,16 @@ namespace fheroes2
         const uint8_t min = step + 5;
         const int stepDelay = ( delayMs * step ) / ( alpha - min );
 
+        const fheroes2::Rect roi{ pos.x, pos.y, shadow.width(), shadow.height() };
+
         while ( alpha > min + endAlpha ) {
             ApplyAlpha( top, shadow, alpha );
-            Copy( shadow, 0, 0, display, pos.x, pos.y, shadow.width(), shadow.height() );
+            Copy( shadow, 0, 0, display, roi.x, roi.y, roi.width, roi.height );
 
-            display.render();
+            display.render( roi );
 
             alpha -= step;
+            // TODO: we should deduct from sleeping delay the time we spent for preparing and rendering the frame.
             delayforMs( stepDelay );
         }
     }
@@ -345,13 +348,14 @@ namespace fheroes2
         const int stepDelay = delayMs / frameCount;
 
         Image shadow = top;
+        const fheroes2::Rect roi{ pos.x, pos.y, shadow.width(), shadow.height() };
 
         for ( int i = 0; i < frameCount; ++i ) {
             ApplyPalette( shadow, paletteId );
-            Copy( shadow, 0, 0, display, pos.x, pos.y, shadow.width(), shadow.height() );
+            Copy( shadow, 0, 0, display, roi.x, roi.y, roi.width, roi.height );
 
-            display.render();
-
+            display.render( roi );
+            // TODO: we should deduct from sleeping delay the time we spent for preparing and rendering the frame.
             delayforMs( stepDelay );
         }
     }
@@ -375,8 +379,8 @@ namespace fheroes2
         for ( int i = 0; i < frameCount; ++i ) {
             InvertedShadow( image, roi, excludedRoi, paletteId, 1 );
 
-            display.render();
-
+            display.render( roi );
+            // TODO: we should deduct from sleeping delay the time we spent for preparing and rendering the frame.
             delayforMs( stepDelay );
         }
     }


### PR DESCRIPTION
- all event loops during battle animations did not check whether it is allowed to do rendering within handle event loop
- custom delays were not reset properly causing slight delays in first frame to be rendered. Video playback was affected the most
- avoid excessive rendering for multiple windows. Render only the area which was changed
- add todo comments for the future changes
- some animations during battle did not play the last frame like monster animation, hero's animation and hero's flag animation
- small code cleanup