### PR TITLE
Rebuild the battle pathfinding cache dynamically if necessary

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -154,11 +154,11 @@ namespace AI
     private:
         void analyzeBattleState( const Battle::Arena & arena, const Battle::Unit & currentUnit );
 
-        Battle::Actions berserkTurn( const Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
-        Battle::Actions archerDecision( const Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
+        Battle::Actions berserkTurn( Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
+        Battle::Actions archerDecision( Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
 
-        BattleTargetPair meleeUnitOffense( const Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
-        BattleTargetPair meleeUnitDefense( const Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
+        BattleTargetPair meleeUnitOffense( Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
+        BattleTargetPair meleeUnitDefense( Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
 
         SpellSelection selectBestSpell( Battle::Arena & arena, const Battle::Unit & currentUnit, bool retreating ) const;
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -154,7 +154,7 @@ namespace AI
     private:
         void analyzeBattleState( const Battle::Arena & arena, const Battle::Unit & currentUnit );
 
-        Battle::Actions berserkTurn( Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
+        static Battle::Actions berserkTurn( Battle::Arena & arena, const Battle::Unit & currentUnit );
         Battle::Actions archerDecision( Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
 
         BattleTargetPair meleeUnitOffense( Battle::Arena & arena, const Battle::Unit & currentUnit ) const;
@@ -181,7 +181,7 @@ namespace AI
 
         // When this limit of turns without deaths is exceeded for an attacking AI-controlled hero,
         // the auto battle should be interrupted (one way or another)
-        const uint32_t MAX_TURNS_WITHOUT_DEATHS = 50;
+        static const uint32_t MAX_TURNS_WITHOUT_DEATHS = 50;
 
         // Member variables related to the logic of checking the limit of the number of turns
         uint32_t _currentTurnNumber = 0;

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2022                                             *
+ *   Copyright (C) 2020 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -854,7 +854,7 @@ namespace AI
         return target;
     }
 
-    Actions BattlePlanner::berserkTurn( Arena & arena, const Unit & currentUnit ) const
+    Actions BattlePlanner::berserkTurn( Arena & arena, const Unit & currentUnit )
     {
         assert( currentUnit.Modes( SP_BERSERKER ) );
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -88,7 +88,7 @@ namespace AI
                     && ValueHasImproved( newOutcome.positionValue, previous.positionValue, newOutcome.attackValue, previous.attackValue ) );
     }
 
-    MeleeAttackOutcome BestAttackOutcome( const Arena & arena, const Unit & attacker, const Unit & defender, const Rand::DeterministicRandomGenerator & randomGenerator )
+    MeleeAttackOutcome BestAttackOutcome( Arena & arena, const Unit & attacker, const Unit & defender, const Rand::DeterministicRandomGenerator & randomGenerator )
     {
         MeleeAttackOutcome bestOutcome;
 
@@ -100,7 +100,7 @@ namespace AI
         for ( const int32_t nearbyIdx : nearbyIndexes ) {
             const Position pos = Position::GetPosition( attacker, nearbyIdx );
 
-            if ( !arena.isPositionReachable( pos, false ) ) {
+            if ( !arena.isPositionReachable( attacker, pos, false ) ) {
                 continue;
             }
 
@@ -181,20 +181,20 @@ namespace AI
         return targetCell;
     }
 
-    std::pair<int32_t, uint32_t> findNearestCellNextToUnit( const Arena & arena, const Unit & currentUnit, const Unit & target )
+    std::pair<int32_t, uint32_t> findNearestCellNextToUnit( Arena & arena, const Unit & currentUnit, const Unit & target )
     {
         std::pair<int32_t, uint32_t> result = { -1, UINT32_MAX };
 
         for ( const int32_t nearbyIdx : Board::GetAroundIndexes( target ) ) {
             const Position pos = Position::GetPosition( currentUnit, nearbyIdx );
 
-            if ( !arena.isPositionReachable( pos, false ) ) {
+            if ( !arena.isPositionReachable( currentUnit, pos, false ) ) {
                 continue;
             }
 
             assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
 
-            const uint32_t dist = arena.CalculateMoveDistance( pos );
+            const uint32_t dist = arena.CalculateMoveDistance( currentUnit, pos );
             if ( result.first == -1 || dist < result.second ) {
                 result = { nearbyIdx, dist };
             }
@@ -208,7 +208,7 @@ namespace AI
         // First try to find the position that is reachable on the current turn
         Position pos = Position::GetReachable( currentUnit, idx );
 
-        // If there is no such position, then use an abstract position that corresponds to the given index
+        // If there is no such position, then use an abstract position corresponding to the specified index
         if ( pos.GetHead() == nullptr ) {
             pos = Position::GetPosition( currentUnit, idx );
         }
@@ -568,7 +568,7 @@ namespace AI
                    "Tactic " << _defensiveTactics << " chosen. Archers: " << _myShooterStr << ", vs enemy " << _enemyShooterStr << " ratio is " << enemyArcherRatio )
     }
 
-    Actions BattlePlanner::archerDecision( const Arena & arena, const Unit & currentUnit ) const
+    Actions BattlePlanner::archerDecision( Arena & arena, const Unit & currentUnit ) const
     {
         Actions actions;
         BattleTargetPair target;
@@ -608,7 +608,7 @@ namespace AI
             }
             else {
                 // Kiting enemy: Search for a safe spot unit can move to
-                target.cell = FindMoveToRetreat( arena.getAllAvailableMoves(), currentUnit, enemies );
+                target.cell = FindMoveToRetreat( arena.getAllAvailableMoves( currentUnit ), currentUnit, enemies );
 
                 if ( target.cell != -1 ) {
                     DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " archer kiting enemy, target cell is " << target.cell )
@@ -672,7 +672,7 @@ namespace AI
         return actions;
     }
 
-    BattleTargetPair BattlePlanner::meleeUnitOffense( const Arena & arena, const Unit & currentUnit ) const
+    BattleTargetPair BattlePlanner::meleeUnitOffense( Arena & arena, const Unit & currentUnit ) const
     {
         BattleTargetPair target;
 
@@ -717,7 +717,7 @@ namespace AI
                     const Position pos = Position::GetPosition( currentUnit, move.first );
                     assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
 
-                    const Indexes path = arena.GetPath( pos );
+                    const Indexes path = arena.GetPath( currentUnit, pos );
 
                     // Normally this shouldn't happen
                     if ( path.empty() ) {
@@ -748,13 +748,13 @@ namespace AI
             for ( const int32_t cellIdx : cellsUnderWallsIndexes ) {
                 const Position pos = Position::GetPosition( currentUnit, cellIdx );
 
-                if ( !arena.isPositionReachable( pos, false ) ) {
+                if ( !arena.isPositionReachable( currentUnit, pos, false ) ) {
                     continue;
                 }
 
                 assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
 
-                const uint32_t dist = arena.CalculateMoveDistance( pos );
+                const uint32_t dist = arena.CalculateMoveDistance( currentUnit, pos );
                 if ( target.cell == -1 || dist < shortestDist ) {
                     shortestDist = dist;
                     target.cell = cellIdx;
@@ -767,7 +767,7 @@ namespace AI
         return target;
     }
 
-    BattleTargetPair BattlePlanner::meleeUnitDefense( const Arena & arena, const Unit & currentUnit ) const
+    BattleTargetPair BattlePlanner::meleeUnitDefense( Arena & arena, const Unit & currentUnit ) const
     {
         BattleTargetPair target;
 
@@ -854,7 +854,7 @@ namespace AI
         return target;
     }
 
-    Actions BattlePlanner::berserkTurn( const Arena & arena, const Unit & currentUnit ) const
+    Actions BattlePlanner::berserkTurn( Arena & arena, const Unit & currentUnit ) const
     {
         assert( currentUnit.Modes( SP_BERSERKER ) );
 
@@ -932,13 +932,13 @@ namespace AI
                 for ( const int32_t cellIdx : cacheItemIter->second ) {
                     const Position pos = Position::GetPosition( currentUnit, cellIdx );
 
-                    if ( !arena.isPositionReachable( pos, false ) ) {
+                    if ( !arena.isPositionReachable( currentUnit, pos, false ) ) {
                         continue;
                     }
 
                     assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
 
-                    const uint32_t dist = arena.CalculateMoveDistance( pos );
+                    const uint32_t dist = arena.CalculateMoveDistance( currentUnit, pos );
                     if ( targetInfo.cell == -1 || dist < shortestDist ) {
                         shortestDist = dist;
                         targetInfo.cell = cellIdx;

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -452,7 +452,7 @@ void Battle::Arena::ApplyActionMove( Command & cmd )
             finalPos = pos;
         }
         else {
-            const Indexes path = GetPath( pos );
+            const Indexes path = GetPath( *unit, pos );
 
             if ( path.empty() ) {
                 DEBUG_LOG( DBG_BATTLE, DBG_WARN,

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -457,8 +457,6 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
                 _bridge->SetPassability( *troop );
             }
 
-            _battlePathfinder.evaluateForUnit( *troop );
-
             if ( troop->isControlRemote() ) {
                 RemoteTurn( *troop, actions );
             }
@@ -718,9 +716,9 @@ void Battle::Arena::CatapultAction()
     }
 }
 
-Battle::Indexes Battle::Arena::GetPath( const Position & position ) const
+Battle::Indexes Battle::Arena::GetPath( const Unit & unit, const Position & position )
 {
-    const Indexes result = _battlePathfinder.buildPath( position );
+    const Indexes result = _battlePathfinder.buildPath( unit, position );
 
     if ( IS_DEBUG( DBG_BATTLE, DBG_TRACE ) && !result.empty() ) {
         std::string pathStr;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -147,9 +147,9 @@ namespace Battle
         }
 
         // Checks whether a given position is reachable for a given unit, either on the current turn or in principle
-        bool isPositionReachable( const Unit & unit, const Position & position, const bool onCurrentTurn )
+        bool isPositionReachable( const Unit & unit, const Position & position, const bool isOnCurrentTurn )
         {
-            return _battlePathfinder.isPositionReachable( unit, position, onCurrentTurn );
+            return _battlePathfinder.isPositionReachable( unit, position, isOnCurrentTurn );
         }
 
         // Returns the indexes of all cells that can be occupied by a given unit's head on the current turn

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -139,32 +139,28 @@ namespace Battle
 
         void FadeArena( bool clearMessageLog ) const;
 
-        // Returns the distance to the given position (i.e. the number of cells that needs to be passed) for the
-        // current unit (to which the current pathfinder graph relates). It's the caller's responsibility to make
-        // sure that this position is reachable before calling this method.
-        uint32_t CalculateMoveDistance( const Position & position ) const
+        // Returns the distance to a given position (i.e. the number of cells to be traversed) for a given unit.
+        // It's the caller's responsibility to make sure that this position is reachable before calling this method.
+        uint32_t CalculateMoveDistance( const Unit & unit, const Position & position )
         {
-            return _battlePathfinder.getDistance( position );
+            return _battlePathfinder.getDistance( unit, position );
         }
 
-        // Checks whether the given position is reachable for the current unit (to which the current pathfinder
-        // graph relates), either on the current turn or in principle
-        bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const
+        // Checks whether a given position is reachable for a given unit, either on the current turn or in principle
+        bool isPositionReachable( const Unit & unit, const Position & position, const bool onCurrentTurn )
         {
-            return _battlePathfinder.isPositionReachable( position, onCurrentTurn );
+            return _battlePathfinder.isPositionReachable( unit, position, onCurrentTurn );
         }
 
-        // Returns the indexes of all cells that can be occupied by the head of the current unit (to which the
-        // current pathfinder graph relates) on the current turn
-        Indexes getAllAvailableMoves() const
+        // Returns the indexes of all cells that can be occupied by a given unit's head on the current turn
+        Indexes getAllAvailableMoves( const Unit & unit )
         {
-            return _battlePathfinder.getAllAvailableMoves();
+            return _battlePathfinder.getAllAvailableMoves( unit );
         }
 
-        // Returns a path (or its part) for the current unit (to which the current pathfinder graph relates)
-        // to the given position that can be traversed during the current turn. If this position is unreachable,
-        // then an empty path is returned.
-        Indexes GetPath( const Position & position ) const;
+        // Returns a path (or its part) for a given unit to a given position that can be traversed during the current
+        // turn. If this position is unreachable by this unit, then an empty path is returned.
+        Indexes GetPath( const Unit & unit, const Position & position );
 
         void ApplyAction( Command & );
 
@@ -256,17 +252,17 @@ namespace Battle
         void ApplyActionAutoFinish( const Command & cmd );
 
         // Performs an actual attack of one unit (defender) by another unit (attacker), applying the attacker's
-        // built-in magic, if necessary. If the given index of the target cell of the attack (dst) is negative,
-        // then an attempt will be made to calculate it automatically based on the adjacency of the unit cells.
-        // If the given direction of the attack (dir) is negative, then an attempt will be made to calculate it
+        // built-in magic, if necessary. If the specified index of the target cell of the attack (dst) is negative,
+        // then an attempt will be made to calculate it automatically based on the adjacency of the unit cells. If
+        // the specified direction of the attack (dir) is negative, then an attempt will be made to calculate it
         // automatically. When an attack is made by firing a shot, the dir should be UNKNOWN (zero).
         void BattleProcess( Unit & attacker, Unit & defender, int32_t dst = -1, int dir = -1 );
 
         // Creates and returns a fully combat-ready elemental, which will be already placed on the board. It's
-        // the caller's responsibility to make sure that this elemental can be created using the given spell
+        // the caller's responsibility to make sure that a given spell is capable of creating an elemental
         // before calling this method.
         Unit * CreateElemental( const Spell & spell );
-        // Creates and returns a mirror image of the given unit. The returned mirror image will have an invalid
+        // Creates and returns a mirror image of a given unit. The returned mirror image will have an invalid
         // position, which should be updated separately.
         Unit * CreateMirrorImage( Unit & unit );
 
@@ -280,7 +276,8 @@ namespace Battle
         int _lastActiveUnitArmyColor;
 
         const Castle * castle;
-        const bool _isTown; // If the battle is in town (village or castle).
+        // If the battle is in town (village or castle)
+        const bool _isTown;
 
         std::array<std::unique_ptr<Tower>, 3> _towers;
         std::unique_ptr<Catapult> _catapult;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -276,7 +276,7 @@ namespace Battle
         int _lastActiveUnitArmyColor;
 
         const Castle * castle;
-        // If the battle is in town (village or castle)
+        // Is the battle taking place in a town or a castle
         const bool _isTown;
 
         std::array<std::unique_ptr<Tower>, 3> _towers;

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -914,16 +914,16 @@ bool Battle::Board::isValidMirrorImageIndex( const int32_t index, const Unit * u
     return true;
 }
 
-bool Battle::Board::CanAttackFromCell( const Unit & currentUnit, const int32_t from )
+bool Battle::Board::CanAttackFromCell( const Unit & unit, const int32_t from )
 {
-    const Position pos = Position::GetReachable( currentUnit, from );
+    const Position pos = Position::GetReachable( unit, from );
 
     // Target unit cannot be attacked if out of reach
     if ( pos.GetHead() == nullptr ) {
         return false;
     }
 
-    assert( !currentUnit.isWide() || pos.GetTail() != nullptr );
+    assert( !unit.isWide() || pos.GetTail() != nullptr );
 
     const Castle * castle = Arena::GetCastle();
 
@@ -933,17 +933,17 @@ bool Battle::Board::CanAttackFromCell( const Unit & currentUnit, const int32_t f
     }
 
     // Target unit isn't attacked from the moat
-    if ( !isMoatIndex( from, currentUnit ) ) {
+    if ( !isMoatIndex( from, unit ) ) {
         return true;
     }
 
     // The moat doesn't stop flying units
-    if ( currentUnit.isFlying() ) {
+    if ( unit.isFlying() ) {
         return true;
     }
 
     // Attacker is already near the target
-    if ( from == currentUnit.GetHeadIndex() || ( currentUnit.isWide() && from == currentUnit.GetTailIndex() ) ) {
+    if ( from == unit.GetHeadIndex() || ( unit.isWide() && from == unit.GetTailIndex() ) ) {
         return true;
     }
 
@@ -951,10 +951,10 @@ bool Battle::Board::CanAttackFromCell( const Unit & currentUnit, const int32_t f
     return false;
 }
 
-bool Battle::Board::CanAttackTargetFromPosition( const Unit & currentUnit, const Unit & target, const int32_t dst )
+bool Battle::Board::CanAttackTargetFromPosition( const Unit & attacker, const Unit & target, const int32_t dst )
 {
     // Get the actual position of the attacker before attacking
-    const Position pos = Position::GetReachable( currentUnit, dst );
+    const Position pos = Position::GetReachable( attacker, dst );
 
     // Check that the attacker is actually capable of attacking the target from this position
     const std::array<const Cell *, 2> cells = { pos.GetHead(), pos.GetTail() };
@@ -964,7 +964,7 @@ bool Battle::Board::CanAttackTargetFromPosition( const Unit & currentUnit, const
             continue;
         }
 
-        if ( !CanAttackFromCell( currentUnit, cell->GetIndex() ) ) {
+        if ( !CanAttackFromCell( attacker, cell->GetIndex() ) ) {
             continue;
         }
 

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -103,12 +103,10 @@ namespace Battle
         static Indexes GetMoveWideIndexes( const int32_t head, const bool reflect );
         static bool isValidMirrorImageIndex( const int32_t index, const Unit * unit );
 
-        // Checks that the current unit (to which the current pathfinder graph relates) is able (in principle)
-        // to attack during the current turn from the cell with the given index
-        static bool CanAttackFromCell( const Unit & currentUnit, const int32_t from );
-        // Checks that the current unit (to which the current pathfinder graph relates) is able to attack the
-        // target during the current turn from the position which corresponds to the given index
-        static bool CanAttackTargetFromPosition( const Unit & currentUnit, const Unit & target, const int32_t dst );
+        // Checks whether a given unit is (in principle) capable of attacking during the current turn from a cell with a given index
+        static bool CanAttackFromCell( const Unit & unit, const int32_t from );
+        // Checks whether this attacker is able to attack the target during the current turn from a position corresponding to a given index
+        static bool CanAttackTargetFromPosition( const Unit & attacker, const Unit & target, const int32_t dst );
 
         static Indexes GetAdjacentEnemies( const Unit & unit );
 

--- a/src/fheroes2/battle/battle_cell.cpp
+++ b/src/fheroes2/battle/battle_cell.cpp
@@ -139,13 +139,13 @@ Battle::Position Battle::Position::GetPosition( const Unit & unit, const int32_t
     return result;
 }
 
-Battle::Position Battle::Position::GetReachable( const Unit & currentUnit, const int32_t dst )
+Battle::Position Battle::Position::GetReachable( const Unit & unit, const int32_t dst )
 {
-    const Arena * arena = GetArena();
+    Arena * arena = GetArena();
     assert( arena != nullptr );
 
-    if ( currentUnit.isWide() ) {
-        auto checkCells = [arena]( Cell * headCell, Cell * tailCell ) -> Position {
+    if ( unit.isWide() ) {
+        auto checkCells = [&unit, arena]( Cell * headCell, Cell * tailCell ) -> Position {
             if ( headCell == nullptr || tailCell == nullptr ) {
                 return {};
             }
@@ -155,15 +155,15 @@ Battle::Position Battle::Position::GetReachable( const Unit & currentUnit, const
             pos.first = headCell;
             pos.second = tailCell;
 
-            if ( arena->isPositionReachable( pos, true ) ) {
+            if ( arena->isPositionReachable( unit, pos, true ) ) {
                 return pos;
             }
 
             return {};
         };
 
-        auto tryHead = [&currentUnit, dst, &checkCells]() -> Position {
-            const int tailDirection = currentUnit.isReflect() ? RIGHT : LEFT;
+        auto tryHead = [&unit, dst, &checkCells]() -> Position {
+            const int tailDirection = unit.isReflect() ? RIGHT : LEFT;
 
             if ( Board::isValidDirection( dst, tailDirection ) ) {
                 Cell * headCell = Board::GetCell( dst );
@@ -175,8 +175,8 @@ Battle::Position Battle::Position::GetReachable( const Unit & currentUnit, const
             return {};
         };
 
-        auto tryTail = [&currentUnit, dst, &checkCells]() -> Position {
-            const int headDirection = currentUnit.isReflect() ? LEFT : RIGHT;
+        auto tryTail = [&unit, dst, &checkCells]() -> Position {
+            const int headDirection = unit.isReflect() ? LEFT : RIGHT;
 
             if ( Board::isValidDirection( dst, headDirection ) ) {
                 Cell * headCell = Board::GetCell( Board::GetIndexDirection( dst, headDirection ) );
@@ -207,7 +207,7 @@ Battle::Position Battle::Position::GetReachable( const Unit & currentUnit, const
 
     pos.first = headCell;
 
-    if ( arena->isPositionReachable( pos, true ) ) {
+    if ( arena->isPositionReachable( unit, pos, true ) ) {
         return pos;
     }
 

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -68,9 +68,9 @@ namespace Battle
 
         void SetArea( const fheroes2::Rect & );
 
-        // Checks that the cell is passable for the given unit located in a certain adjacent cell
+        // Checks that the cell is passable for a given unit located in a certain adjacent cell
         bool isPassableFromAdjacent( const Unit & unit, const Cell & adjacent ) const;
-        // Checks that the cell is passable for the given unit, i.e. unit can occupy it with his head or tail
+        // Checks that the cell is passable for a given unit, i.e. unit can occupy it with his head or tail
         bool isPassableForUnit( const Unit & unit ) const;
         // Checks that the cell is passable, i.e. does not contain an obstacle or (optionally) a unit
         bool isPassable( const bool checkForUnit ) const;
@@ -108,16 +108,15 @@ namespace Battle
         bool isReflect() const;
         bool contains( int cellIndex ) const;
 
-        // Returns the position that the given unit would occupy after moving to the cell
-        // with the given index (without taking into account the current pathfinder graph)
-        // or an empty Position object if the given index is unreachable in principle for
-        // the given unit
+        // Returns the position that a given unit would occupy after moving to the cell
+        // with a given index (without taking into account the pathfinder's info) or an
+        // empty Position object if this index is unreachable in principle for this unit
         static Position GetPosition( const Unit & unit, const int32_t dst );
 
-        // Returns the reachable position for the current unit (to which the current
-        // pathfinder graph relates) which corresponds to the given index or an empty
-        // Position object if the given index is unreachable on the current turn
-        static Position GetReachable( const Unit & currentUnit, const int32_t dst );
+        // Returns the reachable position for a given unit, which corresponds to a given
+        // index, or an empty Position object if this index is unreachable for this unit
+        // on the current turn
+        static Position GetReachable( const Unit & unit, const int32_t dst );
 
         fheroes2::Rect GetRect() const;
         Cell * GetHead();

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <set>
+#include <tuple>
 #include <type_traits>
 #include <vector>
 
@@ -44,9 +45,9 @@ namespace Battle
     {
         assert( unit.GetHeadIndex() != -1 && ( !unit.isWide() || unit.GetTailIndex() != -1 ) );
 
-        auto currentSettings = std::tie( _pathStart, _speed, _isWide, _isFlying, _currentColor );
-        const auto newSettings
-            = std::make_tuple( BattleNodeIndex{ unit.GetHeadIndex(), unit.GetTailIndex() }, unit.GetSpeed(), unit.isWide(), unit.isFlying(), unit.GetCurrentColor() );
+        auto currentSettings = std::tie( _pathStart, _speed, _isWide, _isFlying, _color, _currentColor );
+        const auto newSettings = std::make_tuple( BattleNodeIndex{ unit.GetHeadIndex(), unit.GetTailIndex() }, unit.GetSpeed(), unit.isWide(), unit.isFlying(),
+                                                  unit.GetColor(), unit.GetCurrentColor() );
 
         // If all the parameters of the specified unit match the parameters of the unit for which the current cache was built, then there is no need to rebuild it
         if ( currentSettings == newSettings ) {

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -45,9 +45,9 @@ namespace Battle
     {
         assert( unit.GetHeadIndex() != -1 && ( !unit.isWide() || unit.GetTailIndex() != -1 ) );
 
-        auto currentSettings = std::tie( _pathStart, _speed, _isWide, _isFlying, _color, _currentColor );
-        const auto newSettings = std::make_tuple( BattleNodeIndex{ unit.GetHeadIndex(), unit.GetTailIndex() }, unit.GetSpeed(), unit.isWide(), unit.isFlying(),
-                                                  unit.GetColor(), unit.GetCurrentColor() );
+        auto currentSettings = std::tie( _pathStart, _speed, _isWide, _isFlying, _color );
+        const auto newSettings
+            = std::make_tuple( BattleNodeIndex{ unit.GetHeadIndex(), unit.GetTailIndex() }, unit.GetSpeed(), unit.isWide(), unit.isFlying(), unit.GetColor() );
 
         // If all the parameters of the specified unit match the parameters of the unit for which the current cache was built, then there is no need to rebuild it
         if ( currentSettings == newSettings ) {

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -40,22 +40,29 @@ namespace
 
 namespace Battle
 {
-    void BattlePathfinder::evaluateForUnit( const Unit & unit )
+    void BattlePathfinder::reEvaluateIfNeeded( const Unit & unit )
     {
         assert( unit.GetHeadIndex() != -1 && ( !unit.isWide() || unit.GetTailIndex() != -1 ) );
 
+        auto currentSettings = std::tie( _pathStart, _speed, _isWide, _isFlying, _currentColor );
+        const auto newSettings
+            = std::make_tuple( BattleNodeIndex{ unit.GetHeadIndex(), unit.GetTailIndex() }, unit.GetSpeed(), unit.isWide(), unit.isFlying(), unit.GetCurrentColor() );
+
+        // If all the parameters of the specified unit match the parameters of the unit for which the current cache was built, then there is no need to rebuild it
+        if ( currentSettings == newSettings ) {
+            return;
+        }
+
+        currentSettings = newSettings;
+
         const Castle * castle = Arena::GetCastle();
         const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
-        const bool isUnitWide = unit.isWide();
-
-        _pathStart = { unit.GetHeadIndex(), unit.GetTailIndex() };
-        _unitSpeed = unit.GetSpeed();
 
         _cache.clear();
         _cache.try_emplace( _pathStart );
 
         // Flying units can land wherever they can fit
-        if ( unit.isFlying() ) {
+        if ( _isFlying ) {
             const Board * board = Arena::GetBoard();
             assert( board != nullptr );
 
@@ -66,7 +73,7 @@ namespace Battle
                     continue;
                 }
 
-                assert( !unit.isWide() || pos.GetTail() != nullptr );
+                assert( !_isWide || pos.GetTail() != nullptr );
 
                 const int32_t headCellIdx = pos.GetHead()->GetIndex();
                 const int32_t tailCellIdx = pos.GetTail() ? pos.GetTail()->GetIndex() : -1;
@@ -84,7 +91,7 @@ namespace Battle
 
         // The index of that of the cells of the initial unit's position, which is located
         // in the moat (-1, if there is none)
-        const int32_t pathStartMoatCellIdx = [this, &unit, isMoatBuilt, isUnitWide]() {
+        const int32_t pathStartMoatCellIdx = [this, &unit, isMoatBuilt]() {
             if ( !isMoatBuilt ) {
                 return -1;
             }
@@ -95,7 +102,7 @@ namespace Battle
                 return _pathStart.first;
             }
 
-            if ( isUnitWide ) {
+            if ( _isWide ) {
                 assert( _pathStart.second != -1 );
 
                 if ( Board::isMoatIndex( _pathStart.second, unit ) ) {
@@ -115,7 +122,7 @@ namespace Battle
             const BattleNodeIndex currentNodeIdx = nodesToExplore[nodesToExploreIdx];
             const BattleNode & currentNode = _cache[currentNodeIdx];
 
-            if ( isUnitWide ) {
+            if ( _isWide ) {
                 assert( currentNodeIdx.first != -1 && currentNodeIdx.second != -1 );
 
                 const auto [currentHeadCellIdx, currentTailCellIdx] = currentNodeIdx;
@@ -202,12 +209,14 @@ namespace Battle
         }
     }
 
-    bool BattlePathfinder::isPositionReachable( const Position & position, const bool onCurrentTurn ) const
+    bool BattlePathfinder::isPositionReachable( const Unit & unit, const Position & position, const bool onCurrentTurn )
     {
         // Invalid positions are allowed here, but they are always unreachable
         if ( position.GetHead() == nullptr ) {
             return false;
         }
+
+        reEvaluateIfNeeded( unit );
 
         const BattleNodeIndex nodeIdx = { position.GetHead()->GetIndex(), position.GetTail() ? position.GetTail()->GetIndex() : -1 };
 
@@ -218,12 +227,14 @@ namespace Battle
 
         const auto & [index, node] = *iter;
 
-        return ( index == _pathStart || node._from != BattleNodeIndex{ -1, -1 } ) && ( !onCurrentTurn || node._cost <= _unitSpeed );
+        return ( index == _pathStart || node._from != BattleNodeIndex{ -1, -1 } ) && ( !onCurrentTurn || node._cost <= _speed );
     }
 
-    uint32_t BattlePathfinder::getDistance( const Position & position ) const
+    uint32_t BattlePathfinder::getDistance( const Unit & unit, const Position & position )
     {
         assert( position.GetHead() != nullptr );
+
+        reEvaluateIfNeeded( unit );
 
         const BattleNodeIndex nodeIdx = { position.GetHead()->GetIndex(), position.GetTail() ? position.GetTail()->GetIndex() : -1 };
 
@@ -237,12 +248,14 @@ namespace Battle
         return node._distance;
     }
 
-    Indexes BattlePathfinder::getAllAvailableMoves() const
+    Indexes BattlePathfinder::getAllAvailableMoves( const Unit & unit )
     {
+        reEvaluateIfNeeded( unit );
+
         std::set<int32_t> boardIndexes;
 
         for ( const auto & [index, node] : _cache ) {
-            if ( index == _pathStart || node._from == BattleNodeIndex{ -1, -1 } || node._cost > _unitSpeed ) {
+            if ( index == _pathStart || node._from == BattleNodeIndex{ -1, -1 } || node._cost > _speed ) {
                 continue;
             }
 
@@ -259,9 +272,11 @@ namespace Battle
         return result;
     }
 
-    Indexes BattlePathfinder::buildPath( const Position & position ) const
+    Indexes BattlePathfinder::buildPath( const Unit & unit, const Position & position )
     {
         assert( position.GetHead() != nullptr );
+
+        reEvaluateIfNeeded( unit );
 
         const BattleNodeIndex targetNodeIdx = { position.GetHead()->GetIndex(), position.GetTail() ? position.GetTail()->GetIndex() : -1 };
 
@@ -278,9 +293,9 @@ namespace Battle
 
             nodeIdx = node._from;
 
-            // The given position may be reachable in principle, but is not reachable on the current turn.
+            // A given position may be reachable in principle, but is not reachable on the current turn.
             // Skip the steps that are not reachable on this turn.
-            if ( node._cost > _unitSpeed ) {
+            if ( node._cost > _speed ) {
                 continue;
             }
 

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -210,7 +210,7 @@ namespace Battle
         }
     }
 
-    bool BattlePathfinder::isPositionReachable( const Unit & unit, const Position & position, const bool onCurrentTurn )
+    bool BattlePathfinder::isPositionReachable( const Unit & unit, const Position & position, const bool isOnCurrentTurn )
     {
         // Invalid positions are allowed here, but they are always unreachable
         if ( position.GetHead() == nullptr ) {
@@ -228,7 +228,7 @@ namespace Battle
 
         const auto & [index, node] = *iter;
 
-        return ( index == _pathStart || node._from != BattleNodeIndex{ -1, -1 } ) && ( !onCurrentTurn || node._cost <= _speed );
+        return ( index == _pathStart || node._from != BattleNodeIndex{ -1, -1 } ) && ( !isOnCurrentTurn || node._cost <= _speed );
     }
 
     uint32_t BattlePathfinder::getDistance( const Unit & unit, const Position & position )

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -98,7 +98,7 @@ namespace Battle
         uint32_t _speed = 0;
         bool _isWide = false;
         bool _isFlying = false;
+        // The unit's color (or rather, the unit's army color) affects the ability to pass the castle bridge
         int _color = 0;
-        int _currentColor = 0;
     };
 }

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -98,6 +98,7 @@ namespace Battle
         uint32_t _speed = 0;
         bool _isWide = false;
         bool _isFlying = false;
+        int _color = 0;
         int _currentColor = 0;
     };
 }

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -74,7 +74,7 @@ namespace Battle
         BattlePathfinder & operator=( const BattlePathfinder & ) = delete;
 
         // Checks whether a given position is reachable for a given unit, either on the current turn or in principle
-        bool isPositionReachable( const Unit & unit, const Position & position, const bool onCurrentTurn );
+        bool isPositionReachable( const Unit & unit, const Position & position, const bool isOnCurrentTurn );
 
         // Returns the distance to a given position (i.e. the number of cells to be traversed) for a given unit.
         // It's the caller's responsibility to make sure that this position is reachable before calling this method.

--- a/src/fheroes2/battle/battle_pathfinding.h
+++ b/src/fheroes2/battle/battle_pathfinding.h
@@ -73,27 +73,31 @@ namespace Battle
 
         BattlePathfinder & operator=( const BattlePathfinder & ) = delete;
 
-        // Rebuilds the graph of available positions for the given unit
-        void evaluateForUnit( const Unit & unit );
+        // Checks whether a given position is reachable for a given unit, either on the current turn or in principle
+        bool isPositionReachable( const Unit & unit, const Position & position, const bool onCurrentTurn );
 
-        // Checks whether the given position is reachable, either on the current turn or in principle
-        bool isPositionReachable( const Position & position, const bool onCurrentTurn ) const;
+        // Returns the distance to a given position (i.e. the number of cells to be traversed) for a given unit.
+        // It's the caller's responsibility to make sure that this position is reachable before calling this method.
+        uint32_t getDistance( const Unit & unit, const Position & position );
 
-        // Returns the distance to the given position (i.e. the number of cells that needs to be passed).
-        // It's the caller's responsibility to make sure that this position is reachable before calling
-        // this method.
-        uint32_t getDistance( const Position & position ) const;
+        // Builds and returns a path (or its part) for a given unit to a given position that can be traversed during the
+        // current turn. If this position is unreachable by this unit, then an empty path is returned.
+        Indexes buildPath( const Unit & unit, const Position & position );
 
-        // Builds and returns a path (or its part) to the given position that can be traversed during the
-        // current turn. If this position is unreachable, then an empty path is returned.
-        Indexes buildPath( const Position & position ) const;
-
-        // Returns the indexes of all cells that can be occupied by the unit's head on the current turn
-        Indexes getAllAvailableMoves() const;
+        // Returns the indexes of all cells that can be occupied by a given unit's head on the current turn
+        Indexes getAllAvailableMoves( const Unit & unit );
 
     private:
+        // Rebuilds the graph of available positions for a given unit if necessary (if it is not already cached)
+        void reEvaluateIfNeeded( const Unit & unit );
+
         std::unordered_map<BattleNodeIndex, BattleNode, BattleNodeIndexHash> _cache;
+
+        // Parameters of the unit for which the current cache is created
         BattleNodeIndex _pathStart = { -1, -1 };
-        uint32_t _unitSpeed = 0;
+        uint32_t _speed = 0;
+        bool _isWide = false;
+        bool _isFlying = false;
+        int _currentColor = 0;
     };
 }

--- a/src/fheroes2/battle/battle_tower.h
+++ b/src/fheroes2/battle/battle_tower.h
@@ -65,7 +65,7 @@ namespace Battle
         void SetDestroy();
         fheroes2::Point GetPortPosition() const;
 
-        // Returns a text description of the parameters of the towers of the given castle. Can be
+        // Returns a text description of the parameters of the towers of a given castle. Can be
         // called both during combat and outside of it. In the former case, the current state of
         // the towers destroyed during the siege will be reflected.
         static std::string GetInfo( const Castle & castle );

--- a/src/fheroes2/battle/battle_tower.h
+++ b/src/fheroes2/battle/battle_tower.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -73,7 +73,7 @@ namespace Maps
     bool isValidForDimensionDoor( int32_t targetIndex, bool isWater );
     // Checks if the tile is guarded by a monster
     bool isTileUnderProtection( const int32_t tileIndex );
-    // Returns a list of indexes of tiles with monsters guarding the given tile
+    // Returns a list of indexes of tiles with monsters guarding the specified tile
     Indexes getMonstersProtectingTile( const int32_t tileIndex );
 
     Indexes GetObjectPositions( const MP2::MapObjectType objectType, bool ignoreHeroes );

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *


### PR DESCRIPTION
Related to #6527

Currently battle pathfinding cache is built once per turn (well, not quite, but close enough) for the particular "current" unit (the one whose turn has come). This is inconvenient in cases where you need to quickly recalculate the cache for another arbitrary unit, so with this PR cache will be rebuilt on demand.