### PR TITLE
Fix shooters projectile position. Battlefield.

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2136,6 +2136,19 @@ namespace fheroes2
                     ApplyPalette( out, indexes );
                 }
                 return true;
+            case ICN::TITANMSL:
+                LoadOriginalICN( id );
+                if ( _icnVsSprite[id].size() == 7 ) {
+                    // We need to shift Titan lightning arrow sprite position to correctly render it.
+                    _icnVsSprite[id][0].setPosition( _icnVsSprite[id][0].x(), _icnVsSprite[id][0].y() - 10 );
+                    _icnVsSprite[id][1].setPosition( _icnVsSprite[id][1].x() - 5, _icnVsSprite[id][1].y() - 5 );
+                    _icnVsSprite[id][2].setPosition( _icnVsSprite[id][2].x() - 10, _icnVsSprite[id][2].y() );
+                    _icnVsSprite[id][3].setPosition( _icnVsSprite[id][3].x() - 15, _icnVsSprite[id][3].y() );
+                    _icnVsSprite[id][4].setPosition( _icnVsSprite[id][4].x() - 10, _icnVsSprite[id][2].y() );
+                    _icnVsSprite[id][5].setPosition( _icnVsSprite[id][5].x() - 5, _icnVsSprite[id][5].y() - 5 );
+                    _icnVsSprite[id][6].setPosition( _icnVsSprite[id][6].x(), _icnVsSprite[id][0].y() - 10 );
+                }
+                return true;
             case ICN::TROLLMSL:
                 LoadOriginalICN( id );
                 if ( _icnVsSprite[id].size() == 1 ) {

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2140,13 +2140,13 @@ namespace fheroes2
                 LoadOriginalICN( id );
                 if ( _icnVsSprite[id].size() == 7 ) {
                     // We need to shift Titan lightning arrow sprite position to correctly render it.
-                    _icnVsSprite[id][0].setPosition( _icnVsSprite[id][0].x(), _icnVsSprite[id][0].y() - 10 );
+                    _icnVsSprite[id][0].setPosition( _icnVsSprite[id][0].x(), _icnVsSprite[id][0].y() - 5 );
                     _icnVsSprite[id][1].setPosition( _icnVsSprite[id][1].x() - 5, _icnVsSprite[id][1].y() - 5 );
                     _icnVsSprite[id][2].setPosition( _icnVsSprite[id][2].x() - 10, _icnVsSprite[id][2].y() );
                     _icnVsSprite[id][3].setPosition( _icnVsSprite[id][3].x() - 15, _icnVsSprite[id][3].y() );
                     _icnVsSprite[id][4].setPosition( _icnVsSprite[id][4].x() - 10, _icnVsSprite[id][2].y() );
                     _icnVsSprite[id][5].setPosition( _icnVsSprite[id][5].x() - 5, _icnVsSprite[id][5].y() - 5 );
-                    _icnVsSprite[id][6].setPosition( _icnVsSprite[id][6].x(), _icnVsSprite[id][0].y() - 10 );
+                    _icnVsSprite[id][6].setPosition( _icnVsSprite[id][6].x(), _icnVsSprite[id][6].y() - 5 );
                 }
                 return true;
             case ICN::TROLLMSL:

--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -122,13 +122,92 @@ namespace Bin_Info
             projectileOffset.emplace_back( getValue<int16_t>( data, 174 + ( i * 4 ) ), getValue<int16_t>( data, 176 + ( i * 4 ) ) );
         }
 
-        // Elves and Grand Elves have incorrect start Y position for lower shooting attack
-        if ( monsterID == Monster::ELF || monsterID == Monster::GRAND_ELF ) {
-            if ( projectileOffset[2].y == -1 )
-                projectileOffset[2].y = -32;
+        // We change all projectile start positions to match the last projectile position in shooting animation,
+        // this position will be used to calculate the projectile path, but will not be used in rendering.
+        if ( monsterID == Monster::ARCHER || monsterID == Monster::RANGER ) {
+            projectileOffset[0].x -= 30;
+            projectileOffset[0].y += 5;
+            projectileOffset[1].x -= 46;
+            projectileOffset[1].y -= 5;
+            projectileOffset[2].x -= 30;
+            projectileOffset[2].y -= 40;
         }
 
-        uint8_t projectileCount = data[186];
+        if ( monsterID == Monster::ORC || monsterID == Monster::ORC_CHIEF ) {
+            for ( fheroes2::Point & offset : projectileOffset ) {
+                offset.x -= 20;
+                offset.y = -36;
+            }
+        }
+
+        if ( monsterID == Monster::TROLL || monsterID == Monster::WAR_TROLL ) {
+            for ( fheroes2::Point & offset : projectileOffset ) {
+                offset.x -= 25;
+                offset.y = -49;
+            }
+            projectileOffset[0].y -= 15;
+        }
+
+        if ( monsterID == Monster::ELF || monsterID == Monster::GRAND_ELF ) {
+            projectileOffset[0].x -= 19;
+            projectileOffset[0].y += 22;
+            projectileOffset[1].x -= 40;
+            --projectileOffset[1].y;
+            projectileOffset[2].x -= 19;
+            // IMPORTANT: In BIN file Elves and Grand Elves have incorrect start Y position for lower shooting attack ( -1 ).
+            projectileOffset[2].y = -54;
+        }
+
+        if ( monsterID == Monster::DRUID || monsterID == Monster::GREATER_DRUID ) {
+            projectileOffset[0].x -= 17;
+            projectileOffset[0].y += 23;
+            projectileOffset[1].x -= 20;
+            projectileOffset[2].x -= 7;
+            projectileOffset[2].y -= 21;
+        }
+
+        if ( monsterID == Monster::CENTAUR ) {
+            projectileOffset[0].x -= 24;
+            projectileOffset[0].y += 31;
+            projectileOffset[1].x -= 32;
+            projectileOffset[1].y += 2;
+            projectileOffset[2].x -= 24;
+            projectileOffset[2].y -= 27;
+        }
+
+        if ( monsterID == Monster::HALFLING ) {
+            projectileOffset[0].x -= 7;
+            projectileOffset[0].y += 11;
+            projectileOffset[1].x -= 21;
+            projectileOffset[1].y += 10;
+            projectileOffset[2].x -= 9;
+            projectileOffset[2].y -= 14;
+        }
+
+        if ( monsterID == Monster::MAGE || monsterID == Monster::ARCHMAGE ) {
+            projectileOffset[0].y -= 2;
+            projectileOffset[2].y += 2;
+        }
+
+        if ( monsterID == Monster::TITAN ) {
+            projectileOffset[0].x -= 16;
+            projectileOffset[0].y += 33;
+            projectileOffset[1].x -= 37;
+            projectileOffset[1].y += 8;
+            projectileOffset[2].x -= 20;
+            projectileOffset[2].y -= 38;
+        }
+
+         if ( monsterID == Monster::LICH || monsterID == Monster::POWER_LICH ) {
+            projectileOffset[0].x -= 5;
+            projectileOffset[0].y += 6;
+            projectileOffset[1].x -= 16;
+            projectileOffset[1].y -= 9;
+            projectileOffset[2].x -= 9;
+            projectileOffset[2].y -= 7;
+        }
+
+         uint8_t projectileCount = data[186];
         if ( projectileCount > 12u )
             projectileCount = 12u; // here we need to reset our object
         for ( uint8_t i = 0; i < projectileCount; ++i )

--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -141,11 +141,12 @@ namespace Bin_Info
         }
 
         if ( monsterID == Monster::TROLL || monsterID == Monster::WAR_TROLL ) {
-            for ( fheroes2::Point & offset : projectileOffset ) {
-                offset.x -= 25;
-                offset.y = -49;
-            }
-            projectileOffset[0].y -= 15;
+            projectileOffset[0].x -= 30;
+            projectileOffset[0].y -= 5;
+            projectileOffset[1].x -= 14;
+            --projectileOffset[1].y;
+            projectileOffset[2].x -= 15;
+            projectileOffset[2].y -= 19;
         }
 
         if ( monsterID == Monster::ELF || monsterID == Monster::GRAND_ELF ) {

--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -191,12 +191,12 @@ namespace Bin_Info
         }
 
         if ( monsterID == Monster::TITAN ) {
-            projectileOffset[0].x -= 16;
-            projectileOffset[0].y += 33;
-            projectileOffset[1].x -= 37;
+            projectileOffset[0].x -= 10;
+            projectileOffset[0].y += 22;
+            projectileOffset[1].x -= 20;
             projectileOffset[1].y += 8;
-            projectileOffset[2].x -= 20;
-            projectileOffset[2].y -= 38;
+            projectileOffset[2].x -= 15;
+            projectileOffset[2].y -= 22;
         }
 
         if ( monsterID == Monster::LICH || monsterID == Monster::POWER_LICH ) {

--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -198,7 +198,7 @@ namespace Bin_Info
             projectileOffset[2].y -= 38;
         }
 
-         if ( monsterID == Monster::LICH || monsterID == Monster::POWER_LICH ) {
+        if ( monsterID == Monster::LICH || monsterID == Monster::POWER_LICH ) {
             projectileOffset[0].x -= 5;
             projectileOffset[0].y += 6;
             projectileOffset[1].x -= 16;
@@ -207,7 +207,7 @@ namespace Bin_Info
             projectileOffset[2].y -= 7;
         }
 
-         uint8_t projectileCount = data[186];
+        uint8_t projectileCount = data[186];
         if ( projectileCount > 12u )
             projectileCount = 12u; // here we need to reset our object
         for ( uint8_t i = 0; i < projectileCount; ++i )

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -167,7 +167,8 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
     }
     // This is a shot, update the direction for the attacker only
     else {
-        attacker.UpdateDirection( board[dst].GetPos() );
+        // For shooters we get the target position (not the 'dst') to take into account the wide units.
+        attacker.UpdateDirection( defender.GetRectPosition() );
     }
 
     // Update the attacker's luck right before the attack

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3190,6 +3190,9 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
     // Wait for previously set and not passed delays before rendering a new frame.
     WaitForAllActionDelays();
 
+    // Shooter projectile rendering offset uses 'x' and 'y' from sprite data.
+    const fheroes2::Point missileOffset( reverse ? ( -missile.width() - missile.x() ) : missile.x(), ( angle > 0 ) ? ( -missile.height() - missile.y() ) : missile.y() );
+
     // convert the following code into a function/event service
     while ( le.HandleEvents( false ) && pnt != points.end() ) {
         CheckGlobalEvents( le );
@@ -3204,7 +3207,8 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
                 fheroes2::DrawLine( _mainSurface, { startPos.x, startPos.y + 2 }, { pnt->x, pnt->y + 2 }, 0x77 );
             }
             else {
-                fheroes2::Blit( missile, _mainSurface, reverse ? pnt->x - missile.width() : pnt->x, ( angle > 0 ) ? pnt->y - missile.height() : pnt->y, reverse );
+                // Coordinates in 'pnt' corresponds to the front side of the projectile (arrowhead).
+                fheroes2::Blit( missile, _mainSurface, pnt->x + missileOffset.x, pnt->y + missileOffset.y, reverse );
             }
             RedrawPartialFinish();
             ++pnt;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3178,20 +3178,27 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
     const bool isMage = ( monsterID == Monster::MAGE || monsterID == Monster::ARCHMAGE );
 
     // Mage is channeling the bolt; doesn't have missile sprite
-    if ( isMage )
+    if ( isMage ) {
         fheroes2::delayforMs( Game::ApplyBattleSpeed( 115 ) );
-    else
+    }
+    else {
         missile = fheroes2::AGG::GetICN( Monster::GetMissileICN( monsterID ), static_cast<uint32_t>( Bin_Info::GetMonsterInfo( monsterID ).getProjectileID( angle ) ) );
+    }
 
     // Lich/Power lich has projectile speed of 25
     const std::vector<fheroes2::Point> points = GetEuclideanLine( startPos, endPos, isMage ? 50 : std::max( missile.width(), 25 ) );
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
-    // Wait for previously set and not passed delays before rendering a new frame.
-    WaitForAllActionDelays();
+    // For all shooting creatures we do not render the first missile position.
+    if ( !isMage ) {
+        ++pnt;
+    }
 
     // Shooter projectile rendering offset uses 'x' and 'y' from sprite data.
     const fheroes2::Point missileOffset( reverse ? ( -missile.width() - missile.x() ) : missile.x(), ( angle > 0 ) ? ( -missile.height() - missile.y() ) : missile.y() );
+
+    // Wait for previously set and not passed delays before rendering a new frame.
+    WaitForAllActionDelays();
 
     // convert the following code into a function/event service
     while ( le.HandleEvents( false ) && pnt != points.end() ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3189,8 +3189,8 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
     const std::vector<fheroes2::Point> points = GetEuclideanLine( startPos, endPos, isMage ? 50 : std::max( missile.width(), 25 ) );
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
-    // For all shooting creatures we do not render the first missile position.
-    if ( !isMage ) {
+    // For most shooting creatures we do not render the first missile position to better imitate start position change depending on shooting angle.
+    if ( !isMage && ( monsterID != Monster::TROLL ) && ( monsterID != Monster::WAR_TROLL ) ) {
         ++pnt;
     }
 


### PR DESCRIPTION
This PR adds using of sprite `x` and `y` data to adjust the projectile render position.

This PR:

https://user-images.githubusercontent.com/113276641/212488158-278cb45b-7ef7-4621-bdd8-8a3344753733.mp4

<details><summary>Video of shooting from right to left</summary>

https://user-images.githubusercontent.com/113276641/212488789-0af4edb0-838e-4d60-bfe4-96c51a92dd6c.mp4

</details>

Currently in fheroes2 the archers arrows are shifted in direction from archers so the last animation frame renders the arrow behind the target:
![arrow1](https://user-images.githubusercontent.com/113276641/212488647-feb96cf6-fbb3-4238-b1f5-3e85f55d47f3.png) ![arrow2](https://user-images.githubusercontent.com/113276641/212488707-33e89ec0-02c5-4da6-9679-c2d42c0e6fd0.png)

<details><summary>Video</summary>

https://user-images.githubusercontent.com/113276641/212488176-d472dc9f-62e1-4127-8549-61231bfb18d1.mp4

</details>