### PR TITLE
Add symbols to button font (ASCII)

### DIFF
--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4174,33 +4174,11 @@ namespace
         fheroes2::DrawLine( released[94], { offset + 1, offset + 3 }, { offset + 1, offset + 5 }, buttonGoodReleasedColor );
         fheroes2::DrawLine( released[94], { offset + 2, offset + 2 }, { offset + 2, offset + 6 }, buttonGoodReleasedColor );
         fheroes2::DrawLine( released[94], { offset + 3, offset + 1 }, { offset + 3, offset + 7 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 4, offset + 0 }, { offset + 4, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 5, offset + 0 }, { offset + 5, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 6, offset + 0, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 6, offset + 2 }, { offset + 6, offset + 6 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 6, offset + 8, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 7, offset + 0, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 7, offset + 3 }, { offset + 7, offset + 5 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 7, offset + 8, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 8, offset + 0 }, { offset + 8, offset + 1 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 8, offset + 4, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 8, offset + 7 }, { offset + 8, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 9, offset + 0 }, { offset + 9, offset + 2 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 9, offset + 6 }, { offset + 9, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 10, offset + 0 }, { offset + 10, offset + 2 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 10, offset + 6 }, { offset + 10, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 11, offset + 0 }, { offset + 11, offset + 1 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 11, offset + 4, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 11, offset + 7 }, { offset + 11, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 12, offset + 0, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 12, offset + 3 }, { offset + 12, offset + 5 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 12, offset + 8, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 13, offset + 0, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 13, offset + 2 }, { offset + 13, offset + 6 }, buttonGoodReleasedColor );
-        fheroes2::SetPixel( released[94], offset + 13, offset + 8, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 14, offset + 0 }, { offset + 14, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 15, offset + 0 }, { offset + 15, offset + 8 }, buttonGoodReleasedColor );
-        fheroes2::DrawLine( released[94], { offset + 16, offset + 0 }, { offset + 16, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::Fill( released[94], offset + 4, offset + 0, 13, 9, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 6, offset + 1 }, { offset + 12, offset + 7 }, 12 );
+        fheroes2::DrawLine( released[94], { offset + 7, offset + 1 }, { offset + 13, offset + 7 }, 12 );
+        fheroes2::DrawLine( released[94], { offset + 12, offset + 1 }, { offset + 6, offset + 7 }, 12 );
+        fheroes2::DrawLine( released[94], { offset + 13, offset + 1 }, { offset + 7, offset + 7 }, 12 );
     }
 
     void generateCP1250GoodButtonFont( std::vector<fheroes2::Sprite> & released )

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -3576,10 +3576,108 @@ namespace
             letter.setPosition( buttonFontOffset.x, buttonFontOffset.y );
         }
         // Address symbols that should have even less space to neighboring symbols.
+        released[1].setPosition( buttonFontOffset.x - 1, buttonFontOffset.y );
+        released[13].setPosition( buttonFontOffset.x - 2, buttonFontOffset.y );
         released[14].setPosition( buttonFontOffset.x - 1, buttonFontOffset.y );
+        released[26].setPosition( buttonFontOffset.x - 2, buttonFontOffset.y );
+        released[27].setPosition( buttonFontOffset.x - 1, buttonFontOffset.y );
+        released[31].setPosition( buttonFontOffset.x - 1, buttonFontOffset.y );
         released[33].setPosition( buttonFontOffset.x - 1, buttonFontOffset.y );
         released[54].setPosition( buttonFontOffset.x - 1, buttonFontOffset.y );
         released[57].setPosition( buttonFontOffset.x - 1, buttonFontOffset.y );
+
+        // !
+        released[1].resize( 2 + offset * 2, 10 + offset * 2 );
+        released[1].reset();
+        fheroes2::DrawLine( released[1], { offset + 0, offset + 0 }, { offset + 0, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[1], { offset + 1, offset + 0 }, { offset + 1, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[1], { offset + 0, offset + 8 }, { offset + 0, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[1], { offset + 1, offset + 8 }, { offset + 1, offset + 9 }, buttonGoodReleasedColor );
+
+        // "
+        released[2].resize( 6 + offset * 2, 10 + offset * 2 );
+        released[2].reset();
+        fheroes2::DrawLine( released[2], { offset + 1, offset + 0 }, { offset + 1, offset + 1 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[2], { offset + 5, offset + 0 }, { offset + 5, offset + 1 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[2], offset + 0, offset + 0, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[2], offset + 4, offset + 0, buttonGoodReleasedColor );
+
+        // #
+        released[3].resize( 10 + offset * 2, 10 + offset * 2 );
+        released[3].reset();
+        fheroes2::DrawLine( released[3], { offset + 1, offset + 3 }, { offset + 9, offset + 3 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[3], { offset + 0, offset + 6 }, { offset + 8, offset + 6 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[3], { offset + 4, offset + 0 }, { offset + 2, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[3], { offset + 7, offset + 0 }, { offset + 5, offset + 9 }, buttonGoodReleasedColor );
+
+        // %
+        released[5].resize( 9 + offset * 2, 10 + offset * 2 );
+        released[5].reset();
+        fheroes2::DrawLine( released[5], { offset + 6, offset + 0 }, { offset + 2, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[5], { offset + 1, offset + 0 }, { offset + 2, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[5], { offset + 1, offset + 3 }, { offset + 2, offset + 3 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[5], { offset + 0, offset + 1 }, { offset + 0, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[5], { offset + 3, offset + 1 }, { offset + 3, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[5], { offset + 7, offset + 9 }, { offset + 6, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[5], { offset + 7, offset + 6 }, { offset + 6, offset + 6 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[5], { offset + 8, offset + 8 }, { offset + 8, offset + 7 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[5], { offset + 5, offset + 8 }, { offset + 5, offset + 7 }, buttonGoodReleasedColor );
+
+        // &
+        released[6].resize( 8 + offset * 2, 10 + offset * 2 );
+        released[6].reset();
+        fheroes2::DrawLine( released[6], { offset + 2, offset + 0 }, { offset + 3, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[6], { offset + 1, offset + 1 }, { offset + 1, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[6], { offset + 4, offset + 1 }, { offset + 4, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[6], { offset + 2, offset + 3 }, { offset + 7, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[6], { offset + 3, offset + 3 }, { offset + 1, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[6], { offset + 0, offset + 6 }, { offset + 0, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[6], { offset + 1, offset + 9 }, { offset + 4, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[6], { offset + 5, offset + 8 }, { offset + 7, offset + 5 }, buttonGoodReleasedColor );
+
+        // '
+        released[7].resize( 2 + offset * 2, 10 + offset * 2 );
+        released[7].reset();
+        fheroes2::DrawLine( released[7], { offset + 1, offset + 0 }, { offset + 1, offset + 1 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[7], offset + 0, offset + 0, buttonGoodReleasedColor );
+
+        // (
+        released[8].resize( 3 + offset * 2, 10 + offset * 2 );
+        released[8].reset();
+        fheroes2::DrawLine( released[8], { offset + 0, offset + 3 }, { offset + 0, offset + 6 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[8], { offset + 1, offset + 1 }, { offset + 1, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[8], { offset + 1, offset + 7 }, { offset + 1, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[8], offset + 2, offset + 0, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[8], offset + 2, offset + 9, buttonGoodReleasedColor );
+
+        // )
+        released[9].resize( 3 + offset * 2, 10 + offset * 2 );
+        released[9].reset();
+        fheroes2::DrawLine( released[9], { offset + 2, offset + 3 }, { offset + 2, offset + 6 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[9], { offset + 1, offset + 1 }, { offset + 1, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[9], { offset + 1, offset + 7 }, { offset + 1, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[9], offset + 0, offset + 0, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[9], offset + 0, offset + 9, buttonGoodReleasedColor );
+
+        //*
+        released[10].resize( 5 + offset * 2, 10 + offset * 2 );
+        released[10].reset();
+        fheroes2::DrawLine( released[10], { offset + 2, offset + 0 }, { offset + 2, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[10], { offset + 0, offset + 1 }, { offset + 4, offset + 4 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[10], { offset + 0, offset + 4 }, { offset + 4, offset + 1 }, buttonGoodReleasedColor );
+
+        // +
+        released[11].resize( 5 + offset * 2, 10 + offset * 2 );
+        released[11].reset();
+        fheroes2::DrawLine( released[11], { offset + 0, offset + 5 }, { offset + 4, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[11], { offset + 2, offset + 3 }, { offset + 2, offset + 7 }, buttonGoodReleasedColor );
+
+        // ,
+        released[12].resize( 3 + offset * 2, 11 + offset * 2 );
+        released[12].reset();
+        fheroes2::DrawLine( released[12], { offset + 1, offset + 8 }, { offset + 2, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[12], { offset + 1, offset + 9 }, { offset + 2, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[12], { offset + 0, offset + 10 }, { offset + 1, offset + 10 }, buttonGoodReleasedColor );
 
         // -
         released[13].resize( 6 + offset * 2, 6 + offset * 2 );
@@ -3591,6 +3689,11 @@ namespace
         released[14].reset();
         fheroes2::DrawLine( released[14], { offset + 0, offset + 8 }, { offset + 1, offset + 8 }, buttonGoodReleasedColor );
         fheroes2::DrawLine( released[14], { offset + 0, offset + 9 }, { offset + 1, offset + 9 }, buttonGoodReleasedColor );
+
+        // /
+        released[15].resize( 4 + offset * 2, 10 + offset * 2 );
+        released[15].reset();
+        fheroes2::DrawLine( released[15], { offset + 3, offset + 0 }, { offset + 0, offset + 9 }, buttonGoodReleasedColor );
 
         // 0
         released[16].resize( 9 + offset * 2, 10 + offset * 2 );
@@ -3661,6 +3764,81 @@ namespace
         fheroes2::DrawLine( released[22], { offset + 6, offset + 5 }, { offset + 6, offset + 8 }, buttonGoodReleasedColor );
         fheroes2::DrawLine( released[22], { offset + 1, offset + 9 }, { offset + 5, offset + 9 }, buttonGoodReleasedColor );
         fheroes2::SetPixel( released[22], offset + 6, offset + 1, buttonGoodReleasedColor );
+
+        // 7
+        released[23].resize( 7 + offset * 2, 10 + offset * 2 );
+        released[23].reset();
+        fheroes2::DrawLine( released[23], { offset + 0, offset + 0 }, { offset + 5, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[23], { offset + 6, offset + 0 }, { offset + 2, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[23], offset + 0, offset + 1, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[23], offset + 1, offset + 9, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[23], offset + 3, offset + 9, buttonGoodReleasedColor );
+
+        // 8
+        released[24].resize( 7 + offset * 2, 10 + offset * 2 );
+        released[24].reset();
+        fheroes2::DrawLine( released[24], { offset + 1, offset + 0 }, { offset + 5, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[24], { offset + 0, offset + 1 }, { offset + 0, offset + 3 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[24], { offset + 6, offset + 1 }, { offset + 6, offset + 3 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[24], { offset + 1, offset + 4 }, { offset + 5, offset + 4 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[24], { offset + 0, offset + 5 }, { offset + 0, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[24], { offset + 6, offset + 5 }, { offset + 6, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[24], { offset + 1, offset + 9 }, { offset + 5, offset + 9 }, buttonGoodReleasedColor );
+
+        // 9
+        released[25].resize( 7 + offset * 2, 10 + offset * 2 );
+        released[25].reset();
+        fheroes2::DrawLine( released[25], { offset + 1, offset + 0 }, { offset + 5, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[25], { offset + 0, offset + 1 }, { offset + 0, offset + 4 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[25], { offset + 6, offset + 1 }, { offset + 6, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[25], { offset + 1, offset + 5 }, { offset + 5, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[25], { offset + 1, offset + 9 }, { offset + 5, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[25], offset + 0, offset + 8, buttonGoodReleasedColor );
+
+        // :
+        released[26].resize( 2 + offset * 2, 10 + offset * 2 );
+        released[26].reset();
+        fheroes2::DrawLine( released[26], { offset + 0, offset + 3 }, { offset + 1, offset + 3 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[26], { offset + 0, offset + 4 }, { offset + 1, offset + 4 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[26], { offset + 0, offset + 8 }, { offset + 1, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[26], { offset + 0, offset + 9 }, { offset + 1, offset + 9 }, buttonGoodReleasedColor );
+
+        // ;
+        released[27].resize( 3 + offset * 2, 11 + offset * 2 );
+        released[27].reset();
+        fheroes2::DrawLine( released[27], { offset + 1, offset + 3 }, { offset + 2, offset + 3 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[27], { offset + 1, offset + 4 }, { offset + 2, offset + 4 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[27], { offset + 1, offset + 8 }, { offset + 2, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[27], { offset + 1, offset + 9 }, { offset + 2, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[27], { offset + 0, offset + 10 }, { offset + 1, offset + 10 }, buttonGoodReleasedColor );
+
+        // <
+        released[28].resize( 4 + offset * 2, 10 + offset * 2 );
+        released[28].reset();
+        fheroes2::DrawLine( released[28], { offset + 3, offset + 2 }, { offset + 0, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[28], { offset + 3, offset + 8 }, { offset + 1, offset + 6 }, buttonGoodReleasedColor );
+
+        // =
+        released[29].resize( 6 + offset * 2, 8 + offset * 2 );
+        released[29].reset();
+        fheroes2::DrawLine( released[29], { offset + 0, offset + 3 }, { offset + 5, offset + 3 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[29], { offset + 0, offset + 7 }, { offset + 5, offset + 7 }, buttonGoodReleasedColor );
+
+        // >
+        released[30].resize( 4 + offset * 2, 10 + offset * 2 );
+        released[30].reset();
+        fheroes2::DrawLine( released[30], { offset + 0, offset + 2 }, { offset + 3, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[30], { offset + 0, offset + 8 }, { offset + 2, offset + 6 }, buttonGoodReleasedColor );
+
+        // ?
+        released[31].resize( 6 + offset * 2, 10 + offset * 2 );
+        released[31].reset();
+        fheroes2::DrawLine( released[31], { offset + 0, offset + 1 }, { offset + 0, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[31], { offset + 1, offset + 0 }, { offset + 4, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[31], { offset + 5, offset + 1 }, { offset + 5, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[31], { offset + 4, offset + 3 }, { offset + 3, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[31], { offset + 2, offset + 8 }, { offset + 3, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[31], { offset + 2, offset + 9 }, { offset + 3, offset + 9 }, buttonGoodReleasedColor );
 
         // A
         released[33].resize( 13 + offset * 2, 10 + offset * 2 );
@@ -3942,6 +4120,50 @@ namespace
         fheroes2::DrawLine( released[58], { offset + 7, offset + 1 }, { offset + 0, offset + 8 }, buttonGoodReleasedColor );
         fheroes2::SetPixel( released[58], offset + 0, offset + 1, buttonGoodReleasedColor );
         fheroes2::SetPixel( released[58], offset + 8, offset + 8, buttonGoodReleasedColor );
+
+        // [
+        released[59].resize( 4 + offset * 2, 10 + offset * 2 );
+        released[59].reset();
+        fheroes2::DrawLine( released[59], { offset + 0, offset + 0 }, { offset + 0, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[59], { offset + 1, offset + 0 }, { offset + 3, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[59], { offset + 1, offset + 9 }, { offset + 3, offset + 9 }, buttonGoodReleasedColor );
+
+        /* \ */
+        released[60].resize( 4 + offset * 2, 10 + offset * 2 );
+        released[60].reset();
+        fheroes2::DrawLine( released[60], { offset + 0, offset + 0 }, { offset + 3, offset + 9 }, buttonGoodReleasedColor );
+
+        // ]
+        released[61].resize( 4 + offset * 2, 10 + offset * 2 );
+        released[61].reset();
+        fheroes2::DrawLine( released[61], { offset + 3, offset + 0 }, { offset + 3, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[61], { offset + 0, offset + 0 }, { offset + 2, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[61], { offset + 0, offset + 9 }, { offset + 2, offset + 9 }, buttonGoodReleasedColor );
+
+        // ^
+        released[62].resize( 5 + offset * 2, 3 + offset * 2 );
+        released[62].reset();
+        fheroes2::DrawLine( released[62], { offset + 0, offset + 2 }, { offset + 2, offset + 0 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[62], { offset + 3, offset + 1 }, { offset + 4, offset + 2 }, buttonGoodReleasedColor );
+
+        // _
+        released[63].resize( 8 + offset * 2, 11 + offset * 2 );
+        released[63].reset();
+        fheroes2::DrawLine( released[63], { offset + 0, offset + 10 }, { offset + 7, offset + 10 }, buttonGoodReleasedColor );
+
+        // | - replaced with caps lock symbol for testing
+        released[92].resize( 11 + offset * 2, 11 + offset * 2 );
+        released[92].reset();
+        fheroes2::SetPixel( released[92], offset + 5, offset + 0, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 4, offset + 1 }, { offset + 6, offset + 1 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 3, offset + 2 }, { offset + 7, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 2, offset + 3 }, { offset + 8, offset + 3 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 1, offset + 4 }, { offset + 9, offset + 4 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 0, offset + 5 }, { offset + 10, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 3, offset + 6 }, { offset + 7, offset + 6 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 3, offset + 7 }, { offset + 7, offset + 7 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 3, offset + 9 }, { offset + 7, offset + 9 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[92], { offset + 3, offset + 10 }, { offset + 7, offset + 10 }, buttonGoodReleasedColor );
     }
 
     void generateCP1250GoodButtonFont( std::vector<fheroes2::Sprite> & released )

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -4151,7 +4151,8 @@ namespace
         released[63].reset();
         fheroes2::DrawLine( released[63], { offset + 0, offset + 10 }, { offset + 7, offset + 10 }, buttonGoodReleasedColor );
 
-        // | - replaced with caps lock symbol for testing
+        // | - replaced with Caps Lock symbol for virtual keyboard
+        // TODO: put the Caps Lock symbol to a special font to not replace any other ASCII character.
         released[92].resize( 11 + offset * 2, 11 + offset * 2 );
         released[92].reset();
         fheroes2::SetPixel( released[92], offset + 5, offset + 0, buttonGoodReleasedColor );
@@ -4164,6 +4165,42 @@ namespace
         fheroes2::DrawLine( released[92], { offset + 3, offset + 7 }, { offset + 7, offset + 7 }, buttonGoodReleasedColor );
         fheroes2::DrawLine( released[92], { offset + 3, offset + 9 }, { offset + 7, offset + 9 }, buttonGoodReleasedColor );
         fheroes2::DrawLine( released[92], { offset + 3, offset + 10 }, { offset + 7, offset + 10 }, buttonGoodReleasedColor );
+
+        // ~ - replaced with Backspace symbol (<x]) for virtual keyboard
+        // TODO: put the Backspace symbol to a special font to not replace any other ASCII character.
+        released[94].resize( 17 + offset * 2, 9 + offset * 2 );
+        released[94].reset();
+        fheroes2::SetPixel( released[94], offset + 0, offset + 4, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 1, offset + 3 }, { offset + 1, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 2, offset + 2 }, { offset + 2, offset + 6 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 3, offset + 1 }, { offset + 3, offset + 7 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 4, offset + 0 }, { offset + 4, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 5, offset + 0 }, { offset + 5, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 6, offset + 0, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 6, offset + 2 }, { offset + 6, offset + 6 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 6, offset + 8, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 7, offset + 0, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 7, offset + 3 }, { offset + 7, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 7, offset + 8, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 8, offset + 0 }, { offset + 8, offset + 1 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 8, offset + 4, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 8, offset + 7 }, { offset + 8, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 9, offset + 0 }, { offset + 9, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 9, offset + 6 }, { offset + 9, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 10, offset + 0 }, { offset + 10, offset + 2 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 10, offset + 6 }, { offset + 10, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 11, offset + 0 }, { offset + 11, offset + 1 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 11, offset + 4, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 11, offset + 7 }, { offset + 11, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 12, offset + 0, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 12, offset + 3 }, { offset + 12, offset + 5 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 12, offset + 8, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 13, offset + 0, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 13, offset + 2 }, { offset + 13, offset + 6 }, buttonGoodReleasedColor );
+        fheroes2::SetPixel( released[94], offset + 13, offset + 8, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 14, offset + 0 }, { offset + 14, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 15, offset + 0 }, { offset + 15, offset + 8 }, buttonGoodReleasedColor );
+        fheroes2::DrawLine( released[94], { offset + 16, offset + 0 }, { offset + 16, offset + 8 }, buttonGoodReleasedColor );
     }
 
     void generateCP1250GoodButtonFont( std::vector<fheroes2::Sprite> & released )


### PR DESCRIPTION
Relates to #6750 
The added symbols: 7 8 9 ! " # % & ' ( ) * + , / : ; < = > ? [ \ ] ^ _ 
 
![Button characters](https://user-images.githubusercontent.com/113276641/222903710-ca1e1a67-9744-4ad4-b36f-a8d04b47af7c.png)

A Caps Lock symbol (▲) temporary replaces currently unused `|` character:

![Caps Lock](https://user-images.githubusercontent.com/113276641/222903647-0e68b45f-be05-47dd-9920-2fed74e938da.png)

Backspace symbol (<x]) temporary replaces the currently unused tilde character (~):
![Backspace](https://user-images.githubusercontent.com/113276641/222942875-8996c486-1ae6-420f-9eea-1a333503ac30.png)

 The need of temporary Caps Lock and Backspace symbols and what ASCII character might be replaced by them can be discussed.