### PR TITLE
Combat, Adding tooltip damage info for single target attack spells

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -199,11 +199,6 @@ void StringReplace( std::string & dst, const char * pred, int value )
     StringReplace( dst, pred, std::to_string( value ) );
 }
 
-void StringReplace( std::string & dst, const char * pred, uint32_t value )
-{
-    StringReplace( dst, pred, std::to_string( value ) );
-}
-
 std::vector<std::string> StringSplit( const std::string & str, const std::string & sep )
 {
     std::vector<std::string> vec;

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -199,6 +199,11 @@ void StringReplace( std::string & dst, const char * pred, int value )
     StringReplace( dst, pred, std::to_string( value ) );
 }
 
+void StringReplace( std::string & dst, const char * pred, uint32_t value )
+{
+    StringReplace( dst, pred, std::to_string( value ) );
+}
+
 std::vector<std::string> StringSplit( const std::string & str, const std::string & sep )
 {
     std::vector<std::string> vec;

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -59,7 +59,6 @@ std::vector<std::string> StringSplit( const std::string &, const std::string & )
 void StringReplaceWithLowercase( std::string & workString, const char * pattern, const std::string & patternReplacement );
 void StringReplace( std::string &, const char *, const std::string & );
 void StringReplace( std::string &, const char *, int );
-void StringReplace( std::string & dst, const char * pred, uint32_t value );
 
 int CountBits( uint32_t );
 

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -59,6 +59,7 @@ std::vector<std::string> StringSplit( const std::string &, const std::string & )
 void StringReplaceWithLowercase( std::string & workString, const char * pattern, const std::string & patternReplacement );
 void StringReplace( std::string &, const char *, const std::string & );
 void StringReplace( std::string &, const char *, int );
+void StringReplace( std::string & dst, const char * pred, uint32_t value );
 
 int CountBits( uint32_t );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6040,8 +6040,8 @@ Battle::PopupDamageInfo::PopupDamageInfo()
     : Dialog::FrameBorder( 5 )
     , _cell( nullptr )
     , _defender( nullptr )
-    , _minDamage ( 0 )
-    , _maxDamage ( 0 )
+    , _minDamage( 0 )
+    , _maxDamage( 0 )
     , _redraw( false )
 {}
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6086,12 +6086,15 @@ void Battle::PopupDamageInfo::SetAttackInfo( const Cell * cell, const Unit * att
 
 void Battle::PopupDamageInfo::SetSpellAttackInfo( const Cell * cell, const HeroBase * hero, const Unit * defender, const Spell spell )
 {
-    if ( hero == nullptr || !SetDamageInfoBase( cell, defender ) ) {
+    assert( hero != nullptr );
+
+    // TODO: Currently, this functionality only supports a simple single-target spell case
+    // We should refactor this to apply to all cases
+    if ( !spell.isSingleTarget() || !spell.isDamage() ) {
         return;
     }
 
-    // Only show popup for single target damage spells such as bolt, arrow, or cold ray
-    if ( !spell.isSingleTarget() || !spell.isDamage() ) {
+    if ( !SetDamageInfoBase( cell, defender ) ) {
         return;
     }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6101,7 +6101,7 @@ void Battle::PopupDamageInfo::SetSpellAttackInfo( const Cell * cell, const Unit 
     }
 
     const int spellPoints = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
-    const uint32_t spellDamage = defender->CalculateDamage( spell, (uint32_t)spellPoints, hero, 0 /* targetInfo damage */, true /* ignore defending hero */ );
+    const uint32_t spellDamage = defender->CalculateDamage( spell, (uint32_t)spellPoints, hero, (uint32_t)0 /* targetInfo damage */, true /* ignore defending hero */ );
 
     _redraw = true;
     _minDamage = spellDamage;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6134,8 +6134,8 @@ void Battle::PopupDamageInfo::Redraw() const
 
     std::string str = _minDamage == _maxDamage ? _( "Damage: %{max}" ) : _( "Damage: %{min} - %{max}" );
 
-    StringReplace( str, "%{min}", _minDamage );
-    StringReplace( str, "%{max}", _maxDamage );
+    StringReplace( str, "%{min}", std::to_string( _minDamage ) );
+    StringReplace( str, "%{max}", std::to_string( _maxDamage ) );
 
     Text damageText( str, Font::SMALL );
 
@@ -6146,8 +6146,8 @@ void Battle::PopupDamageInfo::Redraw() const
 
     str = minNumKilled == maxNumKilled ? _( "Perish: %{max}" ) : _( "Perish: %{min} - %{max}" );
 
-    StringReplace( str, "%{min}", minNumKilled );
-    StringReplace( str, "%{max}", maxNumKilled );
+    StringReplace( str, "%{min}", std::to_string( minNumKilled ) );
+    StringReplace( str, "%{max}", std::to_string( maxNumKilled ) );
 
     Text killedText( str, Font::SMALL );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2830,16 +2830,16 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /*b*/, Actions & a, std
 
         bool resetPopup = true;
         const Cell * cell = Board::GetCell( index_pos );
-        if (cell && _currentUnit && humanturn_spell.isSingleTarget() && humanturn_spell.isDamage()) {
+        if ( cell && _currentUnit && humanturn_spell.isSingleTarget() && humanturn_spell.isDamage() ) {
             const Unit * b_enemy = cell->GetUnit();
-            if (b_enemy && b_enemy->AllowApplySpell( humanturn_spell, _currentUnit->GetCurrentOrArmyCommander() ))
+            if ( b_enemy && b_enemy->AllowApplySpell( humanturn_spell, _currentUnit->GetCurrentOrArmyCommander() ) )
             {
                 popup.SetInfo( cell, _currentUnit, b_enemy, &humanturn_spell );
                 resetPopup = false;
             }
         }
 
-        if (resetPopup)
+        if ( resetPopup )
             popup.Reset();
 
         if ( le.MouseClickLeft() && Cursor::WAR_NONE != cursor.Themes() ) {
@@ -6057,7 +6057,7 @@ void Battle::PopupDamageInfo::setBattleUIRect( const fheroes2::Rect & battleUIRe
 
 void Battle::PopupDamageInfo::SetInfo( const Cell * cell, const Unit * attacker, const Unit * defender, const Spell * spell )
 {
-    if ( (cell == nullptr || attacker == nullptr || defender == nullptr) && (cell == nullptr || spell == nullptr || defender == nullptr) ) {
+    if ( ( cell == nullptr || attacker == nullptr || defender == nullptr ) && ( cell == nullptr || spell == nullptr || defender == nullptr ) ) {
         return;
     }
 
@@ -6091,12 +6091,12 @@ void Battle::PopupDamageInfo::Redraw() const
         return;
     }
 
-    assert( (_cell != nullptr && _defender != nullptr && _attacker != nullptr) );
+    assert( ( _cell != nullptr && _defender != nullptr && _attacker != nullptr ) );
 
     uint32_t minDamage = 0;
     uint32_t maxDamage = 0;
 
-    if (_spell != nullptr && _spell->isSingleTarget() && _spell->isDamage()) {
+    if ( _spell != nullptr && _spell->isSingleTarget() && _spell->isDamage() ) {
         const HeroBase * hero = _attacker->GetCurrentOrArmyCommander();
         const uint32_t spoint = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6101,7 +6101,7 @@ void Battle::PopupDamageInfo::SetSpellAttackInfo( const Cell * cell, const Unit 
     }
 
     const int spellPoints = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
-    const uint32_t spellDamage = defender->CalculateDamage( spell, (uint32_t)spellPoints, hero, (uint32_t)0 /* targetInfo damage */, true /* ignore defending hero */ );
+    const uint32_t spellDamage = defender->CalculateDamage( spell, spellPoints, hero, 0 /* targetInfo damage */, true /* ignore defending hero */ );
 
     _redraw = true;
     _minDamage = spellDamage;
@@ -6131,8 +6131,8 @@ void Battle::PopupDamageInfo::Redraw() const
 
     std::string str = _minDamage == _maxDamage ? _( "Damage: %{max}" ) : _( "Damage: %{min} - %{max}" );
 
-    StringReplace( str, "%{min}", _minDamage );
-    StringReplace( str, "%{max}", _maxDamage );
+    StringReplace( str, "%{min}", (int) _minDamage );
+    StringReplace( str, "%{max}", (int) _maxDamage );
 
     Text damageText( str, Font::SMALL );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6100,8 +6100,8 @@ void Battle::PopupDamageInfo::SetSpellAttackInfo( const Cell * cell, const Unit 
         return;
     }
 
-    const uint32_t spellPoints = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
-    const uint32_t spellDamage = defender->CalculateDamage( spell, spellPoints, hero, 0 /* targetInfo damage */, true /* ignore defending hero */ );
+    const int spellPoints = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
+    const uint32_t spellDamage = defender->CalculateDamage( spell, (uint32_t) spellPoints, hero, 0 /* targetInfo damage */, true /* ignore defending hero */ );
 
     _redraw = true;
     _minDamage = spellDamage;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6101,7 +6101,7 @@ void Battle::PopupDamageInfo::SetSpellAttackInfo( const Cell * cell, const Unit 
     }
 
     const int spellPoints = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
-    const uint32_t spellDamage = defender->CalculateDamage( spell, (uint32_t) spellPoints, hero, 0 /* targetInfo damage */, true /* ignore defending hero */ );
+    const uint32_t spellDamage = defender->CalculateDamage( spell, (uint32_t)spellPoints, hero, 0 /* targetInfo damage */, true /* ignore defending hero */ );
 
     _redraw = true;
     _minDamage = spellDamage;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6131,8 +6131,8 @@ void Battle::PopupDamageInfo::Redraw() const
 
     std::string str = _minDamage == _maxDamage ? _( "Damage: %{max}" ) : _( "Damage: %{min} - %{max}" );
 
-    StringReplace( str, "%{min}", (int) _minDamage );
-    StringReplace( str, "%{max}", (int) _maxDamage );
+    StringReplace( str, "%{min}", (int)_minDamage );
+    StringReplace( str, "%{max}", (int)_maxDamage );
 
     Text damageText( str, Font::SMALL );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6100,7 +6100,7 @@ void Battle::PopupDamageInfo::Redraw() const
         const HeroBase * hero = _attacker->GetCurrentOrArmyCommander();
         const uint32_t spoint = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
 
-        uint32_t spellDmg = _defender->CalculateDamage(_spell, spoint, hero, 0);
+        uint32_t spellDmg = _defender->CalculateDamage(_spell, spoint, hero, 0 /* targetInfo damage */, true /* ignore defending hero */);
         
         minDamage = spellDmg;
         maxDamage = spellDmg;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6100,8 +6100,8 @@ void Battle::PopupDamageInfo::Redraw() const
         const HeroBase * hero = _attacker->GetCurrentOrArmyCommander();
         const uint32_t spoint = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
 
-        uint32_t spellDmg = _defender->CalculateDamage(_spell, spoint, hero, 0 /* targetInfo damage */, true /* ignore defending hero */);
-        
+        uint32_t spellDmg = _defender->CalculateDamage( _spell, spoint, hero, 0 /* targetInfo damage */, true /* ignore defending hero */ );
+
         minDamage = spellDmg;
         maxDamage = spellDmg;
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2832,8 +2832,7 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /*b*/, Actions & a, std
         const Cell * cell = Board::GetCell( index_pos );
         if ( cell && _currentUnit && humanturn_spell.isSingleTarget() && humanturn_spell.isDamage() ) {
             const Unit * b_enemy = cell->GetUnit();
-            if ( b_enemy && b_enemy->AllowApplySpell( humanturn_spell, _currentUnit->GetCurrentOrArmyCommander() ) )
-            {
+            if ( b_enemy && b_enemy->AllowApplySpell( humanturn_spell, _currentUnit->GetCurrentOrArmyCommander() ) ) {
                 popup.SetInfo( cell, _currentUnit, b_enemy, &humanturn_spell );
                 resetPopup = false;
             }

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -232,7 +232,7 @@ namespace Battle
         PopupDamageInfo & operator=( const PopupDamageInfo & ) = delete;
 
         void setBattleUIRect( const fheroes2::Rect & battleUIRect );
-        void SetInfo( const Cell * cell, const Unit * attacker, const Unit * defender, const Spell * spell);
+        void SetInfo( const Cell * cell, const Unit * attacker, const Unit * defender, const Spell * spell );
         void Reset();
         void Redraw() const;
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -233,12 +233,13 @@ namespace Battle
 
         void setBattleUIRect( const fheroes2::Rect & battleUIRect );
         void SetAttackInfo( const Cell * cell, const Unit * attacker, const Unit * defender );
-        void SetSpellAttackInfo( const Cell * cell, const Unit * attacker, const Unit * defender, const Spell spell );
+        void SetSpellAttackInfo( const Cell * cell, const HeroBase * hero, const Unit * defender, const Spell spell );
         void Reset();
         void Redraw() const;
 
     private:
-        bool SetDamageInfoBase( const Cell * cell, const Unit * attacker, const Unit * defender );
+        bool SetDamageInfoBase( const Cell * cell, const Unit * defender );
+
         fheroes2::Rect _battleUIRect;
         const Cell * _cell;
         const Unit * _defender;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -232,16 +232,18 @@ namespace Battle
         PopupDamageInfo & operator=( const PopupDamageInfo & ) = delete;
 
         void setBattleUIRect( const fheroes2::Rect & battleUIRect );
-        void SetInfo( const Cell * cell, const Unit * attacker, const Unit * defender, const Spell * spell );
+        void SetAttackInfo( const Cell * cell, const Unit * attacker, const Unit * defender );
+        void SetSpellAttackInfo( const Cell * cell, const Unit * attacker, const Unit * defender, const Spell spell );
         void Reset();
         void Redraw() const;
 
     private:
+        bool SetDamageInfoBase( const Cell * cell, const Unit * attacker, const Unit * defender );
         fheroes2::Rect _battleUIRect;
         const Cell * _cell;
-        const Unit * _attacker;
         const Unit * _defender;
-        const Spell * _spell;
+        uint32_t _minDamage;
+        uint32_t _maxDamage;
         bool _redraw;
     };
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -232,7 +232,7 @@ namespace Battle
         PopupDamageInfo & operator=( const PopupDamageInfo & ) = delete;
 
         void setBattleUIRect( const fheroes2::Rect & battleUIRect );
-        void SetInfo( const Cell * cell, const Unit * attacker, const Unit * defender );
+        void SetInfo( const Cell * cell, const Unit * attacker, const Unit * defender, const Spell * spell);
         void Reset();
         void Redraw() const;
 
@@ -241,6 +241,7 @@ namespace Battle
         const Cell * _cell;
         const Unit * _attacker;
         const Unit * _defender;
+        const Spell * _spell;
         bool _redraw;
     };
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1318,13 +1318,24 @@ void Battle::Unit::SpellModesAction( const Spell & spell, uint32_t duration, con
 
 void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, TargetInfo & target )
 {
+    uint32_t dmg = CalculateDamage(&spell, spoint, hero, target.damage);
+    
+    // apply damage
+    if ( dmg ) {
+        target.damage = dmg;
+        target.killed = ApplyDamage( dmg );
+    }
+}
+
+uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, const HeroBase * hero, uint32_t target_damage ) const
+{
     // TODO: use fheroes2::getSpellDamage function to remove code duplication.
-    uint32_t dmg = spell.Damage() * spoint;
+    uint32_t dmg = spell->Damage() * spoint;
 
     switch ( GetID() ) {
     case Monster::IRON_GOLEM:
     case Monster::STEEL_GOLEM:
-        switch ( spell.GetID() ) {
+        switch ( spell->GetID() ) {
             // 50% damage
         case Spell::COLDRAY:
         case Spell::COLDRING:
@@ -1342,7 +1353,7 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
         break;
 
     case Monster::WATER_ELEMENT:
-        switch ( spell.GetID() ) {
+        switch ( spell->GetID() ) {
             // 200% damage
         case Spell::FIREBALL:
         case Spell::FIREBLAST:
@@ -1354,7 +1365,7 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
         break;
 
     case Monster::AIR_ELEMENT:
-        switch ( spell.GetID() ) {
+        switch ( spell->GetID() ) {
             // 200% damage
         case Spell::ELEMENTALSTORM:
         case Spell::LIGHTNINGBOLT:
@@ -1367,7 +1378,7 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
         break;
 
     case Monster::FIRE_ELEMENT:
-        switch ( spell.GetID() ) {
+        switch ( spell->GetID() ) {
             // 200% damage
         case Spell::COLDRAY:
         case Spell::COLDRING:
@@ -1386,7 +1397,7 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
     if ( hero ) {
         const HeroBase * defendingHero = GetCommander();
 
-        switch ( spell.GetID() ) {
+        switch ( spell->GetID() ) {
         case Spell::COLDRAY:
         case Spell::COLDRING: {
             std::vector<int32_t> extraDamagePercent
@@ -1450,8 +1461,8 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
             }
 
             // update orders damage
-            if ( spell.GetID() == Spell::CHAINLIGHTNING ) {
-                switch ( target.damage ) {
+            if ( spell->GetID() == Spell::CHAINLIGHTNING ) {
+                switch ( target_damage ) {
                 case 0:
                     break;
                 case 1:
@@ -1487,11 +1498,7 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
         }
     }
 
-    // apply damage
-    if ( dmg ) {
-        target.damage = dmg;
-        target.killed = ApplyDamage( dmg );
-    }
+    return dmg;
 }
 
 void Battle::Unit::SpellRestoreAction( const Spell & spell, uint32_t spoint, const HeroBase * hero )

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1316,9 +1316,9 @@ void Battle::Unit::SpellModesAction( const Spell & spell, uint32_t duration, con
     }
 }
 
-void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, TargetInfo & target )
+void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, TargetInfo & target )
 {
-    uint32_t dmg = CalculateDamage( spell, spoint, hero, target.damage, false /* ignore defending hero */ );
+    const uint32_t dmg = CalculateSpellDamage( spell, spellPoints, hero, target.damage, false /* ignore defending hero */ );
 
     // apply damage
     if ( dmg ) {
@@ -1327,10 +1327,10 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
     }
 }
 
-uint32_t Battle::Unit::CalculateDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, uint32_t target_damage, bool ignoreDefendingHero ) const
+uint32_t Battle::Unit::CalculateSpellDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, uint32_t targetDamage, bool ignoreDefendingHero ) const
 {
     // TODO: use fheroes2::getSpellDamage function to remove code duplication.
-    uint32_t dmg = spell.Damage() * spoint;
+    uint32_t dmg = spell.Damage() * spellPoints;
 
     switch ( GetID() ) {
     case Monster::IRON_GOLEM:
@@ -1396,7 +1396,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell & spell, uint32_t spoint, co
     // check artifact
     if ( hero ) {
         const HeroBase * defendingHero = GetCommander();
-        bool useDefendingHeroArts = defendingHero && !ignoreDefendingHero;
+        const bool useDefendingHeroArts = defendingHero && !ignoreDefendingHero;
 
         switch ( spell.GetID() ) {
         case Spell::COLDRAY:
@@ -1463,7 +1463,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell & spell, uint32_t spoint, co
 
             // update orders damage
             if ( spell.GetID() == Spell::CHAINLIGHTNING ) {
-                switch ( target_damage ) {
+                switch ( targetDamage ) {
                 case 0:
                     break;
                 case 1:

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1318,8 +1318,8 @@ void Battle::Unit::SpellModesAction( const Spell & spell, uint32_t duration, con
 
 void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, TargetInfo & target )
 {
-    uint32_t dmg = CalculateDamage(&spell, spoint, hero, target.damage, false /* ignore defending hero */);
-    
+    uint32_t dmg = CalculateDamage( &spell, spoint, hero, target.damage, false /* ignore defending hero */ );
+
     // apply damage
     if ( dmg ) {
         target.damage = dmg;

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1318,7 +1318,7 @@ void Battle::Unit::SpellModesAction( const Spell & spell, uint32_t duration, con
 
 void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, TargetInfo & target )
 {
-    uint32_t dmg = CalculateDamage( &spell, spoint, hero, target.damage, false /* ignore defending hero */ );
+    uint32_t dmg = CalculateDamage( spell, spoint, hero, target.damage, false /* ignore defending hero */ );
 
     // apply damage
     if ( dmg ) {
@@ -1327,15 +1327,15 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
     }
 }
 
-uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, const HeroBase * hero, uint32_t target_damage, bool ignoreDefendingHero ) const
+uint32_t Battle::Unit::CalculateDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, uint32_t target_damage, bool ignoreDefendingHero ) const
 {
     // TODO: use fheroes2::getSpellDamage function to remove code duplication.
-    uint32_t dmg = spell->Damage() * spoint;
+    uint32_t dmg = spell.Damage() * spoint;
 
     switch ( GetID() ) {
     case Monster::IRON_GOLEM:
     case Monster::STEEL_GOLEM:
-        switch ( spell->GetID() ) {
+        switch ( spell.GetID() ) {
             // 50% damage
         case Spell::COLDRAY:
         case Spell::COLDRING:
@@ -1353,7 +1353,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
         break;
 
     case Monster::WATER_ELEMENT:
-        switch ( spell->GetID() ) {
+        switch ( spell.GetID() ) {
             // 200% damage
         case Spell::FIREBALL:
         case Spell::FIREBLAST:
@@ -1365,7 +1365,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
         break;
 
     case Monster::AIR_ELEMENT:
-        switch ( spell->GetID() ) {
+        switch ( spell.GetID() ) {
             // 200% damage
         case Spell::ELEMENTALSTORM:
         case Spell::LIGHTNINGBOLT:
@@ -1378,7 +1378,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
         break;
 
     case Monster::FIRE_ELEMENT:
-        switch ( spell->GetID() ) {
+        switch ( spell.GetID() ) {
             // 200% damage
         case Spell::COLDRAY:
         case Spell::COLDRING:
@@ -1398,7 +1398,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
         const HeroBase * defendingHero = GetCommander();
         bool useDefendingHeroArts = defendingHero && !ignoreDefendingHero;
 
-        switch ( spell->GetID() ) {
+        switch ( spell.GetID() ) {
         case Spell::COLDRAY:
         case Spell::COLDRING: {
             std::vector<int32_t> extraDamagePercent
@@ -1462,7 +1462,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
             }
 
             // update orders damage
-            if ( spell->GetID() == Spell::CHAINLIGHTNING ) {
+            if ( spell.GetID() == Spell::CHAINLIGHTNING ) {
                 switch ( target_damage ) {
                 case 0:
                     break;

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1318,7 +1318,7 @@ void Battle::Unit::SpellModesAction( const Spell & spell, uint32_t duration, con
 
 void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, TargetInfo & target )
 {
-    uint32_t dmg = CalculateDamage(&spell, spoint, hero, target.damage);
+    uint32_t dmg = CalculateDamage(&spell, spoint, hero, target.damage, false /* ignore defending hero */);
     
     // apply damage
     if ( dmg ) {
@@ -1327,7 +1327,7 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spoint, const
     }
 }
 
-uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, const HeroBase * hero, uint32_t target_damage ) const
+uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, const HeroBase * hero, uint32_t target_damage, bool ignoreDefendingHero ) const
 {
     // TODO: use fheroes2::getSpellDamage function to remove code duplication.
     uint32_t dmg = spell->Damage() * spoint;
@@ -1396,6 +1396,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
     // check artifact
     if ( hero ) {
         const HeroBase * defendingHero = GetCommander();
+        bool useDefendingHeroArts = defendingHero && !ignoreDefendingHero;
 
         switch ( spell->GetID() ) {
         case Spell::COLDRAY:
@@ -1406,7 +1407,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
                 dmg = dmg * ( 100 + value ) / 100;
             }
 
-            if ( defendingHero ) {
+            if ( useDefendingHeroArts ) {
                 const std::vector<int32_t> damageReductionPercent
                     = defendingHero->GetBagArtifacts().getTotalArtifactMultipliedPercent( fheroes2::ArtifactBonusType::COLD_SPELL_DAMAGE_REDUCTION_PERCENT );
                 for ( const int32_t value : damageReductionPercent ) {
@@ -1429,7 +1430,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
                 dmg = dmg * ( 100 + value ) / 100;
             }
 
-            if ( defendingHero ) {
+            if ( useDefendingHeroArts ) {
                 const std::vector<int32_t> damageReductionPercent
                     = defendingHero->GetBagArtifacts().getTotalArtifactMultipliedPercent( fheroes2::ArtifactBonusType::FIRE_SPELL_DAMAGE_REDUCTION_PERCENT );
                 for ( const int32_t value : damageReductionPercent ) {
@@ -1452,7 +1453,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
                 dmg = dmg * ( 100 + value ) / 100;
             }
 
-            if ( defendingHero != nullptr ) {
+            if ( useDefendingHeroArts ) {
                 const std::vector<int32_t> damageReductionPercent
                     = defendingHero->GetBagArtifacts().getTotalArtifactMultipliedPercent( fheroes2::ArtifactBonusType::LIGHTNING_SPELL_DAMAGE_REDUCTION_PERCENT );
                 for ( const int32_t value : damageReductionPercent ) {
@@ -1483,7 +1484,7 @@ uint32_t Battle::Unit::CalculateDamage( const Spell * spell, uint32_t spoint, co
         }
         case Spell::ELEMENTALSTORM:
         case Spell::ARMAGEDDON: {
-            if ( defendingHero != nullptr ) {
+            if ( useDefendingHeroArts ) {
                 const std::vector<int32_t> damageReductionPercent
                     = defendingHero->GetBagArtifacts().getTotalArtifactMultipliedPercent( fheroes2::ArtifactBonusType::ELEMENTAL_SPELL_DAMAGE_REDUCTION_PERCENT );
                 for ( const int32_t value : damageReductionPercent ) {

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -193,8 +193,8 @@ namespace Battle
         void ResetBlind();
         void SetBlindAnswer( bool value );
         void SpellModesAction( const Spell &, uint32_t, const HeroBase * );
-        void SpellApplyDamage( const Spell &, uint32_t, const HeroBase *, TargetInfo & );
-        uint32_t CalculateDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, uint32_t target_damage, bool ignoreDefendingHero ) const;
+        void SpellApplyDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, TargetInfo & target);
+        uint32_t CalculateSpellDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, uint32_t targetDamage, bool ignoreDefendingHero ) const;
         void SpellRestoreAction( const Spell &, uint32_t, const HeroBase * );
         uint32_t Resurrect( uint32_t, bool, bool );
 

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -194,7 +194,7 @@ namespace Battle
         void SetBlindAnswer( bool value );
         void SpellModesAction( const Spell &, uint32_t, const HeroBase * );
         void SpellApplyDamage( const Spell &, uint32_t, const HeroBase *, TargetInfo & );
-        uint32_t CalculateDamage( const Spell *, uint32_t, const HeroBase *, uint32_t, bool ) const;
+        uint32_t CalculateDamage( const Spell & spell, uint32_t spoint, const HeroBase * hero, uint32_t target_damage, bool ignoreDefendingHero ) const;
         void SpellRestoreAction( const Spell &, uint32_t, const HeroBase * );
         uint32_t Resurrect( uint32_t, bool, bool );
 

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -193,7 +193,7 @@ namespace Battle
         void ResetBlind();
         void SetBlindAnswer( bool value );
         void SpellModesAction( const Spell &, uint32_t, const HeroBase * );
-        void SpellApplyDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, TargetInfo & target);
+        void SpellApplyDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, TargetInfo & target );
         uint32_t CalculateSpellDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, uint32_t targetDamage, bool ignoreDefendingHero ) const;
         void SpellRestoreAction( const Spell &, uint32_t, const HeroBase * );
         uint32_t Resurrect( uint32_t, bool, bool );

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -194,6 +194,7 @@ namespace Battle
         void SetBlindAnswer( bool value );
         void SpellModesAction( const Spell &, uint32_t, const HeroBase * );
         void SpellApplyDamage( const Spell &, uint32_t, const HeroBase *, TargetInfo & );
+        uint32_t CalculateDamage( const Spell *, uint32_t, const HeroBase *, uint32_t ) const;
         void SpellRestoreAction( const Spell &, uint32_t, const HeroBase * );
         uint32_t Resurrect( uint32_t, bool, bool );
 

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -194,7 +194,7 @@ namespace Battle
         void SetBlindAnswer( bool value );
         void SpellModesAction( const Spell &, uint32_t, const HeroBase * );
         void SpellApplyDamage( const Spell &, uint32_t, const HeroBase *, TargetInfo & );
-        uint32_t CalculateDamage( const Spell *, uint32_t, const HeroBase *, uint32_t ) const;
+        uint32_t CalculateDamage( const Spell *, uint32_t, const HeroBase *, uint32_t, bool ) const;
         void SpellRestoreAction( const Spell &, uint32_t, const HeroBase * );
         uint32_t Resurrect( uint32_t, bool, bool );
 


### PR DESCRIPTION
As mentioned in #1625, the super helpful damage info tooltip that shows the range of damage when attacking the enemy troop does not show anything when using spells. When using a single-target damage spell such as a Lightning Bolt, Arrow, or Coldray, the spell in the magic book shows you the exact damage it would deal, but when hovering over an enemy troop, you have to cancel the spell, check the troop's health to calculate how many troops will perish, and then go back to using the spell again. Additionally, the spellbook does not show the spell adjustments you might encounter when targeting special troops, for example when using a cold ray on an Air Elemental (cold spells have 2x damage on air type monsters).

This damage tooltip, however, will ignore defending hero's artifacts - if the defending hero has an artifact reducing the damage of certain spells (such as the Ice Heart to reduce cold spell damage by half), the tooltip should not show that, as that is not known to the attacking hero.

_Before:_
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/4021245/212501907-8b302472-ee07-48db-ab97-7436bd7af570.png">

_After:_
<img width="1470" alt="image" src="https://user-images.githubusercontent.com/4021245/212501813-57362494-8217-4954-bcb4-7b570b6ec843.png">

Interesting open question - **should magic resistance be mentioned in the tooltip**? Spell will not do any damage 25% of the time on dwarves. 