### PR TITLE
extractor tool: extract each AGG file to a separate subdir

### DIFF
--- a/script/agg/extract_agg.bat
+++ b/script/agg/extract_agg.bat
@@ -36,6 +36,7 @@ exit /B %EXIT_CODE%
 :extract_icn
 
 extractor agg *.AGG *.agg || exit /B 1
-icn2img icn agg\kb.pal agg\*.icn || exit /B 1
+icn2img icn\HEROES2 agg\HEROES2\kb.pal agg\HEROES2\*.icn || exit /B 1
+icn2img icn\HEROES2X agg\HEROES2\kb.pal agg\HEROES2X\*.icn || exit /B 1
 
 exit /B

--- a/script/agg/extract_agg.sh
+++ b/script/agg/extract_agg.sh
@@ -25,4 +25,11 @@ set -e
 PATH="$(dirname "$0"):$PATH"
 
 extractor agg *.AGG *.agg
-icn2img icn agg/kb.pal agg/*.icn
+
+for DIR in agg/*; do
+    if [[ ! -d "$DIR" ]]; then
+        continue
+    fi
+
+    icn2img "icn/$(basename "$DIR")" agg/*/kb.pal "$DIR"/*.icn
+done

--- a/src/tools/extractor.cpp
+++ b/src/tools/extractor.cpp
@@ -92,14 +92,6 @@ int main( int argc, char ** argv )
         }
     }
 
-    std::error_code ec;
-
-    // Using the non-throwing overloads
-    if ( !std::filesystem::exists( dstDir, ec ) && !std::filesystem::create_directories( dstDir, ec ) ) {
-        std::cerr << "Cannot create directory " << dstDir << std::endl;
-        return EXIT_FAILURE;
-    }
-
     uint32_t itemsExtracted = 0;
     uint32_t itemsFailed = 0;
 
@@ -111,6 +103,16 @@ int main( int argc, char ** argv )
             std::cerr << "Cannot open file " << inputFileName << std::endl;
             // A non-existent or inaccessible file is not considered a fatal error
             continue;
+        }
+
+        const std::filesystem::path prefixPath = std::filesystem::path( dstDir ) / std::filesystem::path( inputFileName ).stem();
+
+        std::error_code ec;
+
+        // Using the non-throwing overloads
+        if ( !std::filesystem::exists( prefixPath, ec ) && !std::filesystem::create_directories( prefixPath, ec ) ) {
+            std::cerr << "Cannot create directory " << prefixPath << std::endl;
+            return EXIT_FAILURE;
         }
 
         const size_t inputStreamSize = inputStream.size();
@@ -161,7 +163,7 @@ int main( int argc, char ** argv )
                 continue;
             }
 
-            const std::filesystem::path outputFilePath = std::filesystem::path( dstDir ) / std::filesystem::path( name );
+            const std::filesystem::path outputFilePath = prefixPath / std::filesystem::path( name );
 
             std::ofstream outputStream( outputFilePath, std::ios_base::binary | std::ios_base::trunc );
             if ( !outputStream ) {


### PR DESCRIPTION
Related to #6553

It [turns out](https://github.com/ihhub/fheroes2/issues/6553#issuecomment-1428380378) that `HEROES2.AGG` and `HEROES2X.AGG` may contain items with the same names, thus, extracting both of these files to the same directory is undesirable.