### PR TITLE
Tune MSVC dependencies for xmi2midi tool

### DIFF
--- a/VisualStudio/tools/xmi2midi/sources.props
+++ b/VisualStudio/tools/xmi2midi/sources.props
@@ -1,41 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
-    <ClCompile Include="..\engine\audio.cpp" />
-    <ClCompile Include="..\engine\core.cpp" />
-    <ClCompile Include="..\engine\dir.cpp" />
-    <ClCompile Include="..\engine\image.cpp" />
-    <ClCompile Include="..\engine\image_palette.cpp" />
-    <ClCompile Include="..\engine\localevent.cpp" />
     <ClCompile Include="..\engine\logging.cpp" />
-    <ClCompile Include="..\engine\pal.cpp" />
-    <ClCompile Include="..\engine\screen.cpp" />
     <ClCompile Include="..\engine\serialize.cpp" />
     <ClCompile Include="..\engine\system.cpp" />
-    <ClCompile Include="..\engine\thread.cpp" />
-    <ClCompile Include="..\engine\timing.cpp" />
-    <ClCompile Include="..\engine\tools.cpp" />
-    <ClCompile Include="..\engine\translations.cpp" />
     <ClCompile Include="..\engine\xmi2mid.cpp" />
     <ClCompile Include="xmi2midi.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\engine\audio.h" />
-    <ClInclude Include="..\engine\core.h" />
-    <ClInclude Include="..\engine\dir.h" />
     <ClInclude Include="..\engine\endian_h2.h" />
-    <ClInclude Include="..\engine\image.h" />
-    <ClInclude Include="..\engine\image_palette.h" />
-    <ClInclude Include="..\engine\localevent.h" />
     <ClInclude Include="..\engine\logging.h" />
     <ClInclude Include="..\engine\math_base.h" />
-    <ClInclude Include="..\engine\pal.h" />
-    <ClInclude Include="..\engine\screen.h" />
     <ClInclude Include="..\engine\serialize.h" />
     <ClInclude Include="..\engine\system.h" />
-    <ClInclude Include="..\engine\thread.h" />
-    <ClInclude Include="..\engine\timing.h" />
     <ClInclude Include="..\engine\tools.h" />
-    <ClInclude Include="..\engine\translations.h" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Related to #6652

This removes extra DLL dependencies for the `xmi2midi` tool to run.