### PR TITLE
Rename "scoute"

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -294,7 +294,7 @@ namespace
             hero.GetKingdom().AddCastle( castle );
             world.CaptureObject( dstIndex, hero.GetColor() );
 
-            castle->Scoute();
+            castle->Scout();
         };
 
         Army & army = castle->GetActualArmy();

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2558,7 +2558,7 @@ uint32_t Castle::GetGrownMonthOf()
     return GameStatic::GetCastleGrownMonthOf();
 }
 
-void Castle::Scoute() const
+void Castle::Scout() const
 {
     Maps::ClearFog( GetIndex(), GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::CASTLE ), GetColor() );
 }
@@ -2691,11 +2691,11 @@ void AllCastles::AddCastle( Castle * castle )
     _castleTiles[center + fheroes2::Point( 0, -3 )] = id;
 }
 
-void AllCastles::Scoute( int colors ) const
+void AllCastles::Scout( int colors ) const
 {
     for ( auto it = begin(); it != end(); ++it )
         if ( colors & ( *it )->GetColor() )
-            ( *it )->Scoute();
+            ( *it )->Scout();
 }
 
 /* pack castle */

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -253,7 +253,7 @@ public:
     int CheckBuyBuilding( const uint32_t build ) const;
     static int GetAllBuildingStatus( const Castle & );
 
-    void Scoute() const;
+    void Scout() const;
 
     std::string GetStringBuilding( uint32_t ) const;
     std::string GetDescriptionBuilding( uint32_t ) const;
@@ -417,7 +417,7 @@ public:
         return _castles[iter->second];
     }
 
-    void Scoute( int ) const;
+    void Scout( int ) const;
 
     void NewDay()
     {

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -720,7 +720,7 @@ bool Heroes::Recruit( const int col, const fheroes2::Point & pt )
     kingdom.GetRecruits();
 
     // After recruiting a hero we reveal map in hero scout area.
-    Scoute( GetIndex() );
+    Scout( GetIndex() );
     if ( isControlHuman() ) {
         // And the radar image map for human player.
         ScoutRadar();
@@ -992,7 +992,7 @@ bool Heroes::PickupArtifact( const Artifact & art )
         auto scout = [this]( const int32_t artifactID ) {
             const std::vector<fheroes2::ArtifactBonus> bonuses = fheroes2::getArtifactData( artifactID ).bonuses;
             if ( std::find( bonuses.begin(), bonuses.end(), fheroes2::ArtifactBonus( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) != bonuses.end() ) {
-                Scoute( this->GetIndex() );
+                Scout( this->GetIndex() );
                 ScoutRadar();
                 return true;
             }
@@ -1272,9 +1272,9 @@ void Heroes::LearnSkill( const Skill::Secondary & skill )
         secondary_skills.AddSkill( skill );
 }
 
-void Heroes::Scoute( const int tileIndex ) const
+void Heroes::Scout( const int tileIndex ) const
 {
-    Maps::ClearFog( tileIndex, GetScoute(), GetColor() );
+    Maps::ClearFog( tileIndex, GetScoutingDistance(), GetColor() );
 
 #if defined( WITH_DEBUG )
     // If player gave control to AI we need to update the radar image after every 'ClearFog()' call as in this mode we don't any optimizations.
@@ -1286,7 +1286,7 @@ void Heroes::Scoute( const int tileIndex ) const
 #endif
 }
 
-int Heroes::GetScoute() const
+int Heroes::GetScoutingDistance() const
 {
     return static_cast<int>( GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE )
                              + GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::HEROES ) + GetSecondaryValues( Skill::Secondary::SCOUTING ) );
@@ -1294,7 +1294,7 @@ int Heroes::GetScoute() const
 
 fheroes2::Rect Heroes::GetScoutRoi( const bool ignoreDirection /* = false */ ) const
 {
-    const int32_t scoutRange = GetScoute();
+    const int32_t scoutRange = GetScoutingDistance();
     const fheroes2::Point heroPosition = GetCenter();
 
     if ( ignoreDirection ) {
@@ -1436,7 +1436,7 @@ void Heroes::LevelUpSecondarySkill( const HeroSeedsForLevelUp & seeds, int prima
 
         // post action
         if ( selected.Skill() == Skill::Secondary::SCOUTING ) {
-            Scoute( GetIndex() );
+            Scout( GetIndex() );
             ScoutRadar();
         }
     }
@@ -1589,7 +1589,7 @@ void Heroes::Move2Dest( const int32_t dstIndex )
     if ( dstIndex != GetIndex() ) {
         world.GetTiles( GetIndex() ).SetHeroes( nullptr );
         SetIndex( dstIndex );
-        Scoute( dstIndex );
+        Scout( dstIndex );
         world.GetTiles( dstIndex ).SetHeroes( this );
     }
 }
@@ -1909,11 +1909,11 @@ Heroes * AllHeroes::GetFreeman( const int race, const int heroIDToIgnore ) const
     return at( Rand::Get( freeman_heroes ) );
 }
 
-void AllHeroes::Scoute( int colors ) const
+void AllHeroes::Scout( int colors ) const
 {
     for ( const_iterator it = begin(); it != end(); ++it )
         if ( colors & ( *it )->GetColor() )
-            ( *it )->Scoute( ( *it )->GetIndex() );
+            ( *it )->Scout( ( *it )->GetIndex() );
 }
 
 Heroes * AllHeroes::FromJail( int32_t index ) const

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -494,8 +494,8 @@ public:
 
     void FadeOut( const fheroes2::Point & offset = fheroes2::Point() ) const;
     void FadeIn( const fheroes2::Point & offset = fheroes2::Point() ) const;
-    void Scoute( const int tileIndex ) const;
-    int GetScoute() const;
+    void Scout( const int tileIndex ) const;
+    int GetScoutingDistance() const;
 
     // Returns the area in map tiles around hero's position in his scout range.
     // For non-diagonal hero move the area is set only in move direction and one tile behind (to clear Hero's previous position).
@@ -653,7 +653,7 @@ struct AllHeroes : public VecHeroes
     void Init();
     void clear();
 
-    void Scoute( int ) const;
+    void Scout( int ) const;
 
     void ResetModes( const uint32_t modes ) const
     {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -431,7 +431,7 @@ namespace
             hero.GetKingdom().AddCastle( castle );
             world.CaptureObject( dstIndex, hero.GetColor() );
 
-            castle->Scoute();
+            castle->Scout();
 
             Interface::Basic & I = Interface::Basic::Get();
 
@@ -946,7 +946,7 @@ namespace
 
                 // When Scouting skill is learned we reveal the fog and redraw the radar map image in a new scout area of the hero.
                 if ( skill.Skill() == Skill::Secondary::SCOUTING ) {
-                    hero.Scoute( hero.GetIndex() );
+                    hero.Scout( hero.GetIndex() );
                     hero.ScoutRadar();
                 }
 

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -657,11 +657,11 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
     // If the scout area bonus is increased with the new artifact we reveal the fog and update the radar.
     if ( hero1ScoutAreaBonus < bag_artifacts.getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) {
-        Scoute( GetIndex() );
+        Scout( GetIndex() );
         ScoutRadar();
     }
     if ( hero2ScoutAreaBonus < otherHero.GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) {
-        otherHero.Scoute( otherHero.GetIndex() );
+        otherHero.Scout( otherHero.GetIndex() );
         otherHero.ScoutRadar();
     }
 

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -683,7 +683,7 @@ bool Heroes::MoveStep( bool fast )
         }
         else {
             // Unveil fog before moving the hero.
-            Scoute( indexTo );
+            Scout( indexTo );
 
             MoveStep( *this, indexTo, true );
         }
@@ -707,7 +707,7 @@ bool Heroes::MoveStep( bool fast )
     }
     else if ( ( sprite_index % heroFrameCountPerTile ) == 1 ) {
         // This is a start of hero's movement. We should clear fog around him.
-        Scoute( indexTo );
+        Scout( indexTo );
     }
     else if ( ( sprite_index % heroFrameCountPerTile ) == 8 ) {
         sprite_index -= 8;

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -328,9 +328,9 @@ Maps::Indexes Maps::getAroundIndexes( const int32_t tileIndex, const int32_t max
     return results;
 }
 
-void Maps::ClearFog( const int32_t tileIndex, int scouteValue, const int playerColor )
+void Maps::ClearFog( const int32_t tileIndex, int scoutingDistance, const int playerColor )
 {
-    if ( scouteValue <= 0 || !Maps::isValidAbsIndex( tileIndex ) ) {
+    if ( scoutingDistance <= 0 || !Maps::isValidAbsIndex( tileIndex ) ) {
         // Nothing to uncover.
         return;
     }
@@ -340,19 +340,19 @@ void Maps::ClearFog( const int32_t tileIndex, int scouteValue, const int playerC
     // AI is cheating!
     const bool isAIPlayer = world.GetKingdom( playerColor ).isControlAI();
     if ( isAIPlayer ) {
-        scouteValue += Difficulty::GetScoutingBonus( Game::getDifficulty() );
+        scoutingDistance += Difficulty::GetScoutingBonus( Game::getDifficulty() );
     }
 
     const int alliedColors = Players::GetPlayerFriends( playerColor );
 
-    const int revealRadiusSquared = scouteValue * scouteValue + 4; // constant factor for "backwards compatibility"
+    const int revealRadiusSquared = scoutingDistance * scoutingDistance + 4; // constant factor for "backwards compatibility"
 
-    const int32_t minY = std::max( center.y - scouteValue, 0 );
-    const int32_t maxY = std::min( center.y + scouteValue, world.h() - 1 );
+    const int32_t minY = std::max( center.y - scoutingDistance, 0 );
+    const int32_t maxY = std::min( center.y + scoutingDistance, world.h() - 1 );
     assert( minY < maxY );
 
-    const int32_t minX = std::max( center.x - scouteValue, 0 );
-    const int32_t maxX = std::min( center.x + scouteValue, world.w() - 1 );
+    const int32_t minX = std::max( center.x - scoutingDistance, 0 );
+    const int32_t maxX = std::min( center.x + scoutingDistance, world.w() - 1 );
     assert( minX < maxX );
 
     for ( int32_t y = minY; y <= maxY; ++y ) {
@@ -372,9 +372,9 @@ void Maps::ClearFog( const int32_t tileIndex, int scouteValue, const int playerC
     }
 }
 
-int32_t Maps::getFogTileCountToBeRevealed( const int32_t tileIndex, int scouteValue, const int playerColor )
+int32_t Maps::getFogTileCountToBeRevealed( const int32_t tileIndex, int scoutingDistance, const int playerColor )
 {
-    if ( scouteValue <= 0 || !Maps::isValidAbsIndex( tileIndex ) ) {
+    if ( scoutingDistance <= 0 || !Maps::isValidAbsIndex( tileIndex ) ) {
         return 0;
     }
 
@@ -383,17 +383,17 @@ int32_t Maps::getFogTileCountToBeRevealed( const int32_t tileIndex, int scouteVa
     // AI is cheating!
     const bool isAIPlayer = world.GetKingdom( playerColor ).isControlAI();
     if ( isAIPlayer ) {
-        scouteValue += Difficulty::GetScoutingBonus( Game::getDifficulty() );
+        scoutingDistance += Difficulty::GetScoutingBonus( Game::getDifficulty() );
     }
 
-    const int revealRadiusSquared = scouteValue * scouteValue + 4; // constant factor for "backwards compatibility"
+    const int revealRadiusSquared = scoutingDistance * scoutingDistance + 4; // constant factor for "backwards compatibility"
 
-    const int32_t minY = std::max( center.y - scouteValue, 0 );
-    const int32_t maxY = std::min( center.y + scouteValue, world.h() - 1 );
+    const int32_t minY = std::max( center.y - scoutingDistance, 0 );
+    const int32_t maxY = std::min( center.y + scoutingDistance, world.h() - 1 );
     assert( minY < maxY );
 
-    const int32_t minX = std::max( center.x - scouteValue, 0 );
-    const int32_t maxX = std::min( center.x + scouteValue, world.w() - 1 );
+    const int32_t minX = std::max( center.x - scoutingDistance, 0 );
+    const int32_t maxX = std::min( center.x + scoutingDistance, world.w() - 1 );
     assert( minX < maxX );
 
     int32_t tileCount = 0;

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -79,9 +79,8 @@ namespace Maps
     Indexes GetObjectPositions( const MP2::MapObjectType objectType, bool ignoreHeroes );
     Indexes GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes );
 
-    void ClearFog( const int32_t tileIndex, int scouteValue, const int playerColor );
-
-    int32_t getFogTileCountToBeRevealed( const int32_t tileIndex, int scouteValue, const int playerColor );
+    void ClearFog( const int32_t tileIndex, int scoutingDistance, const int playerColor );
+    int32_t getFogTileCountToBeRevealed( const int32_t tileIndex, int scoutingDistance, const int playerColor );
 
     // Returns the approximate distance between two tiles with given indexes. This distance is calculated as the number of
     // tiles (truncated to the nearest smaller integer value) that would need to be traversed in a straight direction to

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -272,21 +272,21 @@ void CapturedObjects::ClearFog( int colors )
         const ObjectColor & objcol = ( *it ).second.objcol;
 
         if ( objcol.isColor( colors ) ) {
-            int scoute = 0;
+            int scoutingDistance = 0;
 
             switch ( objcol.first ) {
             case MP2::OBJ_MINES:
             case MP2::OBJ_ALCHEMIST_LAB:
             case MP2::OBJ_SAWMILL:
-                scoute = 2;
+                scoutingDistance = 2;
                 break;
 
             default:
                 break;
             }
 
-            if ( scoute )
-                Maps::ClearFog( ( *it ).first, scoute, colors );
+            if ( scoutingDistance )
+                Maps::ClearFog( ( *it ).first, scoutingDistance, colors );
         }
     }
 }
@@ -896,10 +896,10 @@ void World::ClearFog( int colors )
     colors = Players::GetPlayerFriends( colors );
 
     // clear abroad castles
-    vec_castles.Scoute( colors );
+    vec_castles.Scout( colors );
 
     // clear abroad heroes
-    vec_heroes.Scoute( colors );
+    vec_heroes.Scout( colors );
 
     map_captureobj.ClearFog( colors );
 }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -636,7 +636,7 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
     reEvaluateIfNeeded( hero );
 
     const int start = hero.GetIndex();
-    const int scouteValue = hero.GetScoute();
+    const int scoutingDistance = hero.GetScoutingDistance();
 
     const Directions & directions = Direction::All();
     std::vector<bool> tilesVisited( world.getSize(), false );
@@ -650,13 +650,13 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
         const int currentNodeIdx = nodesToExplore[lastProcessedNode];
 
         if ( start != currentNodeIdx ) {
-            int32_t maxTilesToReveal = Maps::getFogTileCountToBeRevealed( currentNodeIdx, scouteValue, _currentColor );
+            int32_t maxTilesToReveal = Maps::getFogTileCountToBeRevealed( currentNodeIdx, scoutingDistance, _currentColor );
             if ( maxTilesToReveal > 0 ) {
                 // Found a tile where we can reveal fog. Check for other tiles in the queue to find the one with the highest value.
                 int bestIndex = currentNodeIdx;
                 for ( ; lastProcessedNode < nodesToExplore.size(); ++lastProcessedNode ) {
                     const int nodeIdx = nodesToExplore[lastProcessedNode];
-                    const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( nodeIdx, scouteValue, _currentColor );
+                    const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( nodeIdx, scoutingDistance, _currentColor );
 
                     if ( std::make_tuple( maxTilesToReveal, _cache[nodeIdx]._cost ) < std::make_tuple( tilesToReveal, _cache[bestIndex]._cost ) ) {
                         maxTilesToReveal = tilesToReveal;


### PR DESCRIPTION
Don't use this wrong word, replace it with "scout" as an action, use "scouting distance" instead of "scoute value", etc, etc.