### PR TITLE
Better support of commandline arguments to check_copyright_headers

### DIFF
--- a/script/tools/check_copyright_headers.py
+++ b/script/tools/check_copyright_headers.py
@@ -13,8 +13,8 @@ CURRENT_YEAR = datetime.datetime.now().date().year
 class CustomArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         self.print_usage(sys.stderr)
-        self.exit(1, '%(prog)s: error: %(message)s\n' %
-                  {'prog': self.prog, 'message': message})
+        self.exit(1, "%(prog)s: error: %(message)s\n" %
+                  {"prog": self.prog, "message": message})
 
 
 def parse_arguments():

--- a/script/tools/check_copyright_headers.py
+++ b/script/tools/check_copyright_headers.py
@@ -2,7 +2,6 @@
 
 import argparse
 import datetime
-from gettext import gettext
 import os
 import re
 import subprocess
@@ -14,7 +13,7 @@ CURRENT_YEAR = datetime.datetime.now().date().year
 class CustomArgumentParser(argparse.ArgumentParser):
     def error(self, message):
         self.print_usage(sys.stderr)
-        self.exit(1, gettext('%(prog)s: error: %(message)s\n') %
+        self.exit(1, '%(prog)s: error: %(message)s\n' %
                   {'prog': self.prog, 'message': message})
 
 

--- a/script/tools/check_copyright_headers.py
+++ b/script/tools/check_copyright_headers.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python3
 
+import argparse
 import datetime
+from gettext import gettext
 import os
 import re
 import subprocess
@@ -8,17 +10,31 @@ import sys
 
 CURRENT_YEAR = datetime.datetime.now().date().year
 
-def main():
-    if len(sys.argv) < 4:
-        print(f"Syntax: {os.path.basename(sys.argv[0])} full_header_file" +
-                                                      " header_template_file" +
-                                                      " source_file ...",
-              file=sys.stderr)
-        return 1
 
-    with open(sys.argv[1], "r", encoding="latin_1") as full_header_file:
+class CustomArgumentParser(argparse.ArgumentParser):
+    def error(self, message):
+        self.print_usage(sys.stderr)
+        self.exit(1, gettext('%(prog)s: error: %(message)s\n') %
+                  {'prog': self.prog, 'message': message})
+
+
+def parse_arguments():
+    parser = CustomArgumentParser()
+    parser.add_argument("full_header_file", help="full header file")
+    parser.add_argument("header_template_file", help="header template file")
+    parser.add_argument("source_file", help="source files (at least one, can be multiple)",
+                        nargs="+")
+    return parser.parse_args()
+
+
+def main():
+    # if something is wrong with the commandline arguments,
+    # the script exits here with return code 1:
+    args = parse_arguments()
+
+    with open(args.full_header_file, "r", encoding="latin_1") as full_header_file:
         copyright_hdr_full = full_header_file.read().strip().replace("{YR}", f"{CURRENT_YEAR}")
-    with open(sys.argv[2], "r", encoding="latin_1") as header_template_file:
+    with open(args.header_template_file, "r", encoding="latin_1") as header_template_file:
         copyright_hdr_tmpl = header_template_file.read().strip()
 
     copyright_hdr_re_tmpl = copyright_hdr_tmpl
@@ -33,7 +49,7 @@ def main():
 
     generic_hdr_re = re.compile("^/\\*.*?\\*/", re.DOTALL)
 
-    for file_name in sys.argv[3:]:
+    for file_name in args.source_file:
         if not os.path.exists(file_name):
             continue
         with open(file_name, "r", encoding="latin_1") as src_file:
@@ -73,7 +89,6 @@ def main():
 
                 os.remove(file_name + ".tmp")
 
-    return 0
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()


### PR DESCRIPTION
Improved support of command line arguments. It allows to simplify future changes and adds auto formatting of usage messages.
Now error message will look like this:

```
usage: check_copyright_headers.py [-h] full_header_file header_template_file source_file [source_file ...]
check_copyright_headers.py: error: the following arguments are required: full_header_file, header_template_file, source_file
```