### PR TITLE
SonarCloud: use the compile_commands.json instead of build wrapper

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -7,7 +7,7 @@ on:
         required: true
 
 env:
-  SONAR_SCANNER_VERSION: 4.5.0.2216
+  SONAR_SCANNER_VERSION: 4.8.0.2856
 
 jobs:
   sonarcloud:
@@ -29,9 +29,7 @@ jobs:
     - name: Initialize SonarCloud
       run: |
         mkdir -p ~/.sonarcloud
-        wget -P ~/.sonarcloud https://sonarcloud.io/static/cpp/build-wrapper-linux-x86.zip
         wget -P ~/.sonarcloud https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-"$SONAR_SCANNER_VERSION"-linux.zip
-        unzip ~/.sonarcloud/build-wrapper-linux-x86.zip -d ~/.sonarcloud
         unzip ~/.sonarcloud/sonar-scanner-cli-"$SONAR_SCANNER_VERSION"-linux.zip -d ~/.sonarcloud
     - name: Prepare SonarCloud cfamily cache
       uses: actions/cache@v3
@@ -43,17 +41,12 @@ jobs:
     - name: Generate version information
       run: |
         sed -i~ "s/%{version}/$(cat version.txt)/" sonar-project.properties
-    - name: Build
+    - name: Prepare compile_commands.json
       run: |
-        ~/.sonarcloud/build-wrapper-linux-x86/build-wrapper-linux-x86-64 --out-dir bw-output make -j 2
-      env:
-        FHEROES2_STRICT_COMPILATION: ON
-        FHEROES2_WITH_DEBUG: ON
-        FHEROES2_WITH_IMAGE: ON
-        FHEROES2_WITH_TOOLS: ON
+        cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DUSE_SDL_VERSION=SDL2 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
-        ~/.sonarcloud/sonar-scanner-"$SONAR_SCANNER_VERSION"-linux/bin/sonar-scanner -Dsonar.cfamily.build-wrapper-output=bw-output \
+        ~/.sonarcloud/sonar-scanner-"$SONAR_SCANNER_VERSION"-linux/bin/sonar-scanner -Dsonar.cfamily.compile-commands=build/compile_commands.json \
                                                                                      -Dsonar.cfamily.cache.enabled=true \
                                                                                      -Dsonar.cfamily.cache.path="$HOME"/.sonar-cfamily-cache \
                                                                                      -Dsonar.host.url=https://sonarcloud.io

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,4 +20,4 @@ sonar.links.ci=https://github.com/ihhub/fheroes2/actions
 sonar.links.scm=https://github.com/ihhub/fheroes2
 sonar.links.issue=https://github.com/ihhub/fheroes2/issues
 
-sonar.exclusions=android/**/*.java,src/thirdparty/**/*,bw-output
+sonar.exclusions=android/**/*.java,src/thirdparty/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,11 +12,8 @@ sonar.sources=.
 # Encoding of the source code. Default is default system encoding
 #sonar.sourceEncoding=UTF-8
 
-sonar.cfamily.threads=2
-
 # Properties specific to the C/C++ analyzer:
-sonar.cfamily.build-wrapper-output=bw-output
-sonar.cfamily.gcov.reportsPath=.
+sonar.cfamily.threads=2
 
 sonar.links.homepage=https://github.com/ihhub/fheroes2
 sonar.links.ci=https://github.com/ihhub/fheroes2/actions


### PR DESCRIPTION
Speed up the analysis, because now we do not need to perform a full build beforehand.