### PR TITLE
Rework the way how object ICN types are used

### DIFF
--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -120,7 +120,7 @@ void Castle::LoadFromMP2( const std::vector<uint8_t> & data )
 
     // Structure containing information about town or castle.
     //
-    // - uint8 (1 byte)
+    // - uint8_t (1 byte)
     //     Owner color. Possible values:
     //     00 - blue
     //     01 - green

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -83,7 +83,7 @@ namespace
         const MP2::MapObjectType objectType = tile.GetObject( false );
 
         // This is a horrible hack but we want to play sounds only for a particular sprite belonging to Rock.
-        if ( objectType == MP2::OBJ_ROCK && tile.containsSprite( 200, 183 ) ) {
+        if ( objectType == MP2::OBJ_ROCK && tile.containsSprite( MP2::OBJ_ICN_TYPE_OBJNWATR, 183 ) ) {
             return M82::LOOP0019;
         }
 

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -756,11 +756,11 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                     tile.drawFog( dst, friendColors, *this );
 
                     if ( drawTowns ) {
-                        tile.drawByIcnId( dst, *this, ICN::OBJNTWBA );
+                        tile.drawByObjectIcnType( dst, *this, MP2::OBJ_ICN_TYPE_OBJNTWBA );
 
                         const MP2::MapObjectType objectType = tile.GetObject( false );
                         if ( objectType == MP2::OBJ_CASTLE || objectType == MP2::OBJ_NON_ACTION_CASTLE ) {
-                            tile.drawByIcnId( dst, *this, ICN::OBJNTOWN );
+                            tile.drawByObjectIcnType( dst, *this, MP2::OBJ_ICN_TYPE_OBJNTOWN );
                         }
                     }
                 }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -31,7 +31,6 @@
 #include "difficulty.h"
 #include "direction.h"
 #include "game.h"
-#include "icn.h"
 #include "kingdom.h"
 #include "logging.h"
 #include "maps.h"

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -621,8 +621,8 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
 
             if ( index == 0 ) {
                 TilesAddon * addon = tile.FindAddonLevel2( castleID );
-                if ( addon && ( addon->_objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_OBJNTWRD ) {
-                    addon->_objectIcnType = ( addon->_objectIcnType % 4 ) + ( MP2::OBJ_ICN_TYPE_OBJNTOWN << 2 );
+                if ( addon && addon->_objectIcnType == MP2::OBJ_ICN_TYPE_OBJNTWRD ) {
+                    addon->_objectIcnType = MP2::OBJ_ICN_TYPE_OBJNTOWN;
                     addon->_imageIndex = fullTownIndex - 16;
                 }
             }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -622,7 +622,7 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
 
             if ( index == 0 ) {
                 TilesAddon * addon = tile.FindAddonLevel2( castleID );
-                if ( addon && MP2::getIcnIdFromObjectIcnType( addon->_objectIcnType >> 2 ) == ICN::OBJNTWRD ) {
+                if ( addon && ( addon->_objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_OBJNTWRD ) {
                     addon->_objectIcnType = ( addon->_objectIcnType % 4 ) + ( MP2::OBJ_ICN_TYPE_OBJNTOWN << 2 );
                     addon->_imageIndex = fullTownIndex - 16;
                 }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -616,14 +616,14 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
             Tiles & tile = world.GetTiles( castleTile );
 
             if ( isRandom )
-                tile.ReplaceObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, ( MP2::OBJ_ICN_TYPE_OBJNTOWN << 2 ), lookupID, fullTownIndex ); // OBJNTWRD to OBJNTOWN
+                tile.replaceObject( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, MP2::OBJ_ICN_TYPE_OBJNTOWN, lookupID, fullTownIndex ); // OBJNTWRD to OBJNTOWN
             else
-                tile.UpdateObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTOWN, ( MP2::OBJ_ICN_TYPE_OBJNTOWN << 2 ), -16 ); // no change in tileset
+                tile.updateObjectImageIndex( castleID, MP2::OBJ_ICN_TYPE_OBJNTOWN, -16 );
 
             if ( index == 0 ) {
                 TilesAddon * addon = tile.FindAddonLevel2( castleID );
-                if ( addon && MP2::GetICNObject( addon->_objectType ) == ICN::OBJNTWRD ) {
-                    addon->_objectType = MP2::OBJ_ICN_TYPE_OBJNTOWN + ( addon->_objectType % 4 );
+                if ( addon && MP2::getIcnIdFromObjectIcnType( addon->_objectIcnType >> 2 ) == ICN::OBJNTWRD ) {
+                    addon->_objectIcnType = ( addon->_objectIcnType % 4 ) + ( MP2::OBJ_ICN_TYPE_OBJNTOWN << 2 );
                     addon->_imageIndex = fullTownIndex - 16;
                 }
             }
@@ -633,9 +633,9 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
         if ( isValidAbsIndex( shadowTileId ) ) {
             Maps::Tiles & shadowTile = world.GetTiles( shadowTileId );
             if ( isRandom )
-                shadowTile.ReplaceObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, ( MP2::OBJ_ICN_TYPE_OBJNTWSH << 2 ), lookupID + 32, fullTownIndex );
+                shadowTile.replaceObject( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, ( MP2::OBJ_ICN_TYPE_OBJNTWSH << 2 ), lookupID + 32, fullTownIndex );
             else
-                shadowTile.UpdateObjectSprite( castleID, MP2::OBJ_ICN_TYPE_OBJNTWSH, ( MP2::OBJ_ICN_TYPE_OBJNTWSH << 2 ), -16 ); // no change in tileset
+                shadowTile.updateObjectImageIndex( castleID, MP2::OBJ_ICN_TYPE_OBJNTWSH, -16 );
         }
     }
 }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -633,7 +633,7 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
         if ( isValidAbsIndex( shadowTileId ) ) {
             Maps::Tiles & shadowTile = world.GetTiles( shadowTileId );
             if ( isRandom )
-                shadowTile.replaceObject( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, ( MP2::OBJ_ICN_TYPE_OBJNTWSH << 2 ), lookupID + 32, fullTownIndex );
+                shadowTile.replaceObject( castleID, MP2::OBJ_ICN_TYPE_OBJNTWRD, MP2::OBJ_ICN_TYPE_OBJNTWSH, lookupID + 32, fullTownIndex );
             else
                 shadowTile.updateObjectImageIndex( castleID, MP2::OBJ_ICN_TYPE_OBJNTWSH, -16 );
         }

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2013 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <ostream>
 #include <vector>
 

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -194,7 +194,7 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
     StreamBuf dataStream( data );
     const uint8_t magicNumber = dataStream.get();
     if ( magicNumber != 0 ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "Sphinx data magic number is incorrect " << static_cast<int>( magicNumber ) )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Sphinx data magic number " << static_cast<int>( magicNumber ) << " is incorrect." )
         return;
     }
 
@@ -225,7 +225,7 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
     }
 
     message = dataStream.toString();
-    if ( !message.empty() ) {
+    if ( message.empty() ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Sphinx question is empty. Marking it as an invalid object." )
         return;
     }

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -96,7 +96,7 @@ struct MapSphinx : public MapObjectSimple
 {
     MapSphinx();
 
-    void LoadFromMP2( int32_t index, StreamBuf );
+    void LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t> & data );
 
     bool AnswerCorrect( const std::string & answer );
     void SetQuiet();

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2013 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <list>
 #include <string>
+#include <vector>
 
 #include "artifact.h"
 #include "position.h"

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2058,20 +2058,23 @@ void Maps::Tiles::updateObjectImageIndex( const uint32_t objectUid, const MP2::O
     // We can immediately return from the function as only one object per tile can have the same UID.
     for ( TilesAddon & addon : addons_level1 ) {
         if ( addon._uid == objectUid && addon._objectIcnType == objectIcnType ) {
-            addon._imageIndex = addon._imageIndex + imageIndexOffset;
+            assert( addon._imageIndex + imageIndexOffset >= 0 && addon._imageIndex + imageIndexOffset < 255 );
+            addon._imageIndex = static_cast<uint8_t>( addon._imageIndex + imageIndexOffset );
             return;
         }
     }
 
     for ( TilesAddon & addon : addons_level2 ) {
         if ( addon._uid == objectUid && addon._objectIcnType == objectIcnType ) {
-            addon._imageIndex = addon._imageIndex + imageIndexOffset;
+            assert( addon._imageIndex + imageIndexOffset >= 0 && addon._imageIndex + imageIndexOffset < 255 );
+            addon._imageIndex = static_cast<uint8_t>( addon._imageIndex + imageIndexOffset );
             return;
         }
     }
 
     if ( _uid == objectUid && _objectIcnType == objectIcnType ) {
-        _imageIndex += imageIndexOffset;
+        assert( _imageIndex + imageIndexOffset >= 0 && _imageIndex + imageIndexOffset < 255 );
+        _imageIndex = static_cast<uint8_t>( _imageIndex + imageIndexOffset );
     }
 }
 
@@ -2246,7 +2249,7 @@ void Maps::Tiles::UpdateRNDResourceSprite( Tiles & tile )
 {
     tile.SetObject( MP2::OBJ_RESOURCE );
 
-    const uint32_t resourceSprite = Resource::GetIndexSprite( Resource::Rand( true ) );
+    const uint8_t resourceSprite = Resource::GetIndexSprite( Resource::Rand( true ) );
 
     uint32_t uidResource = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNRSRC );
     if ( uidResource == 0 ) {
@@ -2257,6 +2260,7 @@ void Maps::Tiles::UpdateRNDResourceSprite( Tiles & tile )
 
     // Replace shadow of the resource.
     if ( Maps::isValidDirection( tile._index, Direction::LEFT ) ) {
+        assert( resourceSprite > 0 );
         updateTileById( world.GetTiles( Maps::GetDirectionIndex( tile._index, Direction::LEFT ) ), uidResource, resourceSprite - 1 );
     }
 }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2220,7 +2220,7 @@ void Maps::Tiles::UpdateRNDArtifactSprite( Tiles & tile )
     }
 
     if ( !art.isValid() ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set an artifact over a random articat on tile " << tile.GetIndex() )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set an artifact over a random artifact on tile " << tile.GetIndex() )
         return;
     }
 
@@ -2824,7 +2824,7 @@ bool Maps::Tiles::isDetachedObject() const
 
 StreamBase & Maps::operator<<( StreamBase & msg, const TilesAddon & ta )
 {
-    return msg << ta._layerType << ta._uid << ta._objectIcnType << ta._imageIndex;
+    return msg << ta._layerType << ta._uid << ta._objectIcnType << ta._hasObjectAnimation << ta._isMarkedAsRoad << ta._imageIndex;
 }
 
 StreamBase & Maps::operator>>( StreamBase & msg, TilesAddon & ta )
@@ -2837,12 +2837,17 @@ StreamBase & Maps::operator>>( StreamBase & msg, TilesAddon & ta )
         msg >> temp;
 
         ta._objectIcnType = static_cast<MP2::ObjectIcnType>( temp >> 2 );
+
+        ta._hasObjectAnimation = false;
+        ta._isMarkedAsRoad = false;
     }
     else {
         uint8_t temp = MP2::OBJ_ICN_TYPE_UNKNOWN;
         msg >> temp;
 
         ta._objectIcnType = static_cast<MP2::ObjectIcnType>( temp );
+
+        msg >> ta._hasObjectAnimation >> ta._isMarkedAsRoad;
     }
 
     msg >> ta._imageIndex;
@@ -2854,9 +2859,9 @@ StreamBase & Maps::operator<<( StreamBase & msg, const Tiles & tile )
 {
     static_assert( sizeof( uint8_t ) == sizeof( MP2::MapObjectType ), "Incorrect type for writing MP2::MapObjectType object" );
 
-    return msg << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile.tilePassable << tile._uid << tile._objectIcnType << tile._imageIndex
-               << static_cast<uint8_t>( tile._mainObjectType ) << tile.fog_colors << tile.quantity1 << tile.quantity2 << tile.additionalMetadata << tile.heroID
-               << tile.tileIsRoad << tile.addons_level1 << tile.addons_level2 << tile._layerType;
+    return msg << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile.tilePassable << tile._uid << tile._objectIcnType << tile._hasObjectAnimation
+               << tile._isMarkedAsRoad << tile._imageIndex << static_cast<uint8_t>( tile._mainObjectType ) << tile.fog_colors << tile.quantity1 << tile.quantity2
+               << tile.additionalMetadata << tile.heroID << tile.tileIsRoad << tile.addons_level1 << tile.addons_level2 << tile._layerType;
 }
 
 StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
@@ -2883,12 +2888,17 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
         msg >> temp;
 
         tile._objectIcnType = static_cast<MP2::ObjectIcnType>( temp >> 2 );
+
+        tile._hasObjectAnimation = false;
+        tile._isMarkedAsRoad = false;
     }
     else {
         uint8_t temp = MP2::OBJ_ICN_TYPE_UNKNOWN;
         msg >> temp;
 
         tile._objectIcnType = static_cast<MP2::ObjectIcnType>( temp );
+
+        msg >> tile._hasObjectAnimation >> tile._isMarkedAsRoad;
     }
 
     msg >> tile._imageIndex;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1742,7 +1742,6 @@ Maps::TilesAddon * Maps::Tiles::getAddonWithFlag( const uint32_t uid )
 void Maps::Tiles::setOwnershipFlag( const MP2::MapObjectType objectType, const int color )
 {
     // All flags in FLAG32.ICN are actually the same except the fact of having different offset.
-    // 14, 21
     uint8_t objectSpriteIndex = 0;
 
     switch ( color ) {
@@ -1882,7 +1881,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
 {
     const MP2::MapObjectType originalObjectType = tile.GetObject( false );
 
-    // Left tile of a skeleton on Desert should be mark as non-action tile.
+    // Left tile of a skeleton on Desert should be marked as non-action tile.
     if ( originalObjectType == MP2::OBJ_SKELETON && tile._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNDSRT && tile._imageIndex == 83 ) {
         tile.SetObject( MP2::OBJ_NON_ACTION_SKELETON );
 
@@ -1891,7 +1890,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
     }
 
     // Original Editor marks Reefs as Stones. We're fixing this issue by changing the type of the object without changing the content of a tile.
-    // This is also required in order to properly calculate Reefs' passbility.
+    // This is also required in order to properly calculate Reefs' passability.
     if ( originalObjectType == MP2::OBJ_ROCK && isValidReefsSprite( tile._objectIcnType, tile._imageIndex ) ) {
         tile.SetObject( MP2::OBJ_REEFS );
 
@@ -1914,7 +1913,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
         return;
     }
 
-    // On some maps (apparently created by some non-standard editor), the object type on tiles with random monsters does not match the index
+    // On some maps (apparently created by some non-standard editors), the object type on tiles with random monsters does not match the index
     // of the monster placeholder sprite. While this engine looks at the object type when placing an actual monster on a tile, the original
     // HoMM2 apparently looks at the placeholder sprite, so we need to keep them in sync.
     if ( tile._objectIcnType == MP2::OBJ_ICN_TYPE_MONS32 ) {
@@ -1965,7 +1964,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
             break;
         }
 
-        // Add-ons of level 1 shouldn't even exist if no top object. However, let's play safe and verify it as well.
+        // Add-ons of level 1 shouldn't even exist if no top object is present. However, let's play safe and verify it as well.
         for ( const TilesAddon & addon : tile.addons_level1 ) {
             objectType = getLoyaltyObject( addon._objectIcnType, addon._imageIndex );
             if ( objectType != MP2::OBJ_NONE )
@@ -2028,13 +2027,13 @@ void Maps::Tiles::Remove( uint32_t uniqID )
 }
 
 void Maps::Tiles::replaceObject( const uint32_t objectUid, const MP2::ObjectIcnType originalObjectIcnType, const MP2::ObjectIcnType newObjectIcnType,
-                                 const uint8_t originalImageIndex, const uint8_t newimageIndex )
+                                 const uint8_t originalImageIndex, const uint8_t newImageIndex )
 {
     // We can immediately return from the function as only one object per tile can have the same UID.
     for ( TilesAddon & addon : addons_level1 ) {
         if ( addon._uid == objectUid && addon._objectIcnType == originalObjectIcnType && addon._imageIndex == originalImageIndex ) {
             addon._objectIcnType = newObjectIcnType;
-            addon._imageIndex = newimageIndex;
+            addon._imageIndex = newImageIndex;
             return;
         }
     }
@@ -2042,14 +2041,14 @@ void Maps::Tiles::replaceObject( const uint32_t objectUid, const MP2::ObjectIcnT
     for ( TilesAddon & addon : addons_level2 ) {
         if ( addon._uid == objectUid && addon._objectIcnType == originalObjectIcnType && addon._imageIndex == originalImageIndex ) {
             addon._objectIcnType = newObjectIcnType;
-            addon._imageIndex = newimageIndex;
+            addon._imageIndex = newImageIndex;
             return;
         }
     }
 
     if ( _uid == objectUid && _objectIcnType == originalObjectIcnType && _imageIndex == originalImageIndex ) {
         _objectIcnType = newObjectIcnType;
-        _imageIndex = newimageIndex;
+        _imageIndex = newImageIndex;
     }
 }
 
@@ -2226,7 +2225,7 @@ void Maps::Tiles::UpdateRNDArtifactSprite( Tiles & tile )
     }
 
     if ( !art.isValid() ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown artifact" )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set an artifact over a random articat on tile " << tile.GetIndex() )
         return;
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -154,14 +154,9 @@ namespace
         return false;
     }
 
-    bool isShadowSprite( const int icn, const uint8_t icnIndex )
-    {
-        return isValidShadowSprite( icn, icnIndex );
-    }
-
     bool isShadowSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
     {
-        return isShadowSprite( MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ), icnIndex );
+        return isValidShadowSprite( MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ), icnIndex );
     }
 
     bool isValidReefsSprite( const uint8_t objectIcnType, const uint8_t icnIndex )
@@ -475,9 +470,9 @@ namespace
         return "Uknown layer";
     }
 
-    MP2::MapObjectType getLoyaltyObject( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
+    MP2::MapObjectType getLoyaltyObject( const uint8_t objectIcnType, const uint8_t icnIndex )
     {
-        switch ( nonCorrectedObjectIcnType >> 2 ) {
+        switch ( objectIcnType ) {
         case MP2::OBJ_ICN_TYPE_X_LOC1:
             if ( icnIndex == 3 )
                 return MP2::OBJ_ALCHEMIST_TOWER;
@@ -624,9 +619,9 @@ bool Maps::TilesAddon::isArtifact( const TilesAddon & ta )
     return ( MP2::OBJ_ICN_TYPE_OBJNARTI == ( ta._objectIcnType >> 2 ) && ( ta._imageIndex > 0x10 ) && ( ta._imageIndex % 2 ) );
 }
 
-int Maps::Tiles::getColorFromBarrierSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
+int Maps::Tiles::getColorFromBarrierSprite( const uint8_t objectIcnType, const uint8_t icnIndex )
 {
-    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == ( nonCorrectedObjectIcnType >> 2 ) && 60 <= icnIndex && 102 >= icnIndex ) {
+    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 60 <= icnIndex && 102 >= icnIndex ) {
         // 60, 66, 72, 78, 84, 90, 96, 102
         return ( ( icnIndex - 60 ) / 6 ) + 1;
     }
@@ -634,9 +629,9 @@ int Maps::Tiles::getColorFromBarrierSprite( const uint8_t nonCorrectedObjectIcnT
     return 0;
 }
 
-int Maps::Tiles::getColorFromTravellerTentSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
+int Maps::Tiles::getColorFromTravellerTentSprite( const uint8_t objectIcnType, const uint8_t icnIndex )
 {
-    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == ( nonCorrectedObjectIcnType >> 2 ) && 110 <= icnIndex && 138 >= icnIndex ) {
+    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 110 <= icnIndex && 138 >= icnIndex ) {
         // 110, 114, 118, 122, 126, 130, 134, 138
         return ( ( icnIndex - 110 ) / 4 ) + 1;
     }
@@ -1256,7 +1251,7 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
             continue;
         }
 
-        if ( isPuzzleDraw && MP2::isHiddenForPuzzle( GetGround(), addon._objectIcnType, addon._imageIndex ) ) {
+        if ( isPuzzleDraw && MP2::isHiddenForPuzzle( GetGround(), addon._objectIcnType >> 2, addon._imageIndex ) ) {
             continue;
         }
 
@@ -1272,7 +1267,7 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
         renderAddonObject( dst, area, mp, addon );
     }
 
-    if ( _objectIcnType != 0 && ( _layerType & 0x03 ) == level && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( GetGround(), _objectIcnType, _imageIndex ) ) ) {
+    if ( _objectIcnType != 0 && ( _layerType & 0x03 ) == level && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( GetGround(), _objectIcnType >> 2, _imageIndex ) ) ) {
         renderMainObject( dst, area, mp );
     }
 
@@ -1531,7 +1526,7 @@ void Maps::Tiles::redrawTopLayerExtraObjects( fheroes2::Image & dst, const bool 
 
 void Maps::Tiles::redrawTopLayerObject( fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area, const TilesAddon & addon ) const
 {
-    if ( isPuzzleDraw && MP2::isHiddenForPuzzle( GetGround(), addon._objectIcnType, addon._imageIndex ) ) {
+    if ( isPuzzleDraw && MP2::isHiddenForPuzzle( GetGround(), addon._objectIcnType >> 2, addon._imageIndex ) ) {
         return;
     }
 
@@ -1973,7 +1968,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
     case MP2::OBJ_NON_ACTION_EXPANSION_OBJECT:
     case MP2::OBJ_EXPANSION_DWELLING:
     case MP2::OBJ_EXPANSION_OBJECT: {
-        MP2::MapObjectType objectType = getLoyaltyObject( tile._objectIcnType, tile._imageIndex );
+        MP2::MapObjectType objectType = getLoyaltyObject( tile._objectIcnType >> 2, tile._imageIndex );
         if ( objectType != MP2::OBJ_NONE ) {
             tile.SetObject( objectType );
             break;
@@ -1981,7 +1976,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
 
         // Add-ons of level 1 shouldn't even exist if no top object. However, let's play safe and verify it as well.
         for ( const TilesAddon & addon : tile.addons_level1 ) {
-            objectType = getLoyaltyObject( addon._objectIcnType, addon._imageIndex );
+            objectType = getLoyaltyObject( addon._objectIcnType >> 2, addon._imageIndex );
             if ( objectType != MP2::OBJ_NONE )
                 break;
         }
@@ -1992,7 +1987,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
         }
 
         for ( const TilesAddon & addon : tile.addons_level2 ) {
-            objectType = getLoyaltyObject( addon._objectIcnType, addon._imageIndex );
+            objectType = getLoyaltyObject( addon._objectIcnType >> 2, addon._imageIndex );
             if ( objectType != MP2::OBJ_NONE )
                 break;
         }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -661,7 +661,7 @@ void Maps::Tiles::UpdateAbandonedMineLeftSprite( uint8_t & nonCorrectedObjectIcn
         nonCorrectedObjectIcnType = ( nonCorrectedObjectIcnType % 4 ) | ( MP2::OBJ_ICN_TYPE_MTNDIRT << 2 );
         imageIndex = 112;
     }
-    else if ( ICN::EXTRAOVR == objectIcnType && imageIndex == 5 ) {
+    else if ( MP2::OBJ_ICN_TYPE_EXTRAOVR == objectIcnType && imageIndex == 5 ) {
         switch ( resource ) {
         case Resource::ORE:
             imageIndex = 0;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -544,21 +544,16 @@ namespace
     }
 }
 
-Maps::TilesAddon::TilesAddon()
-    : _uid( 0 )
-    , _layerType( OBJECT_LAYER )
-    , _objectIcnType( MP2::OBJ_ICN_TYPE_UNKNOWN )
-    , _imageIndex( 255 )
-{}
-
-Maps::TilesAddon::TilesAddon( const uint8_t lv, const uint32_t uid, const uint8_t obj, const uint8_t index_ )
+Maps::TilesAddon::TilesAddon( const uint8_t layerType, const uint32_t uid, const uint8_t objectIcnType, const uint8_t imageIndex )
     : _uid( uid )
-    , _layerType( lv )
-    , _objectIcnType( obj )
-    , _imageIndex( index_ )
+    , _layerType( layerType )
+    , _objectIcnType( objectIcnType )
+    , _imageIndex( imageIndex )
     , _hasObjectAnimation( false )
     , _isMarkedAsRoad( false )
-{}
+{
+    // Do nothing.
+}
 
 std::string Maps::TilesAddon::String( int lvl ) const
 {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -477,8 +477,8 @@ namespace
 
     MP2::MapObjectType getLoyaltyObject( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
     {
-        switch ( MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ) ) {
-        case ICN::X_LOC1:
+        switch ( nonCorrectedObjectIcnType >> 2 ) {
+        case MP2::OBJ_ICN_TYPE_X_LOC1:
             if ( icnIndex == 3 )
                 return MP2::OBJ_ALCHEMIST_TOWER;
             else if ( icnIndex < 3 )
@@ -509,7 +509,7 @@ namespace
                 return MP2::OBJ_NON_ACTION_WATER_ALTAR;
             break;
 
-        case ICN::X_LOC2:
+        case MP2::OBJ_ICN_TYPE_X_LOC2:
             if ( icnIndex == 4 )
                 return MP2::OBJ_STABLES;
             else if ( icnIndex < 4 )
@@ -530,7 +530,7 @@ namespace
                 return MP2::OBJ_REEFS;
             break;
 
-        case ICN::X_LOC3:
+        case MP2::OBJ_ICN_TYPE_X_LOC3:
             if ( icnIndex == 30 )
                 return MP2::OBJ_HUT_OF_MAGI;
             else if ( icnIndex < 32 )
@@ -586,9 +586,9 @@ bool Maps::TilesAddon::PredicateSortRules1( const Maps::TilesAddon & ta1, const 
 
 bool Maps::TilesAddon::isRoad() const
 {
-    switch ( MP2::getIcnIdFromObjectIcnType( _objectIcnType >> 2 ) ) {
+    switch ( _objectIcnType >> 2 ) {
     // road sprite
-    case ICN::ROAD:
+    case MP2::OBJ_ICN_TYPE_ROAD:
         if ( 1 == _imageIndex || 8 == _imageIndex || 10 == _imageIndex || 11 == _imageIndex || 15 == _imageIndex || 22 == _imageIndex || 23 == _imageIndex
              || 24 == _imageIndex || 25 == _imageIndex || 27 == _imageIndex )
             return false;
@@ -596,14 +596,14 @@ bool Maps::TilesAddon::isRoad() const
             return true;
 
     // castle or town gate
-    case ICN::OBJNTOWN:
+    case MP2::OBJ_ICN_TYPE_OBJNTOWN:
         if ( 13 == _imageIndex || 29 == _imageIndex || 45 == _imageIndex || 61 == _imageIndex || 77 == _imageIndex || 93 == _imageIndex || 109 == _imageIndex
              || 125 == _imageIndex || 141 == _imageIndex || 157 == _imageIndex || 173 == _imageIndex || 189 == _imageIndex )
             return true;
         break;
 
     // Random castle or town gate.
-    case ICN::OBJNTWRD:
+    case MP2::OBJ_ICN_TYPE_OBJNTWRD:
         return ( _imageIndex == 13 || _imageIndex == 29 );
 
     default:
@@ -615,18 +615,18 @@ bool Maps::TilesAddon::isRoad() const
 
 bool Maps::TilesAddon::isResource( const TilesAddon & ta )
 {
-    return ICN::OBJNRSRC == MP2::getIcnIdFromObjectIcnType( ta._objectIcnType >> 2 ) && ( ta._imageIndex % 2 );
+    return MP2::OBJ_ICN_TYPE_OBJNRSRC == ( ta._objectIcnType >> 2 ) && ( ta._imageIndex % 2 );
 }
 
 bool Maps::TilesAddon::isArtifact( const TilesAddon & ta )
 {
     // OBJNARTI (skip ultimate)
-    return ( ICN::OBJNARTI == MP2::getIcnIdFromObjectIcnType( ta._objectIcnType >> 2 ) && ( ta._imageIndex > 0x10 ) && ( ta._imageIndex % 2 ) );
+    return ( MP2::OBJ_ICN_TYPE_OBJNARTI == ( ta._objectIcnType >> 2 ) && ( ta._imageIndex > 0x10 ) && ( ta._imageIndex % 2 ) );
 }
 
 int Maps::Tiles::getColorFromBarrierSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
 {
-    if ( ICN::X_LOC3 == MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ) && 60 <= icnIndex && 102 >= icnIndex ) {
+    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == ( nonCorrectedObjectIcnType >> 2 ) && 60 <= icnIndex && 102 >= icnIndex ) {
         // 60, 66, 72, 78, 84, 90, 96, 102
         return ( ( icnIndex - 60 ) / 6 ) + 1;
     }
@@ -636,7 +636,7 @@ int Maps::Tiles::getColorFromBarrierSprite( const uint8_t nonCorrectedObjectIcnT
 
 int Maps::Tiles::getColorFromTravellerTentSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
 {
-    if ( ICN::X_LOC3 == MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ) && 110 <= icnIndex && 138 >= icnIndex ) {
+    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == ( nonCorrectedObjectIcnType >> 2 ) && 110 <= icnIndex && 138 >= icnIndex ) {
         // 110, 114, 118, 122, 126, 130, 134, 138
         return ( ( icnIndex - 110 ) / 4 ) + 1;
     }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -570,8 +570,8 @@ std::string Maps::TilesAddon::String( int lvl ) const
     std::ostringstream os;
     os << "--------- Level " << lvl << " --------" << std::endl
        << "UID             : " << _uid << std::endl
-       << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType >> 2 ) )
-                               << ")" << std::endl
+       << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType >> 2 ) ) << ")"
+       << std::endl
        << "image index     : " << static_cast<int>( _imageIndex ) << std::endl
        << "layer type      : " << static_cast<int>( _layerType ) << " (" << static_cast<int>( _layerType % 4 ) << ")"
        << " - " << getObjectLayerName( _layerType % 4 ) << std::endl
@@ -637,7 +637,7 @@ int Maps::Tiles::getColorFromBarrierSprite( const uint8_t nonCorrectedObjectIcnT
 int Maps::Tiles::getColorFromTravellerTentSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
 {
     if ( ICN::X_LOC3 == MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ) && 110 <= icnIndex && 138 >= icnIndex ) {
-    // 110, 114, 118, 122, 126, 130, 134, 138
+        // 110, 114, 118, 122, 126, 130, 134, 138
         return ( ( icnIndex - 110 ) / 4 ) + 1;
     }
 
@@ -1020,8 +1020,9 @@ void Maps::Tiles::updatePassability()
                           && isShortObject( correctedObjectType ) && ( bottomTile.getOriginalPassability() & Direction::TOP ) == 0 ) {
                     tilePassable &= ~Direction::BOTTOM;
                 }
-                else if ( isShortObject( bottomTileObjectType ) || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() ) &&
-                          ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
+                else if ( isShortObject( bottomTileObjectType )
+                          || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() )
+                               && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
                     tilePassable &= ~Direction::BOTTOM;
                 }
                 else {
@@ -1565,7 +1566,7 @@ std::string Maps::Tiles::String() const
        << "UID             : " << _uid << std::endl
        << "MP2 object type : " << static_cast<int>( objectType ) << " (" << MP2::StringObject( objectType ) << ")" << std::endl
        << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType >> 2 ) ) << ")"
-                               << std::endl
+       << std::endl
        << "image index     : " << static_cast<int>( _imageIndex ) << " (animated: " << hasSpriteAnimation() << ")" << std::endl
        << "layer type      : " << static_cast<int>( _layerType ) << " - " << getObjectLayerName( _layerType ) << std::endl
        << "region          : " << _region << std::endl

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2649,7 +2649,7 @@ std::vector<MP2::ObjectIcnType> Maps::Tiles::getValidObjectIcnTypes() const
 
 bool Maps::Tiles::containsAnyObjectIcnType( const std::vector<MP2::ObjectIcnType> & objectIcnTypes ) const
 {
-    for ( const uint8_t objectIcnType : objectIcnTypes ) {
+    for ( const MP2::ObjectIcnType objectIcnType : objectIcnTypes ) {
         if ( _objectIcnType == objectIcnType ) {
             return true;
         }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1916,18 +1916,23 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
 
         const uint8_t originalObjectSpriteIndex = tile.GetObjectSpriteIndex();
         switch ( originalObjectSpriteIndex ) {
+        // Random monster placeholder "MON"
         case 66:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER;
             break;
+        // Random monster placeholder "MON 1"
         case 67:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER_WEAK;
             break;
+        // Random monster placeholder "MON 2"
         case 68:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER_MEDIUM;
             break;
+        // Random monster placeholder "MON 3"
         case 69:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER_STRONG;
             break;
+        // Random monster placeholder "MON 4"
         case 70:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER_VERY_STRONG;
             break;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -544,13 +544,14 @@ namespace
     }
 }
 
-Maps::TilesAddon::TilesAddon( const uint8_t layerType, const uint32_t uid, const uint8_t objectIcnType, const uint8_t imageIndex )
+Maps::TilesAddon::TilesAddon( const uint8_t layerType, const uint32_t uid, const uint8_t objectIcnType, const uint8_t imageIndex, const bool hasObjectAnimation,
+                              const bool isMarkedAsRoad )
     : _uid( uid )
     , _layerType( layerType )
     , _objectIcnType( objectIcnType )
     , _imageIndex( imageIndex )
-    , _hasObjectAnimation( false )
-    , _isMarkedAsRoad( false )
+    , _hasObjectAnimation( hasObjectAnimation )
+    , _isMarkedAsRoad( isMarkedAsRoad )
 {
     // Do nothing.
 }
@@ -819,7 +820,7 @@ void Maps::Tiles::SetObject( const MP2::MapObjectType objectType )
 void Maps::Tiles::setBoat( int direction )
 {
     if ( _objectIcnType != 0 && _imageIndex != 255 ) {
-        AddonsPushLevel1( TilesAddon( OBJECT_LAYER, _uid, _objectIcnType, _imageIndex ) );
+        AddonsPushLevel1( TilesAddon( OBJECT_LAYER, _uid, _objectIcnType, _imageIndex, false, false ) );
     }
     SetObject( MP2::OBJ_BOAT );
     _objectIcnType = ( MP2::OBJ_ICN_TYPE_BOAT32 << 2 );
@@ -1098,7 +1099,7 @@ bool Maps::Tiles::isClearGround() const
 void Maps::Tiles::AddonsPushLevel1( const MP2::mp2tile_t & mt )
 {
     if ( mt.objectName1 != 0 && mt.level1IcnImageIndex != 0xFF ) {
-        addons_level1.emplace_back( mt.quantity1, mt.level1ObjectUID, mt.objectName1, mt.level1IcnImageIndex );
+        addons_level1.emplace_back( mt.quantity1, mt.level1ObjectUID, mt.objectName1, mt.level1IcnImageIndex, false, false );
     }
 
     // MP2 "objectName" is a bitfield
@@ -1110,7 +1111,7 @@ void Maps::Tiles::AddonsPushLevel1( const MP2::mp2tile_t & mt )
 void Maps::Tiles::AddonsPushLevel1( const MP2::mp2addon_t & ma )
 {
     if ( ma.objectNameN1 != 0 && ma.indexNameN1 != 0xFF ) {
-        addons_level1.emplace_back( ma.quantityN, ma.level1ObjectUID, ma.objectNameN1, ma.indexNameN1 );
+        addons_level1.emplace_back( ma.quantityN, ma.level1ObjectUID, ma.objectNameN1, ma.indexNameN1, false, false );
     }
 }
 
@@ -1123,7 +1124,7 @@ void Maps::Tiles::AddonsPushLevel2( const MP2::mp2tile_t & mt )
 {
     if ( mt.objectName2 != 0 && mt.level2IcnImageIndex != 0xFF ) {
         // TODO: does level 2 even need level value? Verify it.
-        addons_level2.emplace_back( mt.quantity1, mt.level2ObjectUID, mt.objectName2, mt.level2IcnImageIndex );
+        addons_level2.emplace_back( mt.quantity1, mt.level2ObjectUID, mt.objectName2, mt.level2IcnImageIndex, false, false );
     }
 }
 
@@ -1131,7 +1132,7 @@ void Maps::Tiles::AddonsPushLevel2( const MP2::mp2addon_t & ma )
 {
     if ( ma.objectNameN2 != 0 && ma.indexNameN2 != 0xFF ) {
         // TODO: why do we use the same quantityN member for both level 1 and 2?
-        addons_level2.emplace_back( ma.quantityN, ma.level2ObjectUID, ma.objectNameN2, ma.indexNameN2 );
+        addons_level2.emplace_back( ma.quantityN, ma.level2ObjectUID, ma.objectNameN2, ma.indexNameN2, false, false );
     }
 }
 
@@ -1139,7 +1140,7 @@ void Maps::Tiles::AddonsSort()
 {
     // Push everything to the container and sort it by level.
     if ( _objectIcnType != 0 && _imageIndex < 255 ) {
-        addons_level1.emplace_front( _layerType, _uid, _objectIcnType, _imageIndex );
+        addons_level1.emplace_front( _layerType, _uid, _objectIcnType, _imageIndex, false, false );
     }
 
     // Some original maps have issues with identifying tiles as roads. This code fixes it. It's not an ideal solution but works fine in most of cases.
@@ -1874,10 +1875,10 @@ void Maps::Tiles::updateFlag( const int color, const uint8_t objectSpriteIndex, 
         addon->_imageIndex = objectSpriteIndex;
     }
     else if ( setOnUpperLayer ) {
-        addons_level2.emplace_back( OBJECT_LAYER, uid, objectType, objectSpriteIndex );
+        addons_level2.emplace_back( OBJECT_LAYER, uid, objectType, objectSpriteIndex, false, false );
     }
     else {
-        addons_level1.emplace_back( OBJECT_LAYER, uid, objectType, objectSpriteIndex );
+        addons_level1.emplace_back( OBJECT_LAYER, uid, objectType, objectSpriteIndex, false, false );
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1115,11 +1115,6 @@ void Maps::Tiles::AddonsPushLevel1( const MP2::mp2addon_t & ma )
     }
 }
 
-void Maps::Tiles::AddonsPushLevel1( const TilesAddon & ta )
-{
-    addons_level1.emplace_back( ta );
-}
-
 void Maps::Tiles::AddonsPushLevel2( const MP2::mp2tile_t & mt )
 {
     if ( mt.objectName2 != 0 && mt.level2IcnImageIndex != 0xFF ) {
@@ -2636,15 +2631,17 @@ std::vector<MP2::ObjectIcnType> Maps::Tiles::getValidObjectIcnTypes() const
     }
 
     for ( const TilesAddon & addon : addons_level1 ) {
-        if ( addon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
-            objectIcnTypes.emplace_back( addon._objectIcnType );
-        }
+        // If this assertion blows up then you put an empty object into an addon which makes no sense!
+        assert( addon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN );
+
+        objectIcnTypes.emplace_back( addon._objectIcnType );
     }
 
     for ( const TilesAddon & addon : addons_level2 ) {
-        if ( addon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
-            objectIcnTypes.emplace_back( addon._objectIcnType );
-        }
+        // If this assertion blows up then you put an empty object into an addon which makes no sense!
+        assert( addon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN );
+
+        objectIcnTypes.emplace_back( addon._objectIcnType );
     }
 
     return objectIcnTypes;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -561,11 +561,11 @@ std::string Maps::TilesAddon::String( int lvl ) const
     std::ostringstream os;
     os << "--------- Level " << lvl << " --------" << std::endl
        << "UID             : " << _uid << std::endl
-       << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType ) ) << ")" << std::endl
+       << "ICN object type : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType ) ) << ")" << std::endl
        << "image index     : " << static_cast<int>( _imageIndex ) << std::endl
        << "layer type      : " << static_cast<int>( _layerType ) << " (" << static_cast<int>( _layerType % 4 ) << ")"
        << " - " << getObjectLayerName( _layerType % 4 ) << std::endl
-       << "shadow          : " << ( isShadow( *this ) ? "true" : "false" ) << std::endl;
+       << "is shadow       : " << ( isShadow( *this ) ? "yes" : "no" ) << std::endl;
     return os.str();
 }
 
@@ -1555,7 +1555,7 @@ std::string Maps::Tiles::String() const
        << "point: (" << GetCenter().x << ", " << GetCenter().y << ")" << std::endl
        << "UID             : " << _uid << std::endl
        << "MP2 object type : " << static_cast<int>( objectType ) << " (" << MP2::StringObject( objectType ) << ")" << std::endl
-       << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType ) ) << ")" << std::endl
+       << "ICN object type : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType ) ) << ")" << std::endl
        << "image index     : " << static_cast<int>( _imageIndex ) << " (animated: " << hasSpriteAnimation() << ")" << std::endl
        << "layer type      : " << static_cast<int>( _layerType ) << " - " << getObjectLayerName( _layerType ) << std::endl
        << "region          : " << _region << std::endl

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -561,8 +561,7 @@ std::string Maps::TilesAddon::String( int lvl ) const
     std::ostringstream os;
     os << "--------- Level " << lvl << " --------" << std::endl
        << "UID             : " << _uid << std::endl
-       << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType ) ) << ")"
-       << std::endl
+       << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType ) ) << ")" << std::endl
        << "image index     : " << static_cast<int>( _imageIndex ) << std::endl
        << "layer type      : " << static_cast<int>( _layerType ) << " (" << static_cast<int>( _layerType % 4 ) << ")"
        << " - " << getObjectLayerName( _layerType % 4 ) << std::endl

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -903,7 +903,7 @@ int Maps::Tiles::getOriginalPassability() const
         return MP2::getActionObjectDirection( objectType );
     }
 
-    if ( ( _objectIcnType == 0 || _imageIndex == 255 ) || ( ( _layerType >> 1 ) & 1 ) || isShadow() ) {
+    if ( ( ( _objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_UNKNOWN || _imageIndex == 255 ) || ( ( _layerType >> 1 ) & 1 ) || isShadow() ) {
         // No object exists. Make it fully passable.
         return DIRECTION_ALL;
     }
@@ -944,14 +944,14 @@ void Maps::Tiles::updatePassability()
 
     const MP2::MapObjectType objectType = GetObject( false );
     const bool isActionObject = MP2::isActionObject( objectType );
-    if ( !isActionObject && _objectIcnType > 0 && _imageIndex < 255 && ( ( _layerType >> 1 ) & 1 ) == 0 && !isShadow() ) {
+    if ( !isActionObject && ( _objectIcnType >> 2 ) > MP2::OBJ_ICN_TYPE_UNKNOWN && _imageIndex < 255 && ( ( _layerType >> 1 ) & 1 ) == 0 && !isShadow() ) {
         // This is a non-action object.
         if ( Maps::isValidDirection( _index, Direction::BOTTOM ) ) {
             const Tiles & bottomTile = world.GetTiles( Maps::GetDirectionIndex( _index, Direction::BOTTOM ) );
 
             // If a bottom tile has the same object ID then this tile is inaccessible.
             std::vector<uint32_t> tileUIDs;
-            if ( _objectIcnType > 0 && _imageIndex < 255 && _uid != 0 && ( ( _layerType >> 1 ) & 1 ) == 0 ) {
+            if ( ( _objectIcnType >> 2 ) > MP2::OBJ_ICN_TYPE_UNKNOWN && _imageIndex < 255 && _uid != 0 && ( ( _layerType >> 1 ) & 1 ) == 0 ) {
                 tileUIDs.emplace_back( _uid );
             }
 
@@ -989,7 +989,8 @@ void Maps::Tiles::updatePassability()
             const bool isBottomTileObject = ( ( bottomTile._layerType >> 1 ) & 1 ) == 0;
 
             // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
-            if ( !singleObjectTile && !isDetachedObject() && isBottomTileObject && bottomTile._objectIcnType > 0 && bottomTile._imageIndex < 255 ) {
+            if ( !singleObjectTile && !isDetachedObject() && isBottomTileObject && ( bottomTile._objectIcnType >> 2 ) > MP2::OBJ_ICN_TYPE_UNKNOWN
+                 && bottomTile._imageIndex < 255 ) {
                 const MP2::MapObjectType bottomTileObjectType = bottomTile.GetObject( false );
                 const bool isBottomTileActionObject = MP2::isActionObject( bottomTileObjectType );
                 const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( bottomTileObjectType );
@@ -1085,7 +1086,7 @@ bool Maps::Tiles::isClearGround() const
         break;
     }
 
-    if ( _objectIcnType == 0 || _imageIndex == 255 || ( ( _layerType >> 1 ) & 1 ) == 1 ) {
+    if ( ( _objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_UNKNOWN || _imageIndex == 255 || ( ( _layerType >> 1 ) & 1 ) == 1 ) {
         if ( MP2::isActionObject( objectType, isWater() ) ) {
             return false;
         }
@@ -2706,7 +2707,7 @@ bool Maps::Tiles::isTallObject() const
     }
 
     std::vector<uint32_t> tileUIDs;
-    if ( _objectIcnType > 0 && _imageIndex < 255 && _uid != 0 && ( ( _layerType >> 1 ) & 1 ) == 0 ) {
+    if ( ( _objectIcnType >> 2 ) > 0 && _imageIndex < 255 && _uid != 0 && ( ( _layerType >> 1 ) & 1 ) == 0 ) {
         tileUIDs.emplace_back( _uid );
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2843,8 +2843,8 @@ StreamBase & Maps::operator>>( StreamBase & msg, TilesAddon & ta )
 
         ta._objectIcnType = static_cast<MP2::ObjectIcnType>( temp >> 2 );
 
-        ta._hasObjectAnimation = false;
-        ta._isMarkedAsRoad = false;
+        ta._hasObjectAnimation = ( temp & 1 ) != 0;
+        ta._isMarkedAsRoad = ( temp & 2 ) != 0;
     }
     else {
         uint8_t temp = MP2::OBJ_ICN_TYPE_UNKNOWN;
@@ -2894,8 +2894,8 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
 
         tile._objectIcnType = static_cast<MP2::ObjectIcnType>( temp >> 2 );
 
-        tile._hasObjectAnimation = false;
-        tile._isMarkedAsRoad = false;
+        tile._hasObjectAnimation = ( temp & 1 ) != 0;
+        tile._isMarkedAsRoad = ( temp & 2 ) != 0;
     }
     else {
         uint8_t temp = MP2::OBJ_ICN_TYPE_UNKNOWN;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -832,8 +832,7 @@ void Maps::Tiles::setBoat( int direction )
         AddonsPushLevel1( TilesAddon( OBJECT_LAYER, _uid, _objectIcnType, _imageIndex ) );
     }
     SetObject( MP2::OBJ_BOAT );
-    // TODO: this is absolutely wrong to assign ICN id to object type!
-    _objectIcnType = ICN::BOAT32;
+    _objectIcnType = ( MP2::OBJ_ICN_TYPE_BOAT32 << 2 );
 
     // Left-side sprites have to flipped, add 128 to index
     switch ( direction ) {
@@ -872,8 +871,7 @@ void Maps::Tiles::setBoat( int direction )
 int Maps::Tiles::getBoatDirection() const
 {
     // Check if it really is a boat
-    // TODO: this is an incorrect check! We cannot directly compare object type with an ICN.
-    if ( _objectIcnType != ICN::BOAT32 )
+    if ( ( _objectIcnType >> 2 ) != MP2::OBJ_ICN_TYPE_BOAT32 )
         return Direction::UNKNOWN;
 
     // Left-side sprites have to flipped, add 128 to index

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2064,7 +2064,7 @@ void Maps::Tiles::replaceObject( const uint32_t objectUid, const uint8_t origina
     }
 
     if ( _uid == objectUid && ( _objectIcnType >> 2 ) == originalObjectIcnType && _imageIndex == originalImageIndex ) {
-        _objectIcnType = ( _objectIcnType & 0x3 ) | ( newObjectIcnType << 2 );
+        _objectIcnType = ( _objectIcnType % 4 ) | ( newObjectIcnType << 2 );
         _imageIndex = newimageIndex;
     }
 }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -154,9 +154,19 @@ namespace
         return false;
     }
 
-    bool isValidReefsSprite( const int icn, const uint8_t icnIndex )
+    bool isShadowSprite( const int icn, const uint8_t icnIndex )
     {
-        return icn == ICN::X_LOC2 && ObjXlc2::isReefs( icnIndex );
+        return isValidShadowSprite( icn, icnIndex );
+    }
+
+    bool isShadowSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
+    {
+        return isShadowSprite( MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ), icnIndex );
+    }
+
+    bool isValidReefsSprite( const uint8_t objectIcnType, const uint8_t icnIndex )
+    {
+        return objectIcnType == MP2::OBJ_ICN_TYPE_X_LOC2 && ObjXlc2::isReefs( icnIndex );
     }
 
 #if defined( VERIFY_SHADOW_SPRITES )
@@ -464,20 +474,95 @@ namespace
 
         return "Uknown layer";
     }
+
+    MP2::MapObjectType getLoyaltyObject( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
+    {
+        switch ( MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ) ) {
+        case ICN::X_LOC1:
+            if ( icnIndex == 3 )
+                return MP2::OBJ_ALCHEMIST_TOWER;
+            else if ( icnIndex < 3 )
+                return MP2::OBJ_NON_ACTION_ALCHEMIST_TOWER;
+            else if ( 70 == icnIndex )
+                return MP2::OBJ_ARENA;
+            else if ( 3 < icnIndex && icnIndex < 72 )
+                return MP2::OBJ_NON_ACTION_ARENA;
+            else if ( 77 == icnIndex )
+                return MP2::OBJ_BARROW_MOUNDS;
+            else if ( 71 < icnIndex && icnIndex < 78 )
+                return MP2::OBJ_NON_ACTION_BARROW_MOUNDS;
+            else if ( 94 == icnIndex )
+                return MP2::OBJ_EARTH_ALTAR;
+            else if ( 77 < icnIndex && icnIndex < 112 )
+                return MP2::OBJ_NON_ACTION_EARTH_ALTAR;
+            else if ( 118 == icnIndex )
+                return MP2::OBJ_AIR_ALTAR;
+            else if ( 111 < icnIndex && icnIndex < 120 )
+                return MP2::OBJ_NON_ACTION_AIR_ALTAR;
+            else if ( 127 == icnIndex )
+                return MP2::OBJ_FIRE_ALTAR;
+            else if ( 119 < icnIndex && icnIndex < 129 )
+                return MP2::OBJ_NON_ACTION_FIRE_ALTAR;
+            else if ( 135 == icnIndex )
+                return MP2::OBJ_WATER_ALTAR;
+            else if ( 128 < icnIndex && icnIndex < 137 )
+                return MP2::OBJ_NON_ACTION_WATER_ALTAR;
+            break;
+
+        case ICN::X_LOC2:
+            if ( icnIndex == 4 )
+                return MP2::OBJ_STABLES;
+            else if ( icnIndex < 4 )
+                return MP2::OBJ_NON_ACTION_STABLES;
+            else if ( icnIndex == 9 )
+                return MP2::OBJ_JAIL;
+            else if ( 4 < icnIndex && icnIndex < 10 )
+                return MP2::OBJ_NON_ACTION_JAIL;
+            else if ( icnIndex == 37 )
+                return MP2::OBJ_MERMAID;
+            else if ( 9 < icnIndex && icnIndex < 47 )
+                return MP2::OBJ_NON_ACTION_MERMAID;
+            else if ( icnIndex == 101 )
+                return MP2::OBJ_SIRENS;
+            else if ( 46 < icnIndex && icnIndex < 111 )
+                return MP2::OBJ_NON_ACTION_SIRENS;
+            else if ( ObjXlc2::isReefs( icnIndex ) )
+                return MP2::OBJ_REEFS;
+            break;
+
+        case ICN::X_LOC3:
+            if ( icnIndex == 30 )
+                return MP2::OBJ_HUT_OF_MAGI;
+            else if ( icnIndex < 32 )
+                return MP2::OBJ_NON_ACTION_HUT_OF_MAGI;
+            else if ( icnIndex == 50 )
+                return MP2::OBJ_EYE_OF_MAGI;
+            else if ( 31 < icnIndex && icnIndex < 59 )
+                return MP2::OBJ_NON_ACTION_EYE_OF_MAGI;
+            break;
+
+        default:
+            break;
+        }
+
+        return MP2::OBJ_NONE;
+    }
 }
 
 Maps::TilesAddon::TilesAddon()
     : _uid( 0 )
     , _layerType( OBJECT_LAYER )
-    , _objectType( MP2::OBJ_ICN_TYPE_UNKNOWN )
+    , _objectIcnType( MP2::OBJ_ICN_TYPE_UNKNOWN )
     , _imageIndex( 255 )
 {}
 
 Maps::TilesAddon::TilesAddon( const uint8_t lv, const uint32_t uid, const uint8_t obj, const uint8_t index_ )
     : _uid( uid )
     , _layerType( lv )
-    , _objectType( obj )
+    , _objectIcnType( obj )
     , _imageIndex( index_ )
+    , _hasObjectAnimation( false )
+    , _isMarkedAsRoad( false )
 {}
 
 std::string Maps::TilesAddon::String( int lvl ) const
@@ -485,7 +570,8 @@ std::string Maps::TilesAddon::String( int lvl ) const
     std::ostringstream os;
     os << "--------- Level " << lvl << " --------" << std::endl
        << "UID             : " << _uid << std::endl
-       << "object type     : " << static_cast<int>( _objectType ) << " (" << ICN::GetString( MP2::GetICNObject( _objectType ) ) << ")" << std::endl
+       << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType >> 2 ) )
+                               << ")" << std::endl
        << "image index     : " << static_cast<int>( _imageIndex ) << std::endl
        << "layer type      : " << static_cast<int>( _layerType ) << " (" << static_cast<int>( _layerType % 4 ) << ")"
        << " - " << getObjectLayerName( _layerType % 4 ) << std::endl
@@ -498,82 +584,9 @@ bool Maps::TilesAddon::PredicateSortRules1( const Maps::TilesAddon & ta1, const 
     return ( ( ta1._layerType % 4 ) > ( ta2._layerType % 4 ) );
 }
 
-MP2::MapObjectType Maps::Tiles::GetLoyaltyObject( const uint8_t tileset, const uint8_t icnIndex )
-{
-    switch ( MP2::GetICNObject( tileset ) ) {
-    case ICN::X_LOC1:
-        if ( icnIndex == 3 )
-            return MP2::OBJ_ALCHEMIST_TOWER;
-        else if ( icnIndex < 3 )
-            return MP2::OBJ_NON_ACTION_ALCHEMIST_TOWER;
-        else if ( 70 == icnIndex )
-            return MP2::OBJ_ARENA;
-        else if ( 3 < icnIndex && icnIndex < 72 )
-            return MP2::OBJ_NON_ACTION_ARENA;
-        else if ( 77 == icnIndex )
-            return MP2::OBJ_BARROW_MOUNDS;
-        else if ( 71 < icnIndex && icnIndex < 78 )
-            return MP2::OBJ_NON_ACTION_BARROW_MOUNDS;
-        else if ( 94 == icnIndex )
-            return MP2::OBJ_EARTH_ALTAR;
-        else if ( 77 < icnIndex && icnIndex < 112 )
-            return MP2::OBJ_NON_ACTION_EARTH_ALTAR;
-        else if ( 118 == icnIndex )
-            return MP2::OBJ_AIR_ALTAR;
-        else if ( 111 < icnIndex && icnIndex < 120 )
-            return MP2::OBJ_NON_ACTION_AIR_ALTAR;
-        else if ( 127 == icnIndex )
-            return MP2::OBJ_FIRE_ALTAR;
-        else if ( 119 < icnIndex && icnIndex < 129 )
-            return MP2::OBJ_NON_ACTION_FIRE_ALTAR;
-        else if ( 135 == icnIndex )
-            return MP2::OBJ_WATER_ALTAR;
-        else if ( 128 < icnIndex && icnIndex < 137 )
-            return MP2::OBJ_NON_ACTION_WATER_ALTAR;
-        break;
-
-    case ICN::X_LOC2:
-        if ( icnIndex == 4 )
-            return MP2::OBJ_STABLES;
-        else if ( icnIndex < 4 )
-            return MP2::OBJ_NON_ACTION_STABLES;
-        else if ( icnIndex == 9 )
-            return MP2::OBJ_JAIL;
-        else if ( 4 < icnIndex && icnIndex < 10 )
-            return MP2::OBJ_NON_ACTION_JAIL;
-        else if ( icnIndex == 37 )
-            return MP2::OBJ_MERMAID;
-        else if ( 9 < icnIndex && icnIndex < 47 )
-            return MP2::OBJ_NON_ACTION_MERMAID;
-        else if ( icnIndex == 101 )
-            return MP2::OBJ_SIRENS;
-        else if ( 46 < icnIndex && icnIndex < 111 )
-            return MP2::OBJ_NON_ACTION_SIRENS;
-        else if ( ObjXlc2::isReefs( icnIndex ) )
-            return MP2::OBJ_REEFS;
-        break;
-
-    case ICN::X_LOC3:
-        if ( icnIndex == 30 )
-            return MP2::OBJ_HUT_OF_MAGI;
-        else if ( icnIndex < 32 )
-            return MP2::OBJ_NON_ACTION_HUT_OF_MAGI;
-        else if ( icnIndex == 50 )
-            return MP2::OBJ_EYE_OF_MAGI;
-        else if ( 31 < icnIndex && icnIndex < 59 )
-            return MP2::OBJ_NON_ACTION_EYE_OF_MAGI;
-        break;
-
-    default:
-        break;
-    }
-
-    return MP2::OBJ_NONE;
-}
-
 bool Maps::TilesAddon::isRoad() const
 {
-    switch ( MP2::GetICNObject( _objectType ) ) {
+    switch ( MP2::getIcnIdFromObjectIcnType( _objectIcnType >> 2 ) ) {
     // road sprite
     case ICN::ROAD:
         if ( 1 == _imageIndex || 8 == _imageIndex || 10 == _imageIndex || 11 == _imageIndex || 15 == _imageIndex || 22 == _imageIndex || 23 == _imageIndex
@@ -602,68 +615,68 @@ bool Maps::TilesAddon::isRoad() const
 
 bool Maps::TilesAddon::isResource( const TilesAddon & ta )
 {
-    return ICN::OBJNRSRC == MP2::GetICNObject( ta._objectType ) && ( ta._imageIndex % 2 );
+    return ICN::OBJNRSRC == MP2::getIcnIdFromObjectIcnType( ta._objectIcnType >> 2 ) && ( ta._imageIndex % 2 );
 }
 
 bool Maps::TilesAddon::isArtifact( const TilesAddon & ta )
 {
     // OBJNARTI (skip ultimate)
-    return ( ICN::OBJNARTI == MP2::GetICNObject( ta._objectType ) && ( ta._imageIndex > 0x10 ) && ( ta._imageIndex % 2 ) );
+    return ( ICN::OBJNARTI == MP2::getIcnIdFromObjectIcnType( ta._objectIcnType >> 2 ) && ( ta._imageIndex > 0x10 ) && ( ta._imageIndex % 2 ) );
 }
 
-int Maps::Tiles::ColorFromBarrierSprite( const uint8_t tileset, const uint8_t icnIndex )
+int Maps::Tiles::getColorFromBarrierSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
 {
-    // 60, 66, 72, 78, 84, 90, 96, 102
-    return ICN::X_LOC3 == MP2::GetICNObject( tileset ) && 60 <= icnIndex && 102 >= icnIndex ? ( ( icnIndex - 60 ) / 6 ) + 1 : 0;
+    if ( ICN::X_LOC3 == MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ) && 60 <= icnIndex && 102 >= icnIndex ) {
+        // 60, 66, 72, 78, 84, 90, 96, 102
+        return ( ( icnIndex - 60 ) / 6 ) + 1;
+    }
+
+    return 0;
 }
 
-int Maps::Tiles::ColorFromTravellerTentSprite( const uint8_t tileset, const uint8_t icnIndex )
+int Maps::Tiles::getColorFromTravellerTentSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex )
 {
+    if ( ICN::X_LOC3 == MP2::getIcnIdFromObjectIcnType( nonCorrectedObjectIcnType >> 2 ) && 110 <= icnIndex && 138 >= icnIndex ) {
     // 110, 114, 118, 122, 126, 130, 134, 138
-    return ICN::X_LOC3 == MP2::GetICNObject( tileset ) && 110 <= icnIndex && 138 >= icnIndex ? ( ( icnIndex - 110 ) / 4 ) + 1 : 0;
+        return ( ( icnIndex - 110 ) / 4 ) + 1;
+    }
+
+    return 0;
 }
 
 bool Maps::TilesAddon::isShadow( const TilesAddon & ta )
 {
-    return Tiles::isShadowSprite( ta._objectType, ta._imageIndex );
+    return isShadowSprite( ta._objectIcnType, ta._imageIndex );
 }
 
-bool Maps::Tiles::isShadowSprite( const int icn, const uint8_t icnIndex )
+void Maps::Tiles::UpdateAbandonedMineLeftSprite( uint8_t & nonCorrectedObjectIcnType, uint8_t & imageIndex, const int resource )
 {
-    return isValidShadowSprite( icn, icnIndex );
-}
+    const uint8_t objectIcnType = ( nonCorrectedObjectIcnType >> 2 );
 
-bool Maps::Tiles::isShadowSprite( const uint8_t tileset, const uint8_t icnIndex )
-{
-    return isShadowSprite( MP2::GetICNObject( tileset ), icnIndex );
-}
-
-void Maps::Tiles::UpdateAbandonedMineLeftSprite( uint8_t & tileset, uint8_t & index, const int resource )
-{
-    if ( ICN::OBJNGRAS == MP2::GetICNObject( tileset ) && 6 == index ) {
-        tileset = ( MP2::OBJ_ICN_TYPE_MTNGRAS << 2 );
-        index = 82;
+    if ( MP2::OBJ_ICN_TYPE_OBJNGRAS == objectIcnType && imageIndex == 6 ) {
+        nonCorrectedObjectIcnType = ( nonCorrectedObjectIcnType % 4 ) | ( MP2::OBJ_ICN_TYPE_MTNGRAS << 2 );
+        imageIndex = 82;
     }
-    else if ( ICN::OBJNDIRT == MP2::GetICNObject( tileset ) && 8 == index ) {
-        tileset = ( MP2::OBJ_ICN_TYPE_MTNDIRT << 2 );
-        index = 112;
+    else if ( MP2::OBJ_ICN_TYPE_OBJNDIRT == objectIcnType && imageIndex == 8 ) {
+        nonCorrectedObjectIcnType = ( nonCorrectedObjectIcnType % 4 ) | ( MP2::OBJ_ICN_TYPE_MTNDIRT << 2 );
+        imageIndex = 112;
     }
-    else if ( ICN::EXTRAOVR == MP2::GetICNObject( tileset ) && 5 == index ) {
+    else if ( ICN::EXTRAOVR == objectIcnType && imageIndex == 5 ) {
         switch ( resource ) {
         case Resource::ORE:
-            index = 0;
+            imageIndex = 0;
             break;
         case Resource::SULFUR:
-            index = 1;
+            imageIndex = 1;
             break;
         case Resource::CRYSTAL:
-            index = 2;
+            imageIndex = 2;
             break;
         case Resource::GEMS:
-            index = 3;
+            imageIndex = 3;
             break;
         case Resource::GOLD:
-            index = 4;
+            imageIndex = 4;
             break;
         default:
             break;
@@ -671,15 +684,17 @@ void Maps::Tiles::UpdateAbandonedMineLeftSprite( uint8_t & tileset, uint8_t & in
     }
 }
 
-void Maps::Tiles::UpdateAbandonedMineRightSprite( uint8_t & tileset, uint8_t & index )
+void Maps::Tiles::UpdateAbandonedMineRightSprite( uint8_t & nonCorrectedObjectIcnType, uint8_t & imageIndex )
 {
-    if ( ICN::OBJNDIRT == MP2::GetICNObject( tileset ) && index == 9 ) {
-        tileset = ( MP2::OBJ_ICN_TYPE_MTNDIRT << 2 );
-        index = 113;
+    const uint8_t objectIcnType = ( nonCorrectedObjectIcnType >> 2 );
+
+    if ( MP2::OBJ_ICN_TYPE_OBJNDIRT == objectIcnType && imageIndex == 9 ) {
+        nonCorrectedObjectIcnType = ( nonCorrectedObjectIcnType % 4 ) | ( MP2::OBJ_ICN_TYPE_MTNDIRT << 2 );
+        imageIndex = 113;
     }
-    else if ( ICN::OBJNGRAS == MP2::GetICNObject( tileset ) && index == 7 ) {
-        tileset = ( MP2::OBJ_ICN_TYPE_MTNGRAS << 2 );
-        index = 83;
+    else if ( MP2::OBJ_ICN_TYPE_OBJNGRAS == objectIcnType && imageIndex == 7 ) {
+        nonCorrectedObjectIcnType = ( nonCorrectedObjectIcnType % 4 ) | ( MP2::OBJ_ICN_TYPE_MTNGRAS << 2 );
+        imageIndex = 83;
     }
 }
 
@@ -749,14 +764,14 @@ void Maps::Tiles::Init( int32_t index, const MP2::mp2tile_t & mp2 )
     addons_level2.clear();
 
     // those bitfields are set by map editor regardless if map object is there
-    tileIsRoad = ( ( mp2.objectName1 >> 1 ) & 1 ) && ( MP2::GetICNObject( mp2.objectName1 ) == ICN::ROAD );
+    tileIsRoad = ( ( mp2.objectName1 >> 1 ) & 1 ) && ( ( mp2.objectName1 >> 2 ) == MP2::OBJ_ICN_TYPE_ROAD );
 
     // If an object has priority 2 (shadow) or 3 (ground) then we put it as an addon.
     if ( mp2.mapObjectType == MP2::OBJ_NONE && ( _layerType >> 1 ) & 1 ) {
         AddonsPushLevel1( mp2 );
     }
     else {
-        _objectType = mp2.objectName1;
+        _objectIcnType = mp2.objectName1;
         _imageIndex = mp2.level1IcnImageIndex;
         _uid = mp2.level1ObjectUID;
     }
@@ -765,13 +780,13 @@ void Maps::Tiles::Init( int32_t index, const MP2::mp2tile_t & mp2 )
 
 Heroes * Maps::Tiles::GetHeroes() const
 {
-    return MP2::OBJ_HEROES == mp2_object && heroID ? world.GetHeroes( heroID - 1 ) : nullptr;
+    return MP2::OBJ_HEROES == _mainObjectType && heroID ? world.GetHeroes( heroID - 1 ) : nullptr;
 }
 
 void Maps::Tiles::SetHeroes( Heroes * hero )
 {
     if ( hero ) {
-        hero->SetMapsObject( mp2_object );
+        hero->SetMapsObject( _mainObjectType );
         heroID = hero->GetID() + 1;
         SetObject( MP2::OBJ_HEROES );
     }
@@ -797,28 +812,28 @@ fheroes2::Point Maps::Tiles::GetCenter() const
 
 MP2::MapObjectType Maps::Tiles::GetObject( bool ignoreObjectUnderHero /* true */ ) const
 {
-    if ( !ignoreObjectUnderHero && MP2::OBJ_HEROES == mp2_object ) {
+    if ( !ignoreObjectUnderHero && MP2::OBJ_HEROES == _mainObjectType ) {
         const Heroes * hero = GetHeroes();
         return hero ? hero->GetMapsObject() : MP2::OBJ_NONE;
     }
 
-    return mp2_object;
+    return _mainObjectType;
 }
 
 void Maps::Tiles::SetObject( const MP2::MapObjectType objectType )
 {
-    mp2_object = objectType;
+    _mainObjectType = objectType;
     world.resetPathfinder();
 }
 
 void Maps::Tiles::setBoat( int direction )
 {
-    if ( _objectType != 0 && _imageIndex != 255 ) {
-        AddonsPushLevel1( TilesAddon( OBJECT_LAYER, _uid, _objectType, _imageIndex ) );
+    if ( _objectIcnType != 0 && _imageIndex != 255 ) {
+        AddonsPushLevel1( TilesAddon( OBJECT_LAYER, _uid, _objectIcnType, _imageIndex ) );
     }
     SetObject( MP2::OBJ_BOAT );
     // TODO: this is absolutely wrong to assign ICN id to object type!
-    _objectType = ICN::BOAT32;
+    _objectIcnType = ICN::BOAT32;
 
     // Left-side sprites have to flipped, add 128 to index
     switch ( direction ) {
@@ -858,7 +873,7 @@ int Maps::Tiles::getBoatDirection() const
 {
     // Check if it really is a boat
     // TODO: this is an incorrect check! We cannot directly compare object type with an ICN.
-    if ( _objectType != ICN::BOAT32 )
+    if ( _objectIcnType != ICN::BOAT32 )
         return Direction::UNKNOWN;
 
     // Left-side sprites have to flipped, add 128 to index
@@ -899,17 +914,17 @@ int Maps::Tiles::getOriginalPassability() const
         return MP2::getActionObjectDirection( objectType );
     }
 
-    if ( ( _objectType == 0 || _imageIndex == 255 ) || ( ( _layerType >> 1 ) & 1 ) || isShadow() ) {
+    if ( ( _objectIcnType == 0 || _imageIndex == 255 ) || ( ( _layerType >> 1 ) & 1 ) || isShadow() ) {
         // No object exists. Make it fully passable.
         return DIRECTION_ALL;
     }
 
-    if ( isValidReefsSprite( MP2::GetICNObject( _objectType ), _imageIndex ) ) {
+    if ( isValidReefsSprite( _objectIcnType >> 2, _imageIndex ) ) {
         return 0;
     }
 
     for ( const TilesAddon & addon : addons_level1 ) {
-        if ( isValidReefsSprite( MP2::GetICNObject( addon._objectType ), addon._imageIndex ) ) {
+        if ( isValidReefsSprite( addon._objectIcnType >> 2, addon._imageIndex ) ) {
             return 0;
         }
     }
@@ -940,14 +955,14 @@ void Maps::Tiles::updatePassability()
 
     const MP2::MapObjectType objectType = GetObject( false );
     const bool isActionObject = MP2::isActionObject( objectType );
-    if ( !isActionObject && _objectType > 0 && _imageIndex < 255 && ( ( _layerType >> 1 ) & 1 ) == 0 && !isShadow() ) {
+    if ( !isActionObject && _objectIcnType > 0 && _imageIndex < 255 && ( ( _layerType >> 1 ) & 1 ) == 0 && !isShadow() ) {
         // This is a non-action object.
         if ( Maps::isValidDirection( _index, Direction::BOTTOM ) ) {
             const Tiles & bottomTile = world.GetTiles( Maps::GetDirectionIndex( _index, Direction::BOTTOM ) );
 
             // If a bottom tile has the same object ID then this tile is inaccessible.
             std::vector<uint32_t> tileUIDs;
-            if ( _objectType > 0 && _imageIndex < 255 && _uid != 0 && ( ( _layerType >> 1 ) & 1 ) == 0 ) {
+            if ( _objectIcnType > 0 && _imageIndex < 255 && _uid != 0 && ( ( _layerType >> 1 ) & 1 ) == 0 ) {
                 tileUIDs.emplace_back( _uid );
             }
 
@@ -977,15 +992,15 @@ void Maps::Tiles::updatePassability()
                     return false;
                 }
 
-                const int icnType = MP2::GetICNObject( addon._objectType );
-                return icnType != ICN::ROAD && icnType != ICN::STREAM;
+                const uint8_t correctedIcnType = ( addon._objectIcnType >> 2 );
+                return correctedIcnType != MP2::OBJ_ICN_TYPE_ROAD && correctedIcnType != MP2::OBJ_ICN_TYPE_STREAM;
             } );
 
-            const bool singleObjectTile = validLevel1ObjectCount == 0 && addons_level2.empty() && ( bottomTile._objectType >> 2 ) != ( _objectType >> 2 );
+            const bool singleObjectTile = validLevel1ObjectCount == 0 && addons_level2.empty() && ( bottomTile._objectIcnType >> 2 ) != ( _objectIcnType >> 2 );
             const bool isBottomTileObject = ( ( bottomTile._layerType >> 1 ) & 1 ) == 0;
 
             // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
-            if ( !singleObjectTile && !isDetachedObject() && isBottomTileObject && bottomTile._objectType > 0 && bottomTile._imageIndex < 255 ) {
+            if ( !singleObjectTile && !isDetachedObject() && isBottomTileObject && bottomTile._objectIcnType > 0 && bottomTile._imageIndex < 255 ) {
                 const MP2::MapObjectType bottomTileObjectType = bottomTile.GetObject( false );
                 const bool isBottomTileActionObject = MP2::isActionObject( bottomTileObjectType );
                 const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( bottomTileObjectType );
@@ -1001,12 +1016,12 @@ void Maps::Tiles::updatePassability()
                         }
                     }
                 }
-                else if ( bottomTile.mp2_object != MP2::OBJ_NONE && correctedObjectType != bottomTileObjectType && MP2::isActionObject( correctedObjectType )
+                else if ( bottomTile._mainObjectType != MP2::OBJ_NONE && correctedObjectType != bottomTileObjectType && MP2::isActionObject( correctedObjectType )
                           && isShortObject( correctedObjectType ) && ( bottomTile.getOriginalPassability() & Direction::TOP ) == 0 ) {
                     tilePassable &= ~Direction::BOTTOM;
                 }
-                else if ( isShortObject( bottomTileObjectType )
-                          || ( !bottomTile.containsTileSet( getValidTileSets() ) && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
+                else if ( isShortObject( bottomTileObjectType ) || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() ) &&
+                          ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
                     tilePassable &= ~Direction::BOTTOM;
                 }
                 else {
@@ -1080,7 +1095,7 @@ bool Maps::Tiles::isClearGround() const
         break;
     }
 
-    if ( _objectType == 0 || _imageIndex == 255 || ( ( _layerType >> 1 ) & 1 ) == 1 ) {
+    if ( _objectIcnType == 0 || _imageIndex == 255 || ( ( _layerType >> 1 ) & 1 ) == 1 ) {
         if ( MP2::isActionObject( objectType, isWater() ) ) {
             return false;
         }
@@ -1098,8 +1113,8 @@ void Maps::Tiles::AddonsPushLevel1( const MP2::mp2tile_t & mt )
     }
 
     // MP2 "objectName" is a bitfield
-    // 6 bits is ICN tileset id, 1 bit is isRoad flag, 1 bit is hasAnimation flag
-    if ( ( ( mt.objectName1 >> 1 ) & 1 ) && ( MP2::GetICNObject( mt.objectName1 ) == ICN::ROAD ) )
+    // 6 bits is for object ICN type, 1 bit is isRoad flag, 1 bit is hasAnimation flag
+    if ( ( ( mt.objectName1 >> 1 ) & 1 ) && ( ( mt.objectName1 >> 2 ) == MP2::OBJ_ICN_TYPE_ROAD ) )
         tileIsRoad = true;
 }
 
@@ -1134,8 +1149,8 @@ void Maps::Tiles::AddonsPushLevel2( const MP2::mp2addon_t & ma )
 void Maps::Tiles::AddonsSort()
 {
     // Push everything to the container and sort it by level.
-    if ( _objectType != 0 && _imageIndex < 255 ) {
-        addons_level1.emplace_front( _layerType, _uid, _objectType, _imageIndex );
+    if ( _objectIcnType != 0 && _imageIndex < 255 ) {
+        addons_level1.emplace_front( _layerType, _uid, _objectIcnType, _imageIndex );
     }
 
     // Some original maps have issues with identifying tiles as roads. This code fixes it. It's not an ideal solution but works fine in most of cases.
@@ -1153,7 +1168,7 @@ void Maps::Tiles::AddonsSort()
     if ( !addons_level1.empty() ) {
         const TilesAddon & highestPriorityAddon = addons_level1.back();
         _uid = highestPriorityAddon._uid;
-        _objectType = highestPriorityAddon._objectType;
+        _objectIcnType = highestPriorityAddon._objectIcnType;
         _imageIndex = highestPriorityAddon._imageIndex;
         _layerType = highestPriorityAddon._layerType & 0x03;
 
@@ -1242,12 +1257,11 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
             continue;
         }
 
-        if ( isPuzzleDraw && MP2::isHiddenForPuzzle( GetGround(), addon._objectType, addon._imageIndex ) ) {
+        if ( isPuzzleDraw && MP2::isHiddenForPuzzle( GetGround(), addon._objectIcnType, addon._imageIndex ) ) {
             continue;
         }
 
-        const int icn = MP2::GetICNObject( addon._objectType );
-        if ( icn == ICN::FLAG32 ) {
+        if ( ( addon._objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_FLAG32 ) {
             // Based on logically thinking it is impossible to have more than 16 flags on a single tile.
             assert( postRenderAddonCount < maxPostRenderAddons );
 
@@ -1259,7 +1273,7 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
         renderAddonObject( dst, area, mp, addon );
     }
 
-    if ( _objectType != 0 && ( _layerType & 0x03 ) == level && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( GetGround(), _objectType, _imageIndex ) ) ) {
+    if ( _objectIcnType != 0 && ( _layerType & 0x03 ) == level && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( GetGround(), _objectIcnType, _imageIndex ) ) ) {
         renderMainObject( dst, area, mp );
     }
 
@@ -1272,9 +1286,9 @@ void Maps::Tiles::redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzle
 
 void Maps::Tiles::renderAddonObject( fheroes2::Image & output, const Interface::GameArea & area, const fheroes2::Point & offset, const TilesAddon & addon )
 {
-    assert( addon._objectType != 0 && addon._imageIndex != 255 );
+    assert( addon._objectIcnType != 0 && addon._imageIndex != 255 );
 
-    const int icn = MP2::GetICNObject( addon._objectType );
+    const int icn = MP2::getIcnIdFromObjectIcnType( addon._objectIcnType >> 2 );
     if ( isDirectRenderingRestricted( icn ) ) {
         return;
     }
@@ -1307,9 +1321,9 @@ void Maps::Tiles::renderAddonObject( fheroes2::Image & output, const Interface::
 
 void Maps::Tiles::renderMainObject( fheroes2::Image & output, const Interface::GameArea & area, const fheroes2::Point & offset ) const
 {
-    assert( _objectType != 0 && _imageIndex != 255 );
+    assert( _objectIcnType != 0 && _imageIndex != 255 );
 
-    const int mainObjectIcn = MP2::GetICNObject( _objectType );
+    const int mainObjectIcn = MP2::getIcnIdFromObjectIcnType( _objectIcnType >> 2 );
     if ( isDirectRenderingRestricted( mainObjectIcn ) ) {
         return;
     }
@@ -1338,22 +1352,22 @@ void Maps::Tiles::renderMainObject( fheroes2::Image & output, const Interface::G
     }
 }
 
-void Maps::Tiles::drawByIcnId( fheroes2::Image & output, const Interface::GameArea & area, const int32_t icnId ) const
+void Maps::Tiles::drawByObjectIcnType( fheroes2::Image & output, const Interface::GameArea & area, const uint8_t objectIcnType ) const
 {
     const fheroes2::Point & tileOffset = Maps::GetPoint( _index );
 
     for ( const TilesAddon & addon : addons_level1 ) {
-        if ( MP2::GetICNObject( addon._objectType ) == icnId ) {
+        if ( ( addon._objectIcnType >> 2 ) == objectIcnType ) {
             renderAddonObject( output, area, tileOffset, addon );
         }
     }
 
-    if ( MP2::GetICNObject( _objectType ) == icnId ) {
+    if ( ( _objectIcnType >> 2 ) == objectIcnType ) {
         renderMainObject( output, area, tileOffset );
     }
 
     for ( const TilesAddon & addon : addons_level2 ) {
-        if ( MP2::GetICNObject( addon._objectType ) == icnId ) {
+        if ( ( addon._objectIcnType >> 2 ) == objectIcnType ) {
             renderAddonObject( output, area, tileOffset, addon );
         }
     }
@@ -1518,7 +1532,7 @@ void Maps::Tiles::redrawTopLayerExtraObjects( fheroes2::Image & dst, const bool 
 
 void Maps::Tiles::redrawTopLayerObject( fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area, const TilesAddon & addon ) const
 {
-    if ( isPuzzleDraw && MP2::isHiddenForPuzzle( GetGround(), addon._objectType, addon._imageIndex ) ) {
+    if ( isPuzzleDraw && MP2::isHiddenForPuzzle( GetGround(), addon._objectIcnType, addon._imageIndex ) ) {
         return;
     }
 
@@ -1550,12 +1564,13 @@ std::string Maps::Tiles::String() const
        << "point: (" << GetCenter().x << ", " << GetCenter().y << ")" << std::endl
        << "UID             : " << _uid << std::endl
        << "MP2 object type : " << static_cast<int>( objectType ) << " (" << MP2::StringObject( objectType ) << ")" << std::endl
-       << "object type     : " << static_cast<int>( _objectType ) << " (" << ICN::GetString( MP2::GetICNObject( _objectType ) ) << ")" << std::endl
+       << "object type     : " << static_cast<int>( _objectIcnType ) << " (" << ICN::GetString( MP2::getIcnIdFromObjectIcnType( _objectIcnType >> 2 ) ) << ")"
+                               << std::endl
        << "image index     : " << static_cast<int>( _imageIndex ) << " (animated: " << hasSpriteAnimation() << ")" << std::endl
        << "layer type      : " << static_cast<int>( _layerType ) << " - " << getObjectLayerName( _layerType ) << std::endl
        << "region          : " << _region << std::endl
        << "ground          : " << Ground::String( GetGround() ) << " (isRoad: " << tileIsRoad << ")" << std::endl
-       << "shadow          : " << ( isShadowSprite( _objectType, _imageIndex ) ? "true" : "false" ) << std::endl
+       << "shadow          : " << ( isShadowSprite( _objectIcnType, _imageIndex ) ? "true" : "false" ) << std::endl
        << "passable from   : " << ( tilePassable ? Direction::String( tilePassable ) : "nowhere" );
 
     os << std::endl
@@ -1635,7 +1650,7 @@ std::string Maps::Tiles::String() const
 
 void Maps::Tiles::FixObject()
 {
-    if ( MP2::OBJ_NONE == mp2_object ) {
+    if ( MP2::OBJ_NONE == _mainObjectType ) {
         if ( std::any_of( addons_level1.begin(), addons_level1.end(), TilesAddon::isArtifact ) )
             SetObject( MP2::OBJ_ARTIFACT );
         else if ( std::any_of( addons_level1.begin(), addons_level1.end(), TilesAddon::isResource ) )
@@ -1649,7 +1664,7 @@ bool Maps::Tiles::GoodForUltimateArtifact() const
         return false;
     }
 
-    if ( _objectType != 0 && !isShadowSprite( _objectType, _imageIndex ) ) {
+    if ( _objectIcnType != 0 && !isShadowSprite( _objectIcnType, _imageIndex ) ) {
         return false;
     }
 
@@ -1673,12 +1688,12 @@ bool Maps::Tiles::isPassableFrom( const int direction, const bool fromWater, con
     const bool tileIsWater = isWater();
 
     // From the water we can get either to the coast tile or to the water tile (provided there is no boat on this tile).
-    if ( fromWater && mp2_object != MP2::OBJ_COAST && ( !tileIsWater || mp2_object == MP2::OBJ_BOAT ) ) {
+    if ( fromWater && _mainObjectType != MP2::OBJ_COAST && ( !tileIsWater || _mainObjectType == MP2::OBJ_BOAT ) ) {
         return false;
     }
 
     // From the ground we can get to the water tile only if this tile contains a certain object.
-    if ( !fromWater && tileIsWater && mp2_object != MP2::OBJ_SHIPWRECK && mp2_object != MP2::OBJ_HEROES && mp2_object != MP2::OBJ_BOAT ) {
+    if ( !fromWater && tileIsWater && _mainObjectType != MP2::OBJ_SHIPWRECK && _mainObjectType != MP2::OBJ_HEROES && _mainObjectType != MP2::OBJ_BOAT ) {
         return false;
     }
 
@@ -1702,24 +1717,26 @@ void Maps::Tiles::SetObjectPassable( bool pass )
 
 bool Maps::Tiles::isStream() const
 {
-    for ( auto it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
-        const int icn = MP2::GetICNObject( it->_objectType );
-        if ( icn == ICN::STREAM || ( icn == ICN::OBJNMUL2 && it->_imageIndex < 14 ) )
+    for ( const TilesAddon & addon : addons_level1 ) {
+        const uint8_t correctedObjectIcnType = addon._objectIcnType;
+        if ( correctedObjectIcnType == MP2::OBJ_ICN_TYPE_STREAM || ( correctedObjectIcnType == MP2::OBJ_ICN_TYPE_OBJNMUL2 && addon._imageIndex < 14 ) ) {
             return true;
+        }
     }
-    const int tileICN = MP2::GetICNObject( _objectType );
-    return tileICN == ICN::STREAM || ( tileICN == ICN::OBJNMUL2 && _imageIndex < 14 );
+
+    const uint8_t correctedObjectIcnType = _objectIcnType;
+    return correctedObjectIcnType == MP2::OBJ_ICN_TYPE_STREAM || ( correctedObjectIcnType == MP2::OBJ_ICN_TYPE_OBJNMUL2 && _imageIndex < 14 );
 }
 
 bool Maps::Tiles::isShadow() const
 {
-    return isShadowSprite( _objectType, _imageIndex )
+    return isShadowSprite( _objectIcnType, _imageIndex )
            && addons_level1.size() == static_cast<size_t>( std::count_if( addons_level1.begin(), addons_level1.end(), TilesAddon::isShadow ) );
 }
 
 Maps::TilesAddon * Maps::Tiles::getAddonWithFlag( const uint32_t uid )
 {
-    auto isFlag = [uid]( const TilesAddon & addon ) { return addon._uid == uid && MP2::GetICNObject( addon._objectType ) == ICN::FLAG32; };
+    auto isFlag = [uid]( const TilesAddon & addon ) { return addon._uid == uid && ( addon._objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_FLAG32; };
 
     auto iter = std::find_if( addons_level1.begin(), addons_level1.end(), isFlag );
     if ( iter != addons_level1.end() ) {
@@ -1854,7 +1871,7 @@ void Maps::Tiles::updateFlag( const int color, const uint8_t objectSpriteIndex, 
 {
     // Flag deletion or installation must be done in relation to object UID as flag is attached to the object.
     if ( color == Color::NONE ) {
-        auto isFlag = [uid]( const TilesAddon & addon ) { return addon._uid == uid && MP2::GetICNObject( addon._objectType ) == ICN::FLAG32; };
+        auto isFlag = [uid]( const TilesAddon & addon ) { return addon._uid == uid && ( addon._objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_FLAG32; };
         addons_level1.remove_if( isFlag );
         addons_level2.remove_if( isFlag );
         return;
@@ -1878,10 +1895,10 @@ void Maps::Tiles::updateFlag( const int color, const uint8_t objectSpriteIndex, 
 void Maps::Tiles::fixTileObjectType( Tiles & tile )
 {
     const MP2::MapObjectType originalObjectType = tile.GetObject( false );
-    const int originalICN = MP2::GetICNObject( tile._objectType );
+    const uint8_t correctedObjectIcnType = ( tile._objectIcnType >> 2 );
 
     // Left tile of a skeleton on Desert should be mark as non-action tile.
-    if ( originalObjectType == MP2::OBJ_SKELETON && originalICN == ICN::OBJNDSRT && tile._imageIndex == 83 ) {
+    if ( originalObjectType == MP2::OBJ_SKELETON && correctedObjectIcnType == MP2::OBJ_ICN_TYPE_OBJNDSRT && tile._imageIndex == 83 ) {
         tile.SetObject( MP2::OBJ_NON_ACTION_SKELETON );
 
         // There is no need to check the rest of things as we fixed this object.
@@ -1890,7 +1907,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
 
     // Original Editor marks Reefs as Stones. We're fixing this issue by changing the type of the object without changing the content of a tile.
     // This is also required in order to properly calculate Reefs' passbility.
-    if ( originalObjectType == MP2::OBJ_ROCK && isValidReefsSprite( originalICN, tile._imageIndex ) ) {
+    if ( originalObjectType == MP2::OBJ_ROCK && isValidReefsSprite( correctedObjectIcnType, tile._imageIndex ) ) {
         tile.SetObject( MP2::OBJ_REEFS );
 
         // There is no need to check the rest of things as we fixed this object.
@@ -1915,28 +1932,23 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
     // On some maps (apparently created by some non-standard editor), the object type on tiles with random monsters does not match the index
     // of the monster placeholder sprite. While this engine looks at the object type when placing an actual monster on a tile, the original
     // HoMM2 apparently looks at the placeholder sprite, so we need to keep them in sync.
-    if ( originalICN == ICN::MONS32 ) {
+    if ( correctedObjectIcnType == MP2::OBJ_ICN_TYPE_MONS32 ) {
         MP2::MapObjectType monsterObjectType = originalObjectType;
 
         const uint8_t originalObjectSpriteIndex = tile.GetObjectSpriteIndex();
         switch ( originalObjectSpriteIndex ) {
-        // Random monster placeholder "MON"
         case 66:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER;
             break;
-        // Random monster placeholder "MON 1"
         case 67:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER_WEAK;
             break;
-        // Random monster placeholder "MON 2"
         case 68:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER_MEDIUM;
             break;
-        // Random monster placeholder "MON 3"
         case 69:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER_STRONG;
             break;
-        // Random monster placeholder "MON 4"
         case 70:
             monsterObjectType = MP2::OBJ_RANDOM_MONSTER_VERY_STRONG;
             break;
@@ -1962,7 +1974,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
     case MP2::OBJ_NON_ACTION_EXPANSION_OBJECT:
     case MP2::OBJ_EXPANSION_DWELLING:
     case MP2::OBJ_EXPANSION_OBJECT: {
-        MP2::MapObjectType objectType = Maps::Tiles::GetLoyaltyObject( tile._objectType, tile._imageIndex );
+        MP2::MapObjectType objectType = getLoyaltyObject( tile._objectIcnType, tile._imageIndex );
         if ( objectType != MP2::OBJ_NONE ) {
             tile.SetObject( objectType );
             break;
@@ -1970,7 +1982,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
 
         // Add-ons of level 1 shouldn't even exist if no top object. However, let's play safe and verify it as well.
         for ( const TilesAddon & addon : tile.addons_level1 ) {
-            objectType = Maps::Tiles::GetLoyaltyObject( addon._objectType, addon._imageIndex );
+            objectType = getLoyaltyObject( addon._objectIcnType, addon._imageIndex );
             if ( objectType != MP2::OBJ_NONE )
                 break;
         }
@@ -1981,7 +1993,7 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
         }
 
         for ( const TilesAddon & addon : tile.addons_level2 ) {
-            objectType = Maps::Tiles::GetLoyaltyObject( addon._objectType, addon._imageIndex );
+            objectType = getLoyaltyObject( addon._objectIcnType, addon._imageIndex );
             if ( objectType != MP2::OBJ_NONE )
                 break;
         }
@@ -2030,51 +2042,51 @@ void Maps::Tiles::Remove( uint32_t uniqID )
     }
 }
 
-void Maps::Tiles::ReplaceObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, uint8_t indexToReplace, uint8_t newIndex )
+void Maps::Tiles::replaceObject( const uint32_t objectUid, const uint8_t originalObjectIcnType, const uint8_t newObjectIcnType, const uint8_t originalImageIndex,
+                                 const uint8_t newimageIndex )
 {
-    for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
-        if ( it->_uid == uniqID && ( it->_objectType >> 2 ) == rawTileset && it->_imageIndex == indexToReplace ) {
-            // TODO: this is wrong to directly assign new object type ignoring first 2 bits.
-            it->_objectType = newTileset;
-            it->_imageIndex = newIndex;
-        }
-    }
-    for ( Addons::iterator it2 = addons_level2.begin(); it2 != addons_level2.end(); ++it2 ) {
-        if ( it2->_uid == uniqID && ( it2->_objectType >> 2 ) == rawTileset && it2->_imageIndex == indexToReplace ) {
-            // TODO: this is wrong to directly assign new object type ignoring first 2 bits.
-            it2->_objectType = newTileset;
-            it2->_imageIndex = newIndex;
+    // We can immediately return from the function as only one object per tile can have the same UID.
+    for ( TilesAddon & addon : addons_level1 ) {
+        if ( addon._uid == objectUid && ( addon._objectIcnType >> 2 ) == originalObjectIcnType && addon._imageIndex == originalImageIndex ) {
+            addon._objectIcnType = ( addon._objectIcnType % 4 ) | ( newObjectIcnType << 2 );
+            addon._imageIndex = newimageIndex;
+            return;
         }
     }
 
-    if ( _uid == uniqID && ( _objectType >> 2 ) == rawTileset && _imageIndex == indexToReplace ) {
-        // TODO: this is wrong to directly assign new object type ignoring first 2 bits.
-        _objectType = newTileset;
-        _imageIndex = newIndex;
+    for ( TilesAddon & addon : addons_level2 ) {
+        if ( addon._uid == objectUid && ( addon._objectIcnType >> 2 ) == originalObjectIcnType && addon._imageIndex == originalImageIndex ) {
+            addon._objectIcnType = ( addon._objectIcnType % 4 ) | ( newObjectIcnType << 2 );
+            addon._imageIndex = newimageIndex;
+            return;
+        }
+    }
+
+    if ( _uid == objectUid && ( _objectIcnType >> 2 ) == originalObjectIcnType && _imageIndex == originalImageIndex ) {
+        _objectIcnType = ( _objectIcnType & 0x3 ) | ( newObjectIcnType << 2 );
+        _imageIndex = newimageIndex;
     }
 }
 
-void Maps::Tiles::UpdateObjectSprite( uint32_t uniqID, uint8_t rawTileset, uint8_t newTileset, int indexChange )
+void Maps::Tiles::updateObjectImageIndex( const uint32_t objectUid, const uint8_t objectIcnType, const int imageIndexOffset )
 {
-    for ( Addons::iterator it = addons_level1.begin(); it != addons_level1.end(); ++it ) {
-        if ( it->_uid == uniqID && ( it->_objectType >> 2 ) == rawTileset ) {
-            // TODO: this is wrong to directly assign new object type ignoring first 2 bits.
-            it->_objectType = newTileset;
-            it->_imageIndex = it->_imageIndex + indexChange;
-        }
-    }
-    for ( Addons::iterator it2 = addons_level2.begin(); it2 != addons_level2.end(); ++it2 ) {
-        if ( it2->_uid == uniqID && ( it2->_objectType >> 2 ) == rawTileset ) {
-            // TODO: this is wrong to directly assign new object type ignoring first 2 bits.
-            it2->_objectType = newTileset;
-            it2->_imageIndex = it2->_imageIndex + indexChange;
+    // We can immediately return from the function as only one object per tile can have the same UID.
+    for ( TilesAddon & addon : addons_level1 ) {
+        if ( addon._uid == objectUid && ( addon._objectIcnType >> 2 ) == objectIcnType ) {
+            addon._imageIndex = addon._imageIndex + imageIndexOffset;
+            return;
         }
     }
 
-    if ( _uid == uniqID && ( _objectType >> 2 ) == rawTileset ) {
-        // TODO: this is wrong to directly assign new object type ignoring first 2 bits.
-        _objectType = newTileset;
-        _imageIndex += indexChange;
+    for ( TilesAddon & addon : addons_level2 ) {
+        if ( addon._uid == objectUid && ( addon._objectIcnType >> 2 ) == objectIcnType ) {
+            addon._imageIndex = addon._imageIndex + imageIndexOffset;
+            return;
+        }
+    }
+
+    if ( _uid == objectUid && ( _objectIcnType >> 2 ) == objectIcnType ) {
+        _imageIndex += imageIndexOffset;
     }
 }
 
@@ -2089,7 +2101,7 @@ void Maps::Tiles::RemoveObjectSprite()
         tilePassable = DIRECTION_ALL;
         break;
     case MP2::OBJ_ARTIFACT: {
-        const uint32_t uidArtifact = getObjectIdByICNType( ICN::OBJNARTI );
+        const uint32_t uidArtifact = getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNARTI );
         Remove( uidArtifact );
 
         if ( Maps::isValidDirection( _index, Direction::LEFT ) )
@@ -2098,7 +2110,7 @@ void Maps::Tiles::RemoveObjectSprite()
     }
     case MP2::OBJ_TREASURE_CHEST:
     case MP2::OBJ_RESOURCE: {
-        const uint32_t uidResource = getObjectIdByICNType( ICN::OBJNRSRC );
+        const uint32_t uidResource = getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNRSRC );
         Remove( uidResource );
 
         if ( Maps::isValidDirection( _index, Direction::LEFT ) )
@@ -2161,20 +2173,20 @@ void Maps::Tiles::UpdateAbandonedMineSprite( Tiles & tile )
     if ( tile._uid ) {
         const int type = tile.QuantityResourceCount().first;
 
-        Tiles::UpdateAbandonedMineLeftSprite( tile._objectType, tile._imageIndex, type );
+        Tiles::UpdateAbandonedMineLeftSprite( tile._objectIcnType, tile._imageIndex, type );
         for ( Addons::iterator it = tile.addons_level1.begin(); it != tile.addons_level1.end(); ++it )
-            Tiles::UpdateAbandonedMineLeftSprite( it->_objectType, it->_imageIndex, type );
+            Tiles::UpdateAbandonedMineLeftSprite( it->_objectIcnType, it->_imageIndex, type );
 
         if ( Maps::isValidDirection( tile._index, Direction::RIGHT ) ) {
             Tiles & tile2 = world.GetTiles( Maps::GetDirectionIndex( tile._index, Direction::RIGHT ) );
             TilesAddon * mines = tile2.FindAddonLevel1( tile._uid );
 
             if ( mines )
-                Tiles::UpdateAbandonedMineRightSprite( mines->_objectType, mines->_imageIndex );
+                Tiles::UpdateAbandonedMineRightSprite( mines->_objectIcnType, mines->_imageIndex );
 
             if ( tile2.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) {
                 tile2.SetObject( MP2::OBJ_NON_ACTION_MINES );
-                Tiles::UpdateAbandonedMineRightSprite( tile2._objectType, tile2._imageIndex );
+                Tiles::UpdateAbandonedMineRightSprite( tile2._objectIcnType, tile2._imageIndex );
             }
         }
     }
@@ -2232,7 +2244,7 @@ void Maps::Tiles::UpdateRNDArtifactSprite( Tiles & tile )
 
     tile.SetObject( MP2::OBJ_ARTIFACT );
 
-    uint32_t uidArtifact = tile.getObjectIdByICNType( ICN::OBJNARTI );
+    uint32_t uidArtifact = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNARTI );
     if ( uidArtifact == 0 ) {
         uidArtifact = tile._uid;
     }
@@ -2251,7 +2263,7 @@ void Maps::Tiles::UpdateRNDResourceSprite( Tiles & tile )
 
     const uint32_t resourceSprite = Resource::GetIndexSprite( Resource::Rand( true ) );
 
-    uint32_t uidResource = tile.getObjectIdByICNType( ICN::OBJNRSRC );
+    uint32_t uidResource = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNRSRC );
     if ( uidResource == 0 ) {
         uidResource = tile._uid;
     }
@@ -2575,7 +2587,7 @@ void Maps::Tiles::updateTileById( Maps::Tiles & tile, const uint32_t uid, const 
 
 void Maps::Tiles::updateEmpty()
 {
-    if ( mp2_object == MP2::OBJ_NONE ) {
+    if ( _mainObjectType == MP2::OBJ_NONE ) {
         setAsEmpty();
     }
 }
@@ -2607,20 +2619,20 @@ void Maps::Tiles::setAsEmpty()
     SetObject( isCoast ? MP2::OBJ_COAST : MP2::OBJ_NONE );
 }
 
-uint32_t Maps::Tiles::getObjectIdByICNType( const int icnId ) const
+uint32_t Maps::Tiles::getObjectIdByObjectIcnType( const uint8_t objectIcnType ) const
 {
-    if ( MP2::GetICNObject( _objectType ) == icnId ) {
+    if ( ( _objectIcnType >> 2 ) == objectIcnType ) {
         return _uid;
     }
 
     for ( const TilesAddon & addon : addons_level1 ) {
-        if ( MP2::GetICNObject( addon._objectType ) == icnId ) {
+        if ( ( addon._objectIcnType >> 2 ) == objectIcnType ) {
             return addon._uid;
         }
     }
 
     for ( const TilesAddon & addon : addons_level2 ) {
-        if ( MP2::GetICNObject( addon._objectType ) == icnId ) {
+        if ( ( addon._objectIcnType >> 2 ) == objectIcnType ) {
             return addon._uid;
         }
     }
@@ -2628,44 +2640,44 @@ uint32_t Maps::Tiles::getObjectIdByICNType( const int icnId ) const
     return 0;
 }
 
-std::vector<uint8_t> Maps::Tiles::getValidTileSets() const
+std::vector<uint8_t> Maps::Tiles::getValidObjectIcnTypes() const
 {
-    std::vector<uint8_t> tileSets;
+    std::vector<uint8_t> objectIcnTypes;
 
-    if ( _objectType != 0 ) {
-        tileSets.emplace_back( static_cast<uint8_t>( _objectType >> 2 ) );
+    if ( _objectIcnType != 0 ) {
+        objectIcnTypes.emplace_back( static_cast<uint8_t>( _objectIcnType >> 2 ) );
     }
 
     for ( const TilesAddon & addon : addons_level1 ) {
-        if ( addon._objectType != 0 ) {
-            tileSets.emplace_back( static_cast<uint8_t>( addon._objectType >> 2 ) );
+        if ( addon._objectIcnType != 0 ) {
+            objectIcnTypes.emplace_back( static_cast<uint8_t>( addon._objectIcnType >> 2 ) );
         }
     }
 
     for ( const TilesAddon & addon : addons_level2 ) {
-        if ( addon._objectType != 0 ) {
-            tileSets.emplace_back( static_cast<uint8_t>( addon._objectType >> 2 ) );
+        if ( addon._objectIcnType != 0 ) {
+            objectIcnTypes.emplace_back( static_cast<uint8_t>( addon._objectIcnType >> 2 ) );
         }
     }
 
-    return tileSets;
+    return objectIcnTypes;
 }
 
-bool Maps::Tiles::containsTileSet( const std::vector<uint8_t> & tileSets ) const
+bool Maps::Tiles::containsAnyObjectIcnType( const std::vector<uint8_t> & objectIcnTypes ) const
 {
-    for ( const uint8_t tileSetId : tileSets ) {
-        if ( ( _objectType >> 2 ) == tileSetId ) {
+    for ( const uint8_t objectIcnType : objectIcnTypes ) {
+        if ( ( _objectIcnType >> 2 ) == objectIcnType ) {
             return true;
         }
 
         for ( const TilesAddon & addon : addons_level1 ) {
-            if ( ( addon._objectType >> 2 ) == tileSetId ) {
+            if ( ( addon._objectIcnType >> 2 ) == objectIcnType ) {
                 return true;
             }
         }
 
         for ( const TilesAddon & addon : addons_level2 ) {
-            if ( ( addon._objectType >> 2 ) == tileSetId ) {
+            if ( ( addon._objectIcnType >> 2 ) == objectIcnType ) {
                 return true;
             }
         }
@@ -2674,22 +2686,20 @@ bool Maps::Tiles::containsTileSet( const std::vector<uint8_t> & tileSets ) const
     return false;
 }
 
-bool Maps::Tiles::containsSprite( uint8_t tileSetId, const uint32_t objectIdx ) const
+bool Maps::Tiles::containsSprite( const uint8_t objectIcnType, const uint32_t imageIdx ) const
 {
-    tileSetId = tileSetId >> 2;
-
-    if ( ( _objectType >> 2 ) == tileSetId && objectIdx == _imageIndex ) {
+    if ( ( _objectIcnType >> 2 ) == objectIcnType && imageIdx == _imageIndex ) {
         return true;
     }
 
     for ( const TilesAddon & addon : addons_level1 ) {
-        if ( ( addon._objectType >> 2 ) == tileSetId && objectIdx == _imageIndex ) {
+        if ( ( addon._objectIcnType >> 2 ) == objectIcnType && imageIdx == _imageIndex ) {
             return true;
         }
     }
 
     for ( const TilesAddon & addon : addons_level2 ) {
-        if ( ( addon._objectType >> 2 ) == tileSetId && objectIdx == _imageIndex ) {
+        if ( ( addon._objectIcnType >> 2 ) == objectIcnType && imageIdx == _imageIndex ) {
             return true;
         }
     }
@@ -2706,7 +2716,7 @@ bool Maps::Tiles::isTallObject() const
     }
 
     std::vector<uint32_t> tileUIDs;
-    if ( _objectType > 0 && _imageIndex < 255 && _uid != 0 && ( ( _layerType >> 1 ) & 1 ) == 0 ) {
+    if ( _objectIcnType > 0 && _imageIndex < 255 && _uid != 0 && ( ( _layerType >> 1 ) & 1 ) == 0 ) {
         tileUIDs.emplace_back( _uid );
     }
 
@@ -2724,7 +2734,7 @@ bool Maps::Tiles::isTallObject() const
 
     const Tiles & topTile = world.GetTiles( Maps::GetDirectionIndex( _index, Direction::TOP ) );
     for ( const uint32_t tileUID : tileUIDs ) {
-        if ( topTile._uid == tileUID && !topTile.isShadowSprite( topTile._objectType, topTile._imageIndex ) ) {
+        if ( topTile._uid == tileUID && !isShadowSprite( topTile._objectIcnType, topTile._imageIndex ) ) {
             return true;
         }
 
@@ -2830,12 +2840,12 @@ bool Maps::Tiles::isDetachedObject() const
 
 StreamBase & Maps::operator<<( StreamBase & msg, const TilesAddon & ta )
 {
-    return msg << ta._layerType << ta._uid << ta._objectType << ta._imageIndex;
+    return msg << ta._layerType << ta._uid << ta._objectIcnType << ta._imageIndex;
 }
 
 StreamBase & Maps::operator>>( StreamBase & msg, TilesAddon & ta )
 {
-    msg >> ta._layerType >> ta._uid >> ta._objectType >> ta._imageIndex;
+    msg >> ta._layerType >> ta._uid >> ta._objectIcnType >> ta._imageIndex;
 
     return msg;
 }
@@ -2844,8 +2854,8 @@ StreamBase & Maps::operator<<( StreamBase & msg, const Tiles & tile )
 {
     static_assert( sizeof( uint8_t ) == sizeof( MP2::MapObjectType ), "Incorrect type for writing MP2::MapObjectType object" );
 
-    return msg << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile.tilePassable << tile._uid << tile._objectType << tile._imageIndex
-               << static_cast<uint8_t>( tile.mp2_object ) << tile.fog_colors << tile.quantity1 << tile.quantity2 << tile.additionalMetadata << tile.heroID
+    return msg << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile.tilePassable << tile._uid << tile._objectIcnType << tile._imageIndex
+               << static_cast<uint8_t>( tile._mainObjectType ) << tile.fog_colors << tile.quantity1 << tile.quantity2 << tile.additionalMetadata << tile.heroID
                << tile.tileIsRoad << tile.addons_level1 << tile.addons_level2 << tile._layerType;
 }
 
@@ -2866,7 +2876,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
         msg >> tile._terrainImageIndex >> tile._terrainFlags;
     }
 
-    msg >> tile.tilePassable >> tile._uid >> tile._objectType >> tile._imageIndex;
+    msg >> tile.tilePassable >> tile._uid >> tile._objectIcnType >> tile._imageIndex;
 
     static_assert( sizeof( uint8_t ) == sizeof( MP2::MapObjectType ), "Incorrect type for reading MP2::MapObjectType object" );
     uint8_t objectType = MP2::OBJ_NONE;
@@ -2940,7 +2950,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
         }
     }
 
-    tile.mp2_object = static_cast<MP2::MapObjectType>( objectType );
+    tile._mainObjectType = static_cast<MP2::MapObjectType>( objectType );
 
     msg >> tile.fog_colors >> tile.quantity1 >> tile.quantity2 >> tile.additionalMetadata >> tile.heroID >> tile.tileIsRoad >> tile.addons_level1 >> tile.addons_level2
         >> tile._layerType;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -274,7 +274,12 @@ namespace Maps
 
         void AddonsPushLevel1( const MP2::mp2tile_t & mt );
         void AddonsPushLevel1( const MP2::mp2addon_t & ma );
-        void AddonsPushLevel1( const TilesAddon & ta );
+
+        void AddonsPushLevel1( TilesAddon ta )
+        {
+            addons_level1.emplace_back( std::move( ta ) );
+        }
+
         void AddonsPushLevel2( const MP2::mp2tile_t & mt );
         void AddonsPushLevel2( const MP2::mp2addon_t & ma );
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -293,7 +293,7 @@ namespace Maps
         void RemoveObjectSprite();
         void updateObjectImageIndex( const uint32_t objectUid, const MP2::ObjectIcnType objectIcnType, const int imageIndexOffset );
         void replaceObject( const uint32_t objectUid, const MP2::ObjectIcnType originalObjectIcnType, const MP2::ObjectIcnType newObjectIcnType,
-                            const uint8_t originalImageIndex, const uint8_t newimageIndex );
+                            const uint8_t originalImageIndex, const uint8_t newImageIndex );
 
         std::string String() const;
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -70,7 +70,8 @@ namespace Maps
     {
         TilesAddon() = default;
 
-        TilesAddon( const uint8_t layerType, const uint32_t uid, const uint8_t objectIcnType, const uint8_t imageIndex );
+        TilesAddon( const uint8_t layerType, const uint32_t uid, const uint8_t objectIcnType, const uint8_t imageIndex, const bool hasObjectAnimation,
+                    const bool isMarkedAsRoad );
 
         TilesAddon( const TilesAddon & ) = default;
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -68,8 +68,9 @@ namespace Maps
 
     struct TilesAddon
     {
-        TilesAddon();
-        TilesAddon( const uint8_t lv, const uint32_t uid, const uint8_t obj, const uint8_t index_ );
+        TilesAddon() = default;
+
+        TilesAddon( const uint8_t layerType, const uint32_t uid, const uint8_t objectIcnType, const uint8_t imageIndex );
 
         TilesAddon( const TilesAddon & ) = default;
 
@@ -99,10 +100,10 @@ namespace Maps
         static bool PredicateSortRules1( const TilesAddon & ta1, const TilesAddon & ta2 );
 
         // Unique identifier of an object. UID can be shared among multiple object parts if an object is bigger than 1 tile.
-        uint32_t _uid;
+        uint32_t _uid{ 0 };
 
         // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
-        uint8_t _layerType;
+        uint8_t _layerType{ OBJECT_LAYER };
 
         // Structure containing a flag whether the object's image (sprite) has animation, a flag whether the object is road and
         // the type of object which correlates to ICN id.
@@ -110,16 +111,16 @@ namespace Maps
         // The second bit is a flag whether the object considered as road.
         // The last 6 bits the type of object which correlates to ICN id. See MP2::getIcnIdFromObjectIcnType() function for more details.
         // TODO: move first 2 bits out of this member to keep only object type.
-        uint8_t _objectIcnType;
+        uint8_t _objectIcnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
-        uint8_t _imageIndex;
+        uint8_t _imageIndex{ 255 };
 
         // An indicator where the object has extra animation frames on Adventure Map.
-        bool _hasObjectAnimation;
+        bool _hasObjectAnimation{ false };
 
         // An indicator that this tile is a road. Logically it shouldn't be set for addons.
-        bool _isMarkedAsRoad;
+        bool _isMarkedAsRoad{ false };
     };
 
     using Addons = std::list<TilesAddon>;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -70,7 +70,7 @@ namespace Maps
     {
         TilesAddon() = default;
 
-        TilesAddon( const uint8_t layerType, const uint32_t uid, const uint8_t objectIcnType, const uint8_t imageIndex, const bool hasObjectAnimation,
+        TilesAddon( const uint8_t layerType, const uint32_t uid, const MP2::ObjectIcnType objectIcnType, const uint8_t imageIndex, const bool hasObjectAnimation,
                     const bool isMarkedAsRoad );
 
         TilesAddon( const TilesAddon & ) = default;
@@ -88,7 +88,7 @@ namespace Maps
 
         bool hasSpriteAnimation() const
         {
-            return _objectIcnType & 1;
+            return _hasObjectAnimation;
         }
 
         std::string String( int level ) const;
@@ -112,7 +112,7 @@ namespace Maps
         // The second bit is a flag whether the object considered as road.
         // The last 6 bits the type of object which correlates to ICN id. See MP2::getIcnIdFromObjectIcnType() function for more details.
         // TODO: move first 2 bits out of this member to keep only object type.
-        uint8_t _objectIcnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
+        MP2::ObjectIcnType _objectIcnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
         uint8_t _imageIndex{ 255 };
@@ -142,7 +142,7 @@ namespace Maps
 
         MP2::MapObjectType GetObject( bool ignoreObjectUnderHero = true ) const;
 
-        uint8_t getObjectIcnType() const
+        MP2::ObjectIcnType getObjectIcnType() const
         {
             return _objectIcnType;
         }
@@ -226,7 +226,7 @@ namespace Maps
 
         void resetObjectSprite()
         {
-            _objectIcnType = 0;
+            _objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
             _imageIndex = 255;
         }
 
@@ -264,7 +264,7 @@ namespace Maps
         void RedrawPassable( fheroes2::Image & dst, const int friendColors, const Interface::GameArea & area ) const;
         void redrawBottomLayerObjects( fheroes2::Image & dst, bool isPuzzleDraw, const Interface::GameArea & area, const uint8_t level ) const;
 
-        void drawByObjectIcnType( fheroes2::Image & output, const Interface::GameArea & area, const uint8_t objectIcnType ) const;
+        void drawByObjectIcnType( fheroes2::Image & output, const Interface::GameArea & area, const MP2::ObjectIcnType objectIcnType ) const;
 
         std::vector<std::pair<fheroes2::Point, fheroes2::Sprite>> getMonsterSpritesPerTile() const;
         std::vector<std::pair<fheroes2::Point, fheroes2::Sprite>> getMonsterShadowSpritesPerTile() const;
@@ -291,9 +291,9 @@ namespace Maps
         void AddonsSort();
         void Remove( uint32_t uniqID );
         void RemoveObjectSprite();
-        void updateObjectImageIndex( const uint32_t objectUid, const uint8_t objectIcnType, const int imageIndexOffset );
-        void replaceObject( const uint32_t objectUid, const uint8_t originalObjectIcnType, const uint8_t newObjectIcnType, const uint8_t originalImageIndex,
-                            const uint8_t newimageIndex );
+        void updateObjectImageIndex( const uint32_t objectUid, const MP2::ObjectIcnType objectIcnType, const int imageIndexOffset );
+        void replaceObject( const uint32_t objectUid, const MP2::ObjectIcnType originalObjectIcnType, const MP2::ObjectIcnType newObjectIcnType,
+                            const uint8_t originalImageIndex, const uint8_t newimageIndex );
 
         std::string String() const;
 
@@ -362,20 +362,20 @@ namespace Maps
         // Set tile to coast MP2::OBJ_COAST) if it's near water or to empty (MP2::OBJ_NONE)
         void setAsEmpty();
 
-        uint32_t getObjectIdByObjectIcnType( const uint8_t objectIcnType ) const;
+        uint32_t getObjectIdByObjectIcnType( const MP2::ObjectIcnType objectIcnType ) const;
 
-        std::vector<uint8_t> getValidObjectIcnTypes() const;
+        std::vector<MP2::ObjectIcnType> getValidObjectIcnTypes() const;
 
-        bool containsAnyObjectIcnType( const std::vector<uint8_t> & objectIcnTypes ) const;
+        bool containsAnyObjectIcnType( const std::vector<MP2::ObjectIcnType> & objectIcnTypes ) const;
 
-        bool containsSprite( const uint8_t objectIcnType, const uint32_t imageIdx ) const;
+        bool containsSprite( const MP2::ObjectIcnType objectIcnType, const uint32_t imageIdx ) const;
 
-        static int getColorFromBarrierSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex );
-        static int getColorFromTravellerTentSprite( const uint8_t nonCorrectedObjectIcnType, const uint8_t icnIndex );
+        static int getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
+        static int getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
 
-        static void UpdateAbandonedMineLeftSprite( uint8_t & nonCorrectedObjectIcnType, uint8_t & imageIndex, const int resource );
+        static void UpdateAbandonedMineLeftSprite( MP2::ObjectIcnType & objectIcnType, uint8_t & imageIndex, const int resource );
 
-        static void UpdateAbandonedMineRightSprite( uint8_t & nonCorrectedObjectIcnType, uint8_t & imageIndex );
+        static void UpdateAbandonedMineRightSprite( MP2::ObjectIcnType & objectIcnType, uint8_t & imageIndex );
 
         static std::pair<int, int> ColorRaceFromHeroSprite( const uint32_t heroSpriteIndex );
         static std::pair<uint32_t, uint32_t> GetMonsterSpriteIndices( const Tiles & tile, const uint32_t monsterIndex );
@@ -445,7 +445,7 @@ namespace Maps
         // The second bit is a flag whether the object considered as road.
         // The last 6 bits the type of object which correlates to ICN id. See MP2::getIcnIdFromObjectIcnType() function for more details.
         // TODO: move first 2 bits out of this member to keep only object type.
-        uint8_t _objectIcnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
+        MP2::ObjectIcnType _objectIcnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
         uint8_t _imageIndex{ 255 };

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -106,12 +106,7 @@ namespace Maps
         // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
         uint8_t _layerType{ OBJECT_LAYER };
 
-        // Structure containing a flag whether the object's image (sprite) has animation, a flag whether the object is road and
-        // the type of object which correlates to ICN id.
-        // The first bit is a flag whether the object's image (sprite) has animation.
-        // The second bit is a flag whether the object considered as road.
-        // The last 6 bits the type of object which correlates to ICN id. See MP2::getIcnIdFromObjectIcnType() function for more details.
-        // TODO: move first 2 bits out of this member to keep only object type.
+        // The type of object which correlates to ICN id. See MP2::getIcnIdFromObjectIcnType() function for more details.
         MP2::ObjectIcnType _objectIcnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
@@ -444,12 +439,7 @@ namespace Maps
         // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
         uint8_t _layerType{ OBJECT_LAYER };
 
-        // Structure containing a flag whether the object's image (sprite) has animation, a flag whether the object is road and
-        // the type of object which correlates to ICN id.
-        // The first bit is a flag whether the object's image (sprite) has animation.
-        // The second bit is a flag whether the object considered as road.
-        // The last 6 bits the type of object which correlates to ICN id. See MP2::getIcnIdFromObjectIcnType() function for more details.
-        // TODO: move first 2 bits out of this member to keep only object type.
+        // The type of object which correlates to ICN id. See MP2::getIcnIdFromObjectIcnType() function for more details.
         MP2::ObjectIcnType _objectIcnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -190,7 +190,7 @@ namespace Maps
 
         bool hasSpriteAnimation() const
         {
-            return _objectIcnType & 1;
+            return _hasObjectAnimation;
         }
 
         // Checks whether it is possible to move into this tile from the specified direction under the specified conditions

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -277,7 +277,7 @@ namespace Maps
 
         void AddonsPushLevel1( TilesAddon ta )
         {
-            addons_level1.emplace_back( std::move( ta ) );
+            addons_level1.emplace_back( ta );
         }
 
         void AddonsPushLevel2( const MP2::mp2tile_t & mt );

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -819,11 +819,11 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         break;
 
     case MP2::OBJ_BARRIER:
-        QuantitySetColor( Tiles::getColorFromBarrierSprite( _objectIcnType, _imageIndex ) );
+        QuantitySetColor( Tiles::getColorFromBarrierSprite( _objectIcnType >> 2, _imageIndex ) );
         break;
 
     case MP2::OBJ_TRAVELLER_TENT:
-        QuantitySetColor( Tiles::getColorFromTravellerTentSprite( _objectIcnType, _imageIndex ) );
+        QuantitySetColor( Tiles::getColorFromTravellerTentSprite( _objectIcnType >> 2, _imageIndex ) );
         break;
 
     case MP2::OBJ_ALCHEMIST_LAB:

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -562,13 +562,13 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
     case MP2::OBJ_RESOURCE: {
         int resourceType = Resource::UNKNOWN;
 
-        if ( ( _objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
+        if ( _objectIcnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
             // The resource is located at the top.
             resourceType = Resource::FromIndexSprite( _imageIndex );
         }
         else {
             for ( TilesAddon & addon : addons_level1 ) {
-                if ( ( addon._objectIcnType >> 2 ) == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
+                if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
                     resourceType = Resource::FromIndexSprite( addon._imageIndex );
                     // If this happens we are in trouble. It looks like that map maker put the resource under an object which is impossible to do.
                     // Let's swap the addon and main tile objects
@@ -576,6 +576,8 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
                     std::swap( addon._imageIndex, _imageIndex );
                     std::swap( addon._uid, _uid );
                     std::swap( addon._layerType, _layerType );
+                    std::swap( addon._hasObjectAnimation, _hasObjectAnimation );
+                    std::swap( addon._isMarkedAsRoad, _isMarkedAsRoad );
 
                     break;
                 }
@@ -818,11 +820,11 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         break;
 
     case MP2::OBJ_BARRIER:
-        QuantitySetColor( Tiles::getColorFromBarrierSprite( _objectIcnType >> 2, _imageIndex ) );
+        QuantitySetColor( Tiles::getColorFromBarrierSprite( _objectIcnType, _imageIndex ) );
         break;
 
     case MP2::OBJ_TRAVELLER_TENT:
-        QuantitySetColor( Tiles::getColorFromTravellerTentSprite( _objectIcnType >> 2, _imageIndex ) );
+        QuantitySetColor( Tiles::getColorFromTravellerTentSprite( _objectIcnType, _imageIndex ) );
         break;
 
     case MP2::OBJ_ALCHEMIST_LAB:
@@ -867,8 +869,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
     }
 
     case MP2::OBJ_BOAT:
-        // TODO: this is absolutely wrong to assign this value to object type!
-        _objectIcnType = 27;
+        _objectIcnType = MP2::OBJ_ICN_TYPE_BOAT32;
         _imageIndex = 18;
         break;
 
@@ -959,17 +960,14 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
 {
     tile.SetObject( MP2::OBJ_MONSTER );
 
-    const uint8_t correctedObjectIcnType = ( tile._objectIcnType >> 2 );
-
     // If there was another object sprite here (shadow for example) push it down to Addons,
     // except when there is already MONS32.ICN here.
-    if ( tile._objectIcnType != 0 && correctedObjectIcnType != MP2::OBJ_ICN_TYPE_MONS32 && tile._imageIndex != 255 ) {
+    if ( tile._objectIcnType != 0 && tile._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 && tile._imageIndex != 255 ) {
         tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile._uid, tile._objectIcnType, tile._imageIndex, false, false ) );
 
         // TODO: why are we setting UID to 0? It should be unique!
         tile._uid = 0;
-        // TODO: we ignore first 2 bits which might be not 0!
-        tile._objectIcnType = ( MP2::OBJ_ICN_TYPE_MONS32 << 2 );
+        tile._objectIcnType = MP2::OBJ_ICN_TYPE_MONS32;
     }
 
     tile._imageIndex = mons.GetSpriteIndex();

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -962,7 +962,7 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
 
     // If there was another object sprite here (shadow for example) push it down to Addons,
     // except when there is already MONS32.ICN here.
-    if ( tile._objectIcnType != 0 && tile._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 && tile._imageIndex != 255 ) {
+    if ( tile._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && tile._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 && tile._imageIndex != 255 ) {
         tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile._uid, tile._objectIcnType, tile._imageIndex, false, false ) );
 
         // TODO: why are we setting UID to 0? It should be unique!

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -29,7 +29,6 @@
 #include "army_troop.h"
 #include "artifact.h"
 #include "color.h"
-#include "icn.h"
 #include "logging.h"
 #include "maps_tiles.h"
 #include "monster.h"

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -965,7 +965,7 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
     // If there was another object sprite here (shadow for example) push it down to Addons,
     // except when there is already MONS32.ICN here.
     if ( tile._objectIcnType != 0 && correctedObjectIcnType != MP2::OBJ_ICN_TYPE_MONS32 && tile._imageIndex != 255 ) {
-        tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile._uid, tile._objectIcnType, tile._imageIndex ) );
+        tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile._uid, tile._objectIcnType, tile._imageIndex, false, false ) );
 
         // TODO: why are we setting UID to 0? It should be unique!
         tile._uid = 0;

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -181,9 +181,8 @@ int MP2::getIcnIdFromObjectIcnType( const uint8_t objectIcnType )
     return ICN::UNKNOWN;
 }
 
-bool MP2::isHiddenForPuzzle( const int terrainType, uint8_t nonCorrectedObjectIcnType, uint8_t index )
+bool MP2::isHiddenForPuzzle( const int terrainType, const uint8_t objectIcnType, uint8_t index )
 {
-    const int objectIcnType = nonCorrectedObjectIcnType >> 2;
     switch ( objectIcnType ) {
     case OBJ_ICN_TYPE_UNKNOWN:
     case OBJ_ICN_TYPE_UNUSED_1:

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -69,13 +69,6 @@ namespace
     }
 }
 
-int MP2::GetICNObject( const uint8_t tileset )
-{
-    // First 2 bits are used for flags like animation.
-    // TODO: separate these 2 bits and real tile (?) index into 2 variables to avoid this bit shifting operations all over the code.
-    return getIcnIdFromObjectIcnType( tileset >> 2 );
-}
-
 int MP2::getIcnIdFromObjectIcnType( const uint8_t objectIcnType )
 {
     switch ( objectIcnType ) {
@@ -188,9 +181,9 @@ int MP2::getIcnIdFromObjectIcnType( const uint8_t objectIcnType )
     return ICN::UNKNOWN;
 }
 
-bool MP2::isHiddenForPuzzle( const int terrainType, uint8_t tileset, uint8_t index )
+bool MP2::isHiddenForPuzzle( const int terrainType, uint8_t nonCorrectedObjectIcnType, uint8_t index )
 {
-    const int objectIcnType = tileset >> 2;
+    const int objectIcnType = nonCorrectedObjectIcnType >> 2;
     switch ( objectIcnType ) {
     case OBJ_ICN_TYPE_UNKNOWN:
     case OBJ_ICN_TYPE_UNUSED_1:
@@ -224,7 +217,7 @@ bool MP2::isHiddenForPuzzle( const int terrainType, uint8_t tileset, uint8_t ind
         break;
     }
 
-    return isDiggingHoleSprite( terrainType, tileset, index );
+    return isDiggingHoleSprite( terrainType, objectIcnType, index );
 }
 
 const char * MP2::StringObject( MapObjectType objectType, const int count )
@@ -970,49 +963,49 @@ int MP2::getActionObjectDirection( const MapObjectType objectType )
     return Direction::UNKNOWN;
 }
 
-bool MP2::getDiggingHoleSprite( const int terrainType, uint8_t & tileSet, uint8_t & index )
+bool MP2::getDiggingHoleSprite( const int terrainType, uint8_t & objectIcnType, uint8_t & index )
 {
     switch ( terrainType ) {
     case Maps::Ground::DESERT:
-        tileSet = ( OBJ_ICN_TYPE_OBJNDSRT << 2 );
+        objectIcnType = OBJ_ICN_TYPE_OBJNDSRT;
         index = 68;
         return true;
     case Maps::Ground::SNOW:
-        tileSet = ( OBJ_ICN_TYPE_OBJNSNOW << 2 );
+        objectIcnType = OBJ_ICN_TYPE_OBJNSNOW;
         index = 11;
         return true;
     case Maps::Ground::SWAMP:
-        tileSet = ( OBJ_ICN_TYPE_OBJNSWMP << 2 );
+        objectIcnType = OBJ_ICN_TYPE_OBJNSWMP;
         index = 86;
         return true;
     case Maps::Ground::WASTELAND:
-        tileSet = ( OBJ_ICN_TYPE_OBJNCRCK << 2 );
+        objectIcnType = OBJ_ICN_TYPE_OBJNCRCK;
         index = 70;
         return true;
     case Maps::Ground::LAVA:
-        tileSet = ( OBJ_ICN_TYPE_OBJNLAVA << 2 );
+        objectIcnType = OBJ_ICN_TYPE_OBJNLAVA;
         index = 26;
         return true;
     case Maps::Ground::DIRT:
-        tileSet = ( OBJ_ICN_TYPE_OBJNDIRT << 2 );
+        objectIcnType = OBJ_ICN_TYPE_OBJNDIRT;
         index = 140;
         return true;
     case Maps::Ground::BEACH:
     case Maps::Ground::GRASS:
         // Beach doesn't have its digging hole so we use it from Grass terrain.
-        tileSet = ( OBJ_ICN_TYPE_OBJNGRA2 << 2 );
+        objectIcnType = OBJ_ICN_TYPE_OBJNGRA2;
         index = 9;
         return true;
     case Maps::Ground::WATER:
         // It is not possible to dig on water. Remember this!
-        tileSet = 0;
+        objectIcnType = OBJ_ICN_TYPE_UNKNOWN;
         index = 255;
         return false;
     default:
         // Did you add a new terrain type? Add the logic above!
         assert( 0 );
 
-        tileSet = 0;
+        objectIcnType = OBJ_ICN_TYPE_UNKNOWN;
         index = 255;
         break;
     }
@@ -1020,14 +1013,14 @@ bool MP2::getDiggingHoleSprite( const int terrainType, uint8_t & tileSet, uint8_
     return false;
 }
 
-bool MP2::isDiggingHoleSprite( const int terrainType, const uint8_t tileSet, const uint8_t index )
+bool MP2::isDiggingHoleSprite( const int terrainType, const uint8_t objectIcnType, const uint8_t index )
 {
-    uint8_t correctTileSet = 0;
+    uint8_t terrainObjectIcnType = 0;
     uint8_t correctIndex = 0;
 
-    if ( !getDiggingHoleSprite( terrainType, correctTileSet, correctIndex ) ) {
+    if ( !getDiggingHoleSprite( terrainType, terrainObjectIcnType, correctIndex ) ) {
         return false;
     }
 
-    return ( ( tileSet >> 2 ) << 2 ) == correctTileSet && index == correctIndex;
+    return ( objectIcnType == terrainObjectIcnType ) && ( index == correctIndex );
 }

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -69,7 +69,7 @@ namespace
     }
 }
 
-int MP2::getIcnIdFromObjectIcnType( const uint8_t objectIcnType )
+int MP2::getIcnIdFromObjectIcnType( const ObjectIcnType objectIcnType )
 {
     switch ( objectIcnType ) {
     case OBJ_ICN_TYPE_UNKNOWN:
@@ -181,7 +181,7 @@ int MP2::getIcnIdFromObjectIcnType( const uint8_t objectIcnType )
     return ICN::UNKNOWN;
 }
 
-bool MP2::isHiddenForPuzzle( const int terrainType, const uint8_t objectIcnType, uint8_t index )
+bool MP2::isHiddenForPuzzle( const int terrainType, const ObjectIcnType objectIcnType, uint8_t index )
 {
     switch ( objectIcnType ) {
     case OBJ_ICN_TYPE_UNKNOWN:
@@ -962,7 +962,7 @@ int MP2::getActionObjectDirection( const MapObjectType objectType )
     return Direction::UNKNOWN;
 }
 
-bool MP2::getDiggingHoleSprite( const int terrainType, uint8_t & objectIcnType, uint8_t & index )
+bool MP2::getDiggingHoleSprite( const int terrainType, ObjectIcnType & objectIcnType, uint8_t & index )
 {
     switch ( terrainType ) {
     case Maps::Ground::DESERT:
@@ -1012,9 +1012,9 @@ bool MP2::getDiggingHoleSprite( const int terrainType, uint8_t & objectIcnType, 
     return false;
 }
 
-bool MP2::isDiggingHoleSprite( const int terrainType, const uint8_t objectIcnType, const uint8_t index )
+bool MP2::isDiggingHoleSprite( const int terrainType, const ObjectIcnType objectIcnType, const uint8_t index )
 {
-    uint8_t terrainObjectIcnType = 0;
+    ObjectIcnType terrainObjectIcnType = OBJ_ICN_TYPE_UNKNOWN;
     uint8_t correctIndex = 0;
 
     if ( !getDiggingHoleSprite( terrainType, terrainObjectIcnType, correctIndex ) ) {

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -37,7 +37,7 @@ namespace MP2
         SIZEOFMP2SIGN = 10,
         SIZEOFMP2RUMOR = 9,
         SIZEOFMP2EVENT = 50,
-        SIZEOFMP2RIDDLE = 138
+        SIZEOFMP2RIDDLE = 137
     };
 
     // Tile structure from the original map format.
@@ -215,30 +215,6 @@ namespace MP2
     {
         uint8_t id; // 0x00
         uint8_t zero[7]; // 7 byte 0x00
-        char text; // message + '/0'
-    };
-
-    // origin mp2 riddle sphinx
-    struct mp2riddle_t
-    {
-        uint8_t id; // 0x00
-        uint32_t wood;
-        uint32_t mercury;
-        uint32_t ore;
-        uint32_t sulfur;
-        uint32_t crystal;
-        uint32_t gems;
-        uint32_t golds;
-        uint16_t artifact; // 0xffff - none
-        uint8_t count; // count answers (1, 8)
-        char answer1[13];
-        char answer2[13];
-        char answer3[13];
-        char answer4[13];
-        char answer5[13];
-        char answer6[13];
-        char answer7[13];
-        char answer8[13];
         char text; // message + '/0'
     };
 
@@ -590,17 +566,14 @@ namespace MP2
         OBJ_ICN_TYPE_X_LOC2, // Objects from The Price of Loyalty expansion.
         OBJ_ICN_TYPE_X_LOC3 // Objects from The Price of Loyalty expansion.
 
-        // IMPORTANT!!! If you want to add new types firstly use unused entries and only then add new entries in this enumeration.
+        // IMPORTANT!!! If you want to add new types use UNUSED entries first and only then add new entries in this enumeration.
     };
-
-    // Return Icn ID related to this tileset value.
-    int GetICNObject( const uint8_t tileset );
 
     int getIcnIdFromObjectIcnType( const uint8_t objectIcnType );
 
     const char * StringObject( MapObjectType objectType, const int count = 1 );
 
-    bool isHiddenForPuzzle( const int terrainType, uint8_t tileset, uint8_t index );
+    bool isHiddenForPuzzle( const int terrainType, uint8_t nonCorrectedObjectIcnType, uint8_t index );
 
     // The method check whether the object is an action object depending on its location. For example, castle can't be located on water.
     bool isActionObject( const MapObjectType objectType, const bool locatesOnWater );
@@ -634,8 +607,8 @@ namespace MP2
     // Make sure that you pass a valid action object.
     int getActionObjectDirection( const MapObjectType objectType );
 
-    bool getDiggingHoleSprite( const int terrainType, uint8_t & tileSet, uint8_t & index );
-    bool isDiggingHoleSprite( const int terrainType, const uint8_t tileSet, const uint8_t index );
+    bool getDiggingHoleSprite( const int terrainType, uint8_t & objectIcnType, uint8_t & index );
+    bool isDiggingHoleSprite( const int terrainType, const uint8_t objectIcnType, const uint8_t index );
 }
 
 #endif

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -573,7 +573,7 @@ namespace MP2
 
     const char * StringObject( MapObjectType objectType, const int count = 1 );
 
-    bool isHiddenForPuzzle( const int terrainType, uint8_t nonCorrectedObjectIcnType, uint8_t index );
+    bool isHiddenForPuzzle( const int terrainType, const uint8_t objectIcnType, uint8_t index );
 
     // The method check whether the object is an action object depending on its location. For example, castle can't be located on water.
     bool isActionObject( const MapObjectType objectType, const bool locatesOnWater );

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -566,14 +566,14 @@ namespace MP2
         OBJ_ICN_TYPE_X_LOC2, // Objects from The Price of Loyalty expansion.
         OBJ_ICN_TYPE_X_LOC3 // Objects from The Price of Loyalty expansion.
 
-        // IMPORTANT!!! If you want to add new types use UNUSED entries first and only then add new entries in this enumeration.
+        // IMPORTANT!!! If you want to add new types use UNUSED entries only.
     };
 
-    int getIcnIdFromObjectIcnType( const uint8_t objectIcnType );
+    int getIcnIdFromObjectIcnType( const ObjectIcnType objectIcnType );
 
     const char * StringObject( MapObjectType objectType, const int count = 1 );
 
-    bool isHiddenForPuzzle( const int terrainType, const uint8_t objectIcnType, uint8_t index );
+    bool isHiddenForPuzzle( const int terrainType, const ObjectIcnType objectIcnType, uint8_t index );
 
     // The method check whether the object is an action object depending on its location. For example, castle can't be located on water.
     bool isActionObject( const MapObjectType objectType, const bool locatesOnWater );
@@ -607,8 +607,8 @@ namespace MP2
     // Make sure that you pass a valid action object.
     int getActionObjectDirection( const MapObjectType objectType );
 
-    bool getDiggingHoleSprite( const int terrainType, uint8_t & objectIcnType, uint8_t & index );
-    bool isDiggingHoleSprite( const int terrainType, const uint8_t objectIcnType, const uint8_t index );
+    bool getDiggingHoleSprite( const int terrainType, ObjectIcnType & objectIcnType, uint8_t & index );
+    bool isDiggingHoleSprite( const int terrainType, const ObjectIcnType objectIcnType, const uint8_t index );
 }
 
 #endif

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -395,7 +395,7 @@ const char * Resource::getDescription()
               "powerful creatures and buildings." );
 }
 
-uint32_t Resource::GetIndexSprite( int resource )
+uint8_t Resource::GetIndexSprite( int resource )
 {
     switch ( resource ) {
     case Resource::WOOD:
@@ -413,7 +413,7 @@ uint32_t Resource::GetIndexSprite( int resource )
     case Resource::GOLD:
         return 13;
     default:
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown resource" )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown resource type." )
         break;
     }
 

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -121,8 +121,8 @@ namespace Resource
 
     int Rand( const bool includeGold );
 
-    /* return index sprite objnrsrc.icn */
-    uint32_t GetIndexSprite( int resource );
+    // Returns index sprite objnrsrc.icn
+    uint8_t GetIndexSprite( int resource );
     int FromIndexSprite( uint32_t index );
 
     // Return index sprite from resource.icn.

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -28,8 +28,9 @@ enum SaveFileFormat : uint16_t
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
-    FORMAT_VERSION_1001_RELEASE = 10002,
-    FORMAT_VERSION_PRE_1001_RELEASE = 10001,
+    FORMAT_VERSION_1001_RELEASE = 10003,
+    FORMAT_VERSION_PRE2_1001_RELEASE = 10002,
+    FORMAT_VERSION_PRE1_1001_RELEASE = 10001,
     FORMAT_VERSION_1000_RELEASE = 10000,
     FORMAT_VERSION_PRE5_1000_RELEASE = 9964,
     FORMAT_VERSION_PRE4_1000_RELEASE = 9963,

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -932,17 +932,17 @@ bool World::DiggingForUltimateArtifact( const fheroes2::Point & center )
     Maps::Tiles & tile = GetTiles( center.x, center.y );
 
     // Get digging hole sprite.
-    uint8_t objectType = 0;
+    uint8_t objectIcnType = 0;
     uint8_t imageIndex = 0;
 
-    if ( !MP2::getDiggingHoleSprite( tile.GetGround(), objectType, imageIndex ) ) {
+    if ( !MP2::getDiggingHoleSprite( tile.GetGround(), objectIcnType, imageIndex ) ) {
         // Are you sure that you can dig here?
         assert( 0 );
 
         return false;
     }
 
-    tile.AddonsPushLevel1( Maps::TilesAddon( Maps::BACKGROUND_LAYER, GetUniq(), objectType, imageIndex ) );
+    tile.AddonsPushLevel1( Maps::TilesAddon( Maps::BACKGROUND_LAYER, GetUniq(), ( objectIcnType << 2 ), imageIndex ) );
 
     if ( ultimate_artifact.isPosition( tile.GetIndex() ) && !ultimate_artifact.isFound() ) {
         ultimate_artifact.markAsFound();

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -932,7 +932,7 @@ bool World::DiggingForUltimateArtifact( const fheroes2::Point & center )
     Maps::Tiles & tile = GetTiles( center.x, center.y );
 
     // Get digging hole sprite.
-    uint8_t objectIcnType = 0;
+    MP2::ObjectIcnType objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
     uint8_t imageIndex = 0;
 
     if ( !MP2::getDiggingHoleSprite( tile.GetGround(), objectIcnType, imageIndex ) ) {
@@ -942,7 +942,7 @@ bool World::DiggingForUltimateArtifact( const fheroes2::Point & center )
         return false;
     }
 
-    tile.AddonsPushLevel1( Maps::TilesAddon( Maps::BACKGROUND_LAYER, GetUniq(), ( objectIcnType << 2 ), imageIndex, false, false ) );
+    tile.AddonsPushLevel1( Maps::TilesAddon( Maps::BACKGROUND_LAYER, GetUniq(), objectIcnType, imageIndex, false, false ) );
 
     if ( ultimate_artifact.isPosition( tile.GetIndex() ) && !ultimate_artifact.isFound() ) {
         ultimate_artifact.markAsFound();

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -942,7 +942,7 @@ bool World::DiggingForUltimateArtifact( const fheroes2::Point & center )
         return false;
     }
 
-    tile.AddonsPushLevel1( Maps::TilesAddon( Maps::BACKGROUND_LAYER, GetUniq(), ( objectIcnType << 2 ), imageIndex ) );
+    tile.AddonsPushLevel1( Maps::TilesAddon( Maps::BACKGROUND_LAYER, GetUniq(), ( objectIcnType << 2 ), imageIndex, false, false ) );
 
     if ( ultimate_artifact.isPosition( tile.GetIndex() ) && !ultimate_artifact.isFound() ) {
         ultimate_artifact.markAsFound();

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -551,9 +551,9 @@ bool World::LoadMapMP2( const std::string & filename )
                 break;
             case MP2::OBJ_SPHINX:
                 // add riddle sphinx
-                if ( MP2::SIZEOFMP2RIDDLE - 1 < pblock.size() && 0x00 == pblock[0] ) {
+                if ( MP2::SIZEOFMP2RIDDLE < pblock.size() && 0x00 == pblock[0] ) {
                     MapSphinx * obj = new MapSphinx();
-                    obj->LoadFromMP2( findobject, StreamBuf( pblock ) );
+                    obj->LoadFromMP2( findobject, pblock );
                     map_objects.add( obj );
                 }
                 break;
@@ -685,7 +685,7 @@ void World::ProcessNewMap()
 
         case MP2::OBJ_HEROES: {
             // remove map editor sprite
-            if ( MP2::GetICNObject( tile.getObjectType() ) == ICN::MINIHERO )
+            if ( ( tile.getObjectIcnType() >> 2 ) == MP2::OBJ_ICN_TYPE_MINIHERO )
                 tile.Remove( tile.GetObjectUID() );
 
             tile.SetHeroes( GetHeroes( Maps::GetPoint( static_cast<int32_t>( i ) ) ) );
@@ -721,7 +721,7 @@ void World::ProcessNewMap()
 
     // Search for a tile with a predefined Ultimate Artifact
     const MapsTiles::iterator ultArtTileIter
-        = std::find_if( vec_tiles.begin(), vec_tiles.end(), []( const Maps::Tiles & tile ) { return tile.isObject( MP2::OBJ_RANDOM_ULTIMATE_ARTIFACT ); } );
+        = std::find_if( vec_tiles.begin(), vec_tiles.end(), []( const Maps::Tiles & tile ) { return tile.isSameMainObject( MP2::OBJ_RANDOM_ULTIMATE_ARTIFACT ); } );
 
     auto checkTileForSuitabilityForUltArt = [this]( const int32_t idx ) {
         const int32_t x = idx % width;

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -41,7 +41,6 @@
 #include "color.h"
 #include "game_over.h"
 #include "heroes.h"
-#include "icn.h"
 #include "kingdom.h"
 #include "logging.h"
 #include "maps.h"

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -684,7 +684,7 @@ void World::ProcessNewMap()
 
         case MP2::OBJ_HEROES: {
             // remove map editor sprite
-            if ( ( tile.getObjectIcnType() >> 2 ) == MP2::OBJ_ICN_TYPE_MINIHERO )
+            if ( tile.getObjectIcnType() == MP2::OBJ_ICN_TYPE_MINIHERO )
                 tile.Remove( tile.GetObjectUID() );
 
             tile.SetHeroes( GetHeroes( Maps::GetPoint( static_cast<int32_t>( i ) ) ) );

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -406,10 +406,12 @@ bool World::LoadMapMP2( const std::string & filename )
             const Maps::Tiles & tile = vec_tiles[*it_index];
 
             // orders(quantity2, quantity1)
-            uint32_t orders = ( tile.GetQuantity2() ? tile.GetQuantity2() : 0 );
+            uint32_t orders = tile.GetQuantity2();
             orders <<= 8;
             orders |= tile.GetQuantity1();
 
+            // Witchcraft!!!
+            // TODO: change the code to be more readable.
             if ( orders && !( orders % 0x08 ) && ( ii + 1 == orders / 0x08 ) )
                 findobject = *it_index;
         }


### PR DESCRIPTION
- remove **mp2riddle_t** structure and add appropriate comments into `MapSphinx::LoadFromMP2()` method
- rename **_objectType** member into **_objectIcnType** and make it as `MP2::ObjectIcnType` to avoid confusion from `MapObjectType` enumeration
- move multiple static methods from `Tiles` class into anonymous namespace to reduce the complexity of the class
- rename **mp2_object** member of `Tiles` class into **_mainObjectType** to make it clear what it is
- rename all **tileset** usages into **objectIcnType**
- remove all usages of bitwise shift operations on objectIcnTypes (except where we read data from an MP2 file). This was an ultimate goal of the changes as the code was a complete mess and not sustainable to be supported
- fix multiple compilation warnings
~~- add **_hasObjectAnimation** and **_isMarkedAsRoad** members into `TilesAddon` and `Tiles` classes. For now we don't save them as we do not use them anywhere (at least for now)~~

This pull request changes the very core of Adventure Map rendering and passability logic so please test these changes on old saves and new maps very carefully. Pay attention to passability in builds from the master branch and in this branch, as well as Adventure Map object rendering.

relates to #6415