### PR TITLE
Removed redundant redraws when dragging an adventure map with the mouse

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1135,7 +1135,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
         }
 
         // fast scroll
-        if ( ( gameArea.NeedScroll() && !isMovingHero ) || gameArea.isDragScroll() ) {
+        if ( ( gameArea.NeedScroll() && !isMovingHero ) || gameArea.needDragScrollRedraw() ) {
             if ( Game::validateAnimationDelay( Game::SCROLL_DELAY ) ) {
                 if ( ( isScrollLeft( le.GetMouseCursor() ) || isScrollRight( le.GetMouseCursor() ) || isScrollTop( le.GetMouseCursor() )
                        || isScrollBottom( le.GetMouseCursor() ) )

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -898,7 +898,7 @@ void Interface::GameArea::SetScroll( int direct )
 void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
 {
     LocalEvent & le = LocalEvent::Get();
-    const fheroes2::Point & mp = le.GetMouseCursor();
+    const fheroes2::Point & mousePosition = le.GetMouseCursor();
 
     if ( !le.MousePressLeft() ) {
         _mouseDraggingInitiated = false;
@@ -907,28 +907,28 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
     }
     else if ( !_mouseDraggingInitiated ) {
         _mouseDraggingInitiated = true;
-        _startMouseDragPosition = mp;
+        _lastMouseDragPosition = mousePosition;
     }
-    else if ( ( std::abs( _startMouseDragPosition.x - mp.x ) > minimalRequiredDraggingMovement
-                || std::abs( _startMouseDragPosition.y - mp.y ) > minimalRequiredDraggingMovement )
+    else if ( ( std::abs( _lastMouseDragPosition.x - mousePosition.x ) > minimalRequiredDraggingMovement
+                || std::abs( _lastMouseDragPosition.y - mousePosition.y ) > minimalRequiredDraggingMovement )
               && isCursorOverGamearea ) {
         _mouseDraggingMovement = true;
     }
 
     if ( _mouseDraggingMovement ) {
-        if ( _startMouseDragPosition == mp ) {
+        if ( _lastMouseDragPosition == mousePosition ) {
             _needRedrawByMouseDragging = false;
         }
         else {
             // Update the center coordinates and redraw the adventure map only if the mouse was moved.
             _needRedrawByMouseDragging = true;
-            SetCenterInPixels( getCurrentCenterInPixels() + _startMouseDragPosition - mp );
-            _startMouseDragPosition = mp;
+            SetCenterInPixels( getCurrentCenterInPixels() + _lastMouseDragPosition - mousePosition );
+            _lastMouseDragPosition = mousePosition;
         }
         return;
     }
 
-    int32_t index = GetValidTileIdFromPoint( mp );
+    int32_t index = GetValidTileIdFromPoint( mousePosition );
 
     // change cursor if need
     if ( ( updateCursor || index != _prevIndexPos ) && isCursorOverGamearea ) {
@@ -945,7 +945,7 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
     if ( conf.isHideInterfaceEnabled() && conf.ShowControlPanel() && le.MouseCursor( interface.GetControlPanel().GetArea() ) )
         return;
 
-    const fheroes2::Point tileOffset = _topLeftTileOffset + mp - _windowROI.getPosition();
+    const fheroes2::Point tileOffset = _topLeftTileOffset + mousePosition - _windowROI.getPosition();
     const fheroes2::Point tilePos( ( tileOffset.x / TILEWIDTH ) * TILEWIDTH - _topLeftTileOffset.x + _windowROI.x,
                                    ( tileOffset.y / TILEWIDTH ) * TILEWIDTH - _topLeftTileOffset.y + _windowROI.x );
 

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -331,6 +331,7 @@ Interface::GameArea::GameArea( Basic & basic )
     , updateCursor( false )
     , _mouseDraggingInitiated( false )
     , _mouseDraggingMovement( false )
+    , _needRedrawByMouseDragging( false )
 {
     // Do nothing.
 }
@@ -902,6 +903,7 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
     if ( !le.MousePressLeft() ) {
         _mouseDraggingInitiated = false;
         _mouseDraggingMovement = false;
+        _needRedrawByMouseDragging = false;
     }
     else if ( !_mouseDraggingInitiated ) {
         _mouseDraggingInitiated = true;
@@ -914,8 +916,15 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
     }
 
     if ( _mouseDraggingMovement ) {
-        SetCenterInPixels( getCurrentCenterInPixels() + _startMouseDragPosition - mp );
-        _startMouseDragPosition = mp;
+        if ( _startMouseDragPosition == mp ) {
+            _needRedrawByMouseDragging = false;
+        }
+        else {
+            // Update the center coordinates and redraw the adventure map only if the mouse was moved.
+            _needRedrawByMouseDragging = true;
+            SetCenterInPixels( getCurrentCenterInPixels() + _startMouseDragPosition - mp );
+            _startMouseDragPosition = mp;
+        }
         return;
     }
 

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -247,7 +247,7 @@ namespace Interface
 
         bool isDragScroll() const
         {
-            return _mouseDraggingMovement;
+            return _needRedrawByMouseDrag;
         }
 
     private:
@@ -275,6 +275,7 @@ namespace Interface
 
         bool _mouseDraggingInitiated;
         bool _mouseDraggingMovement;
+        bool _needRedrawByMouseDragging;
         fheroes2::Point _startMouseDragPosition;
 
         // Returns middle point of window ROI.

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -276,7 +276,7 @@ namespace Interface
         bool _mouseDraggingInitiated;
         bool _mouseDraggingMovement;
         bool _needRedrawByMouseDragging;
-        fheroes2::Point _startMouseDragPosition;
+        fheroes2::Point _lastMouseDragPosition;
 
         // Returns middle point of window ROI.
         fheroes2::Point _middlePoint() const

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -247,7 +247,7 @@ namespace Interface
 
         bool isDragScroll() const
         {
-            return _needRedrawByMouseDrag;
+            return _needRedrawByMouseDragging;
         }
 
     private:

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -278,10 +278,10 @@ namespace Interface
         // This member needs to be mutable because it is modified during rendering.
         mutable std::vector<std::shared_ptr<BaseObjectAnimationInfo>> _animationInfo;
 
+        fheroes2::Point _lastMouseDragPosition;
         bool _mouseDraggingInitiated;
         bool _mouseDraggingMovement;
         bool _needRedrawByMouseDragging;
-        fheroes2::Point _lastMouseDragPosition;
 
         // Returns middle point of window ROI.
         fheroes2::Point _middlePoint() const

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -247,6 +247,11 @@ namespace Interface
 
         bool isDragScroll() const
         {
+            return _mouseDraggingMovement;
+        }
+
+        bool needDragScrollRedraw() const
+        {
             return _needRedrawByMouseDragging;
         }
 


### PR DESCRIPTION
Currently, when you start dragging the adventure map with the mouse, the engine starts to render the adventure map and radar continuously, even if the mouse is not moving.
This PR makes that the requests for rendering (`isDragScroll()`) are set only if the map is moved with the mouse.