### PR TITLE
Fix AI being stuck on watering hole

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -346,7 +346,7 @@ namespace
         // Objects increasing Movement points and Morale.
         case MP2::OBJ_OASIS:
         case MP2::OBJ_WATERING_HOLE: {
-            if ( !hero.isObjectTypeVisited( objectType ) ) {
+            if ( hero.isObjectTypeVisited( objectType ) ) {
                 return false;
             }
 


### PR DESCRIPTION
We missed this on a recent refactor. Currently AI hero gets stuck in a loop if such object is on the map.