### PR TITLE
Update SDL 2 rendering code

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1040,7 +1040,7 @@ namespace
             bool isPaletteModeSupported = false;
 
             SDL_RendererInfo rendererInfo;
-            _driverIndex = 0;
+            _driverIndex = -1;
 
             const uint32_t renderingFlags = renderFlags();
 
@@ -1060,14 +1060,17 @@ namespace
                     if ( rendererInfo.texture_formats[i] == SDL_PIXELFORMAT_INDEX8 ) {
                         // Bingo! This is the best driver and format.
                         isPaletteModeSupported = true;
+                        _driverIndex = driverId;
                         break;
                     }
                 }
 
-                _driverIndex = driverId;
-
                 if ( isPaletteModeSupported ) {
                     break;
+                }
+
+                if ( _driverIndex < 0 ) {
+                    _driverIndex = driverId;
                 }
             }
 

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -944,8 +944,6 @@ namespace
             if ( _surface == nullptr )
                 return;
 
-            copyImageToSurface( display, _surface, roi );
-
             if ( _texture == nullptr ) {
                 if ( _renderer != nullptr )
                     SDL_DestroyRenderer( _renderer );
@@ -955,42 +953,45 @@ namespace
                 if ( _renderer == nullptr ) {
                     ERROR_LOG( "Failed to create a window renderer. The error: " << SDL_GetError() )
                 }
+
+                return;
             }
-            else {
-                const bool fullFrame = ( roi.width == display.width() ) && ( roi.height == display.height() );
-                if ( fullFrame ) {
-                    int returnCode = SDL_UpdateTexture( _texture, nullptr, _surface->pixels, _surface->pitch );
-                    if ( returnCode < 0 ) {
-                        ERROR_LOG( "Failed to update texture. The error value: " << returnCode << ", description: " << SDL_GetError() )
-                    }
 
-                    returnCode = SDL_RenderClear( _renderer );
-                    if ( returnCode < 0 ) {
-                        ERROR_LOG( "Failed to clear render. The error value: " << returnCode << ", description: " << SDL_GetError() )
-                        return;
-                    }
-                }
-                else {
-                    SDL_Rect area;
-                    area.x = roi.x;
-                    area.y = roi.y;
-                    area.w = roi.width;
-                    area.h = roi.height;
+            copyImageToSurface( display, _surface, roi );
 
-                    int returnCode = SDL_UpdateTexture( _texture, &area, _surface->pixels, _surface->pitch );
-                    if ( returnCode < 0 ) {
-                        ERROR_LOG( "Failed to update texture. The error value: " << returnCode << ", description: " << SDL_GetError() )
-                    }
-                }
-
-                const int returnCode = SDL_RenderCopy( _renderer, _texture, nullptr, nullptr );
+            const bool fullFrame = ( roi.width == display.width() ) && ( roi.height == display.height() );
+            if ( fullFrame ) {
+                int returnCode = SDL_UpdateTexture( _texture, nullptr, _surface->pixels, _surface->pitch );
                 if ( returnCode < 0 ) {
-                    ERROR_LOG( "Failed to copy render.The error value: " << returnCode << ", description: " << SDL_GetError() )
+                    ERROR_LOG( "Failed to update texture. The error value: " << returnCode << ", description: " << SDL_GetError() )
+                }
+
+                returnCode = SDL_RenderClear( _renderer );
+                if ( returnCode < 0 ) {
+                    ERROR_LOG( "Failed to clear render. The error value: " << returnCode << ", description: " << SDL_GetError() )
                     return;
                 }
-
-                SDL_RenderPresent( _renderer );
             }
+            else {
+                SDL_Rect area;
+                area.x = roi.x;
+                area.y = roi.y;
+                area.w = roi.width;
+                area.h = roi.height;
+
+                int returnCode = SDL_UpdateTexture( _texture, &area, _surface->pixels, _surface->pitch );
+                if ( returnCode < 0 ) {
+                    ERROR_LOG( "Failed to update texture. The error value: " << returnCode << ", description: " << SDL_GetError() )
+                }
+            }
+
+            const int returnCode = SDL_RenderCopy( _renderer, _texture, nullptr, nullptr );
+            if ( returnCode < 0 ) {
+                ERROR_LOG( "Failed to copy render.The error value: " << returnCode << ", description: " << SDL_GetError() )
+                return;
+            }
+
+            SDL_RenderPresent( _renderer );
         }
 
         bool allocate( int32_t & width_, int32_t & height_, bool isFullScreen ) override

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1044,9 +1044,6 @@ namespace
 
             const uint32_t renderingFlags = renderFlags();
 
-            bool bestRGBFormatFound = false;
-            bool bestARGBFormatFound = false;
-
             const int driverCount = SDL_GetNumRenderDrivers();
             for ( int driverId = 0; driverId < driverCount; ++driverId ) {
                 int returnCode = SDL_GetRenderDriverInfo( driverId, &rendererInfo );
@@ -1063,20 +1060,11 @@ namespace
                     if ( rendererInfo.texture_formats[i] == SDL_PIXELFORMAT_INDEX8 ) {
                         // Bingo! This is the best driver and format.
                         isPaletteModeSupported = true;
-                        _driverIndex = driverId;
                         break;
                     }
-
-                    if ( rendererInfo.texture_formats[i] == SDL_PIXELFORMAT_XRGB8888 && !bestRGBFormatFound ) {
-                        bestRGBFormatFound = true;
-                        bestARGBFormatFound = true;
-                        _driverIndex = driverId;
-                    }
-                    else if ( rendererInfo.texture_formats[i] == SDL_PIXELFORMAT_ARGB8888 && !bestARGBFormatFound ) {
-                        bestARGBFormatFound = true;
-                        _driverIndex = driverId;
-                    }
                 }
+
+                _driverIndex = driverId;
 
                 if ( isPaletteModeSupported ) {
                     break;
@@ -1245,7 +1233,7 @@ namespace
                 return false;
             }
 
-            _texture = SDL_CreateTexture( _renderer, SDL_PIXELFORMAT_XRGB8888, SDL_TEXTUREACCESS_STATIC, width_, height_ );
+            _texture = SDL_CreateTextureFromSurface( _renderer, _surface );
             if ( _texture == nullptr ) {
                 ERROR_LOG( "Failed to create a texture from a surface of " << width_ << " x " << height_ << " size. The error: " << SDL_GetError() )
                 clear();

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1194,16 +1194,7 @@ namespace
 
         bool _createRenderer( const int32_t width_, const int32_t height_ )
         {
-            SDL_RendererInfo rendererInfo;
-            int returnCode = SDL_GetRenderDriverInfo( _driverIndex, &rendererInfo );
-            if ( returnCode < 0 ) {
-                ERROR_LOG( "Failed to get renderer driver info. The error value: " << returnCode << ", description: " << SDL_GetError() )
-            }
-
             const uint32_t renderingFlags = renderFlags();
-            if ( ( renderingFlags & rendererInfo.flags ) != renderingFlags ) {
-                ERROR_LOG( "Chosen rendering driver does not support all rendering flags" )
-            }
 
             // SDL_PIXELFORMAT_INDEX8 is not supported by SDL 2 even being available in the list of formats.
             _renderer = SDL_CreateRenderer( _window, _driverIndex, renderingFlags );
@@ -1213,7 +1204,7 @@ namespace
                 return false;
             }
 
-            returnCode = SDL_SetRenderTarget( _renderer, nullptr );
+            int returnCode = SDL_SetRenderTarget( _renderer, nullptr );
             if ( returnCode < 0 ) {
                 ERROR_LOG( "Failed to set render target to window. The error value: " << returnCode << ", description: " << SDL_GetError() )
             }

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -899,7 +899,7 @@ namespace
             , _surface( nullptr )
             , _renderer( nullptr )
             , _texture( nullptr )
-            , _driverIndex( 0 )
+            , _driverIndex( -1 )
             , _prevWindowPos( SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED )
             , _isVSyncEnabled( false )
         {
@@ -936,7 +936,7 @@ namespace
 
             _windowedSize = fheroes2::Size();
 
-            _driverIndex = 0;
+            _driverIndex = -1;
         }
 
         void render( const fheroes2::Display & display, const fheroes2::Rect & roi ) override

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1245,7 +1245,7 @@ namespace
                 return false;
             }
 
-            _texture = SDL_CreateTexture( _renderer, SDL_PIXELFORMAT_XRGB8888, SDL_TEXTUREACCESS_STATIC, width_, height_ ); // SDL_CreateTextureFromSurface( _renderer, _surface );
+            _texture = SDL_CreateTexture( _renderer, SDL_PIXELFORMAT_XRGB8888, SDL_TEXTUREACCESS_STATIC, width_, height_ );
             if ( _texture == nullptr ) {
                 ERROR_LOG( "Failed to create a texture from a surface of " << width_ << " x " << height_ << " size. The error: " << SDL_GetError() )
                 clear();


### PR DESCRIPTION
- avoid calling **copyImageToSurface()** within `render()` method if it's not necessary (use side-by-side comparison to see that the code is mostly untouched)
- use `SDL_SetRenderTarget()` function only once as we don't change the destination of rendering
- find the most suitable driver as the first driver might not be the correct one (never happened before but just in case)