### PR TITLE
Instantly update status bar in battle for hero's dialog options

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -998,6 +998,7 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
         if ( statusMessage != status.GetMessage() ) {
             status.SetMessage( statusMessage );
             status.Redraw( display );
+            display.render( status );
         }
     }
 

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/statusbar.cpp
+++ b/src/fheroes2/gui/statusbar.cpp
@@ -25,12 +25,6 @@
 #include "screen.h"
 #include "tools.h"
 
-void StatusBar::SetCenter( int32_t cx, int32_t cy )
-{
-    center.x = cx;
-    center.y = cy;
-}
-
 void StatusBar::ShowMessage( const std::string & msg )
 {
     if ( msg != prev ) {

--- a/src/fheroes2/gui/statusbar.h
+++ b/src/fheroes2/gui/statusbar.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/statusbar.h
+++ b/src/fheroes2/gui/statusbar.h
@@ -35,7 +35,10 @@ class StatusBar : public TextSprite
 public:
     StatusBar() = default;
 
-    void SetCenter( int32_t cx, int32_t cy );
+    void SetCenter( const int32_t cx, const int32_t cy )
+    {
+        center = { cx, cy };
+    }
 
     void ShowMessage( const std::string & msg );
 


### PR DESCRIPTION
There is a lag in the status window. It is updated only due to cycling animation. This is how it looks:

https://user-images.githubusercontent.com/19829520/216804492-3051429d-4d60-446f-ab16-36d4dc2e13bb.mp4

Plus a very tiny optimization.