### PR TITLE
Consider object type while calculating object value over distances for AI heroes

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1604,41 +1604,41 @@ namespace AI
         ObjectValidator objectValidator( hero, _pathfinder, *this );
         ObjectValueStorage valueStorage( hero, *this, lowestPossibleValue );
 
-        auto getObjectValue = [&objectValidator, &valueStorage, this, heroStrength, &hero, leftMovePoints]( const int destination, uint32_t & distance, double & value,
-                                                                                                            const MP2::MapObjectType objectType,
-                                                                                                            const bool isDimensionDoor ) {
-            if ( !isDimensionDoor ) {
-                // Dimension door path does not include any objects on the way.
-                const std::vector<IndexObject> & list = _pathfinder.getObjectsOnTheWay( destination );
-                for ( const IndexObject & pair : list ) {
-                    if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) ) {
-                        const double extraValue = valueStorage.value( pair, 0 ); // object is on the way, we don't loose any movement points.
-                        if ( extraValue > 0 ) {
-                            // There is no need to reduce the quality of the object even if the path has others.
-                            value += extraValue;
-                        }
-                    }
-                }
-            }
+        auto getObjectValue
+            = [&objectValidator, &valueStorage, this, heroStrength, &hero, leftMovePoints]( const int destination, uint32_t & distance, double & value,
+                                                                                            const MP2::MapObjectType objectType, const bool isDimensionDoor ) {
+                  if ( !isDimensionDoor ) {
+                      // Dimension door path does not include any objects on the way.
+                      const std::vector<IndexObject> & list = _pathfinder.getObjectsOnTheWay( destination );
+                      for ( const IndexObject & pair : list ) {
+                          if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) ) {
+                              const double extraValue = valueStorage.value( pair, 0 ); // object is on the way, we don't loose any movement points.
+                              if ( extraValue > 0 ) {
+                                  // There is no need to reduce the quality of the object even if the path has others.
+                                  value += extraValue;
+                              }
+                          }
+                      }
+                  }
 
-            const RegionStats & regionStats = _regions[world.GetTiles( destination ).GetRegion()];
+                  const RegionStats & regionStats = _regions[world.GetTiles( destination ).GetRegion()];
 
-            if ( heroStrength < regionStats.highestThreat ) {
-                const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
+                  if ( heroStrength < regionStats.highestThreat ) {
+                      const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
 
-                if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) )
-                    value -= dangerousTaskPenalty / 2;
-                else
-                    value -= dangerousTaskPenalty;
-            }
+                      if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) )
+                          value -= dangerousTaskPenalty / 2;
+                      else
+                          value -= dangerousTaskPenalty;
+                  }
 
-            if ( distance > leftMovePoints ) {
-                // Distant object which is out of reach for the current turn must have lower priority.
-                distance = leftMovePoints + ( distance - leftMovePoints ) * 2;
-            }
+                  if ( distance > leftMovePoints ) {
+                      // Distant object which is out of reach for the current turn must have lower priority.
+                      distance = leftMovePoints + ( distance - leftMovePoints ) * 2;
+                  }
 
-            value = ScaleWithDistance( value, distance, objectType );
-        };
+                  value = ScaleWithDistance( value, distance, objectType );
+              };
 
         // Set baseline target if it's a special role
         if ( hero.getAIRole() == Heroes::Role::COURIER ) {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1604,41 +1604,40 @@ namespace AI
         ObjectValidator objectValidator( hero, _pathfinder, *this );
         ObjectValueStorage valueStorage( hero, *this, lowestPossibleValue );
 
-        auto getObjectValue
-            = [&objectValidator, &valueStorage, this, heroStrength, &hero, leftMovePoints]( const int destination, uint32_t & distance, double & value,
-                                                                                            const MP2::MapObjectType type, const bool isDimensionDoor ) {
-                  if ( !isDimensionDoor ) {
-                      // Dimension door path does not include any objects on the way.
-                      const std::vector<IndexObject> & list = _pathfinder.getObjectsOnTheWay( destination );
-                      for ( const IndexObject & pair : list ) {
-                          if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) ) {
-                              const double extraValue = valueStorage.value( pair, 0 ); // object is on the way, we don't loose any movement points.
-                              if ( extraValue > 0 ) {
-                                  // There is no need to reduce the quality of the object even if the path has others.
-                                  value += extraValue;
-                              }
-                          }
-                      }
-                  }
+        auto getObjectValue = [&objectValidator, &valueStorage, this, heroStrength, &hero, leftMovePoints]( const int destination, uint32_t & distance, double & value,
+                                                                                                            const MP2::MapObjectType type, const bool isDimensionDoor ) {
+            if ( !isDimensionDoor ) {
+                // Dimension door path does not include any objects on the way.
+                const std::vector<IndexObject> & list = _pathfinder.getObjectsOnTheWay( destination );
+                for ( const IndexObject & pair : list ) {
+                    if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) ) {
+                        const double extraValue = valueStorage.value( pair, 0 ); // object is on the way, we don't loose any movement points.
+                        if ( extraValue > 0 ) {
+                            // There is no need to reduce the quality of the object even if the path has others.
+                            value += extraValue;
+                        }
+                    }
+                }
+            }
 
-                  const RegionStats & regionStats = _regions[world.GetTiles( destination ).GetRegion()];
+            const RegionStats & regionStats = _regions[world.GetTiles( destination ).GetRegion()];
 
-                  if ( heroStrength < regionStats.highestThreat ) {
-                      const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
+            if ( heroStrength < regionStats.highestThreat ) {
+                const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
 
-                      if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) )
-                          value -= dangerousTaskPenalty / 2;
-                      else
-                          value -= dangerousTaskPenalty;
-                  }
+                if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) )
+                    value -= dangerousTaskPenalty / 2;
+                else
+                    value -= dangerousTaskPenalty;
+            }
 
-                  if ( distance > leftMovePoints ) {
-                      // Distant object which is out of reach for the current turn must have lower priority.
-                      distance = leftMovePoints + ( distance - leftMovePoints ) * 2;
-                  }
+            if ( distance > leftMovePoints ) {
+                // Distant object which is out of reach for the current turn must have lower priority.
+                distance = leftMovePoints + ( distance - leftMovePoints ) * 2;
+            }
 
-                  value = ScaleWithDistance( value, distance, type );
-              };
+            value = ScaleWithDistance( value, distance, type );
+        };
 
         // Set baseline target if it's a special role
         if ( hero.getAIRole() == Heroes::Role::COURIER ) {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1606,7 +1606,7 @@ namespace AI
 
         auto getObjectValue
             = [&objectValidator, &valueStorage, this, heroStrength, &hero, leftMovePoints]( const int destination, uint32_t & distance, double & value,
-                                                                                            const MP2::MapObjectType objectType, const bool isDimensionDoor ) {
+                                                                                            const MP2::MapObjectType type, const bool isDimensionDoor ) {
                   if ( !isDimensionDoor ) {
                       // Dimension door path does not include any objects on the way.
                       const std::vector<IndexObject> & list = _pathfinder.getObjectsOnTheWay( destination );
@@ -1637,7 +1637,7 @@ namespace AI
                       distance = leftMovePoints + ( distance - leftMovePoints ) * 2;
                   }
 
-                  value = ScaleWithDistance( value, distance, objectType );
+                  value = ScaleWithDistance( value, distance, type );
               };
 
         // Set baseline target if it's a special role


### PR DESCRIPTION
Right now all objects decrease their value over distance to a hero. Logically it works fine but not always accurate. There are objects on maps which still should have high enough value over distance. For instance, a mine has a value of 2000. When an AI hero stands just 7 tiles away (700 move points) this value drops to ~0. For comparison, a resource located 3 tiles away (300 move points) will still have value 100. The formula should be adjusted for some objects so they don't loose their value drastically. On the other hand, some objects should not be worth visiting if they are far away like Luck modifiers.

relates to #3589, #5307