### PR TITLE
WIP: improve PS Vita rendering speed

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -940,6 +940,8 @@ namespace
 
         void clear() override
         {
+            linkRenderSurface( nullptr );
+
             if ( _texture != nullptr ) {
                 SDL_DestroyTexture( _texture );
                 _texture = nullptr;

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -748,13 +748,11 @@ namespace
         {
             updatePalette( StandardPaletteIndexes() );
 
-            // copy the image from display buffer to SDL surface
             const fheroes2::Display & display = fheroes2::Display::instance();
             const int32_t imageWidth = display.width();
             const int32_t imageHeight = display.height();
             const uint8_t * imageIn = display.image();
 
-            // Display class doesn't have support for image pitch so we mustn't link display to surface if width is not divisible by 4.
             if ( _isLinkedSurface ) {
                 memcpy( _palettedTexturePointer, display.image(), static_cast<size_t>( imageWidth * imageHeight ) );
                 linkRenderSurface( _palettedTexturePointer );

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -600,6 +600,8 @@ namespace
 
         void clear() override
         {
+            linkRenderSurface( nullptr );
+
             if ( _window != nullptr ) {
                 SDL_DestroyWindow( _window );
                 _window = nullptr;


### PR DESCRIPTION
PS Vita `RenderEngine` implementation is based on 8-bit images. `fheroes2::Display` class supports linking an 8-bit array to its image layer avoiding the need to copy the image into a rendering surface (texture).