### PR TITLE
Remove unneeded translations

### DIFF
--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -267,8 +267,8 @@ namespace fheroes2
 
                     conf.setGameLanguage( getLanguageAbbreviation( SupportedLanguage::English ) );
 
-                    fheroes2::showStandardTextMessage( _( "Attention" ),
-                                                       _( "Your version of Heroes of Might and Magic II does not support any other languages than English." ),
+                    fheroes2::showStandardTextMessage( "Attention",
+                                                       "Your version of Heroes of Might and Magic II does not support any other languages than English.",
                                                        Dialog::OK );
                 }
 

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -267,8 +267,7 @@ namespace fheroes2
 
                     conf.setGameLanguage( getLanguageAbbreviation( SupportedLanguage::English ) );
 
-                    fheroes2::showStandardTextMessage( "Attention",
-                                                       "Your version of Heroes of Might and Magic II does not support any other languages than English.",
+                    fheroes2::showStandardTextMessage( "Attention", "Your version of Heroes of Might and Magic II does not support any other languages than English.",
                                                        Dialog::OK );
                 }
 


### PR DESCRIPTION
No use to translate strings which are used only in English.