### PR TITLE
Android Save File Manager: implement filtering of save files by type

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -33,7 +33,7 @@
         android:fullBackupContent="@xml/full_backup_content"
         android:hardwareAccelerated="true"
         android:icon="@mipmap/ic_launcher"
-        android:label="@string/app_name"
+        android:label="@string/app_label"
         android:supportsRtl="false">
 
         <activity
@@ -66,7 +66,7 @@
             android:label="@string/activity_toolset_label"
             android:launchMode="singleTask"
             android:taskAffinity="org.fheroes2.ToolsetTask"
-            android:theme="@style/Theme.Material3.DayNight">
+            android:theme="@style/Theme.MaterialComponents.DayNight">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -80,6 +80,6 @@
             android:icon="@mipmap/ic_launcher_toolset"
             android:label="@string/activity_save_file_manager_label"
             android:taskAffinity="org.fheroes2.ToolsetTask"
-            android:theme="@style/Theme.Material3.DayNight" />
+            android:theme="@style/Theme.MaterialComponents.DayNight" />
     </application>
 </manifest>

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -83,17 +83,29 @@ public final class SaveFileManagerActivity extends Activity
     {
         super.onResume();
 
-        updateUI();
         updateSaveFileList();
     }
 
     public void filterButtonClicked( final View view )
     {
+        final ToggleButton filterToggleButton = (ToggleButton)view;
+
+        int activeFiltersCount = 0;
+
+        activeFiltersCount += filterStandardToggleButton.isChecked() ? 1 : 0;
+        activeFiltersCount += filterCampaignToggleButton.isChecked() ? 1 : 0;
+        activeFiltersCount += filterMultiplayerToggleButton.isChecked() ? 1 : 0;
+
+        // Do not allow all filters to be turned off at the same time.
+        // TODO: Try disabling the button instead by changing its style so that it doesn't look disabled.
+        if ( activeFiltersCount < 1 && !filterToggleButton.isChecked() ) {
+            filterToggleButton.setChecked( true );
+        }
+
         for ( int i = 0; i < saveFileListView.getCount(); ++i ) {
             saveFileListView.setItemChecked( i, false );
         }
 
-        updateUI();
         updateSaveFileList();
     }
 
@@ -243,7 +255,6 @@ public final class SaveFileManagerActivity extends Activity
                 runOnUiThread( () -> {
                     backgroundTask = null;
 
-                    updateUI();
                     updateSaveFileList();
                 } );
             }
@@ -259,17 +270,9 @@ public final class SaveFileManagerActivity extends Activity
         // A quick and dirty way to avoid the re-creation of this activity due to the screen orientation change while running a background task
         setRequestedOrientation( backgroundTask == null ? ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED : ActivityInfo.SCREEN_ORIENTATION_LOCKED );
 
-        int activeFiltersCount = 0;
-
-        activeFiltersCount += filterStandardToggleButton.isChecked() ? 1 : 0;
-        activeFiltersCount += filterCampaignToggleButton.isChecked() ? 1 : 0;
-        activeFiltersCount += filterMultiplayerToggleButton.isChecked() ? 1 : 0;
-
-        // Do not allow all filters to be turned off at the same time
-        filterStandardToggleButton.setEnabled( backgroundTask == null && ( activeFiltersCount != 1 || !filterStandardToggleButton.isChecked() ) );
-        filterCampaignToggleButton.setEnabled( backgroundTask == null && ( activeFiltersCount != 1 || !filterCampaignToggleButton.isChecked() ) );
-        filterMultiplayerToggleButton.setEnabled( backgroundTask == null && ( activeFiltersCount != 1 || !filterMultiplayerToggleButton.isChecked() ) );
-
+        filterStandardToggleButton.setEnabled( backgroundTask == null );
+        filterCampaignToggleButton.setEnabled( backgroundTask == null );
+        filterMultiplayerToggleButton.setEnabled( backgroundTask == null );
         saveFileListView.setEnabled( backgroundTask == null );
         selectAllButton.setEnabled( backgroundTask == null );
         unselectAllButton.setEnabled( backgroundTask == null );

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -97,7 +97,7 @@ public final class SaveFileManagerActivity extends Activity
         activeFiltersCount += filterMultiplayerToggleButton.isChecked() ? 1 : 0;
 
         // Do not allow all filters to be turned off at the same time.
-        // TODO: Try disabling the button instead by changing its style so that it doesn't look disabled.
+        // TODO: Try disabling the button instead and changing its style so that it doesn't look disabled.
         if ( activeFiltersCount < 1 && !filterToggleButton.isChecked() ) {
             filterToggleButton.setChecked( true );
         }

--- a/android/app/src/main/res/layout/activity_save_file_manager.xml
+++ b/android/app/src/main/res/layout/activity_save_file_manager.xml
@@ -5,6 +5,46 @@
     android:layout_height="match_parent"
     android:orientation="vertical">
 
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:layout_marginBottom="8dp">
+
+        <ToggleButton
+            android:id="@+id/activity_save_file_manager_filter_standard_btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:checked="true"
+            android:enabled="false"
+            android:onClick="filterButtonClicked"
+            android:textOff="@string/activity_save_file_manager_filter_standard_btn_text"
+            android:textOn="@string/activity_save_file_manager_filter_standard_btn_text" />
+
+        <ToggleButton
+            android:id="@+id/activity_save_file_manager_filter_campaign_btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:checked="true"
+            android:enabled="false"
+            android:onClick="filterButtonClicked"
+            android:textOff="@string/activity_save_file_manager_filter_campaign_btn_text"
+            android:textOn="@string/activity_save_file_manager_filter_campaign_btn_text" />
+
+        <ToggleButton
+            android:id="@+id/activity_save_file_manager_filter_multiplayer_btn"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:checked="true"
+            android:enabled="false"
+            android:onClick="filterButtonClicked"
+            android:textOff="@string/activity_save_file_manager_filter_multiplayer_btn_text"
+            android:textOn="@string/activity_save_file_manager_filter_multiplayer_btn_text" />
+    </LinearLayout>
+
     <RelativeLayout
         android:layout_width="match_parent"
         android:layout_height="0dp"

--- a/android/app/src/main/res/layout/activity_toolset.xml
+++ b/android/app/src/main/res/layout/activity_toolset.xml
@@ -40,7 +40,7 @@
             android:minWidth="256dp"
             android:onClick="startGameButtonClicked"
             android:padding="8dp"
-            android:text="@string/activity_toolset_start_game_btn_name" />
+            android:text="@string/activity_toolset_start_game_btn_text" />
 
         <Button
             android:id="@+id/activity_toolset_extract_homm2_assets_btn"
@@ -51,7 +51,7 @@
             android:minWidth="256dp"
             android:onClick="extractHoMM2AssetsButtonClicked"
             android:padding="8dp"
-            android:text="@string/activity_toolset_extract_homm2_assets_btn_name" />
+            android:text="@string/activity_toolset_extract_homm2_assets_btn_text" />
 
         <Button
             android:id="@+id/activity_toolset_download_homm2_demo_btn"
@@ -62,7 +62,7 @@
             android:minWidth="256dp"
             android:onClick="downloadHoMM2DemoButtonClicked"
             android:padding="8dp"
-            android:text="@string/activity_toolset_download_homm2_demo_btn_name" />
+            android:text="@string/activity_toolset_download_homm2_demo_btn_text" />
 
         <Button
             android:id="@+id/activity_toolset_save_file_manager_btn"
@@ -73,7 +73,7 @@
             android:minWidth="256dp"
             android:onClick="saveFileManagerButtonClicked"
             android:padding="8dp"
-            android:text="@string/activity_toolset_save_file_manager_btn_name" />
+            android:text="@string/activity_toolset_save_file_manager_btn_text" />
 
         <ProgressBar
             android:id="@+id/activity_toolset_background_task_pb"

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
-    <string name="app_name">fheroes2</string>
+    <string name="app_label">fheroes2</string>
     <string name="activity_toolset_label">fh2 Werkzeugkasten</string>
     <string name="activity_toolset_game_logo_img_content_description">fheroes2 Logo</string>
     <string name="activity_toolset_game_status_lbl_text"><b>Sie können das Spiel im Moment nicht ausführen, da einige Dateien des Originalspiels fehlen.</b>\n\nBitte kopieren Sie den Inhalt des Verzeichnisses mit dem Originalspiel Heroes of Might and Magic II (oder nur die <b>ANIM</b>, <b>DATA</b>, <b>MAPS</b> und <b>MUSIC</b> Ordner) in ein ZIP-Archiv, kopieren Sie dieses auf das Gerät, drücken Sie die \"<b>HoMM2-Assets extrahieren</b>\" Schaltfläche und wählen Sie das ZIP-Archiv.\n\nWenn Sie keine Kopie des Originalspiels haben, können Sie ein ZIP-Archiv der Demoversion herunterladen. Sobald der Download abgeschlossen ist, drücken Sie bitte die Schaltfläche \"<b>HoMM2-Assets extrahieren</b>\" und wählen Sie das neu heruntergeladene Demo-Archiv aus.</string>
-    <string name="activity_toolset_start_game_btn_name">Spiel starten</string>
-    <string name="activity_toolset_extract_homm2_assets_btn_name">HoMM2-Assets extrahieren</string>
-    <string name="activity_toolset_download_homm2_demo_btn_name">HoMM2-Demo herunterladen</string>
+    <string name="activity_toolset_start_game_btn_text">Spiel starten</string>
+    <string name="activity_toolset_extract_homm2_assets_btn_text">HoMM2-Assets extrahieren</string>
+    <string name="activity_toolset_download_homm2_demo_btn_text">HoMM2-Demo herunterladen</string>
     <string name="activity_toolset_extract_homm2_assets_chooser_title">Wählen Sie die ZIP-Datei mit den HoMM2-Assets</string>
     <string name="activity_toolset_last_task_status_lbl_text_completed_successfully">Vorgang erfolgreich abgeschlossen.</string>
     <string name="activity_toolset_last_task_status_lbl_text_no_assets_found">Vorgang erfolgreich abgeschlossen, aber es wurden keine HoMM2-Assets gefunden.</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,20 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <resources>
-    <string name="app_name">fheroes2</string>
+    <string name="app_label">fheroes2</string>
     <string name="activity_toolset_label">fh2 Toolset</string>
     <string name="activity_toolset_game_logo_img_content_description">fheroes2 logo</string>
     <string name="activity_toolset_game_status_lbl_text"><b>You cannot run the game at the moment, because some data files of the original game are missing.</b>\n\nPlease put the contents of the directory with the original Heroes of Might and Magic II game (or just <b>ANIM</b>, <b>DATA</b>, <b>MAPS</b> and <b>MUSIC</b> folders) into a ZIP archive, copy it to this device, press the \"<b>Extract HoMM2 assets</b>\" button and select this ZIP archive.\n\nIf you do not have a copy of the original game, you can download a ZIP archive of the demo version. Once the download is complete please press the \"<b>Extract HoMM2 assets</b>\" button and select the newly downloaded demo archive.</string>
-    <string name="activity_toolset_start_game_btn_name">Start game</string>
-    <string name="activity_toolset_extract_homm2_assets_btn_name">Extract HoMM2 assets</string>
-    <string name="activity_toolset_download_homm2_demo_btn_name">Download HoMM2 demo</string>
-    <string name="activity_toolset_save_file_manager_btn_name">Save file manager</string>
+    <string name="activity_toolset_start_game_btn_text">Start game</string>
+    <string name="activity_toolset_extract_homm2_assets_btn_text">Extract HoMM2 assets</string>
+    <string name="activity_toolset_download_homm2_demo_btn_text">Download HoMM2 demo</string>
+    <string name="activity_toolset_save_file_manager_btn_text">Save file manager</string>
     <string name="activity_toolset_extract_homm2_assets_chooser_title">Choose the ZIP file with HoMM2 assets</string>
     <string name="activity_toolset_last_task_status_lbl_text_completed_successfully">Operation completed successfully.</string>
     <string name="activity_toolset_last_task_status_lbl_text_no_assets_found">Operation completed successfully, but no HoMM2 assets were found.</string>
     <string name="activity_toolset_last_task_status_lbl_text_failed">An error occurred during the operation: %s</string>
     <string name="activity_toolset_homm2_demo_url" translatable="false">https://archive.org/download/HeroesofMightandMagicIITheSuccessionWars_1020/h2demo.zip</string>
     <string name="activity_save_file_manager_label">fh2 Save File Manager</string>
+    <string name="activity_save_file_manager_filter_standard_btn_text">Standard</string>
+    <string name="activity_save_file_manager_filter_campaign_btn_text">Campaign</string>
+    <string name="activity_save_file_manager_filter_multiplayer_btn_text">Multi</string>
     <string name="activity_save_file_manager_save_file_list_empty_lbl_text">No save files available</string>
     <string name="activity_save_file_manager_select_all_btn_content_description">Select all save files</string>
     <string name="activity_save_file_manager_unselect_all_btn_content_description">Unselect all save files</string>


### PR DESCRIPTION
Requested by @Branikolog in #6505

![Screenshot_20230130-183300](https://user-images.githubusercontent.com/32623900/215602016-524961f3-5294-43e9-b80c-521869a50393.jpg)

It is possible to filter standard, campaign and multiplayer save files in various combinations as desired.