### PR TITLE
Optimize Death Wave spell effect rendering. Battlefield.

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4857,9 +4857,13 @@ void Battle::Interface::RedrawActionDeathWaveSpell( const int32_t strength )
 
     fheroes2::Rect area = GetArea();
     // Cut out the battle log image so we don't use it in the death wave effect.
-    area.height -= 36;
+    area.height -= status.height;
+    // And if listlog is open, then cut off it too.
+    if ( listlog && listlog->isOpenLog() ) {
+        area.height -= listlog->GetArea().height;
+    }
 
-    const fheroes2::Sprite & copy = fheroes2::Crop( _mainSurface, area.x, area.y, area.width, area.height );
+    const fheroes2::Sprite & battleFieldCopy = fheroes2::Crop( _mainSurface, area.x, area.y, area.width, area.height );
     // The death wave horizontal length in pixels.
     const int32_t waveLength = 38;
     const int32_t waveStep = 5;
@@ -4875,36 +4879,35 @@ void Battle::Interface::RedrawActionDeathWaveSpell( const int32_t strength )
         deathWaveCurve.push_back( static_cast<int32_t>( std::round( strength * ( cos( posX / waveLimit ) / 2 - 0.5 ) ) ) - 1 );
     }
 
-    AudioManager::PlaySound( M82::MNRDEATH );
-
     // Take into account that the Death Wave starts outside the battle screen.
     area.x -= waveLength;
     // The first frame of spell effect must have a part of the spell, so we start from its first position.
     int32_t position = waveStep;
     fheroes2::Display & display = fheroes2::Display::instance();
 
+    // Prepare the blank image for the Death Wave spell effect with the transform layer equal to "0"
+    fheroes2::Image spellEffect( waveLength, area.height );
+    std::fill( spellEffect.transform(), spellEffect.transform() + static_cast<size_t>( waveLength * area.height ), static_cast<uint8_t>( 0 ) );
+
+    AudioManager::PlaySound( M82::MNRDEATH );
+
     while ( le.HandleEvents() && position < area.width + waveLength ) {
         CheckGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
             const int32_t wavePositionX = ( area.x + position < 0 ) ? 0 : ( area.x + position );
+            const int32_t waveWidth = position > waveLength ? ( position > area.width ? ( waveLength - position + area.width ) : waveLength ) : position;
             const int32_t restorePositionX = ( wavePositionX < waveStep ) ? 0 : ( wavePositionX - waveStep );
             const int32_t restoreWidth = wavePositionX < waveStep ? wavePositionX : waveStep;
 
-            const fheroes2::Image spellEffect = fheroes2::CreateDeathWaveEffect( copy, position, deathWaveCurve );
-
-            const fheroes2::Rect renderArea( _interfacePosition.x + restorePositionX, _interfacePosition.y + area.y, spellEffect.width() + restoreWidth, area.height );
+            const fheroes2::Rect renderArea( _interfacePosition.x + restorePositionX, _interfacePosition.y + area.y, waveWidth + restoreWidth, area.height );
 
             // Place a copy of the original image where the Death Wave effect was on the previous frame.
-            fheroes2::Blit( copy, restorePositionX, area.y, display, renderArea.x, renderArea.y, restoreWidth, renderArea.height );
+            fheroes2::Blit( battleFieldCopy, restorePositionX, area.y, display, renderArea.x, renderArea.y, restoreWidth, renderArea.height );
 
             // Place the Death Wave effect to its new position.
-            fheroes2::Blit( spellEffect, display, renderArea.x + restoreWidth, renderArea.y );
-
-            // If the battle log was open we redraw it.
-            if ( listlog && listlog->isOpenLog() ) {
-                listlog->Redraw();
-            }
+            fheroes2::CreateDeathWaveEffect( spellEffect, battleFieldCopy, position, deathWaveCurve );
+            fheroes2::Blit( spellEffect, 0, 0, display, renderArea.x + restoreWidth, renderArea.y, waveWidth, area.height );
 
             // Render only the changed screen area.
             display.render( renderArea );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4863,7 +4863,9 @@ void Battle::Interface::RedrawActionDeathWaveSpell( const int32_t strength )
         area.height -= listlog->GetArea().height;
     }
 
-    const fheroes2::Sprite & battleFieldCopy = fheroes2::Crop( _mainSurface, area.x, area.y, area.width, area.height );
+    fheroes2::Image battleFieldCopy( area.width, area.height );
+    fheroes2::Copy( _mainSurface, 0, 0, battleFieldCopy, 0, 0, area.width, area.height );
+
     // The death wave horizontal length in pixels.
     const int32_t waveLength = 38;
     const int32_t waveStep = 5;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -349,6 +349,7 @@ namespace Battle
 
         bool IdleTroopsAnimation() const;
         void ResetIdleTroopAnimation() const;
+        void SwitchAllUnitsAnimation( const int32_t animationState ) const;
         void UpdateContourColor();
         void CheckGlobalEvents( LocalEvent & );
         void SetHeroAnimationReactionToTroopDeath( const int32_t deathColor );

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -228,7 +228,7 @@ namespace fheroes2
     Image CreateDeathWaveEffect( const Image & in, const int32_t x, const std::vector<int32_t> & deathWaveCurve )
     {
         if ( in.empty() ) {
-            return Image();
+            return {};
         }
 
         const int32_t inWidth = in.width();
@@ -236,7 +236,7 @@ namespace fheroes2
 
         // If the death wave curve is outside of the battlefield - return an empty image.
         if ( x < 0 || ( x - waveWidth ) >= inWidth || deathWaveCurve.empty() ) {
-            return Image();
+            return {};
         }
 
         const int32_t height = in.height();

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -20,6 +20,7 @@
 
 #include "ui_tool.h"
 
+#include <algorithm>
 #include <cassert>
 #include <chrono>
 #include <cmath>

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -109,7 +109,7 @@ namespace fheroes2
         const bool isOriginalEvilInterface;
     };
 
-    Image CreateDeathWaveEffect( const Image & in, const int32_t x, const std::vector<int32_t> & deathWaveCurve );
+    void CreateDeathWaveEffect( Image & out, const Image & in, const int32_t x, const std::vector<int32_t> & deathWaveCurve );
 
     Image CreateRippleEffect( const Image & in, int32_t frameId, double scaleX = 0.05, double waveFrequency = 20.0 );
 


### PR DESCRIPTION
Reworked the rendering of the Death Wave spell effect. Now the game only renders the part of the screen where the effect is located.
Also in this PR before the spell effect, all creatures are now forced to stop their `IDLE` animation and their unit counter is now turned off, as it is not so aesthetic when the creature freezes in some `IDLE` pose during the spell animation and when the unit counters, that are part of the user interface , are distorted by the spell. The same applies to the Holy Shout spell.

<details><summary>A video of the Death Wave spell effect</summary>

https://user-images.githubusercontent.com/113276641/209446836-30a4f65d-3acd-4739-ba2d-0040ca8fde31.mp4

</details>