### PR TITLE
Gray out summon boat, town gate and town portal spells

### DIFF
--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "heroes_base.h"
+
 #include <algorithm>
 #include <cassert>
 #include <vector>
@@ -30,14 +32,13 @@
 #include "castle.h"
 #include "gamedefs.h"
 #include "heroes.h"
-#include "heroes_base.h"
 #include "kingdom.h"
+#include "maps.h"
 #include "race.h"
 #include "serialize.h"
 #include "spell_info.h"
 #include "tools.h"
 #include "translations.h"
-#include "maps.h"
 
 HeroBase::HeroBase( const int type, const int race )
     : magic_point( 0 )
@@ -401,7 +402,7 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
         }
 
         if ( spell == Spell::SUMMONBOAT ) {
-            int32_t boatDestination = fheroes2::getPossibleBoatPosition(hero);
+            int32_t boatDestination = fheroes2::getPossibleBoatPosition( hero );
             if ( !Maps::isValidAbsIndex( boatDestination ) ) {
                 if ( res != nullptr ) {
                     *res = _( "This spell can be casted only nearby water." );

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -402,7 +402,7 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
         }
 
         if ( spell == Spell::SUMMONBOAT ) {
-            int32_t boatDestination = fheroes2::getPossibleBoatPosition( hero );
+            const int32_t boatDestination = fheroes2::getPossibleBoatPosition( *hero );
             if ( !Maps::isValidAbsIndex( boatDestination ) ) {
                 if ( res != nullptr ) {
                     *res = _( "This spell can be casted only nearby water." );

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -392,6 +392,13 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
             return false;
         }
 
+        if ( ( spell == Spell::SUMMONBOAT || spell == Spell::TOWNGATE || spell == Spell::TOWNPORTAL ) && hero->isShipMaster() ) {
+            if ( res != nullptr ) {
+                *res = _( "This spell cannot be used on a boat." );
+            }
+            return false;
+        }
+
         if ( spell == Spell::TOWNGATE || spell == Spell::TOWNPORTAL ) {
             const KingdomCastles & castles = hero->GetKingdom().GetCastles();
             bool hasCastles = std::any_of( castles.begin(), castles.end(), []( const Castle * castle ) { return castle && castle->GetHero() == nullptr; } );

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -37,6 +37,7 @@
 #include "spell_info.h"
 #include "tools.h"
 #include "translations.h"
+#include "maps.h"
 
 HeroBase::HeroBase( const int type, const int race )
     : magic_point( 0 )
@@ -397,6 +398,16 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
                 *res = _( "This spell cannot be used on a boat." );
             }
             return false;
+        }
+
+        if ( spell == Spell::SUMMONBOAT ) {
+            int32_t boatDestination = fheroes2::getPossibleBoatPosition(hero);
+            if ( !Maps::isValidAbsIndex( boatDestination ) ) {
+                if ( res != nullptr ) {
+                    *res = _( "This spell can be casted only nearby water." );
+                }
+                return false;
+            }
         }
 
         if ( spell == Spell::TOWNGATE || spell == Spell::TOWNPORTAL ) {

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -302,7 +302,7 @@ namespace
     bool ActionSpellSummonBoat( const Heroes & hero )
     {
         const int32_t center = hero.GetIndex();
-        int32_t boatDestination = fheroes2::getPossibleBoatPosition(&hero);
+        int32_t boatDestination = fheroes2::getPossibleBoatPosition( &hero );
 
         for ( const int32_t boatSource : Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false ) ) {
             assert( Maps::isValidAbsIndex( boatSource ) );

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -301,11 +301,6 @@ namespace
 
     bool ActionSpellSummonBoat( const Heroes & hero )
     {
-        if ( hero.isShipMaster() ) {
-            Dialog::Message( "", _( "This spell cannot be used on a boat." ), Font::BIG, Dialog::OK );
-            return false;
-        }
-
         const int32_t center = hero.GetIndex();
 
         const int tilePassability = world.GetTiles( center ).GetPassable();
@@ -672,10 +667,10 @@ void Heroes::ActionSpellCast( const Spell & spell )
         apply = ActionSpellDimensionDoor( *this );
         break;
     case Spell::TOWNGATE:
-        apply = isShipMaster() ? false : ActionSpellTownGate( *this );
+        apply = ActionSpellTownGate( *this );
         break;
     case Spell::TOWNPORTAL:
-        apply = isShipMaster() ? false : ActionSpellTownPortal( *this );
+        apply = ActionSpellTownPortal( *this );
         break;
     case Spell::VISIONS:
         apply = ActionSpellVisions( *this );

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -302,47 +302,7 @@ namespace
     bool ActionSpellSummonBoat( const Heroes & hero )
     {
         const int32_t center = hero.GetIndex();
-
-        const int tilePassability = world.GetTiles( center ).GetPassable();
-
-        const MapsIndexes tilesAround = Maps::GetFreeIndexesAroundTile( center );
-
-        std::vector<int32_t> possibleBoatPositions;
-
-        for ( const int32_t tileId : tilesAround ) {
-            const int direction = Maps::GetDirection( center, tileId );
-            assert( direction != Direction::UNKNOWN );
-
-            if ( ( tilePassability & direction ) != 0 ) {
-                possibleBoatPositions.emplace_back( tileId );
-            }
-        }
-
-        const fheroes2::Point & centerPoint = Maps::GetPoint( center );
-        std::sort( possibleBoatPositions.begin(), possibleBoatPositions.end(), [&centerPoint]( const int32_t left, const int32_t right ) {
-            const fheroes2::Point & leftPoint = Maps::GetPoint( left );
-            const fheroes2::Point & rightPoint = Maps::GetPoint( right );
-            const int32_t leftDiffX = leftPoint.x - centerPoint.x;
-            const int32_t leftDiffY = leftPoint.y - centerPoint.y;
-            const int32_t rightDiffX = rightPoint.x - centerPoint.x;
-            const int32_t rightDiffY = rightPoint.y - centerPoint.y;
-
-            return ( leftDiffX * leftDiffX + leftDiffY * leftDiffY ) < ( rightDiffX * rightDiffX + rightDiffY * rightDiffY );
-        } );
-
-        int32_t boatDestination = -1;
-        for ( const int32_t tileId : possibleBoatPositions ) {
-            const Maps::Tiles & tile = world.GetTiles( tileId );
-            if ( tile.isWater() ) {
-                boatDestination = tileId;
-                break;
-            }
-        }
-
-        if ( !Maps::isValidAbsIndex( boatDestination ) ) {
-            Dialog::Message( "", _( "This spell can be casted only nearby water." ), Font::BIG, Dialog::OK );
-            return false;
-        }
+        int32_t boatDestination = fheroes2::getPossibleBoatPosition(&hero);
 
         for ( const int32_t boatSource : Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false ) ) {
             assert( Maps::isValidAbsIndex( boatSource ) );

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -301,6 +301,8 @@ namespace
 
     bool ActionSpellSummonBoat( const Heroes & hero )
     {
+        assert( !hero.isShipMaster() );
+
         const int32_t center = hero.GetIndex();
         const int32_t boatDestination = fheroes2::getPossibleBoatPosition( hero );
         assert( Maps::isValidAbsIndex( boatDestination ) );
@@ -380,6 +382,8 @@ namespace
 
     bool ActionSpellTownGate( Heroes & hero )
     {
+        assert( !hero.isShipMaster() );
+
         const Castle * castle = fheroes2::getNearestCastleTownGate( hero );
         if ( !castle ) {
             // A hero must be able to have a destination castle. Something is wrong with the logic!
@@ -400,6 +404,8 @@ namespace
 
     bool ActionSpellTownPortal( Heroes & hero )
     {
+        assert( !hero.isShipMaster() );
+
         const Kingdom & kingdom = hero.GetKingdom();
         std::vector<int32_t> castles;
 

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -302,7 +302,7 @@ namespace
     bool ActionSpellSummonBoat( const Heroes & hero )
     {
         const int32_t center = hero.GetIndex();
-        int32_t boatDestination = fheroes2::getPossibleBoatPosition( &hero );
+        const int32_t boatDestination = fheroes2::getPossibleBoatPosition( hero );
         assert( Maps::isValidAbsIndex( boatDestination ) );
 
         for ( const int32_t boatSource : Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false ) ) {

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -303,6 +303,7 @@ namespace
     {
         const int32_t center = hero.GetIndex();
         int32_t boatDestination = fheroes2::getPossibleBoatPosition( &hero );
+        assert( Maps::isValidAbsIndex( boatDestination ) );
 
         for ( const int32_t boatSource : Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false ) ) {
             assert( Maps::isValidAbsIndex( boatSource ) );

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -495,15 +495,6 @@ SpellStorage SpellBook::SetFilter( const Filter filter, const HeroBase * hero ) 
                                    } ) ) );
     }
 
-    // check on water: disable portal spells
-    if ( hero != nullptr && hero->Modes( Heroes::SHIPMASTER ) ) {
-        SpellStorage::iterator itend = res.end();
-        itend = std::remove( res.begin(), itend, Spell( Spell::TOWNGATE ) );
-        itend = std::remove( res.begin(), itend, Spell( Spell::TOWNPORTAL ) );
-        if ( res.end() != itend )
-            res.resize( std::distance( res.begin(), itend ) );
-    }
-
     // sorting results
     std::sort( res.begin(), res.end() );
 

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "spell_book.h"
+
 #include <algorithm>
 #include <cstdint>
 #include <functional>
@@ -32,14 +34,12 @@
 #include "dialog.h"
 #include "dialog_selectitems.h"
 #include "game_hotkeys.h"
-#include "heroes.h"
 #include "heroes_base.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
 #include "math_base.h"
 #include "screen.h"
-#include "spell_book.h"
 #include "text.h"
 #include "tools.h"
 #include "translations.h"

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -317,18 +317,13 @@ namespace fheroes2
         return description;
     }
 
-    int32_t getPossibleBoatPosition( const HeroBase & heroBase )
+    int32_t getPossibleBoatPosition( const Heroes & hero )
     {
-        const Heroes * hero = dynamic_cast<const Heroes *>( &heroBase );
-        if ( hero == nullptr ) {
+        if ( !hero.MayCastAdventureSpells() ) {
             return -1;
         }
 
-        if ( !hero->MayCastAdventureSpells() ) {
-            return -1;
-        }
-
-        const int32_t center = hero->GetIndex();
+        const int32_t center = hero.GetIndex();
         const int tilePassability = world.GetTiles( center ).GetPassable();
         const MapsIndexes tilesAround = Maps::GetFreeIndexesAroundTile( center );
         std::vector<int32_t> possibleBoatPositions;

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -319,12 +319,16 @@ namespace fheroes2
 
     int32_t getPossibleBoatPosition( const HeroBase & heroBase )
     {
-        const Heroes & hero = dynamic_cast<const Heroes &>( heroBase );
-        if ( !hero.MayCastAdventureSpells() ) {
+        const Heroes * hero = dynamic_cast<const Heroes *>( &heroBase );
+        if ( hero == nullptr) {
             return -1;
         }
 
-        const int32_t center = hero.GetIndex();
+        if ( !hero->MayCastAdventureSpells() ) {
+            return -1;
+        }
+
+        const int32_t center = hero->GetIndex();
         const int tilePassability = world.GetTiles( center ).GetPassable();
         const MapsIndexes tilesAround = Maps::GetFreeIndexesAroundTile( center );
         std::vector<int32_t> possibleBoatPositions;

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -317,9 +317,14 @@ namespace fheroes2
         return description;
     }
 
-    int32_t getPossibleBoatPosition( const HeroBase * hero )
+    int32_t getPossibleBoatPosition( const HeroBase & heroBase )
     {
-        const int32_t center = hero->GetIndex();
+        const Heroes & hero = dynamic_cast<const Heroes &>( heroBase );
+        if ( !hero.MayCastAdventureSpells() ) {
+            return -1;
+        }
+
+        const int32_t center = hero.GetIndex();
         const int tilePassability = world.GetTiles( center ).GetPassable();
         const MapsIndexes tilesAround = Maps::GetFreeIndexesAroundTile( center );
         std::vector<int32_t> possibleBoatPositions;

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -20,16 +20,19 @@
 
 #include "spell_info.h"
 
+#include <algorithm>
 #include <cassert>
 #include <vector>
 
 #include "artifact.h"
 #include "artifact_info.h"
 #include "castle.h"
+#include "direction.h"
 #include "heroes.h"
 #include "heroes_base.h"
 #include "kingdom.h"
 #include "maps.h"
+#include "maps_tiles.h"
 #include "math_base.h"
 #include "monster.h"
 #include "spell.h"

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -320,7 +320,7 @@ namespace fheroes2
     int32_t getPossibleBoatPosition( const HeroBase & heroBase )
     {
         const Heroes * hero = dynamic_cast<const Heroes *>( &heroBase );
-        if ( hero == nullptr) {
+        if ( hero == nullptr ) {
             return -1;
         }
 

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -34,6 +34,8 @@
 #include "spell.h"
 #include "tools.h"
 #include "translations.h"
+#include "maps.h"
+#include "world.h"
 
 namespace
 {
@@ -310,5 +312,42 @@ namespace fheroes2
         }
 
         return description;
+    }
+
+    int32_t getPossibleBoatPosition( const HeroBase * hero ) {
+        const int32_t center = hero->GetIndex();
+        const int tilePassability = world.GetTiles( center ).GetPassable();
+        const MapsIndexes tilesAround = Maps::GetFreeIndexesAroundTile( center );
+        std::vector<int32_t> possibleBoatPositions;
+        for ( const int32_t tileId : tilesAround ) {
+            const int direction = Maps::GetDirection( center, tileId );
+            assert( direction != Direction::UNKNOWN );
+
+            if ( ( tilePassability & direction ) != 0 ) {
+                possibleBoatPositions.emplace_back( tileId );
+            }
+        }
+
+        const fheroes2::Point & centerPoint = Maps::GetPoint( center );
+        std::sort( possibleBoatPositions.begin(), possibleBoatPositions.end(), [&centerPoint]( const int32_t left, const int32_t right ) {
+                const fheroes2::Point & leftPoint = Maps::GetPoint( left );
+                const fheroes2::Point & rightPoint = Maps::GetPoint( right );
+                const int32_t leftDiffX = leftPoint.x - centerPoint.x;
+                const int32_t leftDiffY = leftPoint.y - centerPoint.y;
+                const int32_t rightDiffX = rightPoint.x - centerPoint.x;
+                const int32_t rightDiffY = rightPoint.y - centerPoint.y;
+
+                return ( leftDiffX * leftDiffX + leftDiffY * leftDiffY ) < ( rightDiffX * rightDiffX + rightDiffY * rightDiffY );
+                } );
+
+        int32_t boatDestination = -1;
+        for ( const int32_t tileId : possibleBoatPositions ) {
+            const Maps::Tiles & tile = world.GetTiles( tileId );
+            if ( tile.isWater() ) {
+                boatDestination = tileId;
+                break;
+            }
+        }
+        return boatDestination;
     }
 }

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -29,12 +29,12 @@
 #include "heroes.h"
 #include "heroes_base.h"
 #include "kingdom.h"
+#include "maps.h"
 #include "math_base.h"
 #include "monster.h"
 #include "spell.h"
 #include "tools.h"
 #include "translations.h"
-#include "maps.h"
 #include "world.h"
 
 namespace
@@ -314,7 +314,8 @@ namespace fheroes2
         return description;
     }
 
-    int32_t getPossibleBoatPosition( const HeroBase * hero ) {
+    int32_t getPossibleBoatPosition( const HeroBase * hero )
+    {
         const int32_t center = hero->GetIndex();
         const int tilePassability = world.GetTiles( center ).GetPassable();
         const MapsIndexes tilesAround = Maps::GetFreeIndexesAroundTile( center );
@@ -330,15 +331,15 @@ namespace fheroes2
 
         const fheroes2::Point & centerPoint = Maps::GetPoint( center );
         std::sort( possibleBoatPositions.begin(), possibleBoatPositions.end(), [&centerPoint]( const int32_t left, const int32_t right ) {
-                const fheroes2::Point & leftPoint = Maps::GetPoint( left );
-                const fheroes2::Point & rightPoint = Maps::GetPoint( right );
-                const int32_t leftDiffX = leftPoint.x - centerPoint.x;
-                const int32_t leftDiffY = leftPoint.y - centerPoint.y;
-                const int32_t rightDiffX = rightPoint.x - centerPoint.x;
-                const int32_t rightDiffY = rightPoint.y - centerPoint.y;
+            const fheroes2::Point & leftPoint = Maps::GetPoint( left );
+            const fheroes2::Point & rightPoint = Maps::GetPoint( right );
+            const int32_t leftDiffX = leftPoint.x - centerPoint.x;
+            const int32_t leftDiffY = leftPoint.y - centerPoint.y;
+            const int32_t rightDiffX = rightPoint.x - centerPoint.x;
+            const int32_t rightDiffY = rightPoint.y - centerPoint.y;
 
-                return ( leftDiffX * leftDiffX + leftDiffY * leftDiffY ) < ( rightDiffX * rightDiffX + rightDiffY * rightDiffY );
-                } );
+            return ( leftDiffX * leftDiffX + leftDiffY * leftDiffY ) < ( rightDiffX * rightDiffX + rightDiffY * rightDiffY );
+        } );
 
         int32_t boatDestination = -1;
         for ( const int32_t tileId : possibleBoatPositions ) {

--- a/src/fheroes2/spell/spell_info.h
+++ b/src/fheroes2/spell/spell_info.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/spell/spell_info.h
+++ b/src/fheroes2/spell/spell_info.h
@@ -47,7 +47,7 @@ namespace fheroes2
 
     std::string getSpellDescription( const Spell & spell, const HeroBase * hero );
 
-    int32_t getPossibleBoatPosition( const HeroBase & hero );
+    int32_t getPossibleBoatPosition( const Heroes & hero );
 }
 
 #endif

--- a/src/fheroes2/spell/spell_info.h
+++ b/src/fheroes2/spell/spell_info.h
@@ -47,7 +47,7 @@ namespace fheroes2
 
     std::string getSpellDescription( const Spell & spell, const HeroBase * hero );
 
-    int32_t getPossibleBoatPosition( const HeroBase * hero );
+    int32_t getPossibleBoatPosition( const HeroBase & hero );
 }
 
 #endif

--- a/src/fheroes2/spell/spell_info.h
+++ b/src/fheroes2/spell/spell_info.h
@@ -46,6 +46,8 @@ namespace fheroes2
     const Castle * getNearestCastleTownGate( const Heroes & hero );
 
     std::string getSpellDescription( const Spell & spell, const HeroBase * hero );
+
+    int32_t getPossibleBoatPosition( const HeroBase * hero );
 }
 
 #endif


### PR DESCRIPTION
Solves https://github.com/ihhub/fheroes2/issues/5822 by graying Town Gate and Town Portal spells instead of not showing them in the spell book while onboard. Also changes Summon Boat spell to gray out when not near water.