### PR TITLE
Reduce CPU usage in Select Language dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_language_selection.cpp
+++ b/src/fheroes2/dialog/dialog_language_selection.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/dialog/dialog_language_selection.cpp
+++ b/src/fheroes2/dialog/dialog_language_selection.cpp
@@ -199,8 +199,11 @@ namespace
             }
 
             if ( items.isSelected() ) {
-                chosenLanguage = items.GetCurrent();
-                Settings::Get().setGameLanguage( fheroes2::getLanguageAbbreviation( chosenLanguage ) );
+                const fheroes2::SupportedLanguage newChosenLanguage = items.GetCurrent();
+                if ( newChosenLanguage != chosenLanguage ) {
+                    chosenLanguage = newChosenLanguage;
+                    Settings::Get().setGameLanguage( fheroes2::getLanguageAbbreviation( chosenLanguage ) );
+                }
             }
 
             if ( !items.IsNeedRedraw() ) {


### PR DESCRIPTION
close #6445
Do not call `setGameLanguage` on every loop, do it only if `chosenLanguage` was changed.