### PR TITLE
Allow to resurrect Elementals

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4265,7 +4265,7 @@ void Battle::Interface::RedrawActionSpellCastPart2( const Spell & spell, const T
                     status.SetMessage( msg, true );
                 }
             }
-            else if ( spell.isALiveOnly() ) {
+            else if ( spell.isAliveOnly() ) {
                 if ( damagedMonsters == 1 ) {
                     msg = _( "The %{spell} does %{damage} damage to one living creature." );
                     StringReplace( msg, "%{spell}", spell.GetName() );

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -681,7 +681,7 @@ void Battle::Unit::PostKilledAction()
     SetModes( TR_MOVED );
 
     // Save to the graveyard if possible
-    if ( !Modes( CAP_MIRRORIMAGE ) && !Modes( CAP_SUMMONELEM ) ) {
+    if ( !Modes( CAP_MIRRORIMAGE ) && !isElemental() ) {
         Graveyard * graveyard = Arena::GetGraveyard();
         assert( graveyard != nullptr );
 

--- a/src/fheroes2/monster/monster_info.cpp
+++ b/src/fheroes2/monster/monster_info.cpp
@@ -897,13 +897,6 @@ namespace fheroes2
             }
         }
 
-        if ( spell == Spell::RESURRECT || spell == Spell::RESURRECTTRUE || spell == Spell::ANIMATEDEAD ) {
-            foundAbility = std::find( abilities.begin(), abilities.end(), MonsterAbility( MonsterAbilityType::ELEMENTAL ) );
-            if ( foundAbility != abilities.end() ) {
-                return 100;
-            }
-        }
-
         if ( spell.isCold() ) {
             foundAbility = std::find( abilities.begin(), abilities.end(), MonsterAbility( MonsterAbilityType::COLD_SPELL_IMMUNITY ) );
             if ( foundAbility != abilities.end() ) {

--- a/src/fheroes2/monster/monster_info.cpp
+++ b/src/fheroes2/monster/monster_info.cpp
@@ -883,7 +883,7 @@ namespace fheroes2
             }
         }
 
-        if ( spell.isALiveOnly() ) {
+        if ( spell.isAliveOnly() ) {
             foundAbility = std::find( abilities.begin(), abilities.end(), MonsterAbility( MonsterAbilityType::UNDEAD ) );
             if ( foundAbility != abilities.end() ) {
                 return 100;

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -494,7 +494,7 @@ bool Spell::isUndeadOnly() const
     return false;
 }
 
-bool Spell::isALiveOnly() const
+bool Spell::isAliveOnly() const
 {
     switch ( id ) {
     case BLESS:

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -201,7 +201,7 @@ public:
 
     bool isMindInfluence() const;
     bool isUndeadOnly() const;
-    bool isALiveOnly() const;
+    bool isAliveOnly() const;
     bool isSummon() const;
     bool isEffectDispel() const;
     bool isApplyWithoutFocusObject() const;

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *


### PR DESCRIPTION
fix #6784

Resurrect is allowed only while at least one elemental from the stack is still alive.