### PR TITLE
Rewrite standard window generation code

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -18,13 +18,14 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "image.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstdlib>
 #include <cstring>
 #include <type_traits>
 
-#include "image.h"
 #include "image_palette.h"
 
 namespace
@@ -2285,7 +2286,8 @@ namespace fheroes2
             const int32_t halfWidth = width / 2;
 
             for ( int32_t x = 0; x < halfWidth; ++x ) {
-                const int32_t stepY = 1 << ( ( halfWidth - x ) / 2 + 1 ); //static_cast<int32_t>( std::pow( 2, ( halfWidth - x ) / 2 + 1 ) );
+                // The step is 2 to the power, which decreases by 1 every second line and is 1 in the center.
+                const int32_t stepY = 1 << ( ( halfWidth - x ) / 2 + 1 );
                 const int32_t offsetY = stepY / 2 * ( ( x + halfWidth ) % 2 );
 
                 for ( int32_t y = 0; y < height; ++y ) {
@@ -2334,7 +2336,8 @@ namespace fheroes2
                 transformIn += widthIn;
             }
             for ( int32_t y = 0; y < halfHeight; ++y ) {
-                const int32_t stepX = 1 << ( ( halfHeight - y ) / 2 + 1 ); // static_cast<int32_t>( std::pow( 2, ( halfHeight - y ) / 2 + 1 ) );
+                // The step is 2 to the power, which decreases by 1 every second line and is 1 in the center.
+                const int32_t stepX = 1 << ( ( halfHeight - y ) / 2 + 1 );
                 const int32_t offsetX = stepX / 2 * ( ( y + halfHeight ) % 2 );
 
                 for ( int32_t x = 0; x < width; ++x ) {

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -2285,7 +2285,7 @@ namespace fheroes2
             const int32_t halfWidth = width / 2;
 
             for ( int32_t x = 0; x < halfWidth; ++x ) {
-                const int32_t stepY = static_cast<int32_t>( std::pow( 2, ( halfWidth - x ) / 2 + 1 ) );
+                const int32_t stepY = 1 << ( ( halfWidth - x ) / 2 + 1 ); //static_cast<int32_t>( std::pow( 2, ( halfWidth - x ) / 2 + 1 ) );
                 const int32_t offsetY = stepY / 2 * ( ( x + halfWidth ) % 2 );
 
                 for ( int32_t y = 0; y < height; ++y ) {
@@ -2334,7 +2334,7 @@ namespace fheroes2
                 transformIn += widthIn;
             }
             for ( int32_t y = 0; y < halfHeight; ++y ) {
-                const int32_t stepX = static_cast<int32_t>( std::pow( 2, ( halfHeight - y ) / 2 + 1 ) );
+                const int32_t stepX = 1 << ( ( halfHeight - y ) / 2 + 1 ); // static_cast<int32_t>( std::pow( 2, ( halfHeight - y ) / 2 + 1 ) );
                 const int32_t offsetX = stepX / 2 * ( ( y + halfHeight ) % 2 );
 
                 for ( int32_t x = 0; x < width; ++x ) {

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -2295,14 +2295,42 @@ namespace fheroes2
                     const int32_t offsetInX = y * widthIn;
 
                     if ( isReverse ? ( ( y % stepY ) != offsetY ) : ( ( y % stepY ) == offsetY ) ) {
+                        if ( !in.singleLayer() && out.singleLayer() && ( *( transformIn + offsetInX ) == 1 ) ) {
+                            // Skip pixel.
+                            continue;
+                        }
+
                         // First part of transition: we copy single pixels.
                         *( imageOut + offsetOutX ) = *( imageIn + offsetInX );
-                        *( transformOut + offsetOutX ) = *( transformIn + offsetInX );
+
+                        if ( !out.singleLayer() ) {
+                            if ( in.singleLayer() ) {
+                                // Set the copied pixel visible.
+                                *( transformOut + offsetOutX ) = 0;
+                            }
+                            else {
+                                *( transformOut + offsetOutX ) = *( transformIn + offsetInX );
+                            }
+                        }
                     }
                     else {
+                        if ( !in.singleLayer() && out.singleLayer() && ( *( transformIn2 + offsetInX ) == 1 ) ) {
+                            // Skip pixel.
+                            continue;
+                        }
+
                         // Second part of transition: we coppy image excluding single pixels.
                         *( imageOut2 + offsetOutX ) = *( imageIn2 + offsetInX );
-                        *( transformOut2 + offsetOutX ) = *( transformIn2 + offsetInX );
+
+                        if ( !out.singleLayer() ) {
+                            if ( in.singleLayer() ) {
+                                // Set the copied pixel visible.
+                                *( transformOut2 + offsetOutX ) = 0;
+                            }
+                            else {
+                                *( transformOut2 + offsetOutX ) = *( transformIn2 + offsetInX );
+                            }
+                        }
                     }
                 }
 
@@ -2342,14 +2370,44 @@ namespace fheroes2
 
                 for ( int32_t x = 0; x < width; ++x ) {
                     if ( isReverse ? ( ( x % stepX ) != offsetX ) : ( ( x % stepX ) == offsetX ) ) {
+                        if ( !in.singleLayer() && out.singleLayer() && ( *( transformIn + x ) == 1 ) ) {
+                            // Skip pixel.
+                            continue;
+                        }
+
                         // First part of transition: we copy single pixels.
                         *( imageOut + x ) = *( imageIn + x );
+
+                        if ( !out.singleLayer() ) {
+                            if ( in.singleLayer() ) {
+                                // Set the copied pixel visible.
+                                *( transformOut + x ) = 0;
+                            }
+                            else {
+                                *( transformOut + x ) = *( transformIn + x );
+                            }
+                        }
+
                         *( transformOut + x ) = *( transformIn + x );
                     }
                     else {
+                        if ( !in.singleLayer() && out.singleLayer() && ( *( transformIn2 + x ) == 1 ) ) {
+                            // Skip pixel.
+                            continue;
+                        }
+
                         // Second part of transition: we coppy image excluding single pixels.
                         *( imageOut2 + x ) = *( imageIn2 + x );
-                        *( transformOut2 + x ) = *( transformIn2 + x );
+
+                        if ( !out.singleLayer() ) {
+                            if ( in.singleLayer() ) {
+                                // Set the copied pixel visible.
+                                *( transformOut2 + x ) = 0;
+                            }
+                            else {
+                                *( transformOut2 + x ) = *( transformIn2 + x );
+                            }
+                        }
                     }
                 }
 

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1208,6 +1208,214 @@ namespace fheroes2
         return contour;
     }
 
+    void CreateDitheringTransition( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height,
+                                    const bool isVertical, const bool isReverse )
+    {
+        if ( !Verify( in, inX, inY, out, outX, outY, width, height ) ) {
+            return;
+        }
+
+        const int32_t widthIn = in.width();
+        const int32_t offsetIn = inY * widthIn + inX;
+        const uint8_t * imageIn = in.image() + offsetIn;
+        const uint8_t * transformIn = in.transform() + offsetIn;
+
+        const int32_t widthOut = out.width();
+        const int32_t offsetOut = outY * widthOut + outX;
+        uint8_t * imageOut = out.image() + offsetOut;
+        uint8_t * transformOut = out.transform() + offsetOut;
+
+        const bool isInNonSinglelayerToOutSinglelayer = !in.singleLayer() && out.singleLayer();
+
+        if ( isVertical ) {
+            // We also go in a loop from the right part of the image to its center.
+            const uint8_t * imageInRightPoint = imageIn + width - 1;
+            const uint8_t * transformInRightPoint = transformIn + width - 1;
+
+            uint8_t * imageOutRightPoint = imageOut + width - 1;
+            uint8_t * transformOutRightPoint = transformOut + width - 1;
+
+            const int32_t halfWidth = width / 2;
+
+            // We make a symmetric transition and if width is odd we shift one line right.
+            if ( ( width % 2 ) == 1 ) {
+                if ( isReverse ) {
+                    --imageOutRightPoint;
+                    --transformOutRightPoint;
+                    --imageInRightPoint;
+                    --transformInRightPoint;
+                }
+                else {
+                    ++imageOut;
+                    ++transformOut;
+                    ++imageIn;
+                    ++transformIn;
+                }
+            }
+
+            for ( int32_t x = 0; x < halfWidth; ++x ) {
+                // The step is 2 to the power, which decreases by 1 every second line and is 1 in the center.
+                // We limit the step power to 30 to not overflow the 32 bit 'stepY'.
+                const int32_t stepPower = std::min( 30, ( halfWidth - x ) / 2 + 1 );
+                const int32_t stepY = 1 << stepPower;
+
+                // The point position in dithered pattern.
+                const int32_t patternPoint = stepY / 2 * ( ( x + halfWidth ) % 2 );
+
+                for ( int32_t y = 0; y < height; ++y ) {
+                    const int32_t offsetOutX = y * widthOut;
+                    const int32_t offsetInX = y * widthIn;
+                    const int32_t offsetY = y % stepY;
+
+                    if ( isReverse == ( patternPoint != offsetY ) ) {
+                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformIn + offsetInX ) == 1 ) ) {
+                            // Skip pixel.
+                            continue;
+                        }
+
+                        // First part of transition: we copy single pixels.
+                        *( imageOut + offsetOutX ) = *( imageIn + offsetInX );
+
+                        if ( out.singleLayer() ) {
+                            continue;
+                        }
+                        if ( in.singleLayer() ) {
+                            // Set the copied pixel visible.
+                            *( transformOut + offsetOutX ) = 0;
+                        }
+                        else {
+                            *( transformOut + offsetOutX ) = *( transformIn + offsetInX );
+                        }
+                    }
+                    else {
+                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformInRightPoint + offsetInX ) == 1 ) ) {
+                            // Skip pixel.
+                            continue;
+                        }
+
+                        // Second part of transition: we copy image excluding single pixels.
+                        *( imageOutRightPoint + offsetOutX ) = *( imageInRightPoint + offsetInX );
+
+                        if ( out.singleLayer() ) {
+                            continue;
+                        }
+
+                        if ( in.singleLayer() ) {
+                            // Set the copied pixel visible.
+                            *( transformOutRightPoint + offsetOutX ) = 0;
+                        }
+                        else {
+                            *( transformOutRightPoint + offsetOutX ) = *( transformInRightPoint + offsetInX );
+                        }
+                    }
+                }
+
+                ++imageOut;
+                --imageOutRightPoint;
+                ++transformOut;
+                --transformOutRightPoint;
+
+                ++imageIn;
+                --imageInRightPoint;
+                ++transformIn;
+                --transformInRightPoint;
+            }
+        }
+        else {
+            // We also go in a loop from the bottom part of the image to its center.
+            const int32_t offsetInBottomOffset = ( height - 1 ) * widthIn;
+            const uint8_t * imageInBottomPoint = imageIn + offsetInBottomOffset;
+            const uint8_t * transformInBottomPoint = transformIn + offsetInBottomOffset;
+
+            const int32_t offsetOutYBottomOffset = ( height - 1 ) * widthOut;
+            uint8_t * imageOutBottomPoint = imageOut + offsetOutYBottomOffset;
+            uint8_t * transformOutBottomPoint = transformOut + offsetOutYBottomOffset;
+
+            const int32_t halfHeight = height / 2;
+
+            // We make a symmetric transition and if width is odd we shift one line down.
+            if ( ( height % 2 ) == 1 ) {
+                if ( isReverse ) {
+                    imageOutBottomPoint -= widthOut;
+                    transformOutBottomPoint -= widthOut;
+                    imageInBottomPoint -= widthIn;
+                    transformInBottomPoint -= widthIn;
+                }
+                else {
+                    imageOut += widthOut;
+                    transformOut += widthOut;
+                    imageIn += widthIn;
+                    transformIn += widthIn;
+                }
+            }
+
+            for ( int32_t y = 0; y < halfHeight; ++y ) {
+                // The step is 2 to the power, which decreases by 1 every second line and is 1 in the center.
+                // We limit the step power to 30 to not overflow the 32 bit 'stepX'.
+                const int32_t stepPower = std::min( 30, ( halfHeight - y ) / 2 + 1 );
+                const int32_t stepX = 1 << stepPower;
+
+                // The point position in dithered pattern.
+                const int32_t patternPoint = stepX / 2 * ( ( y + halfHeight ) % 2 );
+
+                for ( int32_t x = 0; x < width; ++x ) {
+                    const int32_t offsetX = x % stepX;
+
+                    if ( isReverse == ( patternPoint != offsetX ) ) {
+                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformIn + x ) == 1 ) ) {
+                            // Skip pixel.
+                            continue;
+                        }
+
+                        // First part of transition: we copy single pixels.
+                        *( imageOut + x ) = *( imageIn + x );
+
+                        if ( out.singleLayer() ) {
+                            continue;
+                        }
+                        if ( in.singleLayer() ) {
+                            // Set the copied pixel visible.
+                            *( transformOut + x ) = 0;
+                        }
+                        else {
+                            *( transformOut + x ) = *( transformIn + x );
+                        }
+                    }
+                    else {
+                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformInBottomPoint + x ) == 1 ) ) {
+                            // Skip pixel.
+                            continue;
+                        }
+
+                        // Second part of transition: we copy image excluding single pixels.
+                        *( imageOutBottomPoint + x ) = *( imageInBottomPoint + x );
+
+                        if ( !out.singleLayer() ) {
+                            continue;
+                        }
+                        if ( in.singleLayer() ) {
+                            // Set the copied pixel visible.
+                            *( transformOutBottomPoint + x ) = 0;
+                        }
+                        else {
+                            *( transformOutBottomPoint + x ) = *( transformInBottomPoint + x );
+                        }
+                    }
+                }
+
+                imageOut += widthOut;
+                imageOutBottomPoint -= widthOut;
+                transformOut += widthOut;
+                transformOutBottomPoint -= widthOut;
+
+                imageIn += widthIn;
+                imageInBottomPoint -= widthIn;
+                transformIn += widthIn;
+                transformInBottomPoint -= widthIn;
+            }
+        }
+    }
+
     Sprite Crop( const Image & image, int32_t x, int32_t y, int32_t width, int32_t height )
     {
         if ( image.empty() || width <= 0 || height <= 0 )
@@ -1445,211 +1653,6 @@ namespace fheroes2
         DrawLine( image, { roi.x, roi.y }, { roi.x, roi.y + roi.height }, value, roi );
         DrawLine( image, { roi.x + roi.width - 1, roi.y }, { roi.x + roi.width - 1, roi.y + roi.height }, value, roi );
         DrawLine( image, { roi.x, roi.y + roi.height - 1 }, { roi.x + roi.width, roi.y + roi.height - 1 }, value, roi );
-    }
-
-    void DitheringTransition( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool isVertical,
-                              const bool isReverse )
-    {
-        if ( !Verify( in, inX, inY, out, outX, outY, width, height ) ) {
-            return;
-        }
-
-        const int32_t widthIn = in.width();
-        const int32_t offsetIn = inY * widthIn + inX;
-        const uint8_t * imageIn = in.image() + offsetIn;
-        const uint8_t * transformIn = in.transform() + offsetIn;
-
-        const int32_t widthOut = out.width();
-        const int32_t offsetOut = outY * widthOut + outX;
-        uint8_t * imageOut = out.image() + offsetOut;
-        uint8_t * transformOut = out.transform() + offsetOut;
-
-        const bool isInNonSinglelayerToOutSinglelayer = !in.singleLayer() && out.singleLayer();
-
-        if ( isVertical ) {
-            // We also go in a loop from the right part of the image to its center.
-            const uint8_t * imageInRightPoint = imageIn + width - 1;
-            const uint8_t * transformInRightPoint = transformIn + width - 1;
-
-            uint8_t * imageOutRightPoint = imageOut + width - 1;
-            uint8_t * transformOutRightPoint = transformOut + width - 1;
-
-            const int32_t halfWidth = width / 2;
-
-            // We make a symmetric transition and if width is odd we shift one line right.
-            if ( ( width % 2 ) == 1 ) {
-                if ( isReverse ) {
-                    --imageOutRightPoint;
-                    --transformOutRightPoint;
-                    --imageInRightPoint;
-                    --transformInRightPoint;
-                }
-                else {
-                    ++imageOut;
-                    ++transformOut;
-                    ++imageIn;
-                    ++transformIn;
-                }
-            }
-
-            for ( int32_t x = 0; x < halfWidth; ++x ) {
-                // The step is 2 to the power, which decreases by 1 every second line and is 1 in the center.
-                // We limit the step power to 30 to not overflow the 32 bit 'stepY'.
-                const int32_t stepPower = std::min( 30, ( halfWidth - x ) / 2 + 1 );
-                const int32_t stepY = 1 << stepPower;
-
-                // The point position in dithered pattern.
-                const int32_t patternPoint = stepY / 2 * ( ( x + halfWidth ) % 2 );
-
-                for ( int32_t y = 0; y < height; ++y ) {
-                    const int32_t offsetOutX = y * widthOut;
-                    const int32_t offsetInX = y * widthIn;
-                    const int32_t offsetY = y % stepY;
-
-                    if ( isReverse == ( patternPoint != offsetY ) ) {
-                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformIn + offsetInX ) == 1 ) ) {
-                            // Skip pixel.
-                            continue;
-                        }
-
-                        // First part of transition: we copy single pixels.
-                        *( imageOut + offsetOutX ) = *( imageIn + offsetInX );
-
-                        if ( !out.singleLayer() ) {
-                            if ( in.singleLayer() ) {
-                                // Set the copied pixel visible.
-                                *( transformOut + offsetOutX ) = 0;
-                            }
-                            else {
-                                *( transformOut + offsetOutX ) = *( transformIn + offsetInX );
-                            }
-                        }
-                    }
-                    else {
-                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformInRightPoint + offsetInX ) == 1 ) ) {
-                            // Skip pixel.
-                            continue;
-                        }
-
-                        // Second part of transition: we copy image excluding single pixels.
-                        *( imageOutRightPoint + offsetOutX ) = *( imageInRightPoint + offsetInX );
-
-                        if ( !out.singleLayer() ) {
-                            if ( in.singleLayer() ) {
-                                // Set the copied pixel visible.
-                                *( transformOutRightPoint + offsetOutX ) = 0;
-                            }
-                            else {
-                                *( transformOutRightPoint + offsetOutX ) = *( transformInRightPoint + offsetInX );
-                            }
-                        }
-                    }
-                }
-
-                ++imageOut;
-                --imageOutRightPoint;
-                ++transformOut;
-                --transformOutRightPoint;
-
-                ++imageIn;
-                --imageInRightPoint;
-                ++transformIn;
-                --transformInRightPoint;
-            }
-        }
-        else {
-            // We also go in a loop from the bottom part of the image to its center.
-            const int32_t offsetInBottomOffset = ( height - 1 ) * widthIn;
-            const uint8_t * imageInBottomPoint = imageIn + offsetInBottomOffset;
-            const uint8_t * transformInBottomPoint = transformIn + offsetInBottomOffset;
-
-            const int32_t offsetOutYBottomOffset = ( height - 1 ) * widthOut;
-            uint8_t * imageOutBottomPoint = imageOut + offsetOutYBottomOffset;
-            uint8_t * transformOutBottomPoint = transformOut + offsetOutYBottomOffset;
-
-            const int32_t halfHeight = height / 2;
-
-            // We make a symmetric transition and if width is odd we shift one line down.
-            if ( ( height % 2 ) == 1 ) {
-                if ( isReverse ) {
-                    imageOutBottomPoint -= widthOut;
-                    transformOutBottomPoint -= widthOut;
-                    imageInBottomPoint -= widthIn;
-                    transformInBottomPoint -= widthIn;
-                }
-                else {
-                    imageOut += widthOut;
-                    transformOut += widthOut;
-                    imageIn += widthIn;
-                    transformIn += widthIn;
-                }
-            }
-
-            for ( int32_t y = 0; y < halfHeight; ++y ) {
-                // The step is 2 to the power, which decreases by 1 every second line and is 1 in the center.
-                // We limit the step power to 30 to not overflow the 32 bit 'stepX'.
-                const int32_t stepPower = std::min( 30, ( halfHeight - y ) / 2 + 1 );
-                const int32_t stepX = 1 << stepPower;
-
-                // The point position in dithered pattern.
-                const int32_t patternPoint = stepX / 2 * ( ( y + halfHeight ) % 2 );
-
-                for ( int32_t x = 0; x < width; ++x ) {
-                    const int32_t offsetX = x % stepX;
-
-                    if ( isReverse == ( patternPoint != offsetX ) ) {
-                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformIn + x ) == 1 ) ) {
-                            // Skip pixel.
-                            continue;
-                        }
-
-                        // First part of transition: we copy single pixels.
-                        *( imageOut + x ) = *( imageIn + x );
-
-                        if ( !out.singleLayer() ) {
-                            if ( in.singleLayer() ) {
-                                // Set the copied pixel visible.
-                                *( transformOut + x ) = 0;
-                            }
-                            else {
-                                *( transformOut + x ) = *( transformIn + x );
-                            }
-                        }
-
-                        *( transformOut + x ) = *( transformIn + x );
-                    }
-                    else {
-                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformInBottomPoint + x ) == 1 ) ) {
-                            // Skip pixel.
-                            continue;
-                        }
-
-                        // Second part of transition: we copy image excluding single pixels.
-                        *( imageOutBottomPoint + x ) = *( imageInBottomPoint + x );
-
-                        if ( !out.singleLayer() ) {
-                            if ( in.singleLayer() ) {
-                                // Set the copied pixel visible.
-                                *( transformOutBottomPoint + x ) = 0;
-                            }
-                            else {
-                                *( transformOutBottomPoint + x ) = *( transformInBottomPoint + x );
-                            }
-                        }
-                    }
-                }
-
-                imageOut += widthOut;
-                imageOutBottomPoint -= widthOut;
-                transformOut += widthOut;
-                transformOutBottomPoint -= widthOut;
-
-                imageIn += widthIn;
-                imageInBottomPoint -= widthIn;
-                transformIn += widthIn;
-                transformInBottomPoint -= widthIn;
-            }
-        }
     }
 
     void DivideImageBySquares( const Point & spriteOffset, const Image & original, const int32_t squareSize, const bool flip,

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -293,6 +293,9 @@ namespace fheroes2
 
     Image Stretch( const Image & in, int32_t inX, int32_t inY, int32_t widthIn, int32_t heightIn, int32_t widthOut, int32_t heightOut );
 
+    void DitheringTransition( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool isVertical,
+                              const bool isReverse );
+
     void Transpose( const Image & in, Image & out );
 
     void updateShadow( Image & image, const Point & shadowOffset, const uint8_t transformId );

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -241,6 +241,10 @@ namespace fheroes2
 
     void DrawRect( Image & image, const Rect & roi, uint8_t value );
 
+    // Make a transition to "in" image from left to right or vertically - from top to bottom. The direction of transition can be reversed.
+    void DitheringTransition( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool isVertical,
+                              const bool isReverse );
+
     void DivideImageBySquares( const Point & spriteOffset, const Image & original, const int32_t squareSize, const bool flip,
                                std::vector<std::pair<Point, Sprite>> & output );
 
@@ -292,9 +296,6 @@ namespace fheroes2
     void SetTransformPixel( Image & image, int32_t x, int32_t y, uint8_t value );
 
     Image Stretch( const Image & in, int32_t inX, int32_t inY, int32_t widthIn, int32_t heightIn, int32_t widthOut, int32_t heightOut );
-
-    void DitheringTransition( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool isVertical,
-                              const bool isReverse );
 
     void Transpose( const Image & in, Image & out );
 

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -231,6 +231,11 @@ namespace fheroes2
 
     Sprite CreateContour( const Image & image, uint8_t value );
 
+    // Make a transition to "in" image from left to right or vertically - from top to bottom using dithering (https://en.wikipedia.org/wiki/Dither).
+    // The direction of transition can be reversed.
+    void CreateDitheringTransition( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height,
+                                    const bool isVertical, const bool isReverse );
+
     Sprite Crop( const Image & image, int32_t x, int32_t y, int32_t width, int32_t height );
 
     // skipFactor is responsible for non-solid line. You can interpret it as skip every N pixel
@@ -240,10 +245,6 @@ namespace fheroes2
     void DrawLine( Image & image, const Point & start, const Point & end, uint8_t value, const Rect & roi = Rect() );
 
     void DrawRect( Image & image, const Rect & roi, uint8_t value );
-
-    // Make a transition to "in" image from left to right or vertically - from top to bottom. The direction of transition can be reversed.
-    void DitheringTransition( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool isVertical,
-                              const bool isReverse );
 
     void DivideImageBySquares( const Point & spriteOffset, const Image & original, const int32_t squareSize, const bool flip,
                                std::vector<std::pair<Point, Sprite>> & output );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1298,7 +1298,7 @@ void Battle::Interface::UpdateContourColor()
 void Battle::Interface::fullRedraw()
 {
     if ( !_background ) {
-        _background.reset( new fheroes2::StandardWindow( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT ) );
+        _background.reset( new fheroes2::StandardWindow( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, false ) );
     }
 
     Redraw();

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "battle_interface.h"
+
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -43,7 +45,6 @@
 #include "battle_catapult.h"
 #include "battle_cell.h"
 #include "battle_command.h"
-#include "battle_interface.h"
 #include "battle_tower.h"
 #include "battle_troop.h"
 #include "bin_info.h"
@@ -1298,7 +1299,7 @@ void Battle::Interface::UpdateContourColor()
 void Battle::Interface::fullRedraw()
 {
     if ( !_background ) {
-        _background.reset( new fheroes2::StandardWindow( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, false ) );
+        _background = std::make_unique<fheroes2::StandardWindow>( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, false );
     }
 
     Redraw();

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -111,7 +111,7 @@ bool Battle::Only::ChangeSettings()
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const fheroes2::StandardWindow frameborder( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
+    const fheroes2::StandardWindow frameborder( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, false );
 
     const fheroes2::Point cur_pt( frameborder.activeArea().x, frameborder.activeArea().y );
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -223,7 +223,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     if ( Settings::isFadeEffectEnabled() )
         fheroes2::FadeDisplay();
 
-    const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
+    const fheroes2::StandardWindow background( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, false );
 
     AudioManager::PlayMusicAsync( MUS::FromRace( race ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -233,7 +233,7 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const fheroes2::StandardWindow frameborder( 320, 234 );
+    const fheroes2::StandardWindow frameborder( 320, 234, true );
     const fheroes2::Rect box( frameborder.activeArea() );
 
     Funds funds1( kingdom.GetFunds() );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -892,7 +892,7 @@ namespace
 
     int32_t setCampaignDifficulty( int32_t currentDifficulty, const bool isSelectionAllowed )
     {
-        const fheroes2::StandardWindow frameborder( 234, 270 );
+        const fheroes2::StandardWindow frameborder( 234, 270, true );
         const fheroes2::Rect & windowRoi = frameborder.activeArea();
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -225,7 +225,7 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
 
     fheroes2::Display & display = fheroes2::Display::instance();
     const fheroes2::Point top{ ( display.width() - back.width() ) / 2, ( display.height() - back.height() ) / 2 };
-    const fheroes2::StandardWindow border( display.DEFAULT_WIDTH, display.DEFAULT_HEIGHT );
+    const fheroes2::StandardWindow border( display.DEFAULT_WIDTH, display.DEFAULT_HEIGHT, false );
 
     int32_t selectedEntryIndex = -1;
     uint32_t monsterAnimationFrameId = 0;

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -19,42 +19,280 @@
  ***************************************************************************/
 
 #include "ui_window.h"
+
+#include <utility>
+
 #include "agg_image.h"
 #include "icn.h"
 #include "settings.h"
 
 namespace
 {
-    const int32_t borderSize = 16;
+    const int32_t borderSize = BORDERWIDTH;
 }
 
 namespace fheroes2
 {
-    StandardWindow::StandardWindow( const int32_t width, const int32_t height, Image & output )
+    StandardWindow::StandardWindow( const int32_t width, const int32_t height, const bool renderBackground, Image & output )
         : _output( output )
         , _activeArea( ( output.width() - width ) / 2, ( output.height() - height ) / 2, width, height )
         , _windowArea( _activeArea.x - borderSize, _activeArea.y - borderSize, _activeArea.width + 2 * borderSize, _activeArea.height + 2 * borderSize )
         , _restorer( output, _windowArea.x - borderSize, _windowArea.y, _windowArea.width + borderSize, _windowArea.height + borderSize )
+        , _hasBackground{ renderBackground }
     {
         render();
     }
 
-    StandardWindow::StandardWindow( const int32_t x, const int32_t y, const int32_t width, const int32_t height, Image & output )
+    StandardWindow::StandardWindow( const int32_t x, const int32_t y, const int32_t width, const int32_t height, const bool renderBackground, Image & output )
         : _output( output )
         , _activeArea( x, y, width, height )
         , _windowArea( _activeArea.x - borderSize, _activeArea.y - borderSize, _activeArea.width + 2 * borderSize, _activeArea.height + 2 * borderSize )
         , _restorer( output, _windowArea.x - borderSize, _windowArea.y, _windowArea.width + borderSize, _windowArea.height + borderSize )
+        , _hasBackground{ renderBackground }
     {
         render();
     }
 
     void StandardWindow::render()
     {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
-        const fheroes2::Image renderedImage
-            = fheroes2::Stretch( sprite, borderSize, 0, sprite.width() - borderSize, sprite.height() - borderSize, _windowArea.width, _windowArea.height );
-        fheroes2::Blit( renderedImage, _output, _windowArea.x, _windowArea.y );
+        // Notice: ICN::SURDRBKE and ICN::SURDRBKG has 16 (equals to BORDERWIDTH) pixels shadow from the left and the bottom sides.
+        const fheroes2::Sprite & horizontalSprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
+        const fheroes2::Sprite & verticalSprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::WINLOSEE : ICN::WINLOSE ), 0 );
 
+        // Offset from border egdes (size of evil interface corners is 43 pixels) - this egdes (corners) will not be copied to fill the border.
+        const int32_t borderEdgeOffset{ 43 };
+
+        // Offset from window edges to background copy area and also the size of corners to render.
+        const int32_t cornerSize{ _hasBackground ? 22 : borderSize };
+
+        // Size in pixels of dithered transition from one image to another.
+        const int32_t transitionSize{ 10 };
+
+        const int32_t horizontalSpriteWidth{ horizontalSprite.width() - BORDERWIDTH };
+        const int32_t horizontalSpriteHeight{ horizontalSprite.height() - BORDERWIDTH };
+        const int32_t verticalSpriteHeight{ verticalSprite.height() };
+        const int32_t verticalSpriteWidth{ verticalSprite.width() };
+
+        // Render window corners. The corners are the same in used original images, so we use only 'verticalSprite'.
+        const int32_t rightCornerOffsetX = _windowArea.x + _windowArea.width - cornerSize;
+        const int32_t bottomCornerOffsetY = _windowArea.y + _windowArea.height - cornerSize;
+        const int32_t rightCornerSpriteOffsetX = verticalSpriteWidth - cornerSize;
+        const int32_t bottomCornerSpriteOffsetY = verticalSpriteHeight - cornerSize;
+        fheroes2::Blit( verticalSprite, 0, 0, _output, _windowArea.x, _windowArea.y, cornerSize, cornerSize );
+        fheroes2::Blit( verticalSprite, rightCornerSpriteOffsetX, 0, _output, rightCornerOffsetX, _windowArea.y, cornerSize, cornerSize );
+        fheroes2::Blit( verticalSprite, 0, bottomCornerSpriteOffsetY, _output, _windowArea.x, bottomCornerOffsetY, cornerSize, cornerSize );
+        fheroes2::Blit( verticalSprite, rightCornerSpriteOffsetX, bottomCornerSpriteOffsetY, _output, rightCornerOffsetX, bottomCornerOffsetY, cornerSize, cornerSize );
+
+        // Render additional part of border corners. This part will not be repeated to fill the border length.
+        const int32_t extraCornerSize = borderEdgeOffset - cornerSize;
+
+        fheroes2::Blit( verticalSprite, cornerSize, 0, _output, _windowArea.x + cornerSize, _windowArea.y, extraCornerSize, cornerSize );
+        fheroes2::Blit( verticalSprite, 0, cornerSize, _output, _windowArea.x, _windowArea.y + cornerSize, cornerSize, extraCornerSize );
+
+        fheroes2::Blit( verticalSprite, verticalSpriteWidth - borderEdgeOffset, 0, _output, rightCornerOffsetX - extraCornerSize, _windowArea.y, extraCornerSize,
+                        cornerSize );
+        fheroes2::Blit( verticalSprite, rightCornerSpriteOffsetX, cornerSize, _output, rightCornerOffsetX, _windowArea.y + cornerSize, cornerSize, extraCornerSize );
+
+        fheroes2::Blit( verticalSprite, cornerSize, bottomCornerSpriteOffsetY, _output, _windowArea.x + cornerSize, bottomCornerOffsetY, extraCornerSize, cornerSize );
+        fheroes2::Blit( verticalSprite, 0, verticalSpriteHeight - borderEdgeOffset, _output, _windowArea.x, bottomCornerOffsetY - extraCornerSize, cornerSize,
+                        extraCornerSize );
+
+        fheroes2::Blit( verticalSprite, verticalSpriteWidth - borderEdgeOffset, bottomCornerSpriteOffsetY, _output, rightCornerOffsetX - extraCornerSize,
+                        bottomCornerOffsetY, extraCornerSize, cornerSize );
+        fheroes2::Blit( verticalSprite, rightCornerSpriteOffsetX, verticalSpriteHeight - borderEdgeOffset, _output, rightCornerOffsetX,
+                        bottomCornerOffsetY - extraCornerSize, cornerSize, extraCornerSize );
+
+        // Render the background.
+        if ( _hasBackground ) {
+            const fheroes2::Sprite & backgroundSprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONEBAK_EVIL : ICN::STONEBAK ), 0 );
+            const int32_t backgroundSpriteWidth{ backgroundSprite.width() };
+            const int32_t backgroundSpriteHeight{ backgroundSprite.height() };
+
+            const int32_t backgroundWidth = _windowArea.width - cornerSize * 2;
+            const int32_t backgroundHeight = _windowArea.height - cornerSize * 2;
+            const int32_t backgroundHorizontalCopies = ( backgroundWidth - 1 - transitionSize ) / ( backgroundSpriteWidth - transitionSize );
+            const int32_t backgroundVerticalCopies = ( backgroundHeight - 1 - transitionSize ) / ( backgroundSpriteHeight - transitionSize );
+
+            const int32_t backgroundCopyWidth = std::min( backgroundSpriteWidth, backgroundWidth );
+            const int32_t backgroundCopyHeight = std::min( backgroundSpriteHeight, backgroundHeight );
+            const int32_t backgroundOffsetX = _windowArea.x + cornerSize;
+            const int32_t backgroundOffsetY = _windowArea.y + cornerSize;
+
+            // We do a copy as the background image does not have transparent pixels.
+            fheroes2::Copy( backgroundSprite, 0, 0, _output, backgroundOffsetX, backgroundOffsetY, backgroundCopyWidth, backgroundCopyHeight );
+
+            // If we need more copies to fill background horizontally we make a transition and copy existing image.
+            if ( backgroundHorizontalCopies > 0 ) {
+                int32_t toOffsetX = cornerSize + backgroundSpriteWidth;
+                fheroes2::DitheringTransition( backgroundSprite, 0, 0, _output, _windowArea.x + toOffsetX - transitionSize, backgroundOffsetY, transitionSize,
+                                               backgroundCopyHeight, true, false );
+
+                const int32_t stepX = backgroundSpriteWidth - transitionSize;
+                const int32_t fromOffsetX = cornerSize + transitionSize;
+
+                for ( int32_t i = 0; i < backgroundHorizontalCopies; ++i ) {
+                    fheroes2::Copy( _output, _windowArea.x + fromOffsetX, backgroundOffsetY, _output, _windowArea.x + toOffsetX, backgroundOffsetY,
+                                    std::min( backgroundSpriteWidth, _windowArea.width - cornerSize - toOffsetX ), backgroundCopyHeight );
+                    toOffsetX += stepX;
+                }
+            }
+
+            // If we need more copies to fill background vertically we make a transition and copy existing image in full background width.
+            if ( backgroundVerticalCopies > 0 ) {
+                int32_t toOffsetY = cornerSize + backgroundSpriteHeight;
+                fheroes2::DitheringTransition( _output, backgroundOffsetX, backgroundOffsetY, _output, backgroundOffsetX, _windowArea.y + toOffsetY - transitionSize,
+                                               backgroundWidth, transitionSize, false, false );
+
+                const int32_t stepY = backgroundSpriteHeight - transitionSize;
+                const int32_t fromOffsetY = cornerSize + transitionSize;
+
+                for ( int32_t i = 0; i < backgroundVerticalCopies; ++i ) {
+                    fheroes2::Copy( _output, backgroundOffsetX, _windowArea.y + fromOffsetY, _output, backgroundOffsetX, _windowArea.y + toOffsetY, backgroundWidth,
+                                    std::min( backgroundSpriteHeight, _windowArea.height - cornerSize - toOffsetY ) );
+                    toOffsetY += stepY;
+                }
+            }
+
+            // Make a transition from borders to the background in the corners.
+            fheroes2::DitheringTransition( verticalSprite, cornerSize, cornerSize, _output, _windowArea.x + cornerSize, _windowArea.y + cornerSize, extraCornerSize,
+                                           transitionSize, false, true );
+            fheroes2::DitheringTransition( verticalSprite, cornerSize, cornerSize, _output, _windowArea.x + cornerSize, _windowArea.y + cornerSize, transitionSize,
+                                           extraCornerSize, true, true );
+
+            fheroes2::DitheringTransition( verticalSprite, verticalSpriteWidth - borderEdgeOffset, cornerSize, _output, rightCornerOffsetX - extraCornerSize,
+                                           _windowArea.y + cornerSize, extraCornerSize, transitionSize, false, true );
+            fheroes2::DitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, cornerSize, _output, rightCornerOffsetX - transitionSize,
+                                           _windowArea.y + cornerSize, transitionSize, extraCornerSize, true, false );
+
+            fheroes2::DitheringTransition( verticalSprite, cornerSize, bottomCornerSpriteOffsetY - transitionSize, _output, _windowArea.x + cornerSize,
+                                           bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
+            fheroes2::DitheringTransition( verticalSprite, cornerSize, verticalSpriteHeight - borderEdgeOffset, _output, _windowArea.x + cornerSize,
+                                           bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, true );
+
+            fheroes2::DitheringTransition( verticalSprite, verticalSpriteWidth - borderEdgeOffset, bottomCornerSpriteOffsetY - transitionSize, _output,
+                                           rightCornerOffsetX - extraCornerSize, bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
+            fheroes2::DitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, verticalSpriteHeight - borderEdgeOffset, _output,
+                                           rightCornerOffsetX - transitionSize, bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, false );
+        }
+
+        // Render vertical borders.
+        const int32_t verticalSpriteCopyHeight = std::min( _windowArea.height, verticalSpriteHeight ) - borderEdgeOffset * 2;
+        const int32_t verticalSpriteCopies
+            = ( _windowArea.height - borderEdgeOffset * 2 - 1 - transitionSize ) / ( verticalSpriteHeight - borderEdgeOffset * 2 - transitionSize );
+        const int32_t rightBorderOffsetX = _windowArea.x + _windowArea.width - cornerSize;
+        const int32_t rightBorderSpriteOffsetX = verticalSpriteWidth - cornerSize;
+
+        fheroes2::Blit( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, _windowArea.y + borderEdgeOffset, cornerSize, verticalSpriteCopyHeight );
+        fheroes2::Blit( verticalSprite, rightBorderSpriteOffsetX, borderEdgeOffset, _output, rightBorderOffsetX, _windowArea.y + borderEdgeOffset, cornerSize,
+                        verticalSpriteCopyHeight );
+
+        // Render a transition to the background.
+        if ( _hasBackground ) {
+            fheroes2::DitheringTransition( verticalSprite, cornerSize, borderEdgeOffset, _output, _windowArea.x + cornerSize, _windowArea.y + borderEdgeOffset,
+                                           transitionSize, verticalSpriteCopyHeight, true, true );
+            fheroes2::DitheringTransition( verticalSprite, rightBorderSpriteOffsetX - transitionSize, borderEdgeOffset, _output, rightBorderOffsetX - transitionSize,
+                                           _windowArea.y + borderEdgeOffset, transitionSize, verticalSpriteCopyHeight, true, false );
+        }
+
+        // If we need more copies to fill vertical borders we make a transition and copy the central part of the border.
+        if ( verticalSpriteCopies > 0 ) {
+            int32_t toOffsetY = borderEdgeOffset + verticalSpriteCopyHeight;
+            const int32_t outputY = _windowArea.y + toOffsetY - transitionSize;
+            fheroes2::DitheringTransition( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, outputY, cornerSize, transitionSize, false, false );
+            fheroes2::DitheringTransition( verticalSprite, rightBorderSpriteOffsetX, borderEdgeOffset, _output, rightBorderOffsetX, outputY, cornerSize, transitionSize,
+                                           false, false );
+
+            const int32_t stepY = verticalSpriteCopyHeight - transitionSize;
+            const int32_t fromOffsetY = borderEdgeOffset + transitionSize;
+
+            for ( int32_t i = 0; i < verticalSpriteCopies; ++i ) {
+                const int32_t copyHeight = std::min( verticalSpriteCopyHeight, _windowArea.height - borderEdgeOffset - toOffsetY );
+                const int32_t toY = _windowArea.y + toOffsetY;
+
+                fheroes2::Blit( verticalSprite, 0, fromOffsetY, _output, _windowArea.x, toY, cornerSize, copyHeight );
+                fheroes2::Blit( verticalSprite, rightBorderSpriteOffsetX, fromOffsetY, _output, rightBorderOffsetX, toY, cornerSize, copyHeight );
+
+                // Render a transition to the background.
+                if ( _hasBackground ) {
+                    fheroes2::DitheringTransition( verticalSprite, cornerSize, fromOffsetY, _output, _windowArea.x + cornerSize, toY, transitionSize, copyHeight, true,
+                                                   true );
+                    fheroes2::DitheringTransition( verticalSprite, rightBorderSpriteOffsetX - transitionSize, fromOffsetY, _output, rightBorderOffsetX - transitionSize,
+                                                   toY, transitionSize, copyHeight, true, false );
+                }
+
+                toOffsetY += stepY;
+            }
+        }
+
+        // Make a transition to the bottom corners.
+        const int32_t verticalSpriteBottomCornerEdgeY = verticalSpriteHeight - borderEdgeOffset - transitionSize;
+        const int32_t optputBottomCornerEdgeY = _windowArea.y + _windowArea.height - borderEdgeOffset - transitionSize;
+        fheroes2::DitheringTransition( verticalSprite, 0, verticalSpriteBottomCornerEdgeY, _output, _windowArea.x, optputBottomCornerEdgeY, cornerSize, transitionSize,
+                                       false, false );
+        fheroes2::DitheringTransition( verticalSprite, rightBorderSpriteOffsetX, verticalSpriteBottomCornerEdgeY, _output, rightBorderOffsetX, optputBottomCornerEdgeY,
+                                       cornerSize, transitionSize, false, false );
+
+        // Render horizontal borders. We have to remember that 'verticalSprite' has 16 (equals to BORDERWIDTH) pixels of shadow at the left and bottom sides.
+        const int32_t horizontalSpriteCopyWidth = std::min( _windowArea.width, horizontalSpriteWidth ) - borderEdgeOffset * 2;
+        const int32_t horizontalSpriteCopies
+            = ( _windowArea.width - borderEdgeOffset * 2 - 1 - transitionSize ) / ( horizontalSpriteWidth - borderEdgeOffset * 2 - transitionSize );
+        const int32_t bottomBorderOffsetY = _windowArea.y + _windowArea.height - cornerSize;
+        const int32_t bottomBorderSpriteOffsetY = horizontalSpriteHeight - cornerSize;
+        const int32_t horizontalSpriteCopyStartX = borderEdgeOffset + BORDERWIDTH;
+
+        fheroes2::Blit( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, _windowArea.x + borderEdgeOffset, _windowArea.y, horizontalSpriteCopyWidth,
+                        cornerSize );
+        fheroes2::Blit( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, _windowArea.x + borderEdgeOffset, bottomBorderOffsetY,
+                        horizontalSpriteCopyWidth, cornerSize );
+
+        // Render a transition to the background.
+        if ( _hasBackground ) {
+            fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, cornerSize, _output, _windowArea.x + borderEdgeOffset,
+                                           _windowArea.y + cornerSize, horizontalSpriteCopyWidth, transitionSize, false, true );
+            fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY - transitionSize, _output,
+                                           _windowArea.x + borderEdgeOffset, bottomBorderOffsetY - transitionSize, horizontalSpriteCopyWidth, transitionSize, false,
+                                           false );
+        }
+
+        // If we need more copies to fill horizontal borders we make a transition and copy the central part of the border.
+        if ( horizontalSpriteCopies > 0 ) {
+            int32_t toOffsetX = borderEdgeOffset + horizontalSpriteCopyWidth;
+            const int32_t outputX = _windowArea.x + toOffsetX - transitionSize;
+            fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, outputX, _windowArea.y, transitionSize, cornerSize, true, false );
+            fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, outputX, bottomBorderOffsetY, transitionSize,
+                                           cornerSize, true, false );
+
+            const int32_t stepX = horizontalSpriteCopyWidth - transitionSize;
+            const int32_t fromOffsetX = horizontalSpriteCopyStartX + transitionSize;
+
+            for ( int32_t i = 0; i < horizontalSpriteCopies; ++i ) {
+                const int32_t copyWidth = std::min( horizontalSpriteCopyWidth, _windowArea.width - borderEdgeOffset - toOffsetX );
+                const int32_t toX = _windowArea.x + toOffsetX;
+
+                fheroes2::Blit( horizontalSprite, fromOffsetX, 0, _output, toX, _windowArea.y, copyWidth, cornerSize );
+                fheroes2::Blit( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY, _output, toX, bottomBorderOffsetY, copyWidth, cornerSize );
+
+                // Render a transition to the background.
+                if ( _hasBackground ) {
+                    fheroes2::DitheringTransition( horizontalSprite, fromOffsetX, cornerSize, _output, toX, _windowArea.y + cornerSize, copyWidth, transitionSize, false,
+                                                   true );
+                    fheroes2::DitheringTransition( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY - transitionSize, _output, toX,
+                                                   bottomBorderOffsetY - transitionSize, copyWidth, transitionSize, false, false );
+                }
+
+                toOffsetX += stepX;
+            }
+        }
+
+        // Make a transition to the right corners.
+        const int32_t horizontalSpriteRightCornerEdgeX = horizontalSprite.width() - borderEdgeOffset - transitionSize;
+        const int32_t optputRightCornerEdgeX = _windowArea.x + _windowArea.width - borderEdgeOffset - transitionSize;
+        fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, 0, _output, optputRightCornerEdgeX, _windowArea.y, transitionSize, cornerSize,
+                                       true, false );
+        fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, bottomBorderSpriteOffsetY, _output, optputRightCornerEdgeX,
+                                       bottomBorderOffsetY, transitionSize, cornerSize, true, false );
+
+        // Render shadow.
         fheroes2::ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + borderSize, 1, _windowArea.height - borderSize, 5 );
         fheroes2::ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + borderSize, 1, _windowArea.height - borderSize, 4 );
         fheroes2::ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + borderSize, borderSize - 2, _windowArea.height - borderSize, 3 );

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -31,7 +31,7 @@ namespace
 {
     const int32_t borderSize{ BORDERWIDTH };
 
-    // Offset from border egdes (size of evil interface corners is 43 pixels) - this egdes (corners) will not be copied to fill the border.
+    // Offset from border edges (size of evil interface corners is 43 pixels) - this edges (corners) will not be copied to fill the border.
     const int32_t borderEdgeOffset{ 43 };
 
     // Size in pixels of dithered transition from one image to another.
@@ -65,9 +65,11 @@ namespace fheroes2
 
     void StandardWindow::render()
     {
+        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
+
         // Notice: ICN::SURDRBKE and ICN::SURDRBKG has 16 (equals to BORDERWIDTH) pixels shadow from the left and the bottom sides.
-        const fheroes2::Sprite & horizontalSprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
-        const fheroes2::Sprite & verticalSprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::WINLOSEE : ICN::WINLOSE ), 0 );
+        const Sprite & horizontalSprite = AGG::GetICN( ( isEvilInterface ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
+        const Sprite & verticalSprite = AGG::GetICN( ( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE ), 0 );
 
         // Offset from window edges to background copy area and also the size of corners to render.
         const int32_t cornerSize = _hasBackground ? backgroungOffset : borderSize;
@@ -82,33 +84,31 @@ namespace fheroes2
         const int32_t bottomCornerOffsetY = _windowArea.y + _windowArea.height - cornerSize;
         const int32_t rightCornerSpriteOffsetX = verticalSpriteWidth - cornerSize;
         const int32_t bottomCornerSpriteOffsetY = verticalSpriteHeight - cornerSize;
-        fheroes2::Blit( verticalSprite, 0, 0, _output, _windowArea.x, _windowArea.y, cornerSize, cornerSize );
-        fheroes2::Blit( verticalSprite, rightCornerSpriteOffsetX, 0, _output, rightCornerOffsetX, _windowArea.y, cornerSize, cornerSize );
-        fheroes2::Blit( verticalSprite, 0, bottomCornerSpriteOffsetY, _output, _windowArea.x, bottomCornerOffsetY, cornerSize, cornerSize );
-        fheroes2::Blit( verticalSprite, rightCornerSpriteOffsetX, bottomCornerSpriteOffsetY, _output, rightCornerOffsetX, bottomCornerOffsetY, cornerSize, cornerSize );
+        Blit( verticalSprite, 0, 0, _output, _windowArea.x, _windowArea.y, cornerSize, cornerSize );
+        Blit( verticalSprite, rightCornerSpriteOffsetX, 0, _output, rightCornerOffsetX, _windowArea.y, cornerSize, cornerSize );
+        Blit( verticalSprite, 0, bottomCornerSpriteOffsetY, _output, _windowArea.x, bottomCornerOffsetY, cornerSize, cornerSize );
+        Blit( verticalSprite, rightCornerSpriteOffsetX, bottomCornerSpriteOffsetY, _output, rightCornerOffsetX, bottomCornerOffsetY, cornerSize, cornerSize );
 
         // Render additional part of border corners. This part will not be repeated to fill the border length.
         const int32_t extraCornerSize = borderEdgeOffset - cornerSize;
 
-        fheroes2::Blit( verticalSprite, cornerSize, 0, _output, _windowArea.x + cornerSize, _windowArea.y, extraCornerSize, cornerSize );
-        fheroes2::Blit( verticalSprite, 0, cornerSize, _output, _windowArea.x, _windowArea.y + cornerSize, cornerSize, extraCornerSize );
+        Blit( verticalSprite, cornerSize, 0, _output, _windowArea.x + cornerSize, _windowArea.y, extraCornerSize, cornerSize );
+        Blit( verticalSprite, 0, cornerSize, _output, _windowArea.x, _windowArea.y + cornerSize, cornerSize, extraCornerSize );
 
-        fheroes2::Blit( verticalSprite, verticalSpriteWidth - borderEdgeOffset, 0, _output, rightCornerOffsetX - extraCornerSize, _windowArea.y, extraCornerSize,
-                        cornerSize );
-        fheroes2::Blit( verticalSprite, rightCornerSpriteOffsetX, cornerSize, _output, rightCornerOffsetX, _windowArea.y + cornerSize, cornerSize, extraCornerSize );
+        Blit( verticalSprite, verticalSpriteWidth - borderEdgeOffset, 0, _output, rightCornerOffsetX - extraCornerSize, _windowArea.y, extraCornerSize, cornerSize );
+        Blit( verticalSprite, rightCornerSpriteOffsetX, cornerSize, _output, rightCornerOffsetX, _windowArea.y + cornerSize, cornerSize, extraCornerSize );
 
-        fheroes2::Blit( verticalSprite, cornerSize, bottomCornerSpriteOffsetY, _output, _windowArea.x + cornerSize, bottomCornerOffsetY, extraCornerSize, cornerSize );
-        fheroes2::Blit( verticalSprite, 0, verticalSpriteHeight - borderEdgeOffset, _output, _windowArea.x, bottomCornerOffsetY - extraCornerSize, cornerSize,
-                        extraCornerSize );
+        Blit( verticalSprite, cornerSize, bottomCornerSpriteOffsetY, _output, _windowArea.x + cornerSize, bottomCornerOffsetY, extraCornerSize, cornerSize );
+        Blit( verticalSprite, 0, verticalSpriteHeight - borderEdgeOffset, _output, _windowArea.x, bottomCornerOffsetY - extraCornerSize, cornerSize, extraCornerSize );
 
-        fheroes2::Blit( verticalSprite, verticalSpriteWidth - borderEdgeOffset, bottomCornerSpriteOffsetY, _output, rightCornerOffsetX - extraCornerSize,
-                        bottomCornerOffsetY, extraCornerSize, cornerSize );
-        fheroes2::Blit( verticalSprite, rightCornerSpriteOffsetX, verticalSpriteHeight - borderEdgeOffset, _output, rightCornerOffsetX,
-                        bottomCornerOffsetY - extraCornerSize, cornerSize, extraCornerSize );
+        Blit( verticalSprite, verticalSpriteWidth - borderEdgeOffset, bottomCornerSpriteOffsetY, _output, rightCornerOffsetX - extraCornerSize, bottomCornerOffsetY,
+              extraCornerSize, cornerSize );
+        Blit( verticalSprite, rightCornerSpriteOffsetX, verticalSpriteHeight - borderEdgeOffset, _output, rightCornerOffsetX, bottomCornerOffsetY - extraCornerSize,
+              cornerSize, extraCornerSize );
 
         // Render the background.
         if ( _hasBackground ) {
-            const fheroes2::Sprite & backgroundSprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONEBAK_EVIL : ICN::STONEBAK ), 0 );
+            const Sprite & backgroundSprite = AGG::GetICN( ( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK ), 0 );
             const int32_t backgroundSpriteWidth{ backgroundSprite.width() };
             const int32_t backgroundSpriteHeight{ backgroundSprite.height() };
 
@@ -123,20 +123,20 @@ namespace fheroes2
             const int32_t backgroundOffsetY = _windowArea.y + cornerSize;
 
             // We do a copy as the background image does not have transparent pixels.
-            fheroes2::Copy( backgroundSprite, 0, 0, _output, backgroundOffsetX, backgroundOffsetY, backgroundCopyWidth, backgroundCopyHeight );
+            Copy( backgroundSprite, 0, 0, _output, backgroundOffsetX, backgroundOffsetY, backgroundCopyWidth, backgroundCopyHeight );
 
             // If we need more copies to fill background horizontally we make a transition and copy existing image.
             if ( backgroundHorizontalCopies > 0 ) {
                 int32_t toOffsetX = cornerSize + backgroundSpriteWidth;
-                fheroes2::DitheringTransition( backgroundSprite, 0, 0, _output, _windowArea.x + toOffsetX - transitionSize, backgroundOffsetY, transitionSize,
-                                               backgroundCopyHeight, true, false );
+                DitheringTransition( backgroundSprite, 0, 0, _output, _windowArea.x + toOffsetX - transitionSize, backgroundOffsetY, transitionSize, backgroundCopyHeight,
+                                     true, false );
 
                 const int32_t stepX = backgroundSpriteWidth - transitionSize;
                 const int32_t fromOffsetX = cornerSize + transitionSize;
 
                 for ( int32_t i = 0; i < backgroundHorizontalCopies; ++i ) {
-                    fheroes2::Copy( _output, _windowArea.x + fromOffsetX, backgroundOffsetY, _output, _windowArea.x + toOffsetX, backgroundOffsetY,
-                                    std::min( backgroundSpriteWidth, _windowArea.width - cornerSize - toOffsetX ), backgroundCopyHeight );
+                    Copy( _output, _windowArea.x + fromOffsetX, backgroundOffsetY, _output, _windowArea.x + toOffsetX, backgroundOffsetY,
+                          std::min( backgroundSpriteWidth, _windowArea.width - cornerSize - toOffsetX ), backgroundCopyHeight );
                     toOffsetX += stepX;
                 }
             }
@@ -144,39 +144,39 @@ namespace fheroes2
             // If we need more copies to fill background vertically we make a transition and copy existing image in full background width.
             if ( backgroundVerticalCopies > 0 ) {
                 int32_t toOffsetY = cornerSize + backgroundSpriteHeight;
-                fheroes2::DitheringTransition( _output, backgroundOffsetX, backgroundOffsetY, _output, backgroundOffsetX, _windowArea.y + toOffsetY - transitionSize,
-                                               backgroundWidth, transitionSize, false, false );
+                DitheringTransition( _output, backgroundOffsetX, backgroundOffsetY, _output, backgroundOffsetX, _windowArea.y + toOffsetY - transitionSize,
+                                     backgroundWidth, transitionSize, false, false );
 
                 const int32_t stepY = backgroundSpriteHeight - transitionSize;
                 const int32_t fromOffsetY = cornerSize + transitionSize;
 
                 for ( int32_t i = 0; i < backgroundVerticalCopies; ++i ) {
-                    fheroes2::Copy( _output, backgroundOffsetX, _windowArea.y + fromOffsetY, _output, backgroundOffsetX, _windowArea.y + toOffsetY, backgroundWidth,
-                                    std::min( backgroundSpriteHeight, _windowArea.height - cornerSize - toOffsetY ) );
+                    Copy( _output, backgroundOffsetX, _windowArea.y + fromOffsetY, _output, backgroundOffsetX, _windowArea.y + toOffsetY, backgroundWidth,
+                          std::min( backgroundSpriteHeight, _windowArea.height - cornerSize - toOffsetY ) );
                     toOffsetY += stepY;
                 }
             }
 
             // Make a transition from borders to the background in the corners.
-            fheroes2::DitheringTransition( verticalSprite, cornerSize, cornerSize, _output, _windowArea.x + cornerSize, _windowArea.y + cornerSize, extraCornerSize,
-                                           transitionSize, false, true );
-            fheroes2::DitheringTransition( verticalSprite, cornerSize, cornerSize, _output, _windowArea.x + cornerSize, _windowArea.y + cornerSize, transitionSize,
-                                           extraCornerSize, true, true );
+            DitheringTransition( verticalSprite, cornerSize, cornerSize, _output, _windowArea.x + cornerSize, _windowArea.y + cornerSize, extraCornerSize, transitionSize,
+                                 false, true );
+            DitheringTransition( verticalSprite, cornerSize, cornerSize, _output, _windowArea.x + cornerSize, _windowArea.y + cornerSize, transitionSize, extraCornerSize,
+                                 true, true );
 
-            fheroes2::DitheringTransition( verticalSprite, verticalSpriteWidth - borderEdgeOffset, cornerSize, _output, rightCornerOffsetX - extraCornerSize,
-                                           _windowArea.y + cornerSize, extraCornerSize, transitionSize, false, true );
-            fheroes2::DitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, cornerSize, _output, rightCornerOffsetX - transitionSize,
-                                           _windowArea.y + cornerSize, transitionSize, extraCornerSize, true, false );
+            DitheringTransition( verticalSprite, verticalSpriteWidth - borderEdgeOffset, cornerSize, _output, rightCornerOffsetX - extraCornerSize,
+                                 _windowArea.y + cornerSize, extraCornerSize, transitionSize, false, true );
+            DitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, cornerSize, _output, rightCornerOffsetX - transitionSize,
+                                 _windowArea.y + cornerSize, transitionSize, extraCornerSize, true, false );
 
-            fheroes2::DitheringTransition( verticalSprite, cornerSize, bottomCornerSpriteOffsetY - transitionSize, _output, _windowArea.x + cornerSize,
-                                           bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
-            fheroes2::DitheringTransition( verticalSprite, cornerSize, verticalSpriteHeight - borderEdgeOffset, _output, _windowArea.x + cornerSize,
-                                           bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, true );
+            DitheringTransition( verticalSprite, cornerSize, bottomCornerSpriteOffsetY - transitionSize, _output, _windowArea.x + cornerSize,
+                                 bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
+            DitheringTransition( verticalSprite, cornerSize, verticalSpriteHeight - borderEdgeOffset, _output, _windowArea.x + cornerSize,
+                                 bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, true );
 
-            fheroes2::DitheringTransition( verticalSprite, verticalSpriteWidth - borderEdgeOffset, bottomCornerSpriteOffsetY - transitionSize, _output,
-                                           rightCornerOffsetX - extraCornerSize, bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
-            fheroes2::DitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, verticalSpriteHeight - borderEdgeOffset, _output,
-                                           rightCornerOffsetX - transitionSize, bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, false );
+            DitheringTransition( verticalSprite, verticalSpriteWidth - borderEdgeOffset, bottomCornerSpriteOffsetY - transitionSize, _output,
+                                 rightCornerOffsetX - extraCornerSize, bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
+            DitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, verticalSpriteHeight - borderEdgeOffset, _output,
+                                 rightCornerOffsetX - transitionSize, bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, false );
         }
 
         // Render vertical borders.
@@ -186,25 +186,25 @@ namespace fheroes2
         const int32_t rightBorderOffsetX = _windowArea.x + _windowArea.width - cornerSize;
         const int32_t rightBorderSpriteOffsetX = verticalSpriteWidth - cornerSize;
 
-        fheroes2::Blit( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, _windowArea.y + borderEdgeOffset, cornerSize, verticalSpriteCopyHeight );
-        fheroes2::Blit( verticalSprite, rightBorderSpriteOffsetX, borderEdgeOffset, _output, rightBorderOffsetX, _windowArea.y + borderEdgeOffset, cornerSize,
-                        verticalSpriteCopyHeight );
+        Blit( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, _windowArea.y + borderEdgeOffset, cornerSize, verticalSpriteCopyHeight );
+        Blit( verticalSprite, rightBorderSpriteOffsetX, borderEdgeOffset, _output, rightBorderOffsetX, _windowArea.y + borderEdgeOffset, cornerSize,
+              verticalSpriteCopyHeight );
 
         // Render a transition to the background.
         if ( _hasBackground ) {
-            fheroes2::DitheringTransition( verticalSprite, cornerSize, borderEdgeOffset, _output, _windowArea.x + cornerSize, _windowArea.y + borderEdgeOffset,
-                                           transitionSize, verticalSpriteCopyHeight, true, true );
-            fheroes2::DitheringTransition( verticalSprite, rightBorderSpriteOffsetX - transitionSize, borderEdgeOffset, _output, rightBorderOffsetX - transitionSize,
-                                           _windowArea.y + borderEdgeOffset, transitionSize, verticalSpriteCopyHeight, true, false );
+            DitheringTransition( verticalSprite, cornerSize, borderEdgeOffset, _output, _windowArea.x + cornerSize, _windowArea.y + borderEdgeOffset, transitionSize,
+                                 verticalSpriteCopyHeight, true, true );
+            DitheringTransition( verticalSprite, rightBorderSpriteOffsetX - transitionSize, borderEdgeOffset, _output, rightBorderOffsetX - transitionSize,
+                                 _windowArea.y + borderEdgeOffset, transitionSize, verticalSpriteCopyHeight, true, false );
         }
 
         // If we need more copies to fill vertical borders we make a transition and copy the central part of the border.
         if ( verticalSpriteCopies > 0 ) {
             int32_t toOffsetY = borderEdgeOffset + verticalSpriteCopyHeight;
             const int32_t outputY = _windowArea.y + toOffsetY - transitionSize;
-            fheroes2::DitheringTransition( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, outputY, cornerSize, transitionSize, false, false );
-            fheroes2::DitheringTransition( verticalSprite, rightBorderSpriteOffsetX, borderEdgeOffset, _output, rightBorderOffsetX, outputY, cornerSize, transitionSize,
-                                           false, false );
+            DitheringTransition( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, outputY, cornerSize, transitionSize, false, false );
+            DitheringTransition( verticalSprite, rightBorderSpriteOffsetX, borderEdgeOffset, _output, rightBorderOffsetX, outputY, cornerSize, transitionSize, false,
+                                 false );
 
             const int32_t stepY = verticalSpriteCopyHeight - transitionSize;
             const int32_t fromOffsetY = borderEdgeOffset + transitionSize;
@@ -213,15 +213,14 @@ namespace fheroes2
                 const int32_t copyHeight = std::min( verticalSpriteCopyHeight, _windowArea.height - borderEdgeOffset - toOffsetY );
                 const int32_t toY = _windowArea.y + toOffsetY;
 
-                fheroes2::Blit( verticalSprite, 0, fromOffsetY, _output, _windowArea.x, toY, cornerSize, copyHeight );
-                fheroes2::Blit( verticalSprite, rightBorderSpriteOffsetX, fromOffsetY, _output, rightBorderOffsetX, toY, cornerSize, copyHeight );
+                Blit( verticalSprite, 0, fromOffsetY, _output, _windowArea.x, toY, cornerSize, copyHeight );
+                Blit( verticalSprite, rightBorderSpriteOffsetX, fromOffsetY, _output, rightBorderOffsetX, toY, cornerSize, copyHeight );
 
                 // Render a transition to the background.
                 if ( _hasBackground ) {
-                    fheroes2::DitheringTransition( verticalSprite, cornerSize, fromOffsetY, _output, _windowArea.x + cornerSize, toY, transitionSize, copyHeight, true,
-                                                   true );
-                    fheroes2::DitheringTransition( verticalSprite, rightBorderSpriteOffsetX - transitionSize, fromOffsetY, _output, rightBorderOffsetX - transitionSize,
-                                                   toY, transitionSize, copyHeight, true, false );
+                    DitheringTransition( verticalSprite, cornerSize, fromOffsetY, _output, _windowArea.x + cornerSize, toY, transitionSize, copyHeight, true, true );
+                    DitheringTransition( verticalSprite, rightBorderSpriteOffsetX - transitionSize, fromOffsetY, _output, rightBorderOffsetX - transitionSize, toY,
+                                         transitionSize, copyHeight, true, false );
                 }
 
                 toOffsetY += stepY;
@@ -231,10 +230,10 @@ namespace fheroes2
         // Make a transition to the bottom corners.
         const int32_t verticalSpriteBottomCornerEdgeY = verticalSpriteHeight - borderEdgeOffset - transitionSize;
         const int32_t optputBottomCornerEdgeY = _windowArea.y + _windowArea.height - borderEdgeOffset - transitionSize;
-        fheroes2::DitheringTransition( verticalSprite, 0, verticalSpriteBottomCornerEdgeY, _output, _windowArea.x, optputBottomCornerEdgeY, cornerSize, transitionSize,
-                                       false, false );
-        fheroes2::DitheringTransition( verticalSprite, rightBorderSpriteOffsetX, verticalSpriteBottomCornerEdgeY, _output, rightBorderOffsetX, optputBottomCornerEdgeY,
-                                       cornerSize, transitionSize, false, false );
+        DitheringTransition( verticalSprite, 0, verticalSpriteBottomCornerEdgeY, _output, _windowArea.x, optputBottomCornerEdgeY, cornerSize, transitionSize, false,
+                             false );
+        DitheringTransition( verticalSprite, rightBorderSpriteOffsetX, verticalSpriteBottomCornerEdgeY, _output, rightBorderOffsetX, optputBottomCornerEdgeY, cornerSize,
+                             transitionSize, false, false );
 
         // Render horizontal borders. We have to remember that 'verticalSprite' has 16 (equals to BORDERWIDTH) pixels of shadow at the left and bottom sides.
         const int32_t horizontalSpriteCopyWidth = std::min( _windowArea.width, horizontalSpriteWidth ) - borderEdgeOffset * 2;
@@ -244,27 +243,25 @@ namespace fheroes2
         const int32_t bottomBorderSpriteOffsetY = horizontalSpriteHeight - cornerSize;
         const int32_t horizontalSpriteCopyStartX = borderEdgeOffset + BORDERWIDTH;
 
-        fheroes2::Blit( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, _windowArea.x + borderEdgeOffset, _windowArea.y, horizontalSpriteCopyWidth,
-                        cornerSize );
-        fheroes2::Blit( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, _windowArea.x + borderEdgeOffset, bottomBorderOffsetY,
-                        horizontalSpriteCopyWidth, cornerSize );
+        Blit( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, _windowArea.x + borderEdgeOffset, _windowArea.y, horizontalSpriteCopyWidth, cornerSize );
+        Blit( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, _windowArea.x + borderEdgeOffset, bottomBorderOffsetY,
+              horizontalSpriteCopyWidth, cornerSize );
 
         // Render a transition to the background.
         if ( _hasBackground ) {
-            fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, cornerSize, _output, _windowArea.x + borderEdgeOffset,
-                                           _windowArea.y + cornerSize, horizontalSpriteCopyWidth, transitionSize, false, true );
-            fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY - transitionSize, _output,
-                                           _windowArea.x + borderEdgeOffset, bottomBorderOffsetY - transitionSize, horizontalSpriteCopyWidth, transitionSize, false,
-                                           false );
+            DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, cornerSize, _output, _windowArea.x + borderEdgeOffset, _windowArea.y + cornerSize,
+                                 horizontalSpriteCopyWidth, transitionSize, false, true );
+            DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY - transitionSize, _output, _windowArea.x + borderEdgeOffset,
+                                 bottomBorderOffsetY - transitionSize, horizontalSpriteCopyWidth, transitionSize, false, false );
         }
 
         // If we need more copies to fill horizontal borders we make a transition and copy the central part of the border.
         if ( horizontalSpriteCopies > 0 ) {
             int32_t toOffsetX = borderEdgeOffset + horizontalSpriteCopyWidth;
             const int32_t outputX = _windowArea.x + toOffsetX - transitionSize;
-            fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, outputX, _windowArea.y, transitionSize, cornerSize, true, false );
-            fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, outputX, bottomBorderOffsetY, transitionSize,
-                                           cornerSize, true, false );
+            DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, outputX, _windowArea.y, transitionSize, cornerSize, true, false );
+            DitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, outputX, bottomBorderOffsetY, transitionSize,
+                                 cornerSize, true, false );
 
             const int32_t stepX = horizontalSpriteCopyWidth - transitionSize;
             const int32_t fromOffsetX = horizontalSpriteCopyStartX + transitionSize;
@@ -273,15 +270,14 @@ namespace fheroes2
                 const int32_t copyWidth = std::min( horizontalSpriteCopyWidth, _windowArea.width - borderEdgeOffset - toOffsetX );
                 const int32_t toX = _windowArea.x + toOffsetX;
 
-                fheroes2::Blit( horizontalSprite, fromOffsetX, 0, _output, toX, _windowArea.y, copyWidth, cornerSize );
-                fheroes2::Blit( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY, _output, toX, bottomBorderOffsetY, copyWidth, cornerSize );
+                Blit( horizontalSprite, fromOffsetX, 0, _output, toX, _windowArea.y, copyWidth, cornerSize );
+                Blit( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY, _output, toX, bottomBorderOffsetY, copyWidth, cornerSize );
 
                 // Render a transition to the background.
                 if ( _hasBackground ) {
-                    fheroes2::DitheringTransition( horizontalSprite, fromOffsetX, cornerSize, _output, toX, _windowArea.y + cornerSize, copyWidth, transitionSize, false,
-                                                   true );
-                    fheroes2::DitheringTransition( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY - transitionSize, _output, toX,
-                                                   bottomBorderOffsetY - transitionSize, copyWidth, transitionSize, false, false );
+                    DitheringTransition( horizontalSprite, fromOffsetX, cornerSize, _output, toX, _windowArea.y + cornerSize, copyWidth, transitionSize, false, true );
+                    DitheringTransition( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY - transitionSize, _output, toX, bottomBorderOffsetY - transitionSize,
+                                         copyWidth, transitionSize, false, false );
                 }
 
                 toOffsetX += stepX;
@@ -291,17 +287,17 @@ namespace fheroes2
         // Make a transition to the right corners.
         const int32_t horizontalSpriteRightCornerEdgeX = horizontalSprite.width() - borderEdgeOffset - transitionSize;
         const int32_t optputRightCornerEdgeX = _windowArea.x + _windowArea.width - borderEdgeOffset - transitionSize;
-        fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, 0, _output, optputRightCornerEdgeX, _windowArea.y, transitionSize, cornerSize,
-                                       true, false );
-        fheroes2::DitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, bottomBorderSpriteOffsetY, _output, optputRightCornerEdgeX,
-                                       bottomBorderOffsetY, transitionSize, cornerSize, true, false );
+        DitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, 0, _output, optputRightCornerEdgeX, _windowArea.y, transitionSize, cornerSize, true,
+                             false );
+        DitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, bottomBorderSpriteOffsetY, _output, optputRightCornerEdgeX, bottomBorderOffsetY,
+                             transitionSize, cornerSize, true, false );
 
         // Render shadow.
-        fheroes2::ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + borderSize, 1, _windowArea.height - borderSize, 5 );
-        fheroes2::ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + borderSize, 1, _windowArea.height - borderSize, 4 );
-        fheroes2::ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + borderSize, borderSize - 2, _windowArea.height - borderSize, 3 );
-        fheroes2::ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height, _windowArea.width, borderSize - 2, 3 );
-        fheroes2::ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height + borderSize - 2, _windowArea.width, 1, 4 );
-        fheroes2::ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height + borderSize - 1, _windowArea.width, 1, 5 );
+        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + borderSize, 1, _windowArea.height - borderSize, 5 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + borderSize, 1, _windowArea.height - borderSize, 4 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + borderSize, borderSize - 2, _windowArea.height - borderSize, 3 );
+        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height, _windowArea.width, borderSize - 2, 3 );
+        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height + borderSize - 2, _windowArea.width, 1, 4 );
+        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height + borderSize - 1, _windowArea.width, 1, 5 );
     }
 }

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -20,15 +20,25 @@
 
 #include "ui_window.h"
 
-#include <utility>
+#include <algorithm>
 
 #include "agg_image.h"
+#include "gamedefs.h"
 #include "icn.h"
 #include "settings.h"
 
 namespace
 {
-    const int32_t borderSize = BORDERWIDTH;
+    const int32_t borderSize{ BORDERWIDTH };
+
+    // Offset from border egdes (size of evil interface corners is 43 pixels) - this egdes (corners) will not be copied to fill the border.
+    const int32_t borderEdgeOffset{ 43 };
+
+    // Size in pixels of dithered transition from one image to another.
+    const int32_t transitionSize{ 10 };
+
+    // Offset from window edges to background copy area.
+    const int32_t backgroungOffset{ 22 };
 }
 
 namespace fheroes2
@@ -59,19 +69,13 @@ namespace fheroes2
         const fheroes2::Sprite & horizontalSprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
         const fheroes2::Sprite & verticalSprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::WINLOSEE : ICN::WINLOSE ), 0 );
 
-        // Offset from border egdes (size of evil interface corners is 43 pixels) - this egdes (corners) will not be copied to fill the border.
-        const int32_t borderEdgeOffset{ 43 };
-
         // Offset from window edges to background copy area and also the size of corners to render.
-        const int32_t cornerSize{ _hasBackground ? 22 : borderSize };
+        const int32_t cornerSize = _hasBackground ? backgroungOffset : borderSize;
 
-        // Size in pixels of dithered transition from one image to another.
-        const int32_t transitionSize{ 10 };
-
-        const int32_t horizontalSpriteWidth{ horizontalSprite.width() - BORDERWIDTH };
-        const int32_t horizontalSpriteHeight{ horizontalSprite.height() - BORDERWIDTH };
-        const int32_t verticalSpriteHeight{ verticalSprite.height() };
-        const int32_t verticalSpriteWidth{ verticalSprite.width() };
+        const int32_t horizontalSpriteWidth = horizontalSprite.width() - BORDERWIDTH;
+        const int32_t horizontalSpriteHeight = horizontalSprite.height() - BORDERWIDTH;
+        const int32_t verticalSpriteHeight = verticalSprite.height();
+        const int32_t verticalSpriteWidth = verticalSprite.width();
 
         // Render window corners. The corners are the same in used original images, so we use only 'verticalSprite'.
         const int32_t rightCornerOffsetX = _windowArea.x + _windowArea.width - cornerSize;

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -31,7 +31,7 @@ namespace
 {
     const int32_t borderSize{ BORDERWIDTH };
 
-    // Offset from border edges (size of evil interface corners is 43 pixels) - this edges (corners) will not be copied to fill the border.
+    // Offset from border edges (size of evil interface corners is 43 pixels) - these edges (corners) will not be copied to fill the border.
     const int32_t borderEdgeOffset{ 43 };
 
     // Size in pixels of dithered transition from one image to another.

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -247,13 +247,23 @@ namespace fheroes2
         CreateDitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, bottomBorderSpriteOffsetY, _output, optputRightCornerEdgeX, bottomBorderOffsetY,
                                    transitionSize, cornerSize, true, false );
 
-        // Render shadow.
-        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + borderSize, 1, _windowArea.height - borderSize, 5 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + borderSize, 1, _windowArea.height - borderSize, 4 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + borderSize, borderSize - 2, _windowArea.height - borderSize, 3 );
-        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height, _windowArea.width, borderSize - 2, 3 );
-        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height + borderSize - 2, _windowArea.width, 1, 4 );
+        // Render shadow at the left side of the window.
+        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + borderSize, borderSize, 1, 5 );
+        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + borderSize + 1, 1, _windowArea.height - 2, 5 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + borderSize + 1, borderSize - 1, 1, 4 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + borderSize + 2, 1, _windowArea.height - 4, 4 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + borderSize + 2, borderSize - 2, 1, 3 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + borderSize + 3, 1, _windowArea.height - 6, 3 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 3, _windowArea.y + borderSize + 3, borderSize - 3, _windowArea.height - borderSize - 3, 2 );
+
+        // Render shadow at the bottom side of the window.
+        ApplyTransform( _output, _windowArea.x - borderSize + 3, _windowArea.y + _windowArea.height, _windowArea.width - 6, borderSize - 3, 2 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + _windowArea.height + borderSize - 3, _windowArea.width - 4, 1, 3 );
+        ApplyTransform( _output, _windowArea.x + _windowArea.width - borderSize - 3, _windowArea.y + _windowArea.height, 1, borderSize - 3, 3 );
+        ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + _windowArea.height + borderSize - 2, _windowArea.width - 2, 1, 4 );
+        ApplyTransform( _output, _windowArea.x + _windowArea.width - borderSize - 2, _windowArea.y + _windowArea.height, 1, borderSize - 2, 4 );
         ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height + borderSize - 1, _windowArea.width, 1, 5 );
+        ApplyTransform( _output, _windowArea.x + _windowArea.width - borderSize - 1, _windowArea.y + _windowArea.height, 1, borderSize - 1, 5 );
     }
 
     void StandardWindow::_renderBackground( const bool isEvilInterface )

--- a/src/fheroes2/gui/ui_window.h
+++ b/src/fheroes2/gui/ui_window.h
@@ -53,5 +53,7 @@ namespace fheroes2
         const Rect _windowArea;
         ImageRestorer _restorer;
         const bool _hasBackground{ true };
+
+        void _renderBackground( const bool isEvilInterface );
     };
 }

--- a/src/fheroes2/gui/ui_window.h
+++ b/src/fheroes2/gui/ui_window.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -32,8 +32,8 @@ namespace fheroes2
     class StandardWindow
     {
     public:
-        StandardWindow( const int32_t width, const int32_t height, Image & output = Display::instance() );
-        StandardWindow( const int32_t x, const int32_t y, const int32_t width, const int32_t height, Image & output = Display::instance() );
+        StandardWindow( const int32_t width, const int32_t height, const bool renderBackground, Image & output = Display::instance() );
+        StandardWindow( const int32_t x, const int32_t y, const int32_t width, const int32_t height, const bool renderBackground, Image & output = Display::instance() );
 
         const Rect & activeArea() const
         {
@@ -52,5 +52,6 @@ namespace fheroes2
         const Rect _activeArea;
         const Rect _windowArea;
         ImageRestorer _restorer;
+        const bool _hasBackground{ true };
     };
 }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -69,7 +69,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     std::unique_ptr<fheroes2::StandardWindow> background;
     std::unique_ptr<fheroes2::ImageRestorer> restorer;
     if ( renderBackgroundDialog ) {
-        background = std::make_unique<fheroes2::StandardWindow>( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
+        background = std::make_unique<fheroes2::StandardWindow>( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, false );
         cur_pt = { background->activeArea().x, background->activeArea().y };
     }
     else {

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -444,7 +444,7 @@ namespace
             return false;
         }
 
-        std::unique_ptr<fheroes2::StandardWindow> frameborder = std::make_unique<fheroes2::StandardWindow>( 290, 252 );
+        std::unique_ptr<fheroes2::StandardWindow> frameborder = std::make_unique<fheroes2::StandardWindow>( 290, 252, true );
         const fheroes2::Rect & windowArea = frameborder->windowArea();
         const fheroes2::Rect & activeArea = frameborder->activeArea();
 

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -709,7 +709,7 @@ void Kingdom::openOverviewDialog()
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    fheroes2::StandardWindow background( display.DEFAULT_WIDTH, display.DEFAULT_HEIGHT );
+    fheroes2::StandardWindow background( display.DEFAULT_WIDTH, display.DEFAULT_HEIGHT, false );
 
     const fheroes2::Point cur_pt( background.activeArea().x, background.activeArea().y );
     fheroes2::Point dst_pt( cur_pt );

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -165,7 +165,7 @@ namespace
         const fheroes2::Rect & gameArea = Interface::Basic::Get().GetGameArea().GetROI();
 
         const fheroes2::StandardWindow border( gameArea.x + ( gameArea.width - sf.width() - BORDERWIDTH * 2 ) / 2,
-                                               gameArea.y + ( gameArea.height - sf.height() - BORDERWIDTH * 2 ) / 2, sf.width(), sf.height() );
+                                               gameArea.y + ( gameArea.height - sf.height() - BORDERWIDTH * 2 ) / 2, sf.width(), sf.height(), false );
 
         fheroes2::Rect blitArea = border.activeArea();
 


### PR DESCRIPTION
fix #6547
relates to #6391

Made rendering of a Standard window using game resources and connecting them by using simple transition pattern: 
![pattern](https://user-images.githubusercontent.com/113276641/218273365-5b9802ae-e535-4c45-8528-ccc50a8a3fa0.png)

Also added ability not to render the window background if only the borders are needed (in example for Castle, Battle dialogs).

![castle dialog](https://user-images.githubusercontent.com/113276641/218273157-f200b62c-435a-47d8-8d6a-714f542c322b.png)

<details><summary>Standard Window for Evil interface with and without background</summary>

![evil with background](https://user-images.githubusercontent.com/113276641/218273184-465da02e-1aef-4a2d-b0d3-46f9a3e58b39.png)

![evil without background](https://user-images.githubusercontent.com/113276641/218273192-6ffae5c4-50b6-4c63-a21a-001c38348b9b.png)

</details>
