### PR TITLE
Keep only Patreon link for FlatPak

### DIFF
--- a/script/packaging/common/fheroes2.appdata.xml
+++ b/script/packaging/common/fheroes2.appdata.xml
@@ -23,8 +23,6 @@
   <url type="faq">https://github.com/ihhub/fheroes2/wiki/F.A.Q.</url>
   <url type="translate">https://github.com/ihhub/fheroes2/blob/master/docs/TRANSLATION.md</url>
   <url type="donation">https://www.patreon.com/fheroes2</url>
-  <url type="donation">https://www.paypal.com/paypalme/fheroes2</url>
-  <url type="donation">https://boosty.to/fheroes2</url>
   <content_rating type="oars-1.1">
     <content_attribute id="violence-cartoon">mild</content_attribute>
     <content_attribute id="violence-fantasy">mild</content_attribute>


### PR DESCRIPTION
As Flatpak only shows the last link as a donation link.

![image](https://user-images.githubusercontent.com/19829520/225067712-23828433-497a-46bc-bbb6-ca1959ad7acb.png)
