### PR TITLE
Redraw whole hero portrait in castle.

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -141,7 +141,7 @@ namespace
         }
 
         if ( hero ) {
-            fheroes2::Blit( hero->GetPortrait( PORT_BIG ), display, pt.x + 5, pt.y + 361 );
+            hero->PortraitRedraw( pt.x + 5, pt.y + 361, PORT_BIG, display );
         }
         else {
             fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 3 ), display, pt.x + 5, pt.y + 361 );


### PR DESCRIPTION
Solves #6556 - the sleeping hero icon now gets properly displayed also in the castle.

![image](https://user-images.githubusercontent.com/1482514/221297312-eba6e51b-99c4-4780-806c-4b90505030c0.png)
