### PR TITLE
Fix Mini-map reset of enemy object colors after enemy vanquish

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "kingdom.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -42,7 +44,6 @@
 #include "game_interface.h"
 #include "game_static.h"
 #include "interface_icons.h"
-#include "kingdom.h"
 #include "logging.h"
 #include "maps.h"
 #include "maps_fileinfo.h"
@@ -197,6 +198,9 @@ void Kingdom::LossPostActions()
         }
 
         world.ResetCapturedObjects( GetColor() );
+
+        // Redraw the whole radar image after resetting the captured objects.
+        Interface::Basic::Get().Redraw( Interface::REDRAW_RADAR );
     }
 }
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -21,8 +21,6 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "kingdom.h"
-
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -44,6 +42,7 @@
 #include "game_interface.h"
 #include "game_static.h"
 #include "interface_icons.h"
+#include "kingdom.h"
 #include "logging.h"
 #include "maps.h"
 #include "maps_fileinfo.h"
@@ -198,9 +197,6 @@ void Kingdom::LossPostActions()
         }
 
         world.ResetCapturedObjects( GetColor() );
-
-        // Redraw the whole radar image after resetting the captured objects.
-        Interface::Basic::Get().Redraw( Interface::REDRAW_RADAR );
     }
 }
 


### PR DESCRIPTION
Fix an issue, found by **Dmytr01** (on Discord):
The color of enemy objects (mines) was not reset on Mini-map after enemy vanquish.

This archive contains two saves I used to check the fix (capture an enemy castle, defeat an enemy hero): [saves.zip](https://github.com/ihhub/fheroes2/files/10746348/saves.zip)