### PR TITLE
Fix Hero shadow render on Adventure Map

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3206,6 +3206,41 @@ namespace fheroes2
                     _icnVsSprite[id][i + 128 + 7].setPosition( 0, original.y() );
                 }
                 return true;
+            case ICN::SHADOW32:
+                LoadOriginalICN( id );
+                // The shadow sprite of hero needs to be shifted to match the hero sprite.
+                if ( _icnVsSprite[id].size() == 86 ) {
+                    // Direction: TOP (0-8), TOP_RIGHT (9-17), RIGHT (18-26), BOTTOM_RIGHT (27-35), BOTTOM (36-44)
+                    for ( int32_t i = 0; i < 45; ++i ) {
+                        Sprite & original = _icnVsSprite[id][i];
+                        original.setPosition( original.x(), original.y() - 3 );
+                    }
+
+                    // Direction:TOP_LEFT
+                    for ( int32_t i = 59; i < 68; ++i ) {
+                        Sprite & original = _icnVsSprite[id][i];
+                        original.setPosition( original.x() + 1, original.y() - 3 );
+                    }
+
+                    // Direction:LEFT
+                    for ( int32_t i = 68; i < 77; ++i ) {
+                        Sprite & original = _icnVsSprite[id][i];
+                        original.setPosition( original.x() - 5, original.y() - 3 );
+                    }
+
+                    // Direction:BOTTOM_LEFT
+                    for ( int32_t i = 77; i < 86; ++i ) {
+                        Sprite & original = _icnVsSprite[id][i];
+                        if ( i == 80 ) {
+                            // This sprite needs extra fix.
+                            original.setPosition( original.x() - 5, original.y() - 3 );
+                        }
+                        else {
+                            original.setPosition( original.x() - 10, original.y() - 3 );
+                        }
+                    }
+                }
+                return true;
             case ICN::MINI_MONSTER_IMAGE:
             case ICN::MINI_MONSTER_SHADOW: {
                 // It doesn't matter which image is being called. We are generating both of them at the same time.

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -386,63 +386,42 @@ namespace
 
     void getShadowSpriteInfo( const Heroes & hero, const int heroMovementIndex, int & icnId, uint32_t & icnIndex )
     {
-        if ( hero.isShipMaster() ) {
-            int indexSprite = 0;
+        const int32_t heroDirection = hero.GetDirection();
+        const bool isOnBoat = hero.isShipMaster();
 
-            const int heroDirection = hero.GetDirection();
-            switch ( heroDirection ) {
-            case Direction::TOP:
-                indexSprite = 0;
-                break;
-            case Direction::TOP_RIGHT:
-                indexSprite = 9;
-                break;
-            case Direction::RIGHT:
-                indexSprite = 18;
-                break;
-            case Direction::BOTTOM_RIGHT:
-                indexSprite = 27;
-                break;
-            case Direction::BOTTOM:
-                indexSprite = 36;
-                break;
-            case Direction::BOTTOM_LEFT:
-                indexSprite = 45;
-                break;
-            case Direction::LEFT:
-                indexSprite = 54;
-                break;
-            case Direction::TOP_LEFT:
-                indexSprite = 63;
-                break;
-            default:
-                DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown hero direction " << heroDirection )
-                break;
-            }
-
-            icnId = ICN::BOATSHAD;
-            icnIndex = indexSprite + ( heroMovementIndex % heroFrameCountPerTile );
-            return;
+        switch ( heroDirection ) {
+        case Direction::TOP:
+            icnIndex = 0;
+            break;
+        case Direction::TOP_RIGHT:
+            icnIndex = 9;
+            break;
+        case Direction::RIGHT:
+            icnIndex = 18;
+            break;
+        case Direction::BOTTOM_RIGHT:
+            icnIndex = 27;
+            break;
+        case Direction::BOTTOM:
+            icnIndex = 36;
+            break;
+        case Direction::BOTTOM_LEFT:
+            icnIndex = isOnBoat ? 45 : 77;
+            break;
+        case Direction::LEFT:
+            icnIndex = isOnBoat ? 54 : 68;
+            break;
+        case Direction::TOP_LEFT:
+            icnIndex = isOnBoat ? 63 : 59;
+            break;
+        default:
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown hero direction " << heroDirection )
+            break;
         }
 
-        // TODO: this is incorrect logic of choosing shadow sprite. Fix it!
-        int indexSprite = heroMovementIndex;
+        icnId = isOnBoat ? ICN::BOATSHAD : ICN::SHADOW32;
 
-        if ( indexSprite == 51 )
-            indexSprite = 56;
-        else if ( indexSprite == 50 )
-            indexSprite = 57;
-        else if ( indexSprite == 49 )
-            indexSprite = 58;
-        else if ( indexSprite == 47 )
-            indexSprite = 55;
-        else if ( indexSprite == 46 )
-            indexSprite = 55;
-
-        const int indexOffset = ( indexSprite < 9 || indexSprite >= 36 ) ? 0 : 50;
-
-        icnId = ICN::SHADOW32;
-        icnIndex = indexSprite + indexOffset;
+        icnIndex += ( heroMovementIndex % heroFrameCountPerTile );
     }
 
     void getFrothSpriteInfo( const Heroes & hero, const int heroMovementIndex, int & icnId, uint32_t & icnIndex )
@@ -616,9 +595,6 @@ std::vector<fheroes2::ObjectRenderingInfo> Heroes::getHeroShadowSpritesPerTile()
     // Boat sprite has to be shifted so it matches other boats.
     if ( isShipMaster() ) {
         offset.y -= 11;
-    }
-    else {
-        offset.y -= 1;
     }
 
     // Apply hero offset when he moves from one tile to another.


### PR DESCRIPTION
Close #3015
Relates to #5716

This PR makes render of shadows, corresponding to hero animation:
- fixed Hero shadow ID calculation;
- corrected shadow sprite shift.

In fheroes2:  ![fheroes2 2023-03-13 20-48-43-199](https://user-images.githubusercontent.com/113276641/224788889-b2796a7c-bc8e-4dc0-93da-549b8849b9ff.gif)  This PR:  ![fheroes2 2023-03-13 20-44-42-025](https://user-images.githubusercontent.com/113276641/224788930-730c9d00-3bdd-46ef-b2c6-f51c27693638.gif)

This PR also fixes not properly updated hero shadow during move when hero speed is set to 10.