### PR TITLE
Reset the world pathfinder(s) on fog reveal operations

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2453,6 +2453,9 @@ void Maps::Tiles::ClearFog( const int colors )
 {
     _fogColors &= ~colors;
 
+    // The fog might be cleared even without the hero's movement - for example, the hero can gain a new level of Scouting
+    // skill by picking up a Treasure Chest from a nearby tile or buying a map in a Magellan's Maps object using the space
+    // bar button. Reset the pathfinder(s) to make the newly discovered tiles immediately available for this hero.
     world.resetPathfinder();
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -745,7 +745,7 @@ void Maps::Tiles::Init( int32_t index, const MP2::mp2tile_t & mp2 )
     quantity1 = mp2.quantity1;
     quantity2 = mp2.quantity2;
     additionalMetadata = 0;
-    fog_colors = Color::ALL;
+    _fogColors = Color::ALL;
     _terrainImageIndex = mp2.terrainImageIndex;
     _terrainFlags = mp2.terrainFlags;
 
@@ -824,6 +824,7 @@ MP2::MapObjectType Maps::Tiles::GetObject( bool ignoreObjectUnderHero /* true */
 void Maps::Tiles::SetObject( const MP2::MapObjectType objectType )
 {
     _mainObjectType = objectType;
+
     world.resetPathfinder();
 }
 
@@ -2448,6 +2449,13 @@ bool Maps::Tiles::isFogAllAround( const int color ) const
     return true;
 }
 
+void Maps::Tiles::ClearFog( const int colors )
+{
+    _fogColors &= ~colors;
+
+    world.resetPathfinder();
+}
+
 int Maps::Tiles::GetFogDirections( int color ) const
 {
     int around = 0;
@@ -2984,7 +2992,7 @@ StreamBase & Maps::operator<<( StreamBase & msg, const Tiles & tile )
 
     return msg << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile.tilePassable << tile._uid
                << static_cast<ObjectIcnTypeUnderlyingType>( tile._objectIcnType ) << tile._hasObjectAnimation << tile._isMarkedAsRoad << tile._imageIndex
-               << static_cast<MainObjectTypeUnderlyingType>( tile._mainObjectType ) << tile.fog_colors << tile.quantity1 << tile.quantity2 << tile.additionalMetadata
+               << static_cast<MainObjectTypeUnderlyingType>( tile._mainObjectType ) << tile._fogColors << tile.quantity1 << tile.quantity2 << tile.additionalMetadata
                << tile.heroID << tile.tileIsRoad << tile.addons_level1 << tile.addons_level2 << tile._layerType;
 }
 
@@ -3107,7 +3115,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
 
     tile._mainObjectType = static_cast<MP2::MapObjectType>( mainObjectType );
 
-    msg >> tile.fog_colors >> tile.quantity1 >> tile.quantity2 >> tile.additionalMetadata >> tile.heroID >> tile.tileIsRoad >> tile.addons_level1 >> tile.addons_level2
+    msg >> tile._fogColors >> tile.quantity1 >> tile.quantity2 >> tile.additionalMetadata >> tile.heroID >> tile.tileIsRoad >> tile.addons_level1 >> tile.addons_level2
         >> tile._layerType;
 
     return msg;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -300,15 +300,11 @@ namespace Maps
         bool isFog( const int colors ) const
         {
             // colors may be the union friends
-            return ( fog_colors & colors ) == colors;
+            return ( _fogColors & colors ) == colors;
         }
 
         bool isFogAllAround( const int color ) const;
-
-        void ClearFog( int colors )
-        {
-            fog_colors &= ~colors;
-        }
+        void ClearFog( const int colors );
 
         void MonsterSetCount( uint32_t count );
         uint32_t MonsterCount() const;
@@ -317,7 +313,7 @@ namespace Maps
         // (castle has a hero or garrison, dwelling has creatures, etc)
         bool isCaptureObjectProtected() const;
 
-        /* object quantity operation */
+        // Operations with tile quantities
         void QuantityUpdate( bool isFirstLoad = true );
         void QuantityReset();
         bool QuantityIsValid() const;
@@ -453,7 +449,7 @@ namespace Maps
 
         MP2::MapObjectType _mainObjectType{ MP2::OBJ_NONE };
         uint16_t tilePassable = DIRECTION_ALL;
-        uint8_t fog_colors = Color::ALL;
+        uint8_t _fogColors = Color::ALL;
 
         uint8_t heroID = 0;
 


### PR DESCRIPTION
fix #6733

Not limited to Magellan's Maps only:

https://user-images.githubusercontent.com/32623900/221958406-8aa72aa5-0187-4906-ae06-4d14e6ed52c6.mp4

With this PR:

https://user-images.githubusercontent.com/32623900/221958518-8d701784-f0c9-420e-ab93-ccafab78ba1f.mp4
