### PR TITLE
Fix fog rendering horizontal offset. Adventure map.

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2667,7 +2667,7 @@ void Maps::Tiles::drawFog( fheroes2::Image & dst, int color, const Interface::Ga
         }
 
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CLOP32, index );
-        area.BlitOnTile( dst, sprite, ( revert ? sprite.x() + TILEWIDTH - sprite.width() : sprite.x() ), sprite.y(), mp, revert, 255 );
+        area.BlitOnTile( dst, sprite, ( revert ? TILEWIDTH - sprite.x() - sprite.width() : sprite.x() ), sprite.y(), mp, revert, 255 );
     }
 }
 


### PR DESCRIPTION
fix #4255

![game](https://user-images.githubusercontent.com/113276641/221369338-6583388a-3e11-446b-a4ca-e89ec6621cb9.png)
