### PR TITLE
Tree of Knowledge: fix the experience calculation for AI-controlled heroes

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1116,10 +1116,13 @@ namespace
             const Funds & funds = tile.QuantityFunds();
 
             if ( 0 == funds.GetValidItemsCount() || hero.GetKingdom().AllowPayment( funds ) ) {
-                if ( funds.GetValidItemsCount() )
-                    hero.GetKingdom().OddFundsResource( funds );
+                const int level = hero.GetLevel();
+                assert( level > 0 );
+                const uint32_t experience = Heroes::GetExperienceFromLevel( level ) - Heroes::GetExperienceFromLevel( level - 1 );
+
+                hero.GetKingdom().OddFundsResource( funds );
                 hero.SetVisited( dst_index );
-                hero.IncreaseExperience( Heroes::GetExperienceFromLevel( hero.GetLevel() ) - hero.GetExperience() );
+                hero.IncreaseExperience( experience );
             }
         }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1034,7 +1034,6 @@ void Heroes::IncreaseExperience( const uint32_t amount, const bool autoselect /*
     }
 }
 
-/* calc level from exp */
 int Heroes::GetLevelFromExperience( uint32_t exp )
 {
     for ( int lvl = 1; lvl < 255; ++lvl )
@@ -1044,7 +1043,6 @@ int Heroes::GetLevelFromExperience( uint32_t exp )
     return 0;
 }
 
-/* calc exp from level */
 uint32_t Heroes::GetExperienceFromLevel( int lvl )
 {
     switch ( lvl ) {


### PR DESCRIPTION
At the time #5697 fixed the experience calculation only for human-controlled heroes, but not for AI-controlled ones.

This change was originally the part of #6737, but since the another part of that PR is questionable, I moved the bugfix to the separate PR (this one).