### PR TITLE
Focus on the AI hero before he disappears due to boarding a boat or using a Dimension Door or Town Portal spell

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1454,10 +1454,6 @@ namespace
         hero.SetShipMaster( true );
         hero.GetPath().Reset();
 
-        if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
-            Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
-        }
-
         AI::Get().HeroesClearTask( hero );
 
         world.GetTiles( dst_index ).resetBoatOwnerColor();

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1432,23 +1432,14 @@ namespace
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() )
     }
 
-    void AIToBoat( Heroes & hero, int32_t dst_index )
+    void AIToBoat( Heroes & hero, const int32_t dst_index )
     {
         if ( hero.isShipMaster() )
             return;
 
-        const int32_t from_index = hero.GetIndex();
+        hero.setLastGroundRegion( world.GetTiles( hero.GetIndex() ).GetRegion() );
 
-        // disabled nearest coasts (on week MP2::isWeekLife)
-        MapsIndexes coasts = Maps::ScanAroundObjectWithDistance( from_index, 4, MP2::OBJ_COAST );
-        coasts.push_back( from_index );
-
-        for ( MapsIndexes::const_iterator it = coasts.begin(); it != coasts.end(); ++it )
-            hero.SetVisited( *it );
-
-        hero.setLastGroundRegion( world.GetTiles( from_index ).GetRegion() );
-
-        const fheroes2::Point & destPos = Maps::GetPoint( dst_index );
+        const fheroes2::Point destPos = Maps::GetPoint( dst_index );
         const fheroes2::Point offset( destPos - hero.GetCenter() );
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
@@ -1474,7 +1465,7 @@ namespace
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() )
     }
 
-    void AIToCoast( Heroes & hero, int32_t dst_index )
+    void AIToCoast( Heroes & hero, const int32_t dst_index )
     {
         if ( !hero.isShipMaster() )
             return;
@@ -1483,8 +1474,8 @@ namespace
         Maps::Tiles & from = world.GetTiles( fromIndex );
 
         // Calculate the offset before making the action.
-        const fheroes2::Point & prevPosition = Maps::GetPoint( dst_index );
-        const fheroes2::Point offset( prevPosition - hero.GetCenter() );
+        const fheroes2::Point prevPos = hero.GetCenter();
+        const fheroes2::Point offset( Maps::GetPoint( dst_index ) - prevPos );
 
         hero.ResetMovePoints();
         hero.Move2Dest( dst_index );
@@ -1493,9 +1484,10 @@ namespace
         hero.GetPath().Reset();
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
-            Interface::Basic::Get().GetGameArea().SetCenter( prevPosition );
-            hero.FadeIn( { offset.x * Game::AIHeroAnimSkip(), offset.y * Game::AIHeroAnimSkip() } );
+            Interface::Basic::Get().GetGameArea().SetCenter( prevPos );
+            hero.FadeIn( offset );
         }
+
         hero.ActionNewPosition( true );
 
         AI::Get().HeroesClearTask( hero );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1439,8 +1439,7 @@ namespace
 
         hero.setLastGroundRegion( world.GetTiles( hero.GetIndex() ).GetRegion() );
 
-        const fheroes2::Point destPos = Maps::GetPoint( dst_index );
-        const fheroes2::Point offset( destPos - hero.GetCenter() );
+        const fheroes2::Point offset( Maps::GetPoint( dst_index ) - hero.GetCenter() );
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
@@ -1453,10 +1452,11 @@ namespace
         hero.SetMapsObject( MP2::OBJ_NONE );
         world.GetTiles( dst_index ).resetObjectSprite();
         hero.SetShipMaster( true );
+        hero.GetPath().Reset();
+
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
             Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
         }
-        hero.GetPath().Reset();
 
         AI::Get().HeroesClearTask( hero );
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -772,6 +772,8 @@ namespace
         assert( world.GetTiles( indexTo ).GetObject() != MP2::OBJ_HEROES );
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
+            // AI-controlled hero cannot activate Stone Liths from the same tile, but should move to this tile from some
+            // other tile first, so there is no need to re-center the game area on the hero before his disappearance
             hero.FadeOut();
         }
 
@@ -834,6 +836,8 @@ namespace
         }
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
+            // AI-controlled hero cannot activate Whirlpool from the same tile, but should move to this tile from some
+            // other tile first, so there is no need to re-center the game area on the hero before his disappearance
             hero.FadeOut();
         }
 
@@ -1448,6 +1452,7 @@ namespace
         const fheroes2::Point offset( destPos - hero.GetCenter() );
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
+            Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
             hero.FadeOut( offset );
         }
 
@@ -1997,6 +2002,7 @@ namespace AI
         }
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
+            Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
             hero.FadeOut();
         }
 
@@ -2032,6 +2038,7 @@ namespace AI
         }
 
         if ( AIHeroesShowAnimation( hero, AIGetAllianceColors() ) ) {
+            Interface::Basic::Get().GetGameArea().SetCenter( hero.GetCenter() );
             hero.FadeOut();
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -625,7 +625,7 @@ namespace
         hero.SetShipMaster( false );
         AudioManager::PlaySound( M82::KILLFADE );
         hero.GetPath().Hide();
-        hero.FadeIn( fheroes2::Point( offset.x * Game::HumanHeroAnimSkip(), offset.y * Game::HumanHeroAnimSkip() ) );
+        hero.FadeIn( offset );
 
         // Clear hero position marker from the boat and scout the area on radar after disembarking.
         Interface::Basic & I = Interface::Basic::Get();

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -531,11 +531,6 @@ bool MP2::isWeekLife( const MapObjectType objectType )
     case OBJ_DRAGON_CITY:
     case OBJ_CITY_OF_DEAD:
     case OBJ_TROLL_BRIDGE:
-    // TODO: former AI-related logic, OBJ_COAST should never be set
-    // TODO: as a visited object, remove this temporary check later
-    case OBJ_COAST:
-        assert( 0 );
-        return true;
     // for AI
     case OBJ_HEROES:
         return true;

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -531,8 +531,12 @@ bool MP2::isWeekLife( const MapObjectType objectType )
     case OBJ_DRAGON_CITY:
     case OBJ_CITY_OF_DEAD:
     case OBJ_TROLL_BRIDGE:
-    // for AI
+    // TODO: former AI-related logic, OBJ_COAST should never be set
+    // TODO: as a visited object, remove this temporary check later
     case OBJ_COAST:
+        assert( 0 );
+        return true;
+    // for AI
     case OBJ_HEROES:
         return true;
     default:


### PR DESCRIPTION
fix #6897

Unlike using Stone Liths or Whirlpool, AI hero can cast Dimension Door or Town Portal (or get on board the boat) right at the beginning of his turn without any previous movement, so we need to focus on the corresponding tile first to display the fade-out animation.