### PR TITLE
Prepare code for the future Editor

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -310,7 +310,7 @@ namespace
         const Maps::Addons & lowerTileAddons = tileBelow.getLevel2Addons();
 
         for ( const Maps::TilesAddon & lowerAddon : lowerTileAddons ) {
-            if ( lowerAddon.uniq == uid ) {
+            if ( lowerAddon._uid == uid ) {
                 // This is a tall object.
                 return true;
             }
@@ -664,7 +664,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
             topLayerTallObjects.clear();
             for ( const Maps::TilesAddon & addon : tile.getLevel2Addons() ) {
-                if ( isTallTopLayerObject( x, y, addon.uniq ) ) {
+                if ( isTallTopLayerObject( x, y, addon._uid ) ) {
                     topLayerTallObjects.emplace_back( &addon );
                 }
                 else {

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -622,9 +622,9 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
 
             if ( index == 0 ) {
                 TilesAddon * addon = tile.FindAddonLevel2( castleID );
-                if ( addon && MP2::GetICNObject( addon->object ) == ICN::OBJNTWRD ) {
-                    addon->object -= 12;
-                    addon->index = fullTownIndex - 16;
+                if ( addon && MP2::GetICNObject( addon->_objectType ) == ICN::OBJNTWRD ) {
+                    addon->_objectType = MP2::OBJ_ICN_TYPE_OBJNTOWN + ( addon->_objectType % 4 );
+                    addon->_imageIndex = fullTownIndex - 16;
                 }
             }
         }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -616,9 +616,9 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
             Tiles & tile = world.GetTiles( castleTile );
 
             if ( isRandom )
-                tile.ReplaceObjectSprite( castleID, 38, 35 * 4, lookupID, fullTownIndex ); // OBJNTWRD to OBJNTOWN
+                tile.ReplaceObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, 35 * 4, lookupID, fullTownIndex ); // OBJNTWRD to OBJNTOWN
             else
-                tile.UpdateObjectSprite( castleID, 35, 35 * 4, -16 ); // no change in tileset
+                tile.UpdateObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTOWN, 35 * 4, -16 ); // no change in tileset
 
             if ( index == 0 ) {
                 TilesAddon * addon = tile.FindAddonLevel2( castleID );
@@ -632,9 +632,9 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
         const int shadowTile = GetIndexFromAbsPoint( center.x + shadowCoordinates[index][0], center.y + shadowCoordinates[index][1] );
         if ( isValidAbsIndex( shadowTile ) ) {
             if ( isRandom )
-                world.GetTiles( shadowTile ).ReplaceObjectSprite( castleID, 38, 37 * 4, lookupID + 32, fullTownIndex ); // OBJNTWRD to OBJNTWSH
+                world.GetTiles( shadowTile ).ReplaceObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, 37 * 4, lookupID + 32, fullTownIndex ); // OBJNTWRD to OBJNTWSH
             else
-                world.GetTiles( shadowTile ).UpdateObjectSprite( castleID, 37, 37 * 4, -16 ); // no change in tileset
+                world.GetTiles( shadowTile ).UpdateObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWSH, 37 * 4, -16 ); // no change in tileset
         }
     }
 }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -616,9 +616,9 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
             Tiles & tile = world.GetTiles( castleTile );
 
             if ( isRandom )
-                tile.ReplaceObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, 35 * 4, lookupID, fullTownIndex ); // OBJNTWRD to OBJNTOWN
+                tile.ReplaceObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, ( MP2::OBJ_ICN_TYPE_OBJNTOWN << 2 ), lookupID, fullTownIndex ); // OBJNTWRD to OBJNTOWN
             else
-                tile.UpdateObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTOWN, 35 * 4, -16 ); // no change in tileset
+                tile.UpdateObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTOWN, ( MP2::OBJ_ICN_TYPE_OBJNTOWN << 2 ), -16 ); // no change in tileset
 
             if ( index == 0 ) {
                 TilesAddon * addon = tile.FindAddonLevel2( castleID );
@@ -629,12 +629,13 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
             }
         }
 
-        const int shadowTile = GetIndexFromAbsPoint( center.x + shadowCoordinates[index][0], center.y + shadowCoordinates[index][1] );
-        if ( isValidAbsIndex( shadowTile ) ) {
+        const int shadowTileId = GetIndexFromAbsPoint( center.x + shadowCoordinates[index][0], center.y + shadowCoordinates[index][1] );
+        if ( isValidAbsIndex( shadowTileId ) ) {
+            Maps::Tiles & shadowTile = world.GetTiles( shadowTileId );
             if ( isRandom )
-                world.GetTiles( shadowTile ).ReplaceObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, 37 * 4, lookupID + 32, fullTownIndex ); // OBJNTWRD to OBJNTWSH
+                shadowTile.ReplaceObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, ( MP2::OBJ_ICN_TYPE_OBJNTWSH << 2 ), lookupID + 32, fullTownIndex );
             else
-                world.GetTiles( shadowTile ).UpdateObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWSH, 37 * 4, -16 ); // no change in tileset
+                shadowTile.UpdateObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWSH, ( MP2::OBJ_ICN_TYPE_OBJNTWSH << 2 ), -16 ); // no change in tileset
         }
     }
 }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -473,8 +473,8 @@ namespace
 Maps::TilesAddon::TilesAddon()
     : _uid( 0 )
     , _layerType( OBJECT_LAYER )
-    , _objectType( 0 )
-    , _imageIndex( 0 )
+    , _objectType( MP2::OBJ_ICN_TYPE_UNKNOWN )
+    , _imageIndex( 255 )
 {}
 
 Maps::TilesAddon::TilesAddon( const uint8_t lv, const uint32_t uid, const uint8_t obj, const uint8_t index_ )

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -645,11 +645,11 @@ bool Maps::Tiles::isShadowSprite( const uint8_t tileset, const uint8_t icnIndex 
 void Maps::Tiles::UpdateAbandonedMineLeftSprite( uint8_t & tileset, uint8_t & index, const int resource )
 {
     if ( ICN::OBJNGRAS == MP2::GetICNObject( tileset ) && 6 == index ) {
-        tileset = 128; // MTNGRAS
+        tileset = ( MP2::OBJ_ICN_TYPE_MTNGRAS << 2 );
         index = 82;
     }
     else if ( ICN::OBJNDIRT == MP2::GetICNObject( tileset ) && 8 == index ) {
-        tileset = 104; // MTNDIRT
+        tileset = ( MP2::OBJ_ICN_TYPE_MTNDIRT << 2 );
         index = 112;
     }
     else if ( ICN::EXTRAOVR == MP2::GetICNObject( tileset ) && 5 == index ) {
@@ -678,11 +678,11 @@ void Maps::Tiles::UpdateAbandonedMineLeftSprite( uint8_t & tileset, uint8_t & in
 void Maps::Tiles::UpdateAbandonedMineRightSprite( uint8_t & tileset, uint8_t & index )
 {
     if ( ICN::OBJNDIRT == MP2::GetICNObject( tileset ) && index == 9 ) {
-        tileset = 104;
+        tileset = ( MP2::OBJ_ICN_TYPE_MTNDIRT << 2 );
         index = 113;
     }
     else if ( ICN::OBJNGRAS == MP2::GetICNObject( tileset ) && index == 7 ) {
-        tileset = 128;
+        tileset = ( MP2::OBJ_ICN_TYPE_MTNGRAS << 2 );
         index = 83;
     }
 }
@@ -1872,7 +1872,7 @@ void Maps::Tiles::updateFlag( const int color, const uint8_t objectSpriteIndex, 
         return;
     }
 
-    const uint8_t objectType = 0x38;
+    const uint8_t objectType = ( MP2::OBJ_ICN_TYPE_FLAG32 << 2 );
 
     TilesAddon * addon = getAddonWithFlag( uid );
     if ( addon != nullptr ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -66,43 +66,6 @@ namespace Maps
         TERRAIN_LAYER = 3 // roads, water flaws and cracks. Essentially everything what is a part of terrain.
     };
 
-    struct TileObjectPartInfo
-    {
-        TileObjectPartInfo() = default;
-
-        TileObjectPartInfo( const uint32_t uid_, const uint8_t layerType_, const uint8_t objectType_, const uint8_t imageIndex_, const uint8_t extraInfo_ )
-            : uid( uid_ )
-            , layerType( layerType_ )
-            , objectType( objectType_ )
-            , imageIndex( imageIndex_ )
-            , extraInfo( extraInfo_ )
-        {
-            // Do nothing.
-        }
-
-        TileObjectPartInfo( const TileObjectPartInfo & ) = default;
-
-        ~TileObjectPartInfo() = default;
-
-        TileObjectPartInfo & operator=( const TileObjectPartInfo & ) = delete;
-
-        // Unique identifier of an object. UID can be shared among multiple object parts if an object is bigger than 1 tile.
-        uint32_t uid{ 0 };
-
-        // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
-        uint8_t layerType{ OBJECT_LAYER };
-
-        // The type of object which correlates to ICN id. See MP2::GetICNObject() function for mor details.
-        uint8_t objectType{ 0 };
-
-        // Image index to define which part of the object is the current tile. It is always used in tandem with objectType.
-        uint8_t imageIndex{ 0 };
-
-        // First 2 bits which are used to indicate road and overlay(?).
-        // TODO: verify what both bits do.
-        uint8_t extraInfo{ 0 };
-    };
-
     struct TilesAddon
     {
         TilesAddon();
@@ -166,7 +129,7 @@ namespace Maps
 
         MP2::MapObjectType GetObject( bool ignoreObjectUnderHero = true ) const;
 
-        uint8_t GetObjectTileset() const
+        uint8_t getObjectType() const
         {
             return _objectType;
         }

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -105,6 +105,7 @@ namespace Maps
         uint8_t _layerType;
 
         // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
+        // First 2 bits are used for marking a tile as a road and indicating that the object has animation.
         uint8_t _objectType;
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
@@ -435,6 +436,7 @@ namespace Maps
         uint8_t _layerType{ OBJECT_LAYER };
 
         // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
+        // First 2 bits are used for marking a tile as a road and indicating that the object has animation.
         uint8_t _objectType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -116,7 +116,7 @@ namespace Maps
 
         bool isUniq( const uint32_t id ) const
         {
-            return uniq == id;
+            return _uid == id;
         }
 
         bool isRoad() const;
@@ -135,8 +135,11 @@ namespace Maps
 
         static bool PredicateSortRules1( const TilesAddon & ta1, const TilesAddon & ta2 );
 
-        uint32_t uniq;
-        uint8_t level;
+        // Unique identifier of an object. UID can be shared among multiple object parts if an object is bigger than 1 tile.
+        uint32_t _uid;
+
+        // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
+        uint8_t _layerType;
 
         // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
         uint8_t _objectType;
@@ -175,7 +178,7 @@ namespace Maps
 
         uint32_t GetObjectUID() const
         {
-            return uniq;
+            return _uid;
         }
 
         // Get Tile metadata field #1 (used for things like monster count or resource amount)
@@ -340,7 +343,6 @@ namespace Maps
             fog_colors &= ~colors;
         }
 
-        /* monster operation */
         void MonsterSetCount( uint32_t count );
         uint32_t MonsterCount() const;
 
@@ -463,10 +465,14 @@ namespace Maps
         int32_t _index = 0;
         uint16_t pack_sprite_index = 0;
 
-        uint32_t uniq = 0;
+        // Unique identifier of an object. UID can be shared among multiple object parts if an object is bigger than 1 tile.
+        uint32_t _uid{ 0 };
+
+        // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
+        uint8_t _layerType{ OBJECT_LAYER };
 
         // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
-        uint8_t _objectType = 0;
+        uint8_t _objectType{ 0 };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
         uint8_t _imageIndex{ 255 };
@@ -488,8 +494,6 @@ namespace Maps
 
         // This field does not persist in savegame.
         uint32_t _region = REGION_NODE_BLOCKED;
-
-        uint8_t _level = 0;
     };
 
     StreamBase & operator<<( StreamBase &, const TilesAddon & );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -104,8 +104,12 @@ namespace Maps
         // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
         uint8_t _layerType;
 
-        // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
-        // First 2 bits are used for marking a tile as a road and indicating that the object has animation.
+        // Structure containing a flag whether the object's image (sprite) has animation, a flag whether the object is road and
+        // the type of object which correlates to ICN id.
+        // The first bit is a flag whether the object's image (sprite) has animation.
+        // The second bit is a flag whether the object considered as road.
+        // The last 6 bits the type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
+        // TODO: move first 2 bits out of this member to keep only object type.
         uint8_t _objectType;
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
@@ -435,8 +439,12 @@ namespace Maps
         // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
         uint8_t _layerType{ OBJECT_LAYER };
 
-        // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
-        // First 2 bits are used for marking a tile as a road and indicating that the object has animation.
+        // Structure containing a flag whether the object's image (sprite) has animation, a flag whether the object is road and
+        // the type of object which correlates to ICN id.
+        // The first bit is a flag whether the object's image (sprite) has animation.
+        // The second bit is a flag whether the object considered as road.
+        // The last 6 bits the type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
+        // TODO: move first 2 bits out of this member to keep only object type.
         uint8_t _objectType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -472,7 +472,7 @@ namespace Maps
         uint8_t _layerType{ OBJECT_LAYER };
 
         // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
-        uint8_t _objectType{ 0 };
+        uint8_t _objectType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
         uint8_t _imageIndex{ 255 };

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -66,6 +66,43 @@ namespace Maps
         TERRAIN_LAYER = 3 // roads, water flaws and cracks. Essentially everything what is a part of terrain.
     };
 
+    struct TileObjectPartInfo
+    {
+        TileObjectPartInfo() = default;
+
+        TileObjectPartInfo( const uint32_t uid_, const uint8_t layerType_, const uint8_t objectType_, const uint8_t imageIndex_, const uint8_t extraInfo_ )
+            : uid( uid_ )
+            , layerType( layerType_ )
+            , objectType( objectType_ )
+            , imageIndex( imageIndex_ )
+            , extraInfo( extraInfo_ )
+        {
+            // Do nothing.
+        }
+
+        TileObjectPartInfo( const TileObjectPartInfo & ) = default;
+
+        ~TileObjectPartInfo() = default;
+
+        TileObjectPartInfo & operator=( const TileObjectPartInfo & ) = delete;
+
+        // Unique identifier of an object. UID can be shared among multiple object parts if an object is bigger than 1 tile.
+        uint32_t uid{ 0 };
+
+        // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
+        uint8_t layerType{ OBJECT_LAYER };
+
+        // The type of object which correlates to ICN id. See MP2::GetICNObject() function for mor details.
+        uint8_t objectType{ 0 };
+
+        // Image index to define which part of the object is the current tile. It is always used in tandem with objectType.
+        uint8_t imageIndex{ 0 };
+
+        // First 2 bits which are used to indicate road and overlay(?).
+        // TODO: verify what both bits do.
+        uint8_t extraInfo{ 0 };
+    };
+
     struct TilesAddon
     {
         TilesAddon();
@@ -86,7 +123,7 @@ namespace Maps
 
         bool hasSpriteAnimation() const
         {
-            return object & 1;
+            return _objectType & 1;
         }
 
         std::string String( int level ) const;
@@ -100,8 +137,12 @@ namespace Maps
 
         uint32_t uniq;
         uint8_t level;
-        uint8_t object;
-        uint8_t index;
+
+        // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
+        uint8_t _objectType;
+
+        // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
+        uint8_t _imageIndex;
     };
 
     using Addons = std::list<TilesAddon>;
@@ -124,12 +165,12 @@ namespace Maps
 
         uint8_t GetObjectTileset() const
         {
-            return objectTileset;
+            return _objectType;
         }
 
         uint8_t GetObjectSpriteIndex() const
         {
-            return objectIndex;
+            return _imageIndex;
         }
 
         uint32_t GetObjectUID() const
@@ -180,7 +221,7 @@ namespace Maps
 
         bool hasSpriteAnimation() const
         {
-            return objectTileset & 1;
+            return _objectType & 1;
         }
 
         // Checks whether it is possible to move into this tile from the specified direction under the specified conditions
@@ -216,8 +257,8 @@ namespace Maps
 
         void resetObjectSprite()
         {
-            objectTileset = 0;
-            objectIndex = 255;
+            _objectType = 0;
+            _imageIndex = 255;
         }
 
         void FixObject();
@@ -423,8 +464,13 @@ namespace Maps
         uint16_t pack_sprite_index = 0;
 
         uint32_t uniq = 0;
-        uint8_t objectTileset = 0;
-        uint8_t objectIndex = 255;
+
+        // The type of object which correlates to ICN id. See MP2::GetICNObject() function for more details.
+        uint8_t _objectType = 0;
+
+        // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
+        uint8_t _imageIndex{ 255 };
+
         MP2::MapObjectType mp2_object = MP2::OBJ_ZERO;
         uint16_t tilePassable = DIRECTION_ALL;
         uint8_t fog_colors = Color::ALL;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -578,8 +578,8 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
                     // Let's swap the addon and main tile objects
                     std::swap( addon._objectType, _objectType );
                     std::swap( addon._imageIndex, _imageIndex );
-                    std::swap( addon.uniq, uniq );
-                    std::swap( addon.level, _level );
+                    std::swap( addon._uid, _uid );
+                    std::swap( addon._layerType, _layerType );
 
                     break;
                 }
@@ -973,10 +973,10 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
     // If there was another object sprite here (shadow for example) push it down to Addons,
     // except when there is already MONS32.ICN here.
     if ( tile._objectType != 0 && icnId != ICN::MONS32 && tile._imageIndex != 255 ) {
-        tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile.uniq, tile._objectType, tile._imageIndex ) );
+        tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile._uid, tile._objectType, tile._imageIndex ) );
 
-        // replace sprite with the one for the new monster
-        tile.uniq = 0;
+        // TODO: why are we setting UID to 0? It should be unique!
+        tile._uid = 0;
         // TODO: we ignore first 2 bits which might be not 0!
         tile._objectType = 48; // MONS32.ICN
     }

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -432,7 +432,7 @@ Monster Maps::Tiles::QuantityMonster() const
         return Monster( Monster::GHOST );
 
     case MP2::OBJ_MONSTER:
-        return Monster( objectIndex + 1 );
+        return Monster( _imageIndex + 1 );
 
     default:
         break;
@@ -533,7 +533,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
     }
 
     case MP2::OBJ_ARTIFACT: {
-        const int art = Artifact::FromMP2IndexSprite( objectIndex ).GetID();
+        const int art = Artifact::FromMP2IndexSprite( _imageIndex ).GetID();
 
         if ( Artifact::UNKNOWN != art ) {
             if ( art == Artifact::SPELL_SCROLL ) {
@@ -566,18 +566,18 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         // TODO: add a function opposite to MP2::GetICNObject() to return tileset ID.
         const int resourceTileSet = 46;
 
-        if ( ( objectTileset >> 2 ) == resourceTileSet ) {
+        if ( ( _objectType >> 2 ) == resourceTileSet ) {
             // The resource is located at the top.
-            resourceType = Resource::FromIndexSprite( objectIndex );
+            resourceType = Resource::FromIndexSprite( _imageIndex );
         }
         else {
             for ( TilesAddon & addon : addons_level1 ) {
-                if ( ( addon.object >> 2 ) == resourceTileSet ) {
-                    resourceType = Resource::FromIndexSprite( addon.index );
+                if ( ( addon._objectType >> 2 ) == resourceTileSet ) {
+                    resourceType = Resource::FromIndexSprite( addon._imageIndex );
                     // If this happens we are in trouble. It looks like that map maker put the resource under an object which is impossible to do.
                     // Let's swap the addon and main tile objects
-                    std::swap( addon.object, objectTileset );
-                    std::swap( addon.index, objectIndex );
+                    std::swap( addon._objectType, _objectType );
+                    std::swap( addon._imageIndex, _imageIndex );
                     std::swap( addon.uniq, uniq );
                     std::swap( addon.level, _level );
 
@@ -603,7 +603,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
             break;
         default:
             // Some maps have broken resources being put which ideally we need to correct. Let's make them 0 Wood.
-            DEBUG_LOG( DBG_GAME, DBG_WARN, "Tile " << _index << " contains unknown resource type. Tileset " << objectTileset << ", object index " << objectIndex )
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Tile " << _index << " contains unknown resource type. Object type " << _objectType << ", image index " << _imageIndex )
             resourceType = Resource::WOOD;
             count = 0;
             break;
@@ -822,11 +822,11 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         break;
 
     case MP2::OBJ_BARRIER:
-        QuantitySetColor( Tiles::ColorFromBarrierSprite( objectTileset, objectIndex ) );
+        QuantitySetColor( Tiles::ColorFromBarrierSprite( _objectType, _imageIndex ) );
         break;
 
     case MP2::OBJ_TRAVELLERTENT:
-        QuantitySetColor( Tiles::ColorFromTravellerTentSprite( objectTileset, objectIndex ) );
+        QuantitySetColor( Tiles::ColorFromTravellerTentSprite( _objectType, _imageIndex ) );
         break;
 
     case MP2::OBJ_ALCHEMYLAB:
@@ -838,7 +838,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         break;
 
     case MP2::OBJ_MINES: {
-        switch ( objectIndex ) {
+        switch ( _imageIndex ) {
         case 0:
             QuantitySetResource( Resource::ORE, 2 );
             break;
@@ -871,8 +871,9 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
     }
 
     case MP2::OBJ_BOAT:
-        objectTileset = 27;
-        objectIndex = 18;
+        // TODO: this is absolutely wrong to assign this value to object type!
+        _objectType = 27;
+        _imageIndex = 18;
         break;
 
     case MP2::OBJ_EVENT:
@@ -967,19 +968,20 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
 {
     tile.SetObject( MP2::OBJ_MONSTER );
 
-    const int icnId = MP2::GetICNObject( tile.objectTileset );
+    const int icnId = MP2::GetICNObject( tile._objectType );
 
     // If there was another object sprite here (shadow for example) push it down to Addons,
     // except when there is already MONS32.ICN here.
-    if ( tile.objectTileset != 0 && icnId != ICN::MONS32 && tile.objectIndex != 255 ) {
-        tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile.uniq, tile.objectTileset, tile.objectIndex ) );
+    if ( tile._objectType != 0 && icnId != ICN::MONS32 && tile._imageIndex != 255 ) {
+        tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile.uniq, tile._objectType, tile._imageIndex ) );
 
         // replace sprite with the one for the new monster
         tile.uniq = 0;
-        tile.objectTileset = 48; // MONS32.ICN
+        // TODO: we ignore first 2 bits which might be not 0!
+        tile._objectType = 48; // MONS32.ICN
     }
 
-    tile.objectIndex = mons.GetSpriteIndex();
+    tile._imageIndex = mons.GetSpriteIndex();
 
     const bool setDefinedCount = ( count > 0 );
 
@@ -1016,7 +1018,7 @@ void Maps::Tiles::UpdateMonsterInfo( Tiles & tile )
     Monster mons;
 
     if ( MP2::OBJ_MONSTER == tile.GetObject() ) {
-        mons = Monster( tile.objectIndex + 1 ); // ICN::MONS32 start from PEASANT
+        mons = Monster( tile._imageIndex + 1 ); // ICN::MONS32 start from PEASANT
     }
     else {
         switch ( tile.GetObject() ) {
@@ -1041,7 +1043,7 @@ void Maps::Tiles::UpdateMonsterInfo( Tiles & tile )
 
         // fixed random sprite
         tile.SetObject( MP2::OBJ_MONSTER );
-        tile.objectIndex = mons.GetID() - 1; // ICN::MONS32 start from PEASANT
+        tile._imageIndex = mons.GetID() - 1; // ICN::MONS32 start from PEASANT
     }
 
     uint32_t count = 0;

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -563,16 +563,14 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
 
     case MP2::OBJ_RESOURCE: {
         int resourceType = Resource::UNKNOWN;
-        // TODO: add a function opposite to MP2::GetICNObject() to return tileset ID.
-        const int resourceTileSet = 46;
 
-        if ( ( _objectType >> 2 ) == resourceTileSet ) {
+        if ( ( _objectType >> 2 ) == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
             // The resource is located at the top.
             resourceType = Resource::FromIndexSprite( _imageIndex );
         }
         else {
             for ( TilesAddon & addon : addons_level1 ) {
-                if ( ( addon._objectType >> 2 ) == resourceTileSet ) {
+                if ( ( addon._objectType >> 2 ) == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
                     resourceType = Resource::FromIndexSprite( addon._imageIndex );
                     // If this happens we are in trouble. It looks like that map maker put the resource under an object which is impossible to do.
                     // Let's swap the addon and main tile objects
@@ -978,7 +976,7 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
         // TODO: why are we setting UID to 0? It should be unique!
         tile._uid = 0;
         // TODO: we ignore first 2 bits which might be not 0!
-        tile._objectType = 48; // MONS32.ICN
+        tile._objectType = ( MP2::OBJ_ICN_TYPE_MONS32 << 2 );
     }
 
     tile._imageIndex = mons.GetSpriteIndex();

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -37,156 +37,118 @@ int MP2::GetICNObject( const uint8_t tileset )
 {
     // First 2 bits are used for flags like animation.
     // TODO: separate these 2 bits and real tile (?) index into 2 variables to avoid this bit shifting operations all over the code.
-    switch ( tileset >> 2 ) {
-    // reserverd
-    case 0:
+    return getIcnIdFromObjectIcnType( tileset >> 2 );
+}
+
+int MP2::getIcnIdFromObjectIcnType( const uint8_t objectIcnType )
+{
+    switch ( objectIcnType ) {
+    case OBJ_ICN_TYPE_UNKNOWN:
         return ICN::UNKNOWN;
-    // custom: boat sprite
-    case 6:
+    case OBJ_ICN_TYPE_BOAT32:
         return ICN::BOAT32;
-    // artifact
-    case 11:
+    case OBJ_ICN_TYPE_OBJNARTI:
         return ICN::OBJNARTI;
-    // monster
-    case 12:
+    case OBJ_ICN_TYPE_MONS32:
         return ICN::MONS32;
-    // castle flags
-    case 14:
+    case OBJ_ICN_TYPE_FLAG32:
         return ICN::FLAG32;
-    // heroes
-    case 21:
+    case OBJ_ICN_TYPE_MINIHERO:
         return ICN::MINIHERO;
-    // mountains: snow
-    case 22:
+    case OBJ_ICN_TYPE_MTNSNOW:
         return ICN::MTNSNOW;
-    // mountains: swamp
-    case 23:
+    case OBJ_ICN_TYPE_MTNSWMP:
         return ICN::MTNSWMP;
-    // mountains: lava
-    case 24:
+    case OBJ_ICN_TYPE_MTNLAVA:
         return ICN::MTNLAVA;
-    // mountains: desert
-    case 25:
+    case OBJ_ICN_TYPE_MTNDSRT:
         return ICN::MTNDSRT;
-    // mountains: dirt
-    case 26:
+    case OBJ_ICN_TYPE_MTNDIRT:
         return ICN::MTNDIRT;
-    // mountains: all terrains
-    case 27:
+    case OBJ_ICN_TYPE_MTNMULT:
         return ICN::MTNMULT;
-    // mines
-    case 29:
+    case OBJ_ICN_TYPE_EXTRAOVR:
         return ICN::EXTRAOVR;
-    // road
-    case 30:
+    case OBJ_ICN_TYPE_ROAD:
         return ICN::ROAD;
-    // relief: crck
-    case 31:
+    case OBJ_ICN_TYPE_MTNCRCK:
         return ICN::MTNCRCK;
-    // relief: gras
-    case 32:
+    case OBJ_ICN_TYPE_MTNGRAS:
         return ICN::MTNGRAS;
-    // trees jungle
-    case 33:
+    case OBJ_ICN_TYPE_TREJNGL:
         return ICN::TREJNGL;
-    // trees evil
-    case 34:
+    case OBJ_ICN_TYPE_TREEVIL:
         return ICN::TREEVIL;
-    // castle and town sprites
-    case 35:
+    case OBJ_ICN_TYPE_OBJNTOWN:
         return ICN::OBJNTOWN;
-    // castle base
-    case 36:
+    case OBJ_ICN_TYPE_OBJNTWBA:
         return ICN::OBJNTWBA;
-    // castle shadow
-    case 37:
+    case OBJ_ICN_TYPE_OBJNTWSH:
         return ICN::OBJNTWSH;
-    // random castle
-    case 38:
+    case OBJ_ICN_TYPE_OBJNTWRD:
         return ICN::OBJNTWRD;
-    // mine guardians (elementals)
-    case 39:
+    case OBJ_ICN_TYPE_OBJNXTRA:
         return ICN::OBJNXTRA;
-    // water object
-    case 40:
+    case OBJ_ICN_TYPE_OBJNWAT2:
         return ICN::OBJNWAT2;
-    // object other
-    case 41:
+    case OBJ_ICN_TYPE_OBJNMUL2:
         return ICN::OBJNMUL2;
-    // trees snow
-    case 42:
+    case OBJ_ICN_TYPE_TRESNOW:
         return ICN::TRESNOW;
-    // trees trefir
-    case 43:
+    case OBJ_ICN_TYPE_TREFIR:
         return ICN::TREFIR;
-    // trees
-    case 44:
+    case OBJ_ICN_TYPE_TREFALL:
         return ICN::TREFALL;
-    // river
-    case 45:
+    case OBJ_ICN_TYPE_STREAM:
         return ICN::STREAM;
-    // resource
-    case 46:
+    case OBJ_ICN_TYPE_OBJNRSRC:
         return ICN::OBJNRSRC;
-    // gras object
-    case 48:
+    case OBJ_ICN_TYPE_OBJNGRA2:
         return ICN::OBJNGRA2;
-    // trees tredeci
-    case 49:
+    case OBJ_ICN_TYPE_TREDECI:
         return ICN::TREDECI;
-    // sea object
-    case 50:
+    case OBJ_ICN_TYPE_OBJNWATR:
         return ICN::OBJNWATR;
-    // vegetation gras
-    case 51:
+    case OBJ_ICN_TYPE_OBJNGRAS:
         return ICN::OBJNGRAS;
-    // object on snow
-    case 52:
+    case OBJ_ICN_TYPE_OBJNSNOW:
         return ICN::OBJNSNOW;
-    // object on swamp
-    case 53:
+    case OBJ_ICN_TYPE_OBJNSWMP:
         return ICN::OBJNSWMP;
-    // object on lava
-    case 54:
+    case OBJ_ICN_TYPE_OBJNLAVA:
         return ICN::OBJNLAVA;
-    // object on desert
-    case 55:
+    case OBJ_ICN_TYPE_OBJNDSRT:
         return ICN::OBJNDSRT;
-    // object on dirt
-    case 56:
+    case OBJ_ICN_TYPE_OBJNDIRT:
         return ICN::OBJNDIRT;
-    // object on crck
-    case 57:
+    case OBJ_ICN_TYPE_OBJNCRCK:
         return ICN::OBJNCRCK;
-    // object on lava
-    case 58:
+    case OBJ_ICN_TYPE_OBJNLAV3:
         return ICN::OBJNLAV3;
-    // object on earth
-    case 59:
+    case OBJ_ICN_TYPE_OBJNMULT:
         return ICN::OBJNMULT;
-    //  object on lava
-    case 60:
+    case OBJ_ICN_TYPE_OBJNLAV2:
         return ICN::OBJNLAV2;
-    // extra objects for loyalty version
-    case 61:
-        if ( Settings::Get().isPriceOfLoyaltySupported() )
+    case OBJ_ICN_TYPE_X_LOC1:
+        if ( Settings::Get().isPriceOfLoyaltySupported() ) {
             return ICN::X_LOC1;
+        }
         break;
-    // extra objects for loyalty version
-    case 62:
-        if ( Settings::Get().isPriceOfLoyaltySupported() )
+    case OBJ_ICN_TYPE_X_LOC2:
+        if ( Settings::Get().isPriceOfLoyaltySupported() ) {
             return ICN::X_LOC2;
+        }
         break;
-    // extra objects for loyalty version
-    case 63:
-        if ( Settings::Get().isPriceOfLoyaltySupported() )
+    case OBJ_ICN_TYPE_X_LOC3:
+        if ( Settings::Get().isPriceOfLoyaltySupported() ) {
             return ICN::X_LOC3;
+        }
         break;
     default:
         break;
     }
 
-    DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown tileset: " << static_cast<int>( tileset ) )
+    DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown object ICN type: " << static_cast<int>( objectIcnType ) )
     return ICN::UNKNOWN;
 }
 

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -154,9 +154,38 @@ int MP2::getIcnIdFromObjectIcnType( const uint8_t objectIcnType )
 
 bool MP2::isHiddenForPuzzle( const int terrainType, uint8_t tileset, uint8_t index )
 {
-    const int icnID = tileset >> 2;
-    if ( icnID < 22 || icnID == 46 || ( icnID == 56 && index == 140 ) || ( icnID == 59 && index >= 124 && index <= 137 ) ) {
+    const int objectIcnType = tileset >> 2;
+    switch ( objectIcnType ) {
+    case OBJ_ICN_TYPE_UNKNOWN:
+    case OBJ_ICN_TYPE_UNUSED_1:
+    case OBJ_ICN_TYPE_UNUSED_2:
+    case OBJ_ICN_TYPE_UNUSED_3:
+    case OBJ_ICN_TYPE_UNUSED_4:
+    case OBJ_ICN_TYPE_UNUSED_5:
+    case OBJ_ICN_TYPE_BOAT32:
+    case OBJ_ICN_TYPE_UNUSED_7:
+    case OBJ_ICN_TYPE_UNUSED_8:
+    case OBJ_ICN_TYPE_UNUSED_9:
+    case OBJ_ICN_TYPE_OBJNHAUN:
+    case OBJ_ICN_TYPE_OBJNARTI:
+    case OBJ_ICN_TYPE_MONS32:
+    case OBJ_ICN_TYPE_UNUSED_13:
+    case OBJ_ICN_TYPE_FLAG32:
+    case OBJ_ICN_TYPE_UNUSED_15:
+    case OBJ_ICN_TYPE_UNUSED_16:
+    case OBJ_ICN_TYPE_UNUSED_17:
+    case OBJ_ICN_TYPE_UNUSED_18:
+    case OBJ_ICN_TYPE_UNUSED_19:
+    case OBJ_ICN_TYPE_MINIMON:
+    case OBJ_ICN_TYPE_MINIHERO:
+    case OBJ_ICN_TYPE_OBJNRSRC:
         return true;
+    case OBJ_ICN_TYPE_OBJNMULT:
+        // Campfire.
+        return ( index >= 124 && index <= 137 );
+    default:
+        // TODO: verify whether we need to show pickup objects in water.
+        break;
     }
 
     return isDiggingHoleSprite( terrainType, tileset, index );
@@ -1245,33 +1274,33 @@ bool MP2::getDiggingHoleSprite( const int terrainType, uint8_t & tileSet, uint8_
 {
     switch ( terrainType ) {
     case Maps::Ground::DESERT:
-        tileSet = 0xDC; // ICN::OBJNDSRT
+        tileSet = ( OBJ_ICN_TYPE_OBJNDSRT << 2 );
         index = 68;
         return true;
     case Maps::Ground::SNOW:
-        tileSet = 208; // ICN::OBJNSNOW
+        tileSet = ( OBJ_ICN_TYPE_OBJNSNOW << 2 );
         index = 11;
         return true;
     case Maps::Ground::SWAMP:
-        tileSet = 212; // ICN::OBJNSWMP
+        tileSet = ( OBJ_ICN_TYPE_OBJNSWMP << 2 );
         index = 86;
         return true;
     case Maps::Ground::WASTELAND:
-        tileSet = 0xE4; // ICN::OBJNCRCK
+        tileSet = ( OBJ_ICN_TYPE_OBJNCRCK << 2 );
         index = 70;
         return true;
     case Maps::Ground::LAVA:
-        tileSet = 0xD8; // ICN::OBJNLAVA
+        tileSet = ( OBJ_ICN_TYPE_OBJNLAVA << 2 );
         index = 26;
         return true;
     case Maps::Ground::DIRT:
-        tileSet = 0xE0; // ICN::OBJNDIRT
+        tileSet = ( OBJ_ICN_TYPE_OBJNDIRT << 2 );
         index = 140;
         return true;
     case Maps::Ground::BEACH:
     case Maps::Ground::GRASS:
         // Beach doesn't have its digging hole so we use it from Grass terrain.
-        tileSet = 0xC0; // ICN::OBJNGRA2
+        tileSet = ( OBJ_ICN_TYPE_OBJNGRA2 << 2 );
         index = 9;
         return true;
     case Maps::Ground::WATER:

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -570,68 +570,70 @@ namespace MP2
         OBJ_ICN_TYPE_UNUSED_3, // Unused
         OBJ_ICN_TYPE_UNUSED_4, // Unused
         OBJ_ICN_TYPE_UNUSED_5, // Unused
-        OBJ_ICN_TYPE_BOAT32, // TODO: this is incorrect type set by mistake. Fix it.
+        OBJ_ICN_TYPE_BOAT32, // TODO: this is incorrect type for boats set by mistake. Fix it.
         OBJ_ICN_TYPE_UNUSED_7, // Unused
         OBJ_ICN_TYPE_UNUSED_8, // Unused
         OBJ_ICN_TYPE_UNUSED_9, // Unused
         OBJ_ICN_TYPE_OBJNHAUN,
-        OBJ_ICN_TYPE_OBJNARTI,
+        OBJ_ICN_TYPE_OBJNARTI, // Artifacts
         OBJ_ICN_TYPE_MONS32, // MON32.icn corresponds to static monsters while we use dynamic monster animation from MINIMON.icn.
         OBJ_ICN_TYPE_UNUSED_13, // Unused
-        OBJ_ICN_TYPE_FLAG32,
+        OBJ_ICN_TYPE_FLAG32, // Flags usually used for castles.
         OBJ_ICN_TYPE_UNUSED_15, // Unused
         OBJ_ICN_TYPE_UNUSED_16, // Unused
         OBJ_ICN_TYPE_UNUSED_17, // Unused
         OBJ_ICN_TYPE_UNUSED_18, // Unused
         OBJ_ICN_TYPE_UNUSED_19, // Unused
         OBJ_ICN_TYPE_MINIMON, // Somehow it is unused but we need to use it properly.
-        OBJ_ICN_TYPE_MINIHERO,
-        OBJ_ICN_TYPE_MTNSNOW,
-        OBJ_ICN_TYPE_MTNSWMP,
-        OBJ_ICN_TYPE_MTNLAVA,
-        OBJ_ICN_TYPE_MTNDSRT,
-        OBJ_ICN_TYPE_MTNDIRT,
-        OBJ_ICN_TYPE_MTNMULT,
+        OBJ_ICN_TYPE_MINIHERO, // Heroes which are set in the original Editor.
+        OBJ_ICN_TYPE_MTNSNOW, // Snow mountains.
+        OBJ_ICN_TYPE_MTNSWMP, // Swamp mountains.
+        OBJ_ICN_TYPE_MTNLAVA, // Lava mountains.
+        OBJ_ICN_TYPE_MTNDSRT, // Desert mountains.
+        OBJ_ICN_TYPE_MTNDIRT, // Dirt mountains.
+        OBJ_ICN_TYPE_MTNMULT, // All terrain mountains.
         OBJ_ICN_TYPE_UNUSED_28, // Unused
-        OBJ_ICN_TYPE_EXTRAOVR,
-        OBJ_ICN_TYPE_ROAD,
-        OBJ_ICN_TYPE_MTNCRCK,
-        OBJ_ICN_TYPE_MTNGRAS,
-        OBJ_ICN_TYPE_TREJNGL,
-        OBJ_ICN_TYPE_TREEVIL,
-        OBJ_ICN_TYPE_OBJNTOWN,
-        OBJ_ICN_TYPE_OBJNTWBA,
-        OBJ_ICN_TYPE_OBJNTWSH,
-        OBJ_ICN_TYPE_OBJNTWRD,
-        OBJ_ICN_TYPE_OBJNXTRA,
-        OBJ_ICN_TYPE_OBJNWAT2,
-        OBJ_ICN_TYPE_OBJNMUL2,
-        OBJ_ICN_TYPE_TRESNOW,
-        OBJ_ICN_TYPE_TREFIR,
-        OBJ_ICN_TYPE_TREFALL,
-        OBJ_ICN_TYPE_STREAM,
-        OBJ_ICN_TYPE_OBJNRSRC,
+        OBJ_ICN_TYPE_EXTRAOVR, // Extra overlay for mines.
+        OBJ_ICN_TYPE_ROAD, // Roads.
+        OBJ_ICN_TYPE_MTNCRCK, // Cracked desert mountains.
+        OBJ_ICN_TYPE_MTNGRAS, // Grass mountains.
+        OBJ_ICN_TYPE_TREJNGL, // Jungle trees.
+        OBJ_ICN_TYPE_TREEVIL, // Evil trees.
+        OBJ_ICN_TYPE_OBJNTOWN, // Towns and castles.
+        OBJ_ICN_TYPE_OBJNTWBA, // Town basement.
+        OBJ_ICN_TYPE_OBJNTWSH, // Town shadows.
+        OBJ_ICN_TYPE_OBJNTWRD, // Random town.
+        OBJ_ICN_TYPE_OBJNXTRA, // Elementals as guardians.
+        OBJ_ICN_TYPE_OBJNWAT2, // Coastal water objects.
+        OBJ_ICN_TYPE_OBJNMUL2, // Miscellaneous ground objects.
+        OBJ_ICN_TYPE_TRESNOW, // Snow trees.
+        OBJ_ICN_TYPE_TREFIR, // Fir-trees during Summer.
+        OBJ_ICN_TYPE_TREFALL, // Fir-trees during Autum.
+        OBJ_ICN_TYPE_STREAM, // River streams.
+        OBJ_ICN_TYPE_OBJNRSRC, // Resources.
         OBJ_ICN_TYPE_UNUSED_47, // Unused
-        OBJ_ICN_TYPE_OBJNGRA2,
-        OBJ_ICN_TYPE_TREDECI,
-        OBJ_ICN_TYPE_OBJNWATR,
-        OBJ_ICN_TYPE_OBJNGRAS,
-        OBJ_ICN_TYPE_OBJNSNOW,
-        OBJ_ICN_TYPE_OBJNSWMP,
-        OBJ_ICN_TYPE_OBJNLAVA,
-        OBJ_ICN_TYPE_OBJNDSRT,
-        OBJ_ICN_TYPE_OBJNDIRT,
-        OBJ_ICN_TYPE_OBJNCRCK,
-        OBJ_ICN_TYPE_OBJNLAV3,
-        OBJ_ICN_TYPE_OBJNMULT,
-        OBJ_ICN_TYPE_OBJNLAV2,
-        OBJ_ICN_TYPE_X_LOC1,
-        OBJ_ICN_TYPE_X_LOC2,
-        OBJ_ICN_TYPE_X_LOC3
+        OBJ_ICN_TYPE_OBJNGRA2, // Grass objects.
+        OBJ_ICN_TYPE_TREDECI, // Deciduous trees.
+        OBJ_ICN_TYPE_OBJNWATR, // Water objects.
+        OBJ_ICN_TYPE_OBJNGRAS, // Non-action grass objects.
+        OBJ_ICN_TYPE_OBJNSNOW, // Snow objects.
+        OBJ_ICN_TYPE_OBJNSWMP, // Swamp objects.
+        OBJ_ICN_TYPE_OBJNLAVA, // Lava objects.
+        OBJ_ICN_TYPE_OBJNDSRT, // Desert objects.
+        OBJ_ICN_TYPE_OBJNDIRT, // Dirt objects.
+        OBJ_ICN_TYPE_OBJNCRCK, // Crack desert objects.
+        OBJ_ICN_TYPE_OBJNLAV3, // Animated lava objects.
+        OBJ_ICN_TYPE_OBJNMULT, // Miscellaneous ground objects.
+        OBJ_ICN_TYPE_OBJNLAV2, // Animated lava objects.
+        OBJ_ICN_TYPE_X_LOC1, // Objects from The Price of Loaylty expansion.
+        OBJ_ICN_TYPE_X_LOC2, // Objects from The Price of Loaylty expansion.
+        OBJ_ICN_TYPE_X_LOC3 // Objects from The Price of Loaylty expansion.
     };
 
     // Return Icn ID related to this tileset value.
     int GetICNObject( const uint8_t tileset );
+
+    int getIcnIdFromObjectIcnType( const uint8_t objectIcnType );
 
     const char * StringObject( const MapObjectType objectType, const int count = 1 );
 

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -47,7 +47,12 @@ namespace MP2
 
         uint8_t objectName1; // Ground (bottom) level object type (first 2 bits) and object tile set (6 bits). Tile set refers to ICN ID.
         uint8_t level1IcnImageIndex; // ICN image index (image index for corresponding ICN Id) for ground (bottom) object. 255 means it's an empty object.
-        uint8_t quantity1; // Bitfield, first 3 bits are flags, rest is used as quantity
+
+        // First 2 bits correspond to object layer type used to identify the order of rendering on Adventure Map.
+        // The third bit is unknown. TODO: find out what the third bit is used for.
+        // The last 5 bits are used together with quantity 2 as the value for the object.
+        uint8_t quantity1;
+
         uint8_t quantity2; // Used as a part of quantity, field size is actually 13 bits. Has most significant bits
         uint8_t objectName2; // Top level object type (first 2 bits) and object tile set (6 bits). Tile set refers to ICN ID.
         uint8_t level2IcnImageIndex; // ICN image index (image index for corresponding ICN Id) for top level object. 255 means it's an empty object.

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -562,6 +562,74 @@ namespace MP2
         OBJ_WATERALTAR = 0xFF
     };
 
+    enum ObjectIcnType : uint8_t
+    {
+        OBJ_ICN_TYPE_UNKNOWN,
+        OBJ_ICN_TYPE_UNUSED_1, // Unused
+        OBJ_ICN_TYPE_UNUSED_2, // Unused
+        OBJ_ICN_TYPE_UNUSED_3, // Unused
+        OBJ_ICN_TYPE_UNUSED_4, // Unused
+        OBJ_ICN_TYPE_UNUSED_5, // Unused
+        OBJ_ICN_TYPE_UNUSED_6, // Unused
+        OBJ_ICN_TYPE_UNUSED_7, // Unused
+        OBJ_ICN_TYPE_UNUSED_8, // Unused
+        OBJ_ICN_TYPE_UNUSED_9, // Unused
+        OBJ_ICN_TYPE_OBJNHAUN,
+        OBJ_ICN_TYPE_OBJNARTI,
+        OBJ_ICN_TYPE_MONS32, // MON32.icn corresponds to static monsters while we use dynamic monster animation from MINIMON.icn.
+        OBJ_ICN_TYPE_UNUSED_13, // Unused
+        OBJ_ICN_TYPE_FLAG32,
+        OBJ_ICN_TYPE_UNUSED_15, // Unused
+        OBJ_ICN_TYPE_UNUSED_16, // Unused
+        OBJ_ICN_TYPE_UNUSED_17, // Unused
+        OBJ_ICN_TYPE_UNUSED_18, // Unused
+        OBJ_ICN_TYPE_UNUSED_19, // Unused
+        OBJ_ICN_TYPE_MINIMON, // Somehow it is unused but we need to use it properly.
+        OBJ_ICN_TYPE_MINIHERO,
+        OBJ_ICN_TYPE_MTNSNOW,
+        OBJ_ICN_TYPE_MTNSWMP,
+        OBJ_ICN_TYPE_MTNLAVA,
+        OBJ_ICN_TYPE_MTNDSRT,
+        OBJ_ICN_TYPE_MTNDIRT,
+        OBJ_ICN_TYPE_MTNMULT,
+        OBJ_ICN_TYPE_UNUSED_28, // Unused
+        OBJ_ICN_TYPE_EXTRAOVR,
+        OBJ_ICN_TYPE_ROAD,
+        OBJ_ICN_TYPE_MTNCRCK,
+        OBJ_ICN_TYPE_MTNGRAS,
+        OBJ_ICN_TYPE_TREJNGL,
+        OBJ_ICN_TYPE_TREEVIL,
+        OBJ_ICN_TYPE_OBJNTOWN,
+        OBJ_ICN_TYPE_OBJNTWBA,
+        OBJ_ICN_TYPE_OBJNTWSH,
+        OBJ_ICN_TYPE_OBJNTWRD,
+        OBJ_ICN_TYPE_OBJNXTRA,
+        OBJ_ICN_TYPE_OBJNWAT2,
+        OBJ_ICN_TYPE_OBJNMUL2,
+        OBJ_ICN_TYPE_TRESNOW,
+        OBJ_ICN_TYPE_TREFIR,
+        OBJ_ICN_TYPE_TREFALL,
+        OBJ_ICN_TYPE_STREAM,
+        OBJ_ICN_TYPE_OBJNRSRC,
+        OBJ_ICN_TYPE_UNUSED_47, // Unused
+        OBJ_ICN_TYPE_OBJNGRA2,
+        OBJ_ICN_TYPE_TREDECI,
+        OBJ_ICN_TYPE_OBJNWATR,
+        OBJ_ICN_TYPE_OBJNGRAS,
+        OBJ_ICN_TYPE_OBJNSNOW,
+        OBJ_ICN_TYPE_OBJNSWMP,
+        OBJ_ICN_TYPE_OBJNLAVA,
+        OBJ_ICN_TYPE_OBJNDSRT,
+        OBJ_ICN_TYPE_OBJNDIRT,
+        OBJ_ICN_TYPE_OBJNCRCK,
+        OBJ_ICN_TYPE_OBJNLAV3,
+        OBJ_ICN_TYPE_OBJNMULT,
+        OBJ_ICN_TYPE_OBJNLAV2,
+        OBJ_ICN_TYPE_X_LOC1,
+        OBJ_ICN_TYPE_X_LOC2,
+        OBJ_ICN_TYPE_X_LOC3
+    };
+
     // Return Icn ID related to this tileset value.
     int GetICNObject( const uint8_t tileset );
 

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -574,7 +574,7 @@ namespace MP2
         OBJ_ICN_TYPE_UNUSED_7, // Unused
         OBJ_ICN_TYPE_UNUSED_8, // Unused
         OBJ_ICN_TYPE_UNUSED_9, // Unused
-        OBJ_ICN_TYPE_OBJNHAUN,
+        OBJ_ICN_TYPE_OBJNHAUN, // Flying ghosts over an object (mine).
         OBJ_ICN_TYPE_OBJNARTI, // Artifacts
         OBJ_ICN_TYPE_MONS32, // MON32.icn corresponds to static monsters while we use dynamic monster animation from MINIMON.icn.
         OBJ_ICN_TYPE_UNUSED_13, // Unused

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -564,7 +564,7 @@ namespace MP2
 
     enum ObjectIcnType : uint8_t
     {
-        OBJ_ICN_TYPE_UNKNOWN,
+        OBJ_ICN_TYPE_UNKNOWN, // Object does not exist.
         OBJ_ICN_TYPE_UNUSED_1, // Unused
         OBJ_ICN_TYPE_UNUSED_2, // Unused
         OBJ_ICN_TYPE_UNUSED_3, // Unused
@@ -608,7 +608,7 @@ namespace MP2
         OBJ_ICN_TYPE_OBJNMUL2, // Miscellaneous ground objects.
         OBJ_ICN_TYPE_TRESNOW, // Snow trees.
         OBJ_ICN_TYPE_TREFIR, // Fir-trees during Summer.
-        OBJ_ICN_TYPE_TREFALL, // Fir-trees during Autum.
+        OBJ_ICN_TYPE_TREFALL, // Fir-trees during Autumn.
         OBJ_ICN_TYPE_STREAM, // River streams.
         OBJ_ICN_TYPE_OBJNRSRC, // Resources.
         OBJ_ICN_TYPE_UNUSED_47, // Unused
@@ -625,9 +625,9 @@ namespace MP2
         OBJ_ICN_TYPE_OBJNLAV3, // Animated lava objects.
         OBJ_ICN_TYPE_OBJNMULT, // Miscellaneous ground objects.
         OBJ_ICN_TYPE_OBJNLAV2, // Animated lava objects.
-        OBJ_ICN_TYPE_X_LOC1, // Objects from The Price of Loaylty expansion.
-        OBJ_ICN_TYPE_X_LOC2, // Objects from The Price of Loaylty expansion.
-        OBJ_ICN_TYPE_X_LOC3 // Objects from The Price of Loaylty expansion.
+        OBJ_ICN_TYPE_X_LOC1, // Objects from The Price of Loyalty expansion.
+        OBJ_ICN_TYPE_X_LOC2, // Objects from The Price of Loyalty expansion.
+        OBJ_ICN_TYPE_X_LOC3 // Objects from The Price of Loyalty expansion.
     };
 
     // Return Icn ID related to this tileset value.

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -61,7 +61,9 @@ namespace MP2
         // between land and sea. They can be related to passabilities.
         uint8_t flags;
 
-        uint8_t mapObjectType; // Object type. Please refer to MapObjectType enumeration.
+        // The main object type for the tile. The tile can have multiple objects but the game can display information only about one.
+        // Refer to MapObjectType enumeration below.
+        uint8_t mapObjectType;
 
         uint16_t nextAddonIndex; // Next add-on index. Zero value means it's the last addon chunk.
 
@@ -633,6 +635,8 @@ namespace MP2
         OBJ_ICN_TYPE_X_LOC1, // Objects from The Price of Loyalty expansion.
         OBJ_ICN_TYPE_X_LOC2, // Objects from The Price of Loyalty expansion.
         OBJ_ICN_TYPE_X_LOC3 // Objects from The Price of Loyalty expansion.
+
+        // IMPORTANT!!! If you want to add new types firstly use unused entries and only then add new entries in this enumeration.
     };
 
     // Return Icn ID related to this tileset value.

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -570,7 +570,7 @@ namespace MP2
         OBJ_ICN_TYPE_UNUSED_3, // Unused
         OBJ_ICN_TYPE_UNUSED_4, // Unused
         OBJ_ICN_TYPE_UNUSED_5, // Unused
-        OBJ_ICN_TYPE_UNUSED_6, // Unused
+        OBJ_ICN_TYPE_BOAT32, // TODO: this is incorrect type set by mistake. Fix it.
         OBJ_ICN_TYPE_UNUSED_7, // Unused
         OBJ_ICN_TYPE_UNUSED_8, // Unused
         OBJ_ICN_TYPE_UNUSED_9, // Unused

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -932,17 +932,17 @@ bool World::DiggingForUltimateArtifact( const fheroes2::Point & center )
     Maps::Tiles & tile = GetTiles( center.x, center.y );
 
     // Get digging hole sprite.
-    uint8_t obj = 0;
-    uint8_t idx = 0;
+    uint8_t objectType = 0;
+    uint8_t imageIndex = 0;
 
-    if ( !MP2::getDiggingHoleSprite( tile.GetGround(), obj, idx ) ) {
+    if ( !MP2::getDiggingHoleSprite( tile.GetGround(), objectType, imageIndex ) ) {
         // Are you sure that you can dig here?
         assert( 0 );
 
         return false;
     }
 
-    tile.AddonsPushLevel1( Maps::TilesAddon( Maps::BACKGROUND_LAYER, GetUniq(), obj, idx ) );
+    tile.AddonsPushLevel1( Maps::TilesAddon( Maps::BACKGROUND_LAYER, GetUniq(), objectType, imageIndex ) );
 
     if ( ultimate_artifact.isPosition( tile.GetIndex() ) && !ultimate_artifact.isFound() ) {
         ultimate_artifact.markAsFound();

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -678,7 +678,7 @@ void World::ProcessNewMap()
 
         case MP2::OBJ_HEROES: {
             // remove map editor sprite
-            if ( MP2::GetICNObject( tile.GetObjectTileset() ) == ICN::MINIHERO )
+            if ( MP2::GetICNObject( tile.getObjectType() ) == ICN::MINIHERO )
                 tile.Remove( tile.GetObjectUID() );
 
             tile.SetHeroes( GetHeroes( Maps::GetPoint( static_cast<int32_t>( i ) ) ) );

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *


### PR DESCRIPTION
This is a preparation step towards building the future Editor. Right now the code related to object loading and handling on Adventure Map is a complete mess. This pull request is targeted to cleanup the code and make it more or less readable. The list of changes:
- rename `uniq, level, object and index` of **TilesAddon** structure and `uniq, objectTileset, objectIndex and _level` of class **Tiles** into `_uid, _layerType, _objectType and _imageIndex` to have the same member names as these variables are exactly the same for both classes. In the future class **Tiles** will have only one stack of objects.
- add **ObjectIcnType** enumeration and replace many hardcoded values by entries from the enumeration
- add multiple TODO comments for the future changes (I wanted to keep this pull request as small as possible)

This pull request touches the underlying logic for Adventure Map objects. While it does not change the logic at all there is a chance that these changes might break anything for loaded from save files maps or new maps. I tested multiple maps and everything look correct.

relates to #4330 and #6415