### PR TITLE
Properly handle the situation when wandering monsters and a hero controlled by AI eliminate each other

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -458,7 +458,7 @@ namespace
 
         // Fight
         if ( !destroy ) {
-            DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " attacked monster " << troop.GetName() )
+            DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " attacks monster " << troop.GetName() )
 
             Army army( tile );
 
@@ -472,7 +472,20 @@ namespace
             else {
                 AIBattleLose( hero, res, true );
 
+                // The army can include both the original monsters and their upgraded version
                 const uint32_t monstersLeft = army.getTotalCount();
+#ifndef NDEBUG
+                const Monster originalMonster = troop.GetMonster();
+                const Monster upgradedMonster = originalMonster.GetUpgrade();
+
+                if ( upgradedMonster == originalMonster ) {
+                    assert( monstersLeft == army.GetCountMonsters( originalMonster ) );
+                }
+                else {
+                    assert( monstersLeft == army.GetCountMonsters( originalMonster ) + army.GetCountMonsters( upgradedMonster ) );
+                }
+#endif
+
                 if ( monstersLeft > 0 ) {
                     tile.MonsterSetCount( monstersLeft );
 
@@ -600,7 +613,10 @@ namespace
                 else {
                     AIBattleLose( hero, result, true );
 
+                    // The army should include only the original monsters
                     const uint32_t monstersLeft = army.getTotalCount();
+                    assert( monstersLeft == army.GetCountMonsters( tile.QuantityMonster() ) );
+
                     if ( monstersLeft > 0 ) {
                         capture = false;
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -472,7 +472,7 @@ namespace
             else {
                 AIBattleLose( hero, res, true );
 
-                const uint32_t monstersLeft = army.GetCountMonsters( troop.GetMonster() );
+                const uint32_t monstersLeft = army.getTotalCount();
                 if ( monstersLeft > 0 ) {
                     tile.MonsterSetCount( monstersLeft );
 
@@ -589,30 +589,32 @@ namespace
         if ( !hero.isFriends( tile.QuantityColor() ) ) {
             bool capture = true;
 
-            // check guardians
             if ( tile.isCaptureObjectProtected() ) {
                 Army army( tile );
-                const Monster & mons = tile.QuantityMonster();
 
                 Battle::Result result = Battle::Loader( hero.GetArmy(), army, dst_index );
 
                 if ( result.AttackerWins() ) {
                     hero.IncreaseExperience( result.GetExperienceAttacker() );
-                    // Clear any metadata related to spells.
-                    tile.clearAdditionalMetadata();
                 }
                 else {
-                    capture = false;
-
                     AIBattleLose( hero, result, true );
 
-                    Troop & troop = world.GetCapturedObject( dst_index ).GetTroop();
-                    troop.SetCount( army.GetCountMonsters( mons ) );
+                    const uint32_t monstersLeft = army.getTotalCount();
+                    if ( monstersLeft > 0 ) {
+                        capture = false;
+
+                        Troop & troop = world.GetCapturedObject( dst_index ).GetTroop();
+                        troop.SetCount( monstersLeft );
+                    }
                 }
             }
 
             if ( capture ) {
-                // restore the abandoned mine
+                // Clear any metadata related to spells
+                tile.clearAdditionalMetadata();
+
+                // Restore the abandoned mine
                 if ( objectType == MP2::OBJ_ABANDONED_MINE ) {
                     Maps::Tiles::UpdateAbandonedMineSprite( tile );
                     hero.SetMapsObject( MP2::OBJ_MINES );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -600,7 +600,7 @@ namespace
         Maps::Tiles & tile = world.GetTiles( dstIndex );
 
         if ( !hero.isFriends( tile.QuantityColor() ) ) {
-            auto removeProtection = [&hero, objectType, &tile]() {
+            auto removeObjectProtection = [&hero, objectType, &tile]() {
                 // Clear any metadata related to spells
                 tile.clearAdditionalMetadata();
 
@@ -611,8 +611,8 @@ namespace
                 }
             };
 
-            auto captureObject = [&hero, &tile, &removeProtection]() {
-                removeProtection();
+            auto captureObject = [&hero, &tile, &removeObjectProtection]() {
+                removeObjectProtection();
 
                 tile.QuantitySetColor( hero.GetColor() );
             };
@@ -638,7 +638,7 @@ namespace
                     // If all the guards are defeated, but the hero has lost the battle,
                     // just remove the protection from the object
                     if ( monstersLeft == 0 ) {
-                        removeProtection();
+                        removeObjectProtection();
                     }
 
                     AIBattleLose( hero, result, true );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -456,21 +456,32 @@ namespace
             destroy = true;
         }
 
-        // fight
+        // Fight
         if ( !destroy ) {
             DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " attacked monster " << troop.GetName() )
+
             Army army( tile );
+
             Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
+
                 destroy = true;
             }
             else {
                 AIBattleLose( hero, res, true );
-                tile.MonsterSetCount( army.GetCountMonsters( troop.GetMonster() ) );
-                if ( Maps::isMonsterOnTileJoinConditionFree( tile ) ) {
-                    Maps::setMonsterOnTileJoinCondition( tile, Monster::JOIN_CONDITION_MONEY );
+
+                const uint32_t monstersLeft = army.GetCountMonsters( troop.GetMonster() );
+                if ( monstersLeft > 0 ) {
+                    tile.MonsterSetCount( monstersLeft );
+
+                    if ( Maps::isMonsterOnTileJoinConditionFree( tile ) ) {
+                        Maps::setMonsterOnTileJoinCondition( tile, Monster::JOIN_CONDITION_MONEY );
+                    }
+                }
+                else {
+                    destroy = true;
                 }
             }
         }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -260,15 +260,21 @@ void Troops::UpgradeMonsters( const Monster & m )
     }
 }
 
-uint32_t Troops::GetCountMonsters( const Monster & m ) const
+uint32_t Troops::GetCountMonsters( const Monster & mons ) const
 {
-    uint32_t c = 0;
+    const int monsterId = mons.GetID();
 
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() && **it == m )
-            c += ( *it )->GetCount();
+    uint32_t result = 0;
 
-    return c;
+    for ( const Troop * troop : *this ) {
+        assert( troop != nullptr );
+
+        if ( troop->isValid() && troop->isMonster( monsterId ) ) {
+            result += troop->GetCount();
+        }
+    }
+
+    return result;
 }
 
 double Troops::getReinforcementValue( const Troops & reinforcement ) const
@@ -837,13 +843,16 @@ bool Troops::mergeWeakestTroopsIfNeeded()
     return true;
 }
 
-void Troops::AssignToFirstFreeSlot( const Troop & troop, const uint32_t splitCount )
+void Troops::AssignToFirstFreeSlot( const Troop & troopToAssign, const uint32_t count )
 {
-    for ( iterator it = begin(); it != end(); ++it ) {
-        if ( ( *it )->isValid() )
-            continue;
+    for ( Troop * troop : *this ) {
+        assert( troop != nullptr );
 
-        ( *it )->Set( troop.GetMonster(), splitCount );
+        if ( troop->isValid() ) {
+            continue;
+        }
+
+        troop->Set( troopToAssign.GetMonster(), count );
         break;
     }
 }
@@ -853,10 +862,12 @@ void Troops::JoinAllTroopsOfType( const Troop & targetTroop )
     const int troopID = targetTroop.GetID();
     const int totalMonsterCount = GetCountMonsters( troopID );
 
-    for ( iterator it = begin(); it != end(); ++it ) {
-        Troop * troop = *it;
-        if ( !troop->isValid() || troop->GetID() != troopID )
+    for ( Troop * troop : *this ) {
+        assert( troop != nullptr );
+
+        if ( !troop->isValid() || troop->GetID() != troopID ) {
             continue;
+        }
 
         if ( troop == &targetTroop ) {
             troop->SetCount( totalMonsterCount );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -68,7 +68,7 @@ public:
     const Troop * GetTroop( size_t ) const;
 
     void UpgradeMonsters( const Monster & );
-    uint32_t GetCountMonsters( const Monster & ) const;
+    uint32_t GetCountMonsters( const Monster & mons ) const;
 
     double getReinforcementValue( const Troops & reinforcement ) const;
 
@@ -100,7 +100,7 @@ public:
     void SortStrongest();
 
     void SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selectedSlot, const uint32_t slots );
-    void AssignToFirstFreeSlot( const Troop &, const uint32_t splitCount );
+    void AssignToFirstFreeSlot( const Troop & troopToAssign, const uint32_t count );
     void JoinAllTroopsOfType( const Troop & targetTroop );
 
     void addNewTroopsToFreeSlots( const Troop & troop, uint32_t maxSlots );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -370,7 +370,7 @@ namespace
             else {
                 BattleLose( hero, res, true );
 
-                const uint32_t monstersLeft = army.GetCountMonsters( troop.GetMonster() );
+                const uint32_t monstersLeft = army.getTotalCount();
                 if ( monstersLeft > 0 ) {
                     tile.MonsterSetCount( monstersLeft );
 
@@ -1955,29 +1955,31 @@ namespace
         if ( !hero.isFriends( tile.QuantityColor() ) ) {
             bool capture = true;
 
-            // Check guardians
             if ( tile.isCaptureObjectProtected() ) {
                 Army army( tile );
-                const Monster & mons = tile.QuantityMonster();
 
                 Battle::Result result = Battle::Loader( hero.GetArmy(), army, dst_index );
 
                 if ( result.AttackerWins() ) {
                     hero.IncreaseExperience( result.GetExperienceAttacker() );
-                    // Clear any metadata related to spells.
-                    tile.clearAdditionalMetadata();
                 }
                 else {
-                    capture = false;
-
                     BattleLose( hero, result, true );
 
-                    Troop & troop = world.GetCapturedObject( dst_index ).GetTroop();
-                    troop.SetCount( army.GetCountMonsters( mons ) );
+                    const uint32_t monstersLeft = army.getTotalCount();
+                    if ( monstersLeft > 0 ) {
+                        capture = false;
+
+                        Troop & troop = world.GetCapturedObject( dst_index ).GetTroop();
+                        troop.SetCount( monstersLeft );
+                    }
                 }
             }
 
             if ( capture ) {
+                // Clear any metadata related to spells
+                tile.clearAdditionalMetadata();
+
                 // Restore the abandoned mine
                 if ( objectType == MP2::OBJ_ABANDONED_MINE ) {
                     Maps::Tiles::UpdateAbandonedMineSprite( tile );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -349,11 +349,11 @@ namespace
             }
         }
 
-        // fight
+        // Fight
         if ( !destroy ) {
             DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attack monster " << troop.GetName() )
 
-            // set the hero's attacked monster tile index and immediately redraw game area to show an attacking sprite for this monster
+            // Set the hero's attacked monster tile index and immediately redraw game area to show an attacking sprite for this monster
             hero.SetAttackedMonsterTileIndex( dst_index );
 
             I.Redraw( Interface::REDRAW_GAMEAREA );
@@ -374,7 +374,6 @@ namespace
                 if ( monstersLeft > 0 ) {
                     tile.MonsterSetCount( monstersLeft );
 
-                    // reset join condition
                     if ( Maps::isMonsterOnTileJoinConditionFree( tile ) ) {
                         Maps::setMonsterOnTileJoinCondition( tile, Monster::JOIN_CONDITION_MONEY );
                     }
@@ -395,7 +394,7 @@ namespace
             tile.MonsterSetCount( 0 );
         }
 
-        // clear the hero's attacked monster tile index
+        // Clear the hero's attacked monster tile index
         hero.SetAttackedMonsterTileIndex( -1 );
     }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -351,7 +351,7 @@ namespace
 
         // Fight
         if ( !destroy ) {
-            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attack monster " << troop.GetName() )
+            DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " attacks monster " << troop.GetName() )
 
             // Set the hero's attacked monster tile index and immediately redraw game area to show an attacking sprite for this monster
             hero.SetAttackedMonsterTileIndex( dst_index );
@@ -370,7 +370,20 @@ namespace
             else {
                 BattleLose( hero, res, true );
 
+                // The army can include both the original monsters and their upgraded version
                 const uint32_t monstersLeft = army.getTotalCount();
+#ifndef NDEBUG
+                const Monster originalMonster = troop.GetMonster();
+                const Monster upgradedMonster = originalMonster.GetUpgrade();
+
+                if ( upgradedMonster == originalMonster ) {
+                    assert( monstersLeft == army.GetCountMonsters( originalMonster ) );
+                }
+                else {
+                    assert( monstersLeft == army.GetCountMonsters( originalMonster ) + army.GetCountMonsters( upgradedMonster ) );
+                }
+#endif
+
                 if ( monstersLeft > 0 ) {
                     tile.MonsterSetCount( monstersLeft );
 
@@ -1966,7 +1979,10 @@ namespace
                 else {
                     BattleLose( hero, result, true );
 
+                    // The army should include only the original monsters
                     const uint32_t monstersLeft = army.getTotalCount();
+                    assert( monstersLeft == army.GetCountMonsters( tile.QuantityMonster() ) );
+
                     if ( monstersLeft > 0 ) {
                         capture = false;
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1940,7 +1940,7 @@ namespace
                 I.Redraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
             };
 
-            auto removeProtection = [&hero, objectType, &tile, &updateRadar]( const bool isUpdateRadar ) {
+            auto removeObjectProtection = [&hero, objectType, &tile, &updateRadar]( const bool isUpdateRadar ) {
                 // Clear any metadata related to spells
                 tile.clearAdditionalMetadata();
 
@@ -1955,8 +1955,8 @@ namespace
                 }
             };
 
-            auto captureObject = [&hero, objectType, &tile, &updateRadar, &removeProtection]() {
-                removeProtection( false );
+            auto captureObject = [&hero, objectType, &tile, &updateRadar, &removeObjectProtection]() {
+                removeObjectProtection( false );
 
                 tile.QuantitySetColor( hero.GetColor() );
 
@@ -2061,7 +2061,7 @@ namespace
                     // If all the guards are defeated, but the hero has lost the battle,
                     // just remove the protection from the object
                     if ( monstersLeft == 0 ) {
-                        removeProtection( true );
+                        removeObjectProtection( true );
                     }
 
                     BattleLose( hero, result, true );


### PR DESCRIPTION
fix #6862

This situation is properly handled for a human-controlled hero, but not for an AI-controlled hero.

This PR also implements the following changes:

<details><summary>Now, if a group of wandering monsters has an upgraded stack, and only this stack is left alive after the hero is defeated, this is handled properly.</summary>

In the `master` branch:

https://user-images.githubusercontent.com/32623900/226147178-adcbbd5c-4c4b-4f52-a050-7fec87ddd410.mp4

With this PR:

https://user-images.githubusercontent.com/32623900/226147190-7156bdc0-1933-4600-be54-303319e4482c.mp4
</details>

<details><summary>Now protection of guarded objects is removed if guardians and attacking hero eliminate each other. </summary>

Human player:

https://user-images.githubusercontent.com/32623900/226208755-da152059-8678-408e-9080-840a890af692.mp4

AI-controlled player:

https://user-images.githubusercontent.com/32623900/226208778-2e3d7504-0765-4cce-9a8f-cb9662890926.mp4

In the original game, it worked in the following weird way, which I decided not to reproduce literally:

https://user-images.githubusercontent.com/32623900/226209815-395df984-75ff-4e44-8576-0c36d7ab161f.mp4
</details>
