### PR TITLE
Add checks to identify MX2 being loaded as MP2

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1483,7 +1483,9 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
 
             conf.SetGameType( Game::TYPE_CAMPAIGN );
 
-            if ( !world.LoadMapMP2( mapInfo.file ) ) {
+            const bool isSWCampaign = ( chosenCampaignID == Campaign::ROLAND_CAMPAIGN ) || ( chosenCampaignID == Campaign::ARCHIBALD_CAMPAIGN );
+
+            if ( !world.LoadMapMP2( mapInfo.file, isSWCampaign ) ) {
                 Dialog::Message( _( "Campaign Scenario loading failure" ), _( "Please make sure that campaign files are correct and present." ), Font::BIG, Dialog::OK );
 
                 // TODO: find a way to restore world for the current game after a failure.

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2022                                             *
+ *   Copyright (C) 2020 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -399,7 +399,7 @@ namespace
             std::string ext = lower.substr( lower.size() - 3 );
 
             if ( ext == "mp2" || ext == "mx2" ) {
-                return world.LoadMapMP2( conf.MapsFile() ) ? fheroes2::GameMode::START_GAME : fheroes2::GameMode::MAIN_MENU;
+                return world.LoadMapMP2( conf.MapsFile(), ( ext == "mp2" ) ) ? fheroes2::GameMode::START_GAME : fheroes2::GameMode::MAIN_MENU;
             }
 
             DEBUG_LOG( DBG_GAME, DBG_WARN,

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -177,7 +177,7 @@ public:
     World & operator=( const World & other ) = delete;
     World & operator=( World && other ) = delete;
 
-    bool LoadMapMP2( const std::string & );
+    bool LoadMapMP2( const std::string & filename, const bool isOriginalMp2File );
 
     void NewMaps( int32_t, int32_t );
 

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -236,7 +236,7 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
             case MP2::OBJ_EXPANSION_DWELLING:
             case MP2::OBJ_EXPANSION_OBJECT:
             case MP2::OBJ_JAIL:
-                DEBUG_LOG( DBG_GAME, DBG_INFO, "Failed to load The Price of Loyalty '" << filename << "' map which is not supported by this version of the game." )
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "Failed to load The Price of Loyalty map '" << filename << "' which is not supported by this version of the game." )
                 // You are trying to load a PoL map named as a MP2 file.
                 return false;
             default:

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -55,7 +55,6 @@
 #include "rand.h"
 #include "serialize.h"
 #include "settings.h"
-#include "tools.h"
 #include "world.h"
 
 namespace
@@ -240,6 +239,8 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
                 DEBUG_LOG( DBG_GAME, DBG_INFO, "Failed to load The Price of Loyalty '" << filename << "' map which is not supported by this version of the game." )
                 // You are trying to load a PoL map named as a MP2 file.
                 return false;
+            default:
+                break;
             }
         }
 


### PR DESCRIPTION
Players should not rename maps as they want. If people want to play PoL maps they must own this version of the game.

This is a very basic check but it works on most of maps.

relates to #6047