### PR TITLE
MSVC: enable link-time optimization in release mode

### DIFF
--- a/VisualStudio/Release.props
+++ b/VisualStudio/Release.props
@@ -7,8 +7,11 @@
     <ClCompile>
       <Optimization>Full</Optimization>
       <FavorSizeOrSpeed>Speed</FavorSizeOrSpeed>
-      <WholeProgramOptimization>false</WholeProgramOptimization>
+      <WholeProgramOptimization>true</WholeProgramOptimization>
       <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
+    <Link>
+      <LinkTimeCodeGeneration>UseLinkTimeCodeGeneration</LinkTimeCodeGeneration>
+    </Link>
   </ItemDefinitionGroup>
 </Project>


### PR DESCRIPTION
This slows down the build somewhat in release mode, but performs various useful [optimizations](https://learn.microsoft.com/en-us/cpp/build/reference/ltcg-link-time-code-generation?view=msvc-160), including cross-module inlining.