### PR TITLE
Cleanup the SDL Mixer initialization

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -52,35 +52,24 @@
 
 namespace
 {
-    // TODO: This structure is not used anywhere else except Audio::Init(). Consider this structure to be removed or utilize it properly.
-    struct Spec : public SDL_AudioSpec
+    struct AudioSpec
     {
-        Spec()
-            : SDL_AudioSpec()
-        {
 #if defined( _WIN32 )
-            // Value 22050 causes audio distortion on Windows
-            freq = 44100;
+        // Value 22050 causes audio distortion on Windows
+        int frequency = 44100;
 #else
-            freq = 22050;
+        int frequency = 22050;
 #endif
-            format = AUDIO_S16;
-            channels = 2; // Support stereo audio.
-            silence = 0;
+        uint16_t format = AUDIO_S16;
+        // Stereo audio support
+        int channels = 2;
 #if defined( ANDROID )
-            // Value greater than 1024 causes audio distortion on Android
-            samples = 1024;
+        // Value greater than 1024 causes audio distortion on Android
+        int chunkSize = 1024;
 #else
-            samples = 2048;
+        int chunkSize = 2048;
 #endif
-            size = 0;
-            // TODO: research if we need to utilize these 2 parameters in the future.
-            callback = nullptr;
-            userdata = nullptr;
-        }
     };
-
-    Spec audioSpecs;
 
     std::atomic<bool> isInitialized{ false };
     bool isMuted = false;
@@ -678,7 +667,9 @@ void Audio::Init()
     }
 #endif
 
-    if ( Mix_OpenAudio( audioSpecs.freq, audioSpecs.format, audioSpecs.channels, audioSpecs.samples ) != 0 ) {
+    const AudioSpec audioSpec;
+
+    if ( Mix_OpenAudio( audioSpec.frequency, audioSpec.format, audioSpec.channels, audioSpec.chunkSize ) != 0 ) {
         ERROR_LOG( "Failed to initialize an audio device. The error: " << Mix_GetError() )
         return;
     }
@@ -686,9 +677,10 @@ void Audio::Init()
     // By default this value should be MIX_CHANNELS.
     mixerChannelCount = Mix_AllocateChannels( -1 );
 
-    int channels = 0;
     int frequency = 0;
     uint16_t format = 0;
+    int channels = 0;
+
     const int deviceInitCount = Mix_QuerySpec( &frequency, &format, &channels );
     if ( deviceInitCount == 0 ) {
         ERROR_LOG( "Failed to query an audio device specs. The error: " << Mix_GetError() )
@@ -700,22 +692,19 @@ void Audio::Init()
         ERROR_LOG( "Trying to initialize an audio system that has been already initialized." )
     }
 
-    if ( audioSpecs.freq != frequency ) {
+    if ( audioSpec.frequency != frequency ) {
         // At least on Windows the standard frequency is 48000 Hz. Sounds in the game are 22500 Hz frequency.
         // However, resampling is done inside SDL so this is not exactly an error.
-        DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Audio frequency is initialized as " << frequency << " instead of " << audioSpecs.freq )
+        DEBUG_LOG( DBG_ENGINE, DBG_WARN, "Audio frequency is initialized as " << frequency << " instead of " << audioSpec.frequency )
     }
 
-    if ( audioSpecs.format != format ) {
-        ERROR_LOG( "Audio format is initialized as " << format << " instead of " << audioSpecs.format )
+    if ( audioSpec.format != format ) {
+        ERROR_LOG( "Audio format is initialized as " << format << " instead of " << audioSpec.format )
     }
 
-    // If this assertion blows up it means that SDL doesn't work properly.
-    assert( channels >= 0 && channels < 256 );
-
-    audioSpecs.freq = frequency;
-    audioSpecs.format = format;
-    audioSpecs.channels = static_cast<uint8_t>( channels );
+    if ( audioSpec.channels != channels ) {
+        ERROR_LOG( "Number of audio channels is initialized as " << channels << " instead of " << audioSpec.channels )
+    }
 
     musicRestartManager.createWorker();
 


### PR DESCRIPTION
Remove the last TODOs in the `engine/audio.cpp`.