### PR TITLE
[WIP] Integer display scale factor

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -551,7 +551,6 @@ namespace fheroes2
 
         if ( !image._data ) {
             clear();
-
             return;
         }
 
@@ -1131,7 +1130,6 @@ namespace fheroes2
 
     void Copy( const Image & in, Image & out )
     {
-        out.resize( in.width(), in.height() );
         Copy( in, 0, 0, out, 0, 0, in.width(), in.height() );
     }
 

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1203,16 +1203,17 @@ namespace fheroes2
 
     Sprite CreateContour( const Image & image, uint8_t value )
     {
-        const int32_t width = image._w();
-        const int32_t height = image._h();
-
-        Sprite contour( width, height );
+        Image contour( image.width(), image.height(), image.scaleFactor() );
         contour.reset();
-        if ( width < 2 || height < 2 ) {
+
+        if ( contour.width() < 2 || contour.height() < 2 ) {
             return contour;
         }
 
         assert( !contour.empty() );
+
+        const int32_t width = image._w();
+        const int32_t height = image._h();
 
         const uint8_t * inY = image.transform();
         uint8_t * outImageY = contour.image();

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -435,7 +435,7 @@ namespace fheroes2
     }
 
     Image::Image( int32_t width_, int32_t height_ )
-        : Image( width_, height_, Display::scaleFactor() )
+        : Image( width_, height_, Display::currentScaleFactor() )
     {
     }
 
@@ -452,7 +452,7 @@ namespace fheroes2
         : _width( 0 )
         , _height( 0 )
         , _scaleFactor( 1 )
-        , _singleLayer( false )
+        , _singleLayer( image_._singleLayer )
     {
         copyFrom( image_ );
     }
@@ -510,7 +510,7 @@ namespace fheroes2
 
         _width = 0;
         _height = 0;
-        _scaleFactor = Display::scaleFactor();
+        _scaleFactor = Display::currentScaleFactor();
     }
 
     void Image::fill( uint8_t value )
@@ -529,21 +529,21 @@ namespace fheroes2
 
     void Image::_resize( int32_t physicalWidth_, int32_t physicalHeight_, int32_t scaleFactor_ )
     {
-        if ( _width == physicalWidth_ && _height == physicalHeight_ && _scaleFactor == scaleFactor_ ) {
-            return;
-        }
+        _scaleFactor = scaleFactor_;
 
         if ( physicalWidth_ <= 0 || physicalHeight_ <= 0 ) {
             clear();
             return;
         }
 
+        // don't reset if only changing scale factor, for example
+        if ( _width != physicalWidth_ || _height != physicalHeight_ ) {
+            const size_t totalBytes = static_cast<size_t>( 2 * physicalWidth_ * physicalHeight_ );
+            _data.reset( new uint8_t[totalBytes] );
+        }
+
         _width = physicalWidth_;
         _height = physicalHeight_;
-        _scaleFactor = scaleFactor_;
-
-        const size_t totalBytes = static_cast<size_t>( 2 * _width * _height );
-        _data.reset( new uint8_t[totalBytes] );
     }
 
     void Image::reset()

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -389,8 +389,8 @@ namespace
             return;
         }
 
-        const int32_t widthIn = in.width();
-        const int32_t widthOut = out.width();
+        const int32_t widthIn = in._w();
+        const int32_t widthOut = out._w();
 
         const uint8_t * imageInY = in.image() + inY * widthIn + inX;
         uint8_t * imageOutY = out.image() + outY * widthOut + outX;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -674,6 +674,12 @@ namespace fheroes2
         Image newCapture( _width, _height, _image.scaleFactor() );
         newCapture._disableTransformLayer();
 
+        if ( _x < 0 ) {
+            _x = 0;
+        }
+        if ( _y < 0 ) {
+            _y = 0;
+        }
         Copy( _image, _x, _y, newCapture, 0, 0, _width, _height );
 
         _capturedImage._disableTransformLayer();

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -417,6 +417,7 @@ namespace fheroes2
     Image::Image()
         : _width( 0 )
         , _height( 0 )
+        , _scaleFactor( 1 )
         , _singleLayer( false )
     {
         // Do nothing.
@@ -425,6 +426,16 @@ namespace fheroes2
     Image::Image( int32_t width_, int32_t height_ )
         : _width( 0 )
         , _height( 0 )
+        , _scaleFactor( 1 )
+        , _singleLayer( false )
+    {
+        Image::resize( width_, height_ );
+    }
+
+    Image::Image( int32_t width_, int32_t height_, int32_t scaleFactor_ )
+        : _width( 0 )
+        , _height( 0 )
+        , _scaleFactor( scaleFactor_ )
         , _singleLayer( false )
     {
         Image::resize( width_, height_ );
@@ -433,6 +444,7 @@ namespace fheroes2
     Image::Image( const Image & image_ )
         : _width( 0 )
         , _height( 0 )
+        , _scaleFactor( 1 )
         , _singleLayer( false )
     {
         copy( image_ );
@@ -441,12 +453,14 @@ namespace fheroes2
     Image::Image( Image && image_ ) noexcept
         : _width( 0 )
         , _height( 0 )
+        , _scaleFactor( 1 )
         , _data( std::move( image_._data ) )
         , _singleLayer( false )
     {
         std::swap( _singleLayer, image_._singleLayer );
         std::swap( _width, image_._width );
         std::swap( _height, image_._height );
+        std::swap( _scaleFactor, image_._scaleFactor );
     }
 
     Image & Image::operator=( const Image & image_ )
@@ -466,6 +480,7 @@ namespace fheroes2
 
             std::swap( _width, image_._width );
             std::swap( _height, image_._height );
+            std::swap( _scaleFactor, image_._scaleFactor );
             std::swap( _data, image_._data );
         }
 
@@ -488,6 +503,7 @@ namespace fheroes2
 
         _width = 0;
         _height = 0;
+        _scaleFactor = 1;
     }
 
     void Image::fill( uint8_t value )
@@ -546,6 +562,7 @@ namespace fheroes2
 
             _width = image._width;
             _height = image._height;
+            _scaleFactor = image._scaleFactor;
         }
 
         memcpy( _data.get(), image._data.get(), size * 2 );
@@ -559,8 +576,8 @@ namespace fheroes2
         // Do nothing.
     }
 
-    Sprite::Sprite( int32_t width_, int32_t height_, int32_t x_, int32_t y_ )
-        : Image( width_, height_ )
+    Sprite::Sprite( int32_t width_, int32_t height_, int32_t x_, int32_t y_, int32_t scaleFactor_ )
+        : Image( width_, height_, scaleFactor_ )
         , _x( x_ )
         , _y( y_ )
     {

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1403,7 +1403,7 @@ namespace fheroes2
 
     void DrawLine( Image & image, const Point & start, const Point & end, uint8_t value, const Rect & roi )
     {
-        assert( image.scaleFactor() == 1 );
+        // assert( image.scaleFactor() == 1 );
 
         if ( image.empty() )
             return;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1559,6 +1559,7 @@ namespace fheroes2
 
         for ( size_t i = 1; i < input.size(); ++i ) {
             assert( input[i] != nullptr );
+            assert( input[0]->scaleFactor() == input[i]->scaleFactor() );
             if ( input[i]->width() != input[0]->width() || input[i]->height() != input[0]->height() )
                 return Image();
         }
@@ -1571,7 +1572,7 @@ namespace fheroes2
             transformIn[i] = input[i]->transform();
         }
 
-        Image out( input[0]->width(), input[0]->height() );
+        Image out( input[0]->width(), input[0]->height(), input[0]->scaleFactor() );
         out.reset();
 
         uint8_t * imageOut = out.image();
@@ -1959,7 +1960,7 @@ namespace fheroes2
         }
 
         const int32_t widthMask = mask._w();
-        const int32_t widthOut = out._h();
+        const int32_t widthOut = out._w();
 
         const uint8_t * imageMaskY = mask.transform() + maskY * widthMask + maskX;
         uint8_t * imageOutY = out.transform() + outY * widthOut + outX;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1689,9 +1689,8 @@ namespace fheroes2
         outPos.x -= outputRoi.x;
         outPos.y -= outputRoi.y;
 
-        // FIXME: abusing verify is not the best idea ever
-        if ( !Verify( inPos.x, inPos.y, outPos.x, outPos.y, outputSize.width, outputSize.height, in.width(), in.height(), outputRoi.width, outputRoi.height,
-                      in.scaleFactor() ) ) {
+        // Here we only want the bounding to happen, but not scaling to physical size, so we pass scale factor of 1.
+        if ( !Verify( inPos.x, inPos.y, outPos.x, outPos.y, outputSize.width, outputSize.height, in.width(), in.height(), outputRoi.width, outputRoi.height, 1 ) ) {
             return false;
         }
 

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -2195,6 +2195,8 @@ namespace fheroes2
 
     void SetPixel( Image & image, int32_t x, int32_t y, uint8_t value )
     {
+        assert( image.scaleFactor() == 1 );
+
         if ( image.empty() || x >= image.width() || y >= image.height() || x < 0 || y < 0 ) {
             return;
         }
@@ -2206,6 +2208,8 @@ namespace fheroes2
 
     void SetPixel( Image & image, const std::vector<Point> & points, uint8_t value )
     {
+        assert( image.scaleFactor() == 1 );
+
         if ( image.empty() ) {
             return;
         }
@@ -2226,6 +2230,8 @@ namespace fheroes2
 
     void SetTransformPixel( Image & image, int32_t x, int32_t y, uint8_t value )
     {
+        assert( image.scaleFactor() == 1 );
+
         if ( image.empty() || x >= image.width() || y >= image.height() || x < 0 || y < 0 ) {
             return;
         }

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1245,13 +1245,13 @@ namespace fheroes2
     Sprite Crop( const Image & image, int32_t x, int32_t y, int32_t width, int32_t height )
     {
         if ( image.empty() || width <= 0 || height <= 0 )
-            return Sprite();
+            return Image( 0, 0, image.scaleFactor() );
 
         // This looks a lot like a call to Verify().
         if ( x < 0 ) {
             const int32_t offsetX = -x;
             if ( offsetX >= width )
-                return Sprite();
+                return Image( 0, 0, image.scaleFactor() );
 
             x = 0;
             width -= offsetX;
@@ -1260,14 +1260,14 @@ namespace fheroes2
         if ( y < 0 ) {
             const int32_t offsetY = -y;
             if ( offsetY >= height )
-                return Sprite();
+                return Image( 0, 0, image.scaleFactor() );
 
             y = 0;
             height -= offsetY;
         }
 
         if ( x > image.width() || y > image.height() )
-            return Sprite();
+            return Image( 0, 0, image.scaleFactor() );
 
         if ( x + width > image.width() ) {
             const int32_t offsetX = x + width - image.width();
@@ -1279,18 +1279,19 @@ namespace fheroes2
             height -= offsetY;
         }
 
-        Sprite out( width, height );
+        Sprite out( std::move( Image( width, height, image.scaleFactor() ) ), x, y );
         if ( image.singleLayer() ) {
             out._disableTransformLayer();
         }
-
         Copy( image, x, y, out, 0, 0, width, height );
-        out.setPosition( x, y );
+
         return out;
     }
 
     void DrawBorder( Image & image, uint8_t value, uint32_t skipFactor )
     {
+        // assert( image.scaleFactor() == 1 );
+
         if ( image.empty() || image.width() < 2 || image.height() < 2 ) {
             return;
         }
@@ -1402,6 +1403,8 @@ namespace fheroes2
 
     void DrawLine( Image & image, const Point & start, const Point & end, uint8_t value, const Rect & roi )
     {
+        assert( image.scaleFactor() == 1 );
+
         if ( image.empty() )
             return;
 
@@ -1920,7 +1923,7 @@ namespace fheroes2
             return Sprite();
 
         // Shadow has (-x, +y) offset.
-        Sprite out( in.width() - shadowOffset.x, in.height() + shadowOffset.y, in.x() + shadowOffset.x, in.y() );
+        Sprite out( Image( in.width() - shadowOffset.x, in.height() + shadowOffset.y, in.scaleFactor() ), in.x() + shadowOffset.x, in.y() );
         out.reset();
 
         assert( !out.empty() );

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1652,11 +1652,16 @@ namespace fheroes2
 
     Image FilterOnePixelNoise( const Image & input )
     {
-        if ( input.width() < 3 || input.height() < 3 ) {
+        assert( input.scaleFactor() == 1 );
+
+        const int32_t width = input._w();
+        const int32_t height = input._h();
+
+        if ( width < 3 || height < 3 ) {
             return input;
         }
 
-        Image output( input.width(), input.height() );
+        Image output( width, height, 1 );
         output.reset();
 
         const uint8_t * imageInY = input.image();
@@ -1664,9 +1669,6 @@ namespace fheroes2
 
         uint8_t * imageOutY = output.image();
         uint8_t * transformOutY = output.transform();
-
-        const int32_t width = input._w();
-        const int32_t height = input._h();
 
         for ( int32_t y = 0; y < height; ++y ) {
             const uint8_t * transformInX = transformInY;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -524,17 +524,23 @@ namespace fheroes2
 
     void Image::resize( int32_t width_, int32_t height_ )
     {
-        if ( _width == width_ * _scaleFactor && _height == height_ * _scaleFactor ) {
+        _resize( width_ * _scaleFactor, height_ * _scaleFactor, _scaleFactor );
+    }
+
+    void Image::_resize( int32_t physicalWidth_, int32_t physicalHeight_, int32_t scaleFactor_ )
+    {
+        if ( _width == physicalWidth_ && _height == physicalHeight_ && _scaleFactor == scaleFactor_ ) {
             return;
         }
 
-        if ( width_ <= 0 || height_ <= 0 ) {
+        if ( physicalWidth_ <= 0 || physicalHeight_ <= 0 ) {
             clear();
             return;
         }
 
-        _width = width_ * _scaleFactor;
-        _height = height_ * _scaleFactor;
+        _width = physicalWidth_;
+        _height = physicalHeight_;
+        _scaleFactor = scaleFactor_;
 
         const size_t totalBytes = static_cast<size_t>( 2 * _width * _height );
         _data.reset( new uint8_t[totalBytes] );

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -643,21 +643,16 @@ namespace fheroes2
         : _image( image_ )
         , _isRestored( false )
     {
-        _captured.resize( _image.width(), _image.height() );
-        if ( _image.singleLayer() ) {
-            _captured._disableTransformLayer();
-        }
-        _capture();
     }
 
     ImageRestorer::ImageRestorer( Image & image_, int32_t x_, int32_t y_, int32_t width_, int32_t height_ )
         : _image( image_ )
-        , _captured( width_, height_, x_, y_ )
+        , _x( x_ )
+        , _y( y_ )
+        , _width( width_ )
+        , _height( height_ )
         , _isRestored( false )
     {
-        if ( _image.singleLayer() ) {
-            _captured._disableTransformLayer();
-        }
         _capture();
     }
 
@@ -670,22 +665,30 @@ namespace fheroes2
 
     void ImageRestorer::_capture()
     {
-        Copy( _image, x(), y(), _captured, 0, 0, width(), height() );
+        Image newCapture( _width, _height, _image.scaleFactor() );
+        newCapture._disableTransformLayer();
+
+        Copy( _image, _x, _y, newCapture, 0, 0, _width, _height );
+
+        _capturedImage._disableTransformLayer();
+        _capturedImage = std::move( newCapture );
     }
 
     void ImageRestorer::update( int32_t x_, int32_t y_, int32_t width_, int32_t height_ )
     {
         _isRestored = false;
 
-        _captured.resize( width_, height_ );
-        _captured.setPosition( x_, y_ );
+        _x = x_;
+        _y = y_;
+        _width = width_;
+        _height = height_;
         _capture();
     }
 
     void ImageRestorer::restore()
     {
         _isRestored = true;
-        Copy( _captured, 0, 0, _image, x(), y(), width(), height() );
+        Copy( _capturedImage, 0, 0, _image, _x, _y, _width, _height );
     }
 
     void ImageRestorer::reset()

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -735,8 +735,8 @@ namespace fheroes2
         }
 
         // Blitting one image onto another can be done only for image layer so we don't consider transform part of the output image
-        const int32_t widthIn = in.width();
-        const int32_t widthOut = out.width();
+        const int32_t widthIn = in._w();
+        const int32_t widthOut = out._w();
 
         const uint8_t behindValue = 255 - alphaValue;
 
@@ -889,7 +889,7 @@ namespace fheroes2
         if ( !Verify( image, x, y, width, height ) )
             return;
 
-        const int32_t imageWidth = image.width();
+        const int32_t imageWidth = image._w();
 
         uint8_t * imageY = image.image() + y * imageWidth + x;
         const uint8_t * imageYEnd = imageY + height * imageWidth;
@@ -942,8 +942,8 @@ namespace fheroes2
             return;
         }
 
-        const int32_t widthIn = in.width();
-        const int32_t widthOut = out.width();
+        const int32_t widthIn = in._w();
+        const int32_t widthOut = out._w();
 
         if ( flip ) {
             const int32_t offsetInY = inY * widthIn + widthIn - 1 - inX;
@@ -1116,7 +1116,7 @@ namespace fheroes2
             assert( 0 );
             return;
         }
-        memcpy( out.transform(), in.transform(), in.width() * in.height() );
+        memcpy( out.transform(), in.transform(), in._w() * in._h() );
     }
 
     Image CreateBlurredImage( const Image & in, int32_t blurRadius )
@@ -1127,8 +1127,8 @@ namespace fheroes2
         if ( blurRadius < 1 )
             return in;
 
-        const int32_t width = in.width();
-        const int32_t height = in.height();
+        const int32_t width = in._w();
+        const int32_t height = in._h();
         if ( blurRadius > width )
             blurRadius = width;
         if ( blurRadius > height )
@@ -1200,8 +1200,8 @@ namespace fheroes2
 
     Sprite CreateContour( const Image & image, uint8_t value )
     {
-        const int32_t width = image.width();
-        const int32_t height = image.height();
+        const int32_t width = image._w();
+        const int32_t height = image._h();
 
         Sprite contour( width, height );
         contour.reset();
@@ -1243,6 +1243,7 @@ namespace fheroes2
         if ( image.empty() || width <= 0 || height <= 0 )
             return Sprite();
 
+        // This looks a lot like a call to Verify().
         if ( x < 0 ) {
             const int32_t offsetX = -x;
             if ( offsetX >= width )
@@ -1290,8 +1291,8 @@ namespace fheroes2
             return;
         }
 
-        const int32_t width = image.width();
-        const int32_t height = image.height();
+        const int32_t width = image._w();
+        const int32_t height = image._h();
 
         if ( skipFactor < 2 ) {
             // top side
@@ -1400,8 +1401,8 @@ namespace fheroes2
         if ( image.empty() )
             return;
 
-        const int32_t width = image.width();
-        const int32_t height = image.height();
+        const int32_t width = image._w();
+        const int32_t height = image._h();
 
         int32_t x1 = start.x;
         int32_t y1 = start.y;
@@ -1568,7 +1569,7 @@ namespace fheroes2
 
         uint8_t * imageOut = out.image();
         uint8_t * transformOut = out.transform();
-        const uint8_t * imageOutEnd = imageOut + out.width() * out.height();
+        const uint8_t * imageOutEnd = imageOut + out._w() * out._h();
 
         bool isEqual = false;
 
@@ -1606,7 +1607,7 @@ namespace fheroes2
             return;
         }
 
-        const int32_t imageWidth = image.width();
+        const int32_t imageWidth = image._w();
 
         uint8_t * imageY = image.image() + y * imageWidth + x;
         uint8_t * transformY = image.transform() + y * imageWidth + x;
@@ -1623,7 +1624,7 @@ namespace fheroes2
         if ( !Verify( image, x, y, width, height ) )
             return;
 
-        const int32_t imageWidth = image.width();
+        const int32_t imageWidth = image._w();
 
         uint8_t * imageY = image.image() + y * imageWidth + x;
         uint8_t * transformY = image.transform() + y * imageWidth + x;
@@ -1641,10 +1642,7 @@ namespace fheroes2
             return input;
         }
 
-        const int32_t width = input.width();
-        const int32_t height = input.height();
-
-        Image output( width, height );
+        Image output( input.width(), input.height() );
         output.reset();
 
         const uint8_t * imageInY = input.image();
@@ -1652,6 +1650,9 @@ namespace fheroes2
 
         uint8_t * imageOutY = output.image();
         uint8_t * transformOutY = output.transform();
+
+        const int32_t width = input._w();
+        const int32_t height = input._h();
 
         for ( int32_t y = 0; y < height; ++y ) {
             const uint8_t * transformInX = transformInY;
@@ -1722,8 +1723,8 @@ namespace fheroes2
             return;
         }
 
-        const int32_t widthIn = in.width();
-        const int32_t widthOut = out.width();
+        const int32_t widthIn = in._w();
+        const int32_t widthOut = out._w();
 
         const int32_t offsetOut = outY * widthOut + outX;
         const int32_t offsetIn = inY * widthIn + inX;
@@ -1782,8 +1783,8 @@ namespace fheroes2
         if ( image.empty() )
             return Rect();
 
-        const int32_t width = image.width();
-        const int32_t height = image.height();
+        const int32_t width = image._w();
+        const int32_t height = image._h();
 
         Rect area( -1, -1, -1, -1 );
 
@@ -1854,7 +1855,7 @@ namespace fheroes2
                 break;
         }
 
-        return area;
+        return { area.x / image.scaleFactor(), area.y / image.scaleFactor(), area.width / image.scaleFactor(), area.height / image.scaleFactor() };
     }
 
     uint8_t GetColorId( uint8_t red, uint8_t green, uint8_t blue )
@@ -1877,7 +1878,7 @@ namespace fheroes2
             return table;
         }
 
-        const int32_t imageWidth = in.width();
+        const int32_t imageWidth = in._w();
 
         const int32_t offset = y * imageWidth + x;
 
@@ -1915,19 +1916,19 @@ namespace fheroes2
         if ( in.empty() || shadowOffset.x > 0 || shadowOffset.y < 0 )
             return Sprite();
 
-        const int32_t width = in.width();
-        const int32_t height = in.height();
-
         // Shadow has (-x, +y) offset.
-        Sprite out( width - shadowOffset.x, height + shadowOffset.y, in.x() + shadowOffset.x, in.y() );
+        Sprite out( in.width() - shadowOffset.x, in.height() + shadowOffset.y, in.x() + shadowOffset.x, in.y() );
         out.reset();
 
         assert( !out.empty() );
 
-        const int32_t widthOut = out.width();
+        const int32_t width = in._w();
+        const int32_t height = in._h();
 
         const uint8_t * transformInY = in.transform();
         const uint8_t * transformInYEnd = transformInY + width * height;
+
+        const int32_t widthOut = out._w();
         uint8_t * transformOutY = out.transform() + shadowOffset.y * widthOut;
 
         for ( ; transformInY != transformInYEnd; transformInY += width, transformOutY += widthOut ) {
@@ -1951,8 +1952,8 @@ namespace fheroes2
             return;
         }
 
-        const int32_t widthMask = mask.width();
-        const int32_t widthOut = out.width();
+        const int32_t widthMask = mask._w();
+        const int32_t widthOut = out._h();
 
         const uint8_t * imageMaskY = mask.transform() + maskY * widthMask + maskX;
         uint8_t * imageOutY = out.transform() + outY * widthOut + outX;
@@ -1977,7 +1978,7 @@ namespace fheroes2
             return;
 
         uint8_t * data = image.image();
-        const uint8_t * dataEnd = data + image.width() * image.height();
+        const uint8_t * dataEnd = data + image._w() * image._h();
 
         for ( ; data != dataEnd; ++data ) {
             if ( *data == oldColorId ) {
@@ -1991,8 +1992,8 @@ namespace fheroes2
         if ( transformId > 15 )
             return;
 
-        const int32_t width = image.width();
-        const int32_t height = image.height();
+        const int32_t width = image._w();
+        const int32_t height = image._h();
 
         const uint8_t * imageIn = image.image();
         uint8_t * transformIn = image.transform();
@@ -2195,7 +2196,7 @@ namespace fheroes2
             return;
         }
 
-        const int32_t offset = y * image.width() + x;
+        const int32_t offset = y * image._w() + x;
         *( image.image() + offset ) = value;
         *( image.transform() + offset ) = 0;
     }
@@ -2214,7 +2215,7 @@ namespace fheroes2
                 continue;
             }
 
-            const int32_t offset = point.y * width + point.x;
+            const int32_t offset = point.y * image._w() + point.x;
             *( image.image() + offset ) = value;
             *( image.transform() + offset ) = 0;
         }
@@ -2226,7 +2227,7 @@ namespace fheroes2
             return;
         }
 
-        const int32_t offset = y * image.width() + x;
+        const int32_t offset = y * image._w() + x;
         *( image.image() + offset ) = 0;
         *( image.transform() + offset ) = value;
     }
@@ -2300,8 +2301,8 @@ namespace fheroes2
             out.reset();
             return;
         }
-        const int32_t width = in.width();
-        const int32_t height = in.height();
+        const int32_t width = in._w();
+        const int32_t height = in._h();
 
         const uint8_t * imageInY = in.image();
         const uint8_t * imageInYEnd = imageInY + width * height;
@@ -2332,26 +2333,26 @@ namespace fheroes2
         const int32_t width = image.width() - std::abs( shadowOffset.x );
         const int32_t height = image.height() - std::abs( shadowOffset.y );
 
-        const int32_t imageWidth = image.width();
+        const int32_t imageWidth = image._w();
 
         const uint8_t * transformInY = image.transform();
         uint8_t * transformOutY = image.transform();
 
         if ( shadowOffset.x > 0 ) {
-            transformOutY += shadowOffset.x;
+            transformOutY += shadowOffset.x * image.scaleFactor();
         }
         else {
-            transformInY -= shadowOffset.x;
+            transformInY -= shadowOffset.x * image.scaleFactor();
         }
 
         if ( shadowOffset.y > 0 ) {
-            transformOutY += imageWidth * shadowOffset.y;
+            transformOutY += imageWidth * shadowOffset.y * image.scaleFactor();
         }
         else {
-            transformInY -= imageWidth * shadowOffset.y;
+            transformInY -= imageWidth * shadowOffset.y * image.scaleFactor();
         }
 
-        const uint8_t * transformOutYEnd = transformOutY + imageWidth * height;
+        const uint8_t * transformOutYEnd = transformOutY + imageWidth * height * image.scaleFactor();
 
         for ( ; transformOutY != transformOutYEnd; transformInY += imageWidth, transformOutY += imageWidth ) {
             const uint8_t * transformInX = transformInY;

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -50,12 +50,12 @@ namespace fheroes2
         // It's safe to cast to uint32_t as width and height are always >= 0
         int32_t width() const
         {
-            return _width;
+            return _width / _scaleFactor;
         }
 
         int32_t height() const
         {
-            return _height;
+            return _height / _scaleFactor;
         }
 
         int32_t scaleFactor() const
@@ -68,12 +68,12 @@ namespace fheroes2
 
         uint8_t * transform()
         {
-            return _data.get() + width() * height();
+            return _data.get() + _width * _height;
         }
 
         const uint8_t * transform() const
         {
-            return _data.get() + width() * height();
+            return _data.get() + _width * _height;
         }
 
         bool empty() const
@@ -107,12 +107,13 @@ namespace fheroes2
             _scaleFactor = scaleFactor;
         }
 
+        int32_t _scaleFactor;
+
     private:
-        void copy( const Image & image );
+        void copyFrom( const Image & image );
 
         int32_t _width;
         int32_t _height;
-        int32_t _scaleFactor;
         std::unique_ptr<uint8_t[]> _data; // holds 2 image layers
 
         bool _singleLayer; // only for images which are not used for any other operations except displaying on screen. Non-copyable member.
@@ -122,7 +123,7 @@ namespace fheroes2
     {
     public:
         Sprite();
-        Sprite( int32_t width_, int32_t height_, int32_t x_ = 0, int32_t y_ = 0, int32_t scaleFactor_ = 1 );
+        Sprite( int32_t width_, int32_t height_, int32_t x_ = 0, int32_t y_ = 0 );
         Sprite( const Image & image, int32_t x_ = 0, int32_t y_ = 0 );
         Sprite( const Sprite & sprite );
         Sprite( Sprite && sprite ) noexcept;
@@ -134,12 +135,12 @@ namespace fheroes2
 
         int32_t x() const
         {
-            return _x;
+            return _x / _scaleFactor;
         }
 
         int32_t y() const
         {
-            return _y;
+            return _y / _scaleFactor;
         }
 
         virtual void setPosition( int32_t x_, int32_t y_ );
@@ -153,53 +154,48 @@ namespace fheroes2
     class ImageRestorer
     {
     public:
-        explicit ImageRestorer( Image & image );
-        ImageRestorer( Image & image, int32_t x_, int32_t y_, int32_t width, int32_t height );
+        explicit ImageRestorer( Image & image_ ); // the `image` parameter is not needed: it should always be the display
+        ImageRestorer( Image & image_, int32_t x_, int32_t y_, int32_t width_, int32_t height_ );
         ~ImageRestorer(); // restore method will be call upon object's destruction
 
         ImageRestorer( const ImageRestorer & ) = delete;
 
-        void update( int32_t x_, int32_t y_, int32_t width, int32_t height );
+        void update( int32_t x_, int32_t y_, int32_t width_, int32_t height_ );
 
         int32_t x() const
         {
-            return _x;
+            return _captured.x();
         }
 
         int32_t y() const
         {
-            return _y;
+            return _captured.y();
         }
 
         int32_t width() const
         {
-            return _width;
+            return _captured.width();
         }
 
         int32_t height() const
         {
-            return _height;
+            return _captured.height();
         }
 
         Rect rect() const
         {
-            return { _x, _y, _width, _height };
+            return { x(), y(), width(), height() };
         }
 
         void restore();
         void reset();
 
     private:
+        // void _updateRoi();
+        void _capture();
+
         Image & _image;
-        Image _copy;
-
-        int32_t _x;
-        int32_t _y;
-        int32_t _width;
-        int32_t _height;
-
-        void _updateRoi();
-
+        Sprite _captured;
         bool _isRestored;
     };
 

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -112,11 +112,8 @@ namespace fheroes2
         }
 
     protected:
-        // ONLY FOR THE Display CLASS!
-        void _setScaleFactor( int32_t scaleFactor )
-        {
-            _scaleFactor = scaleFactor;
-        }
+        // For the Display class.
+        void _resize( int32_t physicalWidth_, int32_t physicalHeight_, int32_t scaleFactor_ );
 
     private:
         void copyFrom( const Image & image );

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -198,7 +198,6 @@ namespace fheroes2
         void reset();
 
     private:
-        // void _updateRoi();
         void _capture();
 
         Image & _image;

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -174,27 +174,27 @@ namespace fheroes2
 
         int32_t x() const
         {
-            return _captured.x();
+            return _x;
         }
 
         int32_t y() const
         {
-            return _captured.y();
+            return _y;
         }
 
         int32_t width() const
         {
-            return _captured.width();
+            return _width;
         }
 
         int32_t height() const
         {
-            return _captured.height();
+            return _height;
         }
 
         Rect rect() const
         {
-            return { x(), y(), width(), height() };
+            return { _x, _y, _width, _height };
         }
 
         void restore();
@@ -205,7 +205,12 @@ namespace fheroes2
         void _capture();
 
         Image & _image;
-        Sprite _captured;
+        int32_t _x;
+        int32_t _y;
+        int32_t _width;
+        int32_t _height;
+
+        Image _capturedImage;
         bool _isRestored;
     };
 

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -58,6 +58,17 @@ namespace fheroes2
             return _height / _scaleFactor;
         }
 
+        // Internal width and height for use in the blit routines.
+        int32_t _w() const
+        {
+            return _width;
+        }
+
+        int32_t _h() const
+        {
+            return _height;
+        }
+
         int32_t scaleFactor() const
         {
             return _scaleFactor;
@@ -107,13 +118,12 @@ namespace fheroes2
             _scaleFactor = scaleFactor;
         }
 
-        int32_t _scaleFactor;
-
     private:
         void copyFrom( const Image & image );
 
         int32_t _width;
         int32_t _height;
+        int32_t _scaleFactor;
         std::unique_ptr<uint8_t[]> _data; // holds 2 image layers
 
         bool _singleLayer; // only for images which are not used for any other operations except displaying on screen. Non-copyable member.
@@ -135,12 +145,12 @@ namespace fheroes2
 
         int32_t x() const
         {
-            return _x / _scaleFactor;
+            return _x / scaleFactor();
         }
 
         int32_t y() const
         {
-            return _y / _scaleFactor;
+            return _y / scaleFactor();
         }
 
         virtual void setPosition( int32_t x_, int32_t y_ );

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -36,6 +36,7 @@ namespace fheroes2
     public:
         Image();
         Image( int32_t width_, int32_t height_ );
+        Image( int32_t width_, int32_t height_, int32_t scaleFactor_ );
         Image( const Image & image_ );
         Image( Image && image_ ) noexcept;
 
@@ -55,6 +56,11 @@ namespace fheroes2
         int32_t height() const
         {
             return _height;
+        }
+
+        int32_t scaleFactor() const
+        {
+            return _scaleFactor;
         }
 
         virtual uint8_t * image();
@@ -94,11 +100,19 @@ namespace fheroes2
             _singleLayer = true;
         }
 
+    protected:
+        // ONLY FOR THE Display CLASS!
+        void _setScaleFactor( int32_t scaleFactor )
+        {
+            _scaleFactor = scaleFactor;
+        }
+
     private:
         void copy( const Image & image );
 
         int32_t _width;
         int32_t _height;
+        int32_t _scaleFactor;
         std::unique_ptr<uint8_t[]> _data; // holds 2 image layers
 
         bool _singleLayer; // only for images which are not used for any other operations except displaying on screen. Non-copyable member.
@@ -108,7 +122,7 @@ namespace fheroes2
     {
     public:
         Sprite();
-        Sprite( int32_t width_, int32_t height_, int32_t x_ = 0, int32_t y_ = 0 );
+        Sprite( int32_t width_, int32_t height_, int32_t x_ = 0, int32_t y_ = 0, int32_t scaleFactor_ = 1 );
         Sprite( const Image & image, int32_t x_ = 0, int32_t y_ = 0 );
         Sprite( const Sprite & sprite );
         Sprite( Sprite && sprite ) noexcept;

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -169,7 +169,7 @@ namespace fheroes2
             return false;
         }
 
-        Image image( surface->w, surface->h, scaleFactor );
+        Image image( surface->w / scaleFactor, surface->h / scaleFactor, scaleFactor );
 
         if ( surface->format->BytesPerPixel == 3 ) {
             memset( image.transform(), 0, surface->w * surface->h );
@@ -231,7 +231,7 @@ namespace fheroes2
         }
         SDL_FreeSurface( surface );
 
-        std::swap( image, output );
+        output = std::move( image );
         return true;
     }
 
@@ -322,7 +322,8 @@ namespace fheroes2
             }
         }
 
-        return Sprite( sprite, offsetX, offsetY );
+        // FIXME: meh, but no other way to create sprite with SF=1 for now
+        return Sprite( std::move( sprite ), offsetX, offsetY );
     }
 
     bool isPNGFormatSupported()

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -237,7 +237,7 @@ namespace fheroes2
 
     Sprite decodeICNSprite( const uint8_t * data, uint32_t sizeData, const int32_t width, const int32_t height, const int16_t offsetX, const int16_t offsetY )
     {
-        Sprite sprite( width, height, offsetX, offsetY );
+        Image sprite( width, height, 1 );
         sprite.reset();
 
         uint8_t * imageData = sprite.image();
@@ -322,7 +322,7 @@ namespace fheroes2
             }
         }
 
-        return sprite;
+        return Sprite( sprite, offsetX, offsetY );
     }
 
     bool isPNGFormatSupported()

--- a/src/engine/image_tool.h
+++ b/src/engine/image_tool.h
@@ -32,7 +32,7 @@ namespace fheroes2
     // Save an image into file. 'background' represents palette index from the original palette. Recommended value is 23.
     bool Save( const Image & image, const std::string & path, const uint8_t background );
 
-    bool Load( const std::string & path, Image & image );
+    bool Load( const std::string & path, Image & image, int32_t scaleFactor );
 
     Sprite decodeICNSprite( const uint8_t * data, uint32_t sizeData, const int32_t width, const int32_t height, const int16_t offsetX, const int16_t offsetY );
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1761,10 +1761,10 @@ void LocalEvent::HandleKeyboardEvent( const SDL_KeyboardEvent & event )
 void LocalEvent::HandleMouseMotionEvent( const SDL_MouseMotionEvent & motion )
 {
     SetModes( MOUSE_MOTION );
-    mouse_cu.x = motion.x;
-    mouse_cu.y = motion.y;
-    _emulatedPointerPosX = mouse_cu.x;
-    _emulatedPointerPosY = mouse_cu.y;
+    _emulatedPointerPosX = motion.x;
+    _emulatedPointerPosY = motion.y;
+    mouse_cu.x = motion.x / fheroes2::Display::scaleFactor();
+    mouse_cu.y = motion.y / fheroes2::Display::scaleFactor();
 
     if ( _globalMouseMotionEventHook ) {
         _mouseCursorRenderArea = _globalMouseMotionEventHook( motion.x, motion.y );
@@ -1784,10 +1784,10 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
 
     mouse_button = button.button;
 
-    mouse_cu.x = button.x;
-    mouse_cu.y = button.y;
-    _emulatedPointerPosX = mouse_cu.x;
-    _emulatedPointerPosY = mouse_cu.y;
+    _emulatedPointerPosX = button.x;
+    _emulatedPointerPosY = button.y;
+    mouse_cu.x = button.x / fheroes2::Display::scaleFactor();
+    mouse_cu.y = button.y / fheroes2::Display::scaleFactor();
 
     if ( modes & MOUSE_PRESSED )
         switch ( button.button ) {

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1763,8 +1763,8 @@ void LocalEvent::HandleMouseMotionEvent( const SDL_MouseMotionEvent & motion )
     SetModes( MOUSE_MOTION );
     _emulatedPointerPosX = motion.x;
     _emulatedPointerPosY = motion.y;
-    mouse_cu.x = motion.x / fheroes2::Display::scaleFactor();
-    mouse_cu.y = motion.y / fheroes2::Display::scaleFactor();
+    mouse_cu.x = motion.x / fheroes2::Display::currentScaleFactor();
+    mouse_cu.y = motion.y / fheroes2::Display::currentScaleFactor();
 
     if ( _globalMouseMotionEventHook ) {
         _mouseCursorRenderArea = _globalMouseMotionEventHook( motion.x, motion.y );
@@ -1786,8 +1786,8 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
 
     _emulatedPointerPosX = button.x;
     _emulatedPointerPosY = button.y;
-    mouse_cu.x = button.x / fheroes2::Display::scaleFactor();
-    mouse_cu.y = button.y / fheroes2::Display::scaleFactor();
+    mouse_cu.x = button.x / fheroes2::Display::currentScaleFactor();
+    mouse_cu.y = button.y / fheroes2::Display::currentScaleFactor();
 
     if ( modes & MOUSE_PRESSED )
         switch ( button.button ) {

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1506,8 +1506,11 @@ namespace fheroes2
         }
 
         const int32_t newScaleFactor = std::max( 1, std::min( width_ / fheroes2::Display::DEFAULT_WIDTH, height_ / fheroes2::Display::DEFAULT_HEIGHT ) );
+
+        // FIXME: remove when there's hook no more
         _setScaleFactor( newScaleFactor );
-        Image::resize( width_ / newScaleFactor, height_ / newScaleFactor );
+
+        Image::_resize( width_, height_, newScaleFactor );
 
         // To detect some UI artifacts by invalid code let's put all transform data into pixel skipping mode.
         std::fill( image(), image() + _w() * _h(), static_cast<uint8_t>( 0 ) );
@@ -1517,8 +1520,6 @@ namespace fheroes2
     void Display::_setScaleFactor( int32_t scaleFactor_ )
     {
         const int32_t oldScaleFactor = scaleFactor();
-
-        Image::_setScaleFactor( scaleFactor_ );
         _currentScaleFactor = scaleFactor_;
 
         if ( oldScaleFactor != scaleFactor_ && _onScaleFactorChangeHook != nullptr ) {

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1502,6 +1502,8 @@ namespace fheroes2
             clear();
         }
 
+        _setScaleFactor( std::max( 1, std::min( width_ / fheroes2::Display::DEFAULT_WIDTH, height_ / fheroes2::Display::DEFAULT_HEIGHT ) ) );
+
         Image::resize( width_, height_ );
 
         // To detect some UI artifacts by invalid code let's put all transform data into pixel skipping mode.

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -400,14 +400,14 @@ namespace
                 return;
             }
 
-            SDL_Surface * surface = SDL_CreateRGBSurface( 0, image.width(), image.height(), 32, 0xFF, 0xFF00, 0xFF0000, 0xFF000000 );
+            const uint32_t width = image._w();
+            const uint32_t height = image._h();
+
+            SDL_Surface * surface = SDL_CreateRGBSurface( 0, width, height, 32, 0xFF, 0xFF00, 0xFF0000, 0xFF000000 );
             if ( surface == nullptr ) {
-                ERROR_LOG( "Failed to create a surface of " << image.width() << " x " << image.height() << " size for cursor. The error: " << SDL_GetError() )
+                ERROR_LOG( "Failed to create a surface of " << width << " x " << height << " size for cursor. The error: " << SDL_GetError() )
                 return;
             }
-
-            const uint32_t width = image.width();
-            const uint32_t height = image.height();
 
             uint32_t * out = static_cast<uint32_t *>( surface->pixels );
             const uint32_t * outEnd = out + width * height;

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1476,7 +1476,6 @@ namespace fheroes2
     }
 
     int32_t Display::_currentScaleFactor = 1;
-    Display::onScaleFactorChangeHook Display::_onScaleFactorChangeHook = nullptr;
 
     Display::Display()
         : _engine( RenderEngine::create() )
@@ -1506,30 +1505,13 @@ namespace fheroes2
         }
 
         const int32_t newScaleFactor = std::max( 1, std::min( width_ / fheroes2::Display::DEFAULT_WIDTH, height_ / fheroes2::Display::DEFAULT_HEIGHT ) );
-
-        // FIXME: remove when there's hook no more
-        _setScaleFactor( newScaleFactor );
-
         Image::_resize( width_, height_, newScaleFactor );
+
+        _currentScaleFactor = newScaleFactor;
 
         // To detect some UI artifacts by invalid code let's put all transform data into pixel skipping mode.
         std::fill( image(), image() + _w() * _h(), static_cast<uint8_t>( 0 ) );
         std::fill( transform(), transform() + _w() * _h(), static_cast<uint8_t>( 1 ) );
-    }
-
-    void Display::_setScaleFactor( int32_t scaleFactor_ )
-    {
-        const int32_t oldScaleFactor = scaleFactor();
-        _currentScaleFactor = scaleFactor_;
-
-        if ( oldScaleFactor != scaleFactor_ && _onScaleFactorChangeHook != nullptr ) {
-            _onScaleFactorChangeHook( oldScaleFactor, scaleFactor_ );
-        }
-    }
-
-    void Display::setOnScaleFactorChangeHook( onScaleFactorChangeHook hook )
-    {
-        _onScaleFactorChangeHook = hook;
     }
 
     Display & Display::instance()

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1520,11 +1520,6 @@ namespace fheroes2
         return display;
     }
 
-    int32_t Display::scaleFactor()
-    {
-        return _currentScaleFactor;
-    }
-
     void Display::render( const Rect & roi )
     {
         Rect temp( roi );

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1475,6 +1475,8 @@ namespace fheroes2
         Display::instance().linkRenderSurface( surface );
     }
 
+    int32_t Display::_currentScaleFactor = 1;
+
     Display::Display()
         : _engine( RenderEngine::create() )
         , _cursor( RenderCursor::create() )
@@ -1510,10 +1512,21 @@ namespace fheroes2
         std::fill( transform(), transform() + width() * height(), static_cast<uint8_t>( 1 ) );
     }
 
+    void Display::_setScaleFactor( int32_t scaleFactor_ )
+    {
+        _scaleFactor = scaleFactor_;
+        _currentScaleFactor = scaleFactor_;
+    }
+
     Display & Display::instance()
     {
         static Display display;
         return display;
+    }
+
+    int32_t Display::scaleFactor()
+    {
+        return _currentScaleFactor;
     }
 
     void Display::render( const Rect & roi )

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -212,8 +212,8 @@ namespace
                 }
             }
 
-            const int32_t imageWidth = image.width();
-            const int32_t imageHeight = image.height();
+            const int32_t imageWidth = image._w();
+            const int32_t imageHeight = image._h();
 
             const bool fullFrame = ( roi.width == imageWidth ) && ( roi.height == imageHeight );
 
@@ -1585,14 +1585,14 @@ namespace fheroes2
                 updateImage = ( _renderSurface == nullptr );
                 if ( updateImage ) {
                     // Pre-processing step is applied to the whole image so we forcefully render the full frame.
-                    _engine->render( *this, { 0, 0, width(), height() } );
+                    _engine->render( *this, { 0, 0, _w(), _h() } );
                     return;
                 }
             }
         }
 
         if ( updateImage ) {
-            _engine->render( *this, roi );
+            _engine->render( *this, { roi.x * scaleFactor(), roi.y * scaleFactor(), roi.width * scaleFactor(), roi.height * scaleFactor() } );
         }
     }
 

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1489,7 +1489,7 @@ namespace fheroes2
 
     void Display::resize( int32_t width_, int32_t height_ )
     {
-        if ( width() > 0 && height() > 0 && width_ == width() && height_ == height() ) // nothing to resize
+        if ( width() > 0 && height() > 0 && width_ == width() * scaleFactor() && height_ == height() * scaleFactor() ) // nothing to resize
             return;
 
         const bool isFullScreen = _engine->isFullScreen();
@@ -1505,8 +1505,7 @@ namespace fheroes2
         }
 
         _setScaleFactor( std::max( 1, std::min( width_ / fheroes2::Display::DEFAULT_WIDTH, height_ / fheroes2::Display::DEFAULT_HEIGHT ) ) );
-
-        Image::resize( width_, height_ );
+        Image::resize( width_ / scaleFactor(), height_ / scaleFactor() );
 
         // To detect some UI artifacts by invalid code let's put all transform data into pixel skipping mode.
         std::fill( transform(), transform() + width() * height(), static_cast<uint8_t>( 1 ) );
@@ -1514,7 +1513,7 @@ namespace fheroes2
 
     void Display::_setScaleFactor( int32_t scaleFactor_ )
     {
-        _scaleFactor = scaleFactor_;
+        Image::_setScaleFactor( scaleFactor_ );
         _currentScaleFactor = scaleFactor_;
     }
 

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -144,17 +144,22 @@ namespace fheroes2
             DEFAULT_WIDTH = 640,
             DEFAULT_HEIGHT = 480
         };
-        static const int32_t MAX_SCALE_FACTOR = 4;
 
         static Display & instance();
-        static int32_t scaleFactor();
+
+        static const int32_t MAX_SCALE_FACTOR = 4;
+
+        static int32_t currentScaleFactor()
+        {
+            return _currentScaleFactor;
+        }
 
         friend class ScaleFactorOverride;
         class ScaleFactorOverride
         {
         public:
             explicit ScaleFactorOverride( int32_t tempScaleFactor )
-                : _scaleFactorToRestore( Display::scaleFactor() )
+                : _scaleFactorToRestore( Display::currentScaleFactor() )
             {
                 Display::_setCurrentScaleFactor( tempScaleFactor );
             }
@@ -182,7 +187,6 @@ namespace fheroes2
         void updateNextRenderRoi( const Rect & roi );
 
         void resize( int32_t width_, int32_t height_ ) override;
-        void _setScaleFactor( int32_t scaleFactor_ );
 
         bool isDefaultSize() const
         {
@@ -216,6 +220,10 @@ namespace fheroes2
         static void _setCurrentScaleFactor( int32_t scaleFactor )
         {
             _currentScaleFactor = scaleFactor;
+
+            // a hack to only change scale factor of the display instance
+            Display & display = instance();
+            display._resize( display._w(), display._h(), scaleFactor );
         }
 
         static int32_t _currentScaleFactor;

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -133,7 +133,7 @@ namespace fheroes2
         bool _nearestScaling;
     };
 
-    class Display : public Image
+    class Display : public Image // That's a REALLY bad idea after all...
     {
     public:
         friend class BaseRenderEngine;

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -145,6 +145,7 @@ namespace fheroes2
         };
 
         static Display & instance();
+        static int32_t scaleFactor();
 
         ~Display() override = default;
 
@@ -160,6 +161,7 @@ namespace fheroes2
         void updateNextRenderRoi( const Rect & roi );
 
         void resize( int32_t width_, int32_t height_ ) override;
+        void _setScaleFactor( int32_t scaleFactor_ );
 
         bool isDefaultSize() const
         {
@@ -190,6 +192,8 @@ namespace fheroes2
         friend Cursor & cursor();
 
     private:
+        static int32_t _currentScaleFactor;
+
         std::unique_ptr<BaseRenderEngine> _engine;
         std::unique_ptr<Cursor> _cursor;
         PreRenderProcessing _preprocessing;

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -147,6 +147,9 @@ namespace fheroes2
         static Display & instance();
         static int32_t scaleFactor();
 
+        typedef void ( *onScaleFactorChangeHook )( int32_t oldScaleFactor, int32_t newScaleFactor );
+        static void setOnScaleFactorChangeHook( onScaleFactorChangeHook hook );
+
         ~Display() override = default;
 
         // Render a full frame on screen.
@@ -193,6 +196,7 @@ namespace fheroes2
 
     private:
         static int32_t _currentScaleFactor;
+        static onScaleFactorChangeHook _onScaleFactorChangeHook;
 
         std::unique_ptr<BaseRenderEngine> _engine;
         std::unique_ptr<Cursor> _cursor;

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -213,7 +213,7 @@ void SMKVideoSequence::resetFrame()
 
 void SMKVideoSequence::getNextFrame( fheroes2::Image & image, const int32_t x, const int32_t y, int32_t & width, int32_t & height, std::vector<uint8_t> & palette )
 {
-    if ( _videoFile == nullptr || image.empty() || x < 0 || y < 0 || x >= image.width() || y >= image.height() || !image.singleLayer() ) {
+    if ( _videoFile == nullptr || image.empty() || x < 0 || y < 0 || x >= image._w() || y >= image._h() || !image.singleLayer() ) {
         width = 0;
         height = 0;
         return;
@@ -228,7 +228,7 @@ void SMKVideoSequence::getNextFrame( fheroes2::Image & image, const int32_t x, c
     assert( _heightScaleFactor == 1 || _heightScaleFactor == 2 );
     assert( ( _height % _heightScaleFactor ) == 0 );
 
-    if ( image.width() == _width && image.height() == _height && x == 0 && y == 0 ) {
+    if ( image._w() == _width && image._h() == _height && x == 0 && y == 0 ) {
         const size_t size = static_cast<size_t>( _width ) * _height;
 
         if ( _heightScaleFactor == 2 ) {
@@ -247,16 +247,16 @@ void SMKVideoSequence::getNextFrame( fheroes2::Image & image, const int32_t x, c
         }
     }
     else {
-        if ( x + width > image.width() ) {
-            width = image.width() - x;
+        if ( x + width > image._w() ) {
+            width = image._w() - x;
         }
-        if ( y + height > image.height() ) {
-            height = image.height() - y;
+        if ( y + height > image._h() ) {
+            height = image._h() - y;
         }
 
         const uint8_t * inY = data;
 
-        const int32_t imageWidth = image.width();
+        const int32_t imageWidth = image._w();
         uint8_t * outY = image.image() + x + y * imageWidth;
         const uint8_t * outYEnd = outY + ( height / _heightScaleFactor ) * _heightScaleFactor * imageWidth;
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3430,13 +3430,19 @@ namespace fheroes2
 
             const int32_t imgScaleFactor = _icnVsSprite[id][0].scaleFactor();
             const int32_t displayScaleFactor = Display::instance().scaleFactor();
+
             if ( imgScaleFactor != displayScaleFactor ) {
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
                     const Sprite & original = _icnVsSprite[id][i];
                     // resize the image to match the display's scale factor
-                    Sprite scaled( original.width() * displayScaleFactor / imgScaleFactor, original.height() * displayScaleFactor / imgScaleFactor );
-                    // TODO: set sprite scale factor!
+                    Sprite scaled( original.width() * displayScaleFactor / imgScaleFactor, original.height() * displayScaleFactor / imgScaleFactor, 0, 0,
+                                   displayScaleFactor );
                     scaled.setPosition( original.x() * displayScaleFactor / imgScaleFactor, original.y() * displayScaleFactor / imgScaleFactor );
+
+                    if ( original.singleLayer() ) {
+                        scaled._disableTransformLayer();
+                    }
+
                     Resize( original, scaled, false );
                     _icnVsSprite[id][i] = scaled;
                 }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -176,19 +176,12 @@ namespace
     {
         assert( 1 <= scaleFactor && static_cast<size_t>( scaleFactor ) <= _spritesForScaleFactor.size() );
 
-        auto & icnVsSprite = _spritesForScaleFactor[scaleFactor - 1];
-        if ( icnVsSprite.empty() ) {
-            icnVsSprite.resize( ICN::LASTICN );
+        auto & _icnVsSprite = _spritesForScaleFactor[scaleFactor - 1];
+        if ( _icnVsSprite.empty() ) {
+            _icnVsSprite.resize( ICN::LASTICN );
         }
-        return icnVsSprite;
+        return _icnVsSprite;
     }
-
-    /*
-    std::vector<std::vector<fheroes2::Sprite>> & getSprites()
-    {
-        return getSpritesForScaleFactor( fheroes2::Display::scaleFactor() );
-    }
-    */
 
     std::array<std::vector<std::vector<fheroes2::Image>>, TIL::LASTTIL> & getTILsForScaleFactor( int32_t scaleFactor )
     {
@@ -333,13 +326,13 @@ namespace
             fheroes2::AGG::GetICN( ICN::BUTTON_EVIL_FONT_RELEASED, 0 );
             fheroes2::AGG::GetICN( ICN::BUTTON_EVIL_FONT_PRESSED, 0 );
 
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
-            _normalFont = icnVsSprite[ICN::FONT];
-            _smallFont = icnVsSprite[ICN::SMALFONT];
-            _buttonGoodReleasedFont = icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED];
-            _buttonGoodPressedFont = icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED];
-            _buttonEvilReleasedFont = icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED];
-            _buttonEvilPressedFont = icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED];
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
+            _normalFont = _icnVsSprite[ICN::FONT];
+            _smallFont = _icnVsSprite[ICN::SMALFONT];
+            _buttonGoodReleasedFont = _icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED];
+            _buttonGoodPressedFont = _icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED];
+            _buttonEvilReleasedFont = _icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED];
+            _buttonEvilPressedFont = _icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED];
 
             _isPreserved = true;
         }
@@ -350,22 +343,22 @@ namespace
                 return;
             }
 
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             // Restore the original font.
-            icnVsSprite[ICN::FONT] = _normalFont;
-            icnVsSprite[ICN::SMALFONT] = _smallFont;
-            icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] = _buttonGoodReleasedFont;
-            icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED] = _buttonGoodPressedFont;
-            icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED] = _buttonEvilReleasedFont;
-            icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] = _buttonEvilPressedFont;
+            _icnVsSprite[ICN::FONT] = _normalFont;
+            _icnVsSprite[ICN::SMALFONT] = _smallFont;
+            _icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] = _buttonGoodReleasedFont;
+            _icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED] = _buttonGoodPressedFont;
+            _icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED] = _buttonEvilReleasedFont;
+            _icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] = _buttonEvilPressedFont;
 
             // Clear modified fonts.
-            icnVsSprite[ICN::YELLOW_FONT].clear();
-            icnVsSprite[ICN::YELLOW_SMALLFONT].clear();
-            icnVsSprite[ICN::GRAY_FONT].clear();
-            icnVsSprite[ICN::GRAY_SMALL_FONT].clear();
-            icnVsSprite[ICN::WHITE_LARGE_FONT].clear();
+            _icnVsSprite[ICN::YELLOW_FONT].clear();
+            _icnVsSprite[ICN::YELLOW_SMALLFONT].clear();
+            _icnVsSprite[ICN::GRAY_FONT].clear();
+            _icnVsSprite[ICN::GRAY_SMALL_FONT].clear();
+            _icnVsSprite[ICN::WHITE_LARGE_FONT].clear();
         }
 
     private:
@@ -591,15 +584,15 @@ namespace fheroes2
         //         return false;
         //     }
 
-        //     auto & icnVsSprite = getSpritesForScaleFactor( scaleFactor );
+        //     auto & _icnVsSprite = getSpritesForScaleFactor( scaleFactor );
 
-        //     icnVsSprite[id].resize( count );
+        //     _icnVsSprite[id].resize( count );
 
         //     for ( int i = 0; i < count; ++i ) {
         //         char fname[16];
         //         snprintf( fname, 16, "%03d.png", i );
         //         std::string filepath = System::concatPath( pathToImagesDir, fname );
-        //         if ( !fheroes2::Load( filepath, icnVsSprite[id][i], scaleFactor ) ) {
+        //         if ( !fheroes2::Load( filepath, _icnVsSprite[id][i], scaleFactor ) ) {
         //             DEBUG_LOG( DBG_ENGINE, DBG_WARN, "failed to load image from: " << filepath );
         //             fclose( f );
         //             return false;
@@ -613,7 +606,7 @@ namespace fheroes2
         //             return false;
         //         }
         //         // FIXME: the division here is only because we've multiplied the offsets in the spec file, but we didn't have to
-        //         icnVsSprite[id][i].setPosition( offsetX / scaleFactor, offsetY / scaleFactor );
+        //         _icnVsSprite[id][i].setPosition( offsetX / scaleFactor, offsetY / scaleFactor );
         //     }
         //     fclose( f );
 
@@ -657,9 +650,9 @@ namespace fheroes2
                 return false;
             }
 
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
-            icnVsSprite[id].resize( count );
+            _icnVsSprite[id].resize( count );
 
             for ( uint32_t i = 0; i < count; ++i ) {
                 imageStream.seek( headerSize + i * 13 );
@@ -679,7 +672,7 @@ namespace fheroes2
 
                 const uint8_t * data = body.data() + headerSize + header1.offsetData;
 
-                icnVsSprite[id][i]
+                _icnVsSprite[id][i]
                     = decodeICNSprite( data, sizeData, header1.width, header1.height, static_cast<int16_t>( header1.offsetX ), static_cast<int16_t>( header1.offsetY ) );
             }
 
@@ -693,170 +686,170 @@ namespace fheroes2
 
             GetICN( originalIcnId, 0 ); // always avoid calling LoadOriginalICN directly
 
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
-            icnVsSprite[icnId] = icnVsSprite[originalIcnId];
+            _icnVsSprite[icnId] = _icnVsSprite[originalIcnId];
             const std::vector<uint8_t> & palette = PAL::GetPalette( paletteType );
-            for ( size_t i = 0; i < icnVsSprite[icnId].size(); ++i ) {
-                ApplyPalette( icnVsSprite[icnId][i], palette );
+            for ( size_t i = 0; i < _icnVsSprite[icnId].size(); ++i ) {
+                ApplyPalette( _icnVsSprite[icnId][i], palette );
             }
         }
 
         void generateDefaultImages( const int id )
         {
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             switch ( id ) {
             case ICN::BTNBATTLEONLY: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
 
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "BATTLE\nONLY" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "BATTLE\nONLY" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_NEW_GAME_EVIL:
             case ICN::BUTTON_NEW_GAME_GOOD: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_NEW_GAME_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 0 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 1 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 0 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 1 );
                     break;
                 }
 
                 const int baseIcnId = isEvilInterface ? ICN::EMPTY_EVIL_MEDIUM_BUTTON : ICN::EMPTY_GOOD_MEDIUM_BUTTON;
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "NEW\nGAME" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "NEW\nGAME" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_SAVE_GAME_EVIL:
             case ICN::BUTTON_SAVE_GAME_GOOD: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SAVE_GAME_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 4 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 5 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 4 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 5 );
                     break;
                 }
 
                 const int baseIcnId = isEvilInterface ? ICN::EMPTY_EVIL_MEDIUM_BUTTON : ICN::EMPTY_GOOD_MEDIUM_BUTTON;
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "SAVE\nGAME" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "SAVE\nGAME" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_LOAD_GAME_EVIL:
             case ICN::BUTTON_LOAD_GAME_GOOD: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_LOAD_GAME_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 2 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 3 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 2 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 3 );
                     break;
                 }
 
                 const int baseIcnId = isEvilInterface ? ICN::EMPTY_EVIL_MEDIUM_BUTTON : ICN::EMPTY_GOOD_MEDIUM_BUTTON;
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "LOAD\nGAME" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "LOAD\nGAME" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_INFO_EVIL:
             case ICN::BUTTON_INFO_GOOD: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_INFO_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::APANELE : ICN::APANEL, 4 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::APANELE : ICN::APANEL, 5 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::APANELE : ICN::APANEL, 4 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::APANELE : ICN::APANEL, 5 );
                     break;
                 }
 
                 const int baseIcnId = isEvilInterface ? ICN::EMPTY_EVIL_MEDIUM_BUTTON : ICN::EMPTY_GOOD_MEDIUM_BUTTON;
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "INFO" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "INFO" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_QUIT_EVIL:
             case ICN::BUTTON_QUIT_GOOD: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_QUIT_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 6 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 7 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 6 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 7 );
                     break;
                 }
 
                 const int baseIcnId = isEvilInterface ? ICN::EMPTY_EVIL_MEDIUM_BUTTON : ICN::EMPTY_GOOD_MEDIUM_BUTTON;
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "QUIT" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "QUIT" ), { 7, 5 }, { 6, 6 }, { 86, 48 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_SMALL_CANCEL_GOOD:
             case ICN::BUTTON_SMALL_CANCEL_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_CANCEL_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 8 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 9 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 8 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 9 );
                     break;
                 }
 
                 int32_t textWidth = 86;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "CANCEL" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "CANCEL" ), isEvilInterface );
 
                 break;
             }
@@ -864,19 +857,19 @@ namespace fheroes2
             case ICN::BUTTON_SMALL_OKAY_EVIL:
             case ICN::BUTTON_SMALLER_OKAY_GOOD:
             case ICN::BUTTON_SMALLER_OKAY_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_OKAY_EVIL || id == ICN::BUTTON_SMALLER_OKAY_EVIL );
                 const bool isSameResourceAsLanguage = useOriginalResources();
 
                 if ( isSameResourceAsLanguage && ( id == ICN::BUTTON_SMALL_OKAY_EVIL || id == ICN::BUTTON_SMALL_OKAY_GOOD ) ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 1 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 1 );
                     break;
                 }
                 if ( isSameResourceAsLanguage && ( id == ICN::BUTTON_SMALLER_OKAY_EVIL || id == ICN::BUTTON_SMALLER_OKAY_GOOD ) ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::WINCMBBE : ICN::WINCMBTB, 0 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::WINCMBBE : ICN::WINCMBTB, 1 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::WINCMBBE : ICN::WINCMBTB, 0 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::WINCMBBE : ICN::WINCMBTB, 1 );
                     break;
                 }
 
@@ -885,624 +878,629 @@ namespace fheroes2
                     textWidth = 70;
                 }
 
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "OKAY" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "OKAY" ), isEvilInterface );
 
                 break;
             }
             case ICN::BUTTON_SMALL_ACCEPT_GOOD:
             case ICN::BUTTON_SMALL_ACCEPT_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_ACCEPT_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR, 0 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR, 1 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR, 0 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR, 1 );
                     break;
                 }
 
                 int32_t textWidth = 106;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "ACCEPT" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "ACCEPT" ), isEvilInterface );
 
                 break;
             }
             case ICN::BUTTON_SMALL_DECLINE_GOOD:
             case ICN::BUTTON_SMALL_DECLINE_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_DECLINE_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR, 2 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR, 3 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR, 2 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR, 3 );
                     break;
                 }
 
                 int32_t textWidth = 106;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "DECLINE" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "DECLINE" ), isEvilInterface );
 
                 break;
             }
             case ICN::BUTTON_SMALL_LEARN_GOOD:
             case ICN::BUTTON_SMALL_LEARN_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_LEARN_EVIL );
                 const int baseIcnID = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( baseIcnID, 9 );
-                    icnVsSprite[id][1] = GetICN( baseIcnID, 10 );
+                    _icnVsSprite[id][0] = GetICN( baseIcnID, 9 );
+                    _icnVsSprite[id][1] = GetICN( baseIcnID, 10 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnID, 11 + i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "LEARN" ), { 7, 5 }, { 5, 6 }, { 86, 16 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "LEARN" ), { 7, 5 }, { 5, 6 }, { 86, 16 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_SMALL_TRADE_GOOD:
             case ICN::BUTTON_SMALL_TRADE_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_TRADE_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST, 15 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST, 16 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST, 15 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST, 16 );
                     break;
                 }
 
                 int32_t textWidth = 87;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "TRADE" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "TRADE" ), isEvilInterface );
 
                 break;
             }
             case ICN::BUTTON_SMALL_YES_GOOD:
             case ICN::BUTTON_SMALL_YES_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_YES_EVIL );
                 const int baseIcnID = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( baseIcnID, 5 );
-                    icnVsSprite[id][1] = GetICN( baseIcnID, 6 );
+                    _icnVsSprite[id][0] = GetICN( baseIcnID, 5 );
+                    _icnVsSprite[id][1] = GetICN( baseIcnID, 6 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnID, 11 + i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "YES" ), { 6, 5 }, { 4, 6 }, { 86, 16 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "YES" ), { 6, 5 }, { 4, 6 }, { 86, 16 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_SMALL_NO_GOOD:
             case ICN::BUTTON_SMALL_NO_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_NO_EVIL );
                 const int baseIcnID = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( baseIcnID, 7 );
-                    icnVsSprite[id][1] = GetICN( baseIcnID, 8 );
+                    _icnVsSprite[id][0] = GetICN( baseIcnID, 7 );
+                    _icnVsSprite[id][1] = GetICN( baseIcnID, 8 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnID, 11 + i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "NO" ), { 6, 5 }, { 4, 6 }, { 86, 16 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "NO" ), { 6, 5 }, { 4, 6 }, { 86, 16 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_SMALL_EXIT_GOOD:
             case ICN::BUTTON_SMALL_EXIT_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_EXIT_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 3 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 4 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 3 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 4 );
                     break;
                 }
 
                 int32_t textWidth = 85;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "EXIT" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "EXIT" ), isEvilInterface );
 
                 break;
             }
             case ICN::BUTTON_SMALLER_EXIT: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::TREASURY, 1 );
-                    icnVsSprite[id][1] = GetICN( ICN::TREASURY, 2 );
+                    _icnVsSprite[id][0] = GetICN( ICN::TREASURY, 1 );
+                    _icnVsSprite[id][1] = GetICN( ICN::TREASURY, 2 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TREASURY, 1 + i );
 
                     // clean the button.
                     Fill( out, 6 - i, 4 + i, 70, 16, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "EXIT" ), { 6, 5 }, { 5, 6 }, { 70, 16 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "EXIT" ), { 6, 5 }, { 5, 6 }, { 70, 16 }, fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_SMALL_DISMISS_GOOD:
             case ICN::BUTTON_SMALL_DISMISS_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_DISMISS_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 1 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 2 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 1 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 2 );
                     break;
                 }
 
                 int32_t textWidth = 101;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "DISMISS" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "DISMISS" ), isEvilInterface );
 
                 break;
             }
             case ICN::BUTTON_SMALL_UPGRADE_GOOD:
             case ICN::BUTTON_SMALL_UPGRADE_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_UPGRADE_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 5 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 6 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 5 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY, 6 );
                     break;
                 }
 
                 int32_t textWidth = 101;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "UPGRADE" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "UPGRADE" ), isEvilInterface );
 
                 break;
             }
             case ICN::BUTTON_SMALL_RESTART_GOOD:
             case ICN::BUTTON_SMALL_RESTART_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_RESTART_EVIL );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::NON_UNIFORM_EVIL_RESTART_BUTTON : ICN::NON_UNIFORM_GOOD_RESTART_BUTTON, 0 );
-                    icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::NON_UNIFORM_EVIL_RESTART_BUTTON : ICN::NON_UNIFORM_GOOD_RESTART_BUTTON, 1 );
+                    _icnVsSprite[id][0] = GetICN( isEvilInterface ? ICN::NON_UNIFORM_EVIL_RESTART_BUTTON : ICN::NON_UNIFORM_GOOD_RESTART_BUTTON, 0 );
+                    _icnVsSprite[id][1] = GetICN( isEvilInterface ? ICN::NON_UNIFORM_EVIL_RESTART_BUTTON : ICN::NON_UNIFORM_GOOD_RESTART_BUTTON, 1 );
                     break;
                 }
 
                 int32_t textWidth = 98;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "RESTART" ), isEvilInterface );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "RESTART" ), isEvilInterface );
 
                 break;
             }
             case ICN::BUTTON_KINGDOM_EXIT: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::OVERVIEW, 4 );
-                    icnVsSprite[id][1] = GetICN( ICN::OVERVIEW, 5 );
+                    _icnVsSprite[id][0] = GetICN( ICN::OVERVIEW, 4 );
+                    _icnVsSprite[id][1] = GetICN( ICN::OVERVIEW, 5 );
                     break;
                 }
 
                 // Needs to be generated from original assets because the pressed state is 1px wider than normal.
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::OVERVIEW, 4 + i );
 
                     // clean the button.
                     Fill( out, 6 - i, 4 + i, 89, 16, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "EXIT" ), { 6, 5 }, { 5, 6 }, { 89, 16 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "EXIT" ), { 6, 5 }, { 5, 6 }, { 89, 16 }, fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_MAPSIZE_SMALL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 9 );
-                    icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 10 );
+                    _icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 9 );
+                    _icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 10 );
                     break;
                 }
 
                 int32_t textWidth = 46;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "S" ), false );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "S" ), false );
 
                 break;
             }
             case ICN::BUTTON_MAPSIZE_MEDIUM: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 11 );
-                    icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 12 );
+                    _icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 11 );
+                    _icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 12 );
                     break;
                 }
 
                 int32_t textWidth = 46;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "M" ), false );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "M" ), false );
 
                 break;
             }
             case ICN::BUTTON_MAPSIZE_LARGE: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 13 );
-                    icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 14 );
+                    _icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 13 );
+                    _icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 14 );
                     break;
                 }
 
                 int32_t textWidth = 46;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "L" ), false );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "L" ), false );
 
                 break;
             }
             case ICN::BUTTON_MAPSIZE_XLARGE: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 15 );
-                    icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 16 );
+                    _icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 15 );
+                    _icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 16 );
                     break;
                 }
 
                 int32_t textWidth = 46;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "X-L" ), false );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "X-L" ), false );
 
                 break;
             }
             case ICN::BUTTON_MAPSIZE_ALL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 17 );
-                    icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 18 );
+                    _icnVsSprite[id][0] = GetICN( ICN::REQUESTS, 17 );
+                    _icnVsSprite[id][1] = GetICN( ICN::REQUESTS, 18 );
                     break;
                 }
 
                 int32_t textWidth = 46;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "ALL" ), false );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "ALL" ), false );
 
                 break;
             }
             case ICN::BUTTON_STANDARD_GAME: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNNEWGM, 0 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNNEWGM, 1 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNNEWGM, 0 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNNEWGM, 1 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "STANDARD\nGAME" ), { 12, 5 }, { 11, 6 }, { 120, 47 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "STANDARD\nGAME" ), { 12, 5 }, { 11, 6 }, { 120, 47 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_CAMPAIGN_GAME: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNNEWGM, 2 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNNEWGM, 3 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNNEWGM, 2 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNNEWGM, 3 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "CAMPAIGN\nGAME" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "CAMPAIGN\nGAME" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_MULTIPLAYER_GAME: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNNEWGM, 4 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNNEWGM, 5 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNNEWGM, 4 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNNEWGM, 5 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "MULTI-\nPLAYER\nGAME" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MULTI-\nPLAYER\nGAME" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_LARGE_CANCEL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNNEWGM, 6 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNNEWGM, 7 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNNEWGM, 6 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNNEWGM, 7 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "CANCEL" ), { 12, 5 }, { 11, 6 }, { 117, 47 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "CANCEL" ), { 12, 5 }, { 11, 6 }, { 117, 47 }, fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_LARGE_CONFIG: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNDCCFG, 4 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNDCCFG, 5 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNDCCFG, 4 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNDCCFG, 5 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "CONFIG" ), { 12, 5 }, { 11, 6 }, { 117, 47 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "CONFIG" ), { 12, 5 }, { 11, 6 }, { 117, 47 }, fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_ORIGINAL_CAMPAIGN: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::X_LOADCM, 0 );
-                    icnVsSprite[id][1] = GetICN( ICN::X_LOADCM, 1 );
+                    _icnVsSprite[id][0] = GetICN( ICN::X_LOADCM, 0 );
+                    _icnVsSprite[id][1] = GetICN( ICN::X_LOADCM, 1 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "ORIGINAL\nCAMPAIGN" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "ORIGINAL\nCAMPAIGN" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_EXPANSION_CAMPAIGN: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::X_LOADCM, 2 );
-                    icnVsSprite[id][1] = GetICN( ICN::X_LOADCM, 3 );
+                    _icnVsSprite[id][0] = GetICN( ICN::X_LOADCM, 2 );
+                    _icnVsSprite[id][1] = GetICN( ICN::X_LOADCM, 3 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "EXPANSION\nCAMPAIGN" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "EXPANSION\nCAMPAIGN" ), { 12, 5 }, { 11, 6 }, { 117, 47 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_HOT_SEAT: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNMP, 0 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNMP, 1 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNMP, 0 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNMP, 1 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "HOT SEAT" ), { 11, 5 }, { 10, 6 }, { 120, 47 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "HOT SEAT" ), { 11, 5 }, { 10, 6 }, { 120, 47 }, fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_2_PLAYERS: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 0 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 1 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 0 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 1 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "2 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "2 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 },
+                                    fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_3_PLAYERS: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 2 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 3 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 2 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 3 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "3 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "3 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 },
+                                    fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_4_PLAYERS: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 4 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 5 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 4 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 5 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "4 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "4 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 },
+                                    fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_5_PLAYERS: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 6 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 7 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 6 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 7 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "5 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "5 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 },
+                                    fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_6_PLAYERS: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 8 );
-                    icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 9 );
+                    _icnVsSprite[id][0] = GetICN( ICN::BTNHOTST, 8 );
+                    _icnVsSprite[id][1] = GetICN( ICN::BTNHOTST, 9 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNCOM, i );
                     // clean button.
                     Fill( out, 13, 11, 113, 31, getButtonFillingColor( i == 0 ) );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "6 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "6 PLAYERS" ), { 11, 5 }, { 10, 6 }, { 120, 47 },
+                                    fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BTNGIFT_GOOD:
             case ICN::BTNGIFT_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::BTNGIFT_EVIL );
                 const int baseIcnId = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, 11 + i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "GIFT" ), { 7, 5 }, { 6, 6 }, { 86, 16 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "GIFT" ), { 7, 5 }, { 6, 6 }, { 86, 16 }, buttonFontColor );
 
                 break;
             }
             case ICN::BUTTON_DIFFICULTY_ARCHIBALD: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 int32_t textWidth = 140;
                 fheroes2::Point releasedOffset;
                 fheroes2::Point pressedOffset;
-                getCustomNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], true, textWidth, releasedOffset, pressedOffset );
+                getCustomNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], true, textWidth, releasedOffset, pressedOffset );
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), releasedOffset, pressedOffset, { textWidth, 16 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), releasedOffset, pressedOffset, { textWidth, 16 },
                                     fheroes2::FontColor::GRAY );
 
                 break;
             }
             case ICN::BUTTON_DIFFICULTY_ROLAND: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 int32_t textWidth = 140;
                 fheroes2::Point releasedOffset;
                 fheroes2::Point pressedOffset;
-                getCustomNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], false, textWidth, releasedOffset, pressedOffset );
+                getCustomNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], false, textWidth, releasedOffset, pressedOffset );
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), releasedOffset, pressedOffset, { textWidth, 16 },
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), releasedOffset, pressedOffset, { textWidth, 16 },
                                     fheroes2::FontColor::WHITE );
 
                 break;
             }
             case ICN::BUTTON_DIFFICULTY_POL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::X_CMPBTN, 0 + i );
 
                     // clean the button.
@@ -1512,35 +1510,35 @@ namespace fheroes2
                     }
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 5 }, { 5, 5 }, { 132, 17 }, fheroes2::FontColor::GRAY );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "DIFFICULTY" ), { 5, 5 }, { 5, 5 }, { 132, 17 }, fheroes2::FontColor::GRAY );
 
                 break;
             }
             case ICN::BUTTON_SMALL_MIN_GOOD: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::NON_UNIFORM_GOOD_MIN_BUTTON, 0 );
-                    icnVsSprite[id][1] = GetICN( ICN::NON_UNIFORM_GOOD_MIN_BUTTON, 1 );
+                    _icnVsSprite[id][0] = GetICN( ICN::NON_UNIFORM_GOOD_MIN_BUTTON, 0 );
+                    _icnVsSprite[id][1] = GetICN( ICN::NON_UNIFORM_GOOD_MIN_BUTTON, 1 );
                     break;
                 }
 
                 int32_t textWidth = 61;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "MIN" ), false );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "MIN" ), false );
 
                 break;
             }
             case ICN::BUTTON_SMALL_MAX_GOOD: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( ICN::RECRUIT, 4 );
-                    icnVsSprite[id][1] = GetICN( ICN::RECRUIT, 5 );
+                    _icnVsSprite[id][0] = GetICN( ICN::RECRUIT, 4 );
+                    _icnVsSprite[id][1] = GetICN( ICN::RECRUIT, 5 );
                     break;
                 }
 
                 int32_t textWidth = 61;
-                createNormalButton( icnVsSprite[id][0], icnVsSprite[id][1], textWidth, gettext_noop( "MAX" ), false );
+                createNormalButton( _icnVsSprite[id][0], _icnVsSprite[id][1], textWidth, gettext_noop( "MAX" ), false );
 
                 break;
             }
@@ -1548,13 +1546,13 @@ namespace fheroes2
             case ICN::UNIFORM_EVIL_MIN_BUTTON:
             case ICN::UNIFORM_GOOD_MAX_BUTTON:
             case ICN::UNIFORM_GOOD_MIN_BUTTON: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::UNIFORM_EVIL_MAX_BUTTON || id == ICN::UNIFORM_EVIL_MIN_BUTTON );
                 const int baseIcnId = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
 
                     const Sprite & originalButton = GetICN( ICN::RECRUIT, 4 + i );
                     out.resize( originalButton.width() + 4, originalButton.height() - 5 + i );
@@ -1572,68 +1570,68 @@ namespace fheroes2
                 const char * text( ( id == ICN::UNIFORM_GOOD_MIN_BUTTON || id == ICN::UNIFORM_EVIL_MIN_BUTTON ) ? "MIN" : "MAX" );
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( text ), { 6, 5 }, { 4, 6 }, { 62, 16 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( text ), { 6, 5 }, { 4, 6 }, { 62, 16 }, buttonFontColor );
 
                 break;
             }
             case ICN::UNIFORM_GOOD_OKAY_BUTTON:
             case ICN::UNIFORM_EVIL_OKAY_BUTTON: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::UNIFORM_EVIL_OKAY_BUTTON );
                 const int baseIcnId = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( baseIcnId, 1 );
-                    icnVsSprite[id][1] = GetICN( baseIcnId, 2 );
+                    _icnVsSprite[id][0] = GetICN( baseIcnId, 1 );
+                    _icnVsSprite[id][1] = GetICN( baseIcnId, 2 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, 11 + i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "OKAY" ), { 6, 5 }, { 4, 6 }, { 86, 16 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "OKAY" ), { 6, 5 }, { 4, 6 }, { 86, 16 }, buttonFontColor );
 
                 break;
             }
             case ICN::UNIFORM_GOOD_CANCEL_BUTTON:
             case ICN::UNIFORM_EVIL_CANCEL_BUTTON: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const bool isEvilInterface = ( id == ICN::UNIFORM_EVIL_CANCEL_BUTTON );
                 const int baseIcnId = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
 
                 if ( useOriginalResources() ) {
-                    icnVsSprite[id][0] = GetICN( baseIcnId, 3 );
-                    icnVsSprite[id][1] = GetICN( baseIcnId, 4 );
+                    _icnVsSprite[id][0] = GetICN( baseIcnId, 3 );
+                    _icnVsSprite[id][1] = GetICN( baseIcnId, 4 );
                     break;
                 }
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( baseIcnId, 11 + i );
                 }
 
                 const fheroes2::FontColor buttonFontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "CANCEL" ), { 7, 5 }, { 5, 6 }, { 86, 16 }, buttonFontColor );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "CANCEL" ), { 7, 5 }, { 5, 6 }, { 86, 16 }, buttonFontColor );
 
                 break;
             }
             case ICN::NON_UNIFORM_GOOD_MIN_BUTTON: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::RECRUIT, 4 + i );
 
                     // clean the button.
                     Blit( GetICN( ICN::SYSTEM, 11 + i ), 10 - i, 4 + i, out, 11 - i, 4 + i, 50, 16 );
                 }
 
-                renderTextOnButton( icnVsSprite[id][0], icnVsSprite[id][1], gettext_noop( "MIN" ), { 11, 5 }, { 10, 6 }, { 52, 16 }, fheroes2::FontColor::WHITE );
+                renderTextOnButton( _icnVsSprite[id][0], _icnVsSprite[id][1], gettext_noop( "MIN" ), { 11, 5 }, { 10, 6 }, { 52, 16 }, fheroes2::FontColor::WHITE );
 
                 break;
             }
@@ -1648,13 +1646,13 @@ namespace fheroes2
 
         bool generateGermanSpecificImages( const int id )
         {
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             switch ( id ) {
             case ICN::BTNBATTLEONLY:
-                icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNNEWGM, 6 + i );
                     // Clean the button
                     Fill( out, 25, 18, 88, 23, getButtonFillingColor( i == 0 ) );
@@ -1672,9 +1670,9 @@ namespace fheroes2
                 }
                 return true;
             case ICN::BUTTON_SMALL_MIN_GOOD:
-                icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::RECRUIT, 4 + i );
                     // clean the button
                     Blit( GetICN( ICN::SYSTEM, 11 + i ), 10, 6 + i, out, 30 - 2 * i, 5 + i, 31, 15 );
@@ -1691,13 +1689,13 @@ namespace fheroes2
 
         bool generateFrenchSpecificImages( const int id )
         {
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             switch ( id ) {
             case ICN::BTNBATTLEONLY:
-                icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNNEWGM, 6 + i );
                     // Clean the button
                     Fill( out, 25, 18, 88, 23, getButtonFillingColor( i == 0 ) );
@@ -1732,9 +1730,9 @@ namespace fheroes2
                 }
                 return true;
             case ICN::BTNGIFT_GOOD:
-                icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TRADPOST, 17 + i );
                     // clean the button
                     Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0 ) );
@@ -1779,9 +1777,9 @@ namespace fheroes2
                 }
                 return true;
             case ICN::BTNGIFT_EVIL:
-                icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TRADPOSE, 17 + i );
                     // clean the button
                     Fill( out, 33, 5, 31, 16, getButtonFillingColor( i == 0, false ) );
@@ -1834,9 +1832,9 @@ namespace fheroes2
                 }
                 return true;
             case ICN::BUTTON_SMALL_MIN_GOOD:
-                icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::RECRUIT, 4 + i );
                     // Clean the button and leave 'M'
                     Fill( out, 31 - 2 * i, 5 + i, 25, 15, getButtonFillingColor( i == 0 ) );
@@ -1859,13 +1857,13 @@ namespace fheroes2
 
         bool generatePolishSpecificImages( const int id )
         {
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             switch ( id ) {
             case ICN::BTNBATTLEONLY:
-                icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNNEWGM, 6 + i );
                     // clean the button
                     Fill( out, 25, 18, 88, 23, getButtonFillingColor( i == 0 ) );
@@ -1889,13 +1887,13 @@ namespace fheroes2
 
         bool generateItalianSpecificImages( const int id )
         {
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             switch ( id ) {
             case ICN::BTNBATTLEONLY:
-                icnVsSprite[id].resize( 2 );
-                for ( int32_t i = 0; i < static_cast<int32_t>( icnVsSprite[id].size() ); ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                _icnVsSprite[id].resize( 2 );
+                for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::BTNNEWGM, 6 + i );
                     // clean the button
                     uint8_t buttonFillingColor = getButtonFillingColor( i == 0 );
@@ -1978,7 +1976,7 @@ namespace fheroes2
             // that's some ugly hack right here
             Display::ScaleFactorOverride override( 1 );
 
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             switch ( id ) {
             case ICN::ROUTERED:
@@ -1988,7 +1986,7 @@ namespace fheroes2
             case ICN::SMALFONT: {
                 LoadOriginalICN( id );
 
-                auto & imageArray = icnVsSprite[id];
+                auto & imageArray = _icnVsSprite[id];
 
                 const std::vector<uint8_t> & body = ::AGG::getDataFromAggFile( ICN::GetString( id ) );
                 const uint32_t crc32 = fheroes2::calculateCRC32( body.data(), body.size() );
@@ -2000,7 +1998,7 @@ namespace fheroes2
                             letter.setPosition( letter.x(), letter.y() - 1 );
                         }
                     }
-                    modifyBaseSmallFont( icnVsSprite[id] );
+                    modifyBaseSmallFont( _icnVsSprite[id] );
                 }
 
                 if ( id == ICN::FONT ) {
@@ -2008,7 +2006,7 @@ namespace fheroes2
                     for ( size_t i = 0; i < imageArray.size(); ++i ) {
                         ReplaceColorIdByTransformId( imageArray[i], 50, 2 );
                     }
-                    modifyBaseNormalFont( icnVsSprite[id] );
+                    modifyBaseNormalFont( _icnVsSprite[id] );
                 }
 
                 // Some checks that we really have CP1251 font
@@ -2091,7 +2089,7 @@ namespace fheroes2
                 return true;
             case ICN::SPELLS:
                 LoadOriginalICN( id );
-                icnVsSprite[id].resize( 67 );
+                _icnVsSprite[id].resize( 67 );
                 for ( uint32_t i = 60; i < 66; ++i ) {
                     int originalIndex = 0;
                     if ( i == 60 ) // Mass Cure
@@ -2107,8 +2105,8 @@ namespace fheroes2
                     else if ( i == 65 ) // Mass Shield
                         originalIndex = 15;
 
-                    const Sprite & originalImage = icnVsSprite[id][originalIndex];
-                    Sprite & image = icnVsSprite[id][i];
+                    const Sprite & originalImage = _icnVsSprite[id][originalIndex];
+                    Sprite & image = _icnVsSprite[id][i];
 
                     image.resize( originalImage.width() + 8, originalImage.height() + 8 );
                     image.setPosition( originalImage.x() + 4, originalImage.y() + 4 );
@@ -2122,25 +2120,25 @@ namespace fheroes2
                 }
 
                 // The Petrification spell does not have its own icon in the original game.
-                h2d::readImage( "petrification_spell_icon.image", icnVsSprite[id][66] );
+                h2d::readImage( "petrification_spell_icon.image", _icnVsSprite[id][66] );
 
                 return true;
             case ICN::CSLMARKER:
-                icnVsSprite[id].resize( 3 );
+                _icnVsSprite[id].resize( 3 );
                 for ( uint32_t i = 0; i < 3; ++i ) {
-                    icnVsSprite[id][i] = GetICN( ICN::LOCATORS, 24 );
+                    _icnVsSprite[id][i] = GetICN( ICN::LOCATORS, 24 );
                     if ( i == 1 ) {
-                        ReplaceColorId( icnVsSprite[id][i], 0x0A, 0xD6 );
+                        ReplaceColorId( _icnVsSprite[id][i], 0x0A, 0xD6 );
                     }
                     else if ( i == 2 ) {
-                        ReplaceColorId( icnVsSprite[id][i], 0x0A, 0xDE );
+                        ReplaceColorId( _icnVsSprite[id][i], 0x0A, 0xDE );
                     }
                 }
                 return true;
             case ICN::BATTLESKIP:
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
                 for ( uint32_t i = 0; i < 2; ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::TEXTBAR, 4 + i );
 
                     // clean the button
@@ -2151,9 +2149,9 @@ namespace fheroes2
                 }
                 return true;
             case ICN::BUYMAX:
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
                 for ( uint32_t i = 0; i < 2; ++i ) {
-                    Sprite & out = icnVsSprite[id][i];
+                    Sprite & out = _icnVsSprite[id][i];
                     out = GetICN( ICN::WELLXTRA, i );
 
                     // clean the button
@@ -2241,24 +2239,24 @@ namespace fheroes2
             case ICN::PHOENIX:
                 LoadOriginalICN( id );
                 // First sprite has cropped shadow. We copy missing part from another 'almost' identical frame
-                if ( icnVsSprite[id].size() >= 32 ) {
-                    const Sprite & in = icnVsSprite[id][32];
-                    Copy( in, 60, 73, icnVsSprite[id][1], 60, 73, 14, 13 );
-                    Copy( in, 56, 72, icnVsSprite[id][30], 56, 72, 18, 9 );
+                if ( _icnVsSprite[id].size() >= 32 ) {
+                    const Sprite & in = _icnVsSprite[id][32];
+                    Copy( in, 60, 73, _icnVsSprite[id][1], 60, 73, 14, 13 );
+                    Copy( in, 56, 72, _icnVsSprite[id][30], 56, 72, 18, 9 );
                 }
                 return true;
             case ICN::MONH0028: // phoenix
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() == 1 ) {
+                if ( _icnVsSprite[id].size() == 1 ) {
                     const Sprite & correctFrame = GetICN( ICN::PHOENIX, 32 );
-                    Copy( correctFrame, 60, 73, icnVsSprite[id][0], 58, 70, 14, 13 );
+                    Copy( correctFrame, 60, 73, _icnVsSprite[id][0], 58, 70, 14, 13 );
                 }
                 return true;
             case ICN::CAVALRYR:
                 LoadOriginalICN( id );
                 // Sprite 23 has incorrect colors, we need to replace them
-                if ( icnVsSprite[id].size() >= 23 ) {
-                    Sprite & out = icnVsSprite[id][23];
+                if ( _icnVsSprite[id].size() >= 23 ) {
+                    Sprite & out = _icnVsSprite[id][23];
 
                     std::vector<uint8_t> indexes( 256 );
                     for ( uint32_t i = 0; i < 256; ++i ) {
@@ -2283,8 +2281,8 @@ namespace fheroes2
                 return true;
             case ICN::TROLLMSL:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() == 1 ) {
-                    Sprite & out = icnVsSprite[id][0];
+                if ( _icnVsSprite[id].size() == 1 ) {
+                    Sprite & out = _icnVsSprite[id][0];
                     // The original sprite contains 2 pixels which are empty
                     if ( out.width() * out.height() > 188 && out.transform()[147] == 1 && out.transform()[188] == 1 ) {
                         out.transform()[147] = 0;
@@ -2297,11 +2295,11 @@ namespace fheroes2
                 return true;
             case ICN::TROLL2MSL:
                 LoadOriginalICN( ICN::TROLLMSL );
-                if ( icnVsSprite[ICN::TROLLMSL].size() == 1 ) {
-                    icnVsSprite[id].resize( 1 );
+                if ( _icnVsSprite[ICN::TROLLMSL].size() == 1 ) {
+                    _icnVsSprite[id].resize( 1 );
 
-                    Sprite & out = icnVsSprite[id][0];
-                    out = icnVsSprite[ICN::TROLLMSL][0];
+                    Sprite & out = _icnVsSprite[id][0];
+                    out = _icnVsSprite[ICN::TROLLMSL][0];
 
                     // The original sprite contains 2 pixels which are empty
                     if ( out.width() * out.height() > 188 && out.transform()[147] == 1 && out.transform()[188] == 1 ) {
@@ -2350,21 +2348,21 @@ namespace fheroes2
             case ICN::LOCATORE:
             case ICN::LOCATORS:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() > 15 ) {
-                    if ( icnVsSprite[id][12].width() == 47 ) {
-                        Sprite & out = icnVsSprite[id][12];
+                if ( _icnVsSprite[id].size() > 15 ) {
+                    if ( _icnVsSprite[id][12].width() == 47 ) {
+                        Sprite & out = _icnVsSprite[id][12];
                         out = Crop( out, 0, 0, out.width() - 1, out.height() );
                     }
-                    if ( icnVsSprite[id][15].width() == 47 ) {
-                        Sprite & out = icnVsSprite[id][15];
+                    if ( _icnVsSprite[id][15].width() == 47 ) {
+                        Sprite & out = _icnVsSprite[id][15];
                         out = Crop( out, 0, 0, out.width() - 1, out.height() );
                     }
                 }
                 return true;
             case ICN::TOWNBKG2:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() == 1 ) {
-                    Sprite & out = icnVsSprite[id][0];
+                if ( _icnVsSprite[id].size() == 1 ) {
+                    Sprite & out = _icnVsSprite[id][0];
                     // The pixel pixel of the original sprite has a skip value
                     if ( !out.empty() && out.transform()[0] == 1 ) {
                         out.transform()[0] = 0;
@@ -2374,8 +2372,8 @@ namespace fheroes2
                 return true;
             case ICN::HSICONS:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() > 7 ) {
-                    Sprite & out = icnVsSprite[id][7];
+                if ( _icnVsSprite[id].size() > 7 ) {
+                    Sprite & out = _icnVsSprite[id][7];
                     if ( out.width() == 34 && out.height() == 19 ) {
                         Sprite temp;
                         std::swap( temp, out );
@@ -2389,15 +2387,15 @@ namespace fheroes2
                 return true;
             case ICN::LISTBOX_EVIL:
                 CopyICNWithPalette( id, ICN::LISTBOX, PAL::PaletteType::GRAY );
-                for ( size_t i = 0; i < icnVsSprite[id].size(); ++i ) {
-                    ApplyPalette( icnVsSprite[id][i], 2 );
+                for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
+                    ApplyPalette( _icnVsSprite[id][i], 2 );
                 }
                 return true;
             case ICN::MONS32:
                 LoadOriginalICN( id );
 
-                if ( icnVsSprite[id].size() > 4 ) { // Veteran Pikeman
-                    Sprite & modified = icnVsSprite[id][4];
+                if ( _icnVsSprite[id].size() > 4 ) { // Veteran Pikeman
+                    Sprite & modified = _icnVsSprite[id][4];
 
                     Sprite temp( modified.width(), modified.height() + 1 );
                     temp.reset();
@@ -2405,8 +2403,8 @@ namespace fheroes2
                     modified = std::move( temp );
                     Fill( modified, 7, 0, 4, 1, 36 );
                 }
-                if ( icnVsSprite[id].size() > 6 ) { // Master Swordsman
-                    Sprite & modified = icnVsSprite[id][6];
+                if ( _icnVsSprite[id].size() > 6 ) { // Master Swordsman
+                    Sprite & modified = _icnVsSprite[id][6];
 
                     Sprite temp( modified.width(), modified.height() + 1 );
                     temp.reset();
@@ -2414,8 +2412,8 @@ namespace fheroes2
                     modified = std::move( temp );
                     Fill( modified, 2, 0, 5, 1, 36 );
                 }
-                if ( icnVsSprite[id].size() > 8 ) { // Champion
-                    Sprite & modified = icnVsSprite[id][8];
+                if ( _icnVsSprite[id].size() > 8 ) { // Champion
+                    Sprite & modified = _icnVsSprite[id][8];
 
                     Sprite temp( modified.width(), modified.height() + 1 );
                     temp.reset();
@@ -2423,10 +2421,10 @@ namespace fheroes2
                     modified = std::move( temp );
                     Fill( modified, 12, 0, 5, 1, 36 );
                 }
-                if ( icnVsSprite[id].size() > 62 ) {
+                if ( _icnVsSprite[id].size() > 62 ) {
                     const Point shadowOffset( -1, 2 );
                     for ( size_t i = 0; i < 62; ++i ) {
-                        Sprite & modified = icnVsSprite[id][i];
+                        Sprite & modified = _icnVsSprite[id][i];
                         const Point originalOffset( modified.x(), modified.y() );
                         Sprite temp = addShadow( modified, { -1, 2 }, 2 );
                         temp.setPosition( originalOffset.x - 1, originalOffset.y + 2 );
@@ -2442,18 +2440,18 @@ namespace fheroes2
                         }
                     }
                 }
-                if ( icnVsSprite[id].size() > 63 && icnVsSprite[id][63].width() == 19 && icnVsSprite[id][63].height() == 37 ) { // Air Elemental
-                    Sprite & modified = icnVsSprite[id][63];
+                if ( _icnVsSprite[id].size() > 63 && _icnVsSprite[id][63].width() == 19 && _icnVsSprite[id][63].height() == 37 ) { // Air Elemental
+                    Sprite & modified = _icnVsSprite[id][63];
                     modified.image()[19 * 9 + 9] = modified.image()[19 * 5 + 11];
                     modified.transform()[19 * 9 + 9] = modified.transform()[19 * 5 + 11];
                 }
 
                 return true;
             case ICN::MONSTER_SWITCH_LEFT_ARROW:
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
                 for ( uint32_t i = 0; i < 2; ++i ) {
                     const Sprite & source = GetICN( ICN::RECRUIT, i );
-                    Sprite & out = icnVsSprite[id][i];
+                    Sprite & out = _icnVsSprite[id][i];
                     out.resize( source.height(), source.width() );
                     Transpose( source, out );
                     out = Flip( out, false, true );
@@ -2461,10 +2459,10 @@ namespace fheroes2
                 }
                 return true;
             case ICN::MONSTER_SWITCH_RIGHT_ARROW:
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
                 for ( uint32_t i = 0; i < 2; ++i ) {
                     const Sprite & source = GetICN( ICN::RECRUIT, i + 2 );
-                    Sprite & out = icnVsSprite[id][i];
+                    Sprite & out = _icnVsSprite[id][i];
                     out.resize( source.height(), source.width() );
                     Transpose( source, out );
                     out = Flip( out, false, true );
@@ -2474,19 +2472,19 @@ namespace fheroes2
             case ICN::SURRENDR:
             case ICN::SURRENDE:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 4 ) {
+                if ( _icnVsSprite[id].size() >= 4 ) {
                     if ( id == ICN::SURRENDR ) {
                         // Fix incorrect font color on good ACCEPT button.
-                        ReplaceColorId( icnVsSprite[id][0], 28, 56 );
+                        ReplaceColorId( _icnVsSprite[id][0], 28, 56 );
                     }
                     // Fix pressed buttons background.
                     for ( uint32_t i : { 0, 2 } ) {
-                        Sprite & out = icnVsSprite[id][i + 1];
+                        Sprite & out = _icnVsSprite[id][i + 1];
 
                         Sprite tmp( out.width(), out.height() );
                         tmp.reset();
                         Copy( out, 0, 1, tmp, 1, 0, tmp.width() - 1, tmp.height() - 1 );
-                        CopyTransformLayer( icnVsSprite[id][i], tmp );
+                        CopyTransformLayer( _icnVsSprite[id][i], tmp );
 
                         out.reset();
                         Copy( tmp, 1, 0, out, 0, 1, tmp.width() - 1, tmp.height() - 1 );
@@ -2494,34 +2492,34 @@ namespace fheroes2
                 }
                 return true;
             case ICN::NON_UNIFORM_GOOD_RESTART_BUTTON:
-                icnVsSprite[id].resize( 2 );
-                icnVsSprite[id][0] = Crop( GetICN( ICN::CAMPXTRG, 2 ), 6, 0, 108, 25 );
-                icnVsSprite[id][0].setPosition( 0, 0 );
+                _icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id][0] = Crop( GetICN( ICN::CAMPXTRG, 2 ), 6, 0, 108, 25 );
+                _icnVsSprite[id][0].setPosition( 0, 0 );
 
-                icnVsSprite[id][1] = GetICN( ICN::CAMPXTRG, 3 );
-                icnVsSprite[id][1].setPosition( 0, 0 );
+                _icnVsSprite[id][1] = GetICN( ICN::CAMPXTRG, 3 );
+                _icnVsSprite[id][1].setPosition( 0, 0 );
 
                 // fix transparent corners
-                CopyTransformLayer( icnVsSprite[id][1], icnVsSprite[id][0] );
+                CopyTransformLayer( _icnVsSprite[id][1], _icnVsSprite[id][0] );
                 return true;
             case ICN::NON_UNIFORM_EVIL_RESTART_BUTTON:
-                icnVsSprite[id].resize( 2 );
-                icnVsSprite[id][0] = Crop( GetICN( ICN::CAMPXTRE, 2 ), 4, 0, 108, 25 );
-                icnVsSprite[id][0].setPosition( 0, 0 );
+                _icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id][0] = Crop( GetICN( ICN::CAMPXTRE, 2 ), 4, 0, 108, 25 );
+                _icnVsSprite[id][0].setPosition( 0, 0 );
 
-                icnVsSprite[id][1] = GetICN( ICN::CAMPXTRE, 3 );
-                icnVsSprite[id][1].setPosition( 0, 0 );
+                _icnVsSprite[id][1] = GetICN( ICN::CAMPXTRE, 3 );
+                _icnVsSprite[id][1].setPosition( 0, 0 );
 
                 // fix transparent corners
-                CopyTransformLayer( icnVsSprite[id][1], icnVsSprite[id][0] );
+                CopyTransformLayer( _icnVsSprite[id][1], _icnVsSprite[id][0] );
                 return true;
             case ICN::WHITE_LARGE_FONT: {
                 GetICN( ICN::FONT, 0 );
-                const std::vector<Sprite> & original = icnVsSprite[ICN::FONT];
-                icnVsSprite[id].resize( original.size() );
-                for ( size_t i = 0; i < icnVsSprite[id].size(); ++i ) {
+                const std::vector<Sprite> & original = _icnVsSprite[ICN::FONT];
+                _icnVsSprite[id].resize( original.size() );
+                for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
                     const Sprite & in = original[i];
-                    Sprite & out = icnVsSprite[id][i];
+                    Sprite & out = _icnVsSprite[id][i];
                     out.resize( in.width() * 2, in.height() * 2 );
                     Resize( in, out, true );
                     out.setPosition( in.x() * 2, in.y() * 2 );
@@ -2559,27 +2557,27 @@ namespace fheroes2
                     out.transform()[30 + 3 * width] = 1;
                 }
 
-                icnVsSprite[id].resize( 2 );
-                icnVsSprite[id][0] = ( id == ICN::SWAP_ARROW_LEFT_TO_RIGHT ) ? out : Flip( out, true, false );
+                _icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id][0] = ( id == ICN::SWAP_ARROW_LEFT_TO_RIGHT ) ? out : Flip( out, true, false );
 
-                icnVsSprite[id][1] = icnVsSprite[id][0];
-                icnVsSprite[id][1].setPosition( -1, 1 );
-                ApplyPalette( icnVsSprite[id][1], 4 );
+                _icnVsSprite[id][1] = _icnVsSprite[id][0];
+                _icnVsSprite[id][1].setPosition( -1, 1 );
+                ApplyPalette( _icnVsSprite[id][1], 4 );
 
                 return true;
             }
             case ICN::HEROES:
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() ) {
+                if ( !_icnVsSprite[id].empty() ) {
                     // This is the main menu image which shouldn't have any transform layer.
-                    icnVsSprite[id][0]._disableTransformLayer();
+                    _icnVsSprite[id][0]._disableTransformLayer();
                 }
                 return true;
             case ICN::TOWNBKG3:
                 // Warlock town background image contains 'empty' pixels leading to appear them as black.
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() ) {
-                    Sprite & original = icnVsSprite[id][0];
+                if ( !_icnVsSprite[id].empty() ) {
+                    Sprite & original = _icnVsSprite[id][0];
                     if ( original.width() == 640 && original.height() == 256 ) {
                         replaceTranformPixel( original, 51945, 17 );
                         replaceTranformPixel( original, 61828, 25 );
@@ -2592,8 +2590,8 @@ namespace fheroes2
             case ICN::PORT0091:
                 // Barbarian captain has one bad pixel.
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() ) {
-                    Sprite & original = icnVsSprite[id][0];
+                if ( !_icnVsSprite[id].empty() ) {
+                    Sprite & original = _icnVsSprite[id][0];
                     if ( original.width() == 101 && original.height() == 93 ) {
                         replaceTranformPixel( original, 9084, 77 );
                     }
@@ -2602,8 +2600,8 @@ namespace fheroes2
             case ICN::PORT0090:
                 // Knight captain has multiple bad pixels.
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() ) {
-                    Sprite & original = icnVsSprite[id][0];
+                if ( !_icnVsSprite[id].empty() ) {
+                    Sprite & original = _icnVsSprite[id][0];
                     if ( original.width() == 101 && original.height() == 93 ) {
                         replaceTranformPixel( original, 2314, 70 );
                         replaceTranformPixel( original, 5160, 71 );
@@ -2614,25 +2612,25 @@ namespace fheroes2
                 return true;
             case ICN::CSTLWZRD:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 8 ) {
+                if ( _icnVsSprite[id].size() >= 8 ) {
                     // Statue image has bad pixels.
-                    Sprite & original = icnVsSprite[id][7];
+                    Sprite & original = _icnVsSprite[id][7];
                     if ( original.width() == 135 && original.height() == 57 ) {
                         replaceTranformPixel( original, 3687, 50 );
                         replaceTranformPixel( original, 5159, 108 );
                         replaceTranformPixel( original, 5294, 108 );
                     }
                 }
-                if ( icnVsSprite[id].size() >= 24 ) {
+                if ( _icnVsSprite[id].size() >= 24 ) {
                     // Mage tower image has a bad pixel.
-                    Sprite & original = icnVsSprite[id][23];
+                    Sprite & original = _icnVsSprite[id][23];
                     if ( original.width() == 135 && original.height() == 57 ) {
                         replaceTranformPixel( original, 4333, 23 );
                     }
                 }
-                if ( icnVsSprite[id].size() >= 29 ) {
+                if ( _icnVsSprite[id].size() >= 29 ) {
                     // Mage tower image has a bad pixel.
-                    Sprite & original = icnVsSprite[id][28];
+                    Sprite & original = _icnVsSprite[id][28];
                     if ( original.width() == 135 && original.height() == 57 ) {
                         replaceTranformPixel( original, 4333, 23 );
                     }
@@ -2641,8 +2639,8 @@ namespace fheroes2
             case ICN::CSTLCAPK:
                 // Knight captain has a bad pixel.
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 2 ) {
-                    Sprite & original = icnVsSprite[id][1];
+                if ( _icnVsSprite[id].size() >= 2 ) {
+                    Sprite & original = _icnVsSprite[id][1];
                     if ( original.width() == 84 && original.height() == 81 ) {
                         replaceTranformPixel( original, 4934, 18 );
                     }
@@ -2651,8 +2649,8 @@ namespace fheroes2
             case ICN::CSTLCAPW:
                 // Warlock captain quarters have bad pixels.
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() ) {
-                    Sprite & original = icnVsSprite[id][0];
+                if ( !_icnVsSprite[id].empty() ) {
+                    Sprite & original = _icnVsSprite[id][0];
                     if ( original.width() == 84 && original.height() == 81 ) {
                         replaceTranformPixel( original, 1692, 26 );
                         replaceTranformPixel( original, 2363, 32 );
@@ -2663,9 +2661,9 @@ namespace fheroes2
                 return true;
             case ICN::CSTLSORC:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 14 ) {
+                if ( _icnVsSprite[id].size() >= 14 ) {
                     // Rainbow has bad pixels.
-                    Sprite & original = icnVsSprite[id][13];
+                    Sprite & original = _icnVsSprite[id][13];
                     if ( original.width() == 135 && original.height() == 57 ) {
                         replaceTranformPixel( original, 2047, 160 );
                         replaceTranformPixel( original, 2052, 159 );
@@ -2685,9 +2683,9 @@ namespace fheroes2
                         replaceTranformPixel( original, 4578, 69 );
                     }
                 }
-                if ( icnVsSprite[id].size() >= 25 ) {
+                if ( _icnVsSprite[id].size() >= 25 ) {
                     // Red tower has bad pixels.
-                    Sprite & original = icnVsSprite[id][24];
+                    Sprite & original = _icnVsSprite[id][24];
                     if ( original.width() == 135 && original.height() == 57 ) {
                         replaceTranformPixel( original, 2830, 165 );
                         replaceTranformPixel( original, 3101, 165 );
@@ -2719,25 +2717,25 @@ namespace fheroes2
                 digits[5] = createDigit( 6, 7, sevenPoints, digitColor );
                 digits[6] = addDigit( digits[5], createDigit( 5, 5, plusPoints, digitColor ), { -1, -1 } );
 
-                icnVsSprite[id].reserve( 7 * 8 );
+                _icnVsSprite[id].reserve( 7 * 8 );
 
                 const int originalCursorId = isColorCursor ? ICN::ADVMCO : ICN::MONO_CURSOR_ADVMBW;
 
-                populateCursorIcons( icnVsSprite[id], GetICN( originalCursorId, 4 ), digits, isColorCursor ? Point( -2, 1 ) : Point( -4, -6 ) );
-                populateCursorIcons( icnVsSprite[id], GetICN( originalCursorId, 5 ), digits, isColorCursor ? Point( 1, 1 ) : Point( -6, -6 ) );
-                populateCursorIcons( icnVsSprite[id], GetICN( originalCursorId, 6 ), digits, isColorCursor ? Point( 0, 1 ) : Point( -8, -7 ) );
-                populateCursorIcons( icnVsSprite[id], GetICN( originalCursorId, 7 ), digits, isColorCursor ? Point( -2, 1 ) : Point( -15, -8 ) );
-                populateCursorIcons( icnVsSprite[id], GetICN( originalCursorId, 8 ), digits, isColorCursor ? Point( 1, 1 ) : Point( -16, -11 ) );
-                populateCursorIcons( icnVsSprite[id], GetICN( originalCursorId, 9 ), digits, isColorCursor ? Point( -6, 1 ) : Point( -8, -1 ) );
-                populateCursorIcons( icnVsSprite[id], GetICN( originalCursorId, 28 ), digits, isColorCursor ? Point( 0, 1 ) : Point( -8, -7 ) );
+                populateCursorIcons( _icnVsSprite[id], GetICN( originalCursorId, 4 ), digits, isColorCursor ? Point( -2, 1 ) : Point( -4, -6 ) );
+                populateCursorIcons( _icnVsSprite[id], GetICN( originalCursorId, 5 ), digits, isColorCursor ? Point( 1, 1 ) : Point( -6, -6 ) );
+                populateCursorIcons( _icnVsSprite[id], GetICN( originalCursorId, 6 ), digits, isColorCursor ? Point( 0, 1 ) : Point( -8, -7 ) );
+                populateCursorIcons( _icnVsSprite[id], GetICN( originalCursorId, 7 ), digits, isColorCursor ? Point( -2, 1 ) : Point( -15, -8 ) );
+                populateCursorIcons( _icnVsSprite[id], GetICN( originalCursorId, 8 ), digits, isColorCursor ? Point( 1, 1 ) : Point( -16, -11 ) );
+                populateCursorIcons( _icnVsSprite[id], GetICN( originalCursorId, 9 ), digits, isColorCursor ? Point( -6, 1 ) : Point( -8, -1 ) );
+                populateCursorIcons( _icnVsSprite[id], GetICN( originalCursorId, 28 ), digits, isColorCursor ? Point( 0, 1 ) : Point( -8, -7 ) );
 
                 return true;
             }
             case ICN::DISMISS_HERO_DISABLED_BUTTON:
             case ICN::NEW_CAMPAIGN_DISABLED_BUTTON:
             case ICN::MAX_DISABLED_BUTTON: {
-                icnVsSprite[id].resize( 1 );
-                Sprite & output = icnVsSprite[id][0];
+                _icnVsSprite[id].resize( 1 );
+                Sprite & output = _icnVsSprite[id][0];
 
                 int buttonIcnId = ICN::UNKNOWN;
                 uint32_t startIcnId = 0;
@@ -2772,8 +2770,8 @@ namespace fheroes2
                 return true;
             }
             case ICN::KNIGHT_CASTLE_RIGHT_FARM: {
-                icnVsSprite[id].resize( 1 );
-                Sprite & output = icnVsSprite[id][0];
+                _icnVsSprite[id].resize( 1 );
+                Sprite & output = _icnVsSprite[id][0];
                 output = GetICN( ICN::TWNKWEL2, 0 );
 
                 ApplyPalette( output, 28, 21, output, 28, 21, 39, 1, 8 );
@@ -2784,16 +2782,16 @@ namespace fheroes2
                 return true;
             }
             case ICN::KNIGHT_CASTLE_LEFT_FARM:
-                icnVsSprite[id].resize( 1 );
-                h2d::readImage( "knight_castle_left_farm.image", icnVsSprite[id][0] );
+                _icnVsSprite[id].resize( 1 );
+                h2d::readImage( "knight_castle_left_farm.image", _icnVsSprite[id][0] );
                 return true;
             case ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE:
-                icnVsSprite[id].resize( 1 );
-                h2d::readImage( "barbarian_castle_captain_quarter_left_side.image", icnVsSprite[id][0] );
+                _icnVsSprite[id].resize( 1 );
+                h2d::readImage( "barbarian_castle_captain_quarter_left_side.image", _icnVsSprite[id][0] );
                 return true;
             case ICN::NECROMANCER_CASTLE_STANDALONE_CAPTAIN_QUARTERS: {
-                icnVsSprite[id].resize( 1 );
-                Sprite & output = icnVsSprite[id][0];
+                _icnVsSprite[id].resize( 1 );
+                Sprite & output = _icnVsSprite[id][0];
                 const Sprite & original = GetICN( ICN::TWNNCAPT, 0 );
 
                 output = Crop( original, 21, 0, original.width() - 21, original.height() );
@@ -2809,8 +2807,8 @@ namespace fheroes2
                 return true;
             }
             case ICN::NECROMANCER_CASTLE_CAPTAIN_QUARTERS_BRIDGE: {
-                icnVsSprite[id].resize( 1 );
-                Sprite & output = icnVsSprite[id][0];
+                _icnVsSprite[id].resize( 1 );
+                Sprite & output = _icnVsSprite[id][0];
                 const Sprite & original = GetICN( ICN::TWNNCAPT, 0 );
 
                 output = Crop( original, 0, 0, 23, original.height() );
@@ -2820,9 +2818,9 @@ namespace fheroes2
             }
             case ICN::ESCROLL:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() > 4 ) {
+                if ( _icnVsSprite[id].size() > 4 ) {
                     // fix missing black border on the right side of the "up" button
-                    Sprite & out = icnVsSprite[id][4];
+                    Sprite & out = _icnVsSprite[id][4];
                     if ( out.width() == 16 && out.height() == 16 ) {
                         Copy( out, 0, 0, out, 15, 0, 1, 16 );
                     }
@@ -2830,8 +2828,8 @@ namespace fheroes2
                 return true;
             case ICN::MAP_TYPE_ICON: {
                 // TODO: add a new icon for the Resurrection add-on map type.
-                icnVsSprite[id].resize( 2 );
-                for ( Sprite & icon : icnVsSprite[id] ) {
+                _icnVsSprite[id].resize( 2 );
+                for ( Sprite & icon : _icnVsSprite[id] ) {
                     icon.resize( 17, 17 );
                     icon.fill( 0 );
                 }
@@ -2840,24 +2838,24 @@ namespace fheroes2
                 const Sprite & priceOfLoyaltyIcon = GetICN( ICN::ARTFX, 90 );
 
                 if ( !successionWarsIcon.empty() ) {
-                    Resize( successionWarsIcon, 0, 0, successionWarsIcon.width(), successionWarsIcon.height(), icnVsSprite[id][0], 1, 1, 15, 15 );
+                    Resize( successionWarsIcon, 0, 0, successionWarsIcon.width(), successionWarsIcon.height(), _icnVsSprite[id][0], 1, 1, 15, 15 );
                 }
 
                 if ( !priceOfLoyaltyIcon.empty() ) {
-                    Resize( priceOfLoyaltyIcon, 0, 0, priceOfLoyaltyIcon.width(), priceOfLoyaltyIcon.height(), icnVsSprite[id][1], 1, 1, 15, 15 );
+                    Resize( priceOfLoyaltyIcon, 0, 0, priceOfLoyaltyIcon.width(), priceOfLoyaltyIcon.height(), _icnVsSprite[id][1], 1, 1, 15, 15 );
                 }
 
                 return true;
             }
             case ICN::TWNWWEL2: {
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() == 7 ) {
-                    if ( icnVsSprite[id][0].width() == 122 && icnVsSprite[id][0].height() == 226 ) {
-                        FillTransform( icnVsSprite[id][0], 0, 57, 56, 62, 1 );
+                if ( _icnVsSprite[id].size() == 7 ) {
+                    if ( _icnVsSprite[id][0].width() == 122 && _icnVsSprite[id][0].height() == 226 ) {
+                        FillTransform( _icnVsSprite[id][0], 0, 57, 56, 62, 1 );
                     }
 
                     for ( size_t i = 1; i < 7; ++i ) {
-                        Sprite & original = icnVsSprite[id][i];
+                        Sprite & original = _icnVsSprite[id][i];
                         if ( original.width() == 121 && original.height() == 151 ) {
                             FillTransform( original, 0, 0, 64, 39, 1 );
                         }
@@ -2867,8 +2865,8 @@ namespace fheroes2
             }
             case ICN::TWNWCAPT: {
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() ) {
-                    Sprite & original = icnVsSprite[id][0];
+                if ( !_icnVsSprite[id].empty() ) {
+                    Sprite & original = _icnVsSprite[id][0];
                     if ( original.width() == 118 && original.height() ) {
                         // Remove shadow from left side.
                         FillTransform( original, 85, 84, 33, 26, 1 );
@@ -2884,35 +2882,35 @@ namespace fheroes2
             }
             case ICN::GOOD_ARMY_BUTTON:
             case ICN::GOOD_MARKET_BUTTON: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const int releasedIndex = ( id == ICN::GOOD_ARMY_BUTTON ) ? 0 : 4;
-                icnVsSprite[id][0] = GetICN( ICN::ADVBTNS, releasedIndex );
-                icnVsSprite[id][1] = GetICN( ICN::ADVBTNS, releasedIndex + 1 );
-                AddTransparency( icnVsSprite[id][0], 36 );
-                AddTransparency( icnVsSprite[id][1], 36 );
-                AddTransparency( icnVsSprite[id][1], 61 ); // remove the extra brown border
+                _icnVsSprite[id][0] = GetICN( ICN::ADVBTNS, releasedIndex );
+                _icnVsSprite[id][1] = GetICN( ICN::ADVBTNS, releasedIndex + 1 );
+                AddTransparency( _icnVsSprite[id][0], 36 );
+                AddTransparency( _icnVsSprite[id][1], 36 );
+                AddTransparency( _icnVsSprite[id][1], 61 ); // remove the extra brown border
 
                 return true;
             }
             case ICN::EVIL_ARMY_BUTTON:
             case ICN::EVIL_MARKET_BUTTON: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const int releasedIndex = ( id == ICN::EVIL_ARMY_BUTTON ) ? 0 : 4;
-                icnVsSprite[id][0] = GetICN( ICN::ADVEBTNS, releasedIndex );
-                AddTransparency( icnVsSprite[id][0], 36 );
+                _icnVsSprite[id][0] = GetICN( ICN::ADVEBTNS, releasedIndex );
+                AddTransparency( _icnVsSprite[id][0], 36 );
 
                 Sprite pressed = GetICN( ICN::ADVEBTNS, releasedIndex + 1 );
                 AddTransparency( pressed, 36 );
                 AddTransparency( pressed, 61 ); // remove the extra brown border
 
-                icnVsSprite[id][1] = Sprite( pressed.width(), pressed.height(), pressed.x(), pressed.y() );
-                icnVsSprite[id][1].reset();
+                _icnVsSprite[id][1] = Sprite( pressed.width(), pressed.height(), pressed.x(), pressed.y() );
+                _icnVsSprite[id][1].reset();
 
                 // put back pixels that actually should be black
-                Fill( icnVsSprite[id][1], 1, 4, 31, 31, 36 );
-                Blit( pressed, icnVsSprite[id][1] );
+                Fill( _icnVsSprite[id][1], 1, 4, 31, 31, 36 );
+                Blit( pressed, _icnVsSprite[id][1] );
 
                 return true;
             }
@@ -2921,9 +2919,9 @@ namespace fheroes2
             case ICN::CSPANBTN:
             case ICN::CSPANBTE: {
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() ) {
+                if ( !_icnVsSprite[id].empty() ) {
                     // add missing part of the released button state on the left
-                    Sprite & out = icnVsSprite[id][0];
+                    Sprite & out = _icnVsSprite[id][0];
 
                     Sprite released( out.width() + 1, out.height() );
                     released.reset();
@@ -2937,34 +2935,34 @@ namespace fheroes2
             }
             case ICN::TRADPOSE: {
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 19 ) {
+                if ( _icnVsSprite[id].size() >= 19 ) {
                     // fix background for TRADE and EXIT buttons
                     for ( uint32_t i : { 16, 18 } ) {
                         Sprite pressed;
-                        std::swap( pressed, icnVsSprite[id][i] );
+                        std::swap( pressed, _icnVsSprite[id][i] );
                         AddTransparency( pressed, 25 ); // remove too dark background
 
                         // take background from the empty system button
-                        icnVsSprite[id][i] = GetICN( ICN::SYSTEME, 12 );
+                        _icnVsSprite[id][i] = GetICN( ICN::SYSTEME, 12 );
 
                         // put back dark-gray pixels in the middle of the button
-                        Fill( icnVsSprite[id][i], 5, 5, 86, 17, 25 );
-                        Blit( pressed, icnVsSprite[id][i] );
+                        Fill( _icnVsSprite[id][i], 5, 5, 86, 17, 25 );
+                        Blit( pressed, _icnVsSprite[id][i] );
                     }
                 }
                 return true;
             }
             case ICN::RECRUIT: {
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 10 ) {
+                if ( _icnVsSprite[id].size() >= 10 ) {
                     // fix transparent corners on released OKAY button
-                    CopyTransformLayer( icnVsSprite[id][9], icnVsSprite[id][8] );
+                    CopyTransformLayer( _icnVsSprite[id][9], _icnVsSprite[id][8] );
                 }
                 return true;
             }
             case ICN::NGEXTRA: {
                 LoadOriginalICN( id );
-                std::vector<Sprite> & images = icnVsSprite[id];
+                std::vector<Sprite> & images = _icnVsSprite[id];
 
                 if ( images.size() >= 34 ) {
                     // Fix extra column at the end of AI controlled player.
@@ -2990,10 +2988,10 @@ namespace fheroes2
             }
             case ICN::HSBTNS: {
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 4 ) {
+                if ( _icnVsSprite[id].size() >= 4 ) {
                     // extract the EXIT button without background
-                    Sprite exitReleased = icnVsSprite[id][2];
-                    Sprite exitPressed = icnVsSprite[id][3];
+                    Sprite exitReleased = _icnVsSprite[id][2];
+                    Sprite exitPressed = _icnVsSprite[id][3];
 
                     // make the border parts around EXIT button transparent
                     Image exitCommonMask = ExtractCommonPattern( { &exitReleased, &exitPressed } );
@@ -3003,7 +3001,7 @@ namespace fheroes2
                     CopyTransformLayer( exitCommonMask, exitPressed );
 
                     // fix DISMISS button: get the EXIT button, then slap the text back
-                    Sprite & dismissReleased = icnVsSprite[id][0];
+                    Sprite & dismissReleased = _icnVsSprite[id][0];
 
                     Sprite tmpReleased = dismissReleased;
                     Blit( exitReleased, 0, 0, tmpReleased, 5, 0, 27, 120 );
@@ -3011,7 +3009,7 @@ namespace fheroes2
 
                     dismissReleased = std::move( tmpReleased );
 
-                    Sprite & dismissPressed = icnVsSprite[id][1];
+                    Sprite & dismissPressed = _icnVsSprite[id][1];
 
                     // start with the released state as well to capture more details
                     Sprite tmpPressed = dismissReleased;
@@ -3024,9 +3022,9 @@ namespace fheroes2
             }
             case ICN::TWNWUP_5: {
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() && icnVsSprite[id].front().width() == 84 && icnVsSprite[id].front().height() == 256 ) {
+                if ( !_icnVsSprite[id].empty() && _icnVsSprite[id].front().width() == 84 && _icnVsSprite[id].front().height() == 256 ) {
                     // Fix glowing red pixel.
-                    Copy( icnVsSprite[id].front(), 52, 92, icnVsSprite[id].front(), 54, 92, 1, 1 );
+                    Copy( _icnVsSprite[id].front(), 52, 92, _icnVsSprite[id].front(), 54, 92, 1, 1 );
                 }
 
                 return true;
@@ -3034,53 +3032,53 @@ namespace fheroes2
             case ICN::MONO_CURSOR_ADVMBW: {
                 LoadOriginalICN( ICN::ADVMCO );
 
-                icnVsSprite[id].resize( icnVsSprite[ICN::ADVMCO].size() );
-                for ( size_t i = 0; i < icnVsSprite[id].size(); ++i ) {
+                _icnVsSprite[id].resize( _icnVsSprite[ICN::ADVMCO].size() );
+                for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
                     std::string digit;
                     if ( i < 9 ) {
                         digit += '0';
                     }
                     digit += std::to_string( i + 1 );
 
-                    icnVsSprite[id][i] = loadBMPFile( std::string( "ADVMBW" ) + digit + ".BMP" );
+                    _icnVsSprite[id][i] = loadBMPFile( std::string( "ADVMBW" ) + digit + ".BMP" );
                 }
                 return true;
             }
             case ICN::MONO_CURSOR_SPELBW: {
                 LoadOriginalICN( ICN::SPELCO );
 
-                icnVsSprite[id].resize( icnVsSprite[ICN::SPELCO].size() );
-                for ( size_t i = 0; i < icnVsSprite[id].size(); ++i ) {
+                _icnVsSprite[id].resize( _icnVsSprite[ICN::SPELCO].size() );
+                for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
                     std::string digit;
                     if ( i < 10 ) {
                         digit += '0';
                     }
                     digit += std::to_string( i );
 
-                    icnVsSprite[id][i] = loadBMPFile( std::string( "SPELBW" ) + digit + ".BMP" );
+                    _icnVsSprite[id][i] = loadBMPFile( std::string( "SPELBW" ) + digit + ".BMP" );
                 }
                 return true;
             }
             case ICN::MONO_CURSOR_CMSSBW: {
                 LoadOriginalICN( ICN::CMSECO );
 
-                icnVsSprite[id].resize( icnVsSprite[ICN::CMSECO].size() );
-                for ( size_t i = 0; i < icnVsSprite[id].size(); ++i ) {
+                _icnVsSprite[id].resize( _icnVsSprite[ICN::CMSECO].size() );
+                for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
                     std::string digit;
                     if ( i < 9 ) {
                         digit += '0';
                     }
                     digit += std::to_string( i + 1 );
 
-                    icnVsSprite[id][i] = loadBMPFile( std::string( "CMSEBW" ) + digit + ".BMP" );
+                    _icnVsSprite[id][i] = loadBMPFile( std::string( "CMSEBW" ) + digit + ".BMP" );
                 }
                 return true;
             }
             case ICN::ARTIFACT:
                 LoadOriginalICN( id );
                 // Fix "Arm of the Martyr" artifact rendering.
-                if ( icnVsSprite[id].size() > 88 ) {
-                    Sprite & originalImage = icnVsSprite[id][88];
+                if ( _icnVsSprite[id].size() > 88 ) {
+                    Sprite & originalImage = _icnVsSprite[id][88];
                     Sprite temp( originalImage.width(), originalImage.height() );
                     temp.setPosition( originalImage.x(), originalImage.y() );
                     temp.fill( 0 );
@@ -3090,8 +3088,8 @@ namespace fheroes2
                 return true;
             case ICN::TWNSDW_5:
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() && icnVsSprite[id][0].width() == 140 && icnVsSprite[id][0].height() == 165 ) {
-                    Sprite & image = icnVsSprite[id][0];
+                if ( !_icnVsSprite[id].empty() && _icnVsSprite[id][0].width() == 140 && _icnVsSprite[id][0].height() == 165 ) {
+                    Sprite & image = _icnVsSprite[id][0];
                     // Red Tower has multiple defects.
                     // First one is the area between columns in middle of the Tower is prerendered. We need to remove it.
                     const int32_t windowBottom = 88;
@@ -3172,10 +3170,10 @@ namespace fheroes2
                 return true;
             case ICN::SCENIBKG:
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() && icnVsSprite[id][0].width() == 436 && icnVsSprite[id][0].height() == 476 ) {
+                if ( !_icnVsSprite[id].empty() && _icnVsSprite[id][0].width() == 436 && _icnVsSprite[id][0].height() == 476 ) {
                     const Sprite & helper = GetICN( ICN::CSPANBKE, 1 );
                     if ( !helper.empty() ) {
-                        Sprite & original = icnVsSprite[id][0];
+                        Sprite & original = _icnVsSprite[id][0];
                         Sprite temp( original.width(), original.height() + 12 );
                         temp.reset();
                         Copy( original, 0, 0, temp, 0, 0, original.width(), original.height() );
@@ -3187,18 +3185,18 @@ namespace fheroes2
                 return true;
             case ICN::CSTLCAPS:
                 LoadOriginalICN( id );
-                if ( !icnVsSprite[id].empty() && icnVsSprite[id][0].width() == 84 && icnVsSprite[id][0].height() == 81 ) {
+                if ( !_icnVsSprite[id].empty() && _icnVsSprite[id][0].width() == 84 && _icnVsSprite[id][0].height() == 81 ) {
                     const Sprite & castle = GetICN( ICN::TWNSCSTL, 0 );
                     if ( !castle.empty() ) {
-                        Blit( castle, 206, 106, icnVsSprite[id][0], 2, 2, 33, 67 );
+                        Blit( castle, 206, 106, _icnVsSprite[id][0], 2, 2, 33, 67 );
                     }
                 }
                 return true;
             case ICN::LGNDXTRA:
                 // Exit button is too huge due to 1 pixel presence at the bottom of the image.
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 6 ) {
-                    auto & original = icnVsSprite[id];
+                if ( _icnVsSprite[id].size() >= 6 ) {
+                    auto & original = _icnVsSprite[id];
                     if ( original[4].height() == 142 ) {
                         const Point offset( original[4].x(), original[4].y() );
                         original[4] = Crop( original[4], 0, 0, original[4].width(), 25 );
@@ -3215,8 +3213,8 @@ namespace fheroes2
             case ICN::LGNDXTRE:
                 // Exit button is too huge due to 1 pixel presence at the bottom of the image.
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() >= 6 ) {
-                    auto & original = icnVsSprite[id];
+                if ( _icnVsSprite[id].size() >= 6 ) {
+                    auto & original = _icnVsSprite[id];
                     if ( original[4].height() == 142 ) {
                         const Point offset( original[4].x(), original[4].y() );
                         original[4] = Crop( original[4], 0, 0, original[4].width(), 25 );
@@ -3225,94 +3223,94 @@ namespace fheroes2
                 }
                 return true;
             case ICN::ESPANBKG_EVIL: {
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
                 const Rect roi{ 28, 28, 265, 206 };
 
-                Sprite & output = icnVsSprite[id][0];
-                icnVsSprite[id][0] = GetICN( ICN::CSPANBKE, 0 );
+                Sprite & output = _icnVsSprite[id][0];
+                _icnVsSprite[id][0] = GetICN( ICN::CSPANBKE, 0 );
                 Copy( GetICN( ICN::ESPANBKG, 0 ), roi.x, roi.y, output, roi.x, roi.y, roi.width, roi.height );
 
                 convertToEvilInterface( output, roi );
 
-                icnVsSprite[id][1] = GetICN( ICN::ESPANBKG, 1 );
+                _icnVsSprite[id][1] = GetICN( ICN::ESPANBKG, 1 );
 
                 return true;
             }
             case ICN::RECR2BKG_EVIL: {
                 GetICN( ICN::RECR2BKG, 0 );
-                icnVsSprite[id] = icnVsSprite[ICN::RECR2BKG];
-                if ( !icnVsSprite[id].empty() ) {
-                    const Rect roi( 0, 0, icnVsSprite[id][0].width(), icnVsSprite[id][0].height() );
-                    convertToEvilInterface( icnVsSprite[id][0], roi );
-                    copyEvilInterfaceElements( icnVsSprite[id][0], roi );
+                _icnVsSprite[id] = _icnVsSprite[ICN::RECR2BKG];
+                if ( !_icnVsSprite[id].empty() ) {
+                    const Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() );
+                    convertToEvilInterface( _icnVsSprite[id][0], roi );
+                    copyEvilInterfaceElements( _icnVsSprite[id][0], roi );
                 }
 
                 return true;
             }
             case ICN::RECRBKG_EVIL: {
                 GetICN( ICN::RECRBKG, 0 );
-                icnVsSprite[id] = icnVsSprite[ICN::RECRBKG];
-                if ( !icnVsSprite[id].empty() ) {
-                    const Rect roi( 0, 0, icnVsSprite[id][0].width(), icnVsSprite[id][0].height() );
-                    convertToEvilInterface( icnVsSprite[id][0], roi );
-                    copyEvilInterfaceElements( icnVsSprite[id][0], roi );
+                _icnVsSprite[id] = _icnVsSprite[ICN::RECRBKG];
+                if ( !_icnVsSprite[id].empty() ) {
+                    const Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() );
+                    convertToEvilInterface( _icnVsSprite[id][0], roi );
+                    copyEvilInterfaceElements( _icnVsSprite[id][0], roi );
                 }
 
                 return true;
             }
             case ICN::STONEBAK_EVIL: {
                 GetICN( ICN::STONEBAK, 0 );
-                icnVsSprite[id] = icnVsSprite[ICN::STONEBAK];
-                if ( !icnVsSprite[id].empty() ) {
-                    const Rect roi( 0, 0, icnVsSprite[id][0].width(), icnVsSprite[id][0].height() );
-                    convertToEvilInterface( icnVsSprite[id][0], roi );
+                _icnVsSprite[id] = _icnVsSprite[ICN::STONEBAK];
+                if ( !_icnVsSprite[id].empty() ) {
+                    const Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() );
+                    convertToEvilInterface( _icnVsSprite[id][0], roi );
                 }
 
                 return true;
             }
             case ICN::WELLBKG_EVIL: {
                 GetICN( ICN::WELLBKG, 0 );
-                icnVsSprite[id] = icnVsSprite[ICN::WELLBKG];
-                if ( !icnVsSprite[id].empty() ) {
-                    const Rect roi( 0, 0, icnVsSprite[id][0].width(), icnVsSprite[id][0].height() - 19 );
-                    convertToEvilInterface( icnVsSprite[id][0], roi );
+                _icnVsSprite[id] = _icnVsSprite[ICN::WELLBKG];
+                if ( !_icnVsSprite[id].empty() ) {
+                    const Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() - 19 );
+                    convertToEvilInterface( _icnVsSprite[id][0], roi );
                 }
 
                 return true;
             }
             case ICN::CASLWIND_EVIL: {
                 GetICN( ICN::CASLWIND, 0 );
-                icnVsSprite[id] = icnVsSprite[ICN::CASLWIND];
-                if ( !icnVsSprite[id].empty() ) {
-                    const Rect roi( 0, 0, icnVsSprite[id][0].width(), icnVsSprite[id][0].height() );
-                    convertToEvilInterface( icnVsSprite[id][0], roi );
+                _icnVsSprite[id] = _icnVsSprite[ICN::CASLWIND];
+                if ( !_icnVsSprite[id].empty() ) {
+                    const Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() );
+                    convertToEvilInterface( _icnVsSprite[id][0], roi );
                 }
 
                 return true;
             }
             case ICN::CASLXTRA_EVIL: {
                 GetICN( ICN::CASLXTRA, 0 );
-                icnVsSprite[id] = icnVsSprite[ICN::CASLXTRA];
-                if ( !icnVsSprite[id].empty() ) {
-                    const Rect roi( 0, 0, icnVsSprite[id][0].width(), icnVsSprite[id][0].height() );
-                    convertToEvilInterface( icnVsSprite[id][0], roi );
+                _icnVsSprite[id] = _icnVsSprite[ICN::CASLXTRA];
+                if ( !_icnVsSprite[id].empty() ) {
+                    const Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() );
+                    convertToEvilInterface( _icnVsSprite[id][0], roi );
                 }
 
                 return true;
             }
             case ICN::STRIP_BACKGROUND_EVIL: {
-                icnVsSprite[id].resize( 1 );
-                icnVsSprite[id][0] = GetICN( ICN::STRIP, 11 );
+                _icnVsSprite[id].resize( 1 );
+                _icnVsSprite[id][0] = GetICN( ICN::STRIP, 11 );
 
-                const Rect roi( 0, 0, icnVsSprite[id][0].width(), icnVsSprite[id][0].height() - 7 );
-                convertToEvilInterface( icnVsSprite[id][0], roi );
+                const Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() - 7 );
+                convertToEvilInterface( _icnVsSprite[id][0], roi );
 
                 return true;
             }
             case ICN::GOOD_CAMPAIGN_BUTTONS:
             case ICN::EVIL_CAMPAIGN_BUTTONS: {
-                auto & image = icnVsSprite[id];
+                auto & image = _icnVsSprite[id];
                 image.resize( 8 );
 
                 const int originalIcnId = ( id == ICN::GOOD_CAMPAIGN_BUTTONS ) ? ICN::CAMPXTRG : ICN::CAMPXTRE;
@@ -3345,8 +3343,8 @@ namespace fheroes2
             case ICN::O_BFLG32:
             case ICN::P_BFLG32:
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() > 31 && icnVsSprite[id][31].height() == 248 ) {
-                    Sprite & original = icnVsSprite[id][31];
+                if ( _icnVsSprite[id].size() > 31 && _icnVsSprite[id][31].height() == 248 ) {
+                    Sprite & original = _icnVsSprite[id][31];
                     Sprite temp = Crop( original, 0, 0, original.width(), 4 );
                     temp.setPosition( original.x(), original.y() );
 
@@ -3358,25 +3356,25 @@ namespace fheroes2
                 // Only first 14 images are properly aligned within an Adventure Map tile. The rest of images should be rendered on multiple tiles.
                 // To keep proper rendering logic we are creating new images by diving existing ones into 2 parts and setting up new sprite offsets.
                 // This helps to solve the problem with rendering order.
-                icnVsSprite[id].resize( 128 + icnVsSprite[id].size() * 2 );
+                _icnVsSprite[id].resize( 128 + _icnVsSprite[id].size() * 2 );
                 for ( int32_t i = 14; i < 14 + 7; ++i ) {
-                    const Sprite & original = icnVsSprite[id][i];
+                    const Sprite & original = _icnVsSprite[id][i];
 
-                    icnVsSprite[id][i + 128] = Crop( original, 0, 0, 32 - original.x(), original.height() );
-                    icnVsSprite[id][i + 128].setPosition( original.x(), 32 + original.y() );
+                    _icnVsSprite[id][i + 128] = Crop( original, 0, 0, 32 - original.x(), original.height() );
+                    _icnVsSprite[id][i + 128].setPosition( original.x(), 32 + original.y() );
 
-                    icnVsSprite[id][i + 128 + 7] = Crop( original, 32 - original.x(), 0, original.width(), original.height() );
-                    icnVsSprite[id][i + 128 + 7].setPosition( 0, 32 + original.y() );
+                    _icnVsSprite[id][i + 128 + 7] = Crop( original, 32 - original.x(), 0, original.width(), original.height() );
+                    _icnVsSprite[id][i + 128 + 7].setPosition( 0, 32 + original.y() );
                 }
 
                 for ( int32_t i = 42; i < 42 + 7; ++i ) {
-                    const Sprite & original = icnVsSprite[id][i];
+                    const Sprite & original = _icnVsSprite[id][i];
 
-                    icnVsSprite[id][i + 128] = Crop( original, 0, 0, -original.x(), original.height() );
-                    icnVsSprite[id][i + 128].setPosition( 32 + original.x(), original.y() );
+                    _icnVsSprite[id][i + 128] = Crop( original, 0, 0, -original.x(), original.height() );
+                    _icnVsSprite[id][i + 128].setPosition( 32 + original.x(), original.y() );
 
-                    icnVsSprite[id][i + 128 + 7] = Crop( original, -original.x(), 0, original.width(), original.height() );
-                    icnVsSprite[id][i + 128 + 7].setPosition( 0, original.y() );
+                    _icnVsSprite[id][i + 128 + 7] = Crop( original, -original.x(), 0, original.width(), original.height() );
+                    _icnVsSprite[id][i + 128 + 7].setPosition( 0, original.y() );
                 }
                 return true;
             case ICN::MINI_MONSTER_IMAGE:
@@ -3385,10 +3383,10 @@ namespace fheroes2
                 LoadOriginalICN( ICN::MINIMON );
 
                 // TODO: optimize image sizes.
-                icnVsSprite[ICN::MINI_MONSTER_IMAGE] = icnVsSprite[ICN::MINIMON];
-                icnVsSprite[ICN::MINI_MONSTER_SHADOW] = icnVsSprite[ICN::MINIMON];
+                _icnVsSprite[ICN::MINI_MONSTER_IMAGE] = _icnVsSprite[ICN::MINIMON];
+                _icnVsSprite[ICN::MINI_MONSTER_SHADOW] = _icnVsSprite[ICN::MINIMON];
 
-                for ( Sprite & image : icnVsSprite[ICN::MINI_MONSTER_IMAGE] ) {
+                for ( Sprite & image : _icnVsSprite[ICN::MINI_MONSTER_IMAGE] ) {
                     uint8_t * transform = image.transform();
                     const uint8_t * transformEnd = transform + image.width() * image.height();
                     for ( ; transform != transformEnd; ++transform ) {
@@ -3398,7 +3396,7 @@ namespace fheroes2
                     }
                 }
 
-                for ( Sprite & image : icnVsSprite[ICN::MINI_MONSTER_SHADOW] ) {
+                for ( Sprite & image : _icnVsSprite[ICN::MINI_MONSTER_SHADOW] ) {
                     uint8_t * transform = image.transform();
                     const uint8_t * transformEnd = transform + image.width() * image.height();
                     for ( ; transform != transformEnd; ++transform ) {
@@ -3414,26 +3412,26 @@ namespace fheroes2
             case ICN::BUTTON_GOOD_FONT_PRESSED:
             case ICN::BUTTON_EVIL_FONT_RELEASED:
             case ICN::BUTTON_EVIL_FONT_PRESSED: {
-                generateButtonAlphabet( fheroes2::getCurrentLanguage(), icnVsSprite );
+                generateButtonAlphabet( fheroes2::getCurrentLanguage(), _icnVsSprite );
                 return true;
             }
             case ICN::HISCORE: {
                 LoadOriginalICN( id );
-                if ( icnVsSprite[id].size() > 7 ) {
+                if ( _icnVsSprite[id].size() > 7 ) {
                     // Campaign title bar needs to include rating.
-                    Sprite temp = icnVsSprite[id][7];
+                    Sprite temp = _icnVsSprite[id][7];
 
-                    Copy( temp, 215, 0, icnVsSprite[id][7], 215 - 57, 0, 300, temp.height() );
-                    Copy( icnVsSprite[id][6], 324, 0, icnVsSprite[id][7], 324, 0, icnVsSprite[id][6].width() - 324, temp.height() );
+                    Copy( temp, 215, 0, _icnVsSprite[id][7], 215 - 57, 0, 300, temp.height() );
+                    Copy( _icnVsSprite[id][6], 324, 0, _icnVsSprite[id][7], 324, 0, _icnVsSprite[id][6].width() - 324, temp.height() );
                 }
                 return true;
             }
             case ICN::SPELLINL: {
                 LoadOriginalICN( id );
 
-                if ( icnVsSprite[id].size() > 11 ) {
+                if ( _icnVsSprite[id].size() > 11 ) {
                     // Replace petrification spell mini-icon.
-                    h2d::readImage( "petrification_spell_icon_mini.image", icnVsSprite[id][11] );
+                    h2d::readImage( "petrification_spell_icon_mini.image", _icnVsSprite[id][11] );
                 }
 
                 return true;
@@ -3443,17 +3441,17 @@ namespace fheroes2
                 const int32_t originalId = ( id == ICN::EMPTY_GOOD_BUTTON ) ? ICN::SYSTEM : ICN::SYSTEME;
                 LoadOriginalICN( originalId );
 
-                if ( icnVsSprite[originalId].size() < 13 ) {
+                if ( _icnVsSprite[originalId].size() < 13 ) {
                     break;
                 }
 
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
-                Sprite & released = icnVsSprite[id][0];
-                Sprite & pressed = icnVsSprite[id][1];
+                Sprite & released = _icnVsSprite[id][0];
+                Sprite & pressed = _icnVsSprite[id][1];
 
-                released = icnVsSprite[originalId][11];
-                pressed = icnVsSprite[originalId][12];
+                released = _icnVsSprite[originalId][11];
+                pressed = _icnVsSprite[originalId][12];
 
                 if ( pressed.width() > 2 && pressed.height() > 2 ) {
                     // Make the background transparent.
@@ -3478,17 +3476,17 @@ namespace fheroes2
                 const int32_t originalId = isGoodInterface ? ICN::APANEL : ICN::APANELE;
                 LoadOriginalICN( originalId );
 
-                if ( icnVsSprite[originalId].size() < 10 ) {
+                if ( _icnVsSprite[originalId].size() < 10 ) {
                     break;
                 }
 
-                icnVsSprite[id].resize( 2 );
+                _icnVsSprite[id].resize( 2 );
 
-                Sprite & released = icnVsSprite[id][0];
-                Sprite & pressed = icnVsSprite[id][1];
+                Sprite & released = _icnVsSprite[id][0];
+                Sprite & pressed = _icnVsSprite[id][1];
 
-                released = icnVsSprite[originalId][2];
-                pressed = icnVsSprite[originalId][3];
+                released = _icnVsSprite[originalId][2];
+                pressed = _icnVsSprite[originalId][3];
 
                 if ( released.width() > 2 && released.height() > 2 && pressed.width() > 2 && pressed.height() > 2 ) {
                     // Clean the buttons.
@@ -3506,9 +3504,9 @@ namespace fheroes2
 
         void EnsureICNLoaded( int id )
         {
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
-            if ( !icnVsSprite[id].empty() ) {
+            if ( !_icnVsSprite[id].empty() ) {
                 return;
             }
 
@@ -3525,8 +3523,8 @@ namespace fheroes2
             }
 
             // cannot find your resource anywhere
-            icnVsSprite[id].resize( 1 );
-            icnVsSprite[id][0] = errorImage;
+            _icnVsSprite[id].resize( 1 );
+            _icnVsSprite[id][0] = errorImage;
         }
 
         size_t GetMaximumICNIndex( int id )
@@ -3537,8 +3535,8 @@ namespace fheroes2
 
             EnsureICNLoaded( id );
 
-            auto & icnVsSprite = getSpritesForScaleFactor( _originalICNScaleFactor[id] );
-            return icnVsSprite[id].size();
+            auto & _icnVsSprite = getSpritesForScaleFactor( _originalICNScaleFactor[id] );
+            return _icnVsSprite[id].size();
         }
 
         void EnsureTILLoaded( int id )
@@ -3613,9 +3611,9 @@ namespace fheroes2
             }
 
             const int32_t scaleFactor = Display::currentScaleFactor();
-            auto & icnVsSprite = getSpritesForScaleFactor( scaleFactor );
+            auto & _icnVsSprite = getSpritesForScaleFactor( scaleFactor );
 
-            std::vector<Sprite> & sprites = icnVsSprite[icnId];
+            std::vector<Sprite> & sprites = _icnVsSprite[icnId];
             if ( sprites.empty() ) {
                 const auto & originalICNVsSprite = getSpritesForScaleFactor( _originalICNScaleFactor[icnId] );
                 const std::vector<Sprite> & originalSprites = originalICNVsSprite[icnId];
@@ -3836,7 +3834,7 @@ namespace fheroes2
 
         void updateLanguageDependentResources( const SupportedLanguage language, const bool loadOriginalAlphabet )
         {
-            auto & icnVsSprite = getSpritesForScaleFactor( 1 );
+            auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             if ( loadOriginalAlphabet || !isAlphabetSupported( language ) ) {
                 alphabetPreserver.restore();
@@ -3845,13 +3843,13 @@ namespace fheroes2
                 alphabetPreserver.preserve();
                 // Restore original letters when changing language to avoid changes to them being carried over.
                 alphabetPreserver.restore();
-                generateAlphabet( language, icnVsSprite );
+                generateAlphabet( language, _icnVsSprite );
             }
-            generateButtonAlphabet( language, icnVsSprite );
+            generateButtonAlphabet( language, _icnVsSprite );
 
             // Clear language dependent resources.
             for ( const int id : languageDependentIcnId ) {
-                icnVsSprite[id].clear();
+                _icnVsSprite[id].clear();
             }
         }
     }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -553,6 +553,24 @@ namespace fheroes2
             return true;
         }
 
+        void ScaleICNToDisplayFactor( Sprite & sprite )
+        {
+            const int32_t displayScaleFactor = Display::scaleFactor();
+            const int32_t imgScaleFactor = sprite.scaleFactor();
+            if ( imgScaleFactor != displayScaleFactor ) {
+                // resize and position the sprite to match the display's scale factor
+                Sprite scaled( sprite.width() / imgScaleFactor, sprite.height() / imgScaleFactor, sprite.x() / imgScaleFactor, sprite.y() / imgScaleFactor );
+
+                if ( sprite.singleLayer() ) {
+                    scaled._disableTransformLayer();
+                }
+
+                bool subpixel = imgScaleFactor > displayScaleFactor; // lose less information when scaling down, don't blur when scaling up
+                Resize( sprite, scaled, subpixel );
+                sprite = scaled;
+            }
+        }
+
         bool LoadOriginalICN( int id )
         {
             const char * icnString = ICN::GetString( id );
@@ -603,6 +621,8 @@ namespace fheroes2
 
                 _icnVsSprite[id][i]
                     = decodeICNSprite( data, sizeData, header1.width, header1.height, static_cast<int16_t>( header1.offsetX ), static_cast<int16_t>( header1.offsetY ) );
+
+                ScaleICNToDisplayFactor( _icnVsSprite[id][i] );
             }
 
             return true;
@@ -3426,26 +3446,6 @@ namespace fheroes2
                 _icnVsSprite[id].resize( 1 );
                 _icnVsSprite[id][0] = errorImage;
                 return;
-            }
-
-            const int32_t imgScaleFactor = _icnVsSprite[id][0].scaleFactor();
-            const int32_t displayScaleFactor = Display::scaleFactor();
-
-            if ( imgScaleFactor != displayScaleFactor ) {
-                for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
-                    const Sprite & original = _icnVsSprite[id][i];
-
-                    // resize and position the sprite to match the display's scale factor
-                    Sprite scaled( original.width() / imgScaleFactor, original.height() / imgScaleFactor, original.x() / imgScaleFactor, original.y() / imgScaleFactor );
-
-                    if ( original.singleLayer() ) {
-                        scaled._disableTransformLayer();
-                    }
-
-                    bool subpixel = imgScaleFactor > displayScaleFactor; // lose less information when scaling down, don't blur when scaling up
-                    Resize( original, scaled, subpixel );
-                    _icnVsSprite[id][i] = scaled;
-                }
             }
         }
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -557,15 +557,15 @@ namespace fheroes2
         {
             const char * icnString = ICN::GetString( id );
 
-            const int32_t SCALE_FACTOR_FULLHD = 4;
-            const std::string fullHdPath = System::concatPath( System::GetDataDirectory( "fheroes2" ), "fullhd" );
+            // const int32_t SCALE_FACTOR_FULLHD = 4;
+            // const std::string fullHdPath = System::concatPath( System::GetDataDirectory( "fheroes2" ), "fullhd" );
 
-            if ( LoadImagesFromDir( id, System::concatPath( System::concatPath( fullHdPath, "AGG" ), icnString ), SCALE_FACTOR_FULLHD ) ) {
-                return true;
-            }
-            if ( LoadImagesFromDir( id, System::concatPath( System::concatPath( fullHdPath, "AGGX" ), icnString ), SCALE_FACTOR_FULLHD ) ) {
-                return true;
-            }
+            // if ( LoadImagesFromDir( id, System::concatPath( System::concatPath( fullHdPath, "AGG" ), icnString ), SCALE_FACTOR_FULLHD ) ) {
+            //     return true;
+            // }
+            // if ( LoadImagesFromDir( id, System::concatPath( System::concatPath( fullHdPath, "AGGX" ), icnString ), SCALE_FACTOR_FULLHD ) ) {
+            //     return true;
+            // }
 
             const std::vector<uint8_t> & body = ::AGG::getDataFromAggFile( icnString );
 
@@ -3429,21 +3429,22 @@ namespace fheroes2
             }
 
             const int32_t imgScaleFactor = _icnVsSprite[id][0].scaleFactor();
-            const int32_t displayScaleFactor = Display::instance().scaleFactor();
+            const int32_t displayScaleFactor = Display::scaleFactor();
 
             if ( imgScaleFactor != displayScaleFactor ) {
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
                     const Sprite & original = _icnVsSprite[id][i];
-                    // resize the image to match the display's scale factor
-                    Sprite scaled( original.width() * displayScaleFactor / imgScaleFactor, original.height() * displayScaleFactor / imgScaleFactor, 0, 0,
-                                   displayScaleFactor );
-                    scaled.setPosition( original.x() * displayScaleFactor / imgScaleFactor, original.y() * displayScaleFactor / imgScaleFactor );
+
+                    // resize and position the sprite to match the display's scale factor
+                    Sprite scaled( original.width() * displayScaleFactor / imgScaleFactor, original.height() * displayScaleFactor / imgScaleFactor,
+                                   original.x() * displayScaleFactor / imgScaleFactor, original.y() * displayScaleFactor / imgScaleFactor );
 
                     if ( original.singleLayer() ) {
                         scaled._disableTransformLayer();
                     }
 
-                    Resize( original, scaled, false );
+                    bool subpixel = imgScaleFactor > displayScaleFactor; // lose less information when scaling down, don't blur when scaling up
+                    Resize( original, scaled, subpixel );
                     _icnVsSprite[id][i] = scaled;
                 }
             }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -179,7 +179,10 @@ namespace
         fheroes2::Image digit( width, height );
         digit.reset();
 
-        fheroes2::SetPixel( digit, points, pixelColor );
+        // fheroes2::SetPixel( digit, points, pixelColor );
+        for ( const fheroes2::Point & p : points ) {
+            fheroes2::Fill( digit, p.x, p.y, 1, 1, pixelColor );
+        }
         fheroes2::Blit( fheroes2::CreateContour( digit, 35 ), digit );
 
         return digit;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -533,7 +533,7 @@ namespace fheroes2
             const int32_t imgScaleFactor = image.scaleFactor();
             if ( imgScaleFactor != displayScaleFactor ) {
                 // resize and position the sprite to match the display's scale factor
-                Image scaled( image.width() / imgScaleFactor, image.height() / imgScaleFactor, displayScaleFactor );
+                Image scaled( image.width(), image.height(), displayScaleFactor );
 
                 if ( image.singleLayer() ) {
                     scaled._disableTransformLayer();
@@ -551,7 +551,7 @@ namespace fheroes2
             const int32_t imgScaleFactor = sprite.scaleFactor();
             if ( imgScaleFactor != displayScaleFactor ) {
                 // resize and position the sprite to match the display's scale factor
-                Sprite scaled( sprite.width() / imgScaleFactor, sprite.height() / imgScaleFactor, sprite.x() / imgScaleFactor, sprite.y() / imgScaleFactor );
+                Sprite scaled( sprite.width(), sprite.height(), sprite.x(), sprite.y() );
 
                 if ( sprite.singleLayer() ) {
                     scaled._disableTransformLayer();

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -38,11 +38,13 @@
 #include "icn.h"
 #include "image.h"
 #include "image_tool.h"
+#include "logging.h"
 #include "math_base.h"
 #include "pal.h"
 #include "rand.h"
 #include "screen.h"
 #include "serialize.h"
+#include "system.h"
 #include "text.h"
 #include "til.h"
 #include "tools.h"
@@ -60,8 +62,6 @@ namespace
     const fheroes2::Sprite errorImage;
 
     const uint32_t headerSize = 6;
-
-    std::map<int, std::vector<fheroes2::Sprite>> _icnVsScaledSprite;
 
     // Some resources are language dependent. These are mostly buttons with a text of them.
     // Once a user changes a language we have to update resources. To do this we need to clear the existing images.
@@ -511,12 +511,66 @@ namespace fheroes2
 {
     namespace AGG
     {
-        void LoadOriginalICN( int id )
+        bool LoadImagesFromDir( const int id, const std::string & pathToImagesDir, int32_t scaleFactor )
         {
-            const std::vector<uint8_t> & body = ::AGG::getDataFromAggFile( ICN::GetString( id ) );
+            std::string pathToImagesSpec = System::concatPath( pathToImagesDir, "spec.txt" );
+
+            FILE * const f = fopen( pathToImagesSpec.c_str(), "r" );
+            if ( nullptr == f ) {
+                return false;
+            }
+
+            int count;
+            if ( fscanf( f, "%d", &count ) != 1 ) {
+                DEBUG_LOG( DBG_ENGINE, DBG_WARN, "failed to parse image count from: " << pathToImagesSpec );
+                fclose( f );
+                return false;
+            }
+
+            _icnVsSprite[id].resize( count );
+
+            for ( int i = 0; i < count; ++i ) {
+                int offsetX;
+                int offsetY;
+                if ( fscanf( f, "%d %d", &offsetX, &offsetY ) != 2 ) {
+                    DEBUG_LOG( DBG_ENGINE, DBG_WARN, "failed to parse sprite offsets from: " << pathToImagesSpec << ":" << i );
+                    fclose( f );
+                    return false;
+                }
+                _icnVsSprite[id][i].setPosition( offsetX, offsetY );
+
+                char fname[16];
+                snprintf( fname, 16, "%03d.png", i );
+                std::string filepath = System::concatPath( pathToImagesDir, fname );
+                if ( !fheroes2::Load( filepath, _icnVsSprite[id][i], scaleFactor ) ) {
+                    DEBUG_LOG( DBG_ENGINE, DBG_WARN, "failed to load image from: " << filepath );
+                    fclose( f );
+                    return false;
+                }
+            }
+            fclose( f );
+
+            return true;
+        }
+
+        bool LoadOriginalICN( int id )
+        {
+            const char * icnString = ICN::GetString( id );
+
+            const int32_t SCALE_FACTOR_FULLHD = 4;
+            const std::string fullHdPath = System::concatPath( System::GetDataDirectory( "fheroes2" ), "fullhd" );
+
+            if ( LoadImagesFromDir( id, System::concatPath( System::concatPath( fullHdPath, "AGG" ), icnString ), SCALE_FACTOR_FULLHD ) ) {
+                return true;
+            }
+            if ( LoadImagesFromDir( id, System::concatPath( System::concatPath( fullHdPath, "AGGX" ), icnString ), SCALE_FACTOR_FULLHD ) ) {
+                return true;
+            }
+
+            const std::vector<uint8_t> & body = ::AGG::getDataFromAggFile( icnString );
 
             if ( body.empty() ) {
-                return;
+                return false;
             }
 
             StreamBuf imageStream( body );
@@ -524,7 +578,7 @@ namespace fheroes2
             const uint32_t count = imageStream.getLE16();
             const uint32_t blockSize = imageStream.getLE32();
             if ( count == 0 || blockSize == 0 ) {
-                return;
+                return false;
             }
 
             _icnVsSprite[id].resize( count );
@@ -550,6 +604,8 @@ namespace fheroes2
                 _icnVsSprite[id][i]
                     = decodeICNSprite( data, sizeData, header1.width, header1.height, static_cast<int16_t>( header1.offsetX ), static_cast<int16_t>( header1.offsetY ) );
             }
+
+            return true;
         }
 
         // Helper function for LoadModifiedICN
@@ -3326,7 +3382,7 @@ namespace fheroes2
                     FillTransform( pressed, pressed.width() - 3, pressed.height() - 3, 1, 1, 1 );
                 }
 
-                break;
+                return true;
             }
             case ICN::EMPTY_GOOD_MEDIUM_BUTTON:
             case ICN::EMPTY_EVIL_MEDIUM_BUTTON: {
@@ -3352,7 +3408,7 @@ namespace fheroes2
                     Fill( pressed, 27, 16, 42, 27, getButtonFillingColor( false, isGoodInterface ) );
                 }
 
-                break;
+                return true;
             }
             default:
                 break;
@@ -3361,12 +3417,35 @@ namespace fheroes2
             return false;
         }
 
-        size_t GetMaximumICNIndex( int id )
+        void EnsureICNLoaded( int id )
         {
-            if ( _icnVsSprite[id].empty() && !LoadModifiedICN( id ) ) {
-                LoadOriginalICN( id );
+            if ( !_icnVsSprite[id].empty() ) {
+                return;
+            }
+            if ( !( LoadModifiedICN( id ) || LoadOriginalICN( id ) ) ) {
+                _icnVsSprite[id].resize( 1 );
+                _icnVsSprite[id][0] = errorImage;
+                return;
             }
 
+            const int32_t imgScaleFactor = _icnVsSprite[id][0].scaleFactor();
+            const int32_t displayScaleFactor = Display::instance().scaleFactor();
+            if ( imgScaleFactor != displayScaleFactor ) {
+                for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
+                    const Sprite & original = _icnVsSprite[id][i];
+                    // resize the image to match the display's scale factor
+                    Sprite scaled( original.width() * displayScaleFactor / imgScaleFactor, original.height() * displayScaleFactor / imgScaleFactor );
+                    // TODO: set sprite scale factor!
+                    scaled.setPosition( original.x() * displayScaleFactor / imgScaleFactor, original.y() * displayScaleFactor / imgScaleFactor );
+                    Resize( original, scaled, false );
+                    _icnVsSprite[id][i] = scaled;
+                }
+            }
+        }
+
+        size_t GetMaximumICNIndex( int id )
+        {
+            EnsureICNLoaded( id );
             return _icnVsSprite[id].size();
         }
 
@@ -3419,41 +3498,6 @@ namespace fheroes2
             return _tilVsImage[id][0].size();
         }
 
-        // We have few ICNs which we need to scale like some related to main screen
-        bool IsScalableICN( int id )
-        {
-            return id == ICN::HEROES || id == ICN::BTNSHNGL || id == ICN::SHNGANIM;
-        }
-
-        const Sprite & GetScaledICN( int icnId, uint32_t index )
-        {
-            const Sprite & originalIcn = _icnVsSprite[icnId][index];
-
-            if ( Display::DEFAULT_WIDTH == Display::instance().width() && Display::DEFAULT_HEIGHT == Display::instance().height() ) {
-                return originalIcn;
-            }
-
-            if ( _icnVsScaledSprite[icnId].empty() ) {
-                _icnVsScaledSprite[icnId].resize( _icnVsSprite[icnId].size() );
-            }
-
-            Sprite & resizedIcn = _icnVsScaledSprite[icnId][index];
-
-            const double scaleFactorX = static_cast<double>( Display::instance().width() ) / Display::DEFAULT_WIDTH;
-            const double scaleFactorY = static_cast<double>( Display::instance().height() ) / Display::DEFAULT_HEIGHT;
-
-            const int32_t resizedWidth = static_cast<int32_t>( originalIcn.width() * scaleFactorX + 0.5 );
-            const int32_t resizedHeight = static_cast<int32_t>( originalIcn.height() * scaleFactorY + 0.5 );
-            // Resize only if needed
-            if ( resizedIcn.width() != resizedWidth || resizedIcn.height() != resizedHeight ) {
-                resizedIcn.resize( resizedWidth, resizedHeight );
-                resizedIcn.setPosition( static_cast<int32_t>( originalIcn.x() * scaleFactorX + 0.5 ), static_cast<int32_t>( originalIcn.y() * scaleFactorY + 0.5 ) );
-                Resize( originalIcn, resizedIcn, false );
-            }
-
-            return resizedIcn;
-        }
-
         const Sprite & GetICN( int icnId, uint32_t index )
         {
             if ( !IsValidICNId( icnId ) ) {
@@ -3462,10 +3506,6 @@ namespace fheroes2
 
             if ( index >= GetMaximumICNIndex( icnId ) ) {
                 return errorImage;
-            }
-
-            if ( IsScalableICN( icnId ) ) {
-                return GetScaledICN( icnId, index );
             }
 
             return _icnVsSprite[icnId][index];

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3436,8 +3436,7 @@ namespace fheroes2
                     const Sprite & original = _icnVsSprite[id][i];
 
                     // resize and position the sprite to match the display's scale factor
-                    Sprite scaled( original.width() * displayScaleFactor / imgScaleFactor, original.height() * displayScaleFactor / imgScaleFactor,
-                                   original.x() * displayScaleFactor / imgScaleFactor, original.y() * displayScaleFactor / imgScaleFactor );
+                    Sprite scaled( original.width() / imgScaleFactor, original.height() / imgScaleFactor, original.x() / imgScaleFactor, original.y() / imgScaleFactor );
 
                     if ( original.singleLayer() ) {
                         scaled._disableTransformLayer();

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3848,9 +3848,12 @@ namespace fheroes2
             }
             generateButtonAlphabet( language, _icnVsSprite );
 
-            // Clear language dependent resources.
-            for ( const int id : languageDependentIcnId ) {
-                _icnVsSprite[id].clear();
+            // Clear language dependent resources for all scale factors.
+            for ( int32_t scaleFactor = 1; scaleFactor <= Display::MAX_SCALE_FACTOR; ++scaleFactor ) {
+                auto & icnVsSpriteForSF = getSpritesForScaleFactor( scaleFactor );
+                for ( const int id : languageDependentIcnId ) {
+                    icnVsSpriteForSF[id].clear();
+                }
             }
         }
     }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -199,7 +199,7 @@ namespace
 
     std::array<std::vector<std::vector<fheroes2::Image>>, TIL::LASTTIL> & getTILs()
     {
-        return getTILsForScaleFactor( fheroes2::Display::scaleFactor() );
+        return getTILsForScaleFactor( fheroes2::Display::currentScaleFactor() );
     }
 
     bool IsValidICNId( int id )
@@ -3543,7 +3543,7 @@ namespace fheroes2
 
         void EnsureTILLoaded( int id )
         {
-            const int32_t scaleFactor = Display::scaleFactor();
+            const int32_t scaleFactor = Display::currentScaleFactor();
             auto & tilVsImage = getTILsForScaleFactor( scaleFactor );
 
             if ( tilVsImage[id].empty() ) {
@@ -3612,7 +3612,7 @@ namespace fheroes2
                 return errorImage;
             }
 
-            const int32_t scaleFactor = Display::scaleFactor();
+            const int32_t scaleFactor = Display::currentScaleFactor();
             auto & icnVsSprite = getSpritesForScaleFactor( scaleFactor );
 
             std::vector<Sprite> & sprites = icnVsSprite[icnId];
@@ -3649,7 +3649,7 @@ namespace fheroes2
                 return errorImage;
             }
 
-            const int32_t scaleFactor = Display::scaleFactor();
+            const int32_t scaleFactor = Display::currentScaleFactor();
             auto & tilVsImage = getTILsForScaleFactor( scaleFactor );
 
             std::vector<std::vector<Image>> & images = tilVsImage[tilId];

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -343,6 +343,25 @@ namespace
                 return;
             }
 
+            for ( int32_t scaleFactor = 1; scaleFactor <= fheroes2::Display::MAX_SCALE_FACTOR; ++scaleFactor ) {
+                auto & icnVsSpriteForSF = getSpritesForScaleFactor( scaleFactor );
+
+                // Clear current base fonts.
+                icnVsSpriteForSF[ICN::FONT].clear();
+                icnVsSpriteForSF[ICN::SMALFONT].clear();
+                icnVsSpriteForSF[ICN::BUTTON_GOOD_FONT_RELEASED].clear();
+                icnVsSpriteForSF[ICN::BUTTON_GOOD_FONT_PRESSED].clear();
+                icnVsSpriteForSF[ICN::BUTTON_EVIL_FONT_RELEASED].clear();
+                icnVsSpriteForSF[ICN::BUTTON_EVIL_FONT_PRESSED].clear();
+
+                // Clear modified fonts.
+                icnVsSpriteForSF[ICN::YELLOW_FONT].clear();
+                icnVsSpriteForSF[ICN::YELLOW_SMALLFONT].clear();
+                icnVsSpriteForSF[ICN::GRAY_FONT].clear();
+                icnVsSpriteForSF[ICN::GRAY_SMALL_FONT].clear();
+                icnVsSpriteForSF[ICN::WHITE_LARGE_FONT].clear();
+            }
+
             auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             // Restore the original font.
@@ -352,13 +371,6 @@ namespace
             _icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED] = _buttonGoodPressedFont;
             _icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED] = _buttonEvilReleasedFont;
             _icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] = _buttonEvilPressedFont;
-
-            // Clear modified fonts.
-            _icnVsSprite[ICN::YELLOW_FONT].clear();
-            _icnVsSprite[ICN::YELLOW_SMALLFONT].clear();
-            _icnVsSprite[ICN::GRAY_FONT].clear();
-            _icnVsSprite[ICN::GRAY_SMALL_FONT].clear();
-            _icnVsSprite[ICN::WHITE_LARGE_FONT].clear();
         }
 
     private:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -643,8 +643,6 @@ namespace fheroes2
 
                 _icnVsSprite[id][i]
                     = decodeICNSprite( data, sizeData, header1.width, header1.height, static_cast<int16_t>( header1.offsetX ), static_cast<int16_t>( header1.offsetY ) );
-
-                scaleICNToDisplayFactor( _icnVsSprite[id][i] );
             }
 
             return true;
@@ -2202,6 +2200,9 @@ namespace fheroes2
             case ICN::MONH0028: // phoenix
                 LoadOriginalICN( id );
                 if ( _icnVsSprite[id].size() == 1 ) {
+                    // prepare to work with upscaled images
+                    scaleICNToDisplayFactor( _icnVsSprite[id] );
+
                     const Sprite & correctFrame = GetICN( ICN::PHOENIX, 32 );
                     Copy( correctFrame, 60, 73, _icnVsSprite[id][0], 58, 70, 14, 13 );
                 }
@@ -2327,6 +2328,9 @@ namespace fheroes2
             case ICN::HSICONS:
                 LoadOriginalICN( id );
                 if ( _icnVsSprite[id].size() > 7 ) {
+                    // prepare to work with upscaled images
+                    scaleICNToDisplayFactor( _icnVsSprite[id] );
+
                     Sprite & out = _icnVsSprite[id][7];
                     if ( out.width() == 34 && out.height() == 19 ) {
                         Sprite temp;
@@ -2350,6 +2354,8 @@ namespace fheroes2
 
                 if ( _icnVsSprite[id].size() > 4 ) { // Veteran Pikeman
                     Sprite & modified = _icnVsSprite[id][4];
+                    // prepare to work with upscaled images
+                    scaleToDisplayFactor( modified );
 
                     Sprite temp( modified.width(), modified.height() + 1 );
                     temp.reset();
@@ -2359,6 +2365,8 @@ namespace fheroes2
                 }
                 if ( _icnVsSprite[id].size() > 6 ) { // Master Swordsman
                     Sprite & modified = _icnVsSprite[id][6];
+                    // prepare to work with upscaled images
+                    scaleToDisplayFactor( modified );
 
                     Sprite temp( modified.width(), modified.height() + 1 );
                     temp.reset();
@@ -2368,6 +2376,8 @@ namespace fheroes2
                 }
                 if ( _icnVsSprite[id].size() > 8 ) { // Champion
                     Sprite & modified = _icnVsSprite[id][8];
+                    // prepare to work with upscaled images
+                    scaleToDisplayFactor( modified );
 
                     Sprite temp( modified.width(), modified.height() + 1 );
                     temp.reset();
@@ -2379,6 +2389,9 @@ namespace fheroes2
                     const Point shadowOffset( -1, 2 );
                     for ( size_t i = 0; i < 62; ++i ) {
                         Sprite & modified = _icnVsSprite[id][i];
+                        // prepare to work with upscaled images
+                        scaleToDisplayFactor( modified );
+
                         const Point originalOffset( modified.x(), modified.y() );
                         Sprite temp = addShadow( modified, { -1, 2 }, 2 );
                         temp.setPosition( originalOffset.x - 1, originalOffset.y + 2 );
@@ -2394,8 +2407,9 @@ namespace fheroes2
                         }
                     }
                 }
-                if ( _icnVsSprite[id].size() > 63 && _icnVsSprite[id][63].width() == 19 && _icnVsSprite[id][63].height() == 37 ) { // Air Elemental
+                if ( _icnVsSprite[id].size() > 63 && _icnVsSprite[id][63]._w() == 19 && _icnVsSprite[id][63]._h() == 37 ) { // Air Elemental
                     Sprite & modified = _icnVsSprite[id][63];
+                    // working with 1x scale here
                     modified.image()[19 * 9 + 9] = modified.image()[19 * 5 + 11];
                     modified.transform()[19 * 9 + 9] = modified.transform()[19 * 5 + 11];
                 }
@@ -2435,7 +2449,7 @@ namespace fheroes2
                     for ( uint32_t i : { 0, 2 } ) {
                         Sprite & out = _icnVsSprite[id][i + 1];
 
-                        Sprite tmp( out.width(), out.height() );
+                        Image tmp( out.width(), out.height(), 1 );
                         tmp.reset();
                         Copy( out, 0, 1, tmp, 1, 0, tmp.width() - 1, tmp.height() - 1 );
                         CopyTransformLayer( _icnVsSprite[id][i], tmp );
@@ -2503,6 +2517,7 @@ namespace fheroes2
                 Image out = ExtractCommonPattern( { &input[0], &input[1], &input[2], &input[3] } );
 
                 // Here are 2 pixels which should be removed.
+                // FIXME: scale factor!
                 if ( out.width() == width && out.height() == height ) {
                     out.image()[40] = 0;
                     out.transform()[40] = 1;
@@ -2877,7 +2892,7 @@ namespace fheroes2
                     // add missing part of the released button state on the left
                     Sprite & out = _icnVsSprite[id][0];
 
-                    Sprite released( out.width() + 1, out.height() );
+                    Image released( out.width() + 1, out.height(), 1 );
                     released.reset();
                     const uint8_t color = id == ICN::SPANBTN || id == ICN::CSPANBTN ? 57 : 32;
                     DrawLine( released, { 0, 3 }, { 0, out.height() - 1 }, color );
@@ -2890,6 +2905,9 @@ namespace fheroes2
             case ICN::TRADPOSE: {
                 LoadOriginalICN( id );
                 if ( _icnVsSprite[id].size() >= 19 ) {
+                    // prepare to work with upscaled images
+                    scaleICNToDisplayFactor( _icnVsSprite[id] );
+
                     // fix background for TRADE and EXIT buttons
                     for ( uint32_t i : { 16, 18 } ) {
                         Sprite pressed;
@@ -3033,8 +3051,9 @@ namespace fheroes2
                 // Fix "Arm of the Martyr" artifact rendering.
                 if ( _icnVsSprite[id].size() > 88 ) {
                     Sprite & originalImage = _icnVsSprite[id][88];
-                    Sprite temp( originalImage.width(), originalImage.height() );
-                    temp.setPosition( originalImage.x(), originalImage.y() );
+                    scaleToDisplayFactor( originalImage );
+
+                    Sprite temp( originalImage.width(), originalImage.height(), originalImage.x(), originalImage.y() );
                     temp.fill( 0 );
                     Blit( originalImage, temp );
                     originalImage = std::move( temp );
@@ -3093,7 +3112,7 @@ namespace fheroes2
                     Copy( image, 37, 113, image, 38, 117, 1, 1 );
 
                     // Create a temporary image to be a holder of pixels.
-                    Sprite temp( 4 * 2, 8 );
+                    Image temp( 4 * 2, 8, 1 );
                     Copy( image, 33, 105, temp, 0, 0, 4, 8 );
                     Copy( image, 41, 105, temp, 4, 0, 4, 8 );
                     fillRandomPixelsFromImage( temp, { 0, 0, temp.width(), temp.height() }, image, { 37, 119, 4, 37 }, seededGen );
@@ -3125,6 +3144,9 @@ namespace fheroes2
             case ICN::SCENIBKG:
                 LoadOriginalICN( id );
                 if ( !_icnVsSprite[id].empty() && _icnVsSprite[id][0].width() == 436 && _icnVsSprite[id][0].height() == 476 ) {
+                    // prepare to work with upscaled images
+                    scaleICNToDisplayFactor( _icnVsSprite[id] );
+
                     const Sprite & helper = GetICN( ICN::CSPANBKE, 1 );
                     if ( !helper.empty() ) {
                         Sprite & original = _icnVsSprite[id][0];
@@ -3140,6 +3162,9 @@ namespace fheroes2
             case ICN::CSTLCAPS:
                 LoadOriginalICN( id );
                 if ( !_icnVsSprite[id].empty() && _icnVsSprite[id][0].width() == 84 && _icnVsSprite[id][0].height() == 81 ) {
+                    // prepare to work with upscaled images
+                    scaleICNToDisplayFactor( _icnVsSprite[id] );
+
                     const Sprite & castle = GetICN( ICN::TWNSCSTL, 0 );
                     if ( !castle.empty() ) {
                         Blit( castle, 206, 106, _icnVsSprite[id][0], 2, 2, 33, 67 );
@@ -3366,8 +3391,7 @@ namespace fheroes2
             case ICN::BUTTON_GOOD_FONT_PRESSED:
             case ICN::BUTTON_EVIL_FONT_RELEASED:
             case ICN::BUTTON_EVIL_FONT_PRESSED: {
-                generateBaseButtonFont( _icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED], _icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED],
-                                        _icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED], _icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] );
+                generateButtonAlphabet( fheroes2::getCurrentLanguage(), _icnVsSprite );
                 return true;
             }
             case ICN::HISCORE: {

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3834,6 +3834,7 @@ namespace fheroes2
 
         void updateLanguageDependentResources( const SupportedLanguage language, const bool loadOriginalAlphabet )
         {
+            Display::ScaleFactorOverride override( 1 );
             auto & _icnVsSprite = getSpritesForScaleFactor( 1 );
 
             if ( loadOriginalAlphabet || !isAlphabetSupported( language ) ) {

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2078,7 +2078,9 @@ namespace fheroes2
                     else if ( i == 65 ) // Mass Shield
                         originalIndex = 15;
 
-                    const Sprite & originalImage = _icnVsSprite[id][originalIndex];
+                    Sprite & originalImage = _icnVsSprite[id][originalIndex];
+                    scaleToDisplayFactor( originalImage );
+
                     Sprite & image = _icnVsSprite[id][i];
 
                     image.resize( originalImage.width() + 8, originalImage.height() + 8 );

--- a/src/fheroes2/agg/agg_image.h
+++ b/src/fheroes2/agg/agg_image.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <cstdint>
+#include <vector>
 
 namespace fheroes2
 {
@@ -34,6 +35,9 @@ namespace fheroes2
     {
         // To be called when display's scale factor has changed.
         void ClearLoadedICNs();
+
+        void scaleICNToDisplayFactor( std::vector<Sprite> & sprites );
+        void scaleToDisplayFactor( Sprite & sprite );
 
         const Sprite & GetICN( int icnId, uint32_t index );
         uint32_t GetICNCount( int icnId );

--- a/src/fheroes2/agg/agg_image.h
+++ b/src/fheroes2/agg/agg_image.h
@@ -32,6 +32,9 @@ namespace fheroes2
 
     namespace AGG
     {
+        // To be called when display's scale factor has changed.
+        void ClearLoadedICNs();
+
         const Sprite & GetICN( int icnId, uint32_t index );
         uint32_t GetICNCount( int icnId );
 

--- a/src/fheroes2/agg/agg_image.h
+++ b/src/fheroes2/agg/agg_image.h
@@ -23,23 +23,19 @@
 #include <cstdint>
 #include <vector>
 
+#include "screen.h"
+
 namespace fheroes2
 {
-    class Image;
-    class Sprite;
+    // class Image;
+    // class Sprite;
     enum class FontSize : uint8_t;
     struct FontType;
     enum class SupportedLanguage : int;
 
     namespace AGG
     {
-        // To be called when display's scale factor has changed.
-        void ClearLoadedICNs();
-
-        void scaleICNToDisplayFactor( std::vector<Sprite> & sprites );
-        void scaleToDisplayFactor( Sprite & sprite );
-
-        const Sprite & GetICN( int icnId, uint32_t index );
+        const Sprite & GetICN( int icnId, uint32_t index, int32_t scaleFactor = Display::scaleFactor() );
         uint32_t GetICNCount( int icnId );
 
         // shapeId could be 0, 1, 2 or 3 only

--- a/src/fheroes2/agg/agg_image.h
+++ b/src/fheroes2/agg/agg_image.h
@@ -23,12 +23,10 @@
 #include <cstdint>
 #include <vector>
 
-#include "screen.h"
-
 namespace fheroes2
 {
-    // class Image;
-    // class Sprite;
+    class Image;
+    class Sprite;
     enum class FontSize : uint8_t;
     struct FontType;
     enum class SupportedLanguage : int;

--- a/src/fheroes2/agg/agg_image.h
+++ b/src/fheroes2/agg/agg_image.h
@@ -35,7 +35,7 @@ namespace fheroes2
 
     namespace AGG
     {
-        const Sprite & GetICN( int icnId, uint32_t index, int32_t scaleFactor = Display::scaleFactor() );
+        const Sprite & GetICN( int icnId, uint32_t index );
         uint32_t GetICNCount( int icnId );
 
         // shapeId could be 0, 1, 2 or 3 only

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1174,9 +1174,7 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     }
 
     // hexagon
-    if ( conf.BattleShowGrid() ) {
-        _hexagonGrid = DrawHexagon( fheroes2::GetColorId( 0x68, 0x8C, 0x04 ) );
-    }
+    _hexagonGrid = DrawHexagon( fheroes2::GetColorId( 0x68, 0x8C, 0x04 ) );
     // Shadow under the cursor: the first parameter is the shadow strength (smaller is stronger), the second is the distance between the hexagonal shadows.
     _hexagonCursorShadow = DrawHexagonShadow( 2, 1 );
     // Hexagon shadow for the case when grid is disabled.
@@ -1928,8 +1926,7 @@ void Battle::Interface::RedrawCoverStatic( const Settings & conf, const Board & 
 {
     if ( icn_cbkg != ICN::UNKNOWN ) {
         const fheroes2::Sprite & cbkg = fheroes2::AGG::GetICN( icn_cbkg, 0 );
-        // fheroes2::Copy( cbkg, _mainSurface );
-        _mainSurface = cbkg;
+        fheroes2::Copy( cbkg, _mainSurface );
     }
 
     if ( icn_frng != ICN::UNKNOWN ) {
@@ -5006,8 +5003,7 @@ void Battle::Interface::RedrawActionHolyShoutSpell( const uint8_t strength )
         if ( Game::validateCustomAnimationDelay( spellcastDelay ) ) {
             // stay at maximum blur for 2 frames
             if ( frame < 9 || frame > 10 ) {
-                // fheroes2::Copy( original, _mainSurface );
-                _mainSurface = original;
+                fheroes2::Copy( original, _mainSurface );
                 fheroes2::AlphaBlit( blurred, _mainSurface, alpha );
                 RedrawPartialFinish();
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -560,14 +560,16 @@ fheroes2::Image DrawHexagon( const uint8_t colorId )
     sf.reset();
 
     fheroes2::DrawLine( sf, { r - 1, 1 }, { 0, l + 1 }, colorId );
-    fheroes2::SetPixel( sf, r, 1, colorId );
+    // fheroes2::SetPixel( sf, r, 1, colorId );
+    fheroes2::Fill( sf, r, 1, 1, 1, colorId );
     fheroes2::DrawLine( sf, { r + 1, 1 }, { w, l + 1 }, colorId );
 
     fheroes2::DrawLine( sf, { 0, l + 1 }, { 0, h - l }, colorId );
     fheroes2::DrawLine( sf, { w, l + 1 }, { w, h - l }, colorId );
 
     fheroes2::DrawLine( sf, { r - 1, h }, { 0, h - l }, colorId );
-    fheroes2::SetPixel( sf, r, h, colorId );
+    // fheroes2::SetPixel( sf, r, h, colorId );
+    fheroes2::Fill( sf, r, h, 1, 1, colorId );
     fheroes2::DrawLine( sf, { r + 1, h }, { w, h - l }, colorId );
 
     return sf;
@@ -585,7 +587,8 @@ fheroes2::Image DrawHexagonShadow( const uint8_t alphaValue, const int32_t horiz
     for ( int i = 0; i < w / 2; i += 2 ) {
         for ( int x = 0; x < rt.width; ++x ) {
             for ( int y = 0; y < rt.height; ++y ) {
-                fheroes2::SetTransformPixel( sf, rt.x + x, rt.y + y, alphaValue );
+                // fheroes2::SetTransformPixel( sf, rt.x + x, rt.y + y, alphaValue );
+                fheroes2::FillTransform( sf, rt.x + x, rt.y + y, 1, 1, alphaValue );
             }
         }
         --rt.y;
@@ -1171,7 +1174,9 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     }
 
     // hexagon
-    _hexagonGrid = DrawHexagon( fheroes2::GetColorId( 0x68, 0x8C, 0x04 ) );
+    if ( conf.BattleShowGrid() ) {
+        _hexagonGrid = DrawHexagon( fheroes2::GetColorId( 0x68, 0x8C, 0x04 ) );
+    }
     // Shadow under the cursor: the first parameter is the shadow strength (smaller is stronger), the second is the distance between the hexagonal shadows.
     _hexagonCursorShadow = DrawHexagonShadow( 2, 1 );
     // Hexagon shadow for the case when grid is disabled.

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1923,7 +1923,8 @@ void Battle::Interface::RedrawCoverStatic( const Settings & conf, const Board & 
 {
     if ( icn_cbkg != ICN::UNKNOWN ) {
         const fheroes2::Sprite & cbkg = fheroes2::AGG::GetICN( icn_cbkg, 0 );
-        fheroes2::Copy( cbkg, _mainSurface );
+        // fheroes2::Copy( cbkg, _mainSurface );
+        _mainSurface = cbkg;
     }
 
     if ( icn_frng != ICN::UNKNOWN ) {
@@ -5000,7 +5001,8 @@ void Battle::Interface::RedrawActionHolyShoutSpell( const uint8_t strength )
         if ( Game::validateCustomAnimationDelay( spellcastDelay ) ) {
             // stay at maximum blur for 2 frames
             if ( frame < 9 || frame > 10 ) {
-                fheroes2::Copy( original, _mainSurface );
+                // fheroes2::Copy( original, _mainSurface );
+                _mainSurface = original;
                 fheroes2::AlphaBlit( blurred, _mainSurface, alpha );
                 RedrawPartialFinish();
 

--- a/src/fheroes2/dialog/dialog_resolution.cpp
+++ b/src/fheroes2/dialog/dialog_resolution.cpp
@@ -27,7 +27,6 @@
 #include "agg_image.h"
 #include "cursor.h"
 #include "dialog_resolution.h"
-#include "embedded_image.h"
 #include "game_hotkeys.h"
 #include "gamedefs.h"
 #include "icn.h"
@@ -42,7 +41,6 @@
 #include "ui_dialog.h"
 #include "ui_scrollbar.h"
 #include "ui_text.h"
-#include "zzlib.h"
 
 namespace
 {
@@ -125,11 +123,11 @@ namespace
 
 namespace Dialog
 {
-    bool SelectResolution()
+    fheroes2::Size SelectResolution()
     {
         std::vector<fheroes2::Size> resolutions = fheroes2::engine().getAvailableResolutions();
         if ( resolutions.empty() )
-            return false;
+            return { 0, 0 };
 
         fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -166,7 +164,7 @@ namespace Dialog
 
         resList.SetListContent( resolutions );
 
-        const fheroes2::Size currentResolution( display.width(), display.height() );
+        const fheroes2::Size currentResolution( display._w(), display._h() );
 
         fheroes2::Size selectedResolution;
         for ( size_t i = 0; i < resolutions.size(); ++i ) {
@@ -231,16 +229,9 @@ namespace Dialog
 
         if ( selectedResolution.width > 0 && selectedResolution.height > 0
              && ( selectedResolution.width != currentResolution.width || selectedResolution.height != currentResolution.height ) ) {
-            display.resize( selectedResolution.width, selectedResolution.height );
-
-#if !defined( MACOS_APP_BUNDLE )
-            const fheroes2::Image & appIcon = CreateImageFromZlib( 32, 32, iconImage, sizeof( iconImage ), true );
-            fheroes2::engine().setIcon( appIcon );
-#endif
-
-            return true;
+            return selectedResolution;
         }
 
-        return false;
+        return { 0, 0 };
     }
 }

--- a/src/fheroes2/dialog/dialog_resolution.h
+++ b/src/fheroes2/dialog/dialog_resolution.h
@@ -20,7 +20,9 @@
 
 #pragma once
 
+#include "math_base.h"
+
 namespace Dialog
 {
-    bool SelectResolution(); // returns true if a new resolution is set
+    fheroes2::Size SelectResolution(); // returns size > 0,0 if a new resolution is selected
 }

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -46,6 +46,7 @@
 #endif
 
 #include "agg.h"
+#include "agg_image.h"
 #include "audio_manager.h"
 #include "bin_info.h"
 #include "core.h"
@@ -130,6 +131,8 @@ namespace
             display.resize( conf.VideoMode().width, conf.VideoMode().height );
             display.fill( 0 ); // start from a black screen
 
+            display.setOnScaleFactorChangeHook( onScaleFactorChangeHook );
+
             fheroes2::engine().setTitle( GetCaption() );
 
             SDL_ShowCursor( SDL_DISABLE ); // hide system cursor
@@ -152,6 +155,14 @@ namespace
         ~DisplayInitializer()
         {
             fheroes2::Display::instance().release();
+        }
+
+    private:
+        static void onScaleFactorChangeHook( int32_t oldScaleFactor, int32_t newScaleFactor )
+        {
+            DEBUG_LOG( DBG_GAME, DBG_INFO, "Detected display scale factor change from " << oldScaleFactor << " to " << newScaleFactor << ": clearing loaded ICNs..." )
+
+            fheroes2::AGG::ClearLoadedICNs();
         }
     };
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -131,8 +131,6 @@ namespace
             display.resize( conf.VideoMode().width, conf.VideoMode().height );
             display.fill( 0 ); // start from a black screen
 
-            display.setOnScaleFactorChangeHook( onScaleFactorChangeHook );
-
             fheroes2::engine().setTitle( GetCaption() );
 
             SDL_ShowCursor( SDL_DISABLE ); // hide system cursor
@@ -155,14 +153,6 @@ namespace
         ~DisplayInitializer()
         {
             fheroes2::Display::instance().release();
-        }
-
-    private:
-        static void onScaleFactorChangeHook( int32_t oldScaleFactor, int32_t newScaleFactor )
-        {
-            DEBUG_LOG( DBG_GAME, DBG_INFO, "Detected display scale factor change from " << oldScaleFactor << " to " << newScaleFactor << ": clearing loaded ICNs..." )
-
-            fheroes2::AGG::ClearLoadedICNs();
         }
     };
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -46,7 +46,6 @@
 #endif
 
 #include "agg.h"
-#include "agg_image.h"
 #include "audio_manager.h"
 #include "bin_info.h"
 #include "core.h"

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -84,20 +84,24 @@ fheroes2::GameMode Game::LoadMulti()
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    // image background
-    const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
     fheroes2::drawMainMenuScreen();
 
+    const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
     const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
-    const int32_t panelOffset = fheroes2::Display::DEFAULT_HEIGHT - panel.height();
-    const int32_t panelXPos = back.width() - ( panel.width() + panelOffset );
-    fheroes2::Blit( panel, display, panelXPos, panelOffset );
+
+    const int32_t offX = ( display.width() - back.width() ) / 2;
+    const int32_t offY = ( display.height() - back.height() ) / 2;
+
+    const int32_t panelOffset = back.height() - panel.height();
+    const uint32_t panelXPos = back.width() - ( panel.width() + panelOffset );
+
+    fheroes2::Blit( panel, display, offX + panelXPos, offY + panelOffset );
 
     const int32_t buttonMiddlePos = panelXPos + SHADOWWIDTH + ( panel.width() - SHADOWWIDTH ) / 2;
     const fheroes2::Sprite & buttonSample = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 0 );
     const int32_t buttonWidth = buttonSample.width();
-    const int32_t buttonXPos = buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
-    const int32_t buttonYPos = 46;
+    const int32_t buttonXPos = offX + buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
+    const int32_t buttonYPos = offY + 46;
     const int32_t buttonYStep = 66;
 
     fheroes2::Button buttonHotSeat( buttonXPos, buttonYPos, ICN::BUTTON_HOT_SEAT, 0, 1 );
@@ -155,13 +159,17 @@ fheroes2::GameMode Game::LoadGame()
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
     fheroes2::drawMainMenuScreen();
 
+    const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
     const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
-    const int32_t panelOffset = fheroes2::Display::DEFAULT_HEIGHT - panel.height();
-    const int32_t panelXPos = back.width() - ( panel.width() + panelOffset );
-    fheroes2::Blit( panel, display, panelXPos, panelOffset );
+
+    const int32_t offX = ( display.width() - back.width() ) / 2;
+    const int32_t offY = ( display.height() - back.height() ) / 2;
+
+    const int32_t panelOffset = back.height() - panel.height();
+    const uint32_t panelXPos = back.width() - ( panel.width() + panelOffset );
+    fheroes2::Blit( panel, display, offX + panelXPos, offY + panelOffset );
 
     const int32_t buttonMiddlePos = panelXPos + SHADOWWIDTH + ( panel.width() - SHADOWWIDTH ) / 2;
     const fheroes2::Sprite & buttonSample = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 0 );
@@ -175,8 +183,8 @@ fheroes2::GameMode Game::LoadGame()
     buttons[2].setICNInfo( ICN::BUTTON_MULTIPLAYER_GAME, 0, 1 );
     buttons[3].setICNInfo( ICN::BUTTON_LARGE_CANCEL, 0, 1 );
 
-    const int32_t buttonXPos = buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
-    const int32_t buttonYPos = 46;
+    const int32_t buttonXPos = offX + buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
+    const int32_t buttonYPos = offY + 46;
     const int32_t buttonYStep = 66;
 
     for ( size_t i = 0; i < buttonCount - 1; ++i ) {

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -207,8 +207,11 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
             fheroes2::showStandardTextMessage(
                 _( "Greetings!" ), _( "Welcome to Heroes of Might and Magic II powered by fheroes2 engine! Before starting the game please choose game resolution." ),
                 Dialog::OK );
-            const bool isResolutionChanged = Dialog::SelectResolution();
-            if ( isResolutionChanged ) {
+
+            const fheroes2::Size selectedResolution = Dialog::SelectResolution();
+            if ( selectedResolution.width > 0 && selectedResolution.height > 0 ) {
+                fheroes2::Display::instance().resize( selectedResolution.width, selectedResolution.height );
+
                 fheroes2::drawMainMenuScreen();
             }
         }

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -230,17 +230,21 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 
     LocalEvent & le = LocalEvent::Get();
 
-    fheroes2::Button buttonNewGame( 0, 0, ICN::BTNSHNGL, NEWGAME_DEFAULT, NEWGAME_DEFAULT + 2 );
-    fheroes2::Button buttonLoadGame( 0, 0, ICN::BTNSHNGL, LOADGAME_DEFAULT, LOADGAME_DEFAULT + 2 );
-    fheroes2::Button buttonHighScores( 0, 0, ICN::BTNSHNGL, HIGHSCORES_DEFAULT, HIGHSCORES_DEFAULT + 2 );
-    fheroes2::Button buttonCredits( 0, 0, ICN::BTNSHNGL, CREDITS_DEFAULT, CREDITS_DEFAULT + 2 );
-    fheroes2::Button buttonQuit( 0, 0, ICN::BTNSHNGL, QUIT_DEFAULT, QUIT_DEFAULT + 2 );
+    const fheroes2::Sprite & background = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
+    const int32_t offX = ( display.width() - background.width() ) / 2;
+    const int32_t offY = ( display.height() - background.height() ) / 2;
+
+    fheroes2::Button buttonNewGame( offX, offY, ICN::BTNSHNGL, NEWGAME_DEFAULT, NEWGAME_DEFAULT + 2 );
+    fheroes2::Button buttonLoadGame( offX, offY, ICN::BTNSHNGL, LOADGAME_DEFAULT, LOADGAME_DEFAULT + 2 );
+    fheroes2::Button buttonHighScores( offX, offY, ICN::BTNSHNGL, HIGHSCORES_DEFAULT, HIGHSCORES_DEFAULT + 2 );
+    fheroes2::Button buttonCredits( offX, offY, ICN::BTNSHNGL, CREDITS_DEFAULT, CREDITS_DEFAULT + 2 );
+    fheroes2::Button buttonQuit( offX, offY, ICN::BTNSHNGL, QUIT_DEFAULT, QUIT_DEFAULT + 2 );
 
     const fheroes2::Sprite & lantern10 = fheroes2::AGG::GetICN( ICN::SHNGANIM, 0 );
-    fheroes2::Blit( lantern10, display, lantern10.x(), lantern10.y() );
+    fheroes2::Blit( lantern10, display, offX + lantern10.x(), offY + lantern10.y() );
 
     const fheroes2::Sprite & lantern11 = fheroes2::AGG::GetICN( ICN::SHNGANIM, ICN::AnimationFrame( ICN::SHNGANIM, 0, 0 ) );
-    fheroes2::Blit( lantern11, display, lantern11.x(), lantern11.y() );
+    fheroes2::Blit( lantern11, display, offX + lantern11.x(), offY + lantern11.y() );
 
     buttonNewGame.draw();
     buttonLoadGame.draw();
@@ -250,10 +254,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 
     display.render();
 
-    const double scaleX = static_cast<double>( display.width() ) / fheroes2::Display::DEFAULT_WIDTH;
-    const double scaleY = static_cast<double>( display.height() ) / fheroes2::Display::DEFAULT_HEIGHT;
-    const fheroes2::Rect settingsArea( static_cast<int32_t>( 63 * scaleX ), static_cast<int32_t>( 202 * scaleY ), static_cast<int32_t>( 90 * scaleX ),
-                                       static_cast<int32_t>( 160 * scaleY ) );
+    const fheroes2::Rect settingsArea( 63, 202, 90, 160 );
 
     uint32_t lantern_frame = 0;
 
@@ -265,7 +266,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 
     for ( size_t i = 0; le.MouseMotion() && i < buttons.size(); ++i ) {
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BTNSHNGL, buttons[i].frame );
-        fheroes2::Blit( sprite, display, sprite.x(), sprite.y() );
+        fheroes2::Blit( sprite, display, offX + sprite.x(), offY + sprite.y() );
     }
 
     fheroes2::Sprite highlightDoor = fheroes2::AGG::GetICN( ICN::SHNGANIM, 18 );
@@ -306,7 +307,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
                     redrawScreen = true;
                 }
                 const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BTNSHNGL, frame );
-                fheroes2::Blit( sprite, display, sprite.x(), sprite.y() );
+                fheroes2::Blit( sprite, display, offX + sprite.x(), offY + sprite.y() );
             }
         }
 
@@ -358,10 +359,9 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
         if ( validateAnimationDelay( MAIN_MENU_DELAY ) ) {
             const fheroes2::Sprite & lantern12 = fheroes2::AGG::GetICN( ICN::SHNGANIM, ICN::AnimationFrame( ICN::SHNGANIM, 0, lantern_frame ) );
             ++lantern_frame;
-            fheroes2::Blit( lantern12, display, lantern12.x(), lantern12.y() );
+            fheroes2::Blit( lantern12, display, offX + lantern12.x(), offY + lantern12.y() );
             if ( le.MouseCursor( settingsArea ) ) {
-                const int32_t offsetY = static_cast<int32_t>( 55 * scaleY );
-                fheroes2::Blit( highlightDoor, 0, offsetY, display, highlightDoor.x(), highlightDoor.y() + offsetY, highlightDoor.width(), highlightDoor.height() );
+                fheroes2::Blit( highlightDoor, 0, 55, display, offX + highlightDoor.x(), offY + highlightDoor.y() + 55, highlightDoor.width(), highlightDoor.height() );
             }
 
             display.render();

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -254,7 +254,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 
     display.render();
 
-    const fheroes2::Rect settingsArea( 63, 202, 90, 160 );
+    const fheroes2::Rect settingsArea( offX + 63, offY + 202, 90, 160 );
 
     uint32_t lantern_frame = 0;
 

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -29,22 +29,25 @@
 
 namespace fheroes2
 {
-    void drawSprite( Display & display, const int icnId, const uint32_t index )
+    void drawSprite( Display & display, const int32_t offX, const int32_t offY, const int icnId, const uint32_t index )
     {
         const Sprite & sprite = AGG::GetICN( icnId, index );
-        Blit( sprite, 0, 0, display, sprite.x(), sprite.y(), sprite.width(), sprite.height() );
+        Blit( sprite, display, offX + sprite.x(), offY + sprite.y() );
     }
 
     void drawMainMenuScreen()
     {
         Display & display = Display::instance();
 
-        Copy( AGG::GetICN( ICN::HEROES, 0 ), display );
+        const Sprite & background = AGG::GetICN( ICN::HEROES, 0 );
+        const int32_t offX = ( display.width() - background.width() ) / 2;
+        const int32_t offY = ( display.height() - background.height() ) / 2;
+        Blit( background, display, offX, offY );
 
-        drawSprite( display, ICN::BTNSHNGL, 1 );
-        drawSprite( display, ICN::BTNSHNGL, 5 );
-        drawSprite( display, ICN::BTNSHNGL, 9 );
-        drawSprite( display, ICN::BTNSHNGL, 13 );
-        drawSprite( display, ICN::BTNSHNGL, 17 );
+        drawSprite( display, offX, offY, ICN::BTNSHNGL, 1 );
+        drawSprite( display, offX, offY, ICN::BTNSHNGL, 5 );
+        drawSprite( display, offX, offY, ICN::BTNSHNGL, 9 );
+        drawSprite( display, offX, offY, ICN::BTNSHNGL, 13 );
+        drawSprite( display, offX, offY, ICN::BTNSHNGL, 17 );
     }
 }

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -39,6 +39,9 @@ namespace fheroes2
     {
         Display & display = Display::instance();
 
+        // clear out any artifacts outside of the main background
+        Fill( display, 0, 0, display.width(), display.height(), 0 );
+
         const Sprite & background = AGG::GetICN( ICN::HEROES, 0 );
         const int32_t offX = ( display.width() - background.width() ) / 2;
         const int32_t offY = ( display.height() - background.height() ) / 2;

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -70,12 +70,17 @@ namespace
     // Draw button panel and return the position for a button.
     fheroes2::Point drawButtonPanel()
     {
+        fheroes2::Display & display = fheroes2::Display::instance();
+
         const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
         const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
 
-        const uint32_t panelOffset = fheroes2::Display::DEFAULT_HEIGHT - panel.height();
+        const int32_t offX = ( display.width() - back.width() ) / 2;
+        const int32_t offY = ( display.height() - back.height() ) / 2;
+
+        const int32_t panelOffset = back.height() - panel.height();
         const uint32_t panelXPos = back.width() - ( panel.width() + panelOffset );
-        fheroes2::Blit( panel, fheroes2::Display::instance(), panelXPos, panelOffset );
+        fheroes2::Blit( panel, display, offX + panelXPos, offY + panelOffset );
 
         const int32_t buttonMiddlePos = panelXPos + SHADOWWIDTH + ( panel.width() - SHADOWWIDTH ) / 2;
 
@@ -84,7 +89,7 @@ namespace
         const int32_t buttonXPos = buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
         const int32_t buttonYPos = 46;
 
-        return fheroes2::Point( buttonXPos, buttonYPos );
+        return fheroes2::Point( offX + buttonXPos, offY + buttonYPos );
     }
 
     std::unique_ptr<SMKVideoSequence> getVideo( const std::string & fileName )

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -259,13 +259,16 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
     AudioManager::ResetAudio();
 
     fheroes2::Display & display = fheroes2::Display::instance();
-    const fheroes2::Point roiOffset( ( display.width() - display.DEFAULT_WIDTH ) / 2, ( display.height() - display.DEFAULT_HEIGHT ) / 2 );
+
+    const fheroes2::Point roiOffset( ( display._w() - display.DEFAULT_WIDTH ) / 2, ( display._h() - display.DEFAULT_HEIGHT ) / 2 );
 
     display.fill( 0 );
 
     const Text loadingScreen( "Loading video. Please wait...", Font::BIG );
     loadingScreen.Blit( display.width() / 2 - loadingScreen.w() / 2, display.height() / 2 - loadingScreen.h() / 2 );
     display.render();
+
+    fheroes2::Display::ScaleFactorOverride scaleFactorOverride( 1 );
 
     Video::ShowVideo( "INTRO.SMK", Video::VideoAction::PLAY_TILL_VIDEO_END );
 
@@ -370,7 +373,9 @@ fheroes2::GameMode Game::NewPriceOfLoyaltyCampaign()
     Cursor::Get().setVideoPlaybackCursor();
 
     fheroes2::Display & display = fheroes2::Display::instance();
-    const fheroes2::Point roiOffset( ( display.width() - display.DEFAULT_WIDTH ) / 2, ( display.height() - display.DEFAULT_HEIGHT ) / 2 );
+    fheroes2::Display::ScaleFactorOverride scaleFactorOverride( 1 );
+
+    const fheroes2::Point roiOffset( ( display._w() - display.DEFAULT_WIDTH ) / 2, ( display._h() - display.DEFAULT_HEIGHT ) / 2 );
 
     display.fill( 0 );
 

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -123,7 +123,7 @@ namespace Video
         display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
 
         unsigned int currentFrame = 0;
-        fheroes2::Rect frameRoi( ( display.width() - video.width() ) / 2, ( display.height() - video.height() ) / 2, 0, 0 );
+        fheroes2::Rect frameRoi( ( display._w() - video.width() ) / 2, ( display._h() - video.height() ) / 2, 0, 0 );
 
         const uint32_t delay = static_cast<uint32_t>( 1000.0 / video.fps() + 0.5 ); // This might be not very accurate but it's the best we can have now
 

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -210,7 +210,8 @@ void Interface::Radar::Generate()
                     color += 3;
             }
 
-            fheroes2::SetPixel( spriteArea, x, y, color );
+            // fheroes2::SetPixel( spriteArea, x, y, color );
+            fheroes2::Fill( spriteArea, x, y, 1, 1, color );
         }
     }
 
@@ -389,13 +390,7 @@ void Interface::Radar::RedrawObjects( int color, ViewWorldMode flags ) const
             }
 
             const int dstx = offsetX + ( x * areaw ) / worldWidth;
-
-            if ( sw > 1 ) {
-                fheroes2::Fill( display, dstx, dsty, sw, sw, fillColor );
-            }
-            else {
-                fheroes2::SetPixel( display, dstx, dsty, fillColor );
-            }
+            fheroes2::Fill( display, dstx, dsty, sw, sw, fillColor );
         }
     }
 }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -59,10 +59,10 @@ namespace
 
         fheroes2::Sprite output = input;
 
-        const int32_t width = output.width() + contourOffset.x;
-        const int32_t height = output.height() - contourOffset.y;
+        const int32_t width = output._w() + contourOffset.x;
+        const int32_t height = output._h() - contourOffset.y;
 
-        const int32_t imageWidth = output.width();
+        const int32_t imageWidth = output._w();
 
         uint8_t * imageOutY = output.image() + imageWidth * contourOffset.y;
         const uint8_t * transformInY = input.transform() - contourOffset.x;
@@ -133,11 +133,6 @@ namespace
             applyEvilButtonReleasedLetterEffects( evilReleased[i] );
             applyEvilButtonPressedLetterEffects( evilPressed[i] );
         }
-
-        fheroes2::AGG::scaleICNToDisplayFactor( goodReleased );
-        fheroes2::AGG::scaleICNToDisplayFactor( goodPressed );
-        fheroes2::AGG::scaleICNToDisplayFactor( evilReleased );
-        fheroes2::AGG::scaleICNToDisplayFactor( evilPressed );
     }
 
     void generateCP1250Alphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -26,6 +26,7 @@
 #include <initializer_list>
 #include <memory>
 
+#include "agg_image.h"
 #include "icn.h"
 #include "image.h"
 #include "math_base.h"
@@ -132,6 +133,11 @@ namespace
             applyEvilButtonReleasedLetterEffects( evilReleased[i] );
             applyEvilButtonPressedLetterEffects( evilPressed[i] );
         }
+
+        fheroes2::AGG::scaleICNToDisplayFactor( goodReleased );
+        fheroes2::AGG::scaleICNToDisplayFactor( goodPressed );
+        fheroes2::AGG::scaleICNToDisplayFactor( evilReleased );
+        fheroes2::AGG::scaleICNToDisplayFactor( evilPressed );
     }
 
     void generateCP1250Alphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
@@ -4516,23 +4522,12 @@ namespace fheroes2
         return false;
     }
 
-    void generateBaseButtonFont( std::vector<Sprite> & goodReleased, std::vector<Sprite> & goodPressed, std::vector<Sprite> & evilReleased,
-                                 std::vector<Sprite> & evilPressed )
-    {
-        generateGoodButtonFontBaseShape( goodReleased );
-
-        updateButtonFont( goodReleased, goodPressed, evilReleased, evilPressed );
-    }
-
     void generateButtonAlphabet( const SupportedLanguage language, std::vector<std::vector<Sprite>> & icnVsSprite )
     {
-        generateGoodButtonFontBaseShape( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
-
         switch ( language ) {
         case SupportedLanguage::English:
-            generateBaseButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED], icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED], icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED],
-                                    icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] );
-            return;
+            generateGoodButtonFontBaseShape( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
+            break;
         case SupportedLanguage::Czech:
         case SupportedLanguage::Hungarian:
         case SupportedLanguage::Polish:

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -3565,7 +3565,7 @@ namespace
         // Since all symbols have -1 shift by X axis to avoid any issues with alignment we need to makes all images at least 1 pixel in size.
         // These images are completely transparent.
         for ( fheroes2::Sprite & letter : released ) {
-            letter.resize( 1, 1 );
+            letter = fheroes2::Image( 1, 1, 1 );
             letter.reset();
 
             letter.setPosition( buttonFontOffset.x, buttonFontOffset.y );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -3936,6 +3936,8 @@ namespace
 
     void generateCP1250GoodButtonFont( std::vector<fheroes2::Sprite> & released )
     {
+        assert( !released.empty() );
+
         // Increase size to fit full CP1252 set of characters. Fill with 1px transparent images.
         released.insert( released.end(), 160, released[0] );
 
@@ -4078,6 +4080,8 @@ namespace
 
     void generateCP1251GoodButtonFont( std::vector<fheroes2::Sprite> & released )
     {
+        assert( !released.empty() );
+
         // Increase size to fit full CP1252 set of characters. Fill with 1px transparent images.
         released.insert( released.end(), 160, released[0] );
 
@@ -4362,6 +4366,8 @@ namespace
 
     void generateCP1252GoodButtonFont( std::vector<fheroes2::Sprite> & released )
     {
+        assert( !released.empty() );
+
         // Increase size to fit full CP1252 set of characters. Fill with 1px transparent images.
         released.insert( released.end(), 160, released[0] );
 
@@ -4519,9 +4525,11 @@ namespace fheroes2
 
     void generateButtonAlphabet( const SupportedLanguage language, std::vector<std::vector<Sprite>> & icnVsSprite )
     {
+        generateGoodButtonFontBaseShape( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
+
         switch ( language ) {
         case SupportedLanguage::English:
-            generateGoodButtonFontBaseShape( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED] );
+            // nothing special to do here for English
             break;
         case SupportedLanguage::Czech:
         case SupportedLanguage::Hungarian:

--- a/src/fheroes2/gui/ui_font.h
+++ b/src/fheroes2/gui/ui_font.h
@@ -32,9 +32,6 @@ namespace fheroes2
 
     bool isAlphabetSupported( const SupportedLanguage language );
 
-    void generateBaseButtonFont( std::vector<Sprite> & goodReleased, std::vector<Sprite> & goodPressed, std::vector<Sprite> & evilReleased,
-                                 std::vector<Sprite> & evilPressed );
-
     void generateButtonAlphabet( const SupportedLanguage language, std::vector<std::vector<Sprite>> & icnVsSprite );
 
     void modifyBaseNormalFont( std::vector<fheroes2::Sprite> & icnVsSprite );

--- a/src/fheroes2/gui/ui_scrollbar.cpp
+++ b/src/fheroes2/gui/ui_scrollbar.cpp
@@ -36,7 +36,9 @@ namespace fheroes2
 
     void Scrollbar::setImage( const Image & image )
     {
-        Copy( image, *this );
+        // resize( image.width(), image.height() );
+        // Copy( image, *this );
+        Image::operator=( image );
     }
 
     void Scrollbar::setArea( const Rect & area )

--- a/src/fheroes2/gui/ui_scrollbar.cpp
+++ b/src/fheroes2/gui/ui_scrollbar.cpp
@@ -36,8 +36,6 @@ namespace fheroes2
 
     void Scrollbar::setImage( const Image & image )
     {
-        // resize( image.width(), image.height() );
-        // Copy( image, *this );
         Image::operator=( image );
     }
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -381,7 +381,7 @@ std::string Settings::String() const
     os << "# fheroes2 configuration file (saved by version " << GetVersion() << ")" << std::endl;
 
     os << std::endl << "# video mode (game resolution)" << std::endl;
-    os << "videomode = " << fheroes2::Display::instance().width() << "x" << fheroes2::Display::instance().height() << std::endl;
+    os << "videomode = " << fheroes2::Display::instance()._w() << "x" << fheroes2::Display::instance()._h() << std::endl;
 
     os << std::endl << "# music: original, expansion, external" << std::endl;
     os << "music = " << musicType << std::endl;


### PR DESCRIPTION
Hi!

As announced in #5016, here's a draft for supporting integer factor resource scaling.  E.g., `1920x1080` can fit up to 3 OG screen by width, but only 2 by height, so the factor is 2 in this case.  A resolution of `2560x1440` is `4x:3x` of the OG's `640x480`, so a useful scale factor is either 2 or 3 (for now the maximum is chosen automatically, but we may let user choose the factor freely as well).  Higher resolutions with lower-than-maximum scale factors are likely the most useful combinations.

The change is focused on the rendering engine and tries to avoid touching the application code as much as possible — the vast majority of pixel offsets are hard-coded values in the game code, obtained by measuring the original game's resources, which would be infeasible to touch. ;)

The way this was made possible is by associating an integer "scale factor" value to each `Image` instance (including `Display`) and making the images "lie" about their dimensions: regardless of the scale factor, an image instance will always report the same `width` and `height` — its "logical dimensions".  The actual physical dimensions are only used by the image manipulation and rendering routines, for the most part contained in a single file `image.cpp`.

The resources are loaded with the default scale factor of `1` and on-demand can be resized and cached for higher scale factors (up to `4`).  Resizing is done using our existing nearest neighbour algorithm, but this is where other algorithms may be plugged in later, if desired.

Once this is given, the next step is to always create `Image` instances with the display's current scale factor, and, because the display is also reporting its `width`/`height` in the logical units, the calculations like centering a box on the screen continue to work "magically".

---
Edit: added example.

Consider the code for rendering a window of arbitrary size in the middle of the screen:
https://github.com/ihhub/fheroes2/blob/master/src/fheroes2/gui/ui_window.cpp#L33-L36

```c++
    StandardWindow::StandardWindow( const int32_t width, const int32_t height, Image & output )
        : _output( output )
        , _activeArea( ( output.width() - width ) / 2, ( output.height() - height ) / 2, width, height )
        , _windowArea( _activeArea.x - borderSize, _activeArea.y - borderSize, _activeArea.width + 2 * borderSize, _activeArea.height + 2 * borderSize )
...
```

It takes the dimensions of the inner active area `width`×`height` and adds a border of the hard-coded size of 16 logical pixels around it in all directions.  Let's work out the coordinates for rendering such a window border on the display at resolution `1920x1080` with scale factor 2, for an inner area of `640x480` logical pixels.

As this is application code (not the rendering engine), my priority was to leave it untouched.  The `width()` and `height()` methods used here return the logical dimensions, so for our display these values are `1920/2 = 960` and `1080/2 = 540`.  The `width`  and `height` parameters may either be hard-coded in the caller, or they may come from measuring the dimensions of a game resource, such as result of calling `fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 )`.  In the original resources, this the window displayed when two heroes of the same player meet each other for exchange of armies and artifacts.  It has the dimensions of `640x480` pixels.  Because in this example our display's current scale factor is 2, the `Image` instance returned by the `GetICN()` function is pre-scaled 2×2, so its physical dimensions are actually `1280x960`.  The logical dimensions, visible to the application code, are the same _regardless_ of the current scale factor.

So the `activeArea` works out, in logical pixels, to `{ (960 - 640)/2 = 160, (540 - 480)/2 = 30, 640, 480 }`. The `broderSize` is hard-coded as 16, so  `windowArea` works out, again in logical pixels, to `{ 160 - 16 = 144, 30 - 16 = 14, 640 + 2*16 = 672, 480 + 2*16 = 512}`.

When the window border image is rendered on the display, the logical pixels are translated to physical ones, by simply multiplying them by the scale factor.  This, again, happens in the rendering engine's functions such as `Blit()`, so the application code doesn't need any changes for rendering to work correctly.  The border area becomes, in physical pixels: `{ 144*2 = 288, 14*2 = 28, 1344, 512*2 = 1024 }`.  The inner active window area — `{ 160*2 = 320, 30*2 = 60, 640*2 = 1280, 480*2 = 960 }`.

![image](https://user-images.githubusercontent.com/489601/210167834-7e4d50b9-b4aa-42ba-a723-56339fad0f45.png)

---
Finally, for correct controller operation, the mouse position should be also tracked taking the current scale factor into account.

The rendering code is always working with static pre-scaled resources (there is no real-time upscaling and it's not needed).

As I've mentioned in the original discussion, I observe no performance impact of the adjusted rendering procedure. :mx_claus: :champagne: 

---
Edit: some notes on the implementation.  It's not without hacks, some of which are quite ugly.

This has mostly to do with the fact that `Display::instance()` is used as default parameter in a couple of places, such as default target for rendering buttons, etc.  It would be better to add an abstraction layer of a "rendering context", so that direct rendering on the display is prohibited.  That would also help to reduce code duplication where coordinates of the top-left corner are constantly need to be added manually to each X,Y screen offsets.

Not directly related to this, I think it may make sense to eventually rework the UI controls system to properly encapsulate the state/rendering and event handling.  Right now it's all over the place and is simply copied over from one dialog code to the other, with slight changes.  I don't know what are you exact plans for the Editor, but it feels like this is where even more dialogs and controls will be introduced. ;)

---
TODO:
- [ ] Make changing resolutions / scale factor 100% safe (there are some corner cases right now)
- [x] Figure out the crash in the multi-language font generation
- [ ] Check how it works (or doesn't) on non-default build targets
- [ ] Explore advanced upscaling filters
