### PR TITLE
Added missing gold in Dungeon description

### DIFF
--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -697,7 +697,7 @@ namespace
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
-            return _( "The Dungeon increases the income of the town by %{count} / day." );
+            return _( "The Dungeon increases the income of the town by %{count} gold per day." );
         case BUILD_WEL2:
             return _( "The Waterfall increases production of Centaurs by %{count} per week." );
         default:


### PR DESCRIPTION
Missing in the OG game also, but gold is clearly missing and every other description in game uses "per" and not "/".