### PR TITLE
Rework the battle pathfinding

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -681,7 +681,6 @@ namespace AI
 
         // For walking units that don't have a target within reach, pick based on distance priority
         if ( target.unit == nullptr ) {
-            const uint32_t currentUnitMoveRange = currentUnit.GetMoveRange();
             const double attackDistanceModifier = _enemyArmyStrength / STRENGTH_DISTANCE_FACTOR;
             double maxMovePriority = attackDistanceModifier * ARENASIZE * -1;
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -705,6 +705,11 @@ namespace AI
                     if ( path.empty() ) {
                         target.cell = move.first;
                     }
+                    // Unit rushes through the moat, step into the moat to get more freedom of action on the next turn
+                    else if ( Board::isMoatIndex( path.back(), currentUnit ) ) {
+                        target.cell = path.back();
+                        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Going after target " << enemy->GetName() << " stopping in the moat at " << target.cell )
+                    }
                     else {
                         target.cell = FindNextTurnAttackMove( path, currentUnit, enemies );
                         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Going after target " << enemy->GetName() << " stopping at " << target.cell )

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -562,6 +562,7 @@ namespace AI
         }
 
         _defensiveTactics = enemyArcherRatio < enemyArcherThreshold && ( _defendingCastle || _myShooterStr > _enemyShooterStr ) && !myOverpoweredArmy;
+
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE,
                    "Tactic " << _defensiveTactics << " chosen. Archers: " << _myShooterStr << ", vs enemy " << _enemyShooterStr << " ratio is " << enemyArcherRatio )
     }
@@ -651,6 +652,7 @@ namespace AI
                 if ( highestStrength < attackPriority ) {
                     highestStrength = attackPriority;
                     target.unit = enemy;
+
                     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Set priority on " << enemy->GetName() << " value " << attackPriority )
                 }
             }
@@ -715,10 +717,12 @@ namespace AI
                     // Unit rushes through the moat, step into the moat to get more freedom of action on the next turn
                     else if ( Board::isMoatIndex( path.back(), currentUnit ) ) {
                         target.cell = path.back();
+
                         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Going after target " << enemy->GetName() << " stopping in the moat at " << target.cell )
                     }
                     else {
                         target.cell = FindNextTurnAttackMove( path, currentUnit, enemies );
+
                         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Going after target " << enemy->GetName() << " stopping at " << target.cell )
                     }
                 }
@@ -747,6 +751,7 @@ namespace AI
                     target.cell = cellIdx;
                 }
             }
+
             DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " moving towards castle walls, target cell is " << target.cell )
         }
 
@@ -802,6 +807,7 @@ namespace AI
                 const Unit * enemy = Board::GetCell( cell )->GetUnit();
                 if ( !enemy ) {
                     DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" )
+
                     continue;
                 }
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -699,13 +699,16 @@ namespace AI
                 if ( unitPriority > maxMovePriority ) {
                     maxMovePriority = unitPriority;
 
-                    const Indexes & path = arena.CalculateTwoMoveOverlap( move.first, currentUnitMoveRange );
-                    if ( !path.empty() ) {
-                        target.cell = FindNextTurnAttackMove( path, currentUnit, enemies );
-                        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Going after target " << enemy->GetName() << " stopping at " << target.cell )
+                    const Position pos = Position::GetPosition( currentUnit, move.first );
+                    assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
+
+                    const Indexes path = arena.GetPath( pos );
+                    if ( path.empty() ) {
+                        target.cell = move.first;
                     }
                     else {
-                        target.cell = move.first;
+                        target.cell = FindNextTurnAttackMove( path, currentUnit, enemies );
+                        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Going after target " << enemy->GetName() << " stopping at " << target.cell )
                     }
                 }
             }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -597,7 +597,7 @@ namespace AI
             }
             else {
                 // Kiting enemy: Search for a safe spot unit can move to
-                target.cell = FindMoveToRetreat( arena.getAllAvailableMoves( currentUnit.GetMoveRange() ), currentUnit, enemies );
+                target.cell = FindMoveToRetreat( arena.getAllAvailableMoves(), currentUnit, enemies );
 
                 if ( target.cell != -1 ) {
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer kiting enemy, target cell is " << target.cell )

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -204,7 +204,14 @@ namespace AI
 
     int32_t getUnitMovementTarget( const Unit & currentUnit, const int32_t idx )
     {
-        const Position pos = Position::GetPosition( currentUnit, idx );
+        // First try to find the position that is reachable on the current turn
+        Position pos = Position::GetReachable( currentUnit, idx );
+
+        // If there is no such position, then use an abstract position that corresponds to the given index
+        if ( pos.GetHead() == nullptr ) {
+            pos = Position::GetPosition( currentUnit, idx );
+        }
+
         assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
 
         return pos.GetHead()->GetIndex();

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -593,7 +593,7 @@ namespace AI
                     }
                 }
                 else {
-                    DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" )
+                    DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies() returned a cell " << cell << " that does not contain a unit!" )
                 }
             }
 
@@ -697,8 +697,10 @@ namespace AI
                 // move node pair consists of move hex index and distance
                 const std::pair<int, uint32_t> move = findNearestCellNextToUnit( arena, currentUnit, *enemy );
 
-                if ( move.first == -1 ) // Skip unit if no path found
+                // Skip unit if no path found
+                if ( move.first == -1 ) {
                     continue;
+                }
 
                 // Do not chase after faster units that might kite away and avoid engagement
                 const uint32_t distance = ( !enemy->isArchers() && isUnitFaster( *enemy, currentUnit ) ) ? move.second + ARENAW + ARENAH : move.second;
@@ -711,8 +713,10 @@ namespace AI
                     assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
 
                     const Indexes path = arena.GetPath( pos );
+
+                    // Normally this shouldn't happen
                     if ( path.empty() ) {
-                        target.cell = move.first;
+                        DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Arena::GetPath() returned an empty path to cell " << move.first << " for " << currentUnit.GetName() << "!" )
                     }
                     // Unit rushes through the moat, step into the moat to get more freedom of action on the next turn
                     else if ( Board::isMoatIndex( path.back(), currentUnit ) ) {
@@ -806,7 +810,7 @@ namespace AI
             for ( const int cell : adjacentEnemies ) {
                 const Unit * enemy = Board::GetCell( cell )->GetUnit();
                 if ( !enemy ) {
-                    DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies returned a cell " << cell << " that does not contain a unit!" )
+                    DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetAdjacentEnemies() returned a cell " << cell << " that does not contain a unit!" )
 
                     continue;
                 }
@@ -853,7 +857,7 @@ namespace AI
         const std::vector<Unit *> nearestUnits = Arena::GetBoard()->GetNearestTroops( &currentUnit, {} );
         // Normally this shouldn't happen
         if ( nearestUnits.empty() ) {
-            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetNearestTroops returned an empty result for " << currentUnit.GetName() << "!" )
+            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Board::GetNearestTroops() returned an empty result for " << currentUnit.GetName() << "!" )
 
             return actions;
         }

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -452,7 +452,7 @@ void Battle::Arena::ApplyActionMove( Command & cmd )
             finalPos = pos;
         }
         else {
-            const Indexes path = GetPath( *unit, pos );
+            const Indexes path = GetPath( pos );
 
             if ( path.empty() ) {
                 DEBUG_LOG( DBG_BATTLE, DBG_WARN,

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -743,9 +743,9 @@ bool Battle::Arena::isPositionReachable( const Position & position, const bool o
     return _battlePathfinder.isPositionReachable( position, onCurrentTurn );
 }
 
-Battle::Indexes Battle::Arena::getAllAvailableMoves( uint32_t moveRange ) const
+Battle::Indexes Battle::Arena::getAllAvailableMoves() const
 {
-    return _battlePathfinder.getAllAvailableMoves( moveRange );
+    return _battlePathfinder.getAllAvailableMoves();
 }
 
 Battle::Unit * Battle::Arena::GetTroopBoard( int32_t index )

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -733,12 +733,6 @@ Battle::Indexes Battle::Arena::GetPath( const Position & position ) const
     return result;
 }
 
-Battle::Indexes Battle::Arena::CalculateTwoMoveOverlap( int32_t /* indexTo */, uint32_t /* movementRange = 0 */ ) const
-{
-    // TODO: Not implemented yet
-    return {};
-}
-
 uint32_t Battle::Arena::CalculateMoveDistance( const Position & position ) const
 {
     return _battlePathfinder.getDistance( position );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -723,29 +723,18 @@ Battle::Indexes Battle::Arena::GetPath( const Position & position ) const
     const Indexes result = _battlePathfinder.buildPath( position );
 
     if ( IS_DEBUG( DBG_BATTLE, DBG_TRACE ) && !result.empty() ) {
-        std::stringstream ss;
+        std::string pathStr;
+        pathStr.reserve( Speed::INSTANT * 4 );
 
-        std::for_each( result.begin(), result.end(), [&ss]( const int32_t item ) { ss << item << ", "; } );
+        std::for_each( result.begin(), result.end(), [&pathStr]( const int32_t item ) {
+            pathStr += std::to_string( item );
+            pathStr += ", ";
+        } );
 
-        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, ss.str() )
+        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, pathStr )
     }
 
     return result;
-}
-
-uint32_t Battle::Arena::CalculateMoveDistance( const Position & position ) const
-{
-    return _battlePathfinder.getDistance( position );
-}
-
-bool Battle::Arena::isPositionReachable( const Position & position, const bool onCurrentTurn ) const
-{
-    return _battlePathfinder.isPositionReachable( position, onCurrentTurn );
-}
-
-Battle::Indexes Battle::Arena::getAllAvailableMoves() const
-{
-    return _battlePathfinder.getAllAvailableMoves();
 }
 
 Battle::Unit * Battle::Arena::GetTroopBoard( int32_t index )

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -28,6 +28,7 @@
 #include <iterator>
 #include <ostream>
 #include <random>
+#include <utility>
 
 #include "ai.h"
 #include "army.h"
@@ -420,6 +421,16 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
     bool endOfTurn = false;
 
     while ( !endOfTurn ) {
+        // All cells on the board should be properly reset at the beginning of each iteration
+        assert( std::all_of( board.begin(), board.end(), []( const Cell & cell ) {
+            const Unit * unit = cell.GetUnit();
+            if ( unit && !unit->isValid() ) {
+                return false;
+            }
+
+            return cell.GetQuality() == 0;
+        } ) );
+
         Actions actions;
 
         if ( _interface ) {
@@ -446,7 +457,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
                 _bridge->SetPassability( *troop );
             }
 
-            _globalAIPathfinder.calculate( *troop );
+            _battlePathfinder.evaluateForUnit( *troop );
 
             if ( troop->isControlRemote() ) {
                 RemoteTurn( *troop, actions );
@@ -465,6 +476,8 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
         while ( !actions.empty() ) {
             ApplyAction( actions.front() );
             actions.pop_front();
+
+            board.Reset();
 
             if ( _orderOfUnits ) {
                 // Applied action could kill someone or affect the speed of some unit, update the order of units
@@ -627,7 +640,16 @@ void Battle::Arena::HumanTurn( const Unit & b, Actions & a )
 
 void Battle::Arena::TowerAction( const Tower & twr )
 {
-    board.Reset();
+    // All cells on the board should be properly reset here
+    assert( std::all_of( board.begin(), board.end(), []( const Cell & cell ) {
+        const Unit * unit = cell.GetUnit();
+        if ( unit && !unit->isValid() ) {
+            return false;
+        }
+
+        return cell.GetQuality() == 0;
+    } ) );
+
     board.SetEnemyQuality( twr );
 
     // Target unit and its quality
@@ -654,6 +676,8 @@ void Battle::Arena::TowerAction( const Tower & twr )
     Command cmd( CommandType::MSG_BATTLE_TOWER, twr.GetType(), targetInfo.first->GetUID() );
 
     ApplyAction( cmd );
+
+    board.Reset();
 }
 
 void Battle::Arena::CatapultAction()
@@ -694,93 +718,40 @@ void Battle::Arena::CatapultAction()
     }
 }
 
-Battle::Indexes Battle::Arena::GetPath( const Unit & b, const Position & dst ) const
+Battle::Indexes Battle::Arena::GetPath( const Position & position ) const
 {
-    Indexes result = board.GetPath( b, dst );
+    const Indexes result = _battlePathfinder.buildPath( position );
 
-    if ( !result.empty() && IS_DEBUG( DBG_BATTLE, DBG_TRACE ) ) {
+    if ( IS_DEBUG( DBG_BATTLE, DBG_TRACE ) && !result.empty() ) {
         std::stringstream ss;
-        for ( uint32_t ii = 0; ii < result.size(); ++ii )
-            ss << result[ii] << ", ";
+
+        std::for_each( result.begin(), result.end(), [&ss]( const int32_t item ) { ss << item << ", "; } );
+
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, ss.str() )
     }
 
     return result;
 }
 
-Battle::Indexes Battle::Arena::CalculateTwoMoveOverlap( int32_t indexTo, uint32_t movementRange ) const
+Battle::Indexes Battle::Arena::CalculateTwoMoveOverlap( int32_t /* indexTo */, uint32_t /* movementRange = 0 */ ) const
 {
-    return _globalAIPathfinder.findTwoMovesOverlap( indexTo, movementRange );
+    // TODO: Not implemented yet
+    return {};
 }
 
-std::pair<int, uint32_t> Battle::Arena::CalculateMoveToUnit( const Unit & target ) const
+uint32_t Battle::Arena::CalculateMoveDistance( const Position & position ) const
 {
-    std::pair<int, uint32_t> result = { -1, 65535 };
-
-    const Position & pos = target.GetPosition();
-    const Cell * head = pos.GetHead();
-    const Cell * tail = pos.GetTail();
-
-    if ( head ) {
-        const BattleNode & headNode = _globalAIPathfinder.getNode( head->GetIndex() );
-        if ( headNode._from != -1 ) {
-            result.first = headNode._from;
-            result.second = headNode._cost;
-        }
-    }
-
-    if ( tail ) {
-        const BattleNode & tailNode = _globalAIPathfinder.getNode( tail->GetIndex() );
-        if ( tailNode._from != -1 && tailNode._cost < result.second ) {
-            result.first = tailNode._from;
-            result.second = tailNode._cost;
-        }
-    }
-
-    return result;
+    return _battlePathfinder.getDistance( position );
 }
 
-uint32_t Battle::Arena::CalculateMoveDistance( int32_t indexTo ) const
+bool Battle::Arena::isPositionReachable( const Position & position, const bool onCurrentTurn ) const
 {
-    return Board::isValidIndex( indexTo ) ? _globalAIPathfinder.getDistance( indexTo ) : 65535;
-}
-
-bool Battle::Arena::hexIsPassable( int32_t indexTo ) const
-{
-    return Board::isValidIndex( indexTo ) && _globalAIPathfinder.hexIsPassable( indexTo );
+    return _battlePathfinder.isPositionReachable( position, onCurrentTurn );
 }
 
 Battle::Indexes Battle::Arena::getAllAvailableMoves( uint32_t moveRange ) const
 {
-    return _globalAIPathfinder.getAllAvailableMoves( moveRange );
-}
-
-int32_t Battle::Arena::GetNearestReachableCell( const Unit & currentUnit, const int32_t dst ) const
-{
-    const Position dstPos = Position::GetReachable( currentUnit, dst );
-
-    if ( dstPos.GetHead() != nullptr && ( !currentUnit.isWide() || dstPos.GetTail() != nullptr ) ) {
-        // Destination cell is already reachable
-        return dstPos.GetHead()->GetIndex();
-    }
-
-    const Indexes path = _globalAIPathfinder.buildPath( dst );
-
-    // Destination cell is unreachable in principle according to the AIBattlePathfinder
-    if ( path.empty() ) {
-        return -1;
-    }
-
-    // Search for the reachable cell nearest to the end of the path
-    for ( auto it = path.crbegin(); it != path.crend(); ++it ) {
-        const Position pos = Position::GetReachable( currentUnit, *it );
-
-        if ( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) ) {
-            return pos.GetHead()->GetIndex();
-        }
-    }
-
-    return -1;
+    return _battlePathfinder.getAllAvailableMoves( moveRange );
 }
 
 Battle::Unit * Battle::Arena::GetTroopBoard( int32_t index )

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -142,7 +142,6 @@ namespace Battle
         uint32_t CalculateMoveDistance( const Position & position ) const;
         bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
-        Indexes CalculateTwoMoveOverlap( int32_t indexTo, uint32_t movementRange = 0 ) const;
         Indexes GetPath( const Position & position ) const;
 
         void ApplyAction( Command & );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -139,19 +139,19 @@ namespace Battle
 
         void FadeArena( bool clearMessageLog ) const;
 
-        // Returns the distance to the given position (i.e. the number of cells that needs to be passed)
-        // for the current unit (to which the current passability information relates). It's the caller's
-        // responsibility to make sure that this position is reachable before calling this method.
+        // Returns the distance to the given position (i.e. the number of cells that needs to be passed) for the
+        // current unit (to which the current pathfinder graph relates). It's the caller's responsibility to make
+        // sure that this position is reachable before calling this method.
         uint32_t CalculateMoveDistance( const Position & position ) const;
-        // Checks whether the given position is reachable for the current unit (to which the current
-        // passability information relates), either on the current turn or in principle
+        // Checks whether the given position is reachable for the current unit (to which the current pathfinder
+        // graph relates), either on the current turn or in principle
         bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
-        // Returns the indexes of all cells that can be occupied by the head of the current unit (to which
-        // the current passability information relates) on the current turn
+        // Returns the indexes of all cells that can be occupied by the head of the current unit (to which the
+        // current pathfinder graph relates) on the current turn
         Indexes getAllAvailableMoves() const;
-        // Returns a path (or its part) for the current unit (to which the current passability information
-        // relates) to the given position that can be traversed during the current turn. If this position
-        // is unreachable, then an empty path is returned.
+        // Returns a path (or its part) for the current unit (to which the current pathfinder graph relates)
+        // to the given position that can be traversed during the current turn. If this position is unreachable,
+        // then an empty path is returned.
         Indexes GetPath( const Position & position ) const;
 
         void ApplyAction( Command & );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -29,7 +29,6 @@
 #include <list>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "battle.h"
@@ -140,19 +139,11 @@ namespace Battle
 
         void FadeArena( bool clearMessageLog ) const;
 
-        // returns pair with move cell index and distance
-        std::pair<int, uint32_t> CalculateMoveToUnit( const Unit & target ) const;
-
-        uint32_t CalculateMoveDistance( int32_t indexTo ) const;
-        bool hexIsPassable( int32_t indexTo ) const;
+        uint32_t CalculateMoveDistance( const Position & position ) const;
+        bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
         Indexes getAllAvailableMoves( uint32_t moveRange ) const;
         Indexes CalculateTwoMoveOverlap( int32_t indexTo, uint32_t movementRange = 0 ) const;
-        Indexes GetPath( const Unit &, const Position & ) const;
-
-        // Returns the cell nearest to the end of the path to the cell with the given index (according to the AIBattlePathfinder)
-        // and reachable for the current unit (to which the current board passability information relates) or -1 if the cell with
-        // the given index is unreachable in principle
-        int32_t GetNearestReachableCell( const Unit & currentUnit, const int32_t dst ) const;
+        Indexes GetPath( const Position & position ) const;
 
         void ApplyAction( Command & );
 
@@ -281,7 +272,7 @@ namespace Battle
         SpellStorage usage_spells;
 
         Board board;
-        AIBattlePathfinder _globalAIPathfinder;
+        BattlePathfinder _battlePathfinder;
         int icn_covr;
 
         uint32_t current_turn;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -142,13 +142,25 @@ namespace Battle
         // Returns the distance to the given position (i.e. the number of cells that needs to be passed) for the
         // current unit (to which the current pathfinder graph relates). It's the caller's responsibility to make
         // sure that this position is reachable before calling this method.
-        uint32_t CalculateMoveDistance( const Position & position ) const;
+        uint32_t CalculateMoveDistance( const Position & position ) const
+        {
+            return _battlePathfinder.getDistance( position );
+        }
+
         // Checks whether the given position is reachable for the current unit (to which the current pathfinder
         // graph relates), either on the current turn or in principle
-        bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
+        bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const
+        {
+            return _battlePathfinder.isPositionReachable( position, onCurrentTurn );
+        }
+
         // Returns the indexes of all cells that can be occupied by the head of the current unit (to which the
         // current pathfinder graph relates) on the current turn
-        Indexes getAllAvailableMoves() const;
+        Indexes getAllAvailableMoves() const
+        {
+            return _battlePathfinder.getAllAvailableMoves();
+        }
+
         // Returns a path (or its part) for the current unit (to which the current pathfinder graph relates)
         // to the given position that can be traversed during the current turn. If this position is unreachable,
         // then an empty path is returned.

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -139,9 +139,19 @@ namespace Battle
 
         void FadeArena( bool clearMessageLog ) const;
 
+        // Returns the distance to the given position (i.e. the number of cells that needs to be passed)
+        // for the current unit (to which the current passability information relates). It's the caller's
+        // responsibility to make sure that this position is reachable before calling this method.
         uint32_t CalculateMoveDistance( const Position & position ) const;
+        // Checks whether the given position is reachable for the current unit (to which the current
+        // passability information relates), either on the current turn or in principle
         bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
+        // Returns the indexes of all cells that can be occupied by the head of the current unit (to which
+        // the current passability information relates) on the current turn
         Indexes getAllAvailableMoves() const;
+        // Returns a path (or its part) for the current unit (to which the current passability information
+        // relates) to the given position that can be traversed during the current turn. If this position
+        // is unreachable, then an empty path is returned.
         Indexes GetPath( const Position & position ) const;
 
         void ApplyAction( Command & );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -141,7 +141,7 @@ namespace Battle
 
         uint32_t CalculateMoveDistance( const Position & position ) const;
         bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
-        Indexes getAllAvailableMoves( uint32_t moveRange ) const;
+        Indexes getAllAvailableMoves() const;
         Indexes GetPath( const Position & position ) const;
 
         void ApplyAction( Command & );

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -65,16 +65,16 @@ Battle::Units::Units( const Units & units, const bool isRemoveInvalidUnits )
     }
 }
 
-Battle::Units::Units( const Units & units, const Unit * unitToFilter )
+Battle::Units::Units( const Units & units, const Unit * unitToRemove )
 {
     reserve( unitSizeCapacity < units.size() ? units.size() : unitSizeCapacity );
     assign( units.begin(), units.end() );
 
     erase( std::remove_if( begin(), end(),
-                           [unitToFilter]( const Unit * unit ) {
+                           [unitToRemove]( const Unit * unit ) {
                                assert( unit != nullptr );
 
-                               return !unit->isValid() || unit == unitToFilter;
+                               return !unit->isValid() || unit == unitToRemove;
                            } ),
            end() );
 }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -49,15 +49,34 @@ Battle::Units::Units()
     reserve( unitSizeCapacity );
 }
 
-Battle::Units::Units( const Units & units, const bool filter )
-    : std::vector<Unit *>()
+Battle::Units::Units( const Units & units, const bool isRemoveInvalidUnits )
 {
     reserve( unitSizeCapacity < units.size() ? units.size() : unitSizeCapacity );
     assign( units.begin(), units.end() );
 
-    if ( filter ) {
-        erase( std::remove_if( begin(), end(), []( const Unit * unit ) { return !unit->isValid(); } ), end() );
+    if ( isRemoveInvalidUnits ) {
+        erase( std::remove_if( begin(), end(),
+                               []( const Unit * unit ) {
+                                   assert( unit != nullptr );
+
+                                   return !unit->isValid();
+                               } ),
+               end() );
     }
+}
+
+Battle::Units::Units( const Units & units, const Unit * unitToFilter )
+{
+    reserve( unitSizeCapacity < units.size() ? units.size() : unitSizeCapacity );
+    assign( units.begin(), units.end() );
+
+    erase( std::remove_if( begin(), end(),
+                           [unitToFilter]( const Unit * unit ) {
+                               assert( unit != nullptr );
+
+                               return !unit->isValid() || unit == unitToFilter;
+                           } ),
+           end() );
 }
 
 void Battle::Units::SortFastest()

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -47,12 +47,15 @@ namespace Battle
     {
     public:
         Units();
+
         // Creates a shallow copy of 'units' (only pointers are copied), removing
         // invalid units (i.e. empty slots) if requested
         Units( const Units & units, const bool isRemoveInvalidUnits );
+
         // Creates a shallow copy of 'units' (only pointers are copied), removing
         // invalid units (i.e. empty slots) as well as the specified unit
         Units( const Units & units, const Unit * unitToRemove );
+
         Units( const Units & ) = delete;
 
         virtual ~Units() = default;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -47,8 +47,12 @@ namespace Battle
     {
     public:
         Units();
+        // Creates a shallow copy of 'units' (only pointers are copied), removing
+        // invalid units (i.e. empty slots) if requested
         Units( const Units & units, const bool isRemoveInvalidUnits );
-        Units( const Units & units, const Unit * unitToFilter );
+        // Creates a shallow copy of 'units' (only pointers are copied), removing
+        // invalid units (i.e. empty slots) as well as the specified unit
+        Units( const Units & units, const Unit * unitToRemove );
         Units( const Units & ) = delete;
 
         virtual ~Units() = default;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -47,8 +47,10 @@ namespace Battle
     {
     public:
         Units();
+        Units( const Units & units, const bool isRemoveInvalidUnits );
+        Units( const Units & units, const Unit * unitToFilter );
         Units( const Units & ) = delete;
-        Units( const Units & units, const bool filter );
+
         virtual ~Units() = default;
 
         Units & operator=( const Units & ) = delete;

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -881,7 +881,7 @@ Battle::Indexes Battle::Board::GetDistanceIndexes( const int32_t center, const u
     const int32_t centerY = center / ARENAW;
 
     // Axial coordinates
-    const int32_t centerQ = centerX - ( centerY + centerY % 2 ) / 2;
+    const int32_t centerQ = centerX - ( centerY + ( centerY % 2 ) ) / 2;
     const int32_t centerR = centerY;
 
     Indexes result;
@@ -894,7 +894,7 @@ Battle::Indexes Battle::Board::GetDistanceIndexes( const int32_t center, const u
             const int32_t q = centerQ + dq;
             const int32_t r = centerR + dr;
 
-            const int32_t x = q + ( r + r % 2 ) / 2;
+            const int32_t x = q + ( r + ( r % 2 ) ) / 2;
             const int32_t y = r;
 
             if ( x < 0 || x >= ARENAW || y < 0 || y >= ARENAH ) {

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -884,9 +884,10 @@ Battle::Indexes Battle::Board::GetDistanceIndexes( const int32_t center, const u
     const int32_t centerQ = centerX - ( centerY + centerY % 2 ) / 2;
     const int32_t centerR = centerY;
 
-    const int32_t intRadius = radius;
-
     Indexes result;
+    result.reserve( 3 * radius * ( radius + 1 ) + 1 );
+
+    const int32_t intRadius = radius;
 
     for ( int32_t dq = -intRadius; dq <= intRadius; ++dq ) {
         for ( int32_t dr = std::max( -intRadius, -intRadius - dq ); dr <= std::min( intRadius, intRadius - dq ); ++dr ) {

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -286,28 +286,33 @@ int32_t Battle::Board::OptimalAttackValue( const Unit & attacker, const Unit & t
     return target.GetScoreQuality( attacker );
 }
 
-int Battle::Board::GetDirection( int32_t index1, int32_t index2 )
+int Battle::Board::GetDirection( const int32_t index1, const int32_t index2 )
 {
-    if ( isValidIndex( index1 ) && isValidIndex( index2 ) ) {
-        if ( index1 == index2 )
-            return CENTER;
-        else
-            for ( direction_t dir = TOP_LEFT; dir < CENTER; ++dir )
-                if ( isValidDirection( index1, dir ) && index2 == GetIndexDirection( index1, dir ) )
-                    return dir;
+    if ( !isValidIndex( index1 ) || !isValidIndex( index2 ) ) {
+        return UNKNOWN;
+    }
+
+    if ( index1 == index2 ) {
+        return CENTER;
+    }
+
+    for ( direction_t dir = TOP_LEFT; dir < CENTER; ++dir ) {
+        if ( isValidDirection( index1, dir ) && index2 == GetIndexDirection( index1, dir ) ) {
+            return dir;
+        }
     }
 
     return UNKNOWN;
 }
 
-bool Battle::Board::isNearIndexes( int32_t index1, int32_t index2 )
+bool Battle::Board::isNearIndexes( const int32_t index1, const int32_t index2 )
 {
     return index1 != index2 && UNKNOWN != GetDirection( index1, index2 );
 }
 
-int Battle::Board::GetReflectDirection( int d )
+int Battle::Board::GetReflectDirection( const int dir )
 {
-    switch ( d ) {
+    switch ( dir ) {
     case TOP_LEFT:
         return BOTTOM_RIGHT;
     case TOP_RIGHT:
@@ -332,75 +337,80 @@ bool Battle::Board::IsLeftDirection( const int32_t startCellId, const int32_t en
     const int startX = startCellId % ARENAW;
     const int endX = endCellId % ARENAW;
 
-    if ( prevLeftDirection )
+    if ( prevLeftDirection ) {
         return endX <= startX;
-    else
-        return endX < startX;
+    }
+
+    return endX < startX;
 }
 
-bool Battle::Board::isNegativeDistance( int32_t index1, int32_t index2 )
+bool Battle::Board::isNegativeDistance( const int32_t index1, const int32_t index2 )
 {
     return ( index1 % ARENAW ) - ( index2 % ARENAW ) < 0;
 }
 
-int Battle::Board::DistanceFromOriginX( int32_t index, bool reflect )
+int Battle::Board::DistanceFromOriginX( const int32_t index, const bool reflect )
 {
     const int xPos = index % ARENAW;
     return std::max( 1, reflect ? ARENAW - xPos - 1 : xPos );
 }
 
-bool Battle::Board::isValidDirection( int32_t index, int dir )
+bool Battle::Board::isValidDirection( const int32_t index, const int dir )
 {
-    if ( isValidIndex( index ) ) {
-        const int32_t x = index % ARENAW;
-        const int32_t y = index / ARENAW;
+    if ( !isValidIndex( index ) ) {
+        return false;
+    }
 
-        switch ( dir ) {
-        case CENTER:
-            return true;
-        case TOP_LEFT:
-            return !( 0 == y || ( 0 == x && ( y % 2 ) ) );
-        case TOP_RIGHT:
-            return !( 0 == y || ( ( ARENAW - 1 ) == x && !( y % 2 ) ) );
-        case LEFT:
-            return !( 0 == x );
-        case RIGHT:
-            return !( ( ARENAW - 1 ) == x );
-        case BOTTOM_LEFT:
-            return !( ( ARENAH - 1 ) == y || ( 0 == x && ( y % 2 ) ) );
-        case BOTTOM_RIGHT:
-            return !( ( ARENAH - 1 ) == y || ( ( ARENAW - 1 ) == x && !( y % 2 ) ) );
-        default:
-            break;
-        }
+    const int32_t x = index % ARENAW;
+    const int32_t y = index / ARENAW;
+
+    switch ( dir ) {
+    case CENTER:
+        return true;
+    case TOP_LEFT:
+        return !( 0 == y || ( 0 == x && ( y % 2 ) ) );
+    case TOP_RIGHT:
+        return !( 0 == y || ( ( ARENAW - 1 ) == x && !( y % 2 ) ) );
+    case LEFT:
+        return !( 0 == x );
+    case RIGHT:
+        return !( ( ARENAW - 1 ) == x );
+    case BOTTOM_LEFT:
+        return !( ( ARENAH - 1 ) == y || ( 0 == x && ( y % 2 ) ) );
+    case BOTTOM_RIGHT:
+        return !( ( ARENAH - 1 ) == y || ( ( ARENAW - 1 ) == x && !( y % 2 ) ) );
+    default:
+        break;
     }
 
     return false;
 }
 
-int32_t Battle::Board::GetIndexDirection( int32_t index, int dir )
+int32_t Battle::Board::GetIndexDirection( const int32_t index, const int dir )
 {
-    if ( isValidIndex( index ) ) {
-        const int32_t y = index / ARENAW;
+    if ( !isValidIndex( index ) ) {
+        return -1;
+    }
 
-        switch ( dir ) {
-        case CENTER:
-            return index;
-        case TOP_LEFT:
-            return index - ( ( y % 2 ) ? ARENAW + 1 : ARENAW );
-        case TOP_RIGHT:
-            return index - ( ( y % 2 ) ? ARENAW : ARENAW - 1 );
-        case LEFT:
-            return index - 1;
-        case RIGHT:
-            return index + 1;
-        case BOTTOM_LEFT:
-            return index + ( ( y % 2 ) ? ARENAW - 1 : ARENAW );
-        case BOTTOM_RIGHT:
-            return index + ( ( y % 2 ) ? ARENAW : ARENAW + 1 );
-        default:
-            break;
-        }
+    const int32_t y = index / ARENAW;
+
+    switch ( dir ) {
+    case CENTER:
+        return index;
+    case TOP_LEFT:
+        return index - ( ( y % 2 ) ? ARENAW + 1 : ARENAW );
+    case TOP_RIGHT:
+        return index - ( ( y % 2 ) ? ARENAW : ARENAW - 1 );
+    case LEFT:
+        return index - 1;
+    case RIGHT:
+        return index + 1;
+    case BOTTOM_LEFT:
+        return index + ( ( y % 2 ) ? ARENAW - 1 : ARENAW );
+    case BOTTOM_RIGHT:
+        return index + ( ( y % 2 ) ? ARENAW : ARENAW + 1 );
+    default:
+        break;
     }
 
     return -1;
@@ -417,32 +427,32 @@ int32_t Battle::Board::GetIndexAbsPosition( const fheroes2::Point & pt ) const
     return it != end() ? ( *it ).GetIndex() : -1;
 }
 
-bool Battle::Board::isValidIndex( int32_t index )
+bool Battle::Board::isValidIndex( const int32_t index )
 {
     return 0 <= index && index < ARENASIZE;
 }
 
-bool Battle::Board::isCastleIndex( int32_t index )
+bool Battle::Board::isCastleIndex( const int32_t index )
 {
     return ( ( 8 < index && index <= 10 ) || ( 19 < index && index <= 21 ) || ( 29 < index && index <= 32 ) || ( 40 < index && index <= 43 )
              || ( 50 < index && index <= 54 ) || ( 62 < index && index <= 65 ) || ( 73 < index && index <= 76 ) || ( 85 < index && index <= 87 )
              || ( 96 < index && index <= 98 ) );
 }
 
-bool Battle::Board::isOutOfWallsIndex( int32_t index )
+bool Battle::Board::isOutOfWallsIndex( const int32_t index )
 {
     return ( ( index <= 8 ) || ( 11 <= index && index <= 19 ) || ( 22 <= index && index <= 29 ) || ( 33 <= index && index <= 40 ) || ( 44 <= index && index <= 50 )
              || ( 55 <= index && index <= 62 ) || ( 66 <= index && index <= 73 ) || ( 77 <= index && index <= 85 ) || ( 88 <= index && index <= 96 ) );
 }
 
-bool Battle::Board::isBridgeIndex( int32_t index, const Unit & b )
+bool Battle::Board::isBridgeIndex( const int32_t index, const Unit & unit )
 {
     const Bridge * bridge = Arena::GetBridge();
 
-    return ( index == 49 && !b.isFlying() && bridge && bridge->isPassable( b ) ) || index == 50;
+    return ( index == 49 && !unit.isFlying() && bridge && bridge->isPassable( unit ) ) || index == 50;
 }
 
-bool Battle::Board::isMoatIndex( int32_t index, const Unit & b )
+bool Battle::Board::isMoatIndex( const int32_t index, const Unit & unit )
 {
     switch ( index ) {
     case 7:
@@ -456,7 +466,7 @@ bool Battle::Board::isMoatIndex( int32_t index, const Unit & b )
         return true;
     case 49: {
         const Bridge * bridge = Arena::GetBridge();
-        return b.isFlying() || bridge == nullptr || !bridge->isPassable( b );
+        return unit.isFlying() || bridge == nullptr || !bridge->isPassable( unit );
     }
 
     default:
@@ -708,124 +718,194 @@ void Battle::Board::SetCovrObjects( int icn )
     }
 }
 
-Battle::Cell * Battle::Board::GetCell( int32_t position, int dir )
+Battle::Cell * Battle::Board::GetCell( const int32_t position, const int dir /* = CENTER */ )
 {
-    if ( isValidIndex( position ) && dir != UNKNOWN ) {
-        Board * board = Arena::GetBoard();
-        if ( dir == CENTER ) {
-            return &board->at( position );
-        }
-        if ( isValidDirection( position, dir ) ) {
-            return &board->at( GetIndexDirection( position, dir ) );
-        }
+    if ( !isValidDirection( position, dir ) ) {
+        return nullptr;
     }
 
-    return nullptr;
+    Board * board = Arena::GetBoard();
+    assert( board != nullptr );
+
+    const int32_t idx = GetIndexDirection( position, dir );
+    assert( isValidIndex( idx ) );
+
+    return &board->at( idx );
 }
 
-Battle::Indexes Battle::Board::GetMoveWideIndexes( int32_t center, bool reflect )
+Battle::Indexes Battle::Board::GetMoveWideIndexes( const int32_t head, const bool reflect )
 {
+    if ( !isValidIndex( head ) ) {
+        return {};
+    }
+
     Indexes result;
+    result.reserve( 4 );
 
-    if ( isValidIndex( center ) ) {
-        result.reserve( 4 );
+    if ( isValidDirection( head, LEFT ) ) {
+        result.push_back( GetIndexDirection( head, LEFT ) );
+    }
+    if ( isValidDirection( head, RIGHT ) ) {
+        result.push_back( GetIndexDirection( head, RIGHT ) );
+    }
 
-        if ( reflect ) {
-            if ( isValidDirection( center, LEFT ) )
-                result.push_back( GetIndexDirection( center, LEFT ) );
-            if ( isValidDirection( center, RIGHT ) )
-                result.push_back( GetIndexDirection( center, RIGHT ) );
-            if ( isValidDirection( center, TOP_LEFT ) )
-                result.push_back( GetIndexDirection( center, TOP_LEFT ) );
-            if ( isValidDirection( center, BOTTOM_LEFT ) )
-                result.push_back( GetIndexDirection( center, BOTTOM_LEFT ) );
+    if ( reflect ) {
+        if ( isValidDirection( head, TOP_LEFT ) ) {
+            result.push_back( GetIndexDirection( head, TOP_LEFT ) );
         }
-        else {
-            if ( isValidDirection( center, LEFT ) )
-                result.push_back( GetIndexDirection( center, LEFT ) );
-            if ( isValidDirection( center, RIGHT ) )
-                result.push_back( GetIndexDirection( center, RIGHT ) );
-            if ( isValidDirection( center, TOP_RIGHT ) )
-                result.push_back( GetIndexDirection( center, TOP_RIGHT ) );
-            if ( isValidDirection( center, BOTTOM_RIGHT ) )
-                result.push_back( GetIndexDirection( center, BOTTOM_RIGHT ) );
+        if ( isValidDirection( head, BOTTOM_LEFT ) ) {
+            result.push_back( GetIndexDirection( head, BOTTOM_LEFT ) );
         }
     }
-    return result;
-}
-
-Battle::Indexes Battle::Board::GetAroundIndexes( int32_t center, int32_t ignore )
-{
-    Indexes result;
-
-    if ( isValidIndex( center ) ) {
-        result.reserve( 12 );
-
-        for ( direction_t dir = TOP_LEFT; dir < CENTER; ++dir )
-            if ( isValidDirection( center, dir ) && GetIndexDirection( center, dir ) != ignore )
-                result.push_back( GetIndexDirection( center, dir ) );
+    else {
+        if ( isValidDirection( head, TOP_RIGHT ) ) {
+            result.push_back( GetIndexDirection( head, TOP_RIGHT ) );
+        }
+        if ( isValidDirection( head, BOTTOM_RIGHT ) ) {
+            result.push_back( GetIndexDirection( head, BOTTOM_RIGHT ) );
+        }
     }
 
     return result;
 }
 
-Battle::Indexes Battle::Board::GetAroundIndexes( const Unit & b )
+Battle::Indexes Battle::Board::GetAroundIndexes( const int32_t center )
 {
-    return GetAroundIndexes( b.GetPosition() );
+    if ( !isValidIndex( center ) ) {
+        return {};
+    }
+
+    Indexes result;
+    result.reserve( 6 );
+
+    for ( direction_t dir = TOP_LEFT; dir < CENTER; ++dir ) {
+        if ( !isValidDirection( center, dir ) ) {
+            continue;
+        }
+
+        result.push_back( GetIndexDirection( center, dir ) );
+    }
+
+    return result;
+}
+
+Battle::Indexes Battle::Board::GetAroundIndexes( const Unit & unit )
+{
+    return GetAroundIndexes( unit.GetPosition() );
 }
 
 Battle::Indexes Battle::Board::GetAroundIndexes( const Position & position )
 {
-    const int headIdx = position.GetHead()->GetIndex();
-
-    if ( position.GetTail() ) {
-        const int tailIdx = position.GetTail()->GetIndex();
-
-        Indexes around = GetAroundIndexes( headIdx, tailIdx );
-        const Indexes & tail = GetAroundIndexes( tailIdx, headIdx );
-        around.insert( around.end(), tail.begin(), tail.end() );
-
-        std::sort( around.begin(), around.end() );
-        around.erase( std::unique( around.begin(), around.end() ), around.end() );
-
-        return around;
+    if ( position.GetHead() == nullptr ) {
+        return {};
     }
 
-    return GetAroundIndexes( headIdx );
+    const int32_t headIdx = position.GetHead()->GetIndex();
+
+    if ( position.GetTail() == nullptr ) {
+        return GetAroundIndexes( headIdx );
+    }
+
+    const int32_t tailIdx = position.GetTail()->GetIndex();
+
+    if ( !isValidIndex( headIdx ) || !isValidIndex( tailIdx ) ) {
+        return {};
+    }
+
+    Indexes result;
+    result.reserve( 8 );
+
+    // Traversing cells in a clockwise direction
+    if ( headIdx > tailIdx ) {
+        if ( isValidDirection( tailIdx, TOP_LEFT ) ) {
+            result.push_back( GetIndexDirection( tailIdx, TOP_LEFT ) );
+        }
+        if ( isValidDirection( tailIdx, TOP_RIGHT ) ) {
+            result.push_back( GetIndexDirection( tailIdx, TOP_RIGHT ) );
+        }
+        if ( isValidDirection( headIdx, TOP_RIGHT ) ) {
+            result.push_back( GetIndexDirection( headIdx, TOP_RIGHT ) );
+        }
+        if ( isValidDirection( headIdx, RIGHT ) ) {
+            result.push_back( GetIndexDirection( headIdx, RIGHT ) );
+        }
+        if ( isValidDirection( headIdx, BOTTOM_RIGHT ) ) {
+            result.push_back( GetIndexDirection( headIdx, BOTTOM_RIGHT ) );
+        }
+        if ( isValidDirection( tailIdx, BOTTOM_RIGHT ) ) {
+            result.push_back( GetIndexDirection( tailIdx, BOTTOM_RIGHT ) );
+        }
+        if ( isValidDirection( tailIdx, BOTTOM_LEFT ) ) {
+            result.push_back( GetIndexDirection( tailIdx, BOTTOM_LEFT ) );
+        }
+        if ( isValidDirection( tailIdx, LEFT ) ) {
+            result.push_back( GetIndexDirection( tailIdx, LEFT ) );
+        }
+    }
+    else if ( headIdx < tailIdx ) {
+        if ( isValidDirection( headIdx, TOP_LEFT ) ) {
+            result.push_back( GetIndexDirection( headIdx, TOP_LEFT ) );
+        }
+        if ( isValidDirection( headIdx, TOP_RIGHT ) ) {
+            result.push_back( GetIndexDirection( headIdx, TOP_RIGHT ) );
+        }
+        if ( isValidDirection( tailIdx, TOP_RIGHT ) ) {
+            result.push_back( GetIndexDirection( tailIdx, TOP_RIGHT ) );
+        }
+        if ( isValidDirection( tailIdx, RIGHT ) ) {
+            result.push_back( GetIndexDirection( tailIdx, RIGHT ) );
+        }
+        if ( isValidDirection( tailIdx, BOTTOM_RIGHT ) ) {
+            result.push_back( GetIndexDirection( tailIdx, BOTTOM_RIGHT ) );
+        }
+        if ( isValidDirection( headIdx, BOTTOM_RIGHT ) ) {
+            result.push_back( GetIndexDirection( headIdx, BOTTOM_RIGHT ) );
+        }
+        if ( isValidDirection( headIdx, BOTTOM_LEFT ) ) {
+            result.push_back( GetIndexDirection( headIdx, BOTTOM_LEFT ) );
+        }
+        if ( isValidDirection( headIdx, LEFT ) ) {
+            result.push_back( GetIndexDirection( headIdx, LEFT ) );
+        }
+    }
+
+    return result;
 }
 
-Battle::Indexes Battle::Board::GetDistanceIndexes( int32_t center, uint32_t radius )
+Battle::Indexes Battle::Board::GetDistanceIndexes( const int32_t center, const uint32_t radius )
 {
+    if ( !isValidIndex( center ) ) {
+        return {};
+    }
+
+    const int32_t centerX = center % ARENAW;
+    const int32_t centerY = center / ARENAW;
+
+    // Axial coordinates
+    const int32_t centerQ = centerX - ( centerY + centerY % 2 ) / 2;
+    const int32_t centerR = centerY;
+
+    const int32_t intRadius = radius;
+
     Indexes result;
 
-    if ( isValidIndex( center ) ) {
-        std::set<int32_t> st;
-        Indexes abroad;
+    for ( int32_t dq = -intRadius; dq <= intRadius; ++dq ) {
+        for ( int32_t dr = std::max( -intRadius, -intRadius - dq ); dr <= std::min( intRadius, intRadius - dq ); ++dr ) {
+            const int32_t q = centerQ + dq;
+            const int32_t r = centerR + dr;
 
-        st.insert( center );
-        abroad.push_back( center );
+            const int32_t x = q + ( r + r % 2 ) / 2;
+            const int32_t y = r;
 
-        while ( !abroad.empty() && radius ) {
-            std::set<int32_t> tm = st;
-
-            for ( Indexes::const_iterator it = abroad.begin(); it != abroad.end(); ++it ) {
-                const Indexes around = GetAroundIndexes( *it );
-                tm.insert( around.begin(), around.end() );
+            if ( x < 0 || x >= ARENAW || y < 0 || y >= ARENAH ) {
+                continue;
             }
 
-            abroad.resize( tm.size() );
+            const int32_t idx = y * ARENAW + x;
+            assert( isValidIndex( idx ) );
 
-            Indexes::iterator abroad_end = std::set_difference( tm.begin(), tm.end(), st.begin(), st.end(), abroad.begin() );
-
-            abroad.resize( std::distance( abroad.begin(), abroad_end ) );
-
-            st.swap( tm );
-            --radius;
+            result.push_back( idx );
         }
-
-        st.erase( center );
-        result.reserve( st.size() );
-        std::copy( st.begin(), st.end(), std::back_inserter( result ) );
     }
 
     return result;

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -26,7 +26,6 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
-#include <iterator>
 #include <memory>
 #include <ostream>
 #include <set>

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -80,29 +80,29 @@ namespace Battle
 
         static std::string GetMoatInfo();
 
-        static Cell * GetCell( int32_t position, int dir = CENTER );
-        static bool isNearIndexes( int32_t, int32_t );
-        static bool isValidIndex( int32_t );
-        static bool isCastleIndex( int32_t );
-        static bool isMoatIndex( int32_t index, const Unit & b );
-        static bool isBridgeIndex( int32_t index, const Unit & b );
-        static bool isOutOfWallsIndex( int32_t );
+        static Cell * GetCell( const int32_t position, const int dir = CENTER );
+        static bool isNearIndexes( const int32_t index1, const int32_t index2 );
+        static bool isValidIndex( const int32_t index );
+        static bool isCastleIndex( const int32_t index );
+        static bool isMoatIndex( const int32_t index, const Unit & unit );
+        static bool isBridgeIndex( const int32_t index, const Unit & unit );
+        static bool isOutOfWallsIndex( const int32_t index );
         static bool IsLeftDirection( const int32_t startCellId, const int32_t endCellId, const bool prevLeftDirection );
-        static bool isNegativeDistance( int32_t index1, int32_t index2 );
-        static int DistanceFromOriginX( int32_t index, bool reflect );
-        static int GetReflectDirection( int );
-        static int GetDirection( int32_t, int32_t );
+        static bool isNegativeDistance( const int32_t index1, const int32_t index2 );
+        static int DistanceFromOriginX( const int32_t index, const bool reflect );
+        static int GetReflectDirection( const int dir );
+        static int GetDirection( const int32_t index1, const int32_t index2 );
         static int32_t DoubleCellAttackValue( const Unit & attacker, const Unit & target, const int32_t from, const int32_t targetCell );
         static int32_t OptimalAttackTarget( const Unit & attacker, const Unit & target, const int32_t from );
         static int32_t OptimalAttackValue( const Unit & attacker, const Unit & target, const int32_t from );
         static uint32_t GetDistance( int32_t, int32_t );
-        static bool isValidDirection( int32_t, int );
-        static int32_t GetIndexDirection( int32_t, int );
-        static Indexes GetDistanceIndexes( int32_t, uint32_t );
-        static Indexes GetAroundIndexes( int32_t center, int32_t ignore = -1 );
+        static bool isValidDirection( const int32_t index, const int dir );
+        static int32_t GetIndexDirection( const int32_t index, const int dir );
+        static Indexes GetDistanceIndexes( const int32_t center, const uint32_t radius );
+        static Indexes GetAroundIndexes( const int32_t center );
         static Indexes GetAroundIndexes( const Unit & unit );
         static Indexes GetAroundIndexes( const Position & position );
-        static Indexes GetMoveWideIndexes( int32_t, bool reflect );
+        static Indexes GetMoveWideIndexes( const int32_t head, const bool reflect );
         static bool isValidMirrorImageIndex( const int32_t index, const Unit * unit );
 
         // Checks that the current unit (to which the current pathfinder graph relates) is able (in principle)

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -105,10 +105,10 @@ namespace Battle
         static Indexes GetMoveWideIndexes( int32_t, bool reflect );
         static bool isValidMirrorImageIndex( const int32_t index, const Unit * unit );
 
-        // Checks that the current unit (to which the current passability information relates) is able (in principle)
+        // Checks that the current unit (to which the current pathfinder graph relates) is able (in principle)
         // to attack during the current turn from the cell with the given index
         static bool CanAttackFromCell( const Unit & currentUnit, const int32_t from );
-        // Checks that the current unit (to which the current passability information relates) is able to attack the
+        // Checks that the current unit (to which the current pathfinder graph relates) is able to attack the
         // target during the current turn from the position which corresponds to the given index
         static bool CanAttackTargetFromPosition( const Unit & currentUnit, const Unit & target, const int32_t dst );
 

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -71,11 +71,9 @@ namespace Battle
 
         int32_t GetIndexAbsPosition( const fheroes2::Point & ) const;
         std::vector<Unit *> GetNearestTroops( const Unit * startUnit, const std::vector<Unit *> & blackList );
-        Indexes GetPath( const Unit & unit, const Position & destination, const bool debug = true ) const;
 
         void SetEnemyQuality( const Unit & ) const;
         void SetPositionQuality( const Unit & ) const;
-        void SetScanPassability( const Unit & );
 
         void SetCobjObjects( const Maps::Tiles & tile, std::mt19937 & gen );
         void SetCovrObjects( int icn );
@@ -108,22 +106,16 @@ namespace Battle
         static bool isValidMirrorImageIndex( const int32_t index, const Unit * unit );
 
         // Checks that the current unit (to which the current passability information relates) is able (in principle)
-        // to attack from the cell with the given index
+        // to attack during the current turn from the cell with the given index
         static bool CanAttackFromCell( const Unit & currentUnit, const int32_t from );
         // Checks that the current unit (to which the current passability information relates) is able to attack the
-        // target from the position which corresponds to the given index
+        // target during the current turn from the position which corresponds to the given index
         static bool CanAttackTargetFromPosition( const Unit & currentUnit, const Unit & target, const int32_t dst );
 
         static Indexes GetAdjacentEnemies( const Unit & unit );
 
     private:
         void SetCobjObject( const int icn, const int32_t dst );
-
-        bool GetPathForUnit( const Unit & unit, const Position & destination, const uint32_t remainingSteps, const int32_t currentCellId,
-                             std::vector<bool> & visitedCells, Indexes & result ) const;
-        bool GetPathForWideUnit( const Unit & unit, const Position & destination, const uint32_t remainingSteps, const int32_t currentHeadCellId,
-                                 const int32_t prevHeadCellId, std::vector<bool> & visitedCells, Indexes & result ) const;
-        void StraightenPathForUnit( const int32_t currentCellId, Indexes & path ) const;
     };
 }
 

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -188,13 +188,13 @@ Battle::Position Battle::Position::GetReachable( const Unit & currentUnit, const
             return {};
         };
 
-        Position result = tryHead();
+        Position headPos = tryHead();
 
-        if ( result.GetHead() == nullptr || result.GetTail() == nullptr ) {
-            result = tryTail();
+        if ( headPos.GetHead() != nullptr && headPos.GetTail() != nullptr ) {
+            return headPos;
         }
 
-        return result;
+        return tryTail();
     }
 
     Cell * headCell = Board::GetCell( dst );

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -108,15 +108,15 @@ namespace Battle
         bool isReflect() const;
         bool contains( int cellIndex ) const;
 
-        // Returns the position that the given unit would occupy after moving to the
-        // cell with the given index (without taking into account the cell passability
-        // information) or an empty Position object if the given index is unreachable
-        // in principle for the given unit
+        // Returns the position that the given unit would occupy after moving to the cell
+        // with the given index (without taking into account the current pathfinder graph)
+        // or an empty Position object if the given index is unreachable in principle for
+        // the given unit
         static Position GetPosition( const Unit & unit, const int32_t dst );
 
         // Returns the reachable position for the current unit (to which the current
-        // passability information relates) which corresponds to the given index or an
-        // empty Position object if the given index is unreachable on the current turn
+        // pathfinder graph relates) which corresponds to the given index or an empty
+        // Position object if the given index is unreachable on the current turn
         static Position GetReachable( const Unit & currentUnit, const int32_t dst );
 
         fheroes2::Rect GetRect() const;

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -62,18 +62,11 @@ namespace Battle
         Cell & operator=( Cell && ) = delete;
 
         void ResetQuality();
-        void resetReachability();
 
         void SetObject( int );
         void SetQuality( uint32_t );
 
-        void setReachableForHead();
-        void setReachableForTail();
-
         void SetArea( const fheroes2::Rect & );
-
-        bool isReachableForHead() const;
-        bool isReachableForTail() const;
 
         // Checks that the cell is passable for the given unit located in a certain adjacent cell
         bool isPassableFromAdjacent( const Unit & unit, const Cell & adjacent ) const;
@@ -98,8 +91,6 @@ namespace Battle
         int32_t index;
         fheroes2::Rect pos;
         int object;
-        bool _reachableForHead;
-        bool _reachableForTail;
         int32_t quality;
         Unit * troop;
         fheroes2::Point coord[7];
@@ -120,12 +111,13 @@ namespace Battle
         // Returns the position that the given unit would occupy after moving to the
         // cell with the given index (without taking into account the cell passability
         // information) or an empty Position object if the given index is unreachable
+        // in principle for the given unit
         static Position GetPosition( const Unit & unit, const int32_t dst );
 
         // Returns the reachable position for the current unit (to which the current
-        // passability information relates) which corresponds to the given index or
-        // an empty Position object if the given index is unreachable
-        static Position GetReachable( const Unit & currentUnit, const int32_t dst, const bool tryHeadFirst = true );
+        // passability information relates) which corresponds to the given index or an
+        // empty Position object if the given index is unreachable on the current turn
+        static Position GetReachable( const Unit & currentUnit, const int32_t dst );
 
         fheroes2::Rect GetRect() const;
         Cell * GetHead();

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -110,7 +110,7 @@ namespace Battle
         nodesToExplore.push_back( _pathStart );
 
         for ( size_t nodesToExploreIdx = 0; nodesToExploreIdx < nodesToExplore.size(); ++nodesToExploreIdx ) {
-            const BattleNodeIndex & currentNodeIdx = nodesToExplore[nodesToExploreIdx];
+            const BattleNodeIndex currentNodeIdx = nodesToExplore[nodesToExploreIdx];
             const BattleNode & currentNode = _cache[currentNodeIdx];
 
             if ( isUnitWide ) {

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -81,7 +81,7 @@ namespace Battle
             return;
         }
 
-        // The index of that of the cells of the initial position of the block, which is located
+        // The index of that of the cells of the initial unit's position, which is located
         // in the moat (-1, if there is none)
         const int32_t pathStartMoatIndex = [this, &unit, isMoatBuilt, isUnitWide]() {
             if ( !isMoatBuilt ) {

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -31,6 +31,7 @@
 #include "battle_pathfinding.h"
 #include "battle_troop.h"
 #include "castle.h"
+#include "speed.h"
 
 namespace
 {
@@ -265,6 +266,7 @@ namespace Battle
         const BattleNodeIndex targetNodeIdx = { position.GetHead()->GetIndex(), position.GetTail() ? position.GetTail()->GetIndex() : -1 };
 
         Indexes result;
+        result.reserve( Speed::INSTANT );
 
         BattleNodeIndex nodeIdx = targetNodeIdx;
         for ( auto iter = _cache.find( nodeIdx ); iter != _cache.end(); iter = _cache.find( nodeIdx ) ) {

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -222,11 +222,11 @@ namespace Battle
         const BattleNodeIndex nodeIdx = { position.GetHead()->GetIndex(), position.GetTail() ? position.GetTail()->GetIndex() : -1 };
 
         const auto iter = _cache.find( nodeIdx );
-        if ( iter == _cache.end() ) {
-            return UINT32_MAX;
-        }
+        assert( iter != _cache.end() );
 
-        const auto & [dummy, node] = *iter;
+        const auto & [index, node] = *iter;
+        // MSVC 2017 fails to expand the assert() macro without additional parentheses
+        assert( ( index == _pathStart || node._from != BattleNodeIndex{ -1, -1 } ) );
 
         return node._cost;
     }

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -248,7 +248,7 @@ namespace Battle
         Indexes result;
         result.reserve( boardIndexes.size() );
 
-        std::for_each( boardIndexes.cbegin(), boardIndexes.cend(), [&result]( const int32_t idx ) { result.push_back( idx ); } );
+        std::for_each( boardIndexes.begin(), boardIndexes.end(), [&result]( const int32_t idx ) { result.push_back( idx ); } );
 
         return result;
     }

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -84,7 +84,7 @@ namespace Battle
 
         // The index of that of the cells of the initial unit's position, which is located
         // in the moat (-1, if there is none)
-        const int32_t pathStartMoatIndex = [this, &unit, isMoatBuilt, isUnitWide]() {
+        const int32_t pathStartMoatCellIdx = [this, &unit, isMoatBuilt, isUnitWide]() {
             if ( !isMoatBuilt ) {
                 return -1;
             }
@@ -124,12 +124,12 @@ namespace Battle
                 const Cell * currentHeadCell = Board::GetCell( currentHeadCellIdx );
                 assert( currentHeadCell != nullptr );
 
-                const bool isCurrentLeftDirection = ( Board::GetDirection( currentTailCellIdx, currentHeadCellIdx ) & LEFT_SIDE ) != 0;
+                const bool isCurrentLeftDirection = ( ( Board::GetDirection( currentTailCellIdx, currentHeadCellIdx ) & LEFT_SIDE ) != 0 );
                 // The moat restrictions can be ignored if the wide unit originally occupied a moat cell, and at the current step any part
                 // of this unit occupies the same moat cell
-                const bool isIgnoreMoat = currentHeadCellIdx == pathStartMoatIndex || currentTailCellIdx == pathStartMoatIndex;
+                const bool isIgnoreMoat = ( currentHeadCellIdx == pathStartMoatCellIdx || currentTailCellIdx == pathStartMoatCellIdx );
                 const bool isInMoat = isMoatBuilt && ( Board::isMoatIndex( currentHeadCellIdx, unit ) || Board::isMoatIndex( currentTailCellIdx, unit ) );
-                const uint32_t movementPenalty = !isIgnoreMoat && isInMoat ? MOAT_PENALTY : 1;
+                const uint32_t movementPenalty = ( !isIgnoreMoat && isInMoat ) ? MOAT_PENALTY : 1;
 
                 for ( const int32_t headCellIdx : Board::GetMoveWideIndexes( currentHeadCellIdx, isCurrentLeftDirection ) ) {
                     const Cell * cell = Board::GetCell( headCellIdx );
@@ -169,9 +169,9 @@ namespace Battle
                 assert( currentCell != nullptr );
 
                 // The moat restrictions can be ignored at the first step if the unit starts its movement from the moat
-                const bool isIgnoreMoat = currentCellIdx == pathStartMoatIndex;
+                const bool isIgnoreMoat = ( currentCellIdx == pathStartMoatCellIdx );
                 const bool isInMoat = isMoatBuilt && Board::isMoatIndex( currentCellIdx, unit );
-                const uint32_t movementPenalty = !isIgnoreMoat && isInMoat ? MOAT_PENALTY : 1;
+                const uint32_t movementPenalty = ( !isIgnoreMoat && isInMoat ) ? MOAT_PENALTY : 1;
 
                 for ( const int32_t cellIdx : Board::GetAroundIndexes( currentCellIdx ) ) {
                     const Cell * cell = Board::GetCell( cellIdx );

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -106,7 +106,8 @@ namespace Battle
         }();
 
         std::vector<BattleNodeIndex> nodesToExplore;
-        nodesToExplore.reserve( ARENASIZE );
+
+        nodesToExplore.reserve( ARENASIZE * 2 );
         nodesToExplore.push_back( _pathStart );
 
         for ( size_t nodesToExploreIdx = 0; nodesToExploreIdx < nodesToExplore.size(); ++nodesToExploreIdx ) {
@@ -250,9 +251,9 @@ namespace Battle
         }
 
         Indexes result;
-        result.reserve( boardIndexes.size() );
 
-        std::for_each( boardIndexes.begin(), boardIndexes.end(), [&result]( const int32_t idx ) { result.push_back( idx ); } );
+        result.reserve( boardIndexes.size() );
+        result.assign( boardIndexes.begin(), boardIndexes.end() );
 
         return result;
     }

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2022                                             *
+ *   Copyright (C) 2020 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,267 +22,266 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <memory>
-#include <ostream>
+#include <set>
+#include <type_traits>
 #include <vector>
 
 #include "battle_arena.h"
-#include "battle_bridge.h"
+#include "battle_cell.h"
 #include "battle_pathfinding.h"
 #include "battle_troop.h"
 #include "castle.h"
-#include "logging.h"
+
+namespace
+{
+    const uint32_t MOAT_PENALTY = UINT16_MAX;
+}
 
 namespace Battle
 {
-    void BattleNode::resetNode()
+    void BattlePathfinder::evaluateForUnit( const Unit & unit )
     {
-        _from = -1;
-        _cost = MAX_MOVE_COST;
-        _objectID = 0;
-        _isOpen = true;
-        _isLeftDirection = false;
-    }
+        assert( unit.GetHeadIndex() != -1 && ( !unit.isWide() || unit.GetTailIndex() != -1 ) );
 
-    AIBattlePathfinder::AIBattlePathfinder()
-    {
-        _cache.resize( ARENASIZE );
-    }
+        const Castle * castle = Arena::GetCastle();
+        const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
+        const bool isUnitWide = unit.isWide();
 
-    void AIBattlePathfinder::reset()
-    {
-        _start.Set( -1, false, false );
-        for ( size_t i = 0; i < _cache.size(); ++i ) {
-            _cache[i].resetNode();
-        }
-    }
+        _pathStart = { unit.GetHeadIndex(), unit.GetTailIndex() };
+        _unitSpeed = unit.GetSpeed();
 
-    bool AIBattlePathfinder::hexIsPassable( int targetCell ) const
-    {
-        const size_t index = static_cast<size_t>( targetCell );
-        return index < _cache.size() && nodeIsPassable( _cache[index] );
-    }
+        _cache.clear();
+        _cache[_pathStart] = { { -1, -1 }, 0 };
 
-    bool AIBattlePathfinder::nodeIsPassable( const BattleNode & node ) const
-    {
-        return node._cost == 0 || ( node._isOpen && node._from != -1 );
-    }
+        // Flying units can land wherever they can fit
+        if ( unit.isFlying() ) {
+            const Board * board = Arena::GetBoard();
+            assert( board != nullptr );
 
-    Indexes AIBattlePathfinder::getAllAvailableMoves( uint32_t moveRange ) const
-    {
-        Indexes result;
-        result.reserve( moveRange * 2u );
+            for ( const Cell & cell : *board ) {
+                const Position pos = Position::GetPosition( unit, cell.GetIndex() );
 
-        for ( size_t index = 0; index < _cache.size(); ++index ) {
-            const BattleNode & node = _cache[index];
-            if ( nodeIsPassable( node ) && node._cost <= moveRange ) {
-                result.push_back( static_cast<int>( index ) );
+                if ( pos.GetHead() == nullptr ) {
+                    continue;
+                }
+
+                assert( !unit.isWide() || pos.GetTail() != nullptr );
+
+                const int32_t headCellIdx = pos.GetHead()->GetIndex();
+                const int32_t tailCellIdx = pos.GetTail() ? pos.GetTail()->GetIndex() : -1;
+
+                const BattleNodeIndex newNodeIdx = { headCellIdx, tailCellIdx };
+                if ( newNodeIdx == _pathStart ) {
+                    continue;
+                }
+
+                _cache.try_emplace( newNodeIdx, _pathStart, 1 );
             }
-        }
-        return result;
-    }
 
-    Indexes AIBattlePathfinder::buildPath( int targetCell ) const
-    {
-        Indexes path;
-
-        if ( static_cast<size_t>( targetCell ) >= _cache.size() )
-            return path;
-
-        int currentNode = targetCell;
-        while ( _cache[currentNode]._cost != 0 && !_start.contains( currentNode ) ) {
-            const BattleNode & node = _cache[currentNode];
-            path.push_back( currentNode );
-            currentNode = node._from;
-        }
-        std::reverse( path.begin(), path.end() );
-
-        return path;
-    }
-
-    Indexes AIBattlePathfinder::findTwoMovesOverlap( int targetCell, uint32_t movementRange ) const
-    {
-        Indexes path;
-        if ( static_cast<size_t>( targetCell ) >= _cache.size() )
-            return path;
-
-        const uint32_t pathCost = _cache[targetCell]._cost;
-        if ( pathCost >= movementRange * 2 )
-            return path;
-
-        int currentNode = targetCell;
-        uint32_t nodeCost = pathCost;
-
-        while ( nodeCost != 0 && !_start.contains( currentNode ) ) {
-            const BattleNode & node = _cache[currentNode];
-            // Upper limit
-            if ( movementRange == 0 || node._cost <= movementRange ) {
-                path.push_back( currentNode );
-            }
-            currentNode = node._from;
-            nodeCost = _cache[currentNode]._cost;
-
-            // Lower limit
-            if ( movementRange > 0 && !path.empty() && pathCost - nodeCost >= movementRange )
-                break;
-        }
-        std::reverse( path.begin(), path.end() );
-
-        return path;
-    }
-
-    void AIBattlePathfinder::calculate( const Unit & unit )
-    {
-        reset();
-
-        const bool unitIsWide = unit.isWide();
-
-        _start = unit.GetPosition();
-        const Cell * unitHead = _start.GetHead();
-        const Cell * unitTail = _start.GetTail();
-        if ( !unitHead || ( unitIsWide && !unitTail ) ) {
-            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Pathfinder: Invalid unit is passed in! " << unit.GetName() )
             return;
         }
 
-        const Bridge * bridge = Arena::GetBridge();
-        const Castle * castle = Arena::GetCastle();
+        // The index of that of the cells of the initial position of the block, which is located
+        // in the moat (-1, if there is none)
+        const int32_t pathStartMoatIndex = [this, &unit, isMoatBuilt, isUnitWide]() {
+            if ( !isMoatBuilt ) {
+                return -1;
+            }
 
-        const bool isPassableBridge = bridge == nullptr || bridge->isPassable( unit );
-        const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
-        const uint32_t moatPenalty = unit.GetSpeed();
+            assert( _pathStart.first != -1 );
 
-        // Initialize the starting cells
-        const int32_t pathStart = unitHead->GetIndex();
-        _cache[pathStart]._cost = 0;
-        _cache[pathStart]._isOpen = false;
-        _cache[pathStart]._isLeftDirection = unitIsWide && unit.isReflect();
+            if ( Board::isMoatIndex( _pathStart.first, unit ) ) {
+                return _pathStart.first;
+            }
 
-        if ( unitIsWide ) {
-            const int32_t tailIdx = unitTail->GetIndex();
-            _cache[tailIdx]._from = pathStart;
-            _cache[tailIdx]._cost = 0;
-            _cache[tailIdx]._isOpen = true;
-            _cache[tailIdx]._isLeftDirection = !unit.isReflect();
-        }
+            if ( isUnitWide ) {
+                assert( _pathStart.second != -1 );
 
-        if ( unit.isFlying() ) {
-            const Board & board = *Arena::GetBoard();
-
-            // Find all free spaces on the battle board - flyers can move to any of them
-            for ( const Cell & cell : board ) {
-                const int32_t idx = cell.GetIndex();
-                BattleNode & node = _cache[idx];
-
-                // isPassableForUnit checks if there's space for unit tail (for wide units)
-                if ( cell.isPassableForUnit( unit ) && ( isPassableBridge || !Board::isBridgeIndex( idx, unit ) ) ) {
-                    node._isOpen = true;
-                    node._from = pathStart;
-                    node._cost = Board::GetDistance( pathStart, idx );
-                }
-                else {
-                    node._isOpen = false;
+                if ( Board::isMoatIndex( _pathStart.second, unit ) ) {
+                    return _pathStart.second;
                 }
             }
 
-            // As soon as the possibilities of movement on the board are determined, we look
-            // for units to determine the shortest flight path to them
-            for ( const Cell & cell : board ) {
-                const Unit * boardUnit = cell.GetUnit();
+            return -1;
+        }();
 
-                if ( boardUnit && boardUnit->GetUID() != unit.GetUID() ) {
-                    const int32_t unitIdx = cell.GetIndex();
-                    BattleNode & unitNode = _cache[unitIdx];
+        std::vector<BattleNodeIndex> nodesToExplore;
+        nodesToExplore.reserve( ARENASIZE );
+        nodesToExplore.push_back( _pathStart );
 
-                    for ( const int32_t nearbyIdx : Board::GetAroundIndexes( unitIdx ) ) {
-                        const uint32_t flyingDist = Board::GetDistance( pathStart, nearbyIdx );
+        for ( size_t nodesToExploreIdx = 0; nodesToExploreIdx < nodesToExplore.size(); ++nodesToExploreIdx ) {
+            const BattleNodeIndex & currentNodeIdx = nodesToExplore[nodesToExploreIdx];
+            const BattleNode & currentNode = _cache[currentNodeIdx];
 
-                        if ( hexIsPassable( nearbyIdx ) && ( flyingDist < unitNode._cost ) ) {
-                            unitNode._isOpen = false;
-                            unitNode._from = nearbyIdx;
-                            unitNode._cost = flyingDist;
-                        }
+            if ( isUnitWide ) {
+                assert( currentNodeIdx.first != -1 && currentNodeIdx.second != -1 );
+
+                const auto [currentHeadCellIdx, currentTailCellIdx] = currentNodeIdx;
+                const BattleNodeIndex flippedCurrentNodeIdx = { currentTailCellIdx, currentHeadCellIdx };
+
+                const Cell * currentHeadCell = Board::GetCell( currentHeadCellIdx );
+                assert( currentHeadCell != nullptr );
+
+                const bool isCurrentLeftDirection = ( Board::GetDirection( currentTailCellIdx, currentHeadCellIdx ) & LEFT_SIDE ) != 0;
+                // The moat restrictions can be ignored if the wide unit originally occupied a moat cell, and at the current step any part
+                // of this unit occupies the same moat cell
+                const bool isIgnoreMoat = currentHeadCellIdx == pathStartMoatIndex || currentTailCellIdx == pathStartMoatIndex;
+                const bool isInMoat = isMoatBuilt && ( Board::isMoatIndex( currentHeadCellIdx, unit ) || Board::isMoatIndex( currentTailCellIdx, unit ) );
+                const uint32_t movementPenalty = !isIgnoreMoat && isInMoat ? MOAT_PENALTY : 1;
+
+                for ( const int32_t headCellIdx : Board::GetMoveWideIndexes( currentHeadCellIdx, isCurrentLeftDirection ) ) {
+                    const Cell * cell = Board::GetCell( headCellIdx );
+                    assert( cell != nullptr );
+
+                    if ( !cell->isPassableFromAdjacent( unit, *currentHeadCell ) ) {
+                        continue;
+                    }
+
+                    const int32_t tailCellIdx = ( Board::GetDirection( currentHeadCellIdx, headCellIdx ) & LEFT_SIDE ) ? headCellIdx + 1 : headCellIdx - 1;
+
+                    const BattleNodeIndex newNodeIdx = { headCellIdx, tailCellIdx };
+                    if ( newNodeIdx == _pathStart ) {
+                        continue;
+                    }
+
+                    // Turning back is not a movement
+                    const uint32_t movementCost = currentNode._cost + ( newNodeIdx == flippedCurrentNodeIdx ? 0 : movementPenalty );
+
+                    BattleNode & newNode = _cache.try_emplace( newNodeIdx, BattleNodeIndex{ -1, -1 }, 0 ).first->second;
+                    if ( newNode._from == BattleNodeIndex{ -1, -1 } || newNode._cost > movementCost ) {
+                        newNode._from = currentNodeIdx;
+                        newNode._cost = movementCost;
+
+                        nodesToExplore.push_back( newNodeIdx );
+                    }
+                }
+            }
+            else {
+                assert( currentNodeIdx.first != -1 && currentNodeIdx.second == -1 );
+
+                const auto [currentCellIdx, dummy] = currentNodeIdx;
+
+                const Cell * currentCell = Board::GetCell( currentCellIdx );
+                assert( currentCell != nullptr );
+
+                // The moat restrictions can be ignored at the first step if the unit starts its movement from the moat
+                const bool isIgnoreMoat = currentCellIdx == pathStartMoatIndex;
+                const bool isInMoat = isMoatBuilt && Board::isMoatIndex( currentCellIdx, unit );
+                const uint32_t movementPenalty = !isIgnoreMoat && isInMoat ? MOAT_PENALTY : 1;
+
+                for ( const int32_t cellIdx : Board::GetAroundIndexes( currentCellIdx ) ) {
+                    const Cell * cell = Board::GetCell( cellIdx );
+                    assert( cell != nullptr );
+
+                    if ( !cell->isPassableFromAdjacent( unit, *currentCell ) ) {
+                        continue;
+                    }
+
+                    const BattleNodeIndex newNodeIdx = { cellIdx, -1 };
+                    if ( newNodeIdx == _pathStart ) {
+                        continue;
+                    }
+
+                    const uint32_t movementCost = currentNode._cost + movementPenalty;
+
+                    BattleNode & newNode = _cache.try_emplace( newNodeIdx, BattleNodeIndex{ -1, -1 }, 0 ).first->second;
+                    if ( newNode._from == BattleNodeIndex{ -1, -1 } || newNode._cost > movementCost ) {
+                        newNode._from = currentNodeIdx;
+                        newNode._cost = movementCost;
+
+                        nodesToExplore.push_back( newNodeIdx );
                     }
                 }
             }
         }
-        // Walking units - explore the movements sequentially from both the head and tail cells
-        else {
-            std::vector<int32_t> nodesToExplore;
+    }
 
-            nodesToExplore.push_back( pathStart );
-            if ( unitIsWide ) {
-                nodesToExplore.push_back( unitTail->GetIndex() );
-            }
-
-            for ( size_t lastProcessedNode = 0; lastProcessedNode < nodesToExplore.size(); ++lastProcessedNode ) {
-                const int32_t fromNode = nodesToExplore[lastProcessedNode];
-                const BattleNode & previousNode = _cache[fromNode];
-
-                const Cell * fromCell = Board::GetCell( fromNode );
-                assert( fromCell != nullptr );
-
-                Indexes availableMoves;
-
-                if ( !unitIsWide ) {
-                    availableMoves = Board::GetAroundIndexes( fromNode );
-                }
-                else if ( previousNode._from < 0 ) {
-                    availableMoves = Board::GetMoveWideIndexes( fromNode, unit.isReflect() );
-                }
-                else {
-                    availableMoves = Board::GetMoveWideIndexes( fromNode, ( RIGHT_SIDE & Board::GetDirection( fromNode, previousNode._from ) ) != 0 );
-                }
-
-                for ( const int32_t newNode : availableMoves ) {
-                    const bool isLeftDirection = unitIsWide && Board::IsLeftDirection( fromNode, newNode, previousNode._isLeftDirection );
-
-                    const Cell * newCell = Board::GetCell( newNode );
-                    assert( newCell != nullptr );
-
-                    if ( newCell->isPassableFromAdjacent( unit, *fromCell ) && ( isPassableBridge || !Board::isBridgeIndex( newNode, unit ) ) ) {
-                        const uint32_t cost = previousNode._cost;
-                        BattleNode & node = _cache[newNode];
-
-                        uint32_t additionalCost = 1u;
-
-                        // Turning back is not a movement
-                        if ( isLeftDirection != previousNode._isLeftDirection ) {
-                            additionalCost = 0;
-                        }
-                        else {
-                            const int32_t newTailIndex = isLeftDirection ? newNode + 1 : newNode - 1;
-
-                            // The moat penalty consumes all remaining movement. Be careful when dealing with unsigned values.
-                            if ( isMoatBuilt && ( Board::isMoatIndex( newNode, unit ) || Board::isMoatIndex( newTailIndex, unit ) )
-                                 && moatPenalty > previousNode._cost ) {
-                                additionalCost = moatPenalty - cost;
-                            }
-                        }
-
-                        if ( cost + additionalCost < node._cost ) {
-                            node._isOpen = true;
-                            node._from = fromNode;
-                            node._cost = cost + additionalCost;
-                            node._isLeftDirection = isLeftDirection;
-
-                            nodesToExplore.push_back( newNode );
-                        }
-                    }
-                    // Special case: there is a unit in this cell, mark this cell as impassable, but available for a possible attack
-                    else if ( newCell->GetUnit() ) {
-                        const uint32_t cost = previousNode._cost;
-                        BattleNode & node = _cache[newNode];
-
-                        if ( cost < node._cost ) {
-                            node._isOpen = false;
-                            node._from = fromNode;
-                            node._cost = cost;
-                            node._isLeftDirection = isLeftDirection;
-                        }
-                    }
-                }
-            }
+    bool BattlePathfinder::isPositionReachable( const Position & position, const bool onCurrentTurn ) const
+    {
+        // Invalid positions are allowed here, but they are always unreachable
+        if ( position.GetHead() == nullptr ) {
+            return false;
         }
+
+        const BattleNodeIndex nodeIdx = { position.GetHead()->GetIndex(), position.GetTail() ? position.GetTail()->GetIndex() : -1 };
+
+        const auto iter = _cache.find( nodeIdx );
+        if ( iter == _cache.end() ) {
+            return false;
+        }
+
+        const auto & [index, node] = *iter;
+
+        return ( index == _pathStart || node._from != BattleNodeIndex{ -1, -1 } ) && ( !onCurrentTurn || node._cost <= _unitSpeed );
+    }
+
+    uint32_t BattlePathfinder::getDistance( const Position & position ) const
+    {
+        assert( position.GetHead() != nullptr );
+
+        const BattleNodeIndex nodeIdx = { position.GetHead()->GetIndex(), position.GetTail() ? position.GetTail()->GetIndex() : -1 };
+
+        const auto iter = _cache.find( nodeIdx );
+        if ( iter == _cache.end() ) {
+            return UINT32_MAX;
+        }
+
+        const auto & [dummy, node] = *iter;
+
+        return node._cost;
+    }
+
+    Indexes BattlePathfinder::getAllAvailableMoves( const uint32_t range ) const
+    {
+        std::set<int32_t> boardIndexes;
+
+        for ( const auto & [index, node] : _cache ) {
+            if ( index == _pathStart || node._from == BattleNodeIndex{ -1, -1 } || node._cost > range ) {
+                continue;
+            }
+
+            assert( index.first != -1 );
+
+            boardIndexes.insert( index.first );
+        }
+
+        Indexes result;
+        result.reserve( boardIndexes.size() );
+
+        std::for_each( boardIndexes.cbegin(), boardIndexes.cend(), [&result]( const int32_t idx ) { result.push_back( idx ); } );
+
+        return result;
+    }
+
+    Indexes BattlePathfinder::buildPath( const Position & position ) const
+    {
+        assert( position.GetHead() != nullptr );
+
+        const BattleNodeIndex targetNodeIdx = { position.GetHead()->GetIndex(), position.GetTail() ? position.GetTail()->GetIndex() : -1 };
+
+        Indexes result;
+
+        BattleNodeIndex nodeIdx = targetNodeIdx;
+        for ( auto iter = _cache.find( nodeIdx ); iter != _cache.end(); iter = _cache.find( nodeIdx ) ) {
+            const auto & [index, node] = *iter;
+
+            if ( index == _pathStart || node._from == BattleNodeIndex{ -1, -1 } ) {
+                break;
+            }
+
+            nodeIdx = node._from;
+
+            // The given position may be reachable in principle, but is not reachable on the current turn.
+            // Skip the steps that are not reachable on this turn.
+            if ( node._cost > _unitSpeed ) {
+                continue;
+            }
+
+            result.push_back( index.first );
+        }
+
+        std::reverse( result.begin(), result.end() );
+
+        return result;
     }
 }

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -225,7 +225,7 @@ namespace Battle
         assert( iter != _cache.end() );
 
         const auto & [index, node] = *iter;
-        // MSVC 2017 fails to expand the assert() macro without additional parentheses
+        // MSVC 2017 fails to properly expand the assert() macro without additional parentheses
         assert( ( index == _pathStart || node._from != BattleNodeIndex{ -1, -1 } ) );
 
         return node._cost;

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -20,6 +20,7 @@
 
 #pragma once
 
+#include <cstddef>
 #include <cstdint>
 #include <unordered_map>
 #include <utility>

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -50,12 +50,16 @@ namespace Battle
     struct BattleNode final
     {
         BattleNodeIndex _from = { -1, -1 };
+        // The cost of moving to this cell. May differ from _distance due to penalties (e.g. moat penalty).
         uint32_t _cost = 0;
+        // The distance to this cell, measured in the number of cells that needs to be passed to get here.
+        uint32_t _distance = 0;
 
         BattleNode() = default;
-        BattleNode( BattleNodeIndex node, const uint32_t cost )
+        BattleNode( BattleNodeIndex node, const uint32_t cost, const uint32_t distance )
             : _from( std::move( node ) )
             , _cost( cost )
+            , _distance( distance )
         {}
     };
 
@@ -73,14 +77,15 @@ namespace Battle
         void evaluateForUnit( const Unit & unit );
         // Checks whether the given position is reachable, either on the current turn or in principle
         bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
-        // Returns the distance to the given position. It's the caller's responsibility to make sure
-        // that this position is reachable before calling this method.
+        // Returns the distance to the given position (i.e. the number of cells that needs to be passed).
+        // It's the caller's responsibility to make sure that this position is reachable before calling
+        // this method.
         uint32_t getDistance( const Position & position ) const;
-        // Builds and returns the path to the given position. If this position is unreachable, then
-        // an empty path is returned.
+        // Builds and returns a path (or its part) to the given position that can be traversed during the
+        // current turn. If this position is unreachable, then an empty path is returned.
         Indexes buildPath( const Position & position ) const;
-        // Returns the indexes of all cells in the given range that can be occupied by the unit's head
-        Indexes getAllAvailableMoves( const uint32_t range ) const;
+        // Returns the indexes of all cells that can be occupied by the unit's head on the current turn
+        Indexes getAllAvailableMoves() const;
 
     private:
         std::unordered_map<BattleNodeIndex, BattleNode, BattleNodeIndexHash> _cache;

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -34,7 +34,7 @@ namespace Battle
 
     using BattleNodeIndex = std::pair<int32_t, int32_t>;
 
-    struct BattleNodeIndexHash
+    struct BattleNodeIndexHash final
     {
         std::size_t operator()( const BattleNodeIndex & index ) const noexcept
         {

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -75,15 +75,19 @@ namespace Battle
 
         // Rebuilds the graph of available positions for the given unit
         void evaluateForUnit( const Unit & unit );
+
         // Checks whether the given position is reachable, either on the current turn or in principle
         bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
+
         // Returns the distance to the given position (i.e. the number of cells that needs to be passed).
         // It's the caller's responsibility to make sure that this position is reachable before calling
         // this method.
         uint32_t getDistance( const Position & position ) const;
+
         // Builds and returns a path (or its part) to the given position that can be traversed during the
         // current turn. If this position is unreachable, then an empty path is returned.
         Indexes buildPath( const Position & position ) const;
+
         // Returns the indexes of all cells that can be occupied by the unit's head on the current turn
         Indexes getAllAvailableMoves() const;
 

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -73,7 +73,7 @@ namespace Battle
 
         BattlePathfinder & operator=( const BattlePathfinder & ) = delete;
 
-        // Rebuilds the movements graph for the given unit
+        // Rebuilds the graph of available positions for the given unit
         void evaluateForUnit( const Unit & unit );
         // Checks whether the given position is reachable, either on the current turn or in principle
         bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -73,8 +73,8 @@ namespace Battle
         void evaluateForUnit( const Unit & unit );
         // Checks whether the given position is reachable, either on the current turn or in principle
         bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
-        // Returns the distance to the given position. If this position is unreachable, then the
-        // maximum possible value is returned.
+        // Returns the distance to the given position. It's the caller's responsibility to make sure
+        // that this position is reachable before calling this method.
         uint32_t getDistance( const Position & position ) const;
         // Builds and returns the path to the given position. If this position is unreachable, then
         // an empty path is returned.

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -21,7 +21,7 @@
 #pragma once
 
 #include <cstdint>
-#include <map>
+#include <unordered_map>
 #include <utility>
 
 #include "battle_board.h"
@@ -32,6 +32,19 @@ namespace Battle
     class Unit;
 
     using BattleNodeIndex = std::pair<int32_t, int32_t>;
+
+    struct BattleNodeIndexHash
+    {
+        std::size_t operator()( const BattleNodeIndex & index ) const noexcept
+        {
+            const uint64_t f = index.first;
+            const uint64_t s = index.second;
+
+            std::hash<uint64_t> hasher;
+
+            return hasher( ( f << 32 ) + s );
+        }
+    };
 
     struct BattleNode final
     {
@@ -69,7 +82,7 @@ namespace Battle
         Indexes getAllAvailableMoves( const uint32_t range ) const;
 
     private:
-        std::map<BattleNodeIndex, BattleNode> _cache;
+        std::unordered_map<BattleNodeIndex, BattleNode, BattleNodeIndexHash> _cache;
         BattleNodeIndex _pathStart = { -1, -1 };
         uint32_t _unitSpeed = 0;
     };

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2022                                             *
+ *   Copyright (C) 2020 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -21,69 +21,56 @@
 #pragma once
 
 #include <cstdint>
+#include <map>
+#include <utility>
 
 #include "battle_board.h"
-#include "battle_cell.h"
-#include "pathfinding.h"
 
 namespace Battle
 {
+    class Position;
     class Unit;
 
-    const uint16_t MAX_MOVE_COST = ARENASIZE;
+    using BattleNodeIndex = std::pair<int32_t, int32_t>;
 
-    /* BattleNode, different situations
-     * default:  from: -1, isOpen: true, cost: MAX
-     * starting: from: -1, isOpen: false, cost: 0
-     * passable: from: 0-98, isOpen: true, cost: 1+
-     * oth.unit: from: 0-98, isOpen: false, cost: 0+
-     * terrain:  from: -1, isOpen: false, cost: MAX
-     * if tile wouldn't be reached it stays as default
-     */
-    struct BattleNode : public PathfindingNode<uint16_t>
+    struct BattleNode final
     {
-        bool _isOpen = true;
-        bool _isLeftDirection = false;
+        BattleNodeIndex _from = { -1, -1 };
+        uint32_t _cost = 0;
 
-        // BattleNode uses different default values
-        BattleNode()
-            : PathfindingNode( -1, MAX_MOVE_COST, 0 )
+        BattleNode() = default;
+        BattleNode( BattleNodeIndex node, const uint32_t cost )
+            : _from( std::move( node ) )
+            , _cost( cost )
         {}
-
-        BattleNode( int node, uint16_t cost, bool isOpen, bool isLeftDirection )
-            : PathfindingNode( node, cost, 0 )
-            , _isOpen( isOpen )
-            , _isLeftDirection( isLeftDirection )
-        {}
-
-        BattleNode( const BattleNode & ) = delete;
-        BattleNode( BattleNode && ) = default;
-
-        BattleNode & operator=( const BattleNode & ) = delete;
-        BattleNode & operator=( BattleNode && ) = delete;
-
-        // Override the base version of the call to use proper values
-        void resetNode() override;
     };
 
-    class AIBattlePathfinder : public Pathfinder<BattleNode>
+    class BattlePathfinder final
     {
     public:
-        AIBattlePathfinder();
-        AIBattlePathfinder( const AIBattlePathfinder & ) = delete;
+        BattlePathfinder() = default;
+        BattlePathfinder( const BattlePathfinder & ) = delete;
 
-        AIBattlePathfinder & operator=( const AIBattlePathfinder & ) = delete;
+        ~BattlePathfinder() = default;
 
-        void reset() override;
-        void calculate( const Unit & unit );
-        Indexes buildPath( int targetCell ) const;
-        Indexes findTwoMovesOverlap( int targetCell, uint32_t movementRange ) const;
-        bool hexIsPassable( int targetCell ) const;
-        Indexes getAllAvailableMoves( uint32_t moveRange ) const;
+        BattlePathfinder & operator=( const BattlePathfinder & ) = delete;
+
+        // Rebuilds the movements graph for the given unit
+        void evaluateForUnit( const Unit & unit );
+        // Checks whether the given position is reachable, either on the current turn or in principle
+        bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
+        // Returns the distance to the given position. If this position is unreachable, then the
+        // maximum possible value is returned.
+        uint32_t getDistance( const Position & position ) const;
+        // Builds and returns the path to the given position. If this position is unreachable, then
+        // an empty path is returned.
+        Indexes buildPath( const Position & position ) const;
+        // Returns the indexes of all cells in the given range that can be occupied by the unit's head
+        Indexes getAllAvailableMoves( const uint32_t range ) const;
 
     private:
-        bool nodeIsPassable( const BattleNode & node ) const;
-
-        Position _start;
+        std::map<BattleNodeIndex, BattleNode> _cache;
+        BattleNodeIndex _pathStart = { -1, -1 };
+        uint32_t _unitSpeed = 0;
     };
 }

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -71,7 +71,6 @@ namespace Battle
         uint32_t FindZeroDuration() const;
     };
 
-    // battle troop stats
     class Unit : public ArmyTroop, public BitModes, public Control
     {
     public:


### PR DESCRIPTION
close #6291

<details>
<summary>Issue from #6291</summary>

`master` branch:

https://user-images.githubusercontent.com/32623900/211691123-993c013c-1ddf-400d-8ab9-98d5372d2d95.mp4

This PR:

https://user-images.githubusercontent.com/32623900/211688066-6eca86c3-2d1d-4216-a71a-06ff6f6c9b32.mp4

https://user-images.githubusercontent.com/32623900/211687971-377623be-02d0-46c5-a5a3-38b389674a9c.mp4
</details>

<details>
<summary>Famous issue with wide units retreating one step back diagonally</summary>

`master` branch:

https://user-images.githubusercontent.com/32623900/211690219-2ef3687f-9a8e-4a7a-bc1b-82503464c8a8.mp4

This PR:

https://user-images.githubusercontent.com/32623900/211688089-e640f2db-2d39-4f44-b886-425062ddc225.mp4

https://user-images.githubusercontent.com/32623900/211688110-7712c9a2-1cfc-41b3-b250-5acad30c30cd.mp4
</details>

The idea here is to use a kind of the good old A* algorithm, but with a twist - create a graph with nodes corresponding not to individual cells, but to the positions of units (head+tail pairs). This solves the issue with wide units (at least I hope so). This PR proposes an algorithm equally suitable for both AI battle planning and human battle UI (previously, we used two different algorithms for these purposes).

~~This PR is still WIP, because some secondary functionality for AI is not implemented yet (namely the replacement of the `Battle::Arena::CalculateTwoMoveOverlap()`, there is currently a stub), but in general it works and volunteers to test it are welcome.~~