### PR TITLE
fix stereo audio playing in SMK files

### DIFF
--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2022                                             *
+ *   Copyright (C) 2020 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -161,8 +161,8 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
             wavHeader.putLE16( 0x01 ); // format
             wavHeader.putLE16( channelsPerTrack[i] ); // channels
             wavHeader.putLE32( audioRate[i] ); // samples
-            wavHeader.putLE32( audioRate[i] * audioBitDepth[i] * channelsPerTrack[i] / 8 ); // align
-            wavHeader.putLE16( audioBitDepth[i] * channelsPerTrack[i] / 8 );
+            wavHeader.putLE32( audioRate[i] * audioBitDepth[i] * channelsPerTrack[i] / 8 ); // bytes per second
+            wavHeader.putLE16( audioBitDepth[i] * channelsPerTrack[i] / 8 ); // align
             wavHeader.putLE16( audioBitDepth[i] ); // bits per channel
             wavHeader.putLE32( 0x61746164 ); // DATA
             wavHeader.putLE32( originalSize ); // size

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -161,7 +161,7 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
             wavHeader.putLE16( 0x01 ); // format
             wavHeader.putLE16( channelsPerTrack[i] ); // channels
             wavHeader.putLE32( audioRate[i] ); // samples
-            wavHeader.putLE32( audioRate[i] * audioBitDepth[i] * channelsPerTrack[i] / 8 ); // bytes per second
+            wavHeader.putLE32( audioRate[i] * audioBitDepth[i] * channelsPerTrack[i] / 8 ); // align
             wavHeader.putLE16( audioBitDepth[i] * channelsPerTrack[i] / 8 );
             wavHeader.putLE16( audioBitDepth[i] ); // bits per channel
             wavHeader.putLE32( 0x61746164 ); // DATA

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -161,9 +161,9 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
             wavHeader.putLE16( 0x01 ); // format
             wavHeader.putLE16( channelsPerTrack[i] ); // channels
             wavHeader.putLE32( audioRate[i] ); // samples
-            wavHeader.putLE32( audioRate[i] * audioBitDepth[i] / 8 ); // byteper
-            wavHeader.putLE16( 0x01 ); // align
-            wavHeader.putLE16( audioBitDepth[i] ); // bitsper
+            wavHeader.putLE32( audioRate[i] * audioBitDepth[i] * channelsPerTrack[i] / 8 ); // bytes per second
+            wavHeader.putLE16( audioBitDepth[i] * channelsPerTrack[i] / 8 );
+            wavHeader.putLE16( audioBitDepth[i] ); // bits per channel
             wavHeader.putLE32( 0x61746164 ); // DATA
             wavHeader.putLE32( originalSize ); // size
 


### PR DESCRIPTION
NWCLOGO.SMK constains stereo audio track that isn't played. The game puts "[ERROR]    playSound:  Failed to create an audio chunk from memory. The error: Unsupported block alignment " message.