### PR TITLE
Fix loss of the first frame in the after attack unit animation. Battlefield.

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3502,7 +3502,7 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
     const uint32_t lichCloudMaxFrame = fheroes2::AGG::GetICNCount( ICN::LICHCLOD );
     // Wince animation under the Lich cloud, second part: the frame number after which the target animation will be switched to 'WNCE_UP'.
     const uint32_t wnceUpStartFrame = 1;
-    // Wince animation under the Lich cloud, third part: the frame number after which the target animation will be switched to 'WNCE_SOWN'.
+    // Wince animation under the Lich cloud, third part: the frame number after which the target animation will be switched to 'WNCE_DOWN'.
     const uint32_t wnceDownStartFrame = lichCloudMaxFrame - 3;
 
     if ( drawLichCloud ) {
@@ -3517,7 +3517,17 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
             continue;
         }
 
-        bool redrawBattleField = false;
+        RedrawPartialStart();
+
+        // Render a Lich cloud above the target unit if it is a Lich attack and if the cloud animation is not already finished.
+        if ( drawLichCloud && lichCloudFrame < lichCloudMaxFrame ) {
+            const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( ICN::LICHCLOD, lichCloudFrame );
+            const fheroes2::Point & pos = CalculateSpellPosition( *defender, ICN::LICHCLOD, spellSprite );
+            fheroes2::Blit( spellSprite, _mainSurface, pos.x, pos.y, false );
+            ++lichCloudFrame;
+        }
+
+        RedrawPartialFinish();
 
         if ( attacker != nullptr ) {
             if ( attacker->isFinishAnimFrame() ) {
@@ -3526,30 +3536,6 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
             else {
                 attacker->IncreaseAnimFrame();
             }
-
-            redrawBattleField = true;
-        }
-        else {
-            for ( const Battle::TargetInfo & target : targets ) {
-                if ( target.defender ) {
-                    redrawBattleField = true;
-                    break;
-                }
-            }
-        }
-
-        if ( redrawBattleField ) {
-            RedrawPartialStart();
-
-            // Render a Lich cloud above the target unit if it is a Lich attack and if the cloud animation is not already finished.
-            if ( drawLichCloud && lichCloudFrame < lichCloudMaxFrame ) {
-                const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( ICN::LICHCLOD, lichCloudFrame );
-                const fheroes2::Point & pos = CalculateSpellPosition( *defender, ICN::LICHCLOD, spellSprite );
-                fheroes2::Blit( spellSprite, _mainSurface, pos.x, pos.y, false );
-                ++lichCloudFrame;
-            }
-
-            RedrawPartialFinish();
         }
 
         for ( const Battle::TargetInfo & target : targets ) {
@@ -3599,7 +3585,8 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
         // There sould not be more Lich cloud animation frames than in corresponding ICN.
         assert( lichCloudFrame <= lichCloudMaxFrame );
 
-        if ( ( animatingTargets == finishedAnimationCount ) && ( !drawLichCloud || ( lichCloudFrame == lichCloudMaxFrame ) ) ) {
+        if ( ( animatingTargets == finishedAnimationCount ) && ( !drawLichCloud || ( lichCloudFrame == lichCloudMaxFrame ) )
+             && ( ( attacker == nullptr ) || ( attacker->animation.getCurrentState() == Monster_Info::STATIC ) ) ) {
             // All unit animation frames are rendered and if it was a Lich attack then also its cloud frames are rendered too.
             break;
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3585,8 +3585,11 @@ void Battle::Interface::RedrawActionWincesKills( const TargetsInfo & targets, Un
         // There sould not be more Lich cloud animation frames than in corresponding ICN.
         assert( lichCloudFrame <= lichCloudMaxFrame );
 
+        // IMPORTANT: The game engine can change STATIC animation to IDLE, especially for Ghosts and Zombies,
+        // so we need also to check for IDLE where we check for STATIC.
         if ( ( animatingTargets == finishedAnimationCount ) && ( !drawLichCloud || ( lichCloudFrame == lichCloudMaxFrame ) )
-             && ( ( attacker == nullptr ) || ( attacker->animation.getCurrentState() == Monster_Info::STATIC ) ) ) {
+             && ( ( attacker == nullptr ) || ( attacker->animation.getCurrentState() == Monster_Info::STATIC )
+                  || ( attacker->animation.getCurrentState() == Monster_Info::IDLE ) ) ) {
             // All unit animation frames are rendered and if it was a Lich attack then also its cloud frames are rendered too.
             break;
         }


### PR DESCRIPTION
close #6465 
 
This PR fixes the after attack (melee or distance) animation.
Before this PR the engine did the change of the current frame to the next one (or changed the animation if it is finished) and then made a render. Now it first renders and then changes the frame/animation.
Also in this PR the redundant check for need of render at the start of the loop was removed as it is checked at the end of the loop.