### PR TITLE
Puzzle map window is not centered on the screen

### DIFF
--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -185,8 +185,8 @@ namespace
 
         const fheroes2::Rect & gameArea = Interface::Basic::Get().GetGameArea().GetROI();
 
-        const fheroes2::StandardWindow border( gameArea.x + ( gameArea.width - sf.width() - BORDERWIDTH * 2 ) / 2,
-                                               gameArea.y + ( gameArea.height - sf.height() - BORDERWIDTH * 2 ) / 2, sf.width(), sf.height(), false );
+        const fheroes2::StandardWindow border( gameArea.x + ( gameArea.width - sf.width() ) / 2, gameArea.y + ( gameArea.height - sf.height() ) / 2, sf.width(),
+                                               sf.height(), false );
 
         fheroes2::Rect blitArea = border.activeArea();
 


### PR DESCRIPTION
This is my first PR. Puzzle window is centered nicely in game area after this change.

fixes: #6657