### PR TITLE
clang-format: force reordering of header groups

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -43,6 +43,17 @@ ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
 DerivePointerAlignment: false
 FixNamespaceComments: false
+IncludeBlocks: Regroup
+IncludeCategories:
+  - Regex: '^<SDL'
+    CaseSensitive: true
+    Priority: 3
+  - Regex: '^<[^.]+>$'
+    Priority: 1
+  - Regex: '^<'
+    Priority: 2
+  - Regex: '^"'
+    Priority: 4
 IndentCaseLabels: false
 IndentWidth: 4
 IndentWrappedFunctionNames: true


### PR DESCRIPTION
Inspired by questions in #6590

Example (headers from hypothetical `core.cpp`):

```cpp
#include <assert.h>
#include <cstdint>
#include <stdexcept>
#include <SDL.h>
#include <SDL_error.h>
#include <SDL_version.h>
#include "audio.h"
#include "core.h"
#include "localevent.h"
#include "logging.h"
```

will be reformatted as:

```cpp
#include "core.h"

#include <cstdint>
#include <stdexcept>

#include <assert.h>

#include <SDL.h>
#include <SDL_error.h>
#include <SDL_version.h>

#include "audio.h"
#include "localevent.h"
#include "logging.h"
```
