### PR TITLE
Don't show magic guild if hero in castle does not have a spellbook

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -494,7 +494,9 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                             need_redraw = true;
                         }
 
-                        OpenMageGuild( hero );
+                        if ( !( hero != nullptr && !hero->HaveSpellBook() ) ) {
+                            OpenMageGuild( hero );
+                        }
                     }
                     else if ( isMonsterDwelling ) {
                         fheroes2::ButtonRestorer exitRestorer( buttonExit );


### PR DESCRIPTION
## Current behavior
1. Hero opens magic guild
2. Hero prompted to purchase a spellbook
3. Hero clicks "No"
=> Magic guild opens

3. Hero clicks "Yes"
=> Magic guild opens

## Expected behavior (what is in the original game and this fix)
1. Hero opens magic guild
2. Hero prompted to purchase a spellbook
3. Hero clicks "No"
=> Prompt closes, magic guild does not open

4. Hero clicks "Yes"
=> Spellbook is purchased and magic guild opens

You can argue for both fixing this and not fixing this:
* **Fix**: make it follow the OG game behavior, from the perspective of the hero, if they don't purchase the book, they should not be shown the spells
* **No Fix**: in the OG game it is annoying that having a hero in the castle without a book blocks you from seeing the spells available

This PR is to take the **Fix** path, but I'll defer to the community to weight in on this decision.