### PR TITLE
Fix the spell id calculation for a spell scroll

### DIFF
--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -21,6 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <limits>

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -572,9 +572,13 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
 
         if ( Artifact::UNKNOWN != art ) {
             if ( art == Artifact::SPELL_SCROLL ) {
+                static_assert( std::is_same_v<decltype( quantity1 ), uint8_t> && std::is_same_v<decltype( quantity2 ), uint8_t>,
+                               "Type of quantity1 or quantity2 has been changed, check the logic below" );
+
+                int spell = ( 1 + ( quantity2 << 5 ) + ( quantity1 >> 3 ) ) & 0xFF;
+
                 QuantitySetVariant( 15 );
-                // spell from origin mp2
-                QuantitySetSpell( 1 + ( quantity2 * 256 + quantity1 ) / 8 );
+                QuantitySetSpell( spell );
             }
             else {
                 // 0: 70% none

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -237,7 +237,7 @@ void Maps::Tiles::QuantitySetResource( int res, uint32_t count )
     using Quantity1Type = decltype( quantity1 );
     using Quantity2Type = decltype( quantity2 );
     static_assert( std::is_same_v<Quantity1Type, uint8_t> && std::is_same_v<Quantity2Type, uint8_t>,
-                   "Type of quantity1 or quantity2 has been changed, check the logic below" );
+                   "Types of tile's quantities have been changed, check the logic below" );
 
     assert( res >= std::numeric_limits<Quantity1Type>::min() && res <= std::numeric_limits<Quantity1Type>::max() );
 
@@ -573,9 +573,12 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
         if ( Artifact::UNKNOWN != art ) {
             if ( art == Artifact::SPELL_SCROLL ) {
                 static_assert( std::is_same_v<decltype( quantity1 ), uint8_t> && std::is_same_v<decltype( quantity2 ), uint8_t>,
-                               "Type of quantity1 or quantity2 has been changed, check the logic below" );
+                               "Types of tile's quantities have been changed, check the bitwise arithmetic below" );
+                static_assert( Spell::FIREBALL < Spell::SETWGUARDIAN, "The order of spell IDs has been changed, check the logic below" );
 
-                const int spell = ( 1 + ( quantity2 << 5 ) + ( quantity1 >> 3 ) ) & 0xFF;
+                // Spell id of a spell scroll is represented by 2 low-order bits of quantity2 and 5 high-order bits of quantity1 plus one, and cannot be random
+                const int spell
+                    = std::clamp( ( ( quantity2 & 0x03 ) << 5 ) + ( quantity1 >> 3 ) + 1, static_cast<int>( Spell::FIREBALL ), static_cast<int>( Spell::SETWGUARDIAN ) );
 
                 QuantitySetVariant( 15 );
                 QuantitySetSpell( spell );

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -575,7 +575,7 @@ void Maps::Tiles::QuantityUpdate( bool isFirstLoad )
                 static_assert( std::is_same_v<decltype( quantity1 ), uint8_t> && std::is_same_v<decltype( quantity2 ), uint8_t>,
                                "Type of quantity1 or quantity2 has been changed, check the logic below" );
 
-                int spell = ( 1 + ( quantity2 << 5 ) + ( quantity1 >> 3 ) ) & 0xFF;
+                const int spell = ( 1 + ( quantity2 << 5 ) + ( quantity1 >> 3 ) ) & 0xFF;
 
                 QuantitySetVariant( 15 );
                 QuantitySetSpell( spell );


### PR DESCRIPTION
fix #6676

Previously, the spell id of a spell scroll was not truncated to its lower 8 bits while loading it from MP2 and therefore may have invalid values, which is wrong. This now has been caught by an assertion.