### PR TITLE
Improve AI fog discovery logic

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1652,15 +1652,23 @@ namespace AI
         }
 
         double fogDiscoveryValue = getFogDiscoveryValue( hero );
-        const int fogDiscoveryTarget = _pathfinder.getFogDiscoveryTile( hero );
+        bool isTerritoryExpansion = false;
+        const int fogDiscoveryTarget = _pathfinder.getFogDiscoveryTile( hero, isTerritoryExpansion );
         if ( fogDiscoveryTarget >= 0 ) {
             uint32_t distanceToFogDiscovery = _pathfinder.getDistance( fogDiscoveryTarget );
 
+            // TODO: add logic to check fog discovery based on Dimension Door distance, not the nearest tile.
             bool useDimensionDoor = false;
             const uint32_t dimensionDoorDist = AIWorldPathfinder::calculatePathPenalty( _pathfinder.getDimensionDoorPath( hero, fogDiscoveryTarget ) );
             if ( dimensionDoorDist > 0 && ( distanceToFogDiscovery == 0 || dimensionDoorDist < distanceToFogDiscovery / 2 ) ) {
                 distanceToFogDiscovery = dimensionDoorDist;
                 useDimensionDoor = true;
+            }
+
+            if ( isTerritoryExpansion && fogDiscoveryValue < 0 ) {
+                // This is actually a very useful fog discovery action which might lead to finding of new objects.
+                // Increase the value of this action.
+                fogDiscoveryValue /= 2;
             }
 
             getObjectValue( fogDiscoveryTarget, distanceToFogDiscovery, fogDiscoveryValue, useDimensionDoor );

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -658,8 +658,8 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, bool & isTerrit
             if ( maxTilesToReveal > 0 ) {
                 // Found a tile where we can reveal fog. Check for other tiles in the queue to find the one with the highest value.
                 bestIndex = currentNodeIdx;
-                for ( size_t currentNodeId = lastProcessedNode + 1; currentNodeId < nodesToExplore.size(); ++currentNodeId ) {
-                    const int nodeIdx = nodesToExplore[currentNodeId];
+                for ( size_t i = lastProcessedNode + 1; i < nodesToExplore.size(); ++i ) {
+                    const int nodeIdx = nodesToExplore[i];
                     const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( nodeIdx, scoutingDistance, _currentColor );
 
                     if ( std::make_tuple( maxTilesToReveal, _cache[nodeIdx]._cost ) < std::make_tuple( tilesToReveal, _cache[bestIndex]._cost ) ) {

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -658,8 +658,8 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, bool & isTerrit
             if ( maxTilesToReveal > 0 ) {
                 // Found a tile where we can reveal fog. Check for other tiles in the queue to find the one with the highest value.
                 bestIndex = currentNodeIdx;
-                for ( ; lastProcessedNode < nodesToExplore.size(); ++lastProcessedNode ) {
-                    const int nodeIdx = nodesToExplore[lastProcessedNode];
+                for ( size_t currentNodeId = lastProcessedNode + 1; currentNodeId < nodesToExplore.size(); ++currentNodeId ) {
+                    const int nodeIdx = nodesToExplore[currentNodeId];
                     const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( nodeIdx, scoutingDistance, _currentColor );
 
                     if ( std::make_tuple( maxTilesToReveal, _cache[nodeIdx]._cost ) < std::make_tuple( tilesToReveal, _cache[bestIndex]._cost ) ) {

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -133,7 +133,7 @@ public:
 
     void reEvaluateIfNeeded( const Heroes & hero );
     void reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill );
-    int getFogDiscoveryTile( const Heroes & hero );
+    int getFogDiscoveryTile( const Heroes & hero, bool & isTerritoryExpansion );
 
     // Used for cases when heroes are stuck because one hero might be blocking the way and we have to move him.
     int getNearestTileToMove( const Heroes & hero );


### PR DESCRIPTION
All tiles covered by fog can be divided into 2 categories:
- tiles which are neighboring passable tiles. These tiles most likely be passable and might have some valuable objects
- tiles which are not reachable. These tiles are usually useless unless they are on another part of land / sea separated by impassable objects

In the majority of situations uncovering passable tiles is the best strategy and this is what actually most of human players do. With the proposed changes AI heroes tend to uncover "proper" tiles by expanding the territory which they can access.