### PR TITLE
Added gold missing in statue building description

### DIFF
--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -864,7 +864,7 @@ namespace fheroes2
         case BUILD_WELL:
             return _( "The Well increases the growth rate of all dwellings by %{count} creatures per week." );
         case BUILD_STATUE:
-            return _( "The Statue increases your town's income by %{count} per day." );
+            return _( "The Statue increases your town's income by %{count} gold per day." );
         case BUILD_LEFTTURRET:
             return _( "The Left Turret provides extra firepower during castle combat." );
         case BUILD_RIGHTTURRET:


### PR DESCRIPTION
Missing in the OG game also, but no point of keeping the misstakes and typos of the OG.