### PR TITLE
Fix an infinite loop in the RedrawActionWincesKills() on Lich attack

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3546,7 +3546,6 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
         // There sould not be more Lich cloud animation frames than in corresponding ICN.
         assert( lichCloudFrame <= lichCloudMaxFrame );
 
-        // Important: 'lichCloudFrame' can be more than 'lichCloudMaxFrame' when performing some long 'KILL' animations.
         if ( ( animatingTargets == finishedAnimationCount ) && ( !drawLichCloud || ( lichCloudFrame == lichCloudMaxFrame ) ) ) {
             // All unit animation frames are rendered and if it was a Lich attack then also its cloud frames are rendered too.
             break;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3543,8 +3543,11 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
         // There sould not be more finished animations than we started.
         assert( finishedAnimationCount <= animatingTargets );
 
+        // There sould not be more Lich cloud animation frames than in corresponding ICN.
+        assert( lichCloudFrame <= lichCloudMaxFrame );
+
         // Important: 'lichCloudFrame' can be more than 'lichCloudMaxFrame' when performing some long 'KILL' animations.
-        if ( ( animatingTargets == finishedAnimationCount ) && ( !drawLichCloud || ( lichCloudFrame >= lichCloudMaxFrame ) ) ) {
+        if ( ( animatingTargets == finishedAnimationCount ) && ( !drawLichCloud || ( lichCloudFrame == lichCloudMaxFrame ) ) ) {
             // All unit animation frames are rendered and if it was a Lich attack then also its cloud frames are rendered too.
             break;
         }


### PR DESCRIPTION
close #6482

I changed the logic for checking that Lich cloud animation is finished.