### PR TITLE
Remove path icon after a hero/boat makes a turn, not before

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -681,7 +681,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
         Route::Path::const_iterator currentStep = path.begin();
         Route::Path::const_iterator nextStep = currentStep;
 
-        if ( currentHero->isMoveEnabled() ) {
+        if ( currentHero->isMoveEnabled() && ( currentHero->GetDirection() == path.GetFrontDirection() ) ) {
             // Do not draw the first path mark when hero / boat is moving in the direction of the path.
             ++currentStep;
             ++nextStep;


### PR DESCRIPTION
This fix was made in #6809, but was accidentally lost in that PR.

Path icon is removed after a hero/boat makes a turn (relates to [#5716](https://github.com/ihhub/fheroes2/issues/5716)):

![fheroes2 2023-03-12 20-42-14-819_](https://user-images.githubusercontent.com/113276641/224568449-53b1fa23-6def-4dd1-9074-f0cd7a5bc5a1.gif)              ![fheroes2 2023-04-01 19-41-09-221](https://user-images.githubusercontent.com/113276641/229303620-53ec0145-be6f-41bc-a132-79beaf5754b8.gif)

