### PR TITLE
Fix Druid projectile start position for shooting up (Battlefield)

### DIFF
--- a/src/fheroes2/agg/bin_info.cpp
+++ b/src/fheroes2/agg/bin_info.cpp
@@ -160,7 +160,7 @@ namespace Bin_Info
         }
 
         if ( monsterID == Monster::DRUID || monsterID == Monster::GREATER_DRUID ) {
-            projectileOffset[0].x -= 17;
+            projectileOffset[0].x -= 12;
             projectileOffset[0].y += 23;
             projectileOffset[1].x -= 20;
             projectileOffset[2].x -= 7;


### PR DESCRIPTION
Relates to #6491

<details><summary>
_Originally posted by @Branikolog:

</summary>

https://github.com/ihhub/fheroes2/issues/6491#issuecomment-1410243613

Every creature except druids seem to have proper projectile animation now.
Issue is valid only for such shooting angle:

https://user-images.githubusercontent.com/55348946/215755877-2c450ab1-558c-4699-81b6-10f73a7aabdd.mp4
</details>

This PR:

https://user-images.githubusercontent.com/113276641/215776135-b895a0a2-08e8-4b7d-acf5-3613d4595c09.mp4

