### PR TITLE
Make tiles with allied heroes or castles inaccessible at the pathfinder level

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -261,6 +261,7 @@ namespace
     {
         Castle * castle = world.getCastleEntrance( Maps::GetPoint( dstIndex ) );
         if ( castle == nullptr ) {
+            // This should never happen
             assert( 0 );
 
             DEBUG_LOG( DBG_AI, DBG_WARN,
@@ -280,6 +281,7 @@ namespace
         }
 
         if ( hero.isFriends( castle->GetColor() ) ) {
+            // This should never happen - hero should not be able to visit an allied castle
             assert( 0 );
 
             DEBUG_LOG( DBG_AI, DBG_WARN, hero.GetName() << " could not visit the allied castle " << castle->GetName() )
@@ -350,6 +352,7 @@ namespace
     {
         Heroes * otherHero = world.GetTiles( dstIndex ).GetHeroes();
         if ( otherHero == nullptr ) {
+            // This should never happen
             assert( 0 );
 
             DEBUG_LOG( DBG_AI, DBG_WARN, hero.GetName() << " is trying to meet the hero on tile " << dstIndex << ", but there is no hero on this tile" )
@@ -365,6 +368,7 @@ namespace
         }
 
         if ( hero.isFriends( otherHero->GetColor() ) ) {
+            // This should never happen - hero should not be able to meet an allied hero
             assert( 0 );
 
             DEBUG_LOG( DBG_AI, DBG_WARN, hero.GetName() << " could not meet the allied hero " << otherHero->GetName() )

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -284,7 +284,7 @@ namespace
             // This should never happen - hero should not be able to visit an allied castle
             assert( 0 );
 
-            DEBUG_LOG( DBG_AI, DBG_WARN, hero.GetName() << " could not visit the allied castle " << castle->GetName() )
+            DEBUG_LOG( DBG_AI, DBG_WARN, hero.GetName() << " is not allowed to visit the allied castle " << castle->GetName() )
             return;
         }
 
@@ -371,7 +371,7 @@ namespace
             // This should never happen - hero should not be able to meet an allied hero
             assert( 0 );
 
-            DEBUG_LOG( DBG_AI, DBG_WARN, hero.GetName() << " could not meet the allied hero " << otherHero->GetName() )
+            DEBUG_LOG( DBG_AI, DBG_WARN, hero.GetName() << " is not allowed to meet the allied hero " << otherHero->GetName() )
             return;
         }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1136,13 +1136,13 @@ uint32_t Heroes::GetExperienceFromLevel( int lvl )
     return ( l1 + static_cast<uint32_t>( round( ( l1 - GetExperienceFromLevel( lvl - 2 ) ) * 1.2 / 100 ) * 100 ) );
 }
 
-/* buy book */
-bool Heroes::BuySpellBook( const Castle * castle, int shrine )
+bool Heroes::BuySpellBook( const Castle * castle )
 {
-    if ( HaveSpellBook() || Color::NONE == GetColor() )
+    if ( HaveSpellBook() || Color::NONE == GetColor() ) {
         return false;
+    }
 
-    const payment_t payment = PaymentConditions::BuySpellBook( shrine );
+    const payment_t payment = PaymentConditions::BuySpellBook();
     Kingdom & kingdom = GetKingdom();
 
     std::string header = _( "To cast spells, you must first buy a spell book for %{gold} gold." );
@@ -1175,9 +1175,9 @@ bool Heroes::BuySpellBook( const Castle * castle, int shrine )
     if ( SpellBookActivate() ) {
         kingdom.OddFundsResource( payment );
 
-        // add all spell to book
-        if ( castle )
+        if ( castle ) {
             castle->MageGuildEducateHero( *this );
+        }
 
         return true;
     }
@@ -1185,7 +1185,6 @@ bool Heroes::BuySpellBook( const Castle * castle, int shrine )
     return false;
 }
 
-/* return true is move enable */
 bool Heroes::isMoveEnabled() const
 {
     return Modes( ENABLEMOVE ) && path.isValid() && path.hasAllowedSteps();
@@ -1197,7 +1196,6 @@ bool Heroes::CanMove() const
     return move_point >= ( tile.isRoad() ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, GetLevelSkill( Skill::Secondary::PATHFINDING ) ) );
 }
 
-/* set enable move */
 void Heroes::SetMove( bool f )
 {
     if ( f ) {

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -395,7 +395,7 @@ public:
     void ActionAfterBattle() override;
     void ActionPreBattle() override;
 
-    bool BuySpellBook( const Castle *, int shrine = 0 );
+    bool BuySpellBook( const Castle * castle );
 
     const Route::Path & GetPath() const
     {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -383,129 +383,161 @@ namespace
         hero.SetAttackedMonsterTileIndex( -1 );
     }
 
-    void ActionToCastle( Heroes & hero, int32_t dst_index )
+    void ActionToCastle( Heroes & hero, const int32_t dstIndex )
     {
-        Castle * castle = world.getCastleEntrance( Maps::GetPoint( dst_index ) );
+        Castle * castle = world.getCastleEntrance( Maps::GetPoint( dstIndex ) );
+        if ( castle == nullptr ) {
+            assert( 0 );
 
-        if ( !castle ) {
-            DEBUG_LOG( DBG_GAME, DBG_INFO, "castle not found " << dst_index )
+            DEBUG_LOG( DBG_GAME, DBG_WARN,
+                       hero.GetName() << " is trying to visit the castle on tile " << dstIndex << ", but there is no entrance to the castle on this tile" )
+            return;
         }
-        else if ( hero.GetColor() == castle->GetColor() ) {
-            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " goto castle " << castle->GetName() )
+
+        if ( hero.GetColor() == castle->GetColor() ) {
+            assert( hero.GetIndex() == dstIndex );
+
+            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " visits " << castle->GetName() )
+
             castle->MageGuildEducateHero( hero );
             Game::OpenCastleDialog( *castle );
+
+            return;
         }
-        else if ( hero.isFriends( castle->GetColor() ) ) {
-            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " disable visiting" )
+
+        if ( hero.isFriends( castle->GetColor() ) ) {
+            assert( 0 );
+
+            DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " could not visit the allied castle " << castle->GetName() )
+            return;
         }
-        else {
-            Army & army = castle->GetActualArmy();
 
-            auto captureCastle = [&hero, dst_index, castle]() {
-                Kingdom & enemyKingdom = castle->GetKingdom();
-                enemyKingdom.RemoveCastle( castle );
-                hero.GetKingdom().AddCastle( castle );
-                world.CaptureObject( dst_index, hero.GetColor() );
+        auto captureCastle = [&hero, dstIndex, castle]() {
+            Kingdom & enemyKingdom = castle->GetKingdom();
+            enemyKingdom.RemoveCastle( castle );
+            hero.GetKingdom().AddCastle( castle );
+            world.CaptureObject( dstIndex, hero.GetColor() );
 
-                castle->Scoute();
+            castle->Scoute();
 
-                Interface::Basic & I = Interface::Basic::Get();
+            Interface::Basic & I = Interface::Basic::Get();
 
-                // If the enemy is not vanquished we update only the area around the castle on radar.
-                if ( !enemyKingdom.isLoss() ) {
-                    const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::CASTLE ) );
-                    const fheroes2::Point castlePosition = Maps::GetPoint( dst_index );
+            // If the enemy is not vanquished we update only the area around the castle on radar.
+            if ( !enemyKingdom.isLoss() ) {
+                const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::CASTLE ) );
+                const fheroes2::Point castlePosition = Maps::GetPoint( dstIndex );
 
-                    I.GetRadar().SetRenderArea( { castlePosition.x - scoutRange, castlePosition.y - scoutRange, 2 * scoutRange + 1, 2 * scoutRange + 1 } );
-                }
-                // Otherwise we fully redraw the radar map image as there might be color reset of enemy's objects.
-                I.SetRedraw( Interface::REDRAW_CASTLES | Interface::REDRAW_RADAR );
-            };
-
-            if ( army.isValid() && army.GetColor() != hero.GetColor() ) {
-                DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attack enemy castle " << castle->GetName() )
-
-                Heroes * defender = castle->GetHero();
-                castle->ActionPreBattle();
-
-                // new battle
-                const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
-
-                castle->ActionAfterBattle( res.AttackerWins() );
-
-                // loss defender
-                if ( !res.DefenderWins() && defender )
-                    BattleLose( *defender, res, false );
-
-                // loss attacker
-                if ( !res.AttackerWins() )
-                    BattleLose( hero, res, true );
-
-                // wins attacker
-                if ( res.AttackerWins() ) {
-                    captureCastle();
-
-                    hero.IncreaseExperience( res.GetExperienceAttacker() );
-                }
-                // wins defender
-                else if ( res.DefenderWins() && defender ) {
-                    defender->IncreaseExperience( res.GetExperienceDefender() );
-                }
+                I.GetRadar().SetRenderArea( { castlePosition.x - scoutRange, castlePosition.y - scoutRange, 2 * scoutRange + 1, 2 * scoutRange + 1 } );
             }
-            else {
-                DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " capture enemy castle " << castle->GetName() )
+            // Otherwise we fully redraw the radar map image as there might be color reset of enemy's objects.
+            I.SetRedraw( Interface::REDRAW_CASTLES | Interface::REDRAW_RADAR );
+        };
 
+        Army & army = castle->GetActualArmy();
+
+        // Hero is standing in front of the castle, which means that there must be an enemy army in the castle
+        if ( hero.GetIndex() != dstIndex ) {
+            assert( army.isValid() && army.GetColor() != hero.GetColor() );
+
+            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attacks the enemy castle " << castle->GetName() )
+
+            Heroes * defender = castle->GetHero();
+
+            castle->ActionPreBattle();
+
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dstIndex );
+
+            castle->ActionAfterBattle( res.AttackerWins() );
+
+            // The defender was defeated
+            if ( !res.DefenderWins() && defender ) {
+                BattleLose( *defender, res, false );
+            }
+
+            // The attacker was defeated
+            if ( !res.AttackerWins() ) {
+                BattleLose( hero, res, true );
+            }
+
+            // The attacker won
+            if ( res.AttackerWins() ) {
                 captureCastle();
 
-                castle->MageGuildEducateHero( hero );
-                Game::OpenCastleDialog( *castle );
-            }
-        }
-    }
-
-    void ActionToHeroes( Heroes & hero, int32_t dst_index )
-    {
-        Heroes * other_hero = world.GetTiles( dst_index ).GetHeroes();
-
-        if ( !other_hero )
-            return;
-
-        if ( hero.GetColor() == other_hero->GetColor() ) {
-            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " meeting " << other_hero->GetName() )
-            hero.MeetingDialog( *other_hero );
-        }
-        else if ( hero.isFriends( other_hero->GetColor() ) ) {
-            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " disable meeting" )
-        }
-        else {
-            if ( other_hero->inCastle() ) {
-                ActionToCastle( hero, dst_index );
-                return;
-            }
-
-            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attack enemy hero " << other_hero->GetName() )
-
-            // new battle
-            Battle::Result res = Battle::Loader( hero.GetArmy(), other_hero->GetArmy(), dst_index );
-
-            // TODO: make fading animation of both heroes together.
-
-            // loss defender
-            if ( !res.DefenderWins() )
-                BattleLose( *other_hero, res, false );
-
-            // loss attacker
-            if ( !res.AttackerWins() )
-                BattleLose( hero, res, true );
-
-            // wins attacker
-            if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
             }
-            // wins defender
-            else if ( res.DefenderWins() ) {
-                other_hero->IncreaseExperience( res.GetExperienceDefender() );
+            // The defender won
+            else if ( res.DefenderWins() && defender ) {
+                defender->IncreaseExperience( res.GetExperienceDefender() );
             }
+
+            return;
+        }
+
+        // If hero is already in the castle, then there must be his own army in the castle
+        assert( army.isValid() && army.GetColor() == hero.GetColor() );
+
+        DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " captures the enemy castle " << castle->GetName() )
+
+        captureCastle();
+
+        castle->MageGuildEducateHero( hero );
+        Game::OpenCastleDialog( *castle );
+    }
+
+    void ActionToHeroes( Heroes & hero, const int32_t dstIndex )
+    {
+        Heroes * otherHero = world.GetTiles( dstIndex ).GetHeroes();
+        if ( otherHero == nullptr ) {
+            assert( 0 );
+
+            DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " is trying to meet the hero on tile " << dstIndex << ", but there is no hero on this tile" )
+            return;
+        }
+
+        if ( hero.GetColor() == otherHero->GetColor() ) {
+            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " meets " << otherHero->GetName() )
+
+            hero.MeetingDialog( *otherHero );
+
+            return;
+        }
+
+        if ( hero.isFriends( otherHero->GetColor() ) ) {
+            assert( 0 );
+
+            DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " could not meet the allied hero " << otherHero->GetName() )
+            return;
+        }
+
+        if ( otherHero->inCastle() ) {
+            ActionToCastle( hero, dstIndex );
+
+            return;
+        }
+
+        DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attacks " << otherHero->GetName() )
+
+        Battle::Result res = Battle::Loader( hero.GetArmy(), otherHero->GetArmy(), dstIndex );
+
+        // TODO: make fading animation of both heroes together.
+
+        // The defender was defeated
+        if ( !res.DefenderWins() ) {
+            BattleLose( *otherHero, res, false );
+        }
+
+        // The attacker was defeated
+        if ( !res.AttackerWins() ) {
+            BattleLose( hero, res, true );
+        }
+
+        // The attacker won
+        if ( res.AttackerWins() ) {
+            hero.IncreaseExperience( res.GetExperienceAttacker() );
+        }
+        // The defender won
+        else if ( res.DefenderWins() ) {
+            otherHero->IncreaseExperience( res.GetExperienceDefender() );
         }
     }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -387,6 +387,7 @@ namespace
     {
         Castle * castle = world.getCastleEntrance( Maps::GetPoint( dstIndex ) );
         if ( castle == nullptr ) {
+            // This should never happen
             assert( 0 );
 
             DEBUG_LOG( DBG_GAME, DBG_WARN,
@@ -406,6 +407,7 @@ namespace
         }
 
         if ( hero.isFriends( castle->GetColor() ) ) {
+            // This should never happen - hero should not be able to visit an allied castle
             assert( 0 );
 
             DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " could not visit the allied castle " << castle->GetName() )
@@ -488,6 +490,7 @@ namespace
     {
         Heroes * otherHero = world.GetTiles( dstIndex ).GetHeroes();
         if ( otherHero == nullptr ) {
+            // This should never happen
             assert( 0 );
 
             DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " is trying to meet the hero on tile " << dstIndex << ", but there is no hero on this tile" )
@@ -503,6 +506,7 @@ namespace
         }
 
         if ( hero.isFriends( otherHero->GetColor() ) ) {
+            // This should never happen - hero should not be able to meet an allied hero
             assert( 0 );
 
             DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " could not meet the allied hero " << otherHero->GetName() )

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -410,7 +410,7 @@ namespace
             // This should never happen - hero should not be able to visit an allied castle
             assert( 0 );
 
-            DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " could not visit the allied castle " << castle->GetName() )
+            DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " is not allowed to visit the allied castle " << castle->GetName() )
             return;
         }
 
@@ -509,7 +509,7 @@ namespace
             // This should never happen - hero should not be able to meet an allied hero
             assert( 0 );
 
-            DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " could not meet the allied hero " << otherHero->GetName() )
+            DEBUG_LOG( DBG_GAME, DBG_WARN, hero.GetName() << " is not allowed to meet the allied hero " << otherHero->GetName() )
             return;
         }
 

--- a/src/fheroes2/kingdom/payment.cpp
+++ b/src/fheroes2/kingdom/payment.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -34,19 +34,8 @@ payment_t PaymentConditions::BuyBoat()
     return payment_t( cost_t{ 1000, 10, 0, 0, 0, 0, 0 } );
 }
 
-payment_t PaymentConditions::BuySpellBook( int shrine )
+payment_t PaymentConditions::BuySpellBook()
 {
-    switch ( shrine ) {
-    case 1:
-        return payment_t( cost_t{ 1250, 0, 0, 0, 0, 0, 0 } );
-    case 2:
-        return payment_t( cost_t{ 1000, 0, 0, 0, 0, 0, 0 } );
-    case 3:
-        return payment_t( cost_t{ 750, 0, 0, 0, 0, 0, 0 } );
-    default:
-        break;
-    }
-
     return payment_t( cost_t{ 500, 0, 0, 0, 0, 0, 0 } );
 }
 

--- a/src/fheroes2/kingdom/payment.h
+++ b/src/fheroes2/kingdom/payment.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -34,7 +34,7 @@ namespace PaymentConditions
 {
     payment_t BuyBuilding( int race, uint32_t build );
     payment_t BuyBoat();
-    payment_t BuySpellBook( int shrine = 0 );
+    payment_t BuySpellBook();
     payment_t RecruitHero();
     payment_t ForAlchemist();
 }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1697,6 +1697,25 @@ bool Maps::Tiles::isPassableFrom( const int direction, const bool fromWater, con
         return false;
     }
 
+    // Tiles on which allied heroes are located are inaccessible
+    if ( _mainObjectType == MP2::OBJ_HEROES ) {
+        const Heroes * hero = GetHeroes();
+        assert( hero != nullptr );
+
+        if ( hero->GetColor() != heroColor && hero->isFriends( heroColor ) ) {
+            return false;
+        }
+    }
+
+    // Tiles on which the entrances to the allied castles are located are inaccessible
+    if ( _mainObjectType == MP2::OBJ_CASTLE ) {
+        const Castle * castle = world.getCastleEntrance( GetCenter() );
+
+        if ( castle && castle->GetColor() != heroColor && castle->isFriends( heroColor ) ) {
+            return false;
+        }
+    }
+
     return ( direction & tilePassable ) != 0;
 }
 


### PR DESCRIPTION
fix #6685

Currently, these tiles are inaccessible "at the logical level", i.e. they cannot be chosen as a destination by a human player or AI. However, if they were already chosen before they become occupied by an ally, adventure map pathfinder has no idea that something is wrong and doesn't recalculate the path.