### PR TITLE
Speed up the creation of a file list in Windows

### DIFF
--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -70,24 +70,24 @@ namespace
 
         const std::string pattern( nameAsFilter ? path + "\\*" + name : path + "\\" + name );
         WIN32_FIND_DATA data;
-        HANDLE hFind = FindFirstFile( pattern.c_str(), &data );
+
+        HANDLE hFind = FindFirstFileEx( pattern.c_str(), FindExInfoBasic, &data, FindExSearchNameMatch, nullptr, FIND_FIRST_EX_LARGE_FETCH );
         if ( hFind == INVALID_HANDLE_VALUE ) {
             return;
         }
 
         do {
+            // Ignore any internal directories
             if ( data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY ) {
-                // Ignore any internal directories.
                 continue;
             }
 
-            std::string fullname = System::concatPath( path, data.cFileName );
-
-            // FindFirstFile() searches for both long and short variants of names, so we need additional filtering
-            if ( filterByName( data.cFileName, nameAsFilter, name, _stricmp ) )
+            // FindFirstFileEx() searches for both long and short variants of names, so we need additional filtering
+            if ( filterByName( data.cFileName, nameAsFilter, name, _stricmp ) ) {
                 continue;
+            }
 
-            files.emplace_back( std::move( fullname ) );
+            files.emplace_back( System::concatPath( path, data.cFileName ) );
         } while ( FindNextFile( hFind, &data ) != 0 );
 
         FindClose( hFind );


### PR DESCRIPTION
Use `FindFirstFileEx()` with accelerating flags instead of old `FindFirstFile()`. However, there is unlikely to be a strong accelerating effect in the case of map files (especially at the first run), because we need to open each map file separately to read its header. This operation is instant on my Windows (on SSD and even on 7200RPM HDD) as well as on macOS and Ubuntu (running in VM), but on configurations with a slower HDD, it still can take time.