### PR TITLE
Fix projectile render position when hitting the target creature. Battlefiled.

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3234,10 +3234,12 @@ void Battle::Interface::RedrawActionSkipStatus( const Unit & attacker )
 void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos, const fheroes2::Point & endPos, double angle, uint32_t monsterID )
 {
     LocalEvent & le = LocalEvent::Get();
-    fheroes2::Sprite missile;
 
     const bool reverse = startPos.x > endPos.x;
     const bool isMage = ( monsterID == Monster::MAGE || monsterID == Monster::ARCHMAGE );
+
+    fheroes2::Sprite missile;
+    fheroes2::Point endPosShift{ 0, 0 };
 
     // Mage is channeling the bolt; doesn't have missile sprite
     if ( isMage ) {
@@ -3245,10 +3247,14 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
     }
     else {
         missile = fheroes2::AGG::GetICN( Monster::GetMissileICN( monsterID ), static_cast<uint32_t>( Bin_Info::GetMonsterInfo( monsterID ).getProjectileID( angle ) ) );
+
+        // The projectile has to hit the target but not go through it so its end position is shifted in the direction to the shooter.
+        endPosShift.x = reverse ? ( missile.width() / 2 ) : -( missile.width() / 2 );
+        endPosShift.y = ( startPos.y > endPos.y ) ? ( missile.height() / 2 ) : -( missile.height() / 2 );
     }
 
     // Lich/Power lich has projectile speed of 25
-    const std::vector<fheroes2::Point> points = GetEuclideanLine( startPos, endPos, isMage ? 50 : std::max( missile.width(), 25 ) );
+    const std::vector<fheroes2::Point> points = GetEuclideanLine( startPos, endPos + endPosShift, isMage ? 50 : std::max( missile.width(), 25 ) );
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
     // For most shooting creatures we do not render the first missile position to better imitate start position change depending on shooting angle.


### PR DESCRIPTION
Close #6687

This PR makes the arrow not to be rendered going through the creature.
The last render position is shifted by the half of arrow size so it is rendered hitting the target and does not disappear before the target (like in original game).

https://user-images.githubusercontent.com/113276641/229307566-d10f1b76-756c-4999-92d5-bc8ce9857b0b.mp4