### PR TITLE
Fix mini-map update when interacting with map objects (Teleport, Artifact, Mine, Resource, Hero)

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1076,10 +1076,6 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
                             gameArea.SetCenter( hero->GetCenter() );
                             ResetFocus( GameFocus::HEROES );
 
-                            // Update the radar map image in the area that is visible to the hero after his movement.
-                            radar.SetRenderArea( hero->GetScoutRoi() );
-                            radar.SetRedraw( REDRAW_RADAR );
-
                             RedrawFocus();
 
                             if ( stopHero ) {

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -763,8 +763,11 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
     }
 
     radar.SetHide( false );
+    // Force set radar ROI for the whole world as there could unused ROI from the last allied AI hero move in Hot Seat mode.
+    radar.SetRenderArea( { 0, 0, world.w(), world.h() } );
     statusWindow.Reset();
     gameArea.SetUpdateCursor();
+
     Redraw( REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_ICONS | REDRAW_BUTTONS | REDRAW_STATUS | REDRAW_BORDER );
 
     fheroes2::Display & display = fheroes2::Display::instance();

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -763,8 +763,6 @@ fheroes2::GameMode Interface::Basic::HumanTurn( bool isload )
     }
 
     radar.SetHide( false );
-    // Force set radar ROI for the whole world as there could unused ROI from the last allied AI hero move in Hot Seat mode.
-    radar.SetRenderArea( { 0, 0, world.w(), world.h() } );
     statusWindow.Reset();
     gameArea.SetUpdateCursor();
 

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -221,6 +221,9 @@ void Interface::Radar::Redraw( const bool redrawMapObjects )
         }
         else {
             // We are in "Hide Interface" mode and radar is turned off so we have nothing to render.
+
+            // Force set radar ROI for the whole world to be prepared to fully update radar when it will be shown.
+            _roi = { 0, 0, world.w(), world.h() };
             return;
         }
     }
@@ -229,6 +232,9 @@ void Interface::Radar::Redraw( const bool redrawMapObjects )
     const fheroes2::Rect & rect = GetArea();
     if ( _hide ) {
         fheroes2::Blit( fheroes2::AGG::GetICN( ( conf.isEvilInterfaceEnabled() ? ICN::HEROLOGE : ICN::HEROLOGO ), 0 ), display, rect.x, rect.y );
+
+        // Force set radar ROI for the whole world to be prepared to fully update radar when it will be shown.
+        _roi = { 0, 0, world.w(), world.h() };
     }
     else {
         _cursorArea.hide();

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -723,7 +723,7 @@ bool Heroes::Recruit( const int col, const fheroes2::Point & pt )
     Scout( GetIndex() );
     if ( isControlHuman() ) {
         // And the radar image map for human player.
-        ScoutRadar( true );
+        ScoutRadar();
     }
 
     return true;
@@ -993,7 +993,7 @@ bool Heroes::PickupArtifact( const Artifact & art )
             const std::vector<fheroes2::ArtifactBonus> bonuses = fheroes2::getArtifactData( artifactID ).bonuses;
             if ( std::find( bonuses.begin(), bonuses.end(), fheroes2::ArtifactBonus( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) != bonuses.end() ) {
                 Scout( this->GetIndex() );
-                ScoutRadar( true );
+                ScoutRadar();
                 return true;
             }
             return false;
@@ -1288,7 +1288,7 @@ void Heroes::Scout( const int tileIndex ) const
     if ( player->isAIAutoControlMode() ) {
         // We redraw the radar map fully as there is no need to make a code for rendering optimizations for AI debug tracking.
         // As AI don't waste time for thinking between hero moves we don't need to force radar update in other places.
-        ScoutRadar( true );
+        ScoutRadar();
     }
 #endif
 }
@@ -1299,18 +1299,12 @@ int Heroes::GetScoutingDistance() const
                              + GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::HEROES ) + GetSecondaryValues( Skill::Secondary::SCOUTING ) );
 }
 
-fheroes2::Rect Heroes::GetScoutRoi( const bool ignoreDirection ) const
+fheroes2::Rect Heroes::GetScoutRoi() const
 {
     const int32_t scoutRange = GetScoutingDistance();
     const fheroes2::Point heroPosition = GetCenter();
 
-    if ( ignoreDirection ) {
-        return { heroPosition.x - scoutRange, heroPosition.y - scoutRange, 2 * scoutRange + 1, 2 * scoutRange + 1 };
-    }
-
-    return { heroPosition.x - ( ( direction == Direction::RIGHT ) ? 1 : scoutRange ), heroPosition.y - ( ( direction == Direction::BOTTOM ) ? 1 : scoutRange ),
-             ( ( direction == Direction::LEFT || direction == Direction::RIGHT ) ? 1 : scoutRange ) + scoutRange + 1,
-             ( ( direction == Direction::TOP || direction == Direction::BOTTOM ) ? 1 : scoutRange ) + scoutRange + 1 };
+    return { heroPosition.x - scoutRange, heroPosition.y - scoutRange, 2 * scoutRange + 1, 2 * scoutRange + 1 };
 }
 
 uint32_t Heroes::UpdateMovementPoints( const uint32_t movePoints, const int skill ) const
@@ -1444,7 +1438,7 @@ void Heroes::LevelUpSecondarySkill( const HeroSeedsForLevelUp & seeds, int prima
         // Scout the area around the hero if his Scouting skill was leveled and he belongs to any kingdom.
         if ( ( selected.Skill() == Skill::Secondary::SCOUTING ) && ( GetColor() != Color::NONE ) ) {
             Scout( GetIndex() );
-            ScoutRadar( true );
+            ScoutRadar();
         }
     }
 }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -723,7 +723,7 @@ bool Heroes::Recruit( const int col, const fheroes2::Point & pt )
     Scout( GetIndex() );
     if ( isControlHuman() ) {
         // And the radar image map for human player.
-        ScoutRadar();
+        ScoutRadar( true );
     }
 
     return true;
@@ -993,7 +993,7 @@ bool Heroes::PickupArtifact( const Artifact & art )
             const std::vector<fheroes2::ArtifactBonus> bonuses = fheroes2::getArtifactData( artifactID ).bonuses;
             if ( std::find( bonuses.begin(), bonuses.end(), fheroes2::ArtifactBonus( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) != bonuses.end() ) {
                 Scout( this->GetIndex() );
-                ScoutRadar();
+                ScoutRadar( true );
                 return true;
             }
             return false;
@@ -1288,7 +1288,7 @@ void Heroes::Scout( const int tileIndex ) const
     if ( player->isAIAutoControlMode() ) {
         // We redraw the radar map fully as there is no need to make a code for rendering optimizations for AI debug tracking.
         // As AI don't waste time for thinking between hero moves we don't need to force radar update in other places.
-        ScoutRadar();
+        ScoutRadar( true );
     }
 #endif
 }
@@ -1299,7 +1299,7 @@ int Heroes::GetScoutingDistance() const
                              + GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::HEROES ) + GetSecondaryValues( Skill::Secondary::SCOUTING ) );
 }
 
-fheroes2::Rect Heroes::GetScoutRoi( const bool ignoreDirection /* = false */ ) const
+fheroes2::Rect Heroes::GetScoutRoi( const bool ignoreDirection ) const
 {
     const int32_t scoutRange = GetScoutingDistance();
     const fheroes2::Point heroPosition = GetCenter();
@@ -1444,7 +1444,7 @@ void Heroes::LevelUpSecondarySkill( const HeroSeedsForLevelUp & seeds, int prima
         // Scout the area around the hero if his Scouting skill was leveled and he belongs to any kingdom.
         if ( ( selected.Skill() == Skill::Secondary::SCOUTING ) && ( GetColor() != Color::NONE ) ) {
             Scout( GetIndex() );
-            ScoutRadar();
+            ScoutRadar( true );
         }
     }
 }

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -464,7 +464,7 @@ public:
     void ActionSpellCast( const Spell & spell );
 
     // Update map in the scout area around the Hero on radar (mini-map).
-    void ScoutRadar( const bool ignoreDirection ) const;
+    void ScoutRadar() const;
 
     bool MayCastAdventureSpells() const;
 
@@ -498,8 +498,7 @@ public:
     int GetScoutingDistance() const;
 
     // Returns the area in map tiles around hero's position in his scout range.
-    // For non-diagonal hero move the area is set only in move direction and one tile behind (to clear Hero's previous position).
-    fheroes2::Rect GetScoutRoi( const bool ignoreDirection ) const;
+    fheroes2::Rect GetScoutRoi() const;
 
     uint32_t GetVisionsDistance() const;
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -464,7 +464,7 @@ public:
     void ActionSpellCast( const Spell & spell );
 
     // Update map in the scout area around the Hero on radar (mini-map).
-    void ScoutRadar() const;
+    void ScoutRadar( const bool ignoreDirection ) const;
 
     bool MayCastAdventureSpells() const;
 
@@ -499,7 +499,7 @@ public:
 
     // Returns the area in map tiles around hero's position in his scout range.
     // For non-diagonal hero move the area is set only in move direction and one tile behind (to clear Hero's previous position).
-    fheroes2::Rect GetScoutRoi( const bool ignoreDirection = false ) const;
+    fheroes2::Rect GetScoutRoi( const bool ignoreDirection ) const;
 
     uint32_t GetVisionsDistance() const;
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1787,25 +1787,22 @@ namespace
 
         assert( world.GetTiles( index_to ).GetObject() != MP2::OBJ_HEROES );
 
+        Interface::Basic & I = Interface::Basic::Get();
+        // Update the radar map image after possible hero move before entering a Teleport.
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
+        I.SetRedraw( Interface::REDRAW_RADAR );
+
         AudioManager::PlaySound( M82::KILLFADE );
         hero.GetPath().Hide();
         hero.FadeOut();
 
-        Interface::Basic & I = Interface::Basic::Get();
         const fheroes2::Point fromPoint = Maps::GetPoint( index_from );
-        if ( hero.GetCenter() == fromPoint ) {
-            // If hero was already in Teleport and player hit the space bar.
-            I.GetRadar().SetRenderArea( { fromPoint.x, fromPoint.y, 1, 1 } );
-        }
-        else {
-            // Before entering a Teleport the hero may make a move into it, so we update the radar map image of this move.
-            I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
-        }
 
         // No action and no penalty
         hero.Move2Dest( index_to );
 
         // Clear the previous hero position
+        I.GetRadar().SetRenderArea( { fromPoint.x, fromPoint.y, 1, 1 } );
         I.Redraw( Interface::REDRAW_RADAR );
 
         I.GetGameArea().SetCenter( hero.GetCenter() );
@@ -1834,25 +1831,22 @@ namespace
             return;
         }
 
+        Interface::Basic & I = Interface::Basic::Get();
+        // Update the radar map image after possible hero move before entering a Whirlpool.
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
+        I.SetRedraw( Interface::REDRAW_RADAR );
+
         AudioManager::PlaySound( M82::KILLFADE );
         hero.GetPath().Hide();
         hero.FadeOut();
 
-        Interface::Basic & I = Interface::Basic::Get();
         const fheroes2::Point fromPoint = Maps::GetPoint( index_from );
-        if ( hero.GetCenter() == fromPoint ) {
-            // If hero was already in Whirlpool and player hit the space bar.
-            I.GetRadar().SetRenderArea( { fromPoint.x, fromPoint.y, 1, 1 } );
-        }
-        else {
-            // Before entering a Whirlpool the hero may make a move into it, so we update the radar map image of this move.
-            I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
-        }
 
         // No action and no penalty
         hero.Move2Dest( index_to );
 
         // Clear the previous hero position
+        I.GetRadar().SetRenderArea( { fromPoint.x, fromPoint.y, 1, 1 } );
         I.Redraw( Interface::REDRAW_RADAR );
 
         I.GetGameArea().SetCenter( hero.GetCenter() );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -582,7 +582,7 @@ namespace
 
         // Update the radar map image before changing the direction of the hero.
         Interface::Basic & I = Interface::Basic::Get();
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi( false ) );
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
         I.Redraw( Interface::REDRAW_RADAR );
 
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
@@ -613,7 +613,7 @@ namespace
 
         // Clear hero position marker from the boat and scout the area on radar after disembarking.
         Interface::Basic & I = Interface::Basic::Get();
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi( false ) );
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
         I.SetRedraw( Interface::REDRAW_RADAR );
 
         hero.GetPath().Reset();
@@ -965,7 +965,7 @@ namespace
                 // When Scouting skill is learned we reveal the fog and redraw the radar map image in a new scout area of the hero.
                 if ( skill.Skill() == Skill::Secondary::SCOUTING ) {
                     hero.Scout( hero.GetIndex() );
-                    hero.ScoutRadar( true );
+                    hero.ScoutRadar();
                 }
 
                 msg.append( _( "An ancient and immortal witch living in a hut with bird's legs for stilts teaches you %{skill} for her own inscrutable purposes." ) );
@@ -1827,7 +1827,7 @@ namespace
         I.Redraw( Interface::REDRAW_RADAR );
 
         I.GetGameArea().SetCenter( hero.GetCenter() );
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi( true ) );
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
         I.SetRedraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
 
         AudioManager::PlaySound( M82::KILLFADE );
@@ -1867,7 +1867,7 @@ namespace
         I.Redraw( Interface::REDRAW_RADAR );
 
         I.GetGameArea().SetCenter( hero.GetCenter() );
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi( true ) );
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
         I.SetRedraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
 
         AudioManager::PlaySound( M82::KILLFADE );
@@ -1983,6 +1983,7 @@ namespace
 
                 tile.QuantitySetColor( hero.GetColor() );
 
+                // TODO: make a function that will automatically get the object size in tiles and return a ROI for radar update.
                 // Set the radar update ROI according to captured object size and position.
                 fheroes2::Rect radarRoi( Maps::GetPoint( dst_index ), { 1, 1 } );
                 switch ( objectType ) {
@@ -3389,7 +3390,7 @@ namespace
     }
 }
 
-void Heroes::ScoutRadar( const bool ignoreDirection ) const
+void Heroes::ScoutRadar() const
 {
     Interface::Basic & I = Interface::Basic::Get();
 
@@ -3403,7 +3404,7 @@ void Heroes::ScoutRadar( const bool ignoreDirection ) const
         if ( !player->isAIAutoControlMode() ) {
 #endif
 
-            I.GetRadar().SetRenderArea( GetScoutRoi( ignoreDirection ) );
+            I.GetRadar().SetRenderArea( GetScoutRoi() );
 
 #if defined( WITH_DEBUG )
         }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1654,7 +1654,7 @@ namespace
 
                 const fheroes2::Point artifactPosition = Maps::GetPoint( dst_index );
 
-                // Update the position of picked up artefact on radar to remove its mark.
+                // Update the position of picked up artifact on radar to remove its mark.
                 I.GetRadar().SetRenderArea( { artifactPosition.x, artifactPosition.y, 1, 1 } );
                 I.SetRedraw( Interface::REDRAW_RADAR );
             }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1787,11 +1787,6 @@ namespace
 
         assert( world.GetTiles( index_to ).GetObject() != MP2::OBJ_HEROES );
 
-        Interface::Basic & I = Interface::Basic::Get();
-        // Update the radar map image after possible hero move before entering a Teleport.
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
-        I.SetRedraw( Interface::REDRAW_RADAR );
-
         AudioManager::PlaySound( M82::KILLFADE );
         hero.GetPath().Hide();
         hero.FadeOut();
@@ -1802,6 +1797,7 @@ namespace
         hero.Move2Dest( index_to );
 
         // Clear the previous hero position
+        Interface::Basic & I = Interface::Basic::Get();
         I.GetRadar().SetRenderArea( { fromPoint.x, fromPoint.y, 1, 1 } );
         I.Redraw( Interface::REDRAW_RADAR );
 
@@ -1831,11 +1827,6 @@ namespace
             return;
         }
 
-        Interface::Basic & I = Interface::Basic::Get();
-        // Update the radar map image after possible hero move before entering a Whirlpool.
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
-        I.SetRedraw( Interface::REDRAW_RADAR );
-
         AudioManager::PlaySound( M82::KILLFADE );
         hero.GetPath().Hide();
         hero.FadeOut();
@@ -1846,6 +1837,7 @@ namespace
         hero.Move2Dest( index_to );
 
         // Clear the previous hero position
+        Interface::Basic & I = Interface::Basic::Get();
         I.GetRadar().SetRenderArea( { fromPoint.x, fromPoint.y, 1, 1 } );
         I.Redraw( Interface::REDRAW_RADAR );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -577,7 +577,7 @@ namespace
 
         // Update the radar map image before changing the direction of the hero.
         Interface::Basic & I = Interface::Basic::Get();
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi( false ) );
         I.Redraw( Interface::REDRAW_RADAR );
 
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
@@ -947,7 +947,7 @@ namespace
                 // When Scouting skill is learned we reveal the fog and redraw the radar map image in a new scout area of the hero.
                 if ( skill.Skill() == Skill::Secondary::SCOUTING ) {
                     hero.Scout( hero.GetIndex() );
-                    hero.ScoutRadar();
+                    hero.ScoutRadar( true );
                 }
 
                 msg.append( _( "An ancient and immortal witch living in a hut with bird's legs for stilts teaches you %{skill} for her own inscrutable purposes." ) );
@@ -3334,7 +3334,7 @@ namespace
     }
 }
 
-void Heroes::ScoutRadar() const
+void Heroes::ScoutRadar( const bool ignoreDirection ) const
 {
     Interface::Basic & I = Interface::Basic::Get();
 
@@ -3348,7 +3348,7 @@ void Heroes::ScoutRadar() const
         if ( !player->isAIAutoControlMode() ) {
 #endif
 
-            I.GetRadar().SetRenderArea( GetScoutRoi( true ) );
+            I.GetRadar().SetRenderArea( GetScoutRoi( ignoreDirection ) );
 
 #if defined( WITH_DEBUG )
         }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1977,7 +1977,7 @@ namespace
 
                 tile.QuantitySetColor( hero.GetColor() );
 
-                // Set the radar update ROI according to image size and position.
+                // Set the radar update ROI according to captured object size and position.
                 fheroes2::Rect radarRoi( Maps::GetPoint( dst_index ), { 1, 1 } );
                 switch ( objectType ) {
                 case MP2::OBJ_SAWMILL:

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -610,6 +610,12 @@ namespace
         AudioManager::PlaySound( M82::KILLFADE );
         hero.GetPath().Hide();
         hero.FadeIn( fheroes2::Point( offset.x * Game::HumanHeroAnimSkip(), offset.y * Game::HumanHeroAnimSkip() ) );
+
+        // Clear hero position marker from the boat and scout the area on radar after disembarking.
+        Interface::Basic & I = Interface::Basic::Get();
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi( false ) );
+        I.SetRedraw( Interface::REDRAW_RADAR );
+
         hero.GetPath().Reset();
         hero.ActionNewPosition( true );
 

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -658,11 +658,11 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     // If the scout area bonus is increased with the new artifact we reveal the fog and update the radar.
     if ( hero1ScoutAreaBonus < bag_artifacts.getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) {
         Scout( GetIndex() );
-        ScoutRadar();
+        ScoutRadar( true );
     }
     if ( hero2ScoutAreaBonus < otherHero.GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) {
         otherHero.Scout( otherHero.GetIndex() );
-        otherHero.ScoutRadar();
+        otherHero.ScoutRadar( true );
     }
 
     display.render();

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -658,11 +658,11 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     // If the scout area bonus is increased with the new artifact we reveal the fog and update the radar.
     if ( hero1ScoutAreaBonus < bag_artifacts.getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) {
         Scout( GetIndex() );
-        ScoutRadar( true );
+        ScoutRadar();
     }
     if ( hero2ScoutAreaBonus < otherHero.GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) {
         otherHero.Scout( otherHero.GetIndex() );
-        otherHero.ScoutRadar( true );
+        otherHero.ScoutRadar();
     }
 
     display.render();

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -654,9 +654,9 @@ void Heroes::MoveStep( Heroes & hero, int32_t indexTo, bool newpos )
 
         if ( hero.isControlHuman() ) {
             // Update the radar map image in the area that is visible to the hero after his movement.
-            Interface::Radar & radar = Interface::Basic::Get().GetRadar();
-            radar.SetRenderArea( hero.GetScoutRoi() );
-            radar.SetRedraw( Interface::REDRAW_RADAR );
+            Interface::Basic & iface = Interface::Basic::Get();
+            iface.GetRadar().SetRenderArea( hero.GetScoutRoi() );
+            iface.SetRedraw( Interface::REDRAW_RADAR );
         }
 
         hero.ActionNewPosition( true );

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -651,6 +651,14 @@ void Heroes::MoveStep( Heroes & hero, int32_t indexTo, bool newpos )
     hero.ApplyPenaltyMovement( path.GetFrontPenalty() );
     if ( newpos ) {
         hero.Move2Dest( indexTo );
+
+        if ( hero.isControlHuman() ) {
+            // Update the radar map image in the area that is visible to the hero after his movement.
+            Interface::Radar & radar = Interface::Basic::Get().GetRadar();
+            radar.SetRenderArea( hero.GetScoutRoi() );
+            radar.SetRedraw( Interface::REDRAW_RADAR );
+        }
+
         hero.ActionNewPosition( true );
         path.PopFront();
 

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -654,7 +654,7 @@ void Heroes::MoveStep( Heroes & hero, int32_t indexTo, bool newpos )
 
         if ( hero.isControlHuman() ) {
             // Update the radar map image in the area that is visible to the hero after his movement.
-            hero.ScoutRadar( false );
+            hero.ScoutRadar();
         }
 
         hero.ActionNewPosition( true );

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -654,9 +654,7 @@ void Heroes::MoveStep( Heroes & hero, int32_t indexTo, bool newpos )
 
         if ( hero.isControlHuman() ) {
             // Update the radar map image in the area that is visible to the hero after his movement.
-            Interface::Basic & iface = Interface::Basic::Get();
-            iface.GetRadar().SetRenderArea( hero.GetScoutRoi() );
-            iface.SetRedraw( Interface::REDRAW_RADAR );
+            hero.ScoutRadar( false );
         }
 
         hero.ActionNewPosition( true );

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -238,7 +238,7 @@ namespace
         I.GetGameArea().SetCenter( hero.GetCenter() );
 
         // Update radar image in scout area around Hero after teleport.
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi( true ) );
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
         I.SetRedraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
 
         AudioManager::PlaySound( M82::KILLFADE );
@@ -366,7 +366,7 @@ namespace
         I.GetGameArea().SetCenter( hero.GetCenter() );
 
         // Update radar image in scout area around Hero after teleport.
-        I.GetRadar().SetRenderArea( hero.GetScoutRoi( true ) );
+        I.GetRadar().SetRenderArea( hero.GetScoutRoi() );
         I.SetRedraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
 
         AudioManager::PlaySound( M82::KILLFADE );
@@ -588,7 +588,7 @@ namespace
             if ( spell == Spell::HAUNT ) {
                 world.CaptureObject( tile.GetIndex(), Color::NONE );
                 tile.removeOwnershipFlag( MP2::OBJ_MINES );
-                tile.setAbandonedMineObjectType();
+                Maps::Tiles::setAbandonedMineObjectType( tile );
                 hero.SetMapsObject( MP2::OBJ_ABANDONED_MINE );
 
                 // Update the color of haunted mine on radar.

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -588,7 +588,7 @@ namespace
             if ( spell == Spell::HAUNT ) {
                 world.CaptureObject( tile.GetIndex(), Color::NONE );
                 tile.removeOwnershipFlag( MP2::OBJ_MINES );
-                // TODO: Update all mine tiles around "mine entrance" to OBJ_NON_ACTION_ABANDONED_MINE (like Maps::Tiles::UpdateAbandonedMineSprite())
+                tile.setAbandonedMineObjectType();
                 hero.SetMapsObject( MP2::OBJ_ABANDONED_MINE );
 
                 // Update the color of haunted mine on radar.

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -588,7 +588,15 @@ namespace
             if ( spell == Spell::HAUNT ) {
                 world.CaptureObject( tile.GetIndex(), Color::NONE );
                 tile.removeOwnershipFlag( MP2::OBJ_MINES );
+                // TODO: Update all mine tiles around "mine entrance" to OBJ_NON_ACTION_ABANDONED_MINE (like Maps::Tiles::UpdateAbandonedMineSprite())
                 hero.SetMapsObject( MP2::OBJ_ABANDONED_MINE );
+
+                // Update the color of haunted mine on radar.
+                Interface::Basic & I = Interface::Basic::Get();
+                const fheroes2::Point heroPosition = hero.GetCenter();
+                I.GetRadar().SetRenderArea( { heroPosition.x - 1, heroPosition.y - 1, 3, 2 } );
+
+                I.SetRedraw( Interface::REDRAW_RADAR );
             }
 
             world.GetCapturedObject( tile.GetIndex() ).GetTroop().Set( Monster( spell ), count );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2311,11 +2311,11 @@ void Maps::Tiles::UpdateAbandonedMineSprite( Tiles & tile )
     }
 }
 
-void Maps::Tiles::setAbandonedMineObjectType() const
+void Maps::Tiles::setAbandonedMineObjectType( const Tiles & tile )
 {
     for ( const int32_t direction : { Direction::LEFT, Direction::TOP_LEFT, Direction::TOP, Direction::TOP_RIGHT, Direction::RIGHT } ) {
-        if ( Maps::isValidDirection( _index, direction ) ) {
-            Tiles & tile2 = world.GetTiles( Maps::GetDirectionIndex( _index, direction ) );
+        if ( Maps::isValidDirection( tile._index, direction ) ) {
+            Tiles & tile2 = world.GetTiles( Maps::GetDirectionIndex( tile._index, direction ) );
 
             if ( tile2.GetObject() == MP2::OBJ_NON_ACTION_MINES ) {
                 tile2.SetObject( MP2::OBJ_NON_ACTION_ABANDONED_MINE );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2310,6 +2310,19 @@ void Maps::Tiles::UpdateAbandonedMineSprite( Tiles & tile )
     }
 }
 
+void Maps::Tiles::setAbandonedMineObjectType() const
+{
+    for ( const int32_t direction : { Direction::LEFT, Direction::TOP_LEFT, Direction::TOP, Direction::TOP_RIGHT, Direction::RIGHT } ) {
+        if ( Maps::isValidDirection( _index, direction ) ) {
+            Tiles & tile2 = world.GetTiles( Maps::GetDirectionIndex( _index, direction ) );
+
+            if ( tile2.GetObject() == MP2::OBJ_NON_ACTION_MINES ) {
+                tile2.SetObject( MP2::OBJ_NON_ACTION_ABANDONED_MINE );
+            }
+        }
+    }
+}
+
 void Maps::Tiles::UpdateRNDArtifactSprite( Tiles & tile )
 {
     Artifact art;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -28,6 +28,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
+#include <initializer_list>
 #include <iostream>
 #include <limits>
 #include <map>

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -377,7 +377,7 @@ namespace Maps
         static std::pair<uint32_t, uint32_t> GetMonsterSpriteIndices( const Tiles & tile, const uint32_t monsterIndex );
         static void PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const uint32_t count );
         static void UpdateAbandonedMineSprite( Tiles & tile );
-        void setAbandonedMineObjectType() const;
+        static void setAbandonedMineObjectType( const Tiles & tile );
 
         // Some tiles have incorrect object type. This is due to original Editor issues.
         static void fixTileObjectType( Tiles & tile );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -377,6 +377,7 @@ namespace Maps
         static std::pair<uint32_t, uint32_t> GetMonsterSpriteIndices( const Tiles & tile, const uint32_t monsterIndex );
         static void PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const uint32_t count );
         static void UpdateAbandonedMineSprite( Tiles & tile );
+        void setAbandonedMineObjectType() const;
 
         // Some tiles have incorrect object type. This is due to original Editor issues.
         static void fixTileObjectType( Tiles & tile );


### PR DESCRIPTION
This PR fixes the absence of mini-map update before entering a Teleport or Whirlpool.

The condition used to check if Hero has moved to a Teleport does not work properly so I moved the mini-map redraw after every hero move to `heroes_move.cpp`.

fheroes2:

https://user-images.githubusercontent.com/113276641/223682822-7c3bd128-9f65-442b-825d-48ab74be2f2f.mp4



This PR:

https://user-images.githubusercontent.com/113276641/223691078-1787beca-26b3-4073-bbe3-bf4c622e1a0b.mp4

UPD:
This PR also makes mini-map to update right after hero move in hero scout area.
If hero action leads to mini-map objects change then mini-map is updated only in the area of changed objects (capture of mine, resource or artifact, defeat a hero).
Previously the mini-map update was made only after hero move and action assuming that the action object will be in hero scout area.

UPD2:
This PR also relates to #6808 
And fixes #6810