### PR TITLE
Make dwellings act like in OG: fight the guardians only once per map

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2267,7 +2267,8 @@ namespace
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
 
-                tile.QuantitySetColor( hero.GetColor() );
+                // Set ownership of the dwelling to a Neutral (gray) player so that any player can recruit troops without a fight.
+                tile.QuantitySetColor( Color::UNUSED );
                 tile.SetObjectPassable( true );
 
                 if ( Dialog::Message( title, victoryMsg, Font::BIG, Dialog::YES | Dialog::NO ) == Dialog::YES ) {


### PR DESCRIPTION
In original game a hero has to fight the guardians only once per map. After this any player can recruit troops from this dwelling without fighting the guardians.
After defeating the player who has first captured these dwellings any one can continue visiting them without fighting the guardians.

In fheroes2 the player who has first captured the dwelling gets it to his own (by color), but any other player can recruit creatures without a fight with guardians. But if the owner is vanquished the next hero has to fight the guardians to be able to recruit troops.

This PR makes the dwelling to act like in original game by setting the ownership to the Neutral (gray) player.
This affects City of the Dead, Troll Bridge and Dragon City.
