### PR TITLE
Fix high CPU load on Adventure map when Hero speed is set to Jump

### DIFF
--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -78,7 +78,7 @@ namespace
             multiplier = 4;
             break;
         default:
-            delay.setDelay( 0 );
+            delay.setDelay( 1 );
             multiplier = 4;
         }
     }


### PR DESCRIPTION
close #6534 