### PR TITLE
[Fix] Appdata: correct & extend donation link

### DIFF
--- a/script/packaging/common/fheroes2.appdata.xml
+++ b/script/packaging/common/fheroes2.appdata.xml
@@ -22,7 +22,9 @@
   <url type="bugtracker">https://github.com/ihhub/fheroes2/issues</url>
   <url type="faq">https://github.com/ihhub/fheroes2/wiki/F.A.Q.</url>
   <url type="translate">https://github.com/ihhub/fheroes2/blob/master/docs/TRANSLATION.md</url>
-  <url type="donate">https://www.patreon.com/fheroes2</url>
+  <url type="donation">https://www.patreon.com/fheroes2</url>
+  <url type="donation">https://www.paypal.com/paypalme/fheroes2</url>
+  <url type="donation">https://boosty.to/fheroes2</url>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">mild</content_attribute>
     <content_attribute id="violence-fantasy">mild</content_attribute>


### PR DESCRIPTION
Fix small error which which prevents the successful build process of flatpak.

I have also added all three links.

See here: https://github.com/flathub/io.github.ihhub.Fheroes2/pull/16