### PR TITLE
Rework the radar (mini-map) update calls for AI auto controlled player

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -731,14 +731,6 @@ namespace
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
-
-#if defined( WITH_DEBUG )
-            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls and before 'FadeIn()'.
-            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
-                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
-            }
-#endif
-
             hero.FadeIn();
         }
 
@@ -803,14 +795,6 @@ namespace
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
-
-#if defined( WITH_DEBUG )
-            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls and before 'FadeIn()'.
-            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
-                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
-            }
-#endif
-
             hero.FadeIn();
         }
 
@@ -1405,13 +1389,6 @@ namespace
         hero.SetShipMaster( true );
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
-
-#if defined( WITH_DEBUG )
-            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls.
-            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
-                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
-            }
-#endif
         }
         hero.GetPath().Reset();
 
@@ -1440,14 +1417,6 @@ namespace
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( prevPosition );
-
-#if defined( WITH_DEBUG )
-            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls and before 'FadeIn()'.
-            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
-                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
-            }
-#endif
-
             hero.FadeIn( { offset.x * Game::AIHeroAnimSkip(), offset.y * Game::AIHeroAnimSkip() } );
         }
         hero.ActionNewPosition( true );
@@ -1891,17 +1860,6 @@ namespace AI
                         if ( hero.Move( noMovementAnimation ) ) {
                             if ( AIHeroesShowAnimation( hero, colors ) ) {
                                 gameArea.SetCenter( hero.GetCenter() );
-
-#if defined( WITH_DEBUG )
-                                // If player gave control to AI we need to fully update the radar image on every AI move after every 'Move()' and 'SetCenter()' calls.
-                                if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
-                                    // We redraw the radar map fully as there is no need to make a code for rendering optimizations for debug AI tracking.
-                                    // 'SetRedraw( Interface::REDRAW_RADAR )' should be called after every possible hero move. As AI don't waste time for thinking between
-                                    // hero moves we do not need to update radar in any other places (Scouting skill upgrade, Magelan maps, e.t.c.).
-
-                                    basicInterface.SetRedraw( Interface::REDRAW_RADAR );
-                                }
-#endif
                             }
                         }
                         else {
@@ -1963,14 +1921,6 @@ namespace AI
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
-
-#if defined( WITH_DEBUG )
-            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls and before 'FadeIn()'.
-            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
-                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
-            }
-#endif
-
             hero.FadeIn();
         }
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -731,6 +731,14 @@ namespace
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
+
+#if defined( WITH_DEBUG )
+            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls and before 'FadeIn()'.
+            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
+                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
+            }
+#endif
+
             hero.FadeIn();
         }
 
@@ -795,6 +803,14 @@ namespace
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
+
+#if defined( WITH_DEBUG )
+            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls and before 'FadeIn()'.
+            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
+                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
+            }
+#endif
+
             hero.FadeIn();
         }
 
@@ -1389,6 +1405,13 @@ namespace
         hero.SetShipMaster( true );
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
+
+#if defined( WITH_DEBUG )
+            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls.
+            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
+                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
+            }
+#endif
         }
         hero.GetPath().Reset();
 
@@ -1417,6 +1440,14 @@ namespace
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( prevPosition );
+
+#if defined( WITH_DEBUG )
+            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls and before 'FadeIn()'.
+            if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
+                Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
+            }
+#endif
+
             hero.FadeIn( { offset.x * Game::AIHeroAnimSkip(), offset.y * Game::AIHeroAnimSkip() } );
         }
         hero.ActionNewPosition( true );
@@ -1860,9 +1891,14 @@ namespace AI
                         if ( hero.Move( noMovementAnimation ) ) {
                             if ( AIHeroesShowAnimation( hero, colors ) ) {
                                 gameArea.SetCenter( hero.GetCenter() );
+
 #if defined( WITH_DEBUG )
-                                // If player gave control to AI we need to update radar after every AI move.
+                                // If player gave control to AI we need to fully update the radar image on every AI move after every 'Move()' and 'SetCenter()' calls.
                                 if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
+                                    // We redraw the radar map fully as there is no need to make a code for rendering optimizations for debug AI tracking.
+                                    // 'SetRedraw( Interface::REDRAW_RADAR )' should be called after every possible hero move. As AI don't waste time for thinking between
+                                    // hero moves we do not need to update radar in any other places (Scouting skill upgrade, Magelan maps, e.t.c.).
+
                                     basicInterface.SetRedraw( Interface::REDRAW_RADAR );
                                 }
 #endif
@@ -1927,13 +1963,15 @@ namespace AI
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
-            hero.FadeIn();
+
 #if defined( WITH_DEBUG )
-            // If player gave control to AI we need to update radar after every AI move.
+            // If player gave control to AI we need to fully update the radar image after every 'Move2Dest()' and 'SetCenter()' calls and before 'FadeIn()'.
             if ( Players::Get( hero.GetKingdom().GetColor() )->isAIAutoControlMode() ) {
                 Interface::Basic::Get().SetRedraw( Interface::REDRAW_RADAR );
             }
 #endif
+
+            hero.FadeIn();
         }
 
         hero.ActionNewPosition( false );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "game.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
@@ -43,7 +45,6 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "direction.h"
-#include "game.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
@@ -683,10 +684,13 @@ fheroes2::GameMode Interface::Basic::StartGame()
                     statusWindow.Reset();
                     statusWindow.SetState( StatusType::STATUS_AITURN );
 
+#if defined( WITH_DEBUG )
                     if ( player->isAIAutoControlMode() ) {
+                        // If player gave control to AI we show the radar image and update it fully at the start of player's turn.
                         radar.SetHide( false );
                         radar.SetRedraw( REDRAW_RADAR );
                     }
+#endif
 
                     Redraw();
                     display.render();

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1275,6 +1275,15 @@ void Heroes::LearnSkill( const Skill::Secondary & skill )
 void Heroes::Scoute( const int tileIndex ) const
 {
     Maps::ClearFog( tileIndex, GetScoute(), GetColor() );
+
+#if defined( WITH_DEBUG )
+    // If player gave control to AI we need to update the radar image after every 'ClearFog()' call as in this mode we don't any optimizations.
+    if ( Players::Get( GetKingdom().GetColor() )->isAIAutoControlMode() ) {
+        // We redraw the radar map fully as there is no need to make a code for rendering optimizations for AI debug tracking.
+        // As AI don't waste time for thinking between hero moves we don't need to force radar update in other places.
+        ScoutRadar();
+    }
+#endif
 }
 
 int Heroes::GetScoute() const

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3305,7 +3305,19 @@ namespace
 void Heroes::ScoutRadar() const
 {
     Interface::Basic & I = Interface::Basic::Get();
-    I.GetRadar().SetRenderArea( GetScoutRoi( true ) );
+
+#if defined( WITH_DEBUG )
+    // If player gave control to AI we need to fully update the radar image as there is no need to make a code for rendering optimizations so we don't call
+    // 'SetRenderArea()'.
+    if ( !Players::Get( GetKingdom().GetColor() )->isAIAutoControlMode() ) {
+#endif
+
+        I.GetRadar().SetRenderArea( GetScoutRoi( true ) );
+
+#if defined( WITH_DEBUG )
+    }
+#endif
+
     I.SetRedraw( Interface::REDRAW_RADAR );
 }
 


### PR DESCRIPTION
relates to #6744

The "AI auto control mode" is currently available only in debug version of fheroes2 for AI debugging purposes.
For human player we made special mini-map updates after some actions, which does not include hero movement as the player can do this action and then wants to overview the world and think about the next action. AI don't do this. So mini-map update is needed only after hero move.
The `.SetRedraw( Interface::REDRAW_RADAR )` for "AI auto control mode" player is called from `Heroes::Scoute(()` method.
It could possibly be placed in `Maps::ClearFog()`, for example, but to do this we have to transfer there the player/hero ID and to mix different logic.