### PR TITLE
Display the world date for save files, refactor the game I/O a bit

### DIFF
--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -90,7 +90,7 @@ namespace
     }
 }
 
-bool ZStreamFile::read( const std::string & fn, const size_t offset /* = 0 */ )
+bool ZStreamBuf::read( const std::string & fn, const size_t offset /* = 0 */ )
 {
     StreamFile sf;
     sf.setbigendian( true );
@@ -127,7 +127,7 @@ bool ZStreamFile::read( const std::string & fn, const size_t offset /* = 0 */ )
     return !fail();
 }
 
-bool ZStreamFile::write( const std::string & fn, const bool append /* = false */ ) const
+bool ZStreamBuf::write( const std::string & fn, const bool append /* = false */ ) const
 {
     StreamFile sf;
     sf.setbigendian( true );

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -37,7 +37,7 @@ namespace
 {
     constexpr uint16_t FORMAT_VERSION_0 = 0;
 
-    std::vector<uint8_t> zlibDecompress( const uint8_t * src, size_t srcsz, size_t realsz = 0 )
+    std::vector<uint8_t> zlibDecompress( const uint8_t * src, const size_t srcsz, const size_t realsz = 0 )
     {
         if ( src == nullptr || srcsz == 0 ) {
             return {};
@@ -66,7 +66,7 @@ namespace
         return res;
     }
 
-    std::vector<uint8_t> zlibCompress( const uint8_t * src, size_t srcsz )
+    std::vector<uint8_t> zlibCompress( const uint8_t * src, const size_t srcsz )
     {
         if ( src == nullptr || srcsz == 0 ) {
             return {};
@@ -90,7 +90,7 @@ namespace
     }
 }
 
-bool ZStreamFile::read( const std::string & fn, size_t offset )
+bool ZStreamFile::read( const std::string & fn, const size_t offset /* = 0 */ )
 {
     StreamFile sf;
     sf.setbigendian( true );
@@ -104,10 +104,6 @@ bool ZStreamFile::read( const std::string & fn, size_t offset )
     }
 
     const uint32_t rawSize = sf.get32();
-    if ( rawSize == 0 ) {
-        return false;
-    }
-
     const uint32_t zipSize = sf.get32();
     if ( zipSize == 0 ) {
         return false;
@@ -122,17 +118,18 @@ bool ZStreamFile::read( const std::string & fn, size_t offset )
 
     const std::vector<uint8_t> zip = sf.getRaw( zipSize );
     const std::vector<uint8_t> raw = zlibDecompress( zip.data(), zip.size(), rawSize );
-    if ( raw.empty() ) {
+    if ( raw.size() != rawSize ) {
         return false;
     }
 
+    reset();
+
     putRaw( reinterpret_cast<const char *>( raw.data() ), raw.size() );
-    seek( 0 );
 
     return !fail();
 }
 
-bool ZStreamFile::write( const std::string & fn, bool append ) const
+bool ZStreamFile::write( const std::string & fn, const bool append /* = false */ ) const
 {
     StreamFile sf;
     sf.setbigendian( true );

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -43,11 +43,6 @@ namespace
         }
 
         std::vector<uint8_t> res;
-
-        if ( realsz ) {
-            res.reserve( realsz );
-        }
-
         res.resize( ( realsz ? realsz : srcsz * 7 ), 0 );
 
         uLong dstsz = static_cast<uLong>( res.size() );
@@ -77,7 +72,6 @@ namespace
         }
 
         std::vector<uint8_t> res;
-
         res.resize( compressBound( static_cast<uLong>( srcsz ) ) );
 
         uLong dstsz = static_cast<uLong>( res.size() );

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -75,7 +75,7 @@ namespace
         res.resize( compressBound( static_cast<uLong>( srcsz ) ) );
 
         uLong dstsz = static_cast<uLong>( res.size() );
-        int ret = compress( reinterpret_cast<Bytef *>( res.data() ), &dstsz, reinterpret_cast<const Bytef *>( src ), static_cast<uLong>( srcsz ) );
+        const int ret = compress( reinterpret_cast<Bytef *>( res.data() ), &dstsz, reinterpret_cast<const Bytef *>( src ), static_cast<uLong>( srcsz ) );
 
         if ( ret == Z_OK ) {
             res.resize( dstsz );

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <ostream>
 #include <vector>
 
 #include <zconf.h>

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -108,13 +108,13 @@ bool ZStreamFile::read( const std::string & fn, size_t offset )
         sf.seek( offset );
     }
 
-    const uint32_t size0 = sf.get32(); // Raw size
-    if ( size0 == 0 ) {
+    const uint32_t rawSize = sf.get32();
+    if ( rawSize == 0 ) {
         return false;
     }
 
-    const uint32_t size1 = sf.get32(); // ZIP size
-    if ( size1 == 0 ) {
+    const uint32_t zipSize = sf.get32();
+    if ( zipSize == 0 ) {
         return false;
     }
 
@@ -125,8 +125,8 @@ bool ZStreamFile::read( const std::string & fn, size_t offset )
 
     sf.skip( 2 ); // Unused bytes
 
-    const std::vector<uint8_t> zip = sf.getRaw( size1 );
-    const std::vector<uint8_t> raw = zlibDecompress( zip.data(), zip.size(), size0 );
+    const std::vector<uint8_t> zip = sf.getRaw( zipSize );
+    const std::vector<uint8_t> raw = zlibDecompress( zip.data(), zip.size(), rawSize );
     if ( raw.empty() ) {
         return false;
     }

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -38,27 +38,33 @@ namespace
 
     std::vector<uint8_t> zlibDecompress( const uint8_t * src, size_t srcsz, size_t realsz = 0 )
     {
+        if ( src == nullptr || srcsz == 0 ) {
+            return {};
+        }
+
         std::vector<uint8_t> res;
 
-        if ( src && srcsz ) {
-            if ( realsz )
-                res.reserve( realsz );
-            res.resize( ( realsz ? realsz : srcsz * 7 ), 0 );
-            uLong dstsz = static_cast<uLong>( res.size() );
-            int ret = Z_BUF_ERROR;
+        if ( realsz ) {
+            res.reserve( realsz );
+        }
 
-            while ( Z_BUF_ERROR
-                    == ( ret = uncompress( reinterpret_cast<Bytef *>( res.data() ), &dstsz, reinterpret_cast<const Bytef *>( src ), static_cast<uLong>( srcsz ) ) ) ) {
-                dstsz = static_cast<uLong>( res.size() * 2 );
-                res.resize( dstsz );
-            }
+        res.resize( ( realsz ? realsz : srcsz * 7 ), 0 );
 
-            if ( ret == Z_OK )
-                res.resize( dstsz );
-            else {
-                res.clear();
-                ERROR_LOG( "zlib error: " << ret )
-            }
+        uLong dstsz = static_cast<uLong>( res.size() );
+        int ret = Z_BUF_ERROR;
+
+        while ( Z_BUF_ERROR
+                == ( ret = uncompress( reinterpret_cast<Bytef *>( res.data() ), &dstsz, reinterpret_cast<const Bytef *>( src ), static_cast<uLong>( srcsz ) ) ) ) {
+            dstsz = static_cast<uLong>( res.size() * 2 );
+            res.resize( dstsz );
+        }
+
+        if ( ret == Z_OK ) {
+            res.resize( dstsz );
+        }
+        else {
+            res.clear();
+            ERROR_LOG( "zlib error: " << ret )
         }
 
         return res;
@@ -66,19 +72,23 @@ namespace
 
     std::vector<uint8_t> zlibCompress( const uint8_t * src, size_t srcsz )
     {
+        if ( src == nullptr || srcsz == 0 ) {
+            return {};
+        }
+
         std::vector<uint8_t> res;
 
-        if ( src && srcsz ) {
-            res.resize( compressBound( static_cast<uLong>( srcsz ) ) );
-            uLong dstsz = static_cast<uLong>( res.size() );
-            int ret = compress( reinterpret_cast<Bytef *>( res.data() ), &dstsz, reinterpret_cast<const Bytef *>( src ), static_cast<uLong>( srcsz ) );
+        res.resize( compressBound( static_cast<uLong>( srcsz ) ) );
 
-            if ( ret == Z_OK )
-                res.resize( dstsz );
-            else {
-                res.clear();
-                ERROR_LOG( "zlib error: " << ret )
-            }
+        uLong dstsz = static_cast<uLong>( res.size() );
+        int ret = compress( reinterpret_cast<Bytef *>( res.data() ), &dstsz, reinterpret_cast<const Bytef *>( src ), static_cast<uLong>( srcsz ) );
+
+        if ( ret == Z_OK ) {
+            res.resize( dstsz );
+        }
+        else {
+            res.clear();
+            ERROR_LOG( "zlib error: " << ret )
         }
 
         return res;

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -122,8 +122,6 @@ bool ZStreamFile::read( const std::string & fn, const size_t offset /* = 0 */ )
         return false;
     }
 
-    reset();
-
     putRaw( reinterpret_cast<const char *>( raw.data() ), raw.size() );
 
     return !fail();

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -57,9 +57,7 @@ namespace
                 res.resize( dstsz );
             else {
                 res.clear();
-                std::string errorDesc( "zlib error: " );
-                errorDesc += std::to_string( ret );
-                ERROR_LOG( errorDesc.c_str() )
+                ERROR_LOG( "zlib error: " << ret )
             }
         }
 
@@ -79,9 +77,7 @@ namespace
                 res.resize( dstsz );
             else {
                 res.clear();
-                std::string errorDesc( "zlib error: " );
-                errorDesc += std::to_string( ret );
-                ERROR_LOG( errorDesc.c_str() )
+                ERROR_LOG( "zlib error: " << ret )
             }
         }
 
@@ -102,12 +98,12 @@ bool ZStreamFile::read( const std::string & fn, size_t offset )
         sf.seek( offset );
     }
 
-    const uint32_t size0 = sf.get32(); // raw size
+    const uint32_t size0 = sf.get32(); // Raw size
     if ( size0 == 0 ) {
         return false;
     }
 
-    const uint32_t size1 = sf.get32(); // zip size
+    const uint32_t size1 = sf.get32(); // ZIP size
     if ( size1 == 0 ) {
         return false;
     }

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -36,7 +36,13 @@ class ZStreamFile : public StreamBuf
 public:
     ZStreamFile() = default;
 
+    // Reads & unzips the contents of the specified file and appends it to the end of the buffer.
+    // The current read position of the buffer does not change. Returns true on success or false
+    // on error.
     bool read( const std::string & fn, const size_t offset = 0 );
+    // Zips the contents of the buffer from the current read position to the end of the buffer and
+    // writes it to the specified file. The current read position of the buffer does not change.
+    // Returns true on success and false on error.
     bool write( const std::string & fn, const bool append = false ) const;
 };
 

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -31,18 +31,19 @@
 #include "image.h"
 #include "serialize.h"
 
-class ZStreamFile : public StreamBuf
+class ZStreamBuf : public StreamBuf
 {
 public:
-    ZStreamFile() = default;
+    ZStreamBuf() = default;
 
-    // Reads & unzips the contents of the specified file and appends it to the end of the buffer.
-    // The current read position of the buffer does not change. Returns true on success or false
-    // on error.
+    // Reads & unzips the zipped chunk from the specified file at the specified offset and appends
+    // it to the end of the buffer. The current read position of the buffer does not change. Returns
+    // true on success or false on error.
     bool read( const std::string & fn, const size_t offset = 0 );
+
     // Zips the contents of the buffer from the current read position to the end of the buffer and
-    // writes it to the specified file. The current read position of the buffer does not change.
-    // Returns true on success and false on error.
+    // writes (or appends) it to the specified file. The current read position of the buffer does
+    // not change. Returns true on success and false on error.
     bool write( const std::string & fn, const bool append = false ) const;
 };
 

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -36,8 +36,8 @@ class ZStreamFile : public StreamBuf
 public:
     ZStreamFile() = default;
 
-    bool read( const std::string &, size_t offset = 0 );
-    bool write( const std::string &, bool append = false ) const;
+    bool read( const std::string & fn, const size_t offset = 0 );
+    bool write( const std::string & fn, const bool append = false ) const;
 };
 
 fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );

--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -743,7 +743,7 @@ namespace Campaign
         }
 
         if ( allAIPlayersInAlliance ) {
-            const Colors humanColors( mapInfo.allow_human_colors );
+            const Colors humanColors( mapInfo.colorsAvailableForHumans );
             // Make sure that this is only one human player on the map.
             if ( humanColors.size() != 1 ) {
                 // Looks like somebody is modifying the original map.
@@ -751,7 +751,7 @@ namespace Campaign
                 return;
             }
 
-            const int aiColors = ( mapInfo.kingdom_colors & ( ~mapInfo.allow_human_colors ) );
+            const int aiColors = ( mapInfo.kingdomColors & ( ~mapInfo.colorsAvailableForHumans ) );
             if ( aiColors == 0 ) {
                 // This is definitely not the map to modify.
                 assert( 0 );

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "campaign_scenariodata.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -27,9 +29,8 @@
 #include <utility>
 
 #include "artifact.h"
-#include "campaign_scenariodata.h"
 #include "dir.h"
-#include "game.h"
+#include "game_io.h"
 #include "maps_fileinfo.h"
 #include "monster.h"
 #include "race.h"
@@ -799,7 +800,7 @@ namespace Campaign
         msg >> data._type >> data._subType >> data._amount;
 
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE5_1000_RELEASE, "Remove the check below." );
-        if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE5_1000_RELEASE ) {
+        if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE5_1000_RELEASE ) {
             data._artifactSpellId = Spell::NONE;
         }
         else {

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -123,7 +123,7 @@ namespace
 
 CastleDialog::CacheBuildings::CacheBuildings( const Castle & castle, const fheroes2::Point & top )
 {
-    const std::vector<building_t> ordersBuildings = fheroes2::getBuildingDrawingPriorities( castle.GetRace(), Settings::Get().CurrentFileInfo()._version );
+    const std::vector<building_t> ordersBuildings = fheroes2::getBuildingDrawingPriorities( castle.GetRace(), Settings::Get().CurrentFileInfo().version );
 
     for ( const building_t buildingId : ordersBuildings ) {
         emplace_back( buildingId, fheroes2::getCastleBuildingArea( castle.GetRace(), buildingId ) + top );

--- a/src/fheroes2/dialog/dialog_file.cpp
+++ b/src/fheroes2/dialog/dialog_file.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -25,9 +25,9 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "dir.h"
-#include "game.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
+#include "game_io.h"
 #include "game_mode.h"
 #include "gamedefs.h"
 #include "icn.h"

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -36,8 +36,8 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "dir.h"
-#include "game.h"
 #include "game_hotkeys.h"
+#include "game_io.h"
 #include "gamedefs.h"
 #include "icn.h"
 #include "image.h"
@@ -123,10 +123,21 @@ public:
         fheroes2::Text header( ResizeToShortName( info.file ), fheroes2::FontType::normalYellow() );
 
         fheroes2::MultiFontText body;
+
         body.add( { _( "Map: " ), fheroes2::FontType::normalYellow() } );
         body.add( { info.name, fheroes2::FontType::normalWhite() } );
-        body.add( { _( "\n\nLocation: " ), fheroes2::FontType::normalYellow() } );
-        body.add( { fullPath, fheroes2::FontType::normalWhite() } );
+
+        if ( info.worldDay > 0 || info.worldWeek > 0 || info.worldMonth > 0 ) {
+            body.add( { _( "\n\nMonth: " ), fheroes2::FontType::normalYellow() } );
+            body.add( { std::to_string( info.worldMonth ), fheroes2::FontType::normalWhite() } );
+            body.add( { _( ", week: " ), fheroes2::FontType::normalYellow() } );
+            body.add( { std::to_string( info.worldWeek ), fheroes2::FontType::normalWhite() } );
+            body.add( { _( ", day: " ), fheroes2::FontType::normalYellow() } );
+            body.add( { std::to_string( info.worldDay ), fheroes2::FontType::normalWhite() } );
+        }
+
+        body.add( { _( "\n\nLocation: " ), fheroes2::FontType::smallYellow() } );
+        body.add( { fullPath, fheroes2::FontType::smallWhite() } );
 
         fheroes2::showMessage( header, body, Dialog::ZERO );
     }
@@ -148,7 +159,7 @@ void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, int32_t dstx, int
     char shortHours[20];
     char shortTime[20];
 
-    const tm tmi = System::GetTM( info.localtime );
+    const tm tmi = System::GetTM( info.timestamp );
 
     std::fill( shortDate, std::end( shortDate ), static_cast<char>( 0 ) );
     std::fill( shortHours, std::end( shortHours ), static_cast<char>( 0 ) );
@@ -235,7 +246,7 @@ std::string Dialog::SelectFileSave()
 
 std::string Dialog::SelectFileLoad()
 {
-    const std::string & lastfile = Game::GetLastSavename();
+    const std::string & lastfile = Game::GetLastSaveName();
     return SelectFileListSimple( _( "File to Load:" ), ( !lastfile.empty() ? lastfile : "" ), false );
 }
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -130,9 +130,9 @@ public:
         if ( info.worldDay > 0 || info.worldWeek > 0 || info.worldMonth > 0 ) {
             body.add( { _( "\n\nMonth: " ), fheroes2::FontType::normalYellow() } );
             body.add( { std::to_string( info.worldMonth ), fheroes2::FontType::normalWhite() } );
-            body.add( { _( ", week: " ), fheroes2::FontType::normalYellow() } );
+            body.add( { _( ", Week: " ), fheroes2::FontType::normalYellow() } );
             body.add( { std::to_string( info.worldWeek ), fheroes2::FontType::normalWhite() } );
-            body.add( { _( ", day: " ), fheroes2::FontType::normalYellow() } );
+            body.add( { _( ", Day: " ), fheroes2::FontType::normalYellow() } );
             body.add( { std::to_string( info.worldDay ), fheroes2::FontType::normalWhite() } );
         }
 

--- a/src/fheroes2/dialog/dialog_selectscenario.cpp
+++ b/src/fheroes2/dialog/dialog_selectscenario.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "dialog_selectscenario.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -31,7 +33,6 @@
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
-#include "dialog_selectscenario.h"
 #include "difficulty.h"
 #include "game_hotkeys.h"
 #include "icn.h"
@@ -99,10 +100,9 @@ namespace
         fheroes2::Text header( info.name, fheroes2::FontType::normalYellow() );
 
         fheroes2::MultiFontText body;
-        body.add( { _( "Location: " ), fheroes2::FontType::normalYellow() } );
-        body.add( { fullPath, fheroes2::FontType::normalWhite() } );
-        body.add( { _( "\n\nMap Type:\n" ), fheroes2::FontType::normalYellow() } );
-        switch ( info._version ) {
+
+        body.add( { _( "Map Type:\n" ), fheroes2::FontType::normalYellow() } );
+        switch ( info.version ) {
         case GameVersion::SUCCESSION_WARS:
             body.add( { _( "The Succession Wars" ), fheroes2::FontType::normalWhite() } );
             break;
@@ -115,6 +115,9 @@ namespace
             break;
         }
 
+        body.add( { _( "\n\nLocation: " ), fheroes2::FontType::smallYellow() } );
+        body.add( { fullPath, fheroes2::FontType::smallWhite() } );
+
         fheroes2::showMessage( header, body, Dialog::ZERO );
     }
 
@@ -122,7 +125,7 @@ namespace
     {
         std::string msg;
 
-        switch ( info.conditions_loss ) {
+        switch ( info.lossConditions ) {
         case Maps::FileInfo::LOSS_EVERYTHING:
             msg = _( "Lose all your heroes and towns." );
             break;
@@ -148,7 +151,7 @@ namespace
     {
         std::string msg;
 
-        switch ( info.conditions_wins ) {
+        switch ( info.victoryConditions ) {
         case Maps::FileInfo::VICTORY_DEFEAT_EVERYONE:
             msg = _( "Defeat all enemy heroes and towns." );
             break;
@@ -224,29 +227,29 @@ void ScenarioListBox::RedrawBackground( const fheroes2::Point & dst )
 
 void ScenarioListBox::_renderScenarioListItem( const Maps::FileInfo & info, fheroes2::Display & display, const int32_t dsty, const bool current ) const
 {
-    fheroes2::Blit( _getPlayersCountIcon( info.kingdom_colors ), display, _offsetX + SCENARIO_LIST_COUNT_PLAYERS_OFFSET_X, dsty );
-    _renderMapIcon( info.size_w, display, _offsetX + SCENARIO_LIST_MAP_SIZE_OFFSET_X, dsty );
-    fheroes2::Blit( _getMapTypeIcon( info._version ), display, _offsetX + SCENARIO_LIST_MAP_TYPE_OFFSET_X, dsty );
+    fheroes2::Blit( _getPlayersCountIcon( info.kingdomColors ), display, _offsetX + SCENARIO_LIST_COUNT_PLAYERS_OFFSET_X, dsty );
+    _renderMapIcon( info.width, display, _offsetX + SCENARIO_LIST_MAP_SIZE_OFFSET_X, dsty );
+    fheroes2::Blit( _getMapTypeIcon( info.version ), display, _offsetX + SCENARIO_LIST_MAP_TYPE_OFFSET_X, dsty );
     _renderMapName( info, current, dsty, display );
-    fheroes2::Blit( _getWinConditionsIcon( info.conditions_wins ), display, _offsetX + SCENARIO_LIST_VICTORY_CONDITION_OFFSET_X, dsty );
-    fheroes2::Blit( _getLossConditionsIcon( info.conditions_loss ), display, _offsetX + SCENARIO_LIST_LOSS_CONDITION_OFFSET_X, dsty );
+    fheroes2::Blit( _getWinConditionsIcon( info.victoryConditions ), display, _offsetX + SCENARIO_LIST_VICTORY_CONDITION_OFFSET_X, dsty );
+    fheroes2::Blit( _getLossConditionsIcon( info.lossConditions ), display, _offsetX + SCENARIO_LIST_LOSS_CONDITION_OFFSET_X, dsty );
 }
 
 void ScenarioListBox::_renderSelectedScenarioInfo( fheroes2::Display & display, const fheroes2::Point & dst )
 {
     const Maps::FileInfo & info = GetCurrent();
 
-    fheroes2::Blit( _getPlayersCountIcon( info.kingdom_colors ), display, dst.x + SELECTED_SCENARIO_COUNT_PLAYERS_OFFSET_X, dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
-    _renderMapIcon( info.size_w, display, dst.x + SELECTED_SCENARIO_MAP_SIZE_OFFSET_X, dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
-    fheroes2::Blit( _getMapTypeIcon( info._version ), display, dst.x + SELECTED_SCENARIO_MAP_TYPE_OFFSET_X, dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
+    fheroes2::Blit( _getPlayersCountIcon( info.kingdomColors ), display, dst.x + SELECTED_SCENARIO_COUNT_PLAYERS_OFFSET_X, dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
+    _renderMapIcon( info.width, display, dst.x + SELECTED_SCENARIO_MAP_SIZE_OFFSET_X, dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
+    fheroes2::Blit( _getMapTypeIcon( info.version ), display, dst.x + SELECTED_SCENARIO_MAP_TYPE_OFFSET_X, dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
 
     fheroes2::Text mapNameText( info.name, fheroes2::FontType::normalWhite() );
     mapNameText.draw( GetCenteredTextXCoordinate( dst.x + SELECTED_SCENARIO_MAP_NAME_OFFSET_X, SELECTED_SCENARIO_MAP_NAME_WIDTH, mapNameText.width() ),
                       dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y + 2, display );
 
-    fheroes2::Blit( _getWinConditionsIcon( info.conditions_wins ), display, dst.x + SELECTED_SCENARIO_VICTORY_CONDITION_OFFSET_X,
+    fheroes2::Blit( _getWinConditionsIcon( info.victoryConditions ), display, dst.x + SELECTED_SCENARIO_VICTORY_CONDITION_OFFSET_X,
                     dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
-    fheroes2::Blit( _getLossConditionsIcon( info.conditions_loss ), display, dst.x + SELECTED_SCENARIO_LOSS_CONDITION_OFFSET_X,
+    fheroes2::Blit( _getLossConditionsIcon( info.lossConditions ), display, dst.x + SELECTED_SCENARIO_LOSS_CONDITION_OFFSET_X,
                     dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
 
     fheroes2::Text difficultyLabelText( _( "Map difficulty:" ), fheroes2::FontType::normalWhite() );
@@ -287,7 +290,7 @@ void ScenarioListBox::SelectMapSize( MapsFileInfoList & mapsList, const int sele
 
     SetListContent( mapsList );
 
-    if ( currentScenario.size_w == selectedSize_ || selectedSize_ == Maps::ZERO ) {
+    if ( currentScenario.width == selectedSize_ || selectedSize_ == Maps::ZERO ) {
         SetCurrent( currentScenario );
     }
 
@@ -380,7 +383,7 @@ const Maps::FileInfo * Dialog::SelectScenario( const MapsFileInfoList & allMaps 
     xlarge.reserve( all.size() );
 
     for ( const Maps::FileInfo & info : all ) {
-        switch ( info.size_w ) {
+        switch ( info.width ) {
         case Maps::SMALL:
             small.push_back( info );
             break;

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -52,7 +52,6 @@
 #include "mus.h"
 #include "players.h"
 #include "rand.h"
-#include "save_format_version.h"
 #include "settings.h"
 #include "tools.h"
 #include "world.h"
@@ -61,10 +60,6 @@ namespace
 {
     std::string lastMapFileName;
     std::vector<Player> savedPlayers;
-
-    uint16_t save_version = CURRENT_FORMAT_VERSION;
-
-    std::string last_name;
 
     bool updateSoundsOnFocusUpdate = true;
 
@@ -144,26 +139,6 @@ void Game::SavePlayers( const std::string & mapFileName, const Players & players
 
         savedPlayers.push_back( player );
     }
-}
-
-void Game::SetLoadVersion( uint16_t ver )
-{
-    save_version = ver;
-}
-
-uint16_t Game::GetLoadVersion()
-{
-    return save_version;
-}
-
-const std::string & Game::GetLastSavename()
-{
-    return last_name;
-}
-
-void Game::SetLastSavename( const std::string & name )
-{
-    last_name = name;
 }
 
 fheroes2::GameMode Game::Credits()

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -36,11 +36,6 @@ class Castle;
 namespace Game
 {
     void Init();
-
-    const std::string & GetLastSavename();
-    void SetLastSavename( const std::string & );
-    void SetLoadVersion( uint16_t ver );
-    uint16_t GetLoadVersion();
 
     // type_t
     enum
@@ -115,11 +110,6 @@ namespace Game
     void LoadPlayers( const std::string & mapFileName, Players & players );
     void saveDifficulty( const int difficulty );
     void SavePlayers( const std::string & mapFileName, const Players & players );
-
-    std::string GetSaveDir();
-    std::string GetSaveFileBaseName();
-    std::string GetSaveFileExtension();
-    std::string GetSaveFileExtension( const int gameType );
 
     int32_t GetStep4Player( const int32_t currentId, const int32_t width, const int32_t totalCount );
 

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -38,6 +38,7 @@
 #include "game.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
+#include "game_io.h"
 #include "game_mode.h"
 #include "game_over.h"
 #include "highscores.h"

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -134,7 +134,7 @@ bool Game::Save( const std::string & filePath, const bool autoSave /* = false */
     fz.setbigendian( true );
 
     // Game data in ZIP format
-    fz << saveFileVersion << World::Get() << Settings::Get() << GameOver::Result::Get();
+    fz << World::Get() << Settings::Get() << GameOver::Result::Get();
 
     if ( conf.isCampaignGameType() ) {
         fz << Campaign::CampaignSaveData::Get();
@@ -239,16 +239,19 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
         return fheroes2::GameMode::CANCEL;
     }
 
-    uint16_t zippedSaveFileVersion = 0;
-    fz >> zippedSaveFileVersion;
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1002_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1002_RELEASE ) {
+        uint16_t zippedSaveFileVersion = 0;
+        fz >> zippedSaveFileVersion;
 
-    if ( zippedSaveFileVersion != saveFileVersion ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN,
-                   "In the file " << filePath << " the file version " << saveFileVersion << " does not match the zipped one " << zippedSaveFileVersion )
+        if ( zippedSaveFileVersion != saveFileVersion ) {
+            DEBUG_LOG( DBG_GAME, DBG_WARN,
+                       "In the file " << filePath << " the file version " << saveFileVersion << " does not match the zipped one " << zippedSaveFileVersion )
 
-        showGenericErrorMessage();
+            showGenericErrorMessage();
 
-        return fheroes2::GameMode::CANCEL;
+            return fheroes2::GameMode::CANCEL;
+        }
     }
 
     fz >> World::Get() >> conf >> GameOver::Result::Get();

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "game_io.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cstdint>
@@ -31,7 +33,6 @@
 #include "campaign_scenariodata.h"
 #include "dialog.h"
 #include "game.h"
-#include "game_io.h"
 #include "game_over.h"
 #include "logging.h"
 #include "maps_fileinfo.h"
@@ -42,7 +43,6 @@
 #include "translations.h"
 #include "ui_dialog.h"
 #include "ui_language.h"
-#include "ui_text.h"
 #include "world.h"
 #include "zzlib.h"
 
@@ -50,8 +50,11 @@ namespace
 {
     const std::string autoSaveName{ "AUTOSAVE" };
 
-    const uint16_t SAV2ID2 = 0xFF02;
     const uint16_t SAV2ID3 = 0xFF03;
+
+    uint16_t versionOfCurrentSaveFile = CURRENT_FORMAT_VERSION;
+
+    std::string lastSaveName;
 
     struct HeaderSAV
     {
@@ -65,17 +68,22 @@ namespace
             , gameType( 0 )
         {}
 
-        HeaderSAV( const Maps::FileInfo & fi, const int gameType_ )
+        HeaderSAV( const Maps::FileInfo & fi, const int type, const uint32_t worldDay, const uint32_t worldWeek, const uint32_t worldMonth )
             : status( 0 )
             , info( fi )
-            , gameType( gameType_ )
+            , gameType( type )
         {
             time_t rawtime;
             std::time( &rawtime );
-            info.localtime = static_cast<uint32_t>( rawtime );
 
-            if ( fi._version == GameVersion::PRICE_OF_LOYALTY )
+            info.timestamp = static_cast<uint32_t>( rawtime );
+            info.worldDay = worldDay;
+            info.worldWeek = worldWeek;
+            info.worldMonth = worldMonth;
+
+            if ( fi.version == GameVersion::PRICE_OF_LOYALTY ) {
                 status |= IS_PRICE_OF_LOYALTY_MAP;
+            }
         }
 
         uint16_t status;
@@ -109,103 +117,81 @@ bool Game::Save( const std::string & filePath, const bool autoSave /* = false */
     fs.setbigendian( true );
 
     if ( !fs.open( filePath, "wb" ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, filePath << ", error open" )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Error opening the file " << filePath )
         return false;
     }
 
-    uint16_t loadver = GetLoadVersion();
-    if ( !autoSave ) {
-        Game::SetLastSavename( filePath );
-    }
+    // Always use the latest version of the file save format
+    SetVersionOfCurrentSaveFile( CURRENT_FORMAT_VERSION );
+    uint16_t saveFileVersion = CURRENT_FORMAT_VERSION;
 
-    // raw info content
-    fs << static_cast<uint8_t>( SAV2ID3 >> 8 ) << static_cast<uint8_t>( SAV2ID3 & 0xFF ) << std::to_string( loadver ) << loadver
-       << HeaderSAV( conf.CurrentFileInfo(), conf.GameType() );
+    // Header
+    fs << SAV2ID3 << std::to_string( saveFileVersion ) << saveFileVersion
+       << HeaderSAV( conf.CurrentFileInfo(), conf.GameType(), world.GetDay(), world.GetWeek(), world.GetMonth() );
     fs.close();
 
     ZStreamFile fz;
     fz.setbigendian( true );
 
-    // zip game data content
-    fz << loadver << World::Get() << Settings::Get() << GameOver::Result::Get();
+    // Game data in ZIP format
+    fz << saveFileVersion << World::Get() << Settings::Get() << GameOver::Result::Get();
 
-    if ( conf.isCampaignGameType() )
+    if ( conf.isCampaignGameType() ) {
         fz << Campaign::CampaignSaveData::Get();
+    }
 
-    fz << SAV2ID3; // eof marker
+    // End-of-data marker
+    fz << SAV2ID3;
 
-    return !fz.fail() && fz.write( filePath, true );
+    if ( fz.fail() || !fz.write( filePath, true ) ) {
+        return false;
+    }
+
+    if ( !autoSave ) {
+        Game::SetLastSaveName( filePath );
+    }
+
+    return true;
 }
 
 fheroes2::GameMode Game::Load( const std::string & filePath )
 {
     DEBUG_LOG( DBG_GAME, DBG_INFO, filePath )
 
+    auto showGenericErrorMessage = []() { fheroes2::showStandardTextMessage( _( "Error" ), _( "The save file is corrupted." ), Dialog::OK ); };
+
     StreamFile fs;
     fs.setbigendian( true );
 
     if ( !fs.open( filePath, "rb" ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, filePath << ", error open" )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Error opening the file " << filePath )
+
+        showGenericErrorMessage();
+
         return fheroes2::GameMode::CANCEL;
     }
 
-    char major;
-    char minor;
-    fs >> major >> minor;
-    const uint16_t savid = ( static_cast<uint16_t>( major ) << 8 ) | static_cast<uint16_t>( minor );
+    uint16_t savId = 0;
+    fs >> savId;
 
-    // check version sav file
-    if ( savid != SAV2ID2 && savid != SAV2ID3 ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, filePath << ", incorrect SAV2ID" )
+    if ( savId != SAV2ID3 ) {
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid SAV2ID in the file " << filePath )
+
+        showGenericErrorMessage();
+
         return fheroes2::GameMode::CANCEL;
     }
 
-    std::string strver;
-    uint16_t binver = 0;
+    std::string saveFileVersionStr;
+    uint16_t saveFileVersion = 0;
 
-    // read raw info
-    fs >> strver >> binver;
+    fs >> saveFileVersionStr >> saveFileVersion;
 
-    // hide: unsupported version
-    if ( binver > CURRENT_FORMAT_VERSION || binver < LAST_SUPPORTED_FORMAT_VERSION )
-        return fheroes2::GameMode::CANCEL;
+    DEBUG_LOG( DBG_GAME, DBG_TRACE, "Version of the file " << filePath << ": " << saveFileVersion )
 
-    int fileGameType = Game::TYPE_STANDARD;
-    HeaderSAV header;
-    fs >> header;
-    fileGameType = header.gameType;
-
-    size_t offset = fs.tell();
-    fs.close();
-
-    Settings & conf = Settings::Get();
-    if ( ( conf.GameType() & fileGameType ) == 0 ) {
-        fheroes2::showMessage( fheroes2::Text( _( "Warning" ), fheroes2::FontType::normalYellow() ),
-                               fheroes2::Text( _( "This file contains a save with an invalid game type." ), fheroes2::FontType::normalWhite() ), Dialog::OK );
-        return fheroes2::GameMode::CANCEL;
-    }
-
-    ZStreamFile fz;
-    fz.setbigendian( true );
-
-    if ( !fz.read( filePath, offset ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, ", uncompress: error" )
-        return fheroes2::GameMode::CANCEL;
-    }
-
-    if ( ( header.status & HeaderSAV::IS_PRICE_OF_LOYALTY_MAP ) && !conf.isPriceOfLoyaltySupported() ) {
-        fheroes2::showStandardTextMessage(
-            _( "Warning" ), _( "This file was saved for a \"The Price of Loyalty\" map, but the corresponding game assets have not been provided to the engine." ),
-            Dialog::OK );
-        return fheroes2::GameMode::CANCEL;
-    }
-
-    fz >> binver;
-
-    // check version: false
-    if ( binver > CURRENT_FORMAT_VERSION || binver < LAST_SUPPORTED_FORMAT_VERSION ) {
+    if ( saveFileVersion > CURRENT_FORMAT_VERSION || saveFileVersion < LAST_SUPPORTED_FORMAT_VERSION ) {
         std::string errorMessage( _( "Unsupported save format: " ) );
-        errorMessage += std::to_string( binver );
+        errorMessage += std::to_string( saveFileVersion );
         errorMessage += ".\n";
         errorMessage += _( "Current game version: " );
         errorMessage += std::to_string( CURRENT_FORMAT_VERSION );
@@ -214,30 +200,58 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
         errorMessage += std::to_string( LAST_SUPPORTED_FORMAT_VERSION );
         errorMessage += ".\n";
 
-        fheroes2::showMessage( fheroes2::Text( _( "Error" ), fheroes2::FontType::normalYellow() ), fheroes2::Text( errorMessage, fheroes2::FontType::normalWhite() ),
-                               Dialog::OK );
+        fheroes2::showStandardTextMessage( _( "Error" ), errorMessage, Dialog::OK );
 
         return fheroes2::GameMode::CANCEL;
     }
 
-    DEBUG_LOG( DBG_GAME, DBG_TRACE, "load version: " << binver )
-    SetLoadVersion( binver );
+    SetVersionOfCurrentSaveFile( saveFileVersion );
+
+    HeaderSAV header;
+    fs >> header;
+
+    size_t offset = fs.tell();
+    fs.close();
+
+    Settings & conf = Settings::Get();
+    if ( ( conf.GameType() & header.gameType ) == 0 ) {
+        fheroes2::showStandardTextMessage( _( "Error" ), _( "This file contains a save with an invalid game type." ), Dialog::OK );
+
+        return fheroes2::GameMode::CANCEL;
+    }
+
+    ZStreamFile fz;
+    fz.setbigendian( true );
+
+    if ( !fz.read( filePath, offset ) ) {
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Error uncompressing the file " << filePath )
+
+        showGenericErrorMessage();
+
+        return fheroes2::GameMode::CANCEL;
+    }
+
+    if ( ( header.status & HeaderSAV::IS_PRICE_OF_LOYALTY_MAP ) && !conf.isPriceOfLoyaltySupported() ) {
+        fheroes2::showStandardTextMessage(
+            _( "Error" ), _( "This file was saved for a \"The Price of Loyalty\" map, but the corresponding game assets have not been provided to the engine." ),
+            Dialog::OK );
+
+        return fheroes2::GameMode::CANCEL;
+    }
+
+    uint16_t zippedSaveFileVersion = 0;
+    fz >> zippedSaveFileVersion;
+
+    if ( zippedSaveFileVersion != saveFileVersion ) {
+        DEBUG_LOG( DBG_GAME, DBG_WARN,
+                   "In the file " << filePath << " the file version " << saveFileVersion << " does not match the zipped one " << zippedSaveFileVersion )
+
+        showGenericErrorMessage();
+
+        return fheroes2::GameMode::CANCEL;
+    }
 
     fz >> World::Get() >> conf >> GameOver::Result::Get();
-
-    // Settings should contain the full path to the current map file, if this map is available
-    conf.SetMapsFile( Settings::GetLastFile( "maps", System::GetBasename( conf.MapsFile() ) ) );
-
-    if ( !conf.loadedFileLanguage().empty() && conf.loadedFileLanguage() != "en" && conf.loadedFileLanguage() != conf.getGameLanguage() ) {
-        std::string warningMessage( _( "This saved game is localized to '" ) );
-        warningMessage.append( fheroes2::getLanguageName( fheroes2::getLanguageFromAbbreviation( conf.loadedFileLanguage() ) ) );
-        warningMessage.append( _( "' language, but the current language of the game is '" ) );
-        warningMessage.append( fheroes2::getLanguageName( fheroes2::getLanguageFromAbbreviation( conf.getGameLanguage() ) ) );
-        warningMessage += "'.";
-
-        fheroes2::showMessage( fheroes2::Text( _( "Warning" ), fheroes2::FontType::normalYellow() ), fheroes2::Text( warningMessage, fheroes2::FontType::normalWhite() ),
-                               Dialog::OK );
-    }
 
     fheroes2::GameMode returnValue = fheroes2::GameMode::START_GAME;
 
@@ -251,17 +265,31 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
         }
     }
 
-    uint16_t end_check = 0;
-    fz >> end_check;
+    uint16_t endOfDataMarker = 0;
+    fz >> endOfDataMarker;
 
-    if ( fz.fail() || ( end_check != SAV2ID2 && end_check != SAV2ID3 ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "invalid load file: " << filePath )
+    if ( fz.fail() || endOfDataMarker != SAV2ID3 ) {
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "File " << filePath << " is corrupted" )
+
+        showGenericErrorMessage();
+
         return fheroes2::GameMode::CANCEL;
     }
 
-    SetLoadVersion( CURRENT_FORMAT_VERSION );
+    // Settings should contain the full path to the current map file, if this map is available
+    conf.SetMapsFile( Settings::GetLastFile( "maps", System::GetBasename( conf.MapsFile() ) ) );
 
-    Game::SetLastSavename( filePath );
+    if ( !conf.loadedFileLanguage().empty() && conf.loadedFileLanguage() != "en" && conf.loadedFileLanguage() != conf.getGameLanguage() ) {
+        std::string warningMessage( _( "This saved game is localized to '" ) );
+        warningMessage.append( fheroes2::getLanguageName( fheroes2::getLanguageFromAbbreviation( conf.loadedFileLanguage() ) ) );
+        warningMessage.append( _( "' language, but the current language of the game is '" ) );
+        warningMessage.append( fheroes2::getLanguageName( fheroes2::getLanguageFromAbbreviation( conf.getGameLanguage() ) ) );
+        warningMessage += "'.";
+
+        fheroes2::showStandardTextMessage( _( "Warning" ), warningMessage, Dialog::OK );
+    }
+
+    Game::SetLastSaveName( filePath );
     conf.SetGameType( conf.GameType() | Game::TYPE_LOADFILE );
 
     return returnValue;
@@ -275,43 +303,62 @@ bool Game::LoadSAV2FileInfo( const std::string & filePath, Maps::FileInfo & file
     fs.setbigendian( true );
 
     if ( !fs.open( filePath, "rb" ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, filePath << ", error open" )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Error opening the file " << filePath )
         return false;
     }
 
-    char major;
-    char minor;
-    fs >> major >> minor;
-    const uint16_t savid = ( static_cast<uint16_t>( major ) << 8 ) | static_cast<uint16_t>( minor );
+    uint16_t savId = 0;
+    fs >> savId;
 
-    // check version sav file
-    if ( savid != SAV2ID2 && savid != SAV2ID3 ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, filePath << ", incorrect SAV2ID" )
+    if ( savId != SAV2ID3 ) {
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid SAV2ID in the file " << filePath )
         return false;
     }
 
-    std::string strver;
-    uint16_t binver = 0;
+    std::string saveFileVersionStr;
+    uint16_t saveFileVersion = 0;
 
-    // read raw info
-    fs >> strver >> binver;
+    fs >> saveFileVersionStr >> saveFileVersion;
 
-    // hide: unsupported version
-    if ( binver > CURRENT_FORMAT_VERSION || binver < LAST_SUPPORTED_FORMAT_VERSION )
+    DEBUG_LOG( DBG_GAME, DBG_TRACE, "Version of the file " << filePath << ": " << saveFileVersion )
+
+    if ( saveFileVersion > CURRENT_FORMAT_VERSION || saveFileVersion < LAST_SUPPORTED_FORMAT_VERSION ) {
         return false;
+    }
 
-    int fileGameType = Game::TYPE_STANDARD;
+    SetVersionOfCurrentSaveFile( saveFileVersion );
+
     HeaderSAV header;
     fs >> header;
-    fileGameType = header.gameType;
 
-    if ( ( Settings::Get().GameType() & fileGameType ) == 0 )
+    if ( ( Settings::Get().GameType() & header.gameType ) == 0 ) {
         return false;
+    }
 
     fileInfo = header.info;
     fileInfo.file = filePath;
 
     return true;
+}
+
+void Game::SetVersionOfCurrentSaveFile( const uint16_t version )
+{
+    versionOfCurrentSaveFile = version;
+}
+
+uint16_t Game::GetVersionOfCurrentSaveFile()
+{
+    return versionOfCurrentSaveFile;
+}
+
+const std::string & Game::GetLastSaveName()
+{
+    return lastSaveName;
+}
+
+void Game::SetLastSaveName( const std::string & name )
+{
+    lastSaveName = name;
 }
 
 std::string Game::GetSaveDir()

--- a/src/fheroes2/game/game_io.h
+++ b/src/fheroes2/game/game_io.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -24,6 +24,7 @@
 #ifndef H2GAMEIO_H
 #define H2GAMEIO_H
 
+#include <cstdint>
 #include <string>
 
 #include "game_mode.h"
@@ -35,6 +36,17 @@ namespace Maps
 
 namespace Game
 {
+    const std::string & GetLastSaveName();
+    void SetLastSaveName( const std::string & name );
+
+    uint16_t GetVersionOfCurrentSaveFile();
+    void SetVersionOfCurrentSaveFile( const uint16_t version );
+
+    std::string GetSaveDir();
+    std::string GetSaveFileBaseName();
+    std::string GetSaveFileExtension();
+    std::string GetSaveFileExtension( const int gameType );
+
     bool AutoSave();
     bool Save( const std::string & filePath, const bool autoSave = false );
 

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "game.h"
+
 #include <array>
 #include <cassert>
 #include <cmath>
@@ -39,9 +41,9 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_game_settings.h"
-#include "game.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
+#include "game_io.h"
 #include "game_mainmenu_ui.h"
 #include "game_mode.h"
 #include "game_video.h"
@@ -522,7 +524,7 @@ fheroes2::GameMode Game::NewGame()
     AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
     // reset last save name
-    Game::SetLastSavename( "" );
+    Game::SetLastSaveName( "" );
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "game_over.h"
+
 #include <cassert>
 #include <cstddef>
 #include <utility>
@@ -35,7 +37,7 @@
 #include "color.h"
 #include "dialog.h"
 #include "game.h"
-#include "game_over.h"
+#include "game_io.h"
 #include "game_video.h"
 #include "game_video_type.h"
 #include "gamedefs.h"
@@ -480,7 +482,7 @@ StreamBase & GameOver::operator>>( StreamBase & msg, Result & res )
     msg >> res.colors >> res.result;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE4_1000_RELEASE, "Remove the check below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE4_1000_RELEASE ) {
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE4_1000_RELEASE ) {
         bool dummy;
 
         msg >> dummy;

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -115,7 +115,7 @@ namespace fheroes2
 
     bool HighScoreDataContainer::load( const std::string & fileName )
     {
-        ZStreamFile hdata;
+        ZStreamBuf hdata;
         if ( !hdata.read( fileName ) ) {
             return false;
         }
@@ -159,7 +159,7 @@ namespace fheroes2
 
     bool HighScoreDataContainer::save( const std::string & fileName ) const
     {
-        ZStreamFile hdata;
+        ZStreamBuf hdata;
         hdata.setbigendian( true );
         hdata << highscoreFileMagicValue << _highScoresStandard << _highScoresCampaign;
 

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022                                                    *
+ *   Copyright (C) 2022 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -505,28 +505,6 @@ bool Maps::FileInfo::isAllowCountPlayers( int playerCount ) const
     return humanOnly <= playerCount && playerCount <= humanOnly + compHuman;
 }
 
-std::string Maps::FileInfo::String() const
-{
-    std::ostringstream os;
-
-    os << "file: " << file << ", "
-       << "name: " << name << ", "
-       << "kingdom colors: " << static_cast<int>( kingdomColors ) << ", "
-       << "colors for humans: " << static_cast<int>( colorsAvailableForHumans ) << ", "
-       << "colors for comp: " << static_cast<int>( colorsAvailableForComp ) << ", "
-       << "random races: " << static_cast<int>( colorsOfRandomRaces ) << ", "
-       << "victory conditions: " << static_cast<int>( victoryConditions ) << ", "
-       << "comp also wins: " << ( compAlsoWins ? "true" : "false" ) << ", "
-       << "allow normal victory: " << ( allowNormalVictory ? "true" : "false" ) << ", "
-       << "victory cond param 1: " << victoryConditionsParam1 << ", "
-       << "victory cond param 2: " << victoryConditionsParam2 << ", "
-       << "loss conditions: " << static_cast<int>( lossConditions ) << ", "
-       << "loss cond param 1: " << lossConditionsParam1 << ", "
-       << "loss cond param 2: " << lossConditionsParam2;
-
-    return os.str();
-}
-
 StreamBase & Maps::operator<<( StreamBase & msg, const FileInfo & fi )
 {
     using VersionUnderlyingType = std::underlying_type_t<decltype( fi.version )>;

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -305,11 +305,15 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
     fs.seek( 0x25 );
     startWithHeroInEachCastle = ( 0 == fs.get() );
 
+    static_assert( std::is_same_v<decltype( races ), std::array<uint8_t, KINGDOMMAX>>, "Type of races has been changed, check the logic below" );
+
     // Initial races
     for ( const int color : colors ) {
         const uint8_t race = ByteToRace( fs.get() );
+        const int idx = Color::GetIndex( color );
+        assert( idx < KINGDOMMAX );
 
-        races[Color::GetIndex( color )] = race;
+        races[idx] = race;
 
         if ( Race::RAND == race ) {
             colorsOfRandomRaces |= color;

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -286,18 +286,18 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
     compAlsoWins = ( fs.get() != 0 );
     // Is "normal victory" (defeating all other players) applicable here
     allowNormalVictory = ( fs.get() != 0 );
-    // data wins
+    // Additional parameter of victory conditions
     victoryConditionsParam1 = fs.getLE16();
-    // data wins
+    // Additional parameter of victory conditions
     fs.seek( 0x2c );
     victoryConditionsParam2 = fs.getLE16();
 
     // Loss conditions
     fs.seek( 0x22 );
     lossConditions = fs.get();
-    // data loss
+    // Additional parameter of loss conditions
     lossConditionsParam1 = fs.getLE16();
-    // data loss
+    // Additional parameter of loss conditions
     fs.seek( 0x2e );
     lossConditionsParam2 = fs.getLE16();
 

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -330,8 +330,11 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
         if ( ( colorRace.first & colorsAvailableForHumans ) == 0 ) {
             const int side1 = colorRace.first | colorsAvailableForHumans;
             const int side2 = colorsAvailableForComp ^ colorRace.first;
+
             FillUnions( side1, side2 );
+
             victoryConditions = VICTORY_DEFEAT_OTHER_SIDE;
+
             skipUnionSetup = true;
         }
     }

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -47,6 +47,7 @@
 #include "mp2.h"
 #include "mp2_helper.h"
 #include "race.h"
+#include "save_format_version.h"
 #include "serialize.h"
 #include "settings.h"
 #include "system.h"
@@ -154,47 +155,9 @@ namespace Editor
 }
 
 Maps::FileInfo::FileInfo()
-    : _version( GameVersion::SUCCESSION_WARS )
+    : version( GameVersion::SUCCESSION_WARS )
 {
     Reset();
-}
-
-Maps::FileInfo::FileInfo( const FileInfo & f )
-{
-    *this = f;
-}
-
-Maps::FileInfo & Maps::FileInfo::operator=( const FileInfo & f )
-{
-    file = f.file;
-    name = f.name;
-    description = f.description;
-    size_w = f.size_w;
-    size_h = f.size_h;
-    difficulty = f.difficulty;
-
-    for ( int32_t i = 0; i < KINGDOMMAX; ++i ) {
-        races[i] = f.races[i];
-        unions[i] = f.unions[i];
-    }
-
-    kingdom_colors = f.kingdom_colors;
-    allow_human_colors = f.allow_human_colors;
-    allow_comp_colors = f.allow_comp_colors;
-    rnd_races = f.rnd_races;
-    conditions_wins = f.conditions_wins;
-    comp_also_wins = f.comp_also_wins;
-    allow_normal_victory = f.allow_normal_victory;
-    wins1 = f.wins1;
-    wins2 = f.wins2;
-    conditions_loss = f.conditions_loss;
-    loss1 = f.loss1;
-    loss2 = f.loss2;
-    localtime = f.localtime;
-    startWithHeroInEachCastle = f.startWithHeroInEachCastle;
-    _version = f._version;
-
-    return *this;
 }
 
 void Maps::FileInfo::Reset()
@@ -202,57 +165,68 @@ void Maps::FileInfo::Reset()
     file.clear();
     name.clear();
     description.clear();
-    size_w = 0;
-    size_h = 0;
+
+    width = 0;
+    height = 0;
     difficulty = 0;
-    kingdom_colors = 0;
-    allow_human_colors = 0;
-    allow_comp_colors = 0;
-    rnd_races = 0;
-    conditions_wins = VICTORY_DEFEAT_EVERYONE;
-    comp_also_wins = false;
-    allow_normal_victory = false;
-    wins1 = 0;
-    wins2 = 0;
-    conditions_loss = LOSS_EVERYTHING;
-    loss1 = 0;
-    loss2 = 0;
-    localtime = 0;
-    startWithHeroInEachCastle = false;
 
-    _version = GameVersion::SUCCESSION_WARS;
-
-    for ( int32_t i = 0; i < KINGDOMMAX; ++i ) {
+    for ( int i = 0; i < KINGDOMMAX; ++i ) {
         races[i] = Race::NONE;
         unions[i] = ByteToColor( i );
     }
+
+    kingdomColors = 0;
+    colorsAvailableForHumans = 0;
+    colorsAvailableForComp = 0;
+    colorsOfRandomRaces = 0;
+
+    victoryConditions = VICTORY_DEFEAT_EVERYONE;
+    compAlsoWins = false;
+    allowNormalVictory = false;
+    victoryConditionsParam1 = 0;
+    victoryConditionsParam2 = 0;
+
+    lossConditions = LOSS_EVERYTHING;
+    lossConditionsParam1 = 0;
+    lossConditionsParam2 = 0;
+
+    timestamp = 0;
+
+    startWithHeroInEachCastle = false;
+
+    version = GameVersion::SUCCESSION_WARS;
+
+    worldDay = 0;
+    worldWeek = 0;
+    worldMonth = 0;
 }
 
-bool Maps::FileInfo::ReadSAV( const std::string & filename )
+bool Maps::FileInfo::ReadSAV( const std::string & filePath )
 {
     Reset();
-    return Game::LoadSAV2FileInfo( filename, *this );
+
+    return Game::LoadSAV2FileInfo( filePath, *this );
 }
 
-bool Maps::FileInfo::ReadMP2( const std::string & filename )
+bool Maps::FileInfo::ReadMP2( const std::string & filePath )
 {
     Reset();
+
     StreamFile fs;
-
-    if ( !fs.open( filename, "rb" ) ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "File was not found " << filename )
+    if ( !fs.open( filePath, "rb" ) ) {
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Error opening the file " << filePath )
         return false;
     }
 
     // magic byte
     if ( fs.getBE32() != 0x5C000000 ) {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "Not a valid map file " << filename )
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "File " << filePath << " is not a valid map file" )
         return false;
     }
 
-    file = filename;
+    file = filePath;
 
-    // level
+    // Difficulty level
     switch ( fs.getLE16() ) {
     case 0x00:
         difficulty = Difficulty::EASY;
@@ -271,82 +245,80 @@ bool Maps::FileInfo::ReadMP2( const std::string & filename )
         break;
     }
 
-    // width
-    size_w = fs.get();
-
-    // height
-    size_h = fs.get();
+    // Width & height of the map in tiles
+    width = fs.get();
+    height = fs.get();
 
     const Colors colors( Color::ALL );
 
-    // kingdom color - blue, green, red, yellow, orange, purple
+    // Colors used by kingdoms: blue, green, red, yellow, orange, purple
     for ( const int color : colors ) {
         if ( fs.get() != 0 ) {
-            kingdom_colors |= color;
+            kingdomColors |= color;
         }
     }
 
-    // allow human color - blue, green, red, yellow, orange, purple
+    // Colors available for human players: blue, green, red, yellow, orange, purple
     for ( const int color : colors ) {
         if ( fs.get() != 0 ) {
-            allow_human_colors |= color;
+            colorsAvailableForHumans |= color;
         }
     }
 
-    // allow comp color - blue, green, red, yellow, orange, purple
+    // Colors available for computer players: blue, green, red, yellow, orange, purple
     for ( const int color : colors ) {
         if ( fs.get() != 0 ) {
-            allow_comp_colors |= color;
+            colorsAvailableForComp |= color;
         }
     }
 
-    // kingdom count
+    // TODO: Number of active kingdoms (unused)
     // fs.seekg(0x1A, std::ios_base::beg);
     // fs.get();
 
-    // wins
+    // Victory conditions
     fs.seek( 0x1D );
-    conditions_wins = fs.get();
+    victoryConditions = fs.get();
+    // Do the victory conditions apply to AI too
+    compAlsoWins = ( fs.get() != 0 );
+    // Is "normal victory" (defeating all other players) applicable here
+    allowNormalVictory = ( fs.get() != 0 );
     // data wins
-    comp_also_wins = ( fs.get() != 0 );
-    // data wins
-    allow_normal_victory = ( fs.get() != 0 );
-    // data wins
-    wins1 = fs.getLE16();
+    victoryConditionsParam1 = fs.getLE16();
     // data wins
     fs.seek( 0x2c );
-    wins2 = fs.getLE16();
+    victoryConditionsParam2 = fs.getLE16();
 
-    // loss
+    // Loss conditions
     fs.seek( 0x22 );
-    conditions_loss = fs.get();
+    lossConditions = fs.get();
     // data loss
-    loss1 = fs.getLE16();
+    lossConditionsParam1 = fs.getLE16();
     // data loss
     fs.seek( 0x2e );
-    loss2 = fs.getLE16();
+    lossConditionsParam2 = fs.getLE16();
 
-    // start with hero
+    // Does the game start with heroes in castles automatically
     fs.seek( 0x25 );
     startWithHeroInEachCastle = ( 0 == fs.get() );
 
-    // race color
+    // Initial races
     for ( const int color : colors ) {
         const uint8_t race = ByteToRace( fs.get() );
 
         races[Color::GetIndex( color )] = race;
 
         if ( Race::RAND == race ) {
-            rnd_races |= color;
+            colorsOfRandomRaces |= color;
         }
     }
 
     bool skipUnionSetup = false;
     // If loss conditions are LOSS_HERO and victory conditions are VICTORY_DEFEAT_EVERYONE then we have to verify the color to which this object belongs to.
     // If the color is under computer control only we have to make it as an ally for human player.
-    if ( conditions_loss == LOSS_HERO && conditions_wins == VICTORY_DEFEAT_EVERYONE && Colors( allow_human_colors ).size() == 1 ) {
+    if ( lossConditions == LOSS_HERO && victoryConditions == VICTORY_DEFEAT_EVERYONE && Colors( colorsAvailableForHumans ).size() == 1 ) {
         // Each tile needs 16 + 8 + 8 + 8 + 8 + 8 + 8 + 8 + 8 + 16 + 32 + 32 = 160 bits or 20 bytes.
-        fs.seek( MP2::MP2OFFSETDATA + ( loss1 + loss2 * size_w ) * 20 );
+        fs.seek( MP2::MP2OFFSETDATA + ( lossConditionsParam1 + lossConditionsParam2 * width ) * 20 );
 
         MP2::mp2tile_t mp2tile;
         MP2::loadTile( fs, mp2tile );
@@ -355,56 +327,61 @@ bool Maps::FileInfo::ReadMP2( const std::string & filename )
         tile.Init( 0, mp2tile );
 
         std::pair<int, int> colorRace = Maps::Tiles::ColorRaceFromHeroSprite( tile.GetObjectSpriteIndex() );
-        if ( ( colorRace.first & allow_human_colors ) == 0 ) {
-            const int side1 = colorRace.first | allow_human_colors;
-            const int side2 = allow_comp_colors ^ colorRace.first;
+        if ( ( colorRace.first & colorsAvailableForHumans ) == 0 ) {
+            const int side1 = colorRace.first | colorsAvailableForHumans;
+            const int side2 = colorsAvailableForComp ^ colorRace.first;
             FillUnions( side1, side2 );
-            conditions_wins = VICTORY_DEFEAT_OTHER_SIDE;
+            victoryConditions = VICTORY_DEFEAT_OTHER_SIDE;
             skipUnionSetup = true;
         }
     }
 
-    // name
+    // Map name
     fs.seek( 0x3A );
     name = fs.toString( mapNameLength );
 
-    // description
+    // Map description
     fs.seek( 0x76 );
     description = fs.toString( mapDescriptionLength );
 
-    // fill unions
-    if ( conditions_wins == VICTORY_DEFEAT_OTHER_SIDE && !skipUnionSetup ) {
+    // Alliances of kingdoms
+    if ( victoryConditions == VICTORY_DEFEAT_OTHER_SIDE && !skipUnionSetup ) {
         int side1 = 0;
         int side2 = 0;
 
-        const Colors availableColors( kingdom_colors );
+        const Colors availableColors( kingdomColors );
         if ( availableColors.empty() ) {
-            DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid list of kingdom colors during map load " << filename )
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "File " << filePath << ": invalid list of kingdom colors during map load" )
             return false;
         }
 
-        const int numPlayersSide1 = wins1;
+        const int numPlayersSide1 = victoryConditionsParam1;
         if ( ( numPlayersSide1 <= 0 ) || ( numPlayersSide1 >= static_cast<int>( availableColors.size() ) ) ) {
-            DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid win condition parameter 1 during map load " << filename )
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "File " << filePath << ": invalid victory condition param during map load" )
             return false;
         }
 
         int playerIdx = 0;
         for ( const int color : availableColors ) {
-            if ( playerIdx < numPlayersSide1 )
+            if ( playerIdx < numPlayersSide1 ) {
                 side1 |= color;
-            else
+            }
+            else {
                 side2 |= color;
+            }
+
             ++playerIdx;
         }
+
         FillUnions( side1, side2 );
     }
 
-    // Determine the type of the map.
-    const size_t pos = filename.rfind( '.' );
+    // Determine the type of the map
+    const size_t pos = filePath.rfind( '.' );
     if ( pos != std::string::npos ) {
-        const std::string fileExtension = StringLower( filename.substr( pos + 1 ) );
-        _version = ( fileExtension == "mx2" || fileExtension == "hxc" ) ? GameVersion::PRICE_OF_LOYALTY : GameVersion::SUCCESSION_WARS;
+        const std::string fileExtension = StringLower( filePath.substr( pos + 1 ) );
+
+        version = ( fileExtension == "mx2" || fileExtension == "hxc" ) ? GameVersion::PRICE_OF_LOYALTY : GameVersion::SUCCESSION_WARS;
     }
 
     return true;
@@ -412,8 +389,9 @@ bool Maps::FileInfo::ReadMP2( const std::string & filename )
 
 void Maps::FileInfo::FillUnions( const int side1Colors, const int side2Colors )
 {
-    using UnionsItemType = std::remove_extent_t<decltype( unions )>;
-    static_assert( std::is_same_v<UnionsItemType, uint8_t>, "Type of unions has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( unions ), std::array<uint8_t, KINGDOMMAX>>, "Type of unions has been changed, check the logic below" );
+
+    using UnionsItemType = decltype( unions )::value_type;
 
     for ( int i = 0; i < KINGDOMMAX; ++i ) {
         const uint8_t color = ByteToColor( i );
@@ -434,14 +412,14 @@ void Maps::FileInfo::FillUnions( const int side1Colors, const int side2Colors )
     }
 }
 
-bool Maps::FileInfo::FileSorting( const FileInfo & fi1, const FileInfo & fi2 )
+bool Maps::FileInfo::FileSorting( const FileInfo & lhs, const FileInfo & rhs )
 {
-    return CaseInsensitiveCompare( fi1.file, fi2.file );
+    return CaseInsensitiveCompare( lhs.file, rhs.file );
 }
 
-bool Maps::FileInfo::NameSorting( const FileInfo & fi1, const FileInfo & fi2 )
+bool Maps::FileInfo::NameSorting( const FileInfo & lhs, const FileInfo & rhs )
 {
-    return CaseInsensitiveCompare( fi1.name, fi2.name );
+    return CaseInsensitiveCompare( lhs.name, rhs.name );
 }
 
 int Maps::FileInfo::KingdomRace( int color ) const
@@ -467,19 +445,19 @@ int Maps::FileInfo::KingdomRace( int color ) const
 
 uint32_t Maps::FileInfo::ConditionWins() const
 {
-    switch ( conditions_wins ) {
+    switch ( victoryConditions ) {
     case VICTORY_DEFEAT_EVERYONE:
         return GameOver::WINS_ALL;
     case VICTORY_CAPTURE_TOWN:
-        return allow_normal_victory ? GameOver::WINS_TOWN | GameOver::WINS_ALL : GameOver::WINS_TOWN;
+        return allowNormalVictory ? GameOver::WINS_TOWN | GameOver::WINS_ALL : GameOver::WINS_TOWN;
     case VICTORY_KILL_HERO:
-        return allow_normal_victory ? GameOver::WINS_HERO | GameOver::WINS_ALL : GameOver::WINS_HERO;
+        return allowNormalVictory ? GameOver::WINS_HERO | GameOver::WINS_ALL : GameOver::WINS_HERO;
     case VICTORY_OBTAIN_ARTIFACT:
-        return allow_normal_victory ? GameOver::WINS_ARTIFACT | GameOver::WINS_ALL : GameOver::WINS_ARTIFACT;
+        return allowNormalVictory ? GameOver::WINS_ARTIFACT | GameOver::WINS_ALL : GameOver::WINS_ARTIFACT;
     case VICTORY_DEFEAT_OTHER_SIDE:
         return GameOver::WINS_SIDE;
     case VICTORY_COLLECT_ENOUGH_GOLD:
-        return allow_normal_victory ? GameOver::WINS_GOLD | GameOver::WINS_ALL : GameOver::WINS_GOLD;
+        return allowNormalVictory ? GameOver::WINS_GOLD | GameOver::WINS_ALL : GameOver::WINS_GOLD;
     default:
         // This is an unsupported winning condition! Please add the logic to handle it.
         assert( 0 );
@@ -491,7 +469,7 @@ uint32_t Maps::FileInfo::ConditionWins() const
 
 uint32_t Maps::FileInfo::ConditionLoss() const
 {
-    switch ( conditions_loss ) {
+    switch ( lossConditions ) {
     case LOSS_EVERYTHING:
         return GameOver::LOSS_ALL;
     case LOSS_TOWN:
@@ -511,12 +489,12 @@ uint32_t Maps::FileInfo::ConditionLoss() const
 
 bool Maps::FileInfo::WinsCompAlsoWins() const
 {
-    return comp_also_wins && ( ( GameOver::WINS_TOWN | GameOver::WINS_GOLD ) & ConditionWins() );
+    return compAlsoWins && ( ( GameOver::WINS_TOWN | GameOver::WINS_GOLD ) & ConditionWins() );
 }
 
 int Maps::FileInfo::WinsFindArtifactID() const
 {
-    return wins1 ? wins1 - 1 : Artifact::UNKNOWN;
+    return victoryConditionsParam1 ? victoryConditionsParam1 - 1 : Artifact::UNKNOWN;
 }
 
 bool Maps::FileInfo::isAllowCountPlayers( int playerCount ) const
@@ -533,36 +511,40 @@ std::string Maps::FileInfo::String() const
 
     os << "file: " << file << ", "
        << "name: " << name << ", "
-       << "kingdom colors: " << static_cast<int>( kingdom_colors ) << ", "
-       << "allow human colors: " << static_cast<int>( allow_human_colors ) << ", "
-       << "allow comp colors: " << static_cast<int>( allow_comp_colors ) << ", "
-       << "random races: " << static_cast<int>( rnd_races ) << ", "
-       << "conditions wins: " << static_cast<int>( conditions_wins ) << ", "
-       << "comp also wins: " << ( comp_also_wins ? "true" : "false" ) << ", "
-       << "allow normal victory: " << ( allow_normal_victory ? "true" : "false" ) << ", "
-       << "wins1: " << wins1 << ", "
-       << "wins2: " << wins2 << ", "
-       << "conditions loss: " << static_cast<int>( conditions_loss ) << ", "
-       << "loss1: " << loss1 << ", "
-       << "loss2: " << loss2;
+       << "kingdom colors: " << static_cast<int>( kingdomColors ) << ", "
+       << "colors for humans: " << static_cast<int>( colorsAvailableForHumans ) << ", "
+       << "colors for comp: " << static_cast<int>( colorsAvailableForComp ) << ", "
+       << "random races: " << static_cast<int>( colorsOfRandomRaces ) << ", "
+       << "victory conditions: " << static_cast<int>( victoryConditions ) << ", "
+       << "comp also wins: " << ( compAlsoWins ? "true" : "false" ) << ", "
+       << "allow normal victory: " << ( allowNormalVictory ? "true" : "false" ) << ", "
+       << "victory cond param 1: " << victoryConditionsParam1 << ", "
+       << "victory cond param 2: " << victoryConditionsParam2 << ", "
+       << "loss conditions: " << static_cast<int>( lossConditions ) << ", "
+       << "loss cond param 1: " << lossConditionsParam1 << ", "
+       << "loss cond param 2: " << lossConditionsParam2;
 
     return os.str();
 }
 
 StreamBase & Maps::operator<<( StreamBase & msg, const FileInfo & fi )
 {
+    using VersionUnderlyingType = std::underlying_type_t<decltype( fi.version )>;
+
     // Only the basename of map filename (fi.file) is saved
-    msg << System::GetBasename( fi.file ) << fi.name << fi.description << fi.size_w << fi.size_h << fi.difficulty << static_cast<uint8_t>( KINGDOMMAX );
+    msg << System::GetBasename( fi.file ) << fi.name << fi.description << fi.width << fi.height << fi.difficulty << static_cast<uint8_t>( KINGDOMMAX );
 
-    for ( uint32_t ii = 0; ii < KINGDOMMAX; ++ii )
-        msg << fi.races[ii] << fi.unions[ii];
+    static_assert( std::is_same_v<decltype( fi.races ), std::array<uint8_t, KINGDOMMAX>>, "Type of races has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( fi.unions ), std::array<uint8_t, KINGDOMMAX>>, "Type of unions has been changed, check the logic below" );
 
-    msg << fi.kingdom_colors << fi.allow_human_colors << fi.allow_comp_colors << fi.rnd_races << fi.conditions_wins << fi.comp_also_wins << fi.allow_normal_victory
-        << fi.wins1 << fi.wins2 << fi.conditions_loss << fi.loss1 << fi.loss2 << fi.localtime << fi.startWithHeroInEachCastle;
+    for ( size_t i = 0; i < KINGDOMMAX; ++i ) {
+        msg << fi.races[i] << fi.unions[i];
+    }
 
-    msg << static_cast<int>( fi._version );
-
-    return msg;
+    return msg << fi.kingdomColors << fi.colorsAvailableForHumans << fi.colorsAvailableForComp << fi.colorsOfRandomRaces << fi.victoryConditions << fi.compAlsoWins
+               << fi.allowNormalVictory << fi.victoryConditionsParam1 << fi.victoryConditionsParam2 << fi.lossConditions << fi.lossConditionsParam1
+               << fi.lossConditionsParam2 << fi.timestamp << fi.startWithHeroInEachCastle << static_cast<VersionUnderlyingType>( fi.version ) << fi.worldDay
+               << fi.worldWeek << fi.worldMonth;
 }
 
 StreamBase & Maps::operator>>( StreamBase & msg, FileInfo & fi )
@@ -570,17 +552,43 @@ StreamBase & Maps::operator>>( StreamBase & msg, FileInfo & fi )
     uint8_t kingdommax;
 
     // Only the basename of map filename (fi.file) is loaded
-    msg >> fi.file >> fi.name >> fi.description >> fi.size_w >> fi.size_h >> fi.difficulty >> kingdommax;
+    msg >> fi.file >> fi.name >> fi.description >> fi.width >> fi.height >> fi.difficulty >> kingdommax;
 
-    for ( uint32_t ii = 0; ii < kingdommax; ++ii )
-        msg >> fi.races[ii] >> fi.unions[ii];
+    static_assert( std::is_same_v<decltype( fi.races ), std::array<uint8_t, KINGDOMMAX>>, "Type of races has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( fi.unions ), std::array<uint8_t, KINGDOMMAX>>, "Type of unions has been changed, check the logic below" );
 
-    msg >> fi.kingdom_colors >> fi.allow_human_colors >> fi.allow_comp_colors >> fi.rnd_races >> fi.conditions_wins >> fi.comp_also_wins >> fi.allow_normal_victory
-        >> fi.wins1 >> fi.wins2 >> fi.conditions_loss >> fi.loss1 >> fi.loss2 >> fi.localtime >> fi.startWithHeroInEachCastle;
+    using RacesItemType = decltype( fi.races )::value_type;
+    using UnionsItemType = decltype( fi.unions )::value_type;
 
-    int temp = 0;
-    msg >> temp;
-    fi._version = static_cast<GameVersion>( temp );
+    for ( size_t i = 0; i < kingdommax; ++i ) {
+        RacesItemType racesItem = 0;
+        UnionsItemType unionsItem = 0;
+
+        msg >> racesItem >> unionsItem;
+
+        if ( i < KINGDOMMAX ) {
+            fi.races[i] = racesItem;
+            fi.unions[i] = unionsItem;
+        }
+    }
+
+    msg >> fi.kingdomColors >> fi.colorsAvailableForHumans >> fi.colorsAvailableForComp >> fi.colorsOfRandomRaces >> fi.victoryConditions >> fi.compAlsoWins
+        >> fi.allowNormalVictory >> fi.victoryConditionsParam1 >> fi.victoryConditionsParam2 >> fi.lossConditions >> fi.lossConditionsParam1 >> fi.lossConditionsParam2
+        >> fi.timestamp >> fi.startWithHeroInEachCastle;
+
+    using VersionUnderlyingType = std::underlying_type_t<decltype( fi.version )>;
+    static_assert( std::is_same_v<VersionUnderlyingType, int>, "Type of version has been changed, check the logic below" );
+
+    VersionUnderlyingType version = 0;
+    msg >> version;
+
+    fi.version = static_cast<GameVersion>( version );
+
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1002_RELEASE, "Remove the check below." );
+    if ( Game::GetVersionOfCurrentSaveFile() >= FORMAT_VERSION_1002_RELEASE ) {
+        msg >> fi.worldDay >> fi.worldWeek >> fi.worldMonth;
+    }
+
     return msg;
 }
 

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -170,6 +170,9 @@ void Maps::FileInfo::Reset()
     height = 0;
     difficulty = 0;
 
+    static_assert( std::is_same_v<decltype( races ), std::array<uint8_t, KINGDOMMAX>>, "Type of races has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( unions ), std::array<uint8_t, KINGDOMMAX>>, "Type of unions has been changed, check the logic below" );
+
     for ( int i = 0; i < KINGDOMMAX; ++i ) {
         races[i] = Race::NONE;
         unions[i] = ByteToColor( i );
@@ -530,7 +533,7 @@ StreamBase & Maps::operator<<( StreamBase & msg, const FileInfo & fi )
 
 StreamBase & Maps::operator>>( StreamBase & msg, FileInfo & fi )
 {
-    uint8_t kingdommax;
+    uint8_t kingdommax = 0;
 
     // Only the basename of map filename (fi.file) is loaded
     msg >> fi.file >> fi.name >> fi.description >> fi.width >> fi.height >> fi.difficulty >> kingdommax;

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -123,7 +123,6 @@ namespace Maps
             colorsAvailableForHumans &= ~colors;
         }
 
-        std::string String() const;
         void Reset();
 
         std::string file;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -39,6 +39,7 @@
 #include "army.h"
 #include "castle.h"
 #include "game.h"
+#include "game_io.h"
 #include "ground.h"
 #include "heroes.h"
 #include "icn.h"
@@ -2953,7 +2954,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, TilesAddon & ta )
     static_assert( std::is_same_v<ObjectIcnTypeUnderlyingType, uint8_t>, "Type of _objectIcnType has been changed, check the logic below" );
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1001_RELEASE, "Remove the logic below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_1001_RELEASE ) {
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1001_RELEASE ) {
         ObjectIcnTypeUnderlyingType objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
         msg >> objectIcnType;
 
@@ -2992,7 +2993,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
     msg >> tile._index;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1001_RELEASE, "Remove the logic below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE2_1001_RELEASE ) {
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1001_RELEASE ) {
         // In old save format terrain information is stored in a very fuzzy way.
         uint16_t temp = 0;
         msg >> temp;
@@ -3010,7 +3011,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
     static_assert( std::is_same_v<ObjectIcnTypeUnderlyingType, uint8_t>, "Type of _objectIcnType has been changed, check the logic below" );
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1001_RELEASE, "Remove the logic below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_1001_RELEASE ) {
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1001_RELEASE ) {
         ObjectIcnTypeUnderlyingType objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
         msg >> objectIcnType;
 
@@ -3037,7 +3038,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
     msg >> mainObjectType;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1001_RELEASE, "Remove the logic below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE1_1001_RELEASE ) {
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1001_RELEASE ) {
         if ( mainObjectType == 128 ) {
             // This is an old Sea Chest object type.
             mainObjectType = MP2::OBJ_SEA_CHEST;

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,7 +21,10 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "players.h"
+
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <ostream>
 
@@ -34,7 +37,6 @@
 #include "maps.h"
 #include "maps_fileinfo.h"
 #include "normal/ai_normal.h"
-#include "players.h"
 #include "race.h"
 #include "rand.h"
 #include "serialize.h"
@@ -297,9 +299,9 @@ void Players::Init( int colors )
 
 void Players::Init( const Maps::FileInfo & fi )
 {
-    if ( fi.kingdom_colors ) {
+    if ( fi.kingdomColors ) {
         clear();
-        const Colors vcolors( fi.kingdom_colors );
+        const Colors vcolors( fi.kingdomColors );
 
         Player * first = nullptr;
 

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -28,7 +28,8 @@ enum SaveFileFormat : uint16_t
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
-    FORMAT_VERSION_1002_RELEASE = 10004,
+    FORMAT_VERSION_1002_RELEASE = 10005,
+    FORMAT_VERSION_PRE_1002_RELEASE = 10004,
     FORMAT_VERSION_1001_RELEASE = 10003,
     FORMAT_VERSION_PRE2_1001_RELEASE = 10002,
     FORMAT_VERSION_PRE1_1001_RELEASE = 10001,

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -34,6 +34,7 @@
 #include "cursor.h"
 #include "difficulty.h"
 #include "game.h"
+#include "game_io.h"
 #include "gamedefs.h"
 #include "logging.h"
 #include "save_format_version.h"
@@ -1072,14 +1073,14 @@ StreamBase & operator>>( StreamBase & msg, Settings & conf )
     msg >> conf._loadedFileLanguage >> conf.current_maps_file >> conf.game_difficulty >> conf.game_type >> conf.preferably_count_players;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1000_RELEASE, "Remove the check below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE2_1000_RELEASE ) {
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1000_RELEASE ) {
         int dummy;
 
         msg >> dummy;
     }
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE3_1000_RELEASE, "Remove the check below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_PRE3_1000_RELEASE ) {
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE3_1000_RELEASE ) {
         BitModes dummy;
 
         msg >> dummy >> dummy >> dummy;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -88,7 +88,7 @@ public:
 
     bool isCurrentMapPriceOfLoyalty() const
     {
-        return current_maps_file._version == GameVersion::PRICE_OF_LOYALTY;
+        return current_maps_file.version == GameVersion::PRICE_OF_LOYALTY;
     }
 
     int HeroesMoveSpeed() const
@@ -328,7 +328,7 @@ public:
     // from maps info
     bool AllowChangeRace( int f ) const
     {
-        return ( current_maps_file.rnd_races & f ) != 0;
+        return ( current_maps_file.colorsOfRandomRaces & f ) != 0;
     }
 
     const std::string & MapsFile() const
@@ -353,7 +353,7 @@ public:
 
     fheroes2::Size MapsSize() const
     {
-        return { current_maps_file.size_w, current_maps_file.size_h };
+        return { current_maps_file.width, current_maps_file.height };
     }
 
     bool GameStartWithHeroes() const

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -41,6 +41,7 @@
 #include "color.h"
 #include "direction.h"
 #include "game.h"
+#include "game_io.h"
 #include "game_over.h"
 #include "gamedefs.h"
 #include "heroes.h"
@@ -377,13 +378,13 @@ void World::NewMaps( int32_t sw, int32_t sh )
 
     Maps::FileInfo fi;
 
-    fi.size_w = static_cast<uint16_t>( width );
-    fi.size_h = static_cast<uint16_t>( height );
+    fi.width = static_cast<uint16_t>( width );
+    fi.height = static_cast<uint16_t>( height );
 
     Settings & conf = Settings::Get();
 
     if ( conf.isPriceOfLoyaltySupported() ) {
-        fi._version = GameVersion::PRICE_OF_LOYALTY;
+        fi.version = GameVersion::PRICE_OF_LOYALTY;
     }
 
     conf.SetCurrentFileInfo( fi );
@@ -1392,8 +1393,8 @@ StreamBase & operator>>( StreamBase & msg, World & w )
     msg >> w.vec_tiles >> w.vec_heroes >> w.vec_castles >> w.vec_kingdoms >> w._rumors >> w.vec_eventsday >> w.map_captureobj >> w.ultimate_artifact >> w.day >> w.week
         >> w.month >> w.heroes_cond_wins >> w.heroes_cond_loss;
 
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1002_RELEASE, "Remove the logic below." );
-    if ( Game::GetLoadVersion() < FORMAT_VERSION_1002_RELEASE ) {
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE_1002_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE_1002_RELEASE ) {
         uint32_t dummy = 0xDEADBEEF;
 
         msg >> dummy;


### PR DESCRIPTION
Implement the proposal from #6707

![screenshot](https://user-images.githubusercontent.com/32623900/221370680-c1aee08f-746c-4f36-a10f-c9d562ab1d95.jpg)

There were two main problems because of which it was impossible to make a "naive" implementation and which caused refactoring:

1. The world date is stored in the zipped part of the save file, so we can't just seek & read a few bytes, we should unzip this part first, which is relatively slow;
2. There was no infrastructure to use the save file version in the `struct Maps::FileInfo`, so it was impossible to just add a couple of fields there.