### PR TITLE
Finalize object tile types

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -321,7 +321,7 @@ namespace AI
             AIToPickupResource( hero, objectType, dst_index );
             break;
 
-        case MP2::OBJ_WATERCHEST:
+        case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_TREASURE_CHEST:
             AIToTreasureChest( hero, objectType, dst_index );
             break;
@@ -475,7 +475,6 @@ namespace AI
         case MP2::OBJ_DWARF_COTTAGE:
         case MP2::OBJ_HALFLING_HOLE:
         case MP2::OBJ_PEASANT_HUT:
-        case MP2::OBJ_THATCHED_HUT:
             AIToDwellingJoinMonster( hero, dst_index );
             break;
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -185,7 +185,7 @@ namespace
 
         switch ( objectType ) {
         case MP2::OBJ_SHIPWRECK_SURVIVOR:
-        case MP2::OBJ_WATERCHEST:
+        case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_FLOTSAM:
         case MP2::OBJ_BOTTLE:
         case MP2::OBJ_RESOURCE:
@@ -382,7 +382,6 @@ namespace
         case MP2::OBJ_GOBLIN_HUT:
         case MP2::OBJ_DWARF_COTTAGE:
         case MP2::OBJ_HALFLING_HOLE:
-        case MP2::OBJ_THATCHED_HUT:
         case MP2::OBJ_PEASANT_HUT: {
             const Troop & troop = tile.QuantityTroop();
             if ( !troop.isValid() ) {

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -533,7 +533,6 @@ void Dialog::QuickInfo( const Maps::Tiles & tile, const bool ignoreHeroOnTile )
         case MP2::OBJ_DWARF_COTTAGE:
         case MP2::OBJ_HALFLING_HOLE:
         case MP2::OBJ_PEASANT_HUT:
-        case MP2::OBJ_THATCHED_HUT:
         // recruit army
         case MP2::OBJ_RUINS:
         case MP2::OBJ_TREE_CITY:

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -448,7 +448,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
             ActionToPickupResource( *this, objectType, tileIndex );
             break;
 
-        case MP2::OBJ_WATERCHEST:
+        case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_TREASURE_CHEST:
             ActionToTreasureChest( *this, objectType, tileIndex );
             break;
@@ -569,7 +569,6 @@ void Heroes::Action( int tileIndex, bool isDestination )
         case MP2::OBJ_DWARF_COTTAGE:
         case MP2::OBJ_HALFLING_HOLE:
         case MP2::OBJ_PEASANT_HUT:
-        case MP2::OBJ_THATCHED_HUT:
             ActionToDwellingJoinMonster( *this, objectType, tileIndex );
             break;
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -58,6 +58,7 @@
 #include "objwatr.h"
 #include "objxloc.h"
 #include "race.h"
+#include "save_format_version.h"
 #include "serialize.h"
 #include "spell.h"
 #include "til.h"
@@ -504,7 +505,6 @@ bool Maps::TilesAddon::PredicateSortRules1( const Maps::TilesAddon & ta1, const 
 
 MP2::MapObjectType Maps::Tiles::GetLoyaltyObject( const uint8_t tileset, const uint8_t icnIndex )
 {
-    // TODO: why we return non-action object types which are not equal to (action object type value - 128)?
     switch ( MP2::GetICNObject( tileset ) ) {
     case ICN::X_LOC1:
         if ( icnIndex == 3 )
@@ -1602,7 +1602,6 @@ std::string Maps::Tiles::String() const
     case MP2::OBJ_DWARF_COTTAGE:
     case MP2::OBJ_HALFLING_HOLE:
     case MP2::OBJ_PEASANT_HUT:
-    case MP2::OBJ_THATCHED_HUT:
     case MP2::OBJ_MONSTER:
         os << "monster count   : " << MonsterCount() << std::endl;
         break;
@@ -2869,6 +2868,75 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
     static_assert( sizeof( uint8_t ) == sizeof( MP2::MapObjectType ), "Incorrect type for reading MP2::MapObjectType object" );
     uint8_t objectType = MP2::OBJ_NONE;
     msg >> objectType;
+
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1001_RELEASE, "Remove the logic below." );
+    if ( Game::GetLoadVersion() < FORMAT_VERSION_1001_RELEASE ) {
+        if ( objectType == 128 ) {
+            // This is an old Sea Chest object type.
+            objectType = MP2::OBJ_SEA_CHEST;
+        }
+        else if ( objectType == 235 ) {
+            // This is an old non-action Stables object type.
+            objectType = MP2::OBJ_NON_ACTION_STABLES;
+        }
+        else if ( objectType == 241 ) {
+            // This is an old action Stables object type.
+            objectType = MP2::OBJ_STABLES;
+        }
+        else if ( objectType == 234 ) {
+            // This is an old non-action Alchemist Tower object type.
+            objectType = MP2::OBJ_NON_ACTION_ALCHEMIST_TOWER;
+        }
+        else if ( objectType == 240 ) {
+            // This is an old action Alchemist Tower object type.
+            objectType = MP2::OBJ_ALCHEMIST_TOWER;
+        }
+        else if ( objectType == 118 ) {
+            // This is an old non-action The Hut of Magi object type.
+            objectType = MP2::OBJ_NON_ACTION_HUT_OF_MAGI;
+        }
+        else if ( objectType == 238 ) {
+            // This is an old action The Hut of Magi object type.
+            objectType = MP2::OBJ_HUT_OF_MAGI;
+        }
+        else if ( objectType == 119 ) {
+            // This is an old non-action The Eye of Magi object type.
+            objectType = MP2::OBJ_NON_ACTION_EYE_OF_MAGI;
+        }
+        else if ( objectType == 239 ) {
+            // This is an old action The Eye of Magi object type.
+            objectType = MP2::OBJ_EYE_OF_MAGI;
+        }
+        else if ( objectType == 233 ) {
+            // This is an old non-action Reefs object type.
+            objectType = MP2::OBJ_REEFS;
+        }
+        else if ( objectType == 65 ) {
+            // This is an old non-action Thatched Hut object type.
+            objectType = MP2::OBJ_NON_ACTION_PEASANT_HUT;
+        }
+        else if ( objectType == 193 ) {
+            // This is an old action Thatched Hut object type.
+            objectType = MP2::OBJ_PEASANT_HUT;
+        }
+        else if ( objectType == 117 ) {
+            // This is an old non-action Sirens object type.
+            objectType = MP2::OBJ_NON_ACTION_SIRENS;
+        }
+        else if ( objectType == 237 ) {
+            // This is an old action Sirens object type.
+            objectType = MP2::OBJ_SIRENS;
+        }
+        else if ( objectType == 116 ) {
+            // This is an old non-action Mermaid object type.
+            objectType = MP2::OBJ_NON_ACTION_MERMAID;
+        }
+        else if ( objectType == 236 ) {
+            // This is an old non-action Mermaid object type.
+            objectType = MP2::OBJ_MERMAID;
+        }
+    }
+
     tile.mp2_object = static_cast<MP2::MapObjectType>( objectType );
 
     msg >> tile.fog_colors >> tile.quantity1 >> tile.quantity2 >> tile.additionalMetadata >> tile.heroID >> tile.tileIsRoad >> tile.addons_level1 >> tile.addons_level2

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -51,7 +51,7 @@ bool Maps::Tiles::QuantityIsValid() const
     case MP2::OBJ_FLOTSAM:
     case MP2::OBJ_SHIPWRECK_SURVIVOR:
     case MP2::OBJ_TREASURE_CHEST:
-    case MP2::OBJ_WATERCHEST:
+    case MP2::OBJ_SEA_CHEST:
     case MP2::OBJ_ABANDONED_MINE:
         return true;
 
@@ -187,7 +187,7 @@ Artifact Maps::Tiles::QuantityArtifact() const
 
     case MP2::OBJ_SKELETON:
     case MP2::OBJ_DAEMON_CAVE:
-    case MP2::OBJ_WATERCHEST:
+    case MP2::OBJ_SEA_CHEST:
     case MP2::OBJ_TREASURE_CHEST:
     case MP2::OBJ_SHIPWRECK_SURVIVOR:
     case MP2::OBJ_SHIPWRECK:
@@ -245,7 +245,7 @@ uint32_t Maps::Tiles::QuantityGold() const
 
     case MP2::OBJ_FLOTSAM:
     case MP2::OBJ_CAMPFIRE:
-    case MP2::OBJ_WATERCHEST:
+    case MP2::OBJ_SEA_CHEST:
     case MP2::OBJ_TREASURE_CHEST:
     case MP2::OBJ_DERELICT_SHIP:
     case MP2::OBJ_GRAVEYARD:
@@ -299,7 +299,7 @@ ResourceCount Maps::Tiles::QuantityResourceCount() const
         }
         break;
 
-    case MP2::OBJ_WATERCHEST:
+    case MP2::OBJ_SEA_CHEST:
     case MP2::OBJ_TREASURE_CHEST:
         return ResourceCount( Resource::GOLD, QuantityGold() );
 
@@ -336,7 +336,7 @@ Funds Maps::Tiles::QuantityFunds() const
     case MP2::OBJ_FLOTSAM:
         return Funds( Resource::GOLD, QuantityGold() ) + Funds( Resource::WOOD, quantity1 );
 
-    case MP2::OBJ_WATERCHEST:
+    case MP2::OBJ_SEA_CHEST:
     case MP2::OBJ_TREASURE_CHEST:
     case MP2::OBJ_DERELICT_SHIP:
     case MP2::OBJ_SHIPWRECK:
@@ -397,7 +397,6 @@ Monster Maps::Tiles::QuantityMonster() const
     case MP2::OBJ_HALFLING_HOLE:
         return Monster( Monster::HALFLING );
     case MP2::OBJ_PEASANT_HUT:
-    case MP2::OBJ_THATCHED_HUT:
         return Monster( Monster::PEASANT );
 
     case MP2::OBJ_RUINS:
@@ -457,7 +456,7 @@ void Maps::Tiles::QuantityReset()
     case MP2::OBJ_WAGON:
     case MP2::OBJ_ARTIFACT:
     case MP2::OBJ_SHIPWRECK_SURVIVOR:
-    case MP2::OBJ_WATERCHEST:
+    case MP2::OBJ_SEA_CHEST:
     case MP2::OBJ_TREASURE_CHEST:
     case MP2::OBJ_SHIPWRECK:
     case MP2::OBJ_GRAVEYARD:
@@ -692,7 +691,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         break;
     }
 
-    case MP2::OBJ_WATERCHEST: {
+    case MP2::OBJ_SEA_CHEST: {
         Rand::Queue percents( 3 );
         // 20% - empty
         percents.Push( 0, 20 );
@@ -724,8 +723,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
 
     case MP2::OBJ_TREASURE_CHEST:
         if ( isWater() ) {
-            // TODO: fix invalid object type!
-            SetObject( MP2::OBJ_WATERCHEST );
+            SetObject( MP2::OBJ_SEA_CHEST );
             QuantityUpdate();
         }
         else {
@@ -925,7 +923,6 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
     case MP2::OBJ_DWARF_COTTAGE:
     case MP2::OBJ_HALFLING_HOLE:
     case MP2::OBJ_PEASANT_HUT:
-    case MP2::OBJ_THATCHED_HUT:
     // recruit dwelling
     case MP2::OBJ_RUINS:
     case MP2::OBJ_TREE_CITY:
@@ -1065,7 +1062,6 @@ void Maps::Tiles::UpdateDwellingPopulation( Tiles & tile, bool isFirstLoad )
         count += isFirstLoad ? Rand::Get( 20, 40 ) : Rand::Get( 5, 10 );
         break;
     case MP2::OBJ_PEASANT_HUT:
-    case MP2::OBJ_THATCHED_HUT:
         count += isFirstLoad ? Rand::Get( 20, 50 ) : Rand::Get( 5, 10 );
         break;
     case MP2::OBJ_EXCAVATION:

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -33,6 +33,42 @@
 #include "settings.h"
 #include "translations.h"
 
+namespace
+{
+    bool isObjectCanBeAction( const MP2::MapObjectType objectType )
+    {
+        // This is a list of all objects which cannot be an action object.
+        switch ( objectType ) {
+        case MP2::OBJ_NONE:
+        case MP2::OBJ_COAST:
+        case MP2::OBJ_NOTHING_SPECIAL:
+        case MP2::OBJ_MOSSY_ROCK:
+        case MP2::OBJ_TAR_PIT:
+        case MP2::OBJ_REEFS:
+        case MP2::OBJ_TREES:
+        case MP2::OBJ_MOUNTAINS:
+        case MP2::OBJ_VOLCANO:
+        case MP2::OBJ_FLOWERS:
+        case MP2::OBJ_ROCK:
+        case MP2::OBJ_WATER_LAKE:
+        case MP2::OBJ_MANDRAKE:
+        case MP2::OBJ_DEAD_TREE:
+        case MP2::OBJ_STUMP:
+        case MP2::OBJ_CRATER:
+        case MP2::OBJ_CACTUS:
+        case MP2::OBJ_MOUND:
+        case MP2::OBJ_DUNE:
+        case MP2::OBJ_LAVAPOOL:
+        case MP2::OBJ_SHRUB:
+            return false;
+        default:
+            break;
+        }
+
+        return true;
+    }
+}
+
 int MP2::GetICNObject( const uint8_t tileset )
 {
     // First 2 bits are used for flags like animation.
@@ -191,304 +227,211 @@ bool MP2::isHiddenForPuzzle( const int terrainType, uint8_t tileset, uint8_t ind
     return isDiggingHoleSprite( terrainType, tileset, index );
 }
 
-const char * MP2::StringObject( const MapObjectType objectType, const int count )
+const char * MP2::StringObject( MapObjectType objectType, const int count )
 {
+    if ( ( objectType & OBJ_ACTION_OBJECT_TYPE ) == OBJ_ACTION_OBJECT_TYPE ) {
+        objectType = static_cast<MapObjectType>( objectType & ~OBJ_ACTION_OBJECT_TYPE );
+    }
+
     switch ( objectType ) {
     case OBJ_NONE:
         return _( "No object" );
     case OBJ_NON_ACTION_ALCHEMIST_LAB:
-    case OBJ_ALCHEMIST_LAB:
         return _( "Alchemist Lab" );
     case OBJ_NON_ACTION_SIGN:
-    case OBJ_SIGN:
         return _( "Sign" );
     case OBJ_NON_ACTION_BUOY:
-    case OBJ_BUOY:
         return _( "Buoy" );
     case OBJ_NON_ACTION_SKELETON:
-    case OBJ_SKELETON:
         return _( "Skeleton" );
     case OBJ_NON_ACTION_DAEMON_CAVE:
-    case OBJ_DAEMON_CAVE:
         return _( "Daemon Cave" );
     case OBJ_NON_ACTION_TREASURE_CHEST:
-    case OBJ_TREASURE_CHEST:
         return _( "Treasure Chest" );
     case OBJ_NON_ACTION_FAERIE_RING:
-    case OBJ_FAERIE_RING:
         return _( "Faerie Ring" );
     case OBJ_NON_ACTION_CAMPFIRE:
-    case OBJ_CAMPFIRE:
         return _( "Campfire" );
     case OBJ_NON_ACTION_FOUNTAIN:
-    case OBJ_FOUNTAIN:
         return _( "Fountain" );
     case OBJ_NON_ACTION_GAZEBO:
-    case OBJ_GAZEBO:
         return _( "Gazebo" );
     case OBJ_NON_ACTION_GENIE_LAMP:
-    case OBJ_GENIE_LAMP:
         return _( "Genie Lamp" );
     case OBJ_NON_ACTION_GRAVEYARD:
-    case OBJ_GRAVEYARD:
         return _( "Graveyard" );
     case OBJ_NON_ACTION_ARCHER_HOUSE:
-    case OBJ_ARCHER_HOUSE:
         return _( "Archer's House" );
     case OBJ_NON_ACTION_GOBLIN_HUT:
-    case OBJ_GOBLIN_HUT:
         return _( "Goblin Hut" );
     case OBJ_NON_ACTION_DWARF_COTTAGE:
-    case OBJ_DWARF_COTTAGE:
         return _( "Dwarf Cottage" );
     case OBJ_NON_ACTION_PEASANT_HUT:
-    case OBJ_PEASANT_HUT:
         return _( "Peasant Hut" );
-    case OBJ_NON_ACTION_UNUSED_17:
-    case OBJ_UNUSED_17:
-        return "Log Cabin";
-    case OBJ_NON_ACTION_UNUSED_18:
-    case OBJ_UNUSED_18:
-        return "Road";
+    case OBJ_NON_ACTION_STABLES:
+        return _( "Stables" );
+    case OBJ_NON_ACTION_ALCHEMIST_TOWER:
+        return _( "Alchemist's Tower" );
     case OBJ_NON_ACTION_EVENT:
-    case OBJ_EVENT:
         return _( "Event" );
     case OBJ_NON_ACTION_DRAGON_CITY:
-    case OBJ_DRAGON_CITY:
         return _( "Dragon City" );
     case OBJ_NON_ACTION_LIGHTHOUSE:
-    case OBJ_LIGHTHOUSE:
         return _( "Lighthouse" );
     case OBJ_NON_ACTION_WATER_WHEEL:
-    case OBJ_WATER_WHEEL:
         return _n( "Water Wheel", "Water Wheels", count );
     case OBJ_NON_ACTION_MINES:
-    case OBJ_MINES:
         return _( "Mines" );
     case OBJ_NON_ACTION_MONSTER:
-    case OBJ_MONSTER:
         return _( "Monster" );
     case OBJ_NON_ACTION_OBELISK:
-    case OBJ_OBELISK:
         return _( "Obelisk" );
     case OBJ_NON_ACTION_OASIS:
-    case OBJ_OASIS:
         return _( "Oasis" );
     case OBJ_NON_ACTION_RESOURCE:
-    case OBJ_RESOURCE:
         return _( "Resource" );
     case OBJ_COAST:
-    case OBJ_ACTION_COAST:
         return _( "Beach" );
     case OBJ_NON_ACTION_SAWMILL:
-    case OBJ_SAWMILL:
         return _( "Sawmill" );
     case OBJ_NON_ACTION_ORACLE:
-    case OBJ_ORACLE:
         return _( "Oracle" );
     case OBJ_NON_ACTION_SHRINE_FIRST_CIRCLE:
-    case OBJ_SHRINE_FIRST_CIRCLE:
         return _( "Shrine of the First Circle" );
     case OBJ_NON_ACTION_SHIPWRECK:
-    case OBJ_SHIPWRECK:
         return _( "Shipwreck" );
-    case OBJ_NON_ACTION_UNUSED_33:
-    case OBJ_UNUSED_33:
+    case OBJ_NON_ACTION_SEA_CHEST:
         return _( "Sea Chest" );
     case OBJ_NON_ACTION_DESERT_TENT:
-    case OBJ_DESERT_TENT:
         return _( "Desert Tent" );
     case OBJ_NON_ACTION_CASTLE:
-    case OBJ_CASTLE:
         return _( "Castle" );
     case OBJ_NON_ACTION_STONE_LITHS:
-    case OBJ_STONE_LITHS:
         return _( "Stone Liths" );
     case OBJ_NON_ACTION_WAGON_CAMP:
-    case OBJ_WAGON_CAMP:
         return _( "Wagon Camp" );
-    case OBJ_NON_ACTION_UNUSED_38:
-    case OBJ_UNUSED_38:
-        return "Well";
+    case OBJ_NON_ACTION_HUT_OF_MAGI:
+        return _( "Hut of the Magi" );
     case OBJ_NON_ACTION_WHIRLPOOL:
-    case OBJ_WHIRLPOOL:
         return _( "Whirlpool" );
     case OBJ_NON_ACTION_WINDMILL:
-    case OBJ_WINDMILL:
         return _n( "Windmill", "Windmills", count );
     case OBJ_NON_ACTION_ARTIFACT:
-    case OBJ_ARTIFACT:
         return _( "Artifact" );
-    case OBJ_NON_ACTION_UNUSED_42:
-    case OBJ_UNUSED_42:
-        return "Hero";
+    case OBJ_NON_ACTION_MERMAID:
+        return _( "Mermaid" );
     case OBJ_NON_ACTION_BOAT:
-    case OBJ_BOAT:
         return _( "Boat" );
     case OBJ_NON_ACTION_RANDOM_ULTIMATE_ARTIFACT:
-    case OBJ_RANDOM_ULTIMATE_ARTIFACT:
         return _( "Random Ultimate Artifact" );
     case OBJ_NON_ACTION_RANDOM_ARTIFACT:
-    case OBJ_RANDOM_ARTIFACT:
         return _( "Random Artifact" );
     case OBJ_NON_ACTION_RANDOM_RESOURCE:
-    case OBJ_RANDOM_RESOURCE:
         return _( "Random Resource" );
     case OBJ_NON_ACTION_RANDOM_MONSTER:
-    case OBJ_RANDOM_MONSTER:
         return _( "Random Monster" );
     case OBJ_NON_ACTION_RANDOM_TOWN:
-    case OBJ_RANDOM_TOWN:
         return _( "Random Town" );
     case OBJ_NON_ACTION_RANDOM_CASTLE:
-    case OBJ_RANDOM_CASTLE:
         return _( "Random Castle" );
-    case OBJ_NON_ACTION_UNUSED_50:
-    case OBJ_UNUSED_50:
-        return "Not in use object 50";
+    case OBJ_NON_ACTION_EYE_OF_MAGI:
+        return _( "Eye of the Magi" );
     case OBJ_NON_ACTION_RANDOM_MONSTER_WEAK:
-    case OBJ_RANDOM_MONSTER_WEAK:
         return _( "Random Monster - weak" );
     case OBJ_NON_ACTION_RANDOM_MONSTER_MEDIUM:
-    case OBJ_RANDOM_MONSTER_MEDIUM:
         return _( "Random Monster - medium" );
     case OBJ_NON_ACTION_RANDOM_MONSTER_STRONG:
-    case OBJ_RANDOM_MONSTER_STRONG:
         return _( "Random Monster - strong" );
     case OBJ_NON_ACTION_RANDOM_MONSTER_VERY_STRONG:
-    case OBJ_RANDOM_MONSTER_VERY_STRONG:
         return _( "Random Monster - very strong" );
     case OBJ_NON_ACTION_HEROES:
-    case OBJ_HEROES:
         return _( "Heroes" );
-    case OBJ_NON_ACTION_NOTHING_SPECIAL:
     case OBJ_NOTHING_SPECIAL:
         return _( "Nothing Special" );
-    case OBJ_NON_ACTION_UNUSED_57:
-    case OBJ_UNUSED_57:
-        return "Not in use object 57";
+    case OBJ_MOSSY_ROCK:
+        return _( "Mossy Rock" );
     case OBJ_NON_ACTION_WATCH_TOWER:
-    case OBJ_WATCH_TOWER:
         return _( "Watch Tower" );
     case OBJ_NON_ACTION_TREE_HOUSE:
-    case OBJ_TREE_HOUSE:
         return _( "Tree House" );
     case OBJ_NON_ACTION_TREE_CITY:
-    case OBJ_TREE_CITY:
         return _( "Tree City" );
     case OBJ_NON_ACTION_RUINS:
-    case OBJ_RUINS:
         return _( "Ruins" );
     case OBJ_NON_ACTION_FORT:
-    case OBJ_FORT:
         return _( "Fort" );
     case OBJ_NON_ACTION_TRADING_POST:
-    case OBJ_TRADING_POST:
         return _( "Trading Post" );
     case OBJ_NON_ACTION_ABANDONED_MINE:
-    case OBJ_ABANDONED_MINE:
         return _( "Abandoned Mine" );
-    case OBJ_NON_ACTION_THATCHED_HUT:
-    case OBJ_THATCHED_HUT:
-        return _( "Thatched Hut" );
+    case OBJ_NON_ACTION_SIRENS:
+        return _( "Sirens" );
     case OBJ_NON_ACTION_STANDING_STONES:
-    case OBJ_STANDING_STONES:
         return _( "Standing Stones" );
     case OBJ_NON_ACTION_IDOL:
-    case OBJ_IDOL:
         return _( "Idol" );
     case OBJ_NON_ACTION_TREE_OF_KNOWLEDGE:
-    case OBJ_TREE_OF_KNOWLEDGE:
         return _( "Tree of Knowledge" );
     case OBJ_NON_ACTION_WITCH_DOCTORS_HUT:
-    case OBJ_WITCH_DOCTORS_HUT:
         return _( "Witch Doctor's Hut" );
     case OBJ_NON_ACTION_TEMPLE:
-    case OBJ_TEMPLE:
         return _( "Temple" );
     case OBJ_NON_ACTION_HILL_FORT:
-    case OBJ_HILL_FORT:
         return _( "Hill Fort" );
     case OBJ_NON_ACTION_HALFLING_HOLE:
-    case OBJ_HALFLING_HOLE:
         return _( "Halfling Hole" );
     case OBJ_NON_ACTION_MERCENARY_CAMP:
-    case OBJ_MERCENARY_CAMP:
         return _( "Mercenary Camp" );
     case OBJ_NON_ACTION_SHRINE_SECOND_CIRCLE:
-    case OBJ_SHRINE_SECOND_CIRCLE:
         return _( "Shrine of the Second Circle" );
     case OBJ_NON_ACTION_SHRINE_THIRD_CIRCLE:
-    case OBJ_SHRINE_THIRD_CIRCLE:
         return _( "Shrine of the Third Circle" );
     case OBJ_NON_ACTION_PYRAMID:
-    case OBJ_PYRAMID:
         return _( "Pyramid" );
     case OBJ_NON_ACTION_CITY_OF_DEAD:
-    case OBJ_CITY_OF_DEAD:
         return _( "City of the Dead" );
     case OBJ_NON_ACTION_EXCAVATION:
-    case OBJ_EXCAVATION:
         return _( "Excavation" );
     case OBJ_NON_ACTION_SPHINX:
-    case OBJ_SPHINX:
         return _( "Sphinx" );
     case OBJ_NON_ACTION_WAGON:
-    case OBJ_WAGON:
         return _( "Wagon" );
-    case OBJ_NON_ACTION_TAR_PIT:
     case OBJ_TAR_PIT:
         return _( "Tar Pit" );
     case OBJ_NON_ACTION_ARTESIAN_SPRING:
-    case OBJ_ARTESIAN_SPRING:
         return _( "Artesian Spring" );
     case OBJ_NON_ACTION_TROLL_BRIDGE:
-    case OBJ_TROLL_BRIDGE:
         return _( "Troll Bridge" );
     case OBJ_NON_ACTION_WATERING_HOLE:
-    case OBJ_WATERING_HOLE:
         return _( "Watering Hole" );
     case OBJ_NON_ACTION_WITCHS_HUT:
-    case OBJ_WITCHS_HUT:
         return _( "Witch's Hut" );
     case OBJ_NON_ACTION_XANADU:
-    case OBJ_XANADU:
         return _( "Xanadu" );
     case OBJ_NON_ACTION_CAVE:
-    case OBJ_CAVE:
         return _( "Cave" );
     case OBJ_NON_ACTION_LEAN_TO:
-    case OBJ_LEAN_TO:
         return _( "Lean-To" );
     case OBJ_NON_ACTION_MAGELLANS_MAPS:
-    case OBJ_MAGELLANS_MAPS:
         return _( "Magellan's Maps" );
     case OBJ_NON_ACTION_FLOTSAM:
-    case OBJ_FLOTSAM:
         return _( "Flotsam" );
     case OBJ_NON_ACTION_DERELICT_SHIP:
-    case OBJ_DERELICT_SHIP:
         return _( "Derelict Ship" );
     case OBJ_NON_ACTION_SHIPWRECK_SURVIVOR:
-    case OBJ_SHIPWRECK_SURVIVOR:
         return _( "Shipwreck Survivor" );
     case OBJ_NON_ACTION_BOTTLE:
-    case OBJ_BOTTLE:
         return _( "Bottle" );
     case OBJ_NON_ACTION_MAGIC_WELL:
-    case OBJ_MAGIC_WELL:
         return _( "Magic Well" );
     case OBJ_NON_ACTION_MAGIC_GARDEN:
-    case OBJ_MAGIC_GARDEN:
         return _n( "Magic Garden", "Magic Gardens", count );
     case OBJ_NON_ACTION_OBSERVATION_TOWER:
-    case OBJ_OBSERVATION_TOWER:
         return _( "Observation Tower" );
     case OBJ_NON_ACTION_FREEMANS_FOUNDRY:
-    case OBJ_FREEMANS_FOUNDRY:
         return _( "Freeman's Foundry" );
-    case OBJ_STREAM:
-        return "Steam";
+    case OBJ_REEFS:
+        return _( "Reefs" );
     case OBJ_TREES:
         return _( "Trees" );
     case OBJ_MOUNTAINS:
@@ -520,78 +463,36 @@ const char * MP2::StringObject( const MapObjectType objectType, const int count 
     case OBJ_SHRUB:
         return _( "Shrub" );
     case OBJ_NON_ACTION_ARENA:
-    case OBJ_ARENA:
         return _( "Arena" );
     case OBJ_NON_ACTION_BARROW_MOUNDS:
-    case OBJ_BARROW_MOUNDS:
         return _( "Barrow Mounds" );
-    case OBJ_NON_ACTION_MERMAID:
-    case OBJ_MERMAID:
-        return _( "Mermaid" );
-    case OBJ_NON_ACTION_SIRENS:
-    case OBJ_SIRENS:
-        return _( "Sirens" );
-    case OBJ_NON_ACTION_HUT_OF_MAGI:
-    case OBJ_HUT_OF_MAGI:
-        return _( "Hut of the Magi" );
-    case OBJ_NON_ACTION_EYE_OF_MAGI:
-    case OBJ_EYE_OF_MAGI:
-        return _( "Eye of the Magi" );
+    case OBJ_NON_ACTION_RANDOM_ARTIFACT_TREASURE:
+        return _( "Random Artifact - Treasure" );
+    case OBJ_NON_ACTION_RANDOM_ARTIFACT_MINOR:
+        return _( "Random Artifact - Minor" );
+    case OBJ_NON_ACTION_RANDOM_ARTIFACT_MAJOR:
+        return _( "Random Artifact - Major" );
+    case OBJ_NON_ACTION_BARRIER:
+        return _( "Barrier" );
     case OBJ_NON_ACTION_TRAVELLER_TENT:
-    case OBJ_TRAVELLER_TENT:
         return _( "Traveller's Tent" );
     case OBJ_NON_ACTION_EXPANSION_DWELLING:
-    case OBJ_EXPANSION_DWELLING:
         return "Expansion Dwelling";
     case OBJ_NON_ACTION_EXPANSION_OBJECT:
-    case OBJ_EXPANSION_OBJECT:
         return "Expansion Object";
     case OBJ_NON_ACTION_JAIL:
-    case OBJ_JAIL:
         return _( "Jail" );
     case OBJ_NON_ACTION_FIRE_ALTAR:
-    case OBJ_FIRE_ALTAR:
         return _( "Fire Summoning Altar" );
     case OBJ_NON_ACTION_AIR_ALTAR:
-    case OBJ_AIR_ALTAR:
         return _( "Air Summoning Altar" );
     case OBJ_NON_ACTION_EARTH_ALTAR:
-    case OBJ_EARTH_ALTAR:
         return _( "Earth Summoning Altar" );
     case OBJ_NON_ACTION_WATER_ALTAR:
-    case OBJ_WATER_ALTAR:
         return _( "Water Summoning Altar" );
-    case OBJ_WATERCHEST:
-        return _( "Sea Chest" );
-    case OBJ_ACTION_UNUSED_227:
-        return "Not in use object 227";
-    case OBJ_ACTION_UNUSED_228:
-        return "Not in use object 228";
-    case OBJ_ACTION_UNUSED_229:
-        return "Not in use object 229";
-    case OBJ_ACTION_UNUSED_230:
-        return "Not in use object 230";
-    case OBJ_ACTION_UNUSED_231:
-        return "Not in use object 231";
-    case OBJ_ACTION_UNUSED_232:
-        return "Not in use object 232";
-    case OBJ_REEFS:
-        return _( "Reefs" );
-    case OBJ_NON_ACTION_ALCHEMIST_TOWER:
-    case OBJ_ALCHEMIST_TOWER:
-        return _( "Alchemist's Tower" );
-    case OBJ_NON_ACTION_STABLES:
-    case OBJ_STABLES:
-        return _( "Stables" );
-    case OBJ_RANDOM_ARTIFACT_TREASURE:
-        return _( "Random Artifact - Treasure" );
-    case OBJ_RANDOM_ARTIFACT_MINOR:
-        return _( "Random Artifact - Minor" );
-    case OBJ_RANDOM_ARTIFACT_MAJOR:
-        return _( "Random Artifact - Major" );
-    case OBJ_BARRIER:
-        return _( "Barrier" );
     default:
+        // Did you add a new object type? Add the logic above!
+        assert( 0 );
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown object type: " << static_cast<int>( objectType ) )
         break;
     }
@@ -601,16 +502,8 @@ const char * MP2::StringObject( const MapObjectType objectType, const int count 
 
 bool MP2::isDayLife( const MapObjectType objectType )
 {
-    // TODO: list day object life
-    switch ( objectType ) {
-    case OBJ_MAGIC_WELL:
-        return true;
-
-    default:
-        break;
-    }
-
-    return false;
+    // Only one object on Adventure Map restores every day and this is Magic Well.
+    return ( objectType == OBJ_MAGIC_WELL );
 }
 
 bool MP2::isWeekLife( const MapObjectType objectType )
@@ -632,7 +525,6 @@ bool MP2::isWeekLife( const MapObjectType objectType )
     case OBJ_DWARF_COTTAGE:
     case OBJ_HALFLING_HOLE:
     case OBJ_PEASANT_HUT:
-    case OBJ_THATCHED_HUT:
     // recruit army
     case OBJ_RUINS:
     case OBJ_TREE_CITY:
@@ -700,7 +592,7 @@ bool MP2::isActionObject( const MapObjectType objectType, const bool locatesOnWa
 bool MP2::isWaterActionObject( const MapObjectType objectType )
 {
     switch ( objectType ) {
-    case OBJ_WATERCHEST:
+    case OBJ_SEA_CHEST:
     case OBJ_DERELICT_SHIP:
     case OBJ_SHIPWRECK:
     case OBJ_WHIRLPOOL:
@@ -730,207 +622,53 @@ bool MP2::isWaterActionObject( const MapObjectType objectType )
 
 bool MP2::isActionObject( const MapObjectType objectType )
 {
-    // check if first bit is set
-    if ( objectType < 128 ) {
+    if ( ( objectType & OBJ_ACTION_OBJECT_TYPE ) != OBJ_ACTION_OBJECT_TYPE ) {
+        // It is not an action object.
         return false;
     }
 
-    // TODO: These edge cases shouldn't exist! All PoL objects present here have incorrect values!
-    switch ( objectType ) {
-    case OBJ_EVENT:
-    case OBJ_NON_ACTION_STABLES:
-    case OBJ_NON_ACTION_ALCHEMIST_TOWER:
-    case OBJ_ACTION_UNUSED_226: // This type is not used anywhere
-    case OBJ_ACTION_UNUSED_227: // This type is not used anywhere
-    case OBJ_ACTION_UNUSED_228: // This type is not used anywhere
-    case OBJ_ACTION_UNUSED_229: // This type is not used anywhere
-    case OBJ_ACTION_UNUSED_230: // This type is not used anywhere
-    case OBJ_ACTION_UNUSED_231: // This type is not used anywhere
-    case OBJ_ACTION_UNUSED_232: // This type is not used anywhere
-    case OBJ_EXPANSION_DWELLING:
-    case OBJ_EXPANSION_OBJECT:
-    case OBJ_UNUSED_17: // Log Cabin
-    case OBJ_UNUSED_18: // Road
-    case OBJ_ACTION_COAST: // This type is not used anywhere
-    case OBJ_UNUSED_33: // Sea Chest
-    case OBJ_UNUSED_42: // Hero
-    case OBJ_UNUSED_50:
-    case OBJ_NOTHING_SPECIAL:
-    case OBJ_UNUSED_57:
-    case OBJ_TAR_PIT:
-    case OBJ_REEFS:
+    if ( objectType == OBJ_EVENT ) {
+        // This is the only edge case object type inherited from the original game.
         return false;
-    default:
-        break;
     }
 
-    return true;
+    return isObjectCanBeAction( static_cast<MapObjectType>( objectType & ~OBJ_ACTION_OBJECT_TYPE ) );
 }
 
 MP2::MapObjectType MP2::getBaseActionObjectType( const MapObjectType objectType )
 {
-    // TODO: this function should just check 8th bit in object type instead of having switch-case code.
-    switch ( objectType ) {
-    case OBJ_NON_ACTION_ALCHEMIST_LAB:
-        return OBJ_ALCHEMIST_LAB;
-    case OBJ_NON_ACTION_SKELETON:
-        return OBJ_SKELETON;
-    case OBJ_NON_ACTION_DAEMON_CAVE:
-        return OBJ_DAEMON_CAVE;
-    case OBJ_NON_ACTION_FAERIE_RING:
-        return OBJ_FAERIE_RING;
-    case OBJ_NON_ACTION_GAZEBO:
-        return OBJ_GAZEBO;
-    case OBJ_NON_ACTION_GRAVEYARD:
-        return OBJ_GRAVEYARD;
-    case OBJ_NON_ACTION_ARCHER_HOUSE:
-        return OBJ_ARCHER_HOUSE;
-    case OBJ_NON_ACTION_DWARF_COTTAGE:
-        return OBJ_DWARF_COTTAGE;
-    case OBJ_NON_ACTION_PEASANT_HUT:
-        return OBJ_PEASANT_HUT;
-    case OBJ_NON_ACTION_DRAGON_CITY:
-        return OBJ_DRAGON_CITY;
-    case OBJ_NON_ACTION_LIGHTHOUSE:
-        return OBJ_LIGHTHOUSE;
-    case OBJ_NON_ACTION_WATER_WHEEL:
-        return OBJ_WATER_WHEEL;
-    case OBJ_NON_ACTION_MINES:
-        return OBJ_MINES;
-    case OBJ_NON_ACTION_OBELISK:
-        return OBJ_OBELISK;
-    case OBJ_NON_ACTION_OASIS:
-        return OBJ_OASIS;
-    case OBJ_NON_ACTION_SAWMILL:
-        return OBJ_SAWMILL;
-    case OBJ_NON_ACTION_ORACLE:
-        return OBJ_ORACLE;
-    case OBJ_NON_ACTION_SHIPWRECK:
-        return OBJ_SHIPWRECK;
-    case OBJ_NON_ACTION_DESERT_TENT:
-        return OBJ_DESERT_TENT;
-    case OBJ_NON_ACTION_CASTLE:
-        return OBJ_CASTLE;
-    case OBJ_NON_ACTION_STONE_LITHS:
-        return OBJ_STONE_LITHS;
-    case OBJ_NON_ACTION_WAGON_CAMP:
-        return OBJ_WAGON_CAMP;
-    case OBJ_NON_ACTION_WINDMILL:
-        return OBJ_WINDMILL;
-    case OBJ_NON_ACTION_RANDOM_TOWN:
-        return OBJ_RANDOM_TOWN;
-    case OBJ_NON_ACTION_RANDOM_CASTLE:
-        return OBJ_RANDOM_CASTLE;
-    case OBJ_NON_ACTION_WATCH_TOWER:
-        return OBJ_WATCH_TOWER;
-    case OBJ_NON_ACTION_TREE_HOUSE:
-        return OBJ_TREE_HOUSE;
-    case OBJ_NON_ACTION_TREE_CITY:
-        return OBJ_TREE_CITY;
-    case OBJ_NON_ACTION_RUINS:
-        return OBJ_RUINS;
-    case OBJ_NON_ACTION_FORT:
-        return OBJ_FORT;
-    case OBJ_NON_ACTION_TRADING_POST:
-        return OBJ_TRADING_POST;
-    case OBJ_NON_ACTION_ABANDONED_MINE:
-        return OBJ_ABANDONED_MINE;
-    case OBJ_NON_ACTION_TREE_OF_KNOWLEDGE:
-        return OBJ_TREE_OF_KNOWLEDGE;
-    case OBJ_NON_ACTION_WITCH_DOCTORS_HUT:
-        return OBJ_WITCH_DOCTORS_HUT;
-    case OBJ_NON_ACTION_TEMPLE:
-        return OBJ_TEMPLE;
-    case OBJ_NON_ACTION_HILL_FORT:
-        return OBJ_HILL_FORT;
-    case OBJ_NON_ACTION_HALFLING_HOLE:
-        return OBJ_HALFLING_HOLE;
-    case OBJ_NON_ACTION_MERCENARY_CAMP:
-        return OBJ_MERCENARY_CAMP;
-    case OBJ_NON_ACTION_PYRAMID:
-        return OBJ_PYRAMID;
-    case OBJ_NON_ACTION_CITY_OF_DEAD:
-        return OBJ_CITY_OF_DEAD;
-    case OBJ_NON_ACTION_EXCAVATION:
-        return OBJ_EXCAVATION;
-    case OBJ_NON_ACTION_SPHINX:
-        return OBJ_SPHINX;
-    case OBJ_NON_ACTION_ARTESIAN_SPRING:
-        return OBJ_ARTESIAN_SPRING;
-    case OBJ_NON_ACTION_TROLL_BRIDGE:
-        return OBJ_TROLL_BRIDGE;
-    case OBJ_NON_ACTION_WATERING_HOLE:
-        return OBJ_WATERING_HOLE;
-    case OBJ_NON_ACTION_WITCHS_HUT:
-        return OBJ_WITCHS_HUT;
-    case OBJ_NON_ACTION_XANADU:
-        return OBJ_XANADU;
-    case OBJ_NON_ACTION_CAVE:
-        return OBJ_CAVE;
-    case OBJ_NON_ACTION_MAGELLANS_MAPS:
-        return OBJ_MAGELLANS_MAPS;
-    case OBJ_NON_ACTION_DERELICT_SHIP:
-        return OBJ_DERELICT_SHIP;
-    case OBJ_NON_ACTION_MAGIC_WELL:
-        return OBJ_MAGIC_WELL;
-    case OBJ_NON_ACTION_OBSERVATION_TOWER:
-        return OBJ_OBSERVATION_TOWER;
-    case OBJ_NON_ACTION_FREEMANS_FOUNDRY:
-        return OBJ_FREEMANS_FOUNDRY;
-    case OBJ_NON_ACTION_ARENA:
-        return OBJ_ARENA;
-    case OBJ_NON_ACTION_BARROW_MOUNDS:
-        return OBJ_BARROW_MOUNDS;
-    case OBJ_NON_ACTION_MERMAID:
-        return OBJ_MERMAID;
-    case OBJ_NON_ACTION_SIRENS:
-        return OBJ_SIRENS;
-    case OBJ_NON_ACTION_HUT_OF_MAGI:
-        return OBJ_HUT_OF_MAGI;
-    case OBJ_NON_ACTION_EYE_OF_MAGI:
-        return OBJ_EYE_OF_MAGI;
-    case OBJ_NON_ACTION_TRAVELLER_TENT:
-        return OBJ_TRAVELLER_TENT;
-    case OBJ_NON_ACTION_JAIL:
-        return OBJ_JAIL;
-    case OBJ_NON_ACTION_FIRE_ALTAR:
-        return OBJ_FIRE_ALTAR;
-    case OBJ_NON_ACTION_AIR_ALTAR:
-        return OBJ_AIR_ALTAR;
-    case OBJ_NON_ACTION_EARTH_ALTAR:
-        return OBJ_EARTH_ALTAR;
-    case OBJ_NON_ACTION_WATER_ALTAR:
-        return OBJ_WATER_ALTAR;
-    case OBJ_NON_ACTION_ALCHEMIST_TOWER:
-        return OBJ_ALCHEMIST_TOWER;
-    case OBJ_NON_ACTION_STABLES:
-        return OBJ_STABLES;
-    default:
-        break;
+    if ( ( objectType & OBJ_ACTION_OBJECT_TYPE ) == OBJ_ACTION_OBJECT_TYPE ) {
+        // This is an action object which is considered as base.
+        return objectType;
     }
 
-    return objectType;
+    if ( !isObjectCanBeAction( objectType ) ) {
+        return objectType;
+    }
+
+    return static_cast<MapObjectType>( objectType | OBJ_ACTION_OBJECT_TYPE );
 }
 
 bool MP2::isQuantityObject( const MapObjectType objectType )
 {
+    // Sort things in alphabetical order for better readability.
     switch ( objectType ) {
+    case OBJ_ABANDONED_MINE:
+    case OBJ_CAMPFIRE:
+    case OBJ_DAEMON_CAVE:
+    case OBJ_DERELICT_SHIP:
+    case OBJ_FLOTSAM:
+    case OBJ_GRAVEYARD:
+    case OBJ_LEAN_TO:
+    case OBJ_MAGIC_GARDEN:
+    case OBJ_PYRAMID:
+    case OBJ_SEA_CHEST:
+    case OBJ_SHIPWRECK:
+    case OBJ_SHIPWRECK_SURVIVOR:
     case OBJ_SKELETON:
     case OBJ_WAGON:
-    case OBJ_MAGIC_GARDEN:
     case OBJ_WATER_WHEEL:
     case OBJ_WINDMILL:
-    case OBJ_LEAN_TO:
-    case OBJ_CAMPFIRE:
-    case OBJ_FLOTSAM:
-    case OBJ_SHIPWRECK_SURVIVOR:
-    case OBJ_WATERCHEST:
-    case OBJ_DERELICT_SHIP:
-    case OBJ_SHIPWRECK:
-    case OBJ_GRAVEYARD:
-    case OBJ_PYRAMID:
-    case OBJ_DAEMON_CAVE:
-    case OBJ_ABANDONED_MINE:
         return true;
     default:
         break;
@@ -944,13 +682,14 @@ bool MP2::isQuantityObject( const MapObjectType objectType )
 
 bool MP2::isCaptureObject( const MapObjectType objectType )
 {
+    // Sort things in alphabetical order for better readability.
     switch ( objectType ) {
-    case OBJ_MINES:
     case OBJ_ABANDONED_MINE:
     case OBJ_ALCHEMIST_LAB:
-    case OBJ_SAWMILL:
-    case OBJ_LIGHTHOUSE:
     case OBJ_CASTLE:
+    case OBJ_LIGHTHOUSE:
+    case OBJ_MINES:
+    case OBJ_SAWMILL:
         return true;
     default:
         break;
@@ -961,16 +700,17 @@ bool MP2::isCaptureObject( const MapObjectType objectType )
 
 bool MP2::isPickupObject( const MapObjectType objectType )
 {
+    // Sort things in alphabetical order for better readability.
     switch ( objectType ) {
-    case OBJ_WATERCHEST:
-    case OBJ_SHIPWRECK_SURVIVOR:
-    case OBJ_FLOTSAM:
-    case OBJ_BOTTLE:
-    case OBJ_TREASURE_CHEST:
-    case OBJ_GENIE_LAMP:
-    case OBJ_CAMPFIRE:
-    case OBJ_RESOURCE:
     case OBJ_ARTIFACT:
+    case OBJ_BOTTLE:
+    case OBJ_CAMPFIRE:
+    case OBJ_FLOTSAM:
+    case OBJ_GENIE_LAMP:
+    case OBJ_RESOURCE:
+    case OBJ_SEA_CHEST:
+    case OBJ_SHIPWRECK_SURVIVOR:
+    case OBJ_TREASURE_CHEST:
         return true;
     default:
         break;
@@ -981,16 +721,17 @@ bool MP2::isPickupObject( const MapObjectType objectType )
 
 bool MP2::isArtifactObject( const MapObjectType objectType )
 {
+    // Sort things in alphabetical order for better readability.
     switch ( objectType ) {
     case OBJ_ARTIFACT:
-    case OBJ_WAGON:
-    case OBJ_SKELETON:
     case OBJ_DAEMON_CAVE:
-    case OBJ_WATERCHEST:
-    case OBJ_TREASURE_CHEST:
-    case OBJ_SHIPWRECK_SURVIVOR:
-    case OBJ_SHIPWRECK:
     case OBJ_GRAVEYARD:
+    case OBJ_SEA_CHEST:
+    case OBJ_SHIPWRECK:
+    case OBJ_SHIPWRECK_SURVIVOR:
+    case OBJ_SKELETON:
+    case OBJ_TREASURE_CHEST:
+    case OBJ_WAGON:
         return true;
     default:
         break;
@@ -1001,16 +742,17 @@ bool MP2::isArtifactObject( const MapObjectType objectType )
 
 bool MP2::isHeroUpgradeObject( const MapObjectType objectType )
 {
+    // Sort things in alphabetical order for better readability.
     switch ( objectType ) {
-    case OBJ_GAZEBO:
-    case OBJ_TREE_OF_KNOWLEDGE:
-    case OBJ_MERCENARY_CAMP:
     case OBJ_FORT:
-    case OBJ_STANDING_STONES:
-    case OBJ_WITCH_DOCTORS_HUT:
+    case OBJ_GAZEBO:
+    case OBJ_MERCENARY_CAMP:
     case OBJ_SHRINE_FIRST_CIRCLE:
     case OBJ_SHRINE_SECOND_CIRCLE:
     case OBJ_SHRINE_THIRD_CIRCLE:
+    case OBJ_STANDING_STONES:
+    case OBJ_TREE_OF_KNOWLEDGE:
+    case OBJ_WITCH_DOCTORS_HUT:
     case OBJ_WITCHS_HUT:
     case OBJ_XANADU:
         return true;
@@ -1023,29 +765,29 @@ bool MP2::isHeroUpgradeObject( const MapObjectType objectType )
 
 bool MP2::isMonsterDwelling( const MapObjectType objectType )
 {
+    // Sort things in alphabetical order for better readability.
     switch ( objectType ) {
-    case OBJ_WATCH_TOWER:
-    case OBJ_EXCAVATION:
-    case OBJ_CAVE:
-    case OBJ_TREE_HOUSE:
+    case OBJ_AIR_ALTAR:
     case OBJ_ARCHER_HOUSE:
-    case OBJ_GOBLIN_HUT:
+    case OBJ_BARROW_MOUNDS:
+    case OBJ_CAVE:
+    case OBJ_CITY_OF_DEAD:
+    case OBJ_DESERT_TENT:
+    case OBJ_DRAGON_CITY:
     case OBJ_DWARF_COTTAGE:
+    case OBJ_EARTH_ALTAR:
+    case OBJ_EXCAVATION:
+    case OBJ_FIRE_ALTAR:
+    case OBJ_GOBLIN_HUT:
     case OBJ_HALFLING_HOLE:
     case OBJ_PEASANT_HUT:
-    case OBJ_THATCHED_HUT:
     case OBJ_RUINS:
     case OBJ_TREE_CITY:
-    case OBJ_WAGON_CAMP:
-    case OBJ_DESERT_TENT:
-    case OBJ_WATER_ALTAR:
-    case OBJ_AIR_ALTAR:
-    case OBJ_FIRE_ALTAR:
-    case OBJ_EARTH_ALTAR:
-    case OBJ_BARROW_MOUNDS:
-    case OBJ_CITY_OF_DEAD:
+    case OBJ_TREE_HOUSE:
     case OBJ_TROLL_BRIDGE:
-    case OBJ_DRAGON_CITY:
+    case OBJ_WAGON_CAMP:
+    case OBJ_WATER_ALTAR:
+    case OBJ_WATCH_TOWER:
         return true;
     default:
         break;
@@ -1056,18 +798,19 @@ bool MP2::isMonsterDwelling( const MapObjectType objectType )
 
 bool MP2::isProtectedObject( const MapObjectType objectType )
 {
+    // Sort things in alphabetical order for better readability.
     switch ( objectType ) {
-    case OBJ_MONSTER:
-    case OBJ_ARTIFACT:
-    case OBJ_DERELICT_SHIP:
-    case OBJ_SHIPWRECK:
-    case OBJ_GRAVEYARD:
-    case OBJ_PYRAMID:
-    case OBJ_DAEMON_CAVE:
     case OBJ_ABANDONED_MINE:
+    case OBJ_ARTIFACT:
     case OBJ_CITY_OF_DEAD:
-    case OBJ_TROLL_BRIDGE:
+    case OBJ_DAEMON_CAVE:
+    case OBJ_DERELICT_SHIP:
     case OBJ_DRAGON_CITY:
+    case OBJ_GRAVEYARD:
+    case OBJ_MONSTER:
+    case OBJ_PYRAMID:
+    case OBJ_SHIPWRECK:
+    case OBJ_TROLL_BRIDGE:
         return true;
     default:
         break;
@@ -1133,7 +876,7 @@ int MP2::getActionObjectDirection( const MapObjectType objectType )
     case OBJ_CAMPFIRE:
     case OBJ_SHIPWRECK_SURVIVOR:
     case OBJ_FLOTSAM:
-    case OBJ_WATERCHEST:
+    case OBJ_SEA_CHEST:
     case OBJ_BUOY:
     case OBJ_WHIRLPOOL:
     case OBJ_BOTTLE:
@@ -1146,7 +889,6 @@ int MP2::getActionObjectDirection( const MapObjectType objectType )
     case OBJ_ARCHER_HOUSE:
     case OBJ_WITCH_DOCTORS_HUT:
     case OBJ_DWARF_COTTAGE:
-    case OBJ_THATCHED_HUT:
     case OBJ_FOUNTAIN:
     case OBJ_IDOL:
     case OBJ_LIGHTHOUSE:

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -238,9 +238,11 @@ namespace MP2
     };
 
     // An object type could be action and non-action. If both parts are present the difference between them must be 128.
-    // TODO: right now some PoL objects do not follow this procedure leading to hacks in the code. We must fix it!
     enum MapObjectType : uint8_t
     {
+        // This section defines all types of NON-action objects which are present in the original game.
+        // If the object by nature is an action object name it with prefix OBJ_NON_ACTION_.
+        // Otherwise, name it with prefix OBJ_.
         OBJ_NONE = 0, // No object exist.
         OBJ_NON_ACTION_ALCHEMIST_LAB = 1,
         OBJ_NON_ACTION_SIGN = 2, // Never set in maps.
@@ -258,8 +260,8 @@ namespace MP2
         OBJ_NON_ACTION_GOBLIN_HUT = 14, // Never set in maps.
         OBJ_NON_ACTION_DWARF_COTTAGE = 15,
         OBJ_NON_ACTION_PEASANT_HUT = 16,
-        OBJ_NON_ACTION_UNUSED_17 = 17, // Never set in maps. Based on given information this was a monster dwelling called Log Cabin.
-        OBJ_NON_ACTION_UNUSED_18 = 18, // Never set in maps. Based on given information this was Road.
+        OBJ_NON_ACTION_STABLES = 17, // Never set in maps. Based on given information this was a monster dwelling called Log Cabin but set by the engine as Stables.
+        OBJ_NON_ACTION_ALCHEMIST_TOWER = 18, // Never set in maps. Based on given information this was Road but set by the engine as Alchemist Tower.
         OBJ_NON_ACTION_EVENT = 19, // Never set in maps.
         OBJ_NON_ACTION_DRAGON_CITY = 20,
         OBJ_NON_ACTION_LIGHTHOUSE = 21,
@@ -274,16 +276,16 @@ namespace MP2
         OBJ_NON_ACTION_ORACLE = 30,
         OBJ_NON_ACTION_SHRINE_FIRST_CIRCLE = 31, // Never set in maps.
         OBJ_NON_ACTION_SHIPWRECK = 32,
-        OBJ_NON_ACTION_UNUSED_33 = 33, // Never set in maps. Based on given information this was a Sea Chest object.
+        OBJ_NON_ACTION_SEA_CHEST = 33, // Never set in maps.
         OBJ_NON_ACTION_DESERT_TENT = 34,
         OBJ_NON_ACTION_CASTLE = 35,
         OBJ_NON_ACTION_STONE_LITHS = 36,
         OBJ_NON_ACTION_WAGON_CAMP = 37,
-        OBJ_NON_ACTION_UNUSED_38 = 38, // Never set in maps. Based on given information this was a Well object.
+        OBJ_NON_ACTION_HUT_OF_MAGI = 38, // Never set in maps. Based on given information this was a Well object.
         OBJ_NON_ACTION_WHIRLPOOL = 39, // Never set in maps.
         OBJ_NON_ACTION_WINDMILL = 40,
         OBJ_NON_ACTION_ARTIFACT = 41, // Never set in maps.
-        OBJ_NON_ACTION_UNUSED_42 = 42, // Never set in maps. Based on given information this was a Hero.
+        OBJ_NON_ACTION_MERMAID = 42, // Never set in maps. Based on given information this was a Hero.
         OBJ_NON_ACTION_BOAT = 43, // Never set in maps.
         OBJ_NON_ACTION_RANDOM_ULTIMATE_ARTIFACT = 44, // Never set in maps.
         OBJ_NON_ACTION_RANDOM_ARTIFACT = 45, // Never set in maps.
@@ -291,14 +293,14 @@ namespace MP2
         OBJ_NON_ACTION_RANDOM_MONSTER = 47, // Never set in maps.
         OBJ_NON_ACTION_RANDOM_TOWN = 48,
         OBJ_NON_ACTION_RANDOM_CASTLE = 49,
-        OBJ_NON_ACTION_UNUSED_50 = 50, // Never set in maps. Not in use at all.
+        OBJ_NON_ACTION_EYE_OF_MAGI = 50, // Never set in maps.
         OBJ_NON_ACTION_RANDOM_MONSTER_WEAK = 51, // Never set in maps.
         OBJ_NON_ACTION_RANDOM_MONSTER_MEDIUM = 52, // Never set in maps.
         OBJ_NON_ACTION_RANDOM_MONSTER_STRONG = 53, // Never set in maps.
         OBJ_NON_ACTION_RANDOM_MONSTER_VERY_STRONG = 54, // Never set in maps.
-        OBJ_NON_ACTION_HEROES = 55, // Never set in maps. TODO: this suppose to be a random hero.
-        OBJ_NON_ACTION_NOTHING_SPECIAL = 56,
-        OBJ_NON_ACTION_UNUSED_57 = 57, // TODO: it is used in some maps. Verify what it is.
+        OBJ_NON_ACTION_HEROES = 55, // Never set in maps. This type is used for any types of heroes, including random.
+        OBJ_NOTHING_SPECIAL = 56,
+        OBJ_MOSSY_ROCK = 57, // It is a Rock with moss for Swamp terrain. ICN::OBJNSWMP, images 138-139. In the original game it has no name.
         OBJ_NON_ACTION_WATCH_TOWER = 58,
         OBJ_NON_ACTION_TREE_HOUSE = 59,
         OBJ_NON_ACTION_TREE_CITY = 60,
@@ -306,7 +308,7 @@ namespace MP2
         OBJ_NON_ACTION_FORT = 62,
         OBJ_NON_ACTION_TRADING_POST = 63,
         OBJ_NON_ACTION_ABANDONED_MINE = 64,
-        OBJ_NON_ACTION_THATCHED_HUT = 65, // Never set in maps. TODO: it is a peasant hut! It is used at least in one map. Alternative name is Dwarf Cabin.
+        OBJ_NON_ACTION_SIRENS = 65, // Originally it was Thatched Hut which is replaced by Peasant Hut for all original maps.
         OBJ_NON_ACTION_STANDING_STONES = 66, // Never set in maps.
         OBJ_NON_ACTION_IDOL = 67, // Never set in maps.
         OBJ_NON_ACTION_TREE_OF_KNOWLEDGE = 68,
@@ -322,7 +324,7 @@ namespace MP2
         OBJ_NON_ACTION_EXCAVATION = 78,
         OBJ_NON_ACTION_SPHINX = 79,
         OBJ_NON_ACTION_WAGON = 80, // Never set in maps.
-        OBJ_NON_ACTION_TAR_PIT = 81,
+        OBJ_TAR_PIT = 81,
         OBJ_NON_ACTION_ARTESIAN_SPRING = 82,
         OBJ_NON_ACTION_TROLL_BRIDGE = 83,
         OBJ_NON_ACTION_WATERING_HOLE = 84,
@@ -339,7 +341,7 @@ namespace MP2
         OBJ_NON_ACTION_MAGIC_GARDEN = 95, // Never set in maps.
         OBJ_NON_ACTION_OBSERVATION_TOWER = 96,
         OBJ_NON_ACTION_FREEMANS_FOUNDRY = 97,
-        OBJ_STREAM = 98, // Never set in maps. Not in use within the original Editor.
+        OBJ_REEFS = 98, // Never set in maps. Not in use within the original Editor.
         OBJ_TREES = 99,
         OBJ_MOUNTAINS = 100,
         OBJ_VOLCANO = 101,
@@ -355,151 +357,165 @@ namespace MP2
         OBJ_DUNE = 111,
         OBJ_LAVAPOOL = 112,
         OBJ_SHRUB = 113,
-        OBJ_NON_ACTION_ARENA = 114, // Never set in maps. TODO: check the correct ID for this object.
-        OBJ_NON_ACTION_BARROW_MOUNDS = 115, // Never set in maps. TODO: check the correct ID for this object.
-        OBJ_NON_ACTION_MERMAID = 116, // Never set in maps. TODO: check the correct ID for this object.
-        OBJ_NON_ACTION_SIRENS = 117, // Never set in maps. TODO: check the correct ID for this object.
-        OBJ_NON_ACTION_HUT_OF_MAGI = 118, // Never set in maps. TODO: check the correct ID for this object.
-        OBJ_NON_ACTION_EYE_OF_MAGI = 119, // Never set in maps. TODO: check the correct ID for this object.
+        OBJ_NON_ACTION_ARENA = 114, // Never set in maps.
+        OBJ_NON_ACTION_BARROW_MOUNDS = 115, // Never set in maps.
+        OBJ_NON_ACTION_RANDOM_ARTIFACT_TREASURE = 116, // Never set in maps.
+        OBJ_NON_ACTION_RANDOM_ARTIFACT_MINOR = 117, // Never set in maps.
+        OBJ_NON_ACTION_RANDOM_ARTIFACT_MAJOR = 118, // Never set in maps.
+        OBJ_NON_ACTION_BARRIER = 119, // Never set in maps.
         OBJ_NON_ACTION_TRAVELLER_TENT = 120,
         OBJ_NON_ACTION_EXPANSION_DWELLING = 121,
         OBJ_NON_ACTION_EXPANSION_OBJECT = 122,
         OBJ_NON_ACTION_JAIL = 123,
-        OBJ_NON_ACTION_FIRE_ALTAR = 124, // Never set in maps. TODO: check the correct ID for this object.
-        OBJ_NON_ACTION_AIR_ALTAR = 125, // Never set in maps. TODO: check the correct ID for this object.
-        OBJ_NON_ACTION_EARTH_ALTAR = 126, // Never set in maps. TODO: check the correct ID for this object.
-        OBJ_NON_ACTION_WATER_ALTAR = 127, // Never set in maps. TODO: check the correct ID for this object.
+        OBJ_NON_ACTION_FIRE_ALTAR = 124, // Never set in maps.
+        OBJ_NON_ACTION_AIR_ALTAR = 125, // Never set in maps.
+        OBJ_NON_ACTION_EARTH_ALTAR = 126, // Never set in maps.
+        OBJ_NON_ACTION_WATER_ALTAR = 127, // Never set in maps.
 
-        OBJ_WATERCHEST, // Never set in maps. TODO: this is wrong ID for this object.
-        OBJ_ALCHEMIST_LAB,
-        OBJ_SIGN,
-        OBJ_BUOY,
-        OBJ_SKELETON,
-        OBJ_DAEMON_CAVE,
-        OBJ_TREASURE_CHEST,
-        OBJ_FAERIE_RING,
-        OBJ_CAMPFIRE,
-        OBJ_FOUNTAIN,
-        OBJ_GAZEBO,
-        OBJ_GENIE_LAMP,
-        OBJ_GRAVEYARD,
-        OBJ_ARCHER_HOUSE,
-        OBJ_GOBLIN_HUT,
-        OBJ_DWARF_COTTAGE,
-        OBJ_PEASANT_HUT,
-        OBJ_UNUSED_17, // Never set in maps.
-        OBJ_UNUSED_18, // Never set in maps.
-        OBJ_EVENT,
-        OBJ_DRAGON_CITY,
-        OBJ_LIGHTHOUSE,
-        OBJ_WATER_WHEEL,
-        OBJ_MINES,
-        OBJ_MONSTER,
-        OBJ_OBELISK,
-        OBJ_OASIS,
-        OBJ_RESOURCE,
-        OBJ_ACTION_COAST, // Never set in maps as Coast is not an action object.
-        OBJ_SAWMILL,
-        OBJ_ORACLE,
-        OBJ_SHRINE_FIRST_CIRCLE,
-        OBJ_SHIPWRECK,
-        OBJ_UNUSED_33, // Never set in maps.
-        OBJ_DESERT_TENT,
-        OBJ_CASTLE,
-        OBJ_STONE_LITHS,
-        OBJ_WAGON_CAMP,
-        OBJ_UNUSED_38, // Never set in maps.
-        OBJ_WHIRLPOOL,
-        OBJ_WINDMILL,
-        OBJ_ARTIFACT,
-        OBJ_UNUSED_42, // Never set in maps.
-        OBJ_BOAT,
-        OBJ_RANDOM_ULTIMATE_ARTIFACT,
-        OBJ_RANDOM_ARTIFACT,
-        OBJ_RANDOM_RESOURCE,
-        OBJ_RANDOM_MONSTER,
-        OBJ_RANDOM_TOWN,
-        OBJ_RANDOM_CASTLE,
-        OBJ_UNUSED_50, // Never set in maps.
-        OBJ_RANDOM_MONSTER_WEAK,
-        OBJ_RANDOM_MONSTER_MEDIUM,
-        OBJ_RANDOM_MONSTER_STRONG,
-        OBJ_RANDOM_MONSTER_VERY_STRONG,
-        OBJ_HEROES, // TODO: this suppose to be a random hero.
-        OBJ_NOTHING_SPECIAL, // Never set in maps.
-        OBJ_UNUSED_57, // Never set in maps.
-        OBJ_WATCH_TOWER,
-        OBJ_TREE_HOUSE,
-        OBJ_TREE_CITY,
-        OBJ_RUINS,
-        OBJ_FORT,
-        OBJ_TRADING_POST,
-        OBJ_ABANDONED_MINE,
-        OBJ_THATCHED_HUT, // TODO: it is a peasant hut! It is used at least in one map. Alternative name is Dwarf Cabin.
-        OBJ_STANDING_STONES,
-        OBJ_IDOL,
-        OBJ_TREE_OF_KNOWLEDGE,
-        OBJ_WITCH_DOCTORS_HUT,
-        OBJ_TEMPLE,
-        OBJ_HILL_FORT,
-        OBJ_HALFLING_HOLE,
-        OBJ_MERCENARY_CAMP,
-        OBJ_SHRINE_SECOND_CIRCLE,
-        OBJ_SHRINE_THIRD_CIRCLE,
-        OBJ_PYRAMID,
-        OBJ_CITY_OF_DEAD,
-        OBJ_EXCAVATION,
-        OBJ_SPHINX,
-        OBJ_WAGON,
-        OBJ_TAR_PIT, // Never set in maps. This is not an action object.
-        OBJ_ARTESIAN_SPRING,
-        OBJ_TROLL_BRIDGE,
-        OBJ_WATERING_HOLE,
-        OBJ_WITCHS_HUT,
-        OBJ_XANADU,
-        OBJ_CAVE,
-        OBJ_LEAN_TO,
-        OBJ_MAGELLANS_MAPS,
-        OBJ_FLOTSAM,
-        OBJ_DERELICT_SHIP,
-        OBJ_SHIPWRECK_SURVIVOR,
-        OBJ_BOTTLE,
-        OBJ_MAGIC_WELL,
-        OBJ_MAGIC_GARDEN,
-        OBJ_OBSERVATION_TOWER,
-        OBJ_FREEMANS_FOUNDRY,
-        OBJ_ACTION_UNUSED_226, // Never set in maps.
-        OBJ_ACTION_UNUSED_227, // Never set in maps.
-        OBJ_ACTION_UNUSED_228, // Never set in maps.
-        OBJ_ACTION_UNUSED_229, // Never set in maps.
-        OBJ_ACTION_UNUSED_230, // Never set in maps.
-        OBJ_ACTION_UNUSED_231, // Never set in maps.
-        OBJ_ACTION_UNUSED_232, // Never set in maps.
-        OBJ_REEFS, // Never set in maps. TODO: verify the correct ID for this object as it should not exist in action objects section.
-        OBJ_NON_ACTION_ALCHEMIST_TOWER, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_NON_ACTION_STABLES, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_MERMAID, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_SIRENS, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_HUT_OF_MAGI, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_EYE_OF_MAGI, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_ALCHEMIST_TOWER, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_STABLES, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_ARENA, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_BARROW_MOUNDS, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_RANDOM_ARTIFACT_TREASURE,
-        OBJ_RANDOM_ARTIFACT_MINOR,
-        OBJ_RANDOM_ARTIFACT_MAJOR,
-        OBJ_BARRIER,
-        OBJ_TRAVELLER_TENT,
-        OBJ_EXPANSION_DWELLING,
-        OBJ_EXPANSION_OBJECT,
-        OBJ_JAIL,
-        OBJ_FIRE_ALTAR, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_AIR_ALTAR, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_EARTH_ALTAR, // Never set in maps. TODO: verify the correct ID for this object.
-        OBJ_WATER_ALTAR // Never set in maps. TODO: verify the correct ID for this object.
+        OBJ_ACTION_OBJECT_TYPE = 128, // NEVER use this object type to set in maps. This entry is used to determine if an object is action type.
 
-        // IMPORTANT!!! Do not use any of unused entries for new objects. Add new entries just above this line.
+        // This section defines all types of action objects which are present in the original game.
+        // If the object by nature is an action object name it with prefix OBJ_.
+        // Otherwise, name it with prefix OBJ_ACTON_.
+        // The value of the object must be: non-action object value + OBJ_ACTION_OBJECT_TYPE.
+        OBJ_ALCHEMIST_LAB = OBJ_NON_ACTION_ALCHEMIST_LAB + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SIGN = OBJ_NON_ACTION_SIGN + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_BUOY = OBJ_NON_ACTION_BUOY + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SKELETON = OBJ_NON_ACTION_SKELETON + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_DAEMON_CAVE = OBJ_NON_ACTION_DAEMON_CAVE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_TREASURE_CHEST = OBJ_NON_ACTION_TREASURE_CHEST + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_FAERIE_RING = OBJ_NON_ACTION_FAERIE_RING + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_CAMPFIRE = OBJ_NON_ACTION_CAMPFIRE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_FOUNTAIN = OBJ_NON_ACTION_FOUNTAIN + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_GAZEBO = OBJ_NON_ACTION_GAZEBO + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_GENIE_LAMP = OBJ_NON_ACTION_GENIE_LAMP + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_GRAVEYARD = OBJ_NON_ACTION_GRAVEYARD + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_ARCHER_HOUSE = OBJ_NON_ACTION_ARCHER_HOUSE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_GOBLIN_HUT = OBJ_NON_ACTION_GOBLIN_HUT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_DWARF_COTTAGE = OBJ_NON_ACTION_DWARF_COTTAGE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_PEASANT_HUT = OBJ_NON_ACTION_PEASANT_HUT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_STABLES = OBJ_NON_ACTION_STABLES + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ALCHEMIST_TOWER = OBJ_NON_ACTION_ALCHEMIST_TOWER + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_EVENT = OBJ_NON_ACTION_EVENT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_DRAGON_CITY = OBJ_NON_ACTION_DRAGON_CITY + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_LIGHTHOUSE = OBJ_NON_ACTION_LIGHTHOUSE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_WATER_WHEEL = OBJ_NON_ACTION_WATER_WHEEL + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_MINES = OBJ_NON_ACTION_MINES + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_MONSTER = OBJ_NON_ACTION_MONSTER + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_OBELISK = OBJ_NON_ACTION_OBELISK + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_OASIS = OBJ_NON_ACTION_OASIS + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RESOURCE = OBJ_NON_ACTION_RESOURCE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_ACTION_COAST = OBJ_COAST + OBJ_ACTION_OBJECT_TYPE, // Never set in maps as Coast is not an action object.
+        OBJ_SAWMILL = OBJ_NON_ACTION_SAWMILL + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_ORACLE = OBJ_NON_ACTION_ORACLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SHRINE_FIRST_CIRCLE = OBJ_NON_ACTION_SHRINE_FIRST_CIRCLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SHIPWRECK = OBJ_NON_ACTION_SHIPWRECK + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SEA_CHEST = OBJ_NON_ACTION_SEA_CHEST + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_DESERT_TENT = OBJ_NON_ACTION_DESERT_TENT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_CASTLE = OBJ_NON_ACTION_CASTLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_STONE_LITHS = OBJ_NON_ACTION_STONE_LITHS + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_WAGON_CAMP = OBJ_NON_ACTION_WAGON_CAMP + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_HUT_OF_MAGI = OBJ_NON_ACTION_HUT_OF_MAGI + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_WHIRLPOOL = OBJ_NON_ACTION_WHIRLPOOL + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_WINDMILL = OBJ_NON_ACTION_WINDMILL + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_ARTIFACT = OBJ_NON_ACTION_ARTIFACT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_MERMAID = OBJ_NON_ACTION_MERMAID + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_BOAT = OBJ_NON_ACTION_BOAT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_ULTIMATE_ARTIFACT = OBJ_NON_ACTION_RANDOM_ULTIMATE_ARTIFACT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_ARTIFACT = OBJ_NON_ACTION_RANDOM_ARTIFACT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_RESOURCE = OBJ_NON_ACTION_RANDOM_RESOURCE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_MONSTER = OBJ_NON_ACTION_RANDOM_MONSTER + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_TOWN = OBJ_NON_ACTION_RANDOM_TOWN + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_CASTLE = OBJ_NON_ACTION_RANDOM_CASTLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_EYE_OF_MAGI = OBJ_NON_ACTION_EYE_OF_MAGI + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_RANDOM_MONSTER_WEAK = OBJ_NON_ACTION_RANDOM_MONSTER_WEAK + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_MONSTER_MEDIUM = OBJ_NON_ACTION_RANDOM_MONSTER_MEDIUM + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_MONSTER_STRONG = OBJ_NON_ACTION_RANDOM_MONSTER_STRONG + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_MONSTER_VERY_STRONG = OBJ_NON_ACTION_RANDOM_MONSTER_VERY_STRONG + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_HEROES, // This type is used for any types of heroes, including random.
+        OBJ_ACTION_NOTHING_SPECIAL = OBJ_NOTHING_SPECIAL + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_MOSSY_ROCK = OBJ_MOSSY_ROCK + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_WATCH_TOWER = OBJ_NON_ACTION_WATCH_TOWER + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_TREE_HOUSE = OBJ_NON_ACTION_TREE_HOUSE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_TREE_CITY = OBJ_NON_ACTION_TREE_CITY + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RUINS = OBJ_NON_ACTION_RUINS + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_FORT = OBJ_NON_ACTION_FORT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_TRADING_POST = OBJ_NON_ACTION_TRADING_POST + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_ABANDONED_MINE = OBJ_NON_ACTION_ABANDONED_MINE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SIRENS = OBJ_NON_ACTION_SIRENS + OBJ_ACTION_OBJECT_TYPE, // Originally it was Thatched Hut which is replaced by Peasant Hut for all original maps.
+        OBJ_STANDING_STONES = OBJ_NON_ACTION_STANDING_STONES + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_IDOL = OBJ_NON_ACTION_IDOL + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_TREE_OF_KNOWLEDGE = OBJ_NON_ACTION_TREE_OF_KNOWLEDGE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_WITCH_DOCTORS_HUT = OBJ_NON_ACTION_WITCH_DOCTORS_HUT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_TEMPLE = OBJ_NON_ACTION_TEMPLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_HILL_FORT = OBJ_NON_ACTION_HILL_FORT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_HALFLING_HOLE = OBJ_NON_ACTION_HALFLING_HOLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_MERCENARY_CAMP = OBJ_NON_ACTION_MERCENARY_CAMP + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SHRINE_SECOND_CIRCLE = OBJ_NON_ACTION_SHRINE_SECOND_CIRCLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SHRINE_THIRD_CIRCLE = OBJ_NON_ACTION_SHRINE_THIRD_CIRCLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_PYRAMID = OBJ_NON_ACTION_PYRAMID + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_CITY_OF_DEAD = OBJ_NON_ACTION_CITY_OF_DEAD + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_EXCAVATION = OBJ_NON_ACTION_EXCAVATION + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SPHINX = OBJ_NON_ACTION_SPHINX + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_WAGON = OBJ_NON_ACTION_WAGON + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_ACTION_TAR_PIT = OBJ_TAR_PIT + OBJ_ACTION_OBJECT_TYPE, // Never set in maps. This is not an action object.
+        OBJ_ARTESIAN_SPRING = OBJ_NON_ACTION_ARTESIAN_SPRING + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_TROLL_BRIDGE = OBJ_NON_ACTION_TROLL_BRIDGE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_WATERING_HOLE = OBJ_NON_ACTION_WATERING_HOLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_WITCHS_HUT = OBJ_NON_ACTION_WITCHS_HUT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_XANADU = OBJ_NON_ACTION_XANADU + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_CAVE = OBJ_NON_ACTION_CAVE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_LEAN_TO = OBJ_NON_ACTION_LEAN_TO + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_MAGELLANS_MAPS = OBJ_NON_ACTION_MAGELLANS_MAPS + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_FLOTSAM = OBJ_NON_ACTION_FLOTSAM + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_DERELICT_SHIP = OBJ_NON_ACTION_DERELICT_SHIP + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_SHIPWRECK_SURVIVOR = OBJ_NON_ACTION_SHIPWRECK_SURVIVOR + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_BOTTLE = OBJ_NON_ACTION_BOTTLE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_MAGIC_WELL = OBJ_NON_ACTION_MAGIC_WELL + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_MAGIC_GARDEN = OBJ_NON_ACTION_MAGIC_GARDEN + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_OBSERVATION_TOWER = OBJ_NON_ACTION_OBSERVATION_TOWER + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_FREEMANS_FOUNDRY = OBJ_NON_ACTION_FREEMANS_FOUNDRY + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_ACTION_REEFS = OBJ_REEFS + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_TREES = OBJ_TREES + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_MOUNTAINS = OBJ_MOUNTAINS + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_VOLCANO = OBJ_VOLCANO + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_FLOWERS = OBJ_FLOWERS + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_ROCK = OBJ_ROCK + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_WATER_LAKE = OBJ_WATER_LAKE + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_MANDRAKE = OBJ_MANDRAKE + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_DEAD_TREE = OBJ_DEAD_TREE + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_STUMP = OBJ_STUMP + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_CRATER = OBJ_CRATER + OBJ_ACTION_OBJECT_TYPE, // Never set in maps. TODO: verify the correct ID for this object.
+        OBJ_ACTION_CACTUS = OBJ_CACTUS + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_MOUND = OBJ_MOUND + OBJ_ACTION_OBJECT_TYPE, // Never set in maps
+        OBJ_ACTION_DUNE = OBJ_DUNE + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_LAVAPOOL = OBJ_LAVAPOOL + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ACTION_SHRUB = OBJ_SHRUB + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_ARENA = OBJ_NON_ACTION_ARENA + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_BARROW_MOUNDS = OBJ_NON_ACTION_BARROW_MOUNDS + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_RANDOM_ARTIFACT_TREASURE = OBJ_NON_ACTION_RANDOM_ARTIFACT_TREASURE + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_ARTIFACT_MINOR = OBJ_NON_ACTION_RANDOM_ARTIFACT_MINOR + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_RANDOM_ARTIFACT_MAJOR = OBJ_NON_ACTION_RANDOM_ARTIFACT_MAJOR + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_BARRIER = OBJ_NON_ACTION_BARRIER + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_TRAVELLER_TENT = OBJ_NON_ACTION_TRAVELLER_TENT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_EXPANSION_DWELLING = OBJ_NON_ACTION_EXPANSION_DWELLING + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_EXPANSION_OBJECT = OBJ_NON_ACTION_EXPANSION_OBJECT + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_JAIL = OBJ_NON_ACTION_JAIL + OBJ_ACTION_OBJECT_TYPE,
+        OBJ_FIRE_ALTAR = OBJ_NON_ACTION_FIRE_ALTAR + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_AIR_ALTAR = OBJ_NON_ACTION_AIR_ALTAR + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_EARTH_ALTAR = OBJ_NON_ACTION_EARTH_ALTAR + OBJ_ACTION_OBJECT_TYPE, // Never set in maps.
+        OBJ_WATER_ALTAR = OBJ_NON_ACTION_WATER_ALTAR + OBJ_ACTION_OBJECT_TYPE // Never set in maps.
+
+        // IMPORTANT!!! Do not use any of unused entries for new objects. Add new entries below following the instruction.
+
+        // This section defines all types of NON-action objects which are not present in the original game.
+        // If the object by nature is an action object name it with prefix OBJ_NON_ACTION_.
+        // Otherwise, name it with prefix OBJ_.
+
+        // This section defines all types of action objects which are not present in the original game.
+        // If the object by nature is an action object name it with prefix OBJ_.
+        // Otherwise, name it with prefix OBJ_ACTON_.
+        // The value of the object must be: non-action object value + OBJ_ACTION_OBJECT_TYPE.
     };
 
     enum ObjectIcnType : uint8_t
@@ -577,7 +593,7 @@ namespace MP2
 
     int getIcnIdFromObjectIcnType( const uint8_t objectIcnType );
 
-    const char * StringObject( const MapObjectType objectType, const int count = 1 );
+    const char * StringObject( MapObjectType objectType, const int count = 1 );
 
     bool isHiddenForPuzzle( const int terrainType, uint8_t tileset, uint8_t index );
 

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -1016,7 +1016,7 @@ uint32_t GoldInsteadArtifact( const MP2::MapObjectType objectType )
     case MP2::OBJ_TREASURE_CHEST:
     case MP2::OBJ_SHIPWRECK_SURVIVOR:
         return 1000;
-    case MP2::OBJ_WATERCHEST:
+    case MP2::OBJ_SEA_CHEST:
         return 1500;
     case MP2::OBJ_GRAVEYARD:
         return 2000;

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -28,6 +28,7 @@ enum SaveFileFormat : uint16_t
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
+    FORMAT_VERSION_1001_RELEASE = 10001,
     FORMAT_VERSION_1000_RELEASE = 10000,
     FORMAT_VERSION_PRE5_1000_RELEASE = 9964,
     FORMAT_VERSION_PRE4_1000_RELEASE = 9963,
@@ -38,5 +39,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_0921_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1000_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1001_RELEASE
 };

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1148,8 +1148,7 @@ uint32_t World::CheckKingdomWins( const Kingdom & kingdom ) const
     if ( conf.isCampaignGameType() ) {
         const Campaign::ScenarioVictoryCondition victoryCondition = Campaign::getCurrentScenarioVictoryCondition();
         if ( victoryCondition == Campaign::ScenarioVictoryCondition::CAPTURE_DRAGON_CITY ) {
-            // TODO: why are we checking non-action object type here? Verify it!
-            const bool visited = kingdom.isVisited( MP2::OBJ_DRAGON_CITY ) || kingdom.isVisited( MP2::OBJ_NON_ACTION_DRAGON_CITY );
+            const bool visited = kingdom.isVisited( MP2::OBJ_DRAGON_CITY );
             if ( visited ) {
                 return GameOver::WINS_SIDE;
             }

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -217,6 +217,14 @@ bool World::LoadMapMP2( const std::string & filename )
 
         MP2::mp2tile_t mp2tile;
         MP2::loadTile( fs, mp2tile );
+        // There are some tiles which have object type as 65 and 193 which are Thatched Hut. This is exactly the same object as Peasant Hut.
+        // Since the original number of object types is limited and in order not to confuse players we will convert this type into Peasant Hut.
+        if ( mp2tile.mapObjectType == 65 ) {
+            mp2tile.mapObjectType = MP2::OBJ_NON_ACTION_PEASANT_HUT;
+        }
+        else if ( mp2tile.mapObjectType == 193 ) {
+            mp2tile.mapObjectType = MP2::OBJ_PEASANT_HUT;
+        }
 
         tile.Init( i, mp2tile );
 
@@ -615,7 +623,7 @@ void World::ProcessNewMap()
         case MP2::OBJ_RANDOM_ARTIFACT_MINOR:
         case MP2::OBJ_RANDOM_ARTIFACT_MAJOR:
         case MP2::OBJ_RANDOM_RESOURCE:
-        case MP2::OBJ_WATERCHEST:
+        case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_TREASURE_CHEST:
         case MP2::OBJ_ARTIFACT:
         case MP2::OBJ_RESOURCE:
@@ -656,7 +664,6 @@ void World::ProcessNewMap()
         case MP2::OBJ_DWARF_COTTAGE:
         case MP2::OBJ_HALFLING_HOLE:
         case MP2::OBJ_PEASANT_HUT:
-        case MP2::OBJ_THATCHED_HUT:
         case MP2::OBJ_RUINS:
         case MP2::OBJ_TREE_CITY:
         case MP2::OBJ_WAGON_CAMP:


### PR DESCRIPTION
- convert Thatched Hut into Peasant Hut as this is exactly the same object, only different names. Moreover, when a Peasant Hut was marked as Thatched Hut no sounds appear from this dwelling on Adventure Map
- remap PoL objects to follow the same logic as other objects
- simplify many places for logic, in some functions sort objects per their names
- add Mossy Rock object which appears only on Swamp terrain. In the original game this object has no name but it has passability as any terrain non-action object