### PR TITLE
Fix the number of regenerated spell points with the Mysticism skill

### DIFF
--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -105,7 +105,7 @@ namespace Skill
     values_t _values[] = {
         { "pathfinding", { 25, 50, 100 } }, { "archery", { 10, 25, 50 } },     { "logistics", { 10, 20, 30 } }, { "scouting", { 1, 2, 3 } },
         { "diplomacy", { 25, 50, 100 } },   { "navigation", { 33, 66, 100 } }, { "leadership", { 1, 2, 3 } },   { "wisdom", { 3, 4, 5 } },
-        { "mysticism", { 2, 3, 4 } },       { "luck", { 1, 2, 3 } },           { "ballistics", { 0, 0, 0 } },   { "eagleeye", { 20, 30, 40 } },
+        { "mysticism", { 1, 2, 3 } },       { "luck", { 1, 2, 3 } },           { "ballistics", { 0, 0, 0 } },   { "eagleeye", { 20, 30, 40 } },
         { "necromancy", { 10, 20, 30 } },   { "estates", { 100, 250, 500 } },  { nullptr, { 0, 0, 0 } },
     };
 

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "skill.h"
+
 #include <algorithm>
 #include <cassert>
 #include <iterator>
@@ -35,7 +37,6 @@
 #include "race.h"
 #include "rand.h"
 #include "serialize.h"
-#include "skill.h"
 #include "skill_static.h"
 #include "tools.h"
 #include "translations.h"
@@ -481,7 +482,8 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         break;
     }
     case MYSTICISM: {
-        str = _n( "%{skill} regenerates one of your hero's spell points per day.", "%{skill} regenerates %{count} of your hero's spell points per day.", count );
+        str = _n( "%{skill} additionally regenerates one of your hero's spell points per day.",
+                  "%{skill} additionally regenerates %{count} of your hero's spell points per day.", count );
         break;
     }
     case LUCK: {

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -482,8 +482,8 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         break;
     }
     case MYSTICISM: {
-        str = _n( "%{skill} additionally regenerates one of your hero's spell points per day.",
-                  "%{skill} additionally regenerates %{count} of your hero's spell points per day.", count );
+        str = _n( "%{skill} regenerates one additional spell point per day to your hero.", "%{skill} regenerates %{count} additional spell points per day to your hero.",
+                  count );
         break;
     }
     case LUCK: {


### PR DESCRIPTION
fix #6903

Since the original description of the Mysticism skill is really a bit misleading, I decided to change it a bit. Suggestions are welcome.