### PR TITLE
Cleanup MP2 format and Maps::Tiles class

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -535,14 +535,14 @@ namespace
 
         if ( tile.isWater() ) {
             if ( gold ) {
-                const Artifact & art = tile.QuantityArtifact();
+                const Artifact & art = getArtifactFromTile( tile );
 
                 if ( art.isValid() && !hero.PickupArtifact( art ) )
                     gold = GoldInsteadArtifact( objectType );
             }
         }
         else {
-            const Artifact & art = tile.QuantityArtifact();
+            const Artifact & art = getArtifactFromTile( tile );
 
             if ( gold ) {
                 const uint32_t experience = gold > 500 ? gold - 500 : 500;
@@ -630,7 +630,7 @@ namespace
                 else {
                     // The army should include only the original monsters
                     const uint32_t monstersLeft = army.getTotalCount();
-                    assert( monstersLeft == army.GetCountMonsters( tile.QuantityMonster() ) );
+                    assert( monstersLeft == army.GetCountMonsters( getMonsterFromTile( tile ) ) );
 
                     Troop & troop = world.GetCapturedObject( dstIndex ).GetTroop();
                     troop.SetCount( monstersLeft );
@@ -679,7 +679,7 @@ namespace
 
         // artifact
         if ( tile.QuantityIsValid() ) {
-            const Artifact & art = tile.QuantityArtifact();
+            const Artifact & art = getArtifactFromTile( tile );
 
             if ( !hero.PickupArtifact( art ) ) {
                 uint32_t gold = GoldInsteadArtifact( objectType );
@@ -699,7 +699,7 @@ namespace
         Maps::Tiles & tile = world.GetTiles( dst_index );
 
         if ( tile.QuantityIsValid() ) {
-            const Artifact & art = tile.QuantityArtifact();
+            const Artifact & art = getArtifactFromTile( tile );
 
             if ( art.isValid() )
                 hero.PickupArtifact( art );
@@ -931,7 +931,7 @@ namespace
 
     void AIToShrine( Heroes & hero, int32_t dst_index )
     {
-        const Spell & spell = world.GetTiles( dst_index ).QuantitySpell();
+        const Spell & spell = getSpellFromTile( world.GetTiles( dst_index ) );
         const uint32_t spell_level = spell.Level();
 
         if ( spell.isValid() &&
@@ -1088,7 +1088,7 @@ namespace
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
                 complete = true;
-                const Artifact & art = tile.QuantityArtifact();
+                const Artifact & art = getArtifactFromTile( tile );
 
                 if ( art.isValid() && !hero.PickupArtifact( art ) )
                     gold = GoldInsteadArtifact( objectType );
@@ -1114,7 +1114,7 @@ namespace
     void AIToPyramid( Heroes & hero, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        const Spell & spell = tile.QuantitySpell();
+        const Spell & spell = getSpellFromTile( tile );
 
         if ( spell.isValid() ) {
             // battle
@@ -1374,7 +1374,7 @@ namespace
         if ( hero.IsFullBagArtifacts() )
             hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, GoldInsteadArtifact( objectType ) ) );
         else
-            hero.PickupArtifact( tile.QuantityArtifact() );
+            hero.PickupArtifact( getArtifactFromTile( tile ) );
 
         tile.RemoveObjectSprite();
         tile.QuantityReset();
@@ -1388,7 +1388,7 @@ namespace
 
         if ( !hero.IsFullBagArtifacts() ) {
             uint32_t cond = tile.QuantityVariant();
-            Artifact art = tile.QuantityArtifact();
+            Artifact art = getArtifactFromTile( tile );
 
             bool result = false;
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -529,7 +529,7 @@ namespace
     void AIToTreasureChest( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        uint32_t gold = tile.QuantityGold();
+        uint32_t gold = getGoldAmountFromTile( tile );
 
         Kingdom & kingdom = hero.GetKingdom();
 
@@ -1078,7 +1078,7 @@ namespace
     void AIToPoorMoraleObject( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        uint32_t gold = tile.QuantityGold();
+        uint32_t gold = getGoldAmountFromTile( tile );
         bool complete = false;
 
         if ( gold ) {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -174,7 +174,7 @@ namespace
 
         // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player
         if ( MP2::isArtifactObject( objectType ) ) {
-            const Artifact art = tile.QuantityArtifact();
+            const Artifact art = getArtifactFromTile( tile );
 
             if ( art.isValid() && isFindArtifactVictoryConditionForHuman( art ) ) {
                 return false;
@@ -268,7 +268,7 @@ namespace
         case MP2::OBJ_SHRINE_FIRST_CIRCLE:
         case MP2::OBJ_SHRINE_SECOND_CIRCLE:
         case MP2::OBJ_SHRINE_THIRD_CIRCLE: {
-            const Spell & spell = tile.QuantitySpell();
+            const Spell & spell = getSpellFromTile( tile );
             if ( !spell.isValid() ) {
                 // The spell cannot be invalid!
                 assert( 0 );
@@ -890,7 +890,7 @@ namespace AI
             return 3000.0;
         }
         case MP2::OBJ_ARTIFACT: {
-            const Artifact art = tile.QuantityArtifact();
+            const Artifact art = getArtifactFromTile( tile );
             assert( art.isValid() );
 
             // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player
@@ -905,8 +905,8 @@ namespace AI
         case MP2::OBJ_TREASURE_CHEST: {
             // TODO: add logic if the object contains an artifact and resources.
 
-            if ( tile.QuantityArtifact().isValid() ) {
-                const Artifact art = tile.QuantityArtifact();
+            if ( getArtifactFromTile( tile ).isValid() ) {
+                const Artifact art = getArtifactFromTile( tile );
 
                 // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player
                 if ( isFindArtifactVictoryConditionForHuman( art ) ) {
@@ -925,12 +925,12 @@ namespace AI
         case MP2::OBJ_SHIPWRECK:
         case MP2::OBJ_SKELETON:
         case MP2::OBJ_WAGON: {
-            if ( !tile.QuantityArtifact().isValid() ) {
+            if ( !getArtifactFromTile( tile ).isValid() ) {
                 // Don't waste time to go here.
                 return -dangerousTaskPenalty;
             }
 
-            const Artifact art = tile.QuantityArtifact();
+            const Artifact art = getArtifactFromTile( tile );
 
             // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player
             if ( isFindArtifactVictoryConditionForHuman( art ) ) {
@@ -964,7 +964,7 @@ namespace AI
         case MP2::OBJ_SHRINE_FIRST_CIRCLE:
         case MP2::OBJ_SHRINE_SECOND_CIRCLE:
         case MP2::OBJ_SHRINE_THIRD_CIRCLE: {
-            const Spell & spell = tile.QuantitySpell();
+            const Spell & spell = getSpellFromTile( tile );
             return spell.getStrategicValue( hero.GetArmy().GetStrength(), hero.GetMaxSpellPoints(), hero.GetPower() );
         }
         case MP2::OBJ_ARENA:
@@ -1305,7 +1305,7 @@ namespace AI
             return 5000.0;
         }
         case MP2::OBJ_ARTIFACT: {
-            const Artifact art = tile.QuantityArtifact();
+            const Artifact art = getArtifactFromTile( tile );
             assert( art.isValid() );
 
             // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player
@@ -1336,7 +1336,7 @@ namespace AI
         case MP2::OBJ_SHRINE_FIRST_CIRCLE:
         case MP2::OBJ_SHRINE_SECOND_CIRCLE:
         case MP2::OBJ_SHRINE_THIRD_CIRCLE: {
-            const Spell & spell = tile.QuantitySpell();
+            const Spell & spell = getSpellFromTile( tile );
             return spell.getStrategicValue( hero.GetArmy().GetStrength(), hero.GetMaxSpellPoints(), hero.GetPower() ) * 1.1;
         }
         case MP2::OBJ_ARENA:

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -323,9 +323,9 @@ void Dialog::MakeGiftResource( Kingdom & kingdom )
         EventDate event;
 
         event.resource = funds2;
-        event.computer = true;
-        event.first = world.CountDay() + 1;
-        event.subsequent = 0;
+        event.isApplicableForAIPlayers = true;
+        event.firstOccurrenceDay = world.CountDay() + 1;
+        event.repeatPeriodInDays = 0;
         event.colors = selector.recipients;
         event.message = _( "Gift from %{name}" );
         const Player * player = Players::Get( kingdom.GetColor() );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -244,7 +244,7 @@ namespace
         std::string str = MP2::StringObject( objectType );
 
         if ( isVisited ) {
-            const Spell & spell = tile.QuantitySpell();
+            const Spell & spell = getSpellFromTile( tile );
 
             str.append( "\n(" );
             str.append( spell.GetName() );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1248,7 +1248,7 @@ namespace
     void ActionToPoorMoraleObject( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        uint32_t gold = tile.QuantityGold();
+        uint32_t gold = getGoldAmountFromTile( tile );
         std::string ask;
         std::string msg;
         std::string win;
@@ -1691,7 +1691,7 @@ namespace
         const std::string & hdr = MP2::StringObject( objectType );
 
         std::string msg;
-        uint32_t gold = tile.QuantityGold();
+        uint32_t gold = getGoldAmountFromTile( tile );
 
         // dialog
         if ( tile.isWater() ) {
@@ -2884,7 +2884,7 @@ namespace
                 return Outcome::Experience;
             }
             case 2: {
-                const uint32_t gold = tile.QuantityGold();
+                const uint32_t gold = getGoldAmountFromTile( tile );
 
                 std::string msg = _(
                     "The Demon screams its challenge and attacks! After a short, desperate battle, you slay the monster and receive %{exp} experience points and %{count} gold." );
@@ -2917,7 +2917,7 @@ namespace
             }
             default: {
                 const Kingdom & kingdom = hero.GetKingdom();
-                const uint32_t gold = tile.QuantityGold();
+                const uint32_t gold = getGoldAmountFromTile( tile );
                 const Funds payment( Resource::GOLD, gold );
 
                 if ( !kingdom.AllowPayment( payment ) ) {
@@ -2982,7 +2982,7 @@ namespace
 
                     break;
                 case Outcome::ExperienceAndGold: {
-                    const uint32_t gold = tile.QuantityGold();
+                    const uint32_t gold = getGoldAmountFromTile( tile );
 
                     hero.IncreaseExperience( demonSlayingExperience );
                     kingdom.AddFundsResource( Funds( Resource::GOLD, gold ) );
@@ -2998,7 +2998,7 @@ namespace
                     break;
                 }
                 case Outcome::PayOff: {
-                    const uint32_t gold = tile.QuantityGold();
+                    const uint32_t gold = getGoldAmountFromTile( tile );
                     const Funds payment( Resource::GOLD, gold );
 
                     kingdom.OddFundsResource( payment );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -776,7 +776,7 @@ namespace
                 hero.GetKingdom().AddFundsResource( funds );
             }
             else {
-                const Artifact & art = tile.QuantityArtifact();
+                const Artifact & art = getArtifactFromTile( tile );
                 message += '\n';
                 message.append( _( "Searching through the tattered clothing, you find the %{artifact}." ) );
                 StringReplace( message, "%{artifact}", art.GetName() );
@@ -810,7 +810,7 @@ namespace
         const std::string title( MP2::StringObject( MP2::OBJ_WAGON ) );
 
         if ( tile.QuantityIsValid() ) {
-            const Artifact & art = tile.QuantityArtifact();
+            const Artifact & art = getArtifactFromTile( tile );
 
             if ( art.isValid() ) {
                 if ( hero.IsFullBagArtifacts() ) {
@@ -891,7 +891,7 @@ namespace
 
     void ActionToShrine( Heroes & hero, int32_t dst_index )
     {
-        const Spell & spell = world.GetTiles( dst_index ).QuantitySpell();
+        const Spell & spell = getSpellFromTile( world.GetTiles( dst_index ) );
         const uint32_t spell_level = spell.Level();
 
         std::string head;
@@ -1055,7 +1055,7 @@ namespace
     void ActionToPyramid( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        const Spell & spell = tile.QuantitySpell();
+        const Spell & spell = getSpellFromTile( tile );
 
         const std::string ask = _(
             "You come upon the pyramid of a great and ancient king.\nYou are tempted to search it for treasure, but all the old stories warn of fearful curses and undead "
@@ -1295,7 +1295,7 @@ namespace
 
                     complete = true;
 
-                    const Artifact & art = tile.QuantityArtifact();
+                    const Artifact & art = getArtifactFromTile( tile );
                     if ( art.isValid() ) {
                         if ( hero.IsFullBagArtifacts() ) {
                             gold = GoldInsteadArtifact( objectType );
@@ -1481,7 +1481,7 @@ namespace
             hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, gold ) );
         }
         else {
-            const Artifact & art = tile.QuantityArtifact();
+            const Artifact & art = getArtifactFromTile( tile );
             std::string str = _(
                 "You've pulled a shipwreck survivor from certain death in an unforgiving ocean. Grateful, he rewards you for your act of kindness by giving you the %{art}." );
             StringReplace( str, "%{art}", art.GetName() );
@@ -1514,7 +1514,7 @@ namespace
             Dialog::Message( title, _( "You cannot pick up this artifact, you already have a full load!" ), Font::BIG, Dialog::OK );
         else {
             uint32_t cond = tile.QuantityVariant();
-            Artifact art = tile.QuantityArtifact();
+            Artifact art = getArtifactFromTile( tile );
 
             bool result = false;
             std::string msg;
@@ -1696,7 +1696,7 @@ namespace
         // dialog
         if ( tile.isWater() ) {
             if ( gold ) {
-                const Artifact & art = tile.QuantityArtifact();
+                const Artifact & art = getArtifactFromTile( tile );
 
                 if ( art.isValid() ) {
                     if ( hero.IsFullBagArtifacts() ) {
@@ -1738,7 +1738,7 @@ namespace
             }
         }
         else {
-            const Artifact & art = tile.QuantityArtifact();
+            const Artifact & art = getArtifactFromTile( tile );
 
             if ( gold ) {
                 const uint32_t expr = gold > 500 ? gold - 500 : 500;
@@ -2036,7 +2036,7 @@ namespace
                 else {
                     // The army should include only the original monsters
                     const uint32_t monstersLeft = army.getTotalCount();
-                    assert( monstersLeft == army.GetCountMonsters( tile.QuantityMonster() ) );
+                    assert( monstersLeft == army.GetCountMonsters( getMonsterFromTile( tile ) ) );
 
                     Troop & troop = world.GetCapturedObject( dstIndex ).GetTroop();
                     troop.SetCount( monstersLeft );
@@ -2899,7 +2899,7 @@ namespace
                 return Outcome::ExperienceAndGold;
             }
             case 3: {
-                const Artifact art = tile.QuantityArtifact();
+                const Artifact art = getArtifactFromTile( tile );
                 if ( !art.isValid() ) {
                     return Outcome::Invalid;
                 }
@@ -2990,7 +2990,7 @@ namespace
                     break;
                 }
                 case Outcome::ExperienceAndArtifact: {
-                    const Artifact art = tile.QuantityArtifact();
+                    const Artifact art = getArtifactFromTile( tile );
 
                     hero.IncreaseExperience( demonSlayingExperience );
                     hero.PickupArtifact( art );

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -52,62 +52,127 @@ MapEvent::MapEvent()
     , colors( 0 )
 {}
 
-void MapEvent::LoadFromMP2( int32_t index, StreamBuf st )
+void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & data )
 {
-    // id
-    if ( 1 == st.get() ) {
-        SetIndex( index );
-        SetUID( index );
+    assert( data.size() >= MP2::MP2_EVENT_STRUCTURE_MIN_SIZE );
 
-        // resource
-        resources.wood = st.getLE32();
-        resources.mercury = st.getLE32();
-        resources.ore = st.getLE32();
-        resources.sulfur = st.getLE32();
-        resources.crystal = st.getLE32();
-        resources.gems = st.getLE32();
-        resources.gold = st.getLE32();
+    assert( data[0] == 1 );
 
-        // artifact
-        artifact = st.getLE16();
+    // Structure containing information about a ground event.
+    //
+    // - uint8_t (1 byte)
+    //     Always 1 as an indicator that this indeed a ground event.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Wood to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Mercury to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Ore to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Sulfur to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Crystals to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Gems to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Gold to be given. Can be negative.
+    //
+    // - uint16_t (2 bytes)
+    //     An artifact to be given.
+    //
+    // - uint8_t (1 byte)
+    //     A flag whether the event is applicable for AI players as well.
+    //
+    // - uint8_t (1 bytes)
+    //     Does event occur only once?
+    //
+    // - unused 10 bytes
+    //    Always 0.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Blue player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Green player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Red player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Yellow player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Orange player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Purple player receives the event.
+    //
+    // - string
+    //    Null terminated string containing the event text.
 
-        // allow computer
-        computer = ( st.get() != 0 );
+    SetIndex( index );
+    SetUID( index );
 
-        // cancel event after first visit
-        cancel = ( st.get() != 0 );
+    StreamBuf dataStream( data );
 
-        st.skip( 10 );
+    dataStream.skip( 1 );
 
-        colors = 0;
-        // blue
-        if ( st.get() )
-            colors |= Color::BLUE;
-        // green
-        if ( st.get() )
-            colors |= Color::GREEN;
-        // red
-        if ( st.get() )
-            colors |= Color::RED;
-        // yellow
-        if ( st.get() )
-            colors |= Color::YELLOW;
-        // orange
-        if ( st.get() )
-            colors |= Color::ORANGE;
-        // purple
-        if ( st.get() )
-            colors |= Color::PURPLE;
+    // Get the amount of resources.
+    resources.wood = dataStream.getLE32();
+    resources.mercury = dataStream.getLE32();
+    resources.ore = dataStream.getLE32();
+    resources.sulfur = dataStream.getLE32();
+    resources.crystal = dataStream.getLE32();
+    resources.gems = dataStream.getLE32();
+    resources.gold = dataStream.getLE32();
 
-        // message
-        message = st.toString();
-        DEBUG_LOG( DBG_GAME, DBG_INFO,
-                   "event"
-                       << ": " << message )
+    // An artifact to be given.
+    artifact = dataStream.getLE16();
+
+    // The event applies to AI players as well.
+    computer = ( dataStream.get() != 0 );
+
+    // Does event occur only once?
+    cancel = ( dataStream.get() != 0 );
+
+    dataStream.skip( 10 );
+
+    colors = 0;
+
+    if ( dataStream.get() ){
+        colors |= Color::BLUE;
     }
-    else {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown id" )
+
+    if ( dataStream.get() ) {
+        colors |= Color::GREEN;
     }
+
+    if ( dataStream.get() ) {
+        colors |= Color::RED;
+    }
+
+    if ( dataStream.get() ) {
+        colors |= Color::YELLOW;
+    }
+
+    if ( dataStream.get() ) {
+        colors |= Color::ORANGE;
+    }
+
+    if ( dataStream.get() ) {
+        colors |= Color::PURPLE;
+    }
+
+    message = dataStream.toString();
+
+    DEBUG_LOG( DBG_GAME, DBG_INFO, "Ground event at tile " << index << " has event message: " << message )
 }
 
 void MapEvent::SetVisited( int color )

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -146,7 +146,7 @@ void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & da
 
     colors = 0;
 
-    if ( dataStream.get() ){
+    if ( dataStream.get() ) {
         colors |= Color::BLUE;
     }
 

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -125,13 +125,13 @@ void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & da
     dataStream.skip( 1 );
 
     // Get the amount of resources.
-    resources.wood = dataStream.getLE32();
-    resources.mercury = dataStream.getLE32();
-    resources.ore = dataStream.getLE32();
-    resources.sulfur = dataStream.getLE32();
-    resources.crystal = dataStream.getLE32();
-    resources.gems = dataStream.getLE32();
-    resources.gold = dataStream.getLE32();
+    resources.wood = static_cast<int32_t>( dataStream.getLE32() );
+    resources.mercury = static_cast<int32_t>( dataStream.getLE32() );
+    resources.ore = static_cast<int32_t>( dataStream.getLE32() );
+    resources.sulfur = static_cast<int32_t>( dataStream.getLE32() );
+    resources.crystal = static_cast<int32_t>( dataStream.getLE32() );
+    resources.gems = static_cast<int32_t>( dataStream.getLE32() );
+    resources.gold = static_cast<int32_t>( dataStream.getLE32() );
 
     // An artifact to be given.
     artifact = dataStream.getLE16();

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -75,7 +75,7 @@ struct MapEvent : public MapObjectSimple
 {
     MapEvent();
 
-    void LoadFromMP2( int32_t index, StreamBuf );
+    void LoadFromMP2( const int32_t index, const std::vector<uint8_t> & data );
 
     bool isAllow( int color ) const;
     void SetVisited( int color );

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -34,8 +34,6 @@
 
 class StreamBase;
 
-class StreamBuf;
-
 class MapObjectSimple : public MapPosition
 {
 public:

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -624,26 +624,6 @@ bool Maps::TilesAddon::isArtifact( const TilesAddon & ta )
     return ( MP2::OBJ_ICN_TYPE_OBJNARTI == ta._objectIcnType ) && ( ta._imageIndex > 0x10 ) && ( ta._imageIndex % 2 );
 }
 
-int Maps::Tiles::getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
-{
-    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 60 <= icnIndex && 102 >= icnIndex ) {
-        // 60, 66, 72, 78, 84, 90, 96, 102
-        return ( ( icnIndex - 60 ) / 6 ) + 1;
-    }
-
-    return 0;
-}
-
-int Maps::Tiles::getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
-{
-    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 110 <= icnIndex && 138 >= icnIndex ) {
-        // 110, 114, 118, 122, 126, 130, 134, 138
-        return ( ( icnIndex - 110 ) / 4 ) + 1;
-    }
-
-    return 0;
-}
-
 bool Maps::TilesAddon::isShadow( const TilesAddon & ta )
 {
     return isShadowSprite( ta._objectIcnType, ta._imageIndex );
@@ -1349,7 +1329,7 @@ std::vector<fheroes2::ObjectRenderingInfo> Maps::Tiles::getMonsterSpritesPerTile
 {
     assert( GetObject() == MP2::OBJ_MONSTER );
 
-    const Monster & monster = QuantityMonster();
+    const Monster & monster = getMonsterFromTile( *this );
     const std::pair<uint32_t, uint32_t> spriteIndices = GetMonsterSpriteIndices( *this, monster.GetSpriteIndex() );
 
     const int icnId{ ICN::MINI_MONSTER_IMAGE };
@@ -1392,7 +1372,7 @@ std::vector<fheroes2::ObjectRenderingInfo> Maps::Tiles::getMonsterShadowSpritesP
 {
     assert( GetObject() == MP2::OBJ_MONSTER );
 
-    const Monster & monster = QuantityMonster();
+    const Monster & monster = getMonsterFromTile( *this );
     const std::pair<uint32_t, uint32_t> spriteIndices = GetMonsterSpriteIndices( *this, monster.GetSpriteIndex() );
 
     const int icnId{ ICN::MINI_MONSTER_SHADOW };
@@ -3271,4 +3251,24 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
     }
 
     return msg;
+}
+
+int Maps::getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
+{
+    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 60 <= icnIndex && 102 >= icnIndex ) {
+        // 60, 66, 72, 78, 84, 90, 96, 102
+        return ( ( icnIndex - 60 ) / 6 ) + 1;
+    }
+
+    return 0;
+}
+
+int Maps::getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
+{
+    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 110 <= icnIndex && 138 >= icnIndex ) {
+        // 110, 114, 118, 122, 126, 130, 134, 138
+        return ( ( icnIndex - 110 ) / 4 ) + 1;
+    }
+
+    return 0;
 }

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -337,7 +337,6 @@ namespace Maps
         int QuantityVariant() const;
         int QuantityExt() const;
         int QuantityColor() const;
-        
         Skill::Secondary QuantitySkill() const;
         ResourceCount QuantityResourceCount() const;
         Funds QuantityFunds() const;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -338,12 +338,10 @@ namespace Maps
         int QuantityExt() const;
         int QuantityColor() const;
         uint32_t QuantityGold() const;
-        Spell QuantitySpell() const;
+        
         Skill::Secondary QuantitySkill() const;
-        Artifact QuantityArtifact() const;
         ResourceCount QuantityResourceCount() const;
         Funds QuantityFunds() const;
-        Monster QuantityMonster() const;
         Troop QuantityTroop() const;
 
         void SetObjectPassable( bool );
@@ -381,9 +379,6 @@ namespace Maps
         bool containsAnyObjectIcnType( const std::vector<MP2::ObjectIcnType> & objectIcnTypes ) const;
 
         bool containsSprite( const MP2::ObjectIcnType objectIcnType, const uint32_t imageIdx ) const;
-
-        static int getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
-        static int getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
 
         static std::pair<int, int> ColorRaceFromHeroSprite( const uint32_t heroSpriteIndex );
         static std::pair<uint32_t, uint32_t> GetMonsterSpriteIndices( const Tiles & tile, const uint32_t monsterIndex );
@@ -508,6 +503,15 @@ namespace Maps
     void setMonsterOnTileJoinCondition( Tiles & tile, const int32_t condition );
     bool isMonsterOnTileJoinConditionSkip( const Tiles & tile );
     bool isMonsterOnTileJoinConditionFree( const Tiles & tile );
+
+    int getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
+    int getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
+
+    Monster getMonsterFromTile( const Tiles & tile );
+
+    Spell getSpellFromTile( const Tiles & tile );
+
+    Artifact getArtifactFromTile( const Tiles & tile );
 }
 
 #endif

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -337,7 +337,7 @@ namespace Maps
         int QuantityVariant() const;
         int QuantityExt() const;
         int QuantityColor() const;
-        uint32_t QuantityGold() const;
+        
         Skill::Secondary QuantitySkill() const;
         ResourceCount QuantityResourceCount() const;
         Funds QuantityFunds() const;
@@ -511,6 +511,8 @@ namespace Maps
     Spell getSpellFromTile( const Tiles & tile );
 
     Artifact getArtifactFromTile( const Tiles & tile );
+
+    uint32_t getGoldAmountFromTile( const Tiles & tile );
 }
 
 #endif

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -338,7 +338,6 @@ namespace Maps
         int QuantityExt() const;
         int QuantityColor() const;
         uint32_t QuantityGold() const;
-        
         Skill::Secondary QuantitySkill() const;
         ResourceCount QuantityResourceCount() const;
         Funds QuantityFunds() const;

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -1144,7 +1144,7 @@ namespace Maps
         return tile.GetObject() == MP2::OBJ_MONSTER && tile.getAdditionalMetadata() == Monster::JOIN_CONDITION_FREE;
     }
 
-    Monster Maps::getMonsterFromTile( const Tiles & tile )
+    Monster getMonsterFromTile( const Tiles & tile )
     {
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_WATCH_TOWER:
@@ -1208,7 +1208,7 @@ namespace Maps
         return { Monster::UNKNOWN };
     }
 
-    Spell Maps::getSpellFromTile( const Tiles & tile )
+    Spell getSpellFromTile( const Tiles & tile )
     {
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_ARTIFACT:

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -203,8 +203,6 @@ void Maps::Tiles::QuantitySetResource( int res, uint32_t count )
     quantity2 = static_cast<Quantity2Type>( count );
 }
 
-
-
 ResourceCount Maps::Tiles::QuantityResourceCount() const
 {
     switch ( GetObject( false ) ) {

--- a/src/fheroes2/maps/maps_tiles_quantity.cpp
+++ b/src/fheroes2/maps/maps_tiles_quantity.cpp
@@ -209,11 +209,11 @@ ResourceCount Maps::Tiles::QuantityResourceCount() const
     case MP2::OBJ_ARTIFACT:
         switch ( QuantityVariant() ) {
         case 1:
-            return ResourceCount( Resource::GOLD, getGoldAmountFromTile( *this ) );
+            return { Resource::GOLD, getGoldAmountFromTile( *this ) };
         case 2:
-            return ResourceCount( Resource::getResourceTypeFromIconIndex( QuantityExt() - 1 ), 3 );
+            return { Resource::getResourceTypeFromIconIndex( QuantityExt() - 1 ), 3 };
         case 3:
-            return ResourceCount( Resource::getResourceTypeFromIconIndex( QuantityExt() - 1 ), 5 );
+            return { Resource::getResourceTypeFromIconIndex( QuantityExt() - 1 ), 5 };
         default:
             break;
         }
@@ -221,16 +221,16 @@ ResourceCount Maps::Tiles::QuantityResourceCount() const
 
     case MP2::OBJ_SEA_CHEST:
     case MP2::OBJ_TREASURE_CHEST:
-        return ResourceCount( Resource::GOLD, getGoldAmountFromTile( *this ) );
+        return { Resource::GOLD, getGoldAmountFromTile( *this ) };
 
     case MP2::OBJ_FLOTSAM:
-        return ResourceCount( Resource::WOOD, quantity1 );
+        return { Resource::WOOD, quantity1 };
 
     default:
         break;
     }
 
-    return ResourceCount( quantity1, Resource::GOLD == quantity1 ? getGoldAmountFromTile( *this ) : quantity2 );
+    return { quantity1, Resource::GOLD == quantity1 ? getGoldAmountFromTile( *this ) : quantity2 };
 }
 
 Funds Maps::Tiles::QuantityFunds() const
@@ -262,7 +262,7 @@ Funds Maps::Tiles::QuantityFunds() const
     case MP2::OBJ_SHIPWRECK:
     case MP2::OBJ_GRAVEYARD:
     case MP2::OBJ_DAEMON_CAVE:
-        return Funds( Resource::GOLD, getGoldAmountFromTile( *this ) );
+        return { Resource::GOLD, getGoldAmountFromTile( *this ) };
 
     default:
         break;

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -113,55 +113,6 @@ namespace MP2
         uint32_t level2ObjectUID;
     };
 
-    // origin mp2 event for coord
-    struct mp2eventcoord_t
-    {
-        uint8_t id; // 0x01
-        uint32_t wood;
-        uint32_t mercury;
-        uint32_t ore;
-        uint32_t sulfur;
-        uint32_t crystal;
-        uint32_t gems;
-        uint32_t golds;
-        uint16_t artifact; // 0xffff - none
-        bool computer; // allow events for computer
-        bool cancel; // cancel event after first visit
-        uint8_t zero[10]; // 10 byte 0x00
-        bool blue;
-        bool green;
-        bool red;
-        bool yellow;
-        bool orange;
-        bool purple;
-        char text; // message + '/0'
-    };
-
-    // origin mp2 event for day
-    struct mp2eventday_t
-    {
-        uint8_t id; // 0x00
-        uint32_t wood;
-        uint32_t mercury;
-        uint32_t ore;
-        uint32_t sulfur;
-        uint32_t crystal;
-        uint32_t gems;
-        uint32_t golds;
-        uint16_t artifact; // always 0xffff - none
-        uint16_t computer; // allow events for computer
-        uint16_t first; // day of first occurent
-        uint16_t subsequent; // subsequent occurrences
-        uint8_t zero[6]; // 6 byte 0x00 and end 0x01
-        bool blue;
-        bool green;
-        bool red;
-        bool yellow;
-        bool orange;
-        bool purple;
-        char text; // message + '/0'
-    };
-
     // An object type could be action and non-action. If both parts are present the difference between them must be 128.
     enum MapObjectType : uint8_t
     {

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1519,13 +1519,13 @@ void EventDate::LoadFromMP2( const std::vector<uint8_t> & data )
     dataStream.skip( 1 );
 
     // Get the amount of resources.
-    resource.wood = dataStream.getLE32();
-    resource.mercury = dataStream.getLE32();
-    resource.ore = dataStream.getLE32();
-    resource.sulfur = dataStream.getLE32();
-    resource.crystal = dataStream.getLE32();
-    resource.gems = dataStream.getLE32();
-    resource.gold = dataStream.getLE32();
+    resource.wood = static_cast<int32_t>( dataStream.getLE32() );
+    resource.mercury = static_cast<int32_t>( dataStream.getLE32() );
+    resource.ore = static_cast<int32_t>( dataStream.getLE32() );
+    resource.sulfur = static_cast<int32_t>( dataStream.getLE32() );
+    resource.crystal = static_cast<int32_t>( dataStream.getLE32() );
+    resource.gems = static_cast<int32_t>( dataStream.getLE32() );
+    resource.gold = static_cast<int32_t>( dataStream.getLE32() );
 
     dataStream.skip( 2 );
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1441,81 +1441,166 @@ StreamBase & operator>>( StreamBase & msg, World & w )
     return msg;
 }
 
-void EventDate::LoadFromMP2( StreamBuf st )
+void EventDate::LoadFromMP2( const std::vector<uint8_t> & data )
 {
-    // id
-    if ( 0 == st.get() ) {
-        // resource
-        resource.wood = st.getLE32();
-        resource.mercury = st.getLE32();
-        resource.ore = st.getLE32();
-        resource.sulfur = st.getLE32();
-        resource.crystal = st.getLE32();
-        resource.gems = st.getLE32();
-        resource.gold = st.getLE32();
+    assert( data.size() >= MP2::MP2_EVENT_STRUCTURE_MIN_SIZE );
 
-        st.skip( 2 );
+    assert( data[0] == 0 );
 
-        // allow computer
-        computer = ( st.getLE16() != 0 );
+    assert( data[42] == 1 );
 
-        // day of first occurrence
-        first = st.getLE16();
+    // Structure containing information about a timed global event.
+    //
+    // - uint8_t (1 byte)
+    //     Always 0 as an indicator that this indeed a timed global object.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Wood to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Mercury to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Ore to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Sulfur to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Crystals to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Gems to be given. Can be negative.
+    //
+    // - int32_t (4 bytes)
+    //     The amount of Gold to be given. Can be negative.
+    //
+    // - uint16_t (2 bytes)
+    //     Possible artifacts to be given. Not in use.
+    //
+    // - uint16_t (2 bytes)
+    //     A flag whether the event is applicable for AI players as well.
+    //
+    // - uint16_t (2 bytes)
+    //     The first day of occurrence of the event.
+    //
+    // - uint16_t (2 bytes)
+    //     Period in days when the event repeats. 0 means that the event never repeats.
+    //
+    // - unused 5 bytes
+    //    Always 0.
+    //
+    // - unused 1 byte
+    //    Always 1.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Blue player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Green player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Red player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Yellow player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Orange player receives the event.
+    //
+    // - uint8_t (1 byte)
+    //     A flag to determine whether Purple player receives the event.
+    //
+    // - string
+    //    Null terminated string containing the event text.
 
-        // subsequent occurrences
-        subsequent = st.getLE16();
+    StreamBuf dataStream( data );
 
-        st.skip( 6 );
+    dataStream.skip( 1 );
 
-        colors = 0;
-        // blue
-        if ( st.get() )
-            colors |= Color::BLUE;
-        // green
-        if ( st.get() )
-            colors |= Color::GREEN;
-        // red
-        if ( st.get() )
-            colors |= Color::RED;
-        // yellow
-        if ( st.get() )
-            colors |= Color::YELLOW;
-        // orange
-        if ( st.get() )
-            colors |= Color::ORANGE;
-        // purple
-        if ( st.get() )
-            colors |= Color::PURPLE;
+    // Get the amount of resources.
+    resource.wood = dataStream.getLE32();
+    resource.mercury = dataStream.getLE32();
+    resource.ore = dataStream.getLE32();
+    resource.sulfur = dataStream.getLE32();
+    resource.crystal = dataStream.getLE32();
+    resource.gems = dataStream.getLE32();
+    resource.gold = dataStream.getLE32();
 
-        // message
-        message = st.toString();
-        DEBUG_LOG( DBG_GAME, DBG_INFO,
-                   "event"
-                       << ": " << message )
+    dataStream.skip( 2 );
+
+    // The event applies to AI players as well.
+    isApplicableForAIPlayers = ( dataStream.getLE16() != 0 );
+
+    // Get the first day of occurrence.
+    firstOccurrenceDay = dataStream.getLE16();
+
+    // Get the repeat period.
+    repeatPeriodInDays = dataStream.getLE16();
+
+    dataStream.skip( 6 );
+
+    colors = 0;
+
+    if ( dataStream.get() ) {
+        colors |= Color::BLUE;
     }
-    else {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown id" )
+
+    if ( dataStream.get() ) {
+        colors |= Color::GREEN;
     }
+
+    if ( dataStream.get() ) {
+        colors |= Color::RED;
+    }
+
+    if ( dataStream.get() ) {
+        colors |= Color::YELLOW;
+    }
+
+    if ( dataStream.get() ) {
+        colors |= Color::ORANGE;
+    }
+
+    if ( dataStream.get() ) {
+        colors |= Color::PURPLE;
+    }
+
+    message = dataStream.toString();
+
+    DEBUG_LOG( DBG_GAME, DBG_INFO, "A timed event which occurs at day " << firstOccurrenceDay << " contains a message: " << message )
 }
 
-bool EventDate::isDeprecated( uint32_t date ) const
+bool EventDate::isAllow( const int col, const uint32_t date ) const
 {
-    return 0 == subsequent && first < date;
-}
+    if ( ( col & colors ) == 0 ) {
+        // This player color is not allowed for the event.
+        return false;
+    }
 
-bool EventDate::isAllow( int col, uint32_t date ) const
-{
-    return ( ( first == date || ( subsequent && ( first < date && 0 == ( ( date - first ) % subsequent ) ) ) ) && ( col & colors ) );
+    if ( firstOccurrenceDay < date ) {
+        // The date has not come.
+        return false;
+    }
+
+    if ( firstOccurrenceDay == date ) {
+        return true;
+    }
+
+    if ( repeatPeriodInDays == 0 ) {
+        // This is not the same date and the event does not repeat.
+        return false;
+    }
+
+    return ( ( date - firstOccurrenceDay ) % repeatPeriodInDays ) == 0;
 }
 
 StreamBase & operator<<( StreamBase & msg, const EventDate & obj )
 {
-    return msg << obj.resource << obj.computer << obj.first << obj.subsequent << obj.colors << obj.message << obj.title;
+    return msg << obj.resource << obj.isApplicableForAIPlayers << obj.firstOccurrenceDay << obj.repeatPeriodInDays << obj.colors << obj.message << obj.title;
 }
 
 StreamBase & operator>>( StreamBase & msg, EventDate & obj )
 {
-    msg >> obj.resource >> obj.computer >> obj.first >> obj.subsequent >> obj.colors >> obj.message >> obj.title;
-
-    return msg;
+    return msg >> obj.resource >> obj.isApplicableForAIPlayers >> obj.firstOccurrenceDay >> obj.repeatPeriodInDays >> obj.colors >> obj.message >> obj.title;
 }

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -118,13 +118,6 @@ struct CapturedObjects : std::map<int32_t, CapturedObject>
 
 struct EventDate
 {
-    EventDate()
-        : firstOccurrenceDay( 0 )
-        , repeatPeriodInDays( 0 )
-        , colors( 0 )
-        , isApplicableForAIPlayers( false )
-    {}
-
     void LoadFromMP2( const std::vector<uint8_t> & data );
 
     bool isAllow( const int color, const uint32_t date ) const;
@@ -135,10 +128,10 @@ struct EventDate
     }
 
     Funds resource;
-    uint32_t firstOccurrenceDay;
-    uint32_t repeatPeriodInDays;
-    int colors;
-    bool isApplicableForAIPlayers;
+    uint32_t firstOccurrenceDay{ 0 };
+    uint32_t repeatPeriodInDays{ 0 };
+    int colors{ 0 };
+    bool isApplicableForAIPlayers{ false };
     std::string message;
 
     std::string title;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -48,7 +48,6 @@
 
 class MapObjectSimple;
 class StreamBase;
-class StreamBuf;
 
 struct MapEvent;
 struct Week;

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -119,22 +119,26 @@ struct CapturedObjects : std::map<int32_t, CapturedObject>
 struct EventDate
 {
     EventDate()
-        : first( 0 )
-        , subsequent( 0 )
+        : firstOccurrenceDay( 0 )
+        , repeatPeriodInDays( 0 )
         , colors( 0 )
-        , computer( false )
+        , isApplicableForAIPlayers( false )
     {}
 
-    void LoadFromMP2( StreamBuf );
+    void LoadFromMP2( const std::vector<uint8_t> & data );
 
-    bool isAllow( int color, uint32_t date ) const;
-    bool isDeprecated( uint32_t date ) const;
+    bool isAllow( const int color, const uint32_t date ) const;
+
+    bool isDeprecated( const uint32_t date ) const
+    {
+        return date > firstOccurrenceDay && repeatPeriodInDays == 0;
+    }
 
     Funds resource;
-    uint32_t first;
-    uint32_t subsequent;
+    uint32_t firstOccurrenceDay;
+    uint32_t repeatPeriodInDays;
     int colors;
-    bool computer;
+    bool isApplicableForAIPlayers;
     std::string message;
 
     std::string title;

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -580,7 +580,7 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
             case MP2::OBJ_EVENT:
                 if ( MP2::MP2_EVENT_STRUCTURE_MIN_SIZE <= pblock.size() && 0x01 == pblock[0] ) {
                     MapEvent * obj = new MapEvent();
-                    obj->LoadFromMP2( objectTileId, StreamBuf( pblock ) );
+                    obj->LoadFromMP2( objectTileId, pblock );
                     map_objects.add( obj );
                 }
                 break;
@@ -599,9 +599,9 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
         // other events
         else if ( 0x00 == pblock[0] ) {
             // Daily event.
-            if ( MP2::MP2_EVENT_STRUCTURE_MIN_SIZE <= pblock.size() && 1 == pblock[42] ) {
+            if ( MP2::MP2_EVENT_STRUCTURE_MIN_SIZE <= pblock.size() && pblock[42] == 1 ) {
                 vec_eventsday.emplace_back();
-                vec_eventsday.back().LoadFromMP2( StreamBuf( pblock ) );
+                vec_eventsday.back().LoadFromMP2( pblock );
             }
             else if ( MP2::MP2_RUMOR_STRUCTURE_MIN_SIZE <= pblock.size() ) {
                 // Structure containing information about a rumor.

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -109,7 +109,7 @@ namespace
         }
 
         if ( MP2::isArtifactObject( objectType ) ) {
-            const Artifact art = tile.QuantityArtifact();
+            const Artifact art = Maps::getArtifactFromTile( tile );
             if ( art.isValid() ) {
                 if ( isFindArtifactVictoryConditionForHuman( art ) ) {
                     // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player.


### PR DESCRIPTION
- remove the remaining unused structures in `mp2.h` file
- move several methods out of Maps::Tiles class as they don't belong there being too specific to certain object types. Not all methods were moved to keep this pull request relatively small.

relates to #6845