### PR TITLE
Adjust recruitment window position on castle well and kingdom overview

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -178,6 +178,7 @@ ArmyBar::ArmyBar( Army * ptr, bool mini, bool ro, bool change /* false */ )
     , use_mini_sprite( mini )
     , read_only( ro )
     , can_change( change )
+    , troopInfoWindowOffsetY(0)
 {
     if ( use_mini_sprite )
         SetBackground( { 43, 43 }, fheroes2::GetColorId( 0, 45, 0 ) );
@@ -207,6 +208,10 @@ void ArmyBar::SetArmy( Army * ptr )
     }
 
     SetContentItems();
+}
+
+void ArmyBar::setTroopWindowOffsetY(int32_t offsetY) {
+    troopInfoWindowOffsetY = offsetY;
 }
 
 bool ArmyBar::isValid() const
@@ -551,7 +556,7 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
             }
         }
 
-        switch ( Dialog::ArmyInfo( troop, flags, false, -60 ) ) {
+        switch ( Dialog::ArmyInfo( troop, flags, false, troopInfoWindowOffsetY ) ) {
         case Dialog::UPGRADE:
             world.GetKingdom( _army->GetColor() ).OddFundsResource( troop.GetTotalUpgradeCost() );
             troop.Upgrade();
@@ -618,7 +623,7 @@ bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
             troop.Reset();
         }
         else {
-            Dialog::ArmyInfo( troop, Dialog::ZERO, false, -60 );
+            Dialog::ArmyInfo( troop, Dialog::ZERO, false, troopInfoWindowOffsetY );
         }
     }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -178,7 +178,7 @@ ArmyBar::ArmyBar( Army * ptr, bool mini, bool ro, bool change /* false */ )
     , use_mini_sprite( mini )
     , read_only( ro )
     , can_change( change )
-    , troopInfoWindowOffsetY(0)
+    , troopInfoWindowOffsetY( 0 )
 {
     if ( use_mini_sprite )
         SetBackground( { 43, 43 }, fheroes2::GetColorId( 0, 45, 0 ) );
@@ -210,7 +210,8 @@ void ArmyBar::SetArmy( Army * ptr )
     SetContentItems();
 }
 
-void ArmyBar::setTroopWindowOffsetY(int32_t offsetY) {
+void ArmyBar::setTroopWindowOffsetY( int32_t offsetY )
+{
     troopInfoWindowOffsetY = offsetY;
 }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -178,7 +178,7 @@ ArmyBar::ArmyBar( Army * ptr, bool mini, bool ro, bool change /* false */ )
     , use_mini_sprite( mini )
     , read_only( ro )
     , can_change( change )
-    , troopWindowOffsetY( 0 )
+    , _troopWindowOffsetY( 0 )
 {
     if ( use_mini_sprite )
         SetBackground( { 43, 43 }, fheroes2::GetColorId( 0, 45, 0 ) );
@@ -208,11 +208,6 @@ void ArmyBar::SetArmy( Army * ptr )
     }
 
     SetContentItems();
-}
-
-void ArmyBar::setTroopWindowOffsetY( int32_t offsetY )
-{
-    troopWindowOffsetY = offsetY;
 }
 
 bool ArmyBar::isValid() const
@@ -557,7 +552,7 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
             }
         }
 
-        switch ( Dialog::ArmyInfo( troop, flags, false, troopWindowOffsetY ) ) {
+        switch ( Dialog::ArmyInfo( troop, flags, false, _troopWindowOffsetY ) ) {
         case Dialog::UPGRADE:
             world.GetKingdom( _army->GetColor() ).OddFundsResource( troop.GetTotalUpgradeCost() );
             troop.Upgrade();
@@ -624,7 +619,7 @@ bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
             troop.Reset();
         }
         else {
-            Dialog::ArmyInfo( troop, Dialog::ZERO, false, troopWindowOffsetY );
+            Dialog::ArmyInfo( troop, Dialog::ZERO, false, _troopWindowOffsetY );
         }
     }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -551,7 +551,7 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
             }
         }
 
-        switch ( Dialog::ArmyInfo( troop, flags ) ) {
+        switch ( Dialog::ArmyInfo( troop, flags, false, -60 ) ) {
         case Dialog::UPGRADE:
             world.GetKingdom( _army->GetColor() ).OddFundsResource( troop.GetTotalUpgradeCost() );
             troop.Upgrade();
@@ -618,7 +618,7 @@ bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
             troop.Reset();
         }
         else {
-            Dialog::ArmyInfo( troop, Dialog::ZERO );
+            Dialog::ArmyInfo( troop, Dialog::ZERO, false, -60 );
         }
     }
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -178,7 +178,7 @@ ArmyBar::ArmyBar( Army * ptr, bool mini, bool ro, bool change /* false */ )
     , use_mini_sprite( mini )
     , read_only( ro )
     , can_change( change )
-    , troopInfoWindowOffsetY( 0 )
+    , troopWindowOffsetY( 0 )
 {
     if ( use_mini_sprite )
         SetBackground( { 43, 43 }, fheroes2::GetColorId( 0, 45, 0 ) );
@@ -212,7 +212,7 @@ void ArmyBar::SetArmy( Army * ptr )
 
 void ArmyBar::setTroopWindowOffsetY( int32_t offsetY )
 {
-    troopInfoWindowOffsetY = offsetY;
+    troopWindowOffsetY = offsetY;
 }
 
 bool ArmyBar::isValid() const
@@ -557,7 +557,7 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
             }
         }
 
-        switch ( Dialog::ArmyInfo( troop, flags, false, troopInfoWindowOffsetY ) ) {
+        switch ( Dialog::ArmyInfo( troop, flags, false, troopWindowOffsetY ) ) {
         case Dialog::UPGRADE:
             world.GetKingdom( _army->GetColor() ).OddFundsResource( troop.GetTotalUpgradeCost() );
             troop.Upgrade();
@@ -624,7 +624,7 @@ bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
             troop.Reset();
         }
         else {
-            Dialog::ArmyInfo( troop, Dialog::ZERO, false, troopInfoWindowOffsetY );
+            Dialog::ArmyInfo( troop, Dialog::ZERO, false, troopWindowOffsetY );
         }
     }
 

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -49,7 +49,10 @@ public:
     void SetBackground( const fheroes2::Size & sz, const uint8_t fillColor );
     void SetArmy( Army * );
 
-    void setTroopWindowOffsetY( int32_t offsetY );
+    void setTroopWindowOffsetY( const int32_t offsetY )
+    {
+        _troopWindowOffsetY = offsetY;
+    }
 
     bool isValid() const;
 
@@ -83,7 +86,7 @@ private:
     bool read_only;
     bool can_change;
     std::string msg;
-    int32_t troopWindowOffsetY;
+    int32_t _troopWindowOffsetY;
 };
 
 #endif

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -49,6 +49,8 @@ public:
     void SetBackground( const fheroes2::Size & sz, const uint8_t fillColor );
     void SetArmy( Army * );
 
+    void setTroopWindowOffsetY(int32_t offsetY);
+
     bool isValid() const;
 
     void ResetSelected();
@@ -81,6 +83,7 @@ private:
     bool read_only;
     bool can_change;
     std::string msg;
+    int32_t troopInfoWindowOffsetY;
 };
 
 #endif

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -83,7 +83,7 @@ private:
     bool read_only;
     bool can_change;
     std::string msg;
-    int32_t troopInfoWindowOffsetY;
+    int32_t troopWindowOffsetY;
 };
 
 #endif

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -49,7 +49,7 @@ public:
     void SetBackground( const fheroes2::Size & sz, const uint8_t fillColor );
     void SetArmy( Army * );
 
-    void setTroopWindowOffsetY(int32_t offsetY);
+    void setTroopWindowOffsetY( int32_t offsetY );
 
     bool isValid() const;
 

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -21,13 +21,14 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "buildinginfo.h"
+
 #include <algorithm>
 #include <cassert>
 
 #include "agg_image.h"
 #include "army_troop.h"
 #include "audio_manager.h"
-#include "buildinginfo.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "game_hotkeys.h"

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -732,7 +732,7 @@ void DwellingsBar::RedrawItem( DwellingItem & dwl, const fheroes2::Rect & pos, f
 bool DwellingsBar::ActionBarLeftMouseSingleClick( DwellingItem & dwl )
 {
     if ( castle.isBuild( dwl.type ) ) {
-        castle.RecruitMonster( Dialog::RecruitMonster( dwl.mons, castle.getMonstersInDwelling( dwl.type ), true, 0 ) );
+        castle.RecruitMonster( Dialog::RecruitMonster( dwl.mons, castle.getMonstersInDwelling( dwl.type ), true, -60 ) );
     }
     else if ( !castle.isBuild( BUILD_CASTLE ) )
         Dialog::Message( "", GetBuildConditionDescription( NEED_CASTLE ), Font::BIG, Dialog::OK );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -257,7 +257,7 @@ void Castle::OpenWell()
             recruitCastleMax( currentArmy, allDwellings );
         }
         else if ( ( building & DWELLING_MONSTER1 ) && ( le.MouseClickLeft( rectMonster1 ) || pressedHotkeyBuildingID == DWELLING_MONSTER1 ) )
-            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER1 ) }, dwelling[0], true, 2) );
+            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER1 ) }, dwelling[0], true, 2 ) );
         else if ( ( building & DWELLING_MONSTER2 ) && ( le.MouseClickLeft( rectMonster2 ) || pressedHotkeyBuildingID == DWELLING_MONSTER2 ) )
             RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER2 ) }, dwelling[1], true, 2 ) );
         else if ( ( building & DWELLING_MONSTER3 ) && ( le.MouseClickLeft( rectMonster3 ) || pressedHotkeyBuildingID == DWELLING_MONSTER3 ) )

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -257,17 +257,17 @@ void Castle::OpenWell()
             recruitCastleMax( currentArmy, allDwellings );
         }
         else if ( ( building & DWELLING_MONSTER1 ) && ( le.MouseClickLeft( rectMonster1 ) || pressedHotkeyBuildingID == DWELLING_MONSTER1 ) )
-            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER1 ) }, dwelling[0], true, 0 ) );
+            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER1 ) }, dwelling[0], true, 2) );
         else if ( ( building & DWELLING_MONSTER2 ) && ( le.MouseClickLeft( rectMonster2 ) || pressedHotkeyBuildingID == DWELLING_MONSTER2 ) )
-            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER2 ) }, dwelling[1], true, 0 ) );
+            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER2 ) }, dwelling[1], true, 2 ) );
         else if ( ( building & DWELLING_MONSTER3 ) && ( le.MouseClickLeft( rectMonster3 ) || pressedHotkeyBuildingID == DWELLING_MONSTER3 ) )
-            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER3 ) }, dwelling[2], true, 0 ) );
+            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER3 ) }, dwelling[2], true, 2 ) );
         else if ( ( building & DWELLING_MONSTER4 ) && ( le.MouseClickLeft( rectMonster4 ) || pressedHotkeyBuildingID == DWELLING_MONSTER4 ) )
-            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER4 ) }, dwelling[3], true, 0 ) );
+            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER4 ) }, dwelling[3], true, 2 ) );
         else if ( ( building & DWELLING_MONSTER5 ) && ( le.MouseClickLeft( rectMonster5 ) || pressedHotkeyBuildingID == DWELLING_MONSTER5 ) )
-            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER5 ) }, dwelling[4], true, 0 ) );
+            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER5 ) }, dwelling[4], true, 2 ) );
         else if ( ( building & DWELLING_MONSTER6 ) && ( le.MouseClickLeft( rectMonster6 ) || pressedHotkeyBuildingID == DWELLING_MONSTER6 ) )
-            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER6 ) }, dwelling[5], true, 0 ) );
+            RecruitMonster( Dialog::RecruitMonster( { race, GetActualDwelling( DWELLING_MONSTER6 ) }, dwelling[5], true, 2 ) );
         else if ( ( building & DWELLING_MONSTER1 ) && le.MousePressRight( rectMonster1 ) )
             Dialog::DwellingInfo( { race, GetActualDwelling( DWELLING_MONSTER1 ) }, dwelling[0] );
         else if ( ( building & DWELLING_MONSTER2 ) && le.MousePressRight( rectMonster2 ) )

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -100,7 +100,7 @@ namespace Dialog
     bool InputString( const std::string & header, std::string & result, const std::string & title = std::string(), const size_t charLimit = 0 );
     Troop RecruitMonster( const Monster & monster0, uint32_t available, const bool allowDowngradedMonster, const int32_t windowOffsetY );
     void DwellingInfo( const Monster &, uint32_t available );
-    int ArmyInfo( const Troop & troop, int flags, bool isReflected = false );
+    int ArmyInfo( const Troop & troop, int flags, bool isReflected = false, int32_t windowOffsetY = 0 );
     int ArmyJoinFree( const Troop & troop );
     int ArmyJoinWithCost( const Troop &, const uint32_t join, const uint32_t gold );
     int ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, uint32_t & redistributeCount, bool & useFastSplit );

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -100,7 +100,7 @@ namespace Dialog
     bool InputString( const std::string & header, std::string & result, const std::string & title = std::string(), const size_t charLimit = 0 );
     Troop RecruitMonster( const Monster & monster0, uint32_t available, const bool allowDowngradedMonster, const int32_t windowOffsetY );
     void DwellingInfo( const Monster &, uint32_t available );
-    int ArmyInfo( const Troop & troop, int flags, bool isReflected = false, int32_t windowOffsetY = 0 );
+    int ArmyInfo( const Troop & troop, int flags, bool isReflected = false, const int32_t windowOffsetY = 0 );
     int ArmyJoinFree( const Troop & troop );
     int ArmyJoinWithCost( const Troop &, const uint32_t join, const uint32_t gold );
     int ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, uint32_t & redistributeCount, bool & useFastSplit );

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -450,7 +450,7 @@ namespace
     }
 }
 
-int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
+int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const int32_t windowOffsetY )
 {
     // Unit cannot be dismissed or upgraded during combat
     assert( !troop.isBattle() || !( flags & BUTTONS ) || !( flags & ( UPGRADE | DISMISS ) ) );
@@ -472,6 +472,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected )
     if ( isEvilInterface ) {
         dialogOffset.y += 3;
     }
+    dialogOffset.y += windowOffsetY;
 
     const fheroes2::Point shadowShift( spriteDialogShadow.x() - sprite_dialog.x(), spriteDialogShadow.y() - sprite_dialog.y() );
     const fheroes2::Point shadowOffset( dialogOffset.x + shadowShift.x, dialogOffset.y + shadowShift.y );

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -381,7 +381,7 @@ struct CstlRow
         garrisonArmyBar->SetBackground( { 41, 41 }, fill );
         garrisonArmyBar->setTableSize( { 5, 1 } );
         garrisonArmyBar->setInBetweenItemsOffset( { -1, 0 } );
-        garrisonArmyBar->setTroopWindowOffsetY(-60);
+        garrisonArmyBar->setTroopWindowOffsetY( -60 );
 
         Heroes * hero = world.GetHero( *castle );
 

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -380,6 +380,7 @@ struct CstlRow
         garrisonArmyBar->SetBackground( { 41, 41 }, fill );
         garrisonArmyBar->setTableSize( { 5, 1 } );
         garrisonArmyBar->setInBetweenItemsOffset( { -1, 0 } );
+        garrisonArmyBar->setTroopWindowOffsetY(-60);
 
         Heroes * hero = world.GetHero( *castle );
 

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -113,6 +113,7 @@ struct HeroRow
         armyBar->SetBackground( { 41, 53 }, fheroes2::GetColorId( 72, 28, 0 ) );
         armyBar->setTableSize( { 5, 1 } );
         armyBar->setInBetweenItemsOffset( { -1, 0 } );
+        armyBar->setTroopWindowOffsetY( -60 );
 
         artifactsBar = std::make_unique<ArtifactsBar>( hero, true, false, false, true, nullptr );
         artifactsBar->setTableSize( { 7, 2 } );


### PR DESCRIPTION
Solves https://github.com/ihhub/fheroes2/issues/4749. The recruitment windows is lowered 2 pixels on castle well view and in kingdom overview centered over top part of the window.
