### PR TITLE
Preserve existing object sprite Layer Type on monster spawning. Adventure map.

### DIFF
--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -1020,10 +1020,11 @@ void Maps::Tiles::PlaceMonsterOnTile( Tiles & tile, const Monster & mons, const 
     // If there was another object sprite here (shadow for example) push it down to Addons,
     // except when there is already MONS32.ICN here.
     if ( tile._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && tile._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 && tile._imageIndex != 255 ) {
-        tile.AddonsPushLevel1( TilesAddon( OBJECT_LAYER, tile._uid, tile._objectIcnType, tile._imageIndex, false, false ) );
+        // Push object sprite to Level 1 Addons preserving the Layer Type.
+        tile.AddonsPushLevel1( TilesAddon( tile._layerType, tile._uid, tile._objectIcnType, tile._imageIndex, false, false ) );
 
-        // TODO: why are we setting UID to 0? It should be unique!
-        tile._uid = 0;
+        // Set unique UID for placed monster.
+        tile._uid = World::GetUniq();
         tile._objectIcnType = MP2::OBJ_ICN_TYPE_MONS32;
     }
 


### PR DESCRIPTION
fix #6377 
Relates to #5716 
This PR preserves object sprite Layer Type when pushing it to Addons on monster placing. The previously forced set of Layer Type to `OBJECT_LAYER` made roads parts to be rendered by the engine above hero sprite and possible some other sprites: https://github.com/ihhub/fheroes2/issues/5716#issuecomment-1473823066
![hero](https://user-images.githubusercontent.com/113276641/226101095-4142a39e-07f2-4db1-82cc-66feb930b770.png)

```
--------- Level 1 --------
UID             : 5318
ICN object type : 30 (ROAD.ICN)
layer type      : 0 (0) - Object layer <-- Initially it was: 3 - Terrain layer
```

This PR also implements setting a unique UID for the placed monster.

The changes of this PR don't affect existing save files. The fix is only for newly placed monsters (at the end of the month).

I checked this change on a couple of maps by forcing `MonthOfMonstersAction()` on every day and did not notice rendering bugs.