### PR TITLE
Battle pathfinder: auto-fix the cropped paths for AI-controlled wide units

### DIFF
--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -24,7 +24,6 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <optional>
 #include <set>
 #include <tuple>
 #include <type_traits>
@@ -296,7 +295,7 @@ namespace Battle
         Indexes result;
         result.reserve( Speed::INSTANT );
 
-        std::optional<BattleNodeIndex> lastReachableNodeIdx;
+        BattleNodeIndex lastReachableNodeIdx{ -1, -1 };
         BattleNodeIndex nodeIdx = targetNodeIdx;
 
         for ( auto iter = _cache.find( nodeIdx ); iter != _cache.end(); iter = _cache.find( nodeIdx ) ) {
@@ -314,7 +313,7 @@ namespace Battle
                 continue;
             }
 
-            if ( _isWide && !lastReachableNodeIdx ) {
+            if ( _isWide && lastReachableNodeIdx == BattleNodeIndex{ -1, -1 } ) {
                 assert( index.first != -1 && index.second != -1 );
 
                 lastReachableNodeIdx = index;
@@ -328,15 +327,15 @@ namespace Battle
         // If a given position is not reachable on the current turn, then the last reachable position of
         // a wide unit may be reversed in regard to the target one. Detect this and add an extra U-turn.
         if ( _isWide && !result.empty() ) {
-            assert( lastReachableNodeIdx );
+            assert( lastReachableNodeIdx.first != -1 && lastReachableNodeIdx.second != -1 );
 
-            const bool isReflect = lastReachableNodeIdx->first < lastReachableNodeIdx->second;
+            const bool isReflect = lastReachableNodeIdx.first < lastReachableNodeIdx.second;
 
             if ( isReflect != position.isReflect() ) {
                 // The last reachable position should not be a reversed version of the target position
-                assert( !position.contains( lastReachableNodeIdx->first ) || !position.contains( lastReachableNodeIdx->second ) );
+                assert( !position.contains( lastReachableNodeIdx.first ) || !position.contains( lastReachableNodeIdx.second ) );
 
-                result.push_back( lastReachableNodeIdx->second );
+                result.push_back( lastReachableNodeIdx.second );
             }
         }
 

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -333,7 +333,7 @@ namespace Battle
             const bool isReflect = lastReachableNodeIdx->first < lastReachableNodeIdx->second;
 
             if ( isReflect != position.isReflect() ) {
-                // The last reachable position should not be a straight or reversed version of the target position
+                // The last reachable position should not be a reversed version of the target position
                 assert( !position.contains( lastReachableNodeIdx->first ) || !position.contains( lastReachableNodeIdx->second ) );
 
                 result.push_back( lastReachableNodeIdx->second );

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -24,6 +24,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 #include <set>
 #include <tuple>
 #include <type_traits>
@@ -295,7 +296,9 @@ namespace Battle
         Indexes result;
         result.reserve( Speed::INSTANT );
 
+        std::optional<BattleNodeIndex> lastReachableNodeIdx;
         BattleNodeIndex nodeIdx = targetNodeIdx;
+
         for ( auto iter = _cache.find( nodeIdx ); iter != _cache.end(); iter = _cache.find( nodeIdx ) ) {
             const auto & [index, node] = *iter;
 
@@ -311,10 +314,31 @@ namespace Battle
                 continue;
             }
 
+            if ( _isWide && !lastReachableNodeIdx ) {
+                assert( index.first != -1 && index.second != -1 );
+
+                lastReachableNodeIdx = index;
+            }
+
             result.push_back( index.first );
         }
 
         std::reverse( result.begin(), result.end() );
+
+        // If a given position is not reachable on the current turn, then the last reachable position of
+        // a wide unit may be reversed in regard to the target one. Detect this and add an extra U-turn.
+        if ( _isWide && !result.empty() ) {
+            assert( lastReachableNodeIdx );
+
+            const bool isReflect = lastReachableNodeIdx->first < lastReachableNodeIdx->second;
+
+            if ( isReflect != position.isReflect() ) {
+                // The last reachable position should not be a straight or reversed version of the target position
+                assert( !position.contains( lastReachableNodeIdx->first ) || !position.contains( lastReachableNodeIdx->second ) );
+
+                result.push_back( lastReachableNodeIdx->second );
+            }
+        }
 
         return result;
     }


### PR DESCRIPTION
An alternative approach to #6717

fix #6715

https://user-images.githubusercontent.com/32623900/221380571-9d719000-c63a-4e10-ae90-6b5e53cfbb15.mp4

```
26.02.2023 00:32:35: [DBG_BATTLE]       AI::BattlePlanner::meleeUnitDefense:  Hydras protecting friendly archer, moving to 12
26.02.2023 00:32:35: [DBG_BATTLE]       AI::BattlePlanner::planUnitTurn:  Hydras melee phase end, target cell is 12
26.02.2023 00:32:35: [DBG_BATTLE]       AI::BattlePlanner::planUnitTurn:  Hydras moving to cell 12
```