### PR TITLE
Exclude Java files from SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -23,4 +23,4 @@ sonar.links.ci=https://github.com/ihhub/fheroes2/actions
 sonar.links.scm=https://github.com/ihhub/fheroes2
 sonar.links.issue=https://github.com/ihhub/fheroes2/issues
 
-sonar.exclusions=src/thirdparty/**/*,bw-output
+sonar.exclusions=android/**/*.java,src/thirdparty/**/*,bw-output


### PR DESCRIPTION
Currently SonarCloud [fails the analysis](https://github.com/ihhub/fheroes2/actions/runs/3842572586/jobs/6544128440) because project now includes multiple Java files (for Android) and they are not compiled in the SonarCloud workflow. While in theory we can try to build Android project for SonarCloud, this means that we will not build some other parts of the project (for example, tools), and also this will be slower than just build the Linux project, so I decided to just exclude Java files from SonarCloud analysis.