### PR TITLE
PS Vita fixes and gamepad mapping improvements

### DIFF
--- a/docs/README_PSV.md
+++ b/docs/README_PSV.md
@@ -37,7 +37,7 @@ make -f Makefile.vita
 - △ - Open spellbook
 - D-Pad left - Next hero
 - D-Pad right - Next castle
-- D-Pad down - Re-visit the field that hero stands on
+- D-Pad down - Re-visit the object that hero stands on
 - R1 - Cursor acceleration
 - SELECT - System menu
 - START - Enter

--- a/docs/README_PSV.md
+++ b/docs/README_PSV.md
@@ -35,11 +35,12 @@ make -f Makefile.vita
 - ○ - Right mouse button
 - □ - End turn
 - △ - Open spellbook
-- L1 - Next hero
-- R1 - Next castle
+- D-Pad left - Next hero
+- D-Pad right - Next castle
+- D-Pad down - Re-visit the field that hero stands on
+- R1 - Cursor acceleration
 - SELECT - System menu
 - START - Enter
-- D-Pad down - re-visit the field that hero stands on
 
 Text input is done with D-Pad.
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1372,6 +1372,12 @@ void LocalEvent::HandleMouseWheelEvent( const SDL_MouseWheelEvent & wheel )
 
 void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
 {
+#if defined( TARGET_PS_VITA )
+    // Ignore rear touchpad on PS Vita
+    if ( event.touchId != 0 )
+        return;
+#endif
+
     switch ( event.type ) {
     case SDL_FINGERDOWN:
         if ( !_fingerIds.first ) {
@@ -1571,16 +1577,23 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
             else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN ) {
                 key_value = fheroes2::Key::KEY_DOWN;
             }
+            else {
+                key_value = fheroes2::Key::NONE;
+            }
             return;
         }
 #endif
-        if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN ) {
+        if ( button.button == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER ) {
+            _controllerPointerSpeed *= CONTROLLER_TRIGGER_CURSOR_SPEEDUP;
+            key_value = fheroes2::Key::NONE;
+        }
+        else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_DOWN ) {
             key_value = fheroes2::Key::KEY_SPACE;
         }
-        else if ( button.button == SDL_CONTROLLER_BUTTON_LEFTSHOULDER ) {
+        else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_LEFT ) {
             key_value = fheroes2::Key::KEY_H;
         }
-        else if ( button.button == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER ) {
+        else if ( button.button == SDL_CONTROLLER_BUTTON_DPAD_RIGHT ) {
             key_value = fheroes2::Key::KEY_T;
         }
         else if ( button.button == SDL_CONTROLLER_BUTTON_X ) {
@@ -1594,6 +1607,9 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
         }
         else if ( button.button == SDL_CONTROLLER_BUTTON_START ) {
             key_value = fheroes2::Key::KEY_ENTER;
+        }
+        else {
+            key_value = fheroes2::Key::NONE;
         }
 #if defined( TARGET_NINTENDO_SWITCH )
         // Custom button mapping for Nintendo Switch
@@ -1615,7 +1631,15 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
         else if ( button.button == SWITCH_BUTTON_PLUS ) {
             key_value = fheroes2::Key::KEY_C;
         }
+        else {
+            key_value = fheroes2::Key::NONE;
+        }
 #endif
+    }
+    else {
+        if ( button.button == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER ) {
+            _controllerPointerSpeed /= CONTROLLER_TRIGGER_CURSOR_SPEEDUP;
+        }
     }
 }
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2008 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1636,10 +1636,8 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
         }
 #endif
     }
-    else {
-        if ( button.button == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER ) {
-            _controllerPointerSpeed /= CONTROLLER_TRIGGER_CURSOR_SPEEDUP;
-        }
+    else if ( button.button == SDL_CONTROLLER_BUTTON_RIGHTSHOULDER ) {
+        _controllerPointerSpeed /= CONTROLLER_TRIGGER_CURSOR_SPEEDUP;
     }
 }
 

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2008 by Josh Matthews <josh@joshmatthews.net>           *

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -389,6 +389,7 @@ private:
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
     // bigger value correndsponds to faster pointer movement speed with bigger stick axis values
     const double CONTROLLER_AXIS_SPEEDUP = 1.03;
+    const double CONTROLLER_TRIGGER_CURSOR_SPEEDUP = 2.0;
 
     SDL_GameController * _gameController = nullptr;
     fheroes2::Time _controllerTimer;

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -715,35 +715,39 @@ namespace
             updatePalette( StandardPaletteIndexes() );
         }
 
-        void _calculateScreenScaling( int32_t width_, int32_t height_, bool isFullScreen )
+        void _calculateScreenScaling( const int32_t width_, const int32_t height_, const bool isFullScreen )
         {
             _destRect.x = 0;
             _destRect.y = 0;
             _destRect.width = width_;
             _destRect.height = height_;
 
-            if ( width_ != VITA_FULLSCREEN_WIDTH || height_ != VITA_FULLSCREEN_HEIGHT ) {
-                if ( isFullScreen ) {
-                    vita2d_texture_set_filters( _texBuffer, isNearestScaling() ? SCE_GXM_TEXTURE_FILTER_POINT : SCE_GXM_TEXTURE_FILTER_LINEAR,
-                                                isNearestScaling() ? SCE_GXM_TEXTURE_FILTER_POINT : SCE_GXM_TEXTURE_FILTER_LINEAR );
-                    if ( ( static_cast<float>( VITA_FULLSCREEN_WIDTH ) / VITA_FULLSCREEN_HEIGHT ) >= ( static_cast<float>( width_ ) / height_ ) ) {
-                        const float scale = static_cast<float>( VITA_FULLSCREEN_HEIGHT ) / height_;
-                        _destRect.width = static_cast<int32_t>( static_cast<float>( width_ ) * scale );
-                        _destRect.height = VITA_FULLSCREEN_HEIGHT;
-                        _destRect.x = ( VITA_FULLSCREEN_WIDTH - _destRect.width ) / 2;
-                    }
-                    else {
-                        const float scale = static_cast<float>( VITA_FULLSCREEN_WIDTH ) / width_;
-                        _destRect.width = VITA_FULLSCREEN_WIDTH;
-                        _destRect.height = static_cast<int32_t>( static_cast<float>( height_ ) * scale );
-                        _destRect.y = ( VITA_FULLSCREEN_HEIGHT - _destRect.height ) / 2;
-                    }
-                }
-                else {
-                    // center game area
-                    _destRect.x = ( VITA_FULLSCREEN_WIDTH - width_ ) / 2;
-                    _destRect.y = ( VITA_FULLSCREEN_HEIGHT - height_ ) / 2;
-                }
+            if ( width_ == VITA_FULLSCREEN_WIDTH && height_ == VITA_FULLSCREEN_HEIGHT ) {
+                // Nothing to do more.
+                return;
+            }
+
+            if ( !isFullScreen ) {
+                // Center game area.
+                _destRect.x = ( VITA_FULLSCREEN_WIDTH - width_ ) / 2;
+                _destRect.y = ( VITA_FULLSCREEN_HEIGHT - height_ ) / 2;
+                return;
+            }
+
+            const SceGxmTextureFilter textureFilter = isNearestScaling() ? SCE_GXM_TEXTURE_FILTER_POINT : SCE_GXM_TEXTURE_FILTER_LINEAR;
+
+            vita2d_texture_set_filters( _texBuffer, textureFilter, textureFilter );
+            if ( ( static_cast<float>( VITA_FULLSCREEN_WIDTH ) / VITA_FULLSCREEN_HEIGHT ) >= ( static_cast<float>( width_ ) / height_ ) ) {
+                const float scale = static_cast<float>( VITA_FULLSCREEN_HEIGHT ) / height_;
+                _destRect.width = static_cast<int32_t>( static_cast<float>( width_ ) * scale );
+                _destRect.height = VITA_FULLSCREEN_HEIGHT;
+                _destRect.x = ( VITA_FULLSCREEN_WIDTH - _destRect.width ) / 2;
+            }
+            else {
+                const float scale = static_cast<float>( VITA_FULLSCREEN_WIDTH ) / width_;
+                _destRect.width = VITA_FULLSCREEN_WIDTH;
+                _destRect.height = static_cast<int32_t>( static_cast<float>( height_ ) * scale );
+                _destRect.y = ( VITA_FULLSCREEN_HEIGHT - _destRect.height ) / 2;
             }
         }
     };

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2022                                             *
+ *   Copyright (C) 2020 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
Bunch of fixes related to PS Vita
- Disabled rear touchpad
- Added gamepad mapping for cursor speedup
- Fixed fullscreen/windowed toggle in display options