### PR TITLE
Render background between HEROES and TOWSN/CASTLES buttons in Kingdom Overview window

### DIFF
--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -727,7 +727,7 @@ void Kingdom::openOverviewDialog()
     dst_pt.y = cur_pt.y + 360;
     fheroes2::Button buttonHeroes( dst_pt.x, dst_pt.y, ICN::OVERVIEW, 0, 1 );
 
-    // We need to additionally render the background between HEROES and TOWSN/CASTLES buttons.
+    // We need to additionally render the background between HEROES and TOWNS/CASTLES buttons.
     dst_pt.y += 42;
     fheroes2::Copy( fheroes2::AGG::GetICN( ICN::OVERBACK, 0 ), 540, 444, display, dst_pt.x, dst_pt.y, 99, 5 );
 

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -727,11 +727,13 @@ void Kingdom::openOverviewDialog()
     dst_pt.y = cur_pt.y + 360;
     fheroes2::Button buttonHeroes( dst_pt.x, dst_pt.y, ICN::OVERVIEW, 0, 1 );
 
-    dst_pt.x = cur_pt.x + 540;
+    // We need to additionally render the background between HEROES and TOWSN/CASTLES buttons.
+    dst_pt.y += 42;
+    fheroes2::Copy( fheroes2::AGG::GetICN( ICN::OVERBACK, 0 ), 540, 444, display, dst_pt.x, dst_pt.y, 99, 5 );
+
     dst_pt.y = cur_pt.y + 405;
     fheroes2::Button buttonCastle( dst_pt.x, dst_pt.y, ICN::OVERVIEW, 2, 3 );
 
-    dst_pt.x = cur_pt.x + 540;
     dst_pt.y = cur_pt.y + 453;
     fheroes2::Button buttonExit( dst_pt.x, dst_pt.y, ICN::BUTTON_KINGDOM_EXIT, 0, 1 );
 


### PR DESCRIPTION
fix #6699 

![k_overview](https://user-images.githubusercontent.com/113276641/220923615-8d90c0fa-85ad-49e0-b718-96bd3d547bcf.png)
