### PR TITLE
Shaw Dragon City always grey on mini-map

### DIFF
--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -312,6 +312,11 @@ void Interface::Radar::RedrawObjects( const int32_t playerColor, const ViewWorld
                 break;
             }
             case MP2::OBJ_DRAGON_CITY:
+            case MP2::OBJ_NON_ACTION_DRAGON_CITY:
+                if ( visibleTile ) {
+                    fillColor = COLOR_GRAY;
+                }
+                break;
             case MP2::OBJ_LIGHTHOUSE:
             case MP2::OBJ_ALCHEMIST_LAB:
             case MP2::OBJ_MINES:
@@ -321,7 +326,6 @@ void Interface::Radar::RedrawObjects( const int32_t playerColor, const ViewWorld
                     fillColor = GetPaletteIndexFromColor( tile.QuantityColor() );
                 }
                 break;
-            case MP2::OBJ_NON_ACTION_DRAGON_CITY:
             case MP2::OBJ_NON_ACTION_LIGHTHOUSE:
             case MP2::OBJ_NON_ACTION_ALCHEMIST_LAB:
             case MP2::OBJ_NON_ACTION_MINES:


### PR DESCRIPTION
As Dragon City can not be literally captured (add +1 Dragon to your castle Dragon growth like in HoMM3) displaying it in some player's color confuses a little.
This PR makes it displayed always grey on mini-map.

![Dragon City](https://user-images.githubusercontent.com/113276641/223764871-e3fbffa1-469b-432b-944a-5f480e0619fa.png)
