### PR TITLE
Fix invalid Kingdom income calculation

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -81,7 +81,16 @@ namespace
     Funds getHandicapDependentIncome( const Funds & original, const Player::HandicapStatus handicapStatus )
     {
         const int32_t handicapPercentage = getHandicapIncomePercentage( handicapStatus );
-        return ( original * handicapPercentage + Funds( 99, 99, 99, 99, 99, 99, 99 ) ) / 100;
+        Funds corrected( original );
+        corrected.wood = std::min( corrected.wood, ( corrected.wood * handicapPercentage + 99 ) / 100 );
+        corrected.mercury = std::min( corrected.mercury, ( corrected.mercury * handicapPercentage + 99 ) / 100 );
+        corrected.ore = std::min( corrected.ore, ( corrected.ore * handicapPercentage + 99 ) / 100 );
+        corrected.sulfur = std::min( corrected.sulfur, ( corrected.sulfur * handicapPercentage + 99 ) / 100 );
+        corrected.crystal = std::min( corrected.crystal, ( corrected.crystal * handicapPercentage + 99 ) / 100 );
+        corrected.gems = std::min( corrected.gems, ( corrected.gems * handicapPercentage + 99 ) / 100 );
+        corrected.gold = std::min( corrected.gold, ( corrected.gold * handicapPercentage + 99 ) / 100 );
+
+        return corrected;
     }
 }
 


### PR DESCRIPTION
If one of resources has negative value per day then the original formula was just increasing it. This is how it was before the fix:
![image](https://user-images.githubusercontent.com/19829520/216778676-23d31abd-975b-4c05-806a-792bd3c1f637.png)
and this is how it should be (after the fix):
![image](https://user-images.githubusercontent.com/19829520/216778733-af490ce4-0425-4dea-ab45-c935397956c5.png)
