### PR TITLE
extract_homm2_resources.sh: detect multiple Python versions

### DIFF
--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -36,7 +36,7 @@ jobs:
     - name: Commit changes
       run: |
         git diff --name-only -z -- files/lang/*.po \
-        | xargs -r0 bash -c 'set -e; for NAME in "$@"; do if [[ "$(git diff "-I^\"POT-Creation-Date:[^\"]*\"$" -- "$NAME")" != "" ]]; then git add -- "$NAME"; fi; done' dummy
+        | xargs -r0 bash -c 'set -e; for NAME in "$@"; do if [[ -n "$(git diff "-I^\"POT-Creation-Date:[^\"]*\"$" -- "$NAME")" ]]; then git add -- "$NAME"; fi; done' dummy
         if git commit -m "Update translation files"; then git push origin HEAD; echo "CREATE_PR=YES" >> "$GITHUB_ENV"; fi
     - name: Create PR
       if: ${{ env.CREATE_PR == 'YES' }}

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -8,9 +8,9 @@ PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/an
 
 TMP_DIR="$(mktemp -d)"
 
-if [[ "$(command -v wget)" != "" ]]; then
+if [[ -n "$(command -v wget)" ]]; then
     wget -O "$TMP_DIR/$PKG_FILE" "$PKG_URL"
-elif [[ "$(command -v curl)" != "" ]]; then
+elif [[ -n "$(command -v curl)" ]]; then
     curl -o "$TMP_DIR/$PKG_FILE" -L "$PKG_URL"
 else
     echo "Neither wget nor curl were found in your system. Unable to download the package archive. Installation aborted."
@@ -19,9 +19,9 @@ fi
 
 echo "$PKG_FILE_SHA256 *$PKG_FILE" > "$TMP_DIR/checksums"
 
-if [[ "$(command -v shasum)" != "" ]]; then
+if [[ -n "$(command -v shasum)" ]]; then
     (cd "$TMP_DIR" && shasum --check --algorithm 256 checksums)
-elif [[ "$(command -v sha256sum)" != "" ]]; then
+elif [[ -n "$(command -v sha256sum)" ]]; then
     (cd "$TMP_DIR" && sha256sum --check --strict checksums)
 else
     echo "Neither shasum nor sha256sum were found in your system. Unable to verify the downloaded file. Installation aborted."

--- a/script/demo/download_demo_version.sh
+++ b/script/demo/download_demo_version.sh
@@ -51,9 +51,9 @@ echo_stage "[2/4] downloading the demo version"
 
 cd "$DEST_PATH/demo"
 
-if [[ "$(command -v wget)" != "" ]]; then
+if [[ -n "$(command -v wget)" ]]; then
     wget -O h2demo.zip "$H2DEMO_URL"
-elif [[ "$(command -v curl)" != "" ]]; then
+elif [[ -n "$(command -v curl)" ]]; then
     curl -o h2demo.zip -L "$H2DEMO_URL"
 else
     echo_red "Neither wget nor curl were found in your system. Unable to download the demo version. Installation aborted."
@@ -62,9 +62,9 @@ fi
 
 echo "$H2DEMO_SHA256 *h2demo.zip" > checksums
 
-if [[ "$(command -v shasum)" != "" ]]; then
+if [[ -n "$(command -v shasum)" ]]; then
     shasum --check --algorithm 256 checksums
-elif [[ "$(command -v sha256sum)" != "" ]]; then
+elif [[ -n "$(command -v sha256sum)" ]]; then
     sha256sum --check --strict checksums
 else
     echo_red "Neither shasum nor sha256sum were found in your system. Unable to verify the downloaded file. Installation aborted."

--- a/script/homm2/extract_homm2_resources.sh
+++ b/script/homm2/extract_homm2_resources.sh
@@ -83,18 +83,18 @@ fi
 
 # Special case - CD image from GOG
 
-if [[ "$(command -v python3)" != "" ]]; then
+if [[ -n "$(command -v python3)" ]]; then
     PYTHON="python3"
-elif [[ "$(command -v python2)" != "" ]]; then
+elif [[ -n "$(command -v python2)" ]]; then
     PYTHON="python2"
-elif [[ "$(command -v python)" != "" ]]; then
+elif [[ -n "$(command -v python)" ]]; then
     PYTHON="python"
 else
     echo_yellow "python was not found in your system. Please install it and re-run this script to extract animation resources."
     exit 0
 fi
 
-if [[ "$(command -v bsdtar)" == "" ]]; then
+if [[ -z "$(command -v bsdtar)" ]]; then
     echo_yellow "bsdtar was not found in your system. Please install it and re-run this script to extract animation resources."
     exit 0
 fi

--- a/script/homm2/extract_homm2_resources.sh
+++ b/script/homm2/extract_homm2_resources.sh
@@ -82,10 +82,18 @@ if [[ ! -f "$HOMM2_PATH/homm2.gog" ]]; then
 fi
 
 # Special case - CD image from GOG
-if [[ "$(command -v python)" == "" ]]; then
+
+if [[ "$(command -v python3)" != "" ]]; then
+    PYTHON="python3"
+elif [[ "$(command -v python2)" != "" ]]; then
+    PYTHON="python2"
+elif [[ "$(command -v python)" != "" ]]; then
+    PYTHON="python"
+else
     echo_yellow "python was not found in your system. Please install it and re-run this script to extract animation resources."
     exit 0
 fi
+
 if [[ "$(command -v bsdtar)" == "" ]]; then
     echo_yellow "bsdtar was not found in your system. Please install it and re-run this script to extract animation resources."
     exit 0
@@ -93,7 +101,7 @@ fi
 
 echo_green "Extracting animation resources, please wait..."
 
-python - << EOF
+"$PYTHON" - << EOF
 with open("$HOMM2_PATH/homm2.gog", "rb") as raw_file:
     with open("homm2.iso", "wb") as iso_file:
         while True:


### PR DESCRIPTION
On certain systems (including the modern macOS versions) there may be only `python3` binary available.