### PR TITLE
Fix multiple issues in the Dialog::ArmyInfo()

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -987,10 +987,10 @@ void Battle::ArmiesOrder::QueueEventProcessing( std::string & msg, const fheroes
         const Unit & unit = *( unitPos.first );
 
         if ( le.MouseClickLeft( unitRoi ) ) {
-            Dialog::ArmyInfo( unit, Dialog::READONLY | Dialog::BUTTONS, unit.isReflect() );
+            Dialog::ArmyInfo( unit, Dialog::BUTTONS, unit.isReflect() );
         }
         else if ( le.MousePressRight( unitRoi ) ) {
-            Dialog::ArmyInfo( unit, Dialog::READONLY, unit.isReflect() );
+            Dialog::ArmyInfo( unit, Dialog::ZERO, unit.isReflect() );
         }
     }
 }
@@ -3040,12 +3040,12 @@ void Battle::Interface::MousePressRightBoardAction( const Cell & cell ) const
     const Unit * unitOnCell = cell.GetUnit();
 
     if ( unitOnCell != nullptr ) {
-        Dialog::ArmyInfo( *unitOnCell, Dialog::READONLY, unitOnCell->isReflect() );
+        Dialog::ArmyInfo( *unitOnCell, Dialog::ZERO, unitOnCell->isReflect() );
     }
     else {
         unitOnCell = arena.GraveyardLastTroop( cell.GetIndex() );
         if ( unitOnCell != nullptr ) {
-            Dialog::ArmyInfo( *unitOnCell, Dialog::READONLY, unitOnCell->isReflect() );
+            Dialog::ArmyInfo( *unitOnCell, Dialog::ZERO, unitOnCell->isReflect() );
         }
     }
 }
@@ -3113,7 +3113,7 @@ void Battle::Interface::MouseLeftClickBoardAction( int themes, const Cell & cell
 
         case Cursor::WAR_INFO: {
             if ( b ) {
-                Dialog::ArmyInfo( *b, Dialog::BUTTONS | Dialog::READONLY, b->isReflect() );
+                Dialog::ArmyInfo( *b, Dialog::BUTTONS, b->isReflect() );
                 humanturn_redraw = true;
             }
             break;

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -77,8 +77,6 @@ namespace Dialog
         DIG = 0x1000,
 
         UPGRADE_DISABLE = MAX,
-
-        READONLY = 0x2000,
         BUTTONS = ( YES | OK | NO | CANCEL )
     };
 

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -452,7 +452,7 @@ namespace
 int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
 {
     // Unit in combat cannot be dismissed or upgraded
-    assert( !troop.isBattle() || !( flags & BUTTONS ) || ( ( flags & READONLY ) && !( flags & UPGRADE ) ) );
+    assert( !troop.isBattle() || !( flags & BUTTONS ) || !( flags & ( UPGRADE | DISMISS ) ) );
 
     // The active size of the window is 520 by 256 pixels
     fheroes2::Display & display = fheroes2::Display::instance();
@@ -529,7 +529,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
         buttonUpgrade.disable();
     }
 
-    if ( ( flags & BUTTONS ) && !( flags & READONLY ) ) {
+    if ( ( flags & ( BUTTONS | DISMISS ) ) == ( BUTTONS | DISMISS ) ) {
         buttonDismiss.enable();
         buttonDismiss.draw();
     }

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -451,6 +451,9 @@ namespace
 
 int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
 {
+    // Unit in combat cannot be dismissed or upgraded
+    assert( !troop.isBattle() || !( flags & BUTTONS ) || ( ( flags & READONLY ) && !( flags & UPGRADE ) ) );
+
     // The active size of the window is 520 by 256 pixels
     fheroes2::Display & display = fheroes2::Display::instance();
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
@@ -518,11 +521,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
     dst_pt.y = pos_rt.y + 221;
     fheroes2::Button buttonExit( dst_pt.x, dst_pt.y, exitButtonIcnID, 0, 1 );
 
-    if ( READONLY & flags ) {
-        buttonDismiss.disable();
-    }
-
-    if ( !troop.isBattle() && troop.isAllowUpgrade() && ( UPGRADE & flags ) ) {
+    if ( ( flags & ( BUTTONS | UPGRADE ) ) == ( BUTTONS | UPGRADE ) && troop.isAllowUpgrade() ) {
         buttonUpgrade.enable();
         buttonUpgrade.draw();
     }
@@ -530,11 +529,15 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
         buttonUpgrade.disable();
     }
 
-    if ( BUTTONS & flags ) {
-        if ( !troop.isBattle() && !( READONLY & flags ) ) {
-            buttonDismiss.draw();
-        }
+    if ( ( flags & BUTTONS ) && !( flags & READONLY ) ) {
+        buttonDismiss.enable();
+        buttonDismiss.draw();
+    }
+    else {
+        buttonDismiss.disable();
+    }
 
+    if ( flags & BUTTONS ) {
         buttonExit.draw();
     }
 

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -452,8 +452,10 @@ namespace
 
 int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
 {
-    // Unit in combat cannot be dismissed or upgraded
+    // Unit cannot be dismissed or upgraded during combat
     assert( !troop.isBattle() || !( flags & BUTTONS ) || !( flags & ( UPGRADE | DISMISS ) ) );
+    // This function should not be called with the UPGRADE flag for a non-upgradeable unit
+    assert( !( flags & BUTTONS ) || !( flags & UPGRADE ) || troop.isAllowUpgrade() );
 
     // The active size of the window is 520 by 256 pixels
     fheroes2::Display & display = fheroes2::Display::instance();
@@ -522,7 +524,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
     dst_pt.y = pos_rt.y + 221;
     fheroes2::Button buttonExit( dst_pt.x, dst_pt.y, exitButtonIcnID, 0, 1 );
 
-    if ( ( flags & ( BUTTONS | UPGRADE ) ) == ( BUTTONS | UPGRADE ) && troop.isAllowUpgrade() ) {
+    if ( ( flags & ( BUTTONS | UPGRADE ) ) == ( BUTTONS | UPGRADE ) ) {
         buttonUpgrade.enable();
         buttonUpgrade.draw();
     }

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -267,16 +268,16 @@ namespace
             break;
         }
 
-        return fheroes2::Sprite();
+        return {};
     }
 
     std::vector<std::pair<fheroes2::Rect, Spell>> DrawBattleStats( const fheroes2::Point & dst, const Troop & b )
     {
         std::vector<std::pair<fheroes2::Rect, Spell>> output;
 
-        const uint32_t modes[15] = { Battle::SP_BLOODLUST,    Battle::SP_BLESS,     Battle::SP_HASTE,     Battle::SP_SHIELD,   Battle::SP_STONESKIN,
-                                     Battle::SP_DRAGONSLAYER, Battle::SP_STEELSKIN, Battle::SP_ANTIMAGIC, Battle::SP_CURSE,    Battle::SP_SLOW,
-                                     Battle::SP_BERSERKER,    Battle::SP_HYPNOTIZE, Battle::SP_BLIND,     Battle::SP_PARALYZE, Battle::SP_STONE };
+        const std::array<uint32_t, 15> modes = { Battle::SP_BLOODLUST,    Battle::SP_BLESS,     Battle::SP_HASTE,     Battle::SP_SHIELD,   Battle::SP_STONESKIN,
+                                                 Battle::SP_DRAGONSLAYER, Battle::SP_STEELSKIN, Battle::SP_ANTIMAGIC, Battle::SP_CURSE,    Battle::SP_SLOW,
+                                                 Battle::SP_BERSERKER,    Battle::SP_HYPNOTIZE, Battle::SP_BLIND,     Battle::SP_PARALYZE, Battle::SP_STONE };
 
         int32_t ow = 0;
         int32_t spritesWidth = 0;

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -122,13 +122,332 @@ namespace
 
         return Spell::NONE;
     }
-}
 
-void DrawMonsterStats( const fheroes2::Point & dst, const Troop & troop );
-std::vector<std::pair<fheroes2::Rect, Spell>> DrawBattleStats( const fheroes2::Point & dst, const Troop & b );
-void DrawMonsterInfo( const fheroes2::Point & dst, const Troop & troop );
-void DrawMonster( fheroes2::RandomMonsterAnimation & monsterAnimation, const Troop & troop, const fheroes2::Point & offset, bool isReflected, bool isAnimated,
-                  const fheroes2::Rect & roi );
+    void DrawMonsterStats( const fheroes2::Point & dst, const Troop & troop )
+    {
+        fheroes2::Point dst_pt;
+        Text text;
+
+        // attack
+        text.Set( std::string( _( "Attack Skill" ) ) + ":" );
+        dst_pt.x = dst.x - text.w();
+        dst_pt.y = dst.y;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        const int offsetX = 6;
+        const int offsetY = 16;
+
+        text.Set( troop.GetAttackString() );
+        dst_pt.x = dst.x + offsetX;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        // defense
+        text.Set( std::string( _( "Defense Skill" ) ) + ":" );
+        dst_pt.x = dst.x - text.w();
+        dst_pt.y += offsetY;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        text.Set( troop.GetDefenseString() );
+        dst_pt.x = dst.x + offsetX;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        // shot
+        if ( troop.isArchers() ) {
+            std::string message = troop.isBattle() ? _( "Shots Left" ) : _( "Shots" );
+            message += ':';
+            text.Set( message );
+            dst_pt.x = dst.x - text.w();
+            dst_pt.y += offsetY;
+            text.Blit( dst_pt.x, dst_pt.y );
+
+            text.Set( troop.GetShotString() );
+            dst_pt.x = dst.x + offsetX;
+            text.Blit( dst_pt.x, dst_pt.y );
+        }
+
+        // damage
+        text.Set( std::string( _( "Damage" ) ) + ":" );
+        dst_pt.x = dst.x - text.w();
+        dst_pt.y += offsetY;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        if ( troop.GetMonster().GetDamageMin() != troop.GetMonster().GetDamageMax() )
+            text.Set( std::to_string( troop.GetMonster().GetDamageMin() ) + "-" + std::to_string( troop.GetMonster().GetDamageMax() ) );
+        else
+            text.Set( std::to_string( troop.GetMonster().GetDamageMin() ) );
+        dst_pt.x = dst.x + offsetX;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        // hp
+        text.Set( std::string( _( "Hit Points" ) ) + ":" );
+        dst_pt.x = dst.x - text.w();
+        dst_pt.y += offsetY;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        text.Set( std::to_string( troop.GetMonster().GetHitPoints() ) );
+        dst_pt.x = dst.x + offsetX;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        if ( troop.isBattle() && troop.GetCount() != 0 ) {
+            text.Set( std::string( _( "Hit Points Left" ) ) + ":" );
+            dst_pt.x = dst.x - text.w();
+            dst_pt.y += offsetY;
+            text.Blit( dst_pt.x, dst_pt.y );
+
+            text.Set( std::to_string( troop.GetHitPointsLeft() ) );
+            dst_pt.x = dst.x + offsetX;
+            text.Blit( dst_pt.x, dst_pt.y );
+        }
+
+        // speed
+        text.Set( std::string( _( "Speed" ) ) + ":" );
+        dst_pt.x = dst.x - text.w();
+        dst_pt.y += offsetY;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        text.Set( troop.GetSpeedString() );
+        dst_pt.x = dst.x + offsetX;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        // morale
+        text.Set( std::string( _( "Morale" ) ) + ":" );
+        dst_pt.x = dst.x - text.w();
+        dst_pt.y += offsetY;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        text.Set( Morale::String( troop.GetMorale() ) );
+        dst_pt.x = dst.x + offsetX;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        // luck
+        text.Set( std::string( _( "Luck" ) ) + ":" );
+        dst_pt.x = dst.x - text.w();
+        dst_pt.y += offsetY;
+        text.Blit( dst_pt.x, dst_pt.y );
+
+        text.Set( Luck::String( troop.GetLuck() ) );
+        dst_pt.x = dst.x + offsetX;
+        text.Blit( dst_pt.x, dst_pt.y );
+    }
+
+    fheroes2::Sprite GetModesSprite( uint32_t mod )
+    {
+        switch ( mod ) {
+        case Battle::SP_BLOODLUST:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 9 );
+        case Battle::SP_BLESS:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 3 );
+        case Battle::SP_HASTE:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 0 );
+        case Battle::SP_SHIELD:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 10 );
+        case Battle::SP_STONESKIN:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 13 );
+        case Battle::SP_DRAGONSLAYER:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 8 );
+        case Battle::SP_STEELSKIN:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 14 );
+        case Battle::SP_ANTIMAGIC:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 12 );
+        case Battle::SP_CURSE:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 4 );
+        case Battle::SP_SLOW:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 1 );
+        case Battle::SP_BERSERKER:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 5 );
+        case Battle::SP_HYPNOTIZE:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 7 );
+        case Battle::SP_BLIND:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 2 );
+        case Battle::SP_PARALYZE:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 6 );
+        case Battle::SP_STONE:
+            return fheroes2::AGG::GetICN( ICN::SPELLINL, 11 );
+        default:
+            break;
+        }
+
+        return fheroes2::Sprite();
+    }
+
+    std::vector<std::pair<fheroes2::Rect, Spell>> DrawBattleStats( const fheroes2::Point & dst, const Troop & b )
+    {
+        std::vector<std::pair<fheroes2::Rect, Spell>> output;
+
+        const uint32_t modes[15] = { Battle::SP_BLOODLUST,    Battle::SP_BLESS,     Battle::SP_HASTE,     Battle::SP_SHIELD,   Battle::SP_STONESKIN,
+                                     Battle::SP_DRAGONSLAYER, Battle::SP_STEELSKIN, Battle::SP_ANTIMAGIC, Battle::SP_CURSE,    Battle::SP_SLOW,
+                                     Battle::SP_BERSERKER,    Battle::SP_HYPNOTIZE, Battle::SP_BLIND,     Battle::SP_PARALYZE, Battle::SP_STONE };
+
+        int32_t ow = 0;
+        int32_t spritesWidth = 0;
+
+        std::vector<SpellInfo> spellsInfo;
+        for ( const uint32_t mode : modes ) {
+            if ( !b.isModes( mode ) )
+                continue;
+
+            const fheroes2::Sprite & sprite = GetModesSprite( mode );
+            if ( sprite.empty() )
+                continue;
+
+            const uint32_t duration = b.GetAffectedDuration( mode );
+            int offset = 0;
+            if ( duration > 0 ) {
+                offset = duration >= 10 ? 12 : 7;
+                if ( mode >= Battle::SP_BLESS && mode <= Battle::SP_DRAGONSLAYER )
+                    offset -= 5;
+            }
+            const int space = ( offset == 2 ) ? 10 : 5;
+
+            spellsInfo.emplace_back( mode, duration, offset, space );
+            ow += sprite.width() + offset + space;
+            spritesWidth += sprite.width();
+        }
+
+        if ( spellsInfo.empty() )
+            return output;
+
+        std::sort( spellsInfo.begin(), spellsInfo.end(),
+                   []( const SpellInfo & first, const SpellInfo & second ) { return first.duration > 0 && first.duration < second.duration; } );
+
+        ow -= spellsInfo.back().space;
+
+        const int maxSpritesWidth = 212;
+        const int maxSpriteHeight = 32;
+
+        Text text;
+        if ( ow <= maxSpritesWidth ) {
+            ow = dst.x - ow / 2;
+            for ( const auto & spell : spellsInfo ) {
+                const fheroes2::Sprite & sprite = GetModesSprite( spell.mode );
+                const fheroes2::Point imageOffset( ow, dst.y + maxSpriteHeight - sprite.height() );
+
+                fheroes2::Blit( sprite, fheroes2::Display::instance(), imageOffset.x, imageOffset.y );
+                output.emplace_back( fheroes2::Rect( imageOffset.x, imageOffset.y, sprite.width(), sprite.height() ), modeToSpell( spell.mode ) );
+
+                if ( spell.duration > 0 ) {
+                    text.Set( std::to_string( spell.duration ), Font::SMALL );
+                    ow += sprite.width() + spell.offset;
+                    text.Blit( ow - text.w(), dst.y + maxSpriteHeight - text.h() + 1 );
+                }
+                ow += spell.space;
+            }
+        }
+        else {
+            // Too many spells
+            const int widthDiff = maxSpritesWidth - spritesWidth;
+            int space = widthDiff / static_cast<int>( spellsInfo.size() - 1 );
+            if ( widthDiff > 0 ) {
+                if ( space > 10 )
+                    space = 10;
+                ow = dst.x + ( spritesWidth + space * static_cast<int>( spellsInfo.size() - 1 ) ) / 2;
+            }
+            else {
+                ow = dst.x + maxSpritesWidth / 2;
+            }
+
+            for ( auto spellIt = spellsInfo.crbegin(); spellIt != spellsInfo.crend(); ++spellIt ) {
+                const fheroes2::Sprite & sprite = GetModesSprite( spellIt->mode );
+                const fheroes2::Point imageOffset( ow - sprite.width(), dst.y + maxSpriteHeight - sprite.height() );
+
+                fheroes2::Blit( sprite, fheroes2::Display::instance(), imageOffset.x, imageOffset.y );
+                output.emplace_back( fheroes2::Rect( imageOffset.x, imageOffset.y, sprite.width(), sprite.height() ), modeToSpell( spellIt->mode ) );
+
+                if ( spellIt->duration > 0 ) {
+                    text.Set( std::to_string( spellIt->duration ), Font::SMALL );
+                    text.Blit( ow - text.w(), dst.y + maxSpriteHeight - text.h() + 1 );
+                }
+                ow -= sprite.width() + space;
+            }
+        }
+
+        return output;
+    }
+
+    void DrawMonsterInfo( const fheroes2::Point & offset, const Troop & troop )
+    {
+        // name
+        Text text( troop.GetName(), Font::YELLOW_BIG );
+        fheroes2::Point pos( offset.x + 140 - text.w() / 2, offset.y + 40 );
+        text.Blit( pos.x, pos.y );
+
+        // Description.
+        const std::vector<std::string> descriptions = fheroes2::getMonsterPropertiesDescription( troop.GetID() );
+        if ( !descriptions.empty() ) {
+            const int32_t descriptionWidth = 210;
+            const int32_t maximumRowCount = 3;
+            const int32_t rowHeight = fheroes2::Text( std::string(), fheroes2::FontType::smallWhite() ).height();
+
+            bool asSolidText = true;
+            if ( descriptions.size() <= static_cast<size_t>( maximumRowCount ) ) {
+                asSolidText = false;
+                for ( const std::string & sentence : descriptions ) {
+                    if ( fheroes2::Text( sentence, fheroes2::FontType::smallWhite() ).width() > descriptionWidth ) {
+                        asSolidText = true;
+                        break;
+                    }
+                }
+            }
+
+            if ( asSolidText ) {
+                std::string description;
+                for ( const std::string & sentence : descriptions ) {
+                    if ( !description.empty() ) {
+                        description += ' ';
+                    }
+
+                    description += sentence;
+                }
+
+                const fheroes2::Text descriptionText( description, fheroes2::FontType::smallWhite() );
+                const int32_t rowCount = descriptionText.rows( descriptionWidth );
+
+                descriptionText.draw( offset.x + 37, offset.y + 185 + ( maximumRowCount - rowCount ) * rowHeight, descriptionWidth, fheroes2::Display::instance() );
+            }
+            else {
+                int32_t sentenceId = maximumRowCount - static_cast<int32_t>( descriptions.size() ); // safe to cast as we check the size before.
+                for ( const std::string & sentence : descriptions ) {
+                    const fheroes2::Text descriptionText( sentence, fheroes2::FontType::smallWhite() );
+
+                    descriptionText.draw( offset.x + 37, offset.y + 185 + sentenceId * rowHeight, descriptionWidth, fheroes2::Display::instance() );
+                    ++sentenceId;
+                }
+            }
+        }
+
+        // amount
+        if ( troop.GetCount() != 0 ) {
+            text.Set( std::to_string( troop.GetCount() ), Font::BIG );
+            pos.x = offset.x + offsetXAmountBox + widthAmountBox / 2 - text.w() / 2;
+            pos.y = offset.y + offsetYAmountBox + heightAmountBox / 2 - text.h() / 2;
+            text.Blit( pos.x, pos.y );
+        }
+    }
+
+    void DrawMonster( fheroes2::RandomMonsterAnimation & monsterAnimation, const Troop & troop, const fheroes2::Point & offset, bool isReflected, bool isAnimated,
+                      const fheroes2::Rect & roi )
+    {
+        const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( monsterAnimation.icnFile(), monsterAnimation.frameId() );
+        fheroes2::Point monsterPos( offset.x, offset.y + monsterSprite.y() );
+        if ( isReflected )
+            monsterPos.x -= monsterSprite.x() - ( troop.isWide() ? CELLW / 2 : 0 ) - monsterAnimation.offset() + monsterSprite.width();
+        else
+            monsterPos.x += monsterSprite.x() - ( troop.isWide() ? CELLW / 2 : 0 ) - monsterAnimation.offset();
+
+        fheroes2::Point inPos( 0, 0 );
+        fheroes2::Point outPos( monsterPos.x, monsterPos.y );
+        fheroes2::Size inSize( monsterSprite.width(), monsterSprite.height() );
+
+        fheroes2::Display & display = fheroes2::Display::instance();
+
+        if ( fheroes2::FitToRoi( monsterSprite, inPos, display, outPos, inSize, roi ) ) {
+            fheroes2::Blit( monsterSprite, inPos, display, outPos, inSize, isReflected );
+        }
+
+        if ( isAnimated )
+            monsterAnimation.increment();
+    }
+}
 
 int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
 {
@@ -224,7 +543,6 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
 
     display.render( restorer.rect() );
 
-    // dialog menu loop
     while ( le.HandleEvents( ( flags & BUTTONS ) ? Game::isDelayNeeded( { Game::CASTLE_UNIT_DELAY } ) : true ) ) {
         if ( !( flags & BUTTONS ) ) {
             if ( !le.MousePressRight() ) {
@@ -305,331 +623,6 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
     }
 
     return result;
-}
-
-void DrawMonsterStats( const fheroes2::Point & dst, const Troop & troop )
-{
-    fheroes2::Point dst_pt;
-    Text text;
-
-    // attack
-    text.Set( std::string( _( "Attack Skill" ) ) + ":" );
-    dst_pt.x = dst.x - text.w();
-    dst_pt.y = dst.y;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    const int offsetX = 6;
-    const int offsetY = 16;
-
-    text.Set( troop.GetAttackString() );
-    dst_pt.x = dst.x + offsetX;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    // defense
-    text.Set( std::string( _( "Defense Skill" ) ) + ":" );
-    dst_pt.x = dst.x - text.w();
-    dst_pt.y += offsetY;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    text.Set( troop.GetDefenseString() );
-    dst_pt.x = dst.x + offsetX;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    // shot
-    if ( troop.isArchers() ) {
-        std::string message = troop.isBattle() ? _( "Shots Left" ) : _( "Shots" );
-        message += ':';
-        text.Set( message );
-        dst_pt.x = dst.x - text.w();
-        dst_pt.y += offsetY;
-        text.Blit( dst_pt.x, dst_pt.y );
-
-        text.Set( troop.GetShotString() );
-        dst_pt.x = dst.x + offsetX;
-        text.Blit( dst_pt.x, dst_pt.y );
-    }
-
-    // damage
-    text.Set( std::string( _( "Damage" ) ) + ":" );
-    dst_pt.x = dst.x - text.w();
-    dst_pt.y += offsetY;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    if ( troop.GetMonster().GetDamageMin() != troop.GetMonster().GetDamageMax() )
-        text.Set( std::to_string( troop.GetMonster().GetDamageMin() ) + "-" + std::to_string( troop.GetMonster().GetDamageMax() ) );
-    else
-        text.Set( std::to_string( troop.GetMonster().GetDamageMin() ) );
-    dst_pt.x = dst.x + offsetX;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    // hp
-    text.Set( std::string( _( "Hit Points" ) ) + ":" );
-    dst_pt.x = dst.x - text.w();
-    dst_pt.y += offsetY;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    text.Set( std::to_string( troop.GetMonster().GetHitPoints() ) );
-    dst_pt.x = dst.x + offsetX;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    if ( troop.isBattle() && troop.GetCount() != 0 ) {
-        text.Set( std::string( _( "Hit Points Left" ) ) + ":" );
-        dst_pt.x = dst.x - text.w();
-        dst_pt.y += offsetY;
-        text.Blit( dst_pt.x, dst_pt.y );
-
-        text.Set( std::to_string( troop.GetHitPointsLeft() ) );
-        dst_pt.x = dst.x + offsetX;
-        text.Blit( dst_pt.x, dst_pt.y );
-    }
-
-    // speed
-    text.Set( std::string( _( "Speed" ) ) + ":" );
-    dst_pt.x = dst.x - text.w();
-    dst_pt.y += offsetY;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    text.Set( troop.GetSpeedString() );
-    dst_pt.x = dst.x + offsetX;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    // morale
-    text.Set( std::string( _( "Morale" ) ) + ":" );
-    dst_pt.x = dst.x - text.w();
-    dst_pt.y += offsetY;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    text.Set( Morale::String( troop.GetMorale() ) );
-    dst_pt.x = dst.x + offsetX;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    // luck
-    text.Set( std::string( _( "Luck" ) ) + ":" );
-    dst_pt.x = dst.x - text.w();
-    dst_pt.y += offsetY;
-    text.Blit( dst_pt.x, dst_pt.y );
-
-    text.Set( Luck::String( troop.GetLuck() ) );
-    dst_pt.x = dst.x + offsetX;
-    text.Blit( dst_pt.x, dst_pt.y );
-}
-
-fheroes2::Sprite GetModesSprite( uint32_t mod )
-{
-    switch ( mod ) {
-    case Battle::SP_BLOODLUST:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 9 );
-    case Battle::SP_BLESS:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 3 );
-    case Battle::SP_HASTE:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 0 );
-    case Battle::SP_SHIELD:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 10 );
-    case Battle::SP_STONESKIN:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 13 );
-    case Battle::SP_DRAGONSLAYER:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 8 );
-    case Battle::SP_STEELSKIN:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 14 );
-    case Battle::SP_ANTIMAGIC:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 12 );
-    case Battle::SP_CURSE:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 4 );
-    case Battle::SP_SLOW:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 1 );
-    case Battle::SP_BERSERKER:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 5 );
-    case Battle::SP_HYPNOTIZE:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 7 );
-    case Battle::SP_BLIND:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 2 );
-    case Battle::SP_PARALYZE:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 6 );
-    case Battle::SP_STONE:
-        return fheroes2::AGG::GetICN( ICN::SPELLINL, 11 );
-    default:
-        break;
-    }
-
-    return fheroes2::Sprite();
-}
-
-std::vector<std::pair<fheroes2::Rect, Spell>> DrawBattleStats( const fheroes2::Point & dst, const Troop & b )
-{
-    std::vector<std::pair<fheroes2::Rect, Spell>> output;
-
-    const uint32_t modes[15] = { Battle::SP_BLOODLUST,    Battle::SP_BLESS,     Battle::SP_HASTE,     Battle::SP_SHIELD,   Battle::SP_STONESKIN,
-                                 Battle::SP_DRAGONSLAYER, Battle::SP_STEELSKIN, Battle::SP_ANTIMAGIC, Battle::SP_CURSE,    Battle::SP_SLOW,
-                                 Battle::SP_BERSERKER,    Battle::SP_HYPNOTIZE, Battle::SP_BLIND,     Battle::SP_PARALYZE, Battle::SP_STONE };
-
-    int32_t ow = 0;
-    int32_t spritesWidth = 0;
-
-    std::vector<SpellInfo> spellsInfo;
-    for ( const uint32_t mode : modes ) {
-        if ( !b.isModes( mode ) )
-            continue;
-
-        const fheroes2::Sprite & sprite = GetModesSprite( mode );
-        if ( sprite.empty() )
-            continue;
-
-        const uint32_t duration = b.GetAffectedDuration( mode );
-        int offset = 0;
-        if ( duration > 0 ) {
-            offset = duration >= 10 ? 12 : 7;
-            if ( mode >= Battle::SP_BLESS && mode <= Battle::SP_DRAGONSLAYER )
-                offset -= 5;
-        }
-        const int space = ( offset == 2 ) ? 10 : 5;
-
-        spellsInfo.emplace_back( mode, duration, offset, space );
-        ow += sprite.width() + offset + space;
-        spritesWidth += sprite.width();
-    }
-
-    if ( spellsInfo.empty() )
-        return output;
-
-    std::sort( spellsInfo.begin(), spellsInfo.end(),
-               []( const SpellInfo & first, const SpellInfo & second ) { return first.duration > 0 && first.duration < second.duration; } );
-
-    ow -= spellsInfo.back().space;
-
-    const int maxSpritesWidth = 212;
-    const int maxSpriteHeight = 32;
-
-    Text text;
-    if ( ow <= maxSpritesWidth ) {
-        ow = dst.x - ow / 2;
-        for ( const auto & spell : spellsInfo ) {
-            const fheroes2::Sprite & sprite = GetModesSprite( spell.mode );
-            const fheroes2::Point imageOffset( ow, dst.y + maxSpriteHeight - sprite.height() );
-
-            fheroes2::Blit( sprite, fheroes2::Display::instance(), imageOffset.x, imageOffset.y );
-            output.emplace_back( fheroes2::Rect( imageOffset.x, imageOffset.y, sprite.width(), sprite.height() ), modeToSpell( spell.mode ) );
-
-            if ( spell.duration > 0 ) {
-                text.Set( std::to_string( spell.duration ), Font::SMALL );
-                ow += sprite.width() + spell.offset;
-                text.Blit( ow - text.w(), dst.y + maxSpriteHeight - text.h() + 1 );
-            }
-            ow += spell.space;
-        }
-    }
-    else {
-        // Too many spells
-        const int widthDiff = maxSpritesWidth - spritesWidth;
-        int space = widthDiff / static_cast<int>( spellsInfo.size() - 1 );
-        if ( widthDiff > 0 ) {
-            if ( space > 10 )
-                space = 10;
-            ow = dst.x + ( spritesWidth + space * static_cast<int>( spellsInfo.size() - 1 ) ) / 2;
-        }
-        else {
-            ow = dst.x + maxSpritesWidth / 2;
-        }
-
-        for ( auto spellIt = spellsInfo.crbegin(); spellIt != spellsInfo.crend(); ++spellIt ) {
-            const fheroes2::Sprite & sprite = GetModesSprite( spellIt->mode );
-            const fheroes2::Point imageOffset( ow - sprite.width(), dst.y + maxSpriteHeight - sprite.height() );
-
-            fheroes2::Blit( sprite, fheroes2::Display::instance(), imageOffset.x, imageOffset.y );
-            output.emplace_back( fheroes2::Rect( imageOffset.x, imageOffset.y, sprite.width(), sprite.height() ), modeToSpell( spellIt->mode ) );
-
-            if ( spellIt->duration > 0 ) {
-                text.Set( std::to_string( spellIt->duration ), Font::SMALL );
-                text.Blit( ow - text.w(), dst.y + maxSpriteHeight - text.h() + 1 );
-            }
-            ow -= sprite.width() + space;
-        }
-    }
-
-    return output;
-}
-
-void DrawMonsterInfo( const fheroes2::Point & offset, const Troop & troop )
-{
-    // name
-    Text text( troop.GetName(), Font::YELLOW_BIG );
-    fheroes2::Point pos( offset.x + 140 - text.w() / 2, offset.y + 40 );
-    text.Blit( pos.x, pos.y );
-
-    // Description.
-    const std::vector<std::string> descriptions = fheroes2::getMonsterPropertiesDescription( troop.GetID() );
-    if ( !descriptions.empty() ) {
-        const int32_t descriptionWidth = 210;
-        const int32_t maximumRowCount = 3;
-        const int32_t rowHeight = fheroes2::Text( std::string(), fheroes2::FontType::smallWhite() ).height();
-
-        bool asSolidText = true;
-        if ( descriptions.size() <= static_cast<size_t>( maximumRowCount ) ) {
-            asSolidText = false;
-            for ( const std::string & sentence : descriptions ) {
-                if ( fheroes2::Text( sentence, fheroes2::FontType::smallWhite() ).width() > descriptionWidth ) {
-                    asSolidText = true;
-                    break;
-                }
-            }
-        }
-
-        if ( asSolidText ) {
-            std::string description;
-            for ( const std::string & sentence : descriptions ) {
-                if ( !description.empty() ) {
-                    description += ' ';
-                }
-
-                description += sentence;
-            }
-
-            const fheroes2::Text descriptionText( description, fheroes2::FontType::smallWhite() );
-            const int32_t rowCount = descriptionText.rows( descriptionWidth );
-
-            descriptionText.draw( offset.x + 37, offset.y + 185 + ( maximumRowCount - rowCount ) * rowHeight, descriptionWidth, fheroes2::Display::instance() );
-        }
-        else {
-            int32_t sentenceId = maximumRowCount - static_cast<int32_t>( descriptions.size() ); // safe to cast as we check the size before.
-            for ( const std::string & sentence : descriptions ) {
-                const fheroes2::Text descriptionText( sentence, fheroes2::FontType::smallWhite() );
-
-                descriptionText.draw( offset.x + 37, offset.y + 185 + sentenceId * rowHeight, descriptionWidth, fheroes2::Display::instance() );
-                ++sentenceId;
-            }
-        }
-    }
-
-    // amount
-    if ( troop.GetCount() != 0 ) {
-        text.Set( std::to_string( troop.GetCount() ), Font::BIG );
-        pos.x = offset.x + offsetXAmountBox + widthAmountBox / 2 - text.w() / 2;
-        pos.y = offset.y + offsetYAmountBox + heightAmountBox / 2 - text.h() / 2;
-        text.Blit( pos.x, pos.y );
-    }
-}
-
-void DrawMonster( fheroes2::RandomMonsterAnimation & monsterAnimation, const Troop & troop, const fheroes2::Point & offset, bool isReflected, bool isAnimated,
-                  const fheroes2::Rect & roi )
-{
-    const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( monsterAnimation.icnFile(), monsterAnimation.frameId() );
-    fheroes2::Point monsterPos( offset.x, offset.y + monsterSprite.y() );
-    if ( isReflected )
-        monsterPos.x -= monsterSprite.x() - ( troop.isWide() ? CELLW / 2 : 0 ) - monsterAnimation.offset() + monsterSprite.width();
-    else
-        monsterPos.x += monsterSprite.x() - ( troop.isWide() ? CELLW / 2 : 0 ) - monsterAnimation.offset();
-
-    fheroes2::Point inPos( 0, 0 );
-    fheroes2::Point outPos( monsterPos.x, monsterPos.y );
-    fheroes2::Size inSize( monsterSprite.width(), monsterSprite.height() );
-
-    fheroes2::Display & display = fheroes2::Display::instance();
-
-    if ( fheroes2::FitToRoi( monsterSprite, inPos, display, outPos, inSize, roi ) ) {
-        fheroes2::Blit( monsterSprite, inPos, display, outPos, inSize, isReflected );
-    }
-
-    if ( isAnimated )
-        monsterAnimation.increment();
 }
 
 int Dialog::ArmyJoinFree( const Troop & troop )

--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -437,13 +437,13 @@ Troop Dialog::RecruitMonster( const Monster & monster0, uint32_t available, cons
         bool skipHotKeyCheck = false;
 
         if ( le.MousePressRight( monsterArea ) ) {
-            ArmyInfo( Troop( monster, available ), READONLY );
+            ArmyInfo( Troop( monster, available ), ZERO );
 
             // Perform a full rendering to properly restore the parts of the screen outside of this dialog
             display.render();
         }
         else if ( le.MouseClickLeft( monsterArea ) ) {
-            ArmyInfo( Troop( monster, available ), READONLY | BUTTONS );
+            ArmyInfo( Troop( monster, available ), BUTTONS );
 
             skipHotKeyCheck = true;
 

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -148,7 +148,7 @@ public:
     void ActionListPressRight( int & index ) override
     {
         Troop troop( Monster( index ), 1 );
-        Dialog::ArmyInfo( troop, 0 );
+        Dialog::ArmyInfo( troop, Dialog::ZERO );
     }
 };
 


### PR DESCRIPTION
This PR fixes the following issues:

1. CPU hog when viewing quick info on a unit using the right mouse button. How to reproduce:
1.1. Open hero window or any other window where you can view quick info on the unit;
1.2. Hover the mouse over the unit, press and hold the right mouse button;
1.3. Observe the 100% CPU load in Task Manager.

2. Hero is able to upgrade troops during the battle if he is defending a castle, this castle has an upgraded dwelling and there is non-upgraded unit from that dwelling in hero's army. How to reproduce:

https://user-images.githubusercontent.com/32623900/219902090-cf8cb47f-c721-47ef-9681-30083451ede8.mp4

Also I moved all auxiliary functions in the `dialog_armyinfo.cpp` to the anonymous namespace.