### PR TITLE
Clean up AI priority tasks if attacker was killed

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -64,7 +64,7 @@ namespace AI
     };
 
     // Although AI heroes are capable to find their own tasks strategic AI should be able to focus them on most critical tasks
-    enum class PriorityTask : int
+    enum class PriorityTaskType : int
     {
         // AI will focus on siegeing or chasing the selected enemy castle or hero.
         ATTACK,

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -103,6 +103,26 @@ namespace AI
         uint32_t patrolDistance = 0;
     };
 
+    struct PriorityTask
+    {
+        PriorityTaskType type = PriorityTaskType::ATTACK;
+        double threatLevel = 0.0;
+        std::vector<int> secondary;
+
+        PriorityTask() = default;
+        PriorityTask( PriorityTaskType t, double threat )
+            : type( t )
+            , threatLevel( threat )
+        {}
+
+        PriorityTask( PriorityTaskType t, double threat, int secondaryTask )
+            : type( t )
+            , threatLevel( threat )
+        {
+            secondary.push_back( secondaryTask );
+        }
+    };
+
     struct BattleTargetPair
     {
         int cell = -1;
@@ -258,6 +278,8 @@ namespace AI
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getCourierObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getCourierMainTarget( const Heroes & hero, double lowestPossibleValue ) const;
+
+        void updatePriorityTargets( Heroes & hero, int32_t tileIndex, const MP2::MapObjectType objectType );
 
         bool purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, int32_t availableHeroCount,
                                 bool moreTasksForHeroes );

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -21,7 +21,6 @@
 #ifndef H2AI_NORMAL_H
 #define H2AI_NORMAL_H
 
-#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <map>
@@ -108,7 +107,7 @@ namespace AI
     {
         PriorityTaskType type = PriorityTaskType::ATTACK;
         double threatLevel = 0.0;
-        std::vector<int> secondary;
+        std::set<int> secondaryTaskTileId;
 
         PriorityTask() = default;
         PriorityTask( PriorityTaskType t, double threat )
@@ -120,7 +119,7 @@ namespace AI
             : type( t )
             , threatLevel( threat )
         {
-            secondary.push_back( secondaryTask );
+            secondaryTaskTileId.insert( secondaryTask );
         }
     };
 
@@ -280,7 +279,7 @@ namespace AI
         double getCourierObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getCourierMainTarget( const Heroes & hero, double lowestPossibleValue ) const;
 
-        void updatePriorityTargets( Heroes & hero, int32_t tileIndex, const MP2::MapObjectType objectType );
+        void updatePriorityTargets( Heroes & hero, const int32_t tileIndex, const MP2::MapObjectType objectType );
 
         bool purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, int32_t availableHeroCount,
                                 bool moreTasksForHeroes );

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -21,6 +21,7 @@
 #ifndef H2AI_NORMAL_H
 #define H2AI_NORMAL_H
 
+#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <map>

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1713,6 +1713,7 @@ namespace AI
 
                 if ( !attackHero && ( !attackCastle || attackCastle->GetColor() == hero.GetColor() ) ) {
                     for ( const int secondaryTask : task.secondary ) {
+                        assert( secondaryTask != tileIndex );
                         _priorityTargets.erase( secondaryTask );
                     }
                     _priorityTargets.erase( tileIndex );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -405,15 +405,21 @@ namespace AI
                         // castle is under threat
                         castlesInDanger.insert( castleIndex );
 
-                        auto it = _priorityTargets.find( enemy.first );
-                        if ( it == _priorityTargets.end() ) {
+                        auto attackTask = _priorityTargets.find( enemy.first );
+                        if ( attackTask == _priorityTargets.end() ) {
                             _priorityTargets[enemy.first] = { PriorityTaskType::ATTACK, attackerStrength, castleIndex };
                         }
                         else {
-                            it->second.secondary.push_back( castleIndex );
+                            attackTask->second.secondaryTaskTileId.insert( castleIndex );
                         }
 
-                        _priorityTargets[castleIndex] = { PriorityTaskType::DEFEND, attackerThreat };
+                        auto defenseTask = _priorityTargets.find( castleIndex );
+                        if ( defenseTask == _priorityTargets.end() ) {
+                            _priorityTargets[castleIndex] = { PriorityTaskType::DEFEND, attackerThreat, enemy.first };
+                        }
+                        else {
+                            defenseTask->second.secondaryTaskTileId.insert( enemy.first );
+                        }
                     }
                 }
             }

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -400,13 +400,20 @@ namespace AI
 
                 const double attackerThreat = attackerStrength - defenders;
                 if ( attackerThreat > 0 ) {
-                    _priorityTargets[enemy.first] = PriorityTask::ATTACK;
                     const uint32_t dist = _pathfinder.getDistance( enemy.first, castleIndex, myColor, attackerStrength );
                     if ( dist && dist < threatDistanceLimit ) {
                         // castle is under threat
                         castlesInDanger.insert( castleIndex );
 
-                        _priorityTargets[castleIndex] = PriorityTask::DEFEND;
+                        auto it = _priorityTargets.find( enemy.first );
+                        if ( it == _priorityTargets.end() ) {
+                            _priorityTargets[enemy.first] = { PriorityTaskType::ATTACK, attackerStrength, castleIndex };
+                        }
+                        else {
+                            it->second.secondary.push_back( castleIndex );
+                        }
+
+                        _priorityTargets[castleIndex] = { PriorityTaskType::DEFEND, attackerThreat };
                     }
                 }
             }


### PR DESCRIPTION
Currently AI could rush to castle defence even if enemy hero threatening it was taken out. Adding more information to track & finally taking advantage of attack tasks.