### PR TITLE
Add Virtual Keyboard open button to Save Game and Player Name dialogs

### DIFF
--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -279,12 +279,15 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
     dst_pt.y = box_rt.y + box_rt.height - fheroes2::AGG::GetICN( cancelButtonIcnID, 0 ).height();
     fheroes2::Button buttonCancel( dst_pt.x, dst_pt.y, cancelButtonIcnID, 0, 1 );
 
-    fheroes2::Sprite released;
-    fheroes2::Sprite pressed;
+    // Generate a button to open the Virtual Keyboard window.
+    fheroes2::Sprite releasedVirtualKB;
+    fheroes2::Sprite pressedVirtualKB;
     const int32_t buttonVirtualKBWidth = 15;
-    makeButtonSprites( released, pressed, "...", buttonVirtualKBWidth, isEvilInterface, true );
+
+    makeButtonSprites( releasedVirtualKB, pressedVirtualKB, "...", buttonVirtualKBWidth, isEvilInterface, true );
+    // To center the button horizontally we have to take into account that actual button sprite is 10 pixels longer then the requested button width.
     fheroes2::ButtonSprite buttonVirtualKB
-        = makeButtonWithBackground( box_rt.x + ( box_rt.width - buttonVirtualKBWidth - 10 ) / 2, dst_pt.y, released, pressed, display );
+        = makeButtonWithBackground( box_rt.x + ( box_rt.width - buttonVirtualKBWidth - 10 ) / 2, dst_pt.y, releasedVirtualKB, pressedVirtualKB, display );
 
     if ( res.empty() ) {
         buttonOk.disable();
@@ -297,7 +300,7 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
     buttonCancel.draw();
     buttonVirtualKB.draw();
 
-    display.render( box_rt );
+    display.render();
 
     LocalEvent & le = LocalEvent::Get();
 
@@ -336,7 +339,7 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
             Dialog::Message( _( "Cancel" ), _( "Exit this menu without doing anything." ), Font::BIG );
         }
         else if ( le.MousePressRight( buttonOk.area() ) ) {
-            Dialog::Message( _( "Okay" ), _( "Click to apply the entered string." ), Font::BIG );
+            Dialog::Message( _( "Okay" ), _( "Click to apply the entered text." ), Font::BIG );
         }
         else if ( le.MousePressRight( buttonVirtualKB.area() ) ) {
             Dialog::Message( _( "Open Virtual Keyboard" ), _( "Click to open the Virtual Keyboard dialog." ), Font::BIG );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -120,7 +120,7 @@ public:
         const fheroes2::Sprite & sprite_edit = fheroes2::AGG::GetICN( ICN::TOWNWIND, 4 );
         fheroes2::Blit( sprite_edit, display, pos.x, pos.y + 4 );
 
-        Text text( std::to_string( vcur ), Font::BIG );
+        const Text text( std::to_string( vcur ), Font::BIG );
         text.Blit( pos.x + ( sprite_edit.width() - text.w() ) / 2, pos.y + 5 );
 
         btnUp.draw();
@@ -135,13 +135,12 @@ public:
         le.MousePressLeft( btnDn.area() ) ? btnDn.drawOnPress() : btnDn.drawOnRelease();
 
         if ( ( le.MouseWheelUp() || le.MouseClickLeft( btnUp.area() ) || timedBtnUp.isDelayPassed() ) && vcur < vmax ) {
-            vcur += vcur + step <= vmax ? step : vmax - vcur;
+            vcur += ( ( vcur + step ) <= vmax ) ? step : ( vmax - vcur );
             return true;
         }
-        else
-            // down
-            if ( ( le.MouseWheelDn() || le.MouseClickLeft( btnDn.area() ) || timedBtnDn.isDelayPassed() ) && vmin < vcur ) {
-            vcur -= vmin + vcur >= step ? step : vcur;
+
+        if ( ( le.MouseWheelDn() || le.MouseClickLeft( btnDn.area() ) || timedBtnDn.isDelayPassed() ) && vmin < vcur ) {
+            vcur -= ( ( vmin + vcur ) >= step ) ? step : ( vcur - vmin );
             return true;
         }
 
@@ -173,7 +172,7 @@ bool Dialog::SelectCount( const std::string & header, uint32_t min, uint32_t max
     Text text( header, Font::BIG );
     const int spacer = 10;
 
-    FrameBox box( text.h() + spacer + 30, true );
+    const FrameBox box( text.h() + spacer + 30, true );
     SelectValue sel( min, max, cur, step );
 
     const fheroes2::Rect & pos = box.GetArea();
@@ -209,8 +208,10 @@ bool Dialog::SelectCount( const std::string & header, uint32_t min, uint32_t max
             sel.SetCur( max );
             redraw_count = true;
         }
-        if ( sel.QueueEventProcessing() )
+
+        if ( sel.QueueEventProcessing() ) {
             redraw_count = true;
+        }
 
         if ( redraw_count ) {
             sel.Redraw();
@@ -243,12 +244,13 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
 
     const fheroes2::Sprite & inputArea = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::BUYBUILD : ICN::BUYBUILE ), 3 );
 
-    const uint32_t titleHeight = title.empty() ? 0 : titlebox.h() + 10;
-    FrameBox box( 10 + titleHeight + textbox.h() + 10 + inputArea.height(), true );
+    const int32_t titleHeight = title.empty() ? 0 : titlebox.h() + 10;
+    const FrameBox box( 10 + titleHeight + textbox.h() + 10 + inputArea.height(), true );
     const fheroes2::Rect & box_rt = box.GetArea();
 
-    if ( !title.empty() )
+    if ( !title.empty() ) {
         titlebox.Blit( box_rt.x + ( box_rt.width - textbox.w() ) / 2, box_rt.y + 10 );
+    }
 
     // text
     fheroes2::Point dst_pt;
@@ -277,15 +279,25 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
     dst_pt.y = box_rt.y + box_rt.height - fheroes2::AGG::GetICN( cancelButtonIcnID, 0 ).height();
     fheroes2::Button buttonCancel( dst_pt.x, dst_pt.y, cancelButtonIcnID, 0, 1 );
 
-    if ( res.empty() )
+    fheroes2::Sprite released;
+    fheroes2::Sprite pressed;
+    const int32_t buttonVirtualKBWidth = 15;
+    makeButtonSprites( released, pressed, "...", buttonVirtualKBWidth, isEvilInterface, true );
+    fheroes2::ButtonSprite buttonVirtualKB
+        = makeButtonWithBackground( box_rt.x + ( box_rt.width - buttonVirtualKBWidth - 10 ) / 2, dst_pt.y, released, pressed, display );
+
+    if ( res.empty() ) {
         buttonOk.disable();
-    else
+    }
+    else {
         buttonOk.enable();
+    }
 
     buttonOk.draw();
     buttonCancel.draw();
+    buttonVirtualKB.draw();
 
-    display.render();
+    display.render( box_rt );
 
     LocalEvent & le = LocalEvent::Get();
 
@@ -293,10 +305,11 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
 
     // message loop
     while ( le.HandleEvents() ) {
-        bool redraw = true;
+        bool redraw = false;
 
         buttonOk.isEnabled() && le.MousePressLeft( buttonOk.area() ) ? buttonOk.drawOnPress() : buttonOk.drawOnRelease();
         le.MousePressLeft( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
+        le.MousePressLeft( buttonVirtualKB.area() ) ? buttonVirtualKB.drawOnPress() : buttonVirtualKB.drawOnRelease();
 
         if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) || ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) ) {
             break;
@@ -307,24 +320,38 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
             break;
         }
 
-        if ( isInGameKeyboardRequired ) {
-            if ( le.MouseClickLeft( text_rt ) ) {
-                fheroes2::openVirtualKeyboard( res );
-                charInsertPos = res.size();
-            }
+        if ( le.MouseClickLeft( buttonVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( text_rt ) ) ) {
+            fheroes2::openVirtualKeyboard( res );
+            charInsertPos = res.size();
+            redraw = true;
         }
         else if ( le.KeyPress() ) {
-            if ( charLimit == 0 || charLimit > res.size() || le.KeyValue() == fheroes2::Key::KEY_BACKSPACE )
+            if ( charLimit == 0 || charLimit > res.size() || le.KeyValue() == fheroes2::Key::KEY_BACKSPACE ) {
                 charInsertPos = InsertKeySym( res, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
-            redraw = true;
+                redraw = true;
+            }
+        }
+
+        if ( le.MousePressRight( buttonCancel.area() ) ) {
+            Dialog::Message( _( "Cancel" ), _( "Exit this menu without doing anything." ), Font::BIG );
+        }
+        else if ( le.MousePressRight( buttonOk.area() ) ) {
+            Dialog::Message( _( "Okay" ), _( "Click to apply the entered string." ), Font::BIG );
+        }
+        else if ( le.MousePressRight( buttonVirtualKB.area() ) ) {
+            Dialog::Message( _( "Open Virtual Keyboard" ), _( "Click to open the Virtual Keyboard dialog." ), Font::BIG );
         }
 
         if ( redraw ) {
-            if ( res.empty() )
+            if ( res.empty() && buttonOk.isEnabled() ) {
                 buttonOk.disable();
-            else
+                buttonOk.draw();
+            }
+
+            if ( !res.empty() && !buttonOk.isEnabled() ) {
                 buttonOk.enable();
-            buttonOk.draw();
+                buttonOk.draw();
+            }
 
             text.Set( InsertString( res, charInsertPos, "_" ) );
 
@@ -355,7 +382,7 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
     const int boxHeight = freeSlots > 1 ? 90 + spacer : 45;
     const int boxYPosition = defaultYPosition + ( ( display.height() - display.DEFAULT_HEIGHT ) / 2 ) - boxHeight;
 
-    NonFixedFrameBox box( boxHeight, boxYPosition, true );
+    const NonFixedFrameBox box( boxHeight, boxYPosition, true );
     SelectValue sel( min, redistributeMax, redistributeCount, 1 );
     Text text;
 
@@ -425,10 +452,13 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
     while ( bres == Dialog::ZERO && le.HandleEvents() ) {
         bool redraw_count = false;
 
-        if ( buttonMax.isVisible() )
+        if ( buttonMax.isVisible() ) {
             le.MousePressLeft( buttonMax.area() ) ? buttonMax.drawOnPress() : buttonMax.drawOnRelease();
-        if ( buttonMin.isVisible() )
+        }
+
+        if ( buttonMin.isVisible() ) {
             le.MousePressLeft( buttonMin.area() ) ? buttonMin.drawOnPress() : buttonMin.drawOnRelease();
+        }
 
         if ( fheroes2::PressIntKey( redistributeMax, redistributeCount ) ) {
             sel.SetCur( redistributeCount );
@@ -446,10 +476,11 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
             sel.SetCur( min );
             redraw_count = true;
         }
-        else if ( sel.QueueEventProcessing() )
+        else if ( sel.QueueEventProcessing() ) {
             redraw_count = true;
+        }
 
-        if ( !ssp.empty() )
+        if ( !ssp.empty() ) {
             for ( std::vector<fheroes2::Rect>::const_iterator it = vrts.begin(); it != vrts.end(); ++it ) {
                 if ( le.MouseClickLeft( *it ) ) {
                     ssp.setPosition( it->x, it->y );
@@ -457,17 +488,22 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
                     display.render();
                 }
             }
+        }
 
         if ( redraw_count ) {
             SwitchMaxMinButtons( buttonMin, buttonMax, sel.getCur(), min );
-            if ( !ssp.empty() )
+            if ( !ssp.empty() ) {
                 ssp.hide();
+            }
             sel.Redraw();
 
-            if ( buttonMax.isVisible() )
+            if ( buttonMax.isVisible() ) {
                 buttonMax.draw();
-            if ( buttonMin.isVisible() )
+            }
+
+            if ( buttonMin.isVisible() ) {
                 buttonMin.draw();
+            }
 
             display.render();
         }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -226,7 +226,7 @@ MapsFileInfoList GetSortedMapsFileInfoList()
 
     MapsFileInfoList list2( list1.size() );
     int32_t saveFileCount = 0;
-    for ( std::string saveFile : list1 ) {
+    for ( const std::string & saveFile : list1 ) {
         if ( list2[saveFileCount].ReadSAV( saveFile ) ) {
             ++saveFileCount;
         }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -279,7 +279,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
     fheroes2::Button buttonOk( rt.x + 34, rt.y + 315, ICN::BUTTON_SMALL_OKAY_GOOD, 0, 1 );
     fheroes2::Button buttonCancel( rt.x + 244, rt.y + 315, ICN::BUTTON_SMALL_CANCEL_GOOD, 0, 1 );
 
-    fheroes2::ButtonSprite openVirtualKB;
+    fheroes2::ButtonSprite buttonVirtualKB;
 
     MapsFileInfoList lists = GetSortedMapsFileInfoList();
     FileInfoListBox listbox( rt.getPosition() );
@@ -344,11 +344,11 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
         fheroes2::Sprite released;
         fheroes2::Sprite pressed;
 
-        makeButtonSprites( released, pressed, "...", 15, false );
+        makeButtonSprites( released, pressed, "...", 15, false, true );
 
-        openVirtualKB = makeButtonWithShadow( rt.x + 315, rt.y + 283, released, pressed, display, { -4, 4 } );
+        buttonVirtualKB = makeButtonWithShadow( rt.x + 315, rt.y + 283, released, pressed, display, { -4, 4 } );
 
-        openVirtualKB.draw();
+        buttonVirtualKB.draw();
     }
 
     display.render();
@@ -363,7 +363,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
         le.MousePressLeft( buttonOk.area() ) && buttonOk.isEnabled() ? buttonOk.drawOnPress() : buttonOk.drawOnRelease();
         le.MousePressLeft( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
         if ( isEditing ) {
-            le.MousePressLeft( openVirtualKB.area() ) ? openVirtualKB.drawOnPress() : openVirtualKB.drawOnRelease();
+            le.MousePressLeft( buttonVirtualKB.area() ) ? buttonVirtualKB.drawOnPress() : buttonVirtualKB.drawOnRelease();
         }
 
         listbox.QueueEventProcessing();
@@ -384,7 +384,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
             break;
         }
         else if ( isEditing ) {
-            if ( le.MouseClickLeft( openVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( enter_field ) ) ) {
+            if ( le.MouseClickLeft( buttonVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( enter_field ) ) ) {
                 fheroes2::openVirtualKeyboard( filename );
                 charInsertPos = filename.size();
                 listbox.Unselect();
@@ -425,7 +425,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
                 Dialog::Message( _( "Okay" ), _( "Click to load a previously saved game." ), Font::BIG );
             }
         }
-        else if ( isEditing && le.MousePressRight( openVirtualKB.area() ) ) {
+        else if ( isEditing && le.MousePressRight( buttonVirtualKB.area() ) ) {
             Dialog::Message( _( "Open Virtual Keyboard" ), _( "Click to open the Virtual Keyboard dialog." ), Font::BIG );
         }
 
@@ -477,7 +477,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
         buttonCancel.draw();
 
         if ( isEditing ) {
-            openVirtualKB.draw();
+            buttonVirtualKB.draw();
         }
 
         display.render();

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -225,14 +225,14 @@ MapsFileInfoList GetSortedMapsFileInfoList()
     list1.ReadDir( Game::GetSaveDir(), Game::GetSaveFileExtension(), false );
 
     MapsFileInfoList list2( list1.size() );
-    int ii = 0;
-    for ( ListFiles::const_iterator itd = list1.begin(); itd != list1.end(); ++itd, ++ii ) {
-        if ( !list2[ii].ReadSAV( *itd ) ) {
-            --ii;
+    int32_t saveFileCount = 0;
+    for ( std::string saveFile : list1 ) {
+        if ( list2[saveFileCount].ReadSAV( saveFile ) ) {
+            ++saveFileCount;
         }
     }
-    if ( static_cast<size_t>( ii ) != list2.size() ) {
-        list2.resize( ii );
+    if ( static_cast<size_t>( saveFileCount ) != list2.size() ) {
+        list2.resize( saveFileCount );
     }
     std::sort( list2.begin(), list2.end(), Maps::FileInfo::FileSorting );
 
@@ -339,13 +339,12 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
     buttonOk.draw();
     buttonCancel.draw();
 
-    // Generate and render the "..." button for Virtual Keyboard dialog.
     if ( isEditing ) {
+        // Generate and render a button to open the Virtual Keyboard window.
         fheroes2::Sprite released;
         fheroes2::Sprite pressed;
 
         makeButtonSprites( released, pressed, "...", 15, false, true );
-
         buttonVirtualKB = makeButtonWithShadow( rt.x + 315, rt.y + 283, released, pressed, display, { -4, 4 } );
 
         buttonVirtualKB.draw();

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -389,6 +389,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
                 charInsertPos = filename.size();
                 listbox.Unselect();
                 isListboxSelected = false;
+                needRedraw = true;
             }
             else if ( le.MouseClickLeft( enter_field ) ) {
                 charInsertPos = GetInsertPosition( filename, le.GetMouseCursor().x, enter_field.x );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -84,9 +84,10 @@ namespace
     std::string ResizeToShortName( const std::string & str )
     {
         std::string res = System::GetBasename( str );
-        size_t it = res.rfind( '.' );
-        if ( std::string::npos != it )
+        const size_t it = res.rfind( '.' );
+        if ( std::string::npos != it ) {
             res.resize( it );
+        }
         return res;
     }
 }
@@ -121,7 +122,7 @@ public:
         std::string fullPath = info.file;
         StringReplace( fullPath, "\\", "/" );
 
-        fheroes2::Text header( ResizeToShortName( info.file ), fheroes2::FontType::normalYellow() );
+        const fheroes2::Text header( ResizeToShortName( info.file ), fheroes2::FontType::normalYellow() );
 
         fheroes2::MultiFontText body;
 
@@ -225,11 +226,14 @@ MapsFileInfoList GetSortedMapsFileInfoList()
 
     MapsFileInfoList list2( list1.size() );
     int ii = 0;
-    for ( ListFiles::const_iterator itd = list1.begin(); itd != list1.end(); ++itd, ++ii )
-        if ( !list2[ii].ReadSAV( *itd ) )
+    for ( ListFiles::const_iterator itd = list1.begin(); itd != list1.end(); ++itd, ++ii ) {
+        if ( !list2[ii].ReadSAV( *itd ) ) {
             --ii;
-    if ( static_cast<size_t>( ii ) != list2.size() )
+        }
+    }
+    if ( static_cast<size_t>( ii ) != list2.size() ) {
         list2.resize( ii );
+    }
     std::sort( list2.begin(), list2.end(), Maps::FileInfo::FileSorting );
 
     return list2;
@@ -265,7 +269,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
     const fheroes2::Point dialogOffset( ( display.width() - sprite.width() ) / 2, ( display.height() - sprite.height() ) / 2 );
     const fheroes2::Point shadowOffset( dialogOffset.x - BORDERWIDTH, dialogOffset.y );
 
-    fheroes2::ImageRestorer restorer( display, shadowOffset.x, shadowOffset.y, sprite.width() + BORDERWIDTH, sprite.height() + BORDERWIDTH );
+    const fheroes2::ImageRestorer restorer( display, shadowOffset.x, shadowOffset.y, sprite.width() + BORDERWIDTH, sprite.height() + BORDERWIDTH );
     const fheroes2::Rect rt( dialogOffset.x, dialogOffset.y, sprite.width(), sprite.height() );
 
     fheroes2::Blit( spriteShadow, display, rt.x - BORDERWIDTH, rt.y + BORDERWIDTH );
@@ -274,6 +278,8 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
 
     fheroes2::Button buttonOk( rt.x + 34, rt.y + 315, ICN::BUTTON_SMALL_OKAY_GOOD, 0, 1 );
     fheroes2::Button buttonCancel( rt.x + 244, rt.y + 315, ICN::BUTTON_SMALL_CANCEL_GOOD, 0, 1 );
+
+    fheroes2::ButtonSprite openVirtualKB;
 
     MapsFileInfoList lists = GetSortedMapsFileInfoList();
     FileInfoListBox listbox( rt.getPosition() );
@@ -300,9 +306,11 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
         charInsertPos = filename.size();
 
         MapsFileInfoList::iterator it = lists.begin();
-        for ( ; it != lists.end(); ++it )
-            if ( ( *it ).file == lastfile )
+        for ( ; it != lists.end(); ++it ) {
+            if ( ( *it ).file == lastfile ) {
                 break;
+            }
+        }
 
         if ( it != lists.end() ) {
             listbox.SetCurrent( std::distance( lists.begin(), it ) );
@@ -316,8 +324,9 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
         }
     }
 
-    if ( !isEditing && lists.empty() )
+    if ( !isEditing && lists.empty() ) {
         buttonOk.disable();
+    }
 
     if ( filename.empty() && listbox.isSelected() ) {
         filename = ResizeToShortName( listbox.GetCurrent().file );
@@ -330,6 +339,31 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
     buttonOk.draw();
     buttonCancel.draw();
 
+    // Generate and render the "..." button for Virtual Keyboard dialog.
+    if ( isEditing ) {
+        fheroes2::Sprite released;
+        fheroes2::Sprite pressed;
+        fheroes2::Point releasedOffset;
+        fheroes2::Point pressedOffset;
+        const int32_t buttonWidth = 15;
+
+        fheroes2::getCustomNormalButton( released, pressed, false, buttonWidth, releasedOffset, pressedOffset );
+
+        const fheroes2::FontColor fontColor = fheroes2::FontColor::WHITE;
+
+        const fheroes2::Text releasedText( "...", { fheroes2::FontSize::BUTTON_RELEASED, fontColor } );
+        const fheroes2::Text pressedText( "...", { fheroes2::FontSize::BUTTON_PRESSED, fontColor } );
+
+        const fheroes2::Point textOffset{ ( buttonWidth - releasedText.width() ) / 2, ( 16 - fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) ) / 2 };
+
+        releasedText.draw( releasedOffset.x + textOffset.x, releasedOffset.y + textOffset.y, released );
+        pressedText.draw( pressedOffset.x + textOffset.x, pressedOffset.y + textOffset.y, pressed );
+
+        openVirtualKB = makeButtonWithShadow( rt.x + 315, rt.y + 283, released, pressed, display, { -4, 4 } );
+
+        openVirtualKB.draw();
+    }
+
     display.render();
 
     std::string result;
@@ -341,6 +375,9 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
     while ( le.HandleEvents() && result.empty() ) {
         le.MousePressLeft( buttonOk.area() ) && buttonOk.isEnabled() ? buttonOk.drawOnPress() : buttonOk.drawOnRelease();
         le.MousePressLeft( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
+        if ( isEditing ) {
+            le.MousePressLeft( openVirtualKB.area() ) ? openVirtualKB.drawOnPress() : openVirtualKB.drawOnRelease();
+        }
 
         listbox.QueueEventProcessing();
 
@@ -349,39 +386,44 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
 
         if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY )
              || listbox.isDoubleClicked() ) {
-            if ( !filename.empty() )
+            if ( !filename.empty() ) {
                 result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
-            else if ( isListboxSelected )
+            }
+            else if ( isListboxSelected ) {
                 result = listbox.GetCurrent().file;
+            }
         }
         else if ( le.MouseClickLeft( buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
             break;
         }
-        else if ( le.MouseClickLeft( enter_field ) && isEditing ) {
-            if ( isInGameKeyboardRequired ) {
+        else if ( isEditing ) {
+            if ( le.MouseClickLeft( openVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( enter_field ) ) ) {
                 fheroes2::openVirtualKeyboard( filename );
                 charInsertPos = filename.size();
                 listbox.Unselect();
                 isListboxSelected = false;
             }
-            else {
+            else if ( le.MouseClickLeft( enter_field ) ) {
                 charInsertPos = GetInsertPosition( filename, le.GetMouseCursor().x, enter_field.x );
-                if ( filename.empty() )
+                if ( filename.empty() ) {
                     buttonOk.disable();
+                }
+
+                needRedraw = true;
             }
+            else if ( le.KeyPress() && ( !is_limit || fheroes2::Key::KEY_BACKSPACE == le.KeyValue() || fheroes2::Key::KEY_DELETE == le.KeyValue() ) ) {
+                charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
+                if ( filename.empty() ) {
+                    buttonOk.disable();
+                }
+                else {
+                    buttonOk.enable();
+                }
 
-            needRedraw = true;
-        }
-        else if ( isEditing && le.KeyPress() && ( !is_limit || fheroes2::Key::KEY_BACKSPACE == le.KeyValue() || fheroes2::Key::KEY_DELETE == le.KeyValue() ) ) {
-            charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
-            if ( filename.empty() )
-                buttonOk.disable();
-            else
-                buttonOk.enable();
-
-            needRedraw = true;
-            listbox.Unselect();
-            isListboxSelected = false;
+                needRedraw = true;
+                listbox.Unselect();
+                isListboxSelected = false;
+            }
         }
 
         if ( le.MousePressRight( buttonCancel.area() ) ) {
@@ -395,6 +437,9 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
                 Dialog::Message( _( "Okay" ), _( "Click to load a previously saved game." ), Font::BIG );
             }
         }
+        else if ( isEditing && le.MousePressRight( openVirtualKB.area() ) ) {
+            Dialog::Message( _( "Open Virtual Keyboard" ), _( "Click to open the Virtual Keyboard dialog." ), Font::BIG );
+        }
 
         if ( !isEditing && le.KeyPress( fheroes2::Key::KEY_DELETE ) && isListboxSelected ) {
             std::string msg( _( "Are you sure you want to delete file:" ) );
@@ -403,8 +448,9 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
             if ( Dialog::YES == Dialog::Message( _( "Warning!" ), msg, Font::BIG, Dialog::YES | Dialog::NO ) ) {
                 System::Unlink( listbox.GetCurrent().file );
                 listbox.RemoveSelected();
-                if ( lists.empty() || filename.empty() )
+                if ( lists.empty() || filename.empty() ) {
                     buttonOk.disable();
+                }
 
                 const fheroes2::Image updatedScrollbarSlider
                     = fheroes2::generateScrollbarSlider( originalSlider, false, 180, 11, static_cast<int32_t>( lists.size() ), { 0, 0, originalSlider.width(), 8 },
@@ -424,7 +470,7 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
 
         listbox.Redraw();
 
-        std::string selectedFileName = isListboxSelected ? ResizeToShortName( listbox.GetCurrent().file ) : "";
+        const std::string selectedFileName = isListboxSelected ? ResizeToShortName( listbox.GetCurrent().file ) : "";
         if ( isListboxSelected && lastSelectedSaveFileName != selectedFileName ) {
             lastSelectedSaveFileName = selectedFileName;
             filename = selectedFileName;
@@ -441,6 +487,11 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
 
         buttonOk.draw();
         buttonCancel.draw();
+
+        if ( isEditing ) {
+            openVirtualKB.draw();
+        }
+
         display.render();
     }
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -343,21 +343,8 @@ std::string SelectFileListSimple( const std::string & header, const std::string 
     if ( isEditing ) {
         fheroes2::Sprite released;
         fheroes2::Sprite pressed;
-        fheroes2::Point releasedOffset;
-        fheroes2::Point pressedOffset;
-        const int32_t buttonWidth = 15;
 
-        fheroes2::getCustomNormalButton( released, pressed, false, buttonWidth, releasedOffset, pressedOffset );
-
-        const fheroes2::FontColor fontColor = fheroes2::FontColor::WHITE;
-
-        const fheroes2::Text releasedText( "...", { fheroes2::FontSize::BUTTON_RELEASED, fontColor } );
-        const fheroes2::Text pressedText( "...", { fheroes2::FontSize::BUTTON_PRESSED, fontColor } );
-
-        const fheroes2::Point textOffset{ ( buttonWidth - releasedText.width() ) / 2, ( 16 - fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) ) / 2 };
-
-        releasedText.draw( releasedOffset.x + textOffset.x, releasedOffset.y + textOffset.y, released );
-        pressedText.draw( pressedOffset.x + textOffset.x, pressedOffset.y + textOffset.y, pressed );
+        makeButtonSprites( released, pressed, "...", 15, false );
 
         openVirtualKB = makeButtonWithShadow( rt.x + 315, rt.y + 283, released, pressed, display, { -4, 4 } );
 

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -525,7 +525,8 @@ namespace fheroes2
         return { offsetX + shadow.x(), offsetY + shadow.y(), releasedWithBackground, pressedWithBackground, disabledWithBackground };
     }
 
-    void getCustomNormalButton( Sprite & released, Sprite & pressed, const bool isEvilInterface, int32_t width, Point & releasedOffset, Point & pressedOffset )
+    void getCustomNormalButton( Sprite & released, Sprite & pressed, const bool isEvilInterface, int32_t width, Point & releasedOffset, Point & pressedOffset,
+                                const bool isTransparentBackground /* = false */ )
     {
         assert( width > 0 );
 
@@ -543,29 +544,36 @@ namespace fheroes2
         const Sprite & originalReleased = AGG::GetICN( icnId, 0 );
         const Sprite & originalPressed = AGG::GetICN( icnId, 1 );
 
-        const int32_t backgroundIcnId = isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK;
-        const Sprite & background = AGG::GetICN( backgroundIcnId, 0 );
+        if ( isTransparentBackground ) {
+            released = resizeButton( originalReleased, width );
+            pressed = resizeButton( originalPressed, width );
+        }
+        else {
+            const int32_t backgroundIcnId = isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK;
+            const Sprite & background = AGG::GetICN( backgroundIcnId, 0 );
 
-        Image temp = resizeButton( originalReleased, width );
-        released.resize( temp.width(), temp.height() );
-        assert( background.width() >= temp.width() && background.height() >= temp.height() );
-        Copy( background, ( background.width() - temp.width() ) / 2, ( background.height() - temp.height() ) / 2, released, 0, 0, temp.width(), temp.height() );
-        Blit( temp, released );
-        released.setPosition( originalReleased.x(), originalReleased.y() );
+            Image temp = resizeButton( originalReleased, width );
+            released.resize( temp.width(), temp.height() );
+            assert( background.width() >= temp.width() && background.height() >= temp.height() );
+            Copy( background, ( background.width() - temp.width() ) / 2, ( background.height() - temp.height() ) / 2, released, 0, 0, temp.width(), temp.height() );
+            Blit( temp, released );
+            released.setPosition( originalReleased.x(), originalReleased.y() );
 
-        temp = resizeButton( originalPressed, width );
-        pressed.resize( temp.width(), temp.height() );
-        assert( background.width() >= temp.width() && background.height() >= temp.height() );
-        Copy( background, ( background.width() - temp.width() ) / 2, ( background.height() - temp.height() ) / 2, pressed, 0, 0, temp.width(), temp.height() );
-        Blit( temp, pressed );
-        pressed.setPosition( originalPressed.x(), originalPressed.y() );
+            temp = resizeButton( originalPressed, width );
+            pressed.resize( temp.width(), temp.height() );
+            assert( background.width() >= temp.width() && background.height() >= temp.height() );
+            Copy( background, ( background.width() - temp.width() ) / 2, ( background.height() - temp.height() ) / 2, pressed, 0, 0, temp.width(), temp.height() );
+            Blit( temp, pressed );
+            pressed.setPosition( originalPressed.x(), originalPressed.y() );
+        }
     }
 
-    void makeButtonSprites( Sprite & released, Sprite & pressed, const std::string & text, const int32_t buttonWidth, const bool isEvilInterface )
+    void makeButtonSprites( Sprite & released, Sprite & pressed, const std::string & text, const int32_t buttonWidth, const bool isEvilInterface,
+                            const bool isTransparentBackground )
     {
         fheroes2::Point releasedOffset;
         fheroes2::Point pressedOffset;
-        fheroes2::getCustomNormalButton( released, pressed, isEvilInterface, buttonWidth, releasedOffset, pressedOffset );
+        fheroes2::getCustomNormalButton( released, pressed, isEvilInterface, buttonWidth, releasedOffset, pressedOffset, isTransparentBackground );
 
         const fheroes2::FontColor fontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
 

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -31,6 +31,8 @@
 #include "localevent.h"
 #include "pal.h"
 #include "settings.h"
+#include "tools.h"
+#include "ui_text.h"
 
 namespace
 {
@@ -557,5 +559,22 @@ namespace fheroes2
         Copy( background, ( background.width() - temp.width() ) / 2, ( background.height() - temp.height() ) / 2, pressed, 0, 0, temp.width(), temp.height() );
         Blit( temp, pressed );
         pressed.setPosition( originalPressed.x(), originalPressed.y() );
+    }
+
+    void makeButtonSprites( Sprite & released, Sprite & pressed, const std::string & text, const int32_t buttonWidth, const bool isEvilInterface )
+    {
+        fheroes2::Point releasedOffset;
+        fheroes2::Point pressedOffset;
+        fheroes2::getCustomNormalButton( released, pressed, isEvilInterface, buttonWidth, releasedOffset, pressedOffset );
+
+        const fheroes2::FontColor fontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
+
+        const fheroes2::Text releasedText( StringUpper( text ), { fheroes2::FontSize::BUTTON_RELEASED, fontColor } );
+        const fheroes2::Text pressedText( StringUpper( text ), { fheroes2::FontSize::BUTTON_PRESSED, fontColor } );
+
+        const fheroes2::Point textOffset{ ( buttonWidth - releasedText.width() ) / 2, ( 16 - fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) ) / 2 };
+
+        releasedText.draw( releasedOffset.x + textOffset.x, releasedOffset.y + textOffset.y, released );
+        pressedText.draw( pressedOffset.x + textOffset.x, pressedOffset.y + textOffset.y, pressed );
     }
 }

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <string>
 #include <utility>
 
 #include "agg_image.h"

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <string>
 #include <utility>
 
 #include "agg_image.h"

--- a/src/fheroes2/gui/ui_button.h
+++ b/src/fheroes2/gui/ui_button.h
@@ -23,6 +23,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <string>
 #include <vector>
 
 #include "image.h"

--- a/src/fheroes2/gui/ui_button.h
+++ b/src/fheroes2/gui/ui_button.h
@@ -238,4 +238,8 @@ namespace fheroes2
 
     // The height of text area is only 16 pixels.
     void getCustomNormalButton( Sprite & released, Sprite & pressed, const bool isEvilInterface, int32_t width, Point & releasedOffset, Point & pressedOffset );
+
+    // Generate released and pressed button sprites with the text.
+    void makeButtonSprites( Sprite & released, Sprite & pressed, const std::string & text, const int32_t buttonWidth, const bool isEvilInterface );
+
 }

--- a/src/fheroes2/gui/ui_button.h
+++ b/src/fheroes2/gui/ui_button.h
@@ -241,5 +241,4 @@ namespace fheroes2
 
     // Generate released and pressed button sprites with the text.
     void makeButtonSprites( Sprite & released, Sprite & pressed, const std::string & text, const int32_t buttonWidth, const bool isEvilInterface );
-
 }

--- a/src/fheroes2/gui/ui_button.h
+++ b/src/fheroes2/gui/ui_button.h
@@ -23,7 +23,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <memory>
-#include <string>
 #include <vector>
 
 #include "image.h"
@@ -238,8 +237,10 @@ namespace fheroes2
                                        const Point & shadowOffset = Point( -4, 6 ) );
 
     // The height of text area is only 16 pixels.
-    void getCustomNormalButton( Sprite & released, Sprite & pressed, const bool isEvilInterface, int32_t width, Point & releasedOffset, Point & pressedOffset );
+    void getCustomNormalButton( Sprite & released, Sprite & pressed, const bool isEvilInterface, int32_t width, Point & releasedOffset, Point & pressedOffset,
+                                const bool isTransparentBackground = false );
 
     // Generate released and pressed button sprites with the text.
-    void makeButtonSprites( Sprite & released, Sprite & pressed, const std::string & text, const int32_t buttonWidth, const bool isEvilInterface );
+    void makeButtonSprites( Sprite & released, Sprite & pressed, const std::string & text, const int32_t buttonWidth, const bool isEvilInterface,
+                            const bool isTransparentBackground );
 }

--- a/src/fheroes2/gui/ui_button.h
+++ b/src/fheroes2/gui/ui_button.h
@@ -237,11 +237,12 @@ namespace fheroes2
     ButtonSprite makeButtonWithShadow( int32_t offsetX, int32_t offsetY, const Sprite & released, const Sprite & pressed, const Image & background,
                                        const Point & shadowOffset = Point( -4, 6 ) );
 
-    // The height of text area is only 16 pixels.
+    // The height of text area is only 16 pixels. If 'isTransparentBackground' is set to false the button sprite will have a default background pattern from
+    // STONEBAK or STONEBAK_EVIL (for Evil interface). The pattern is the same for all buttons.
     void getCustomNormalButton( Sprite & released, Sprite & pressed, const bool isEvilInterface, int32_t width, Point & releasedOffset, Point & pressedOffset,
                                 const bool isTransparentBackground = false );
 
-    // Generate released and pressed button sprites with the text.
+    // Generate released and pressed button sprites with the text on it over a transparent or a default (STONEBAK/STONEBAK_EVIL) background.
     void makeButtonSprites( Sprite & released, Sprite & pressed, const std::string & text, const int32_t buttonWidth, const bool isEvilInterface,
                             const bool isTransparentBackground );
 }

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -156,19 +156,8 @@ namespace
     {
         fheroes2::Sprite released;
         fheroes2::Sprite pressed;
-        fheroes2::Point releasedOffset;
-        fheroes2::Point pressedOffset;
-        fheroes2::getCustomNormalButton( released, pressed, isEvilInterface, buttonWidth, releasedOffset, pressedOffset );
 
-        const fheroes2::FontColor fontColor = isEvilInterface ? fheroes2::FontColor::GRAY : fheroes2::FontColor::WHITE;
-
-        const fheroes2::Text releasedText( StringUpper( info ), { fheroes2::FontSize::BUTTON_RELEASED, fontColor } );
-        const fheroes2::Text pressedText( StringUpper( info ), { fheroes2::FontSize::BUTTON_PRESSED, fontColor } );
-
-        const fheroes2::Point textOffset{ ( buttonWidth - releasedText.width() ) / 2, ( 16 - fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) ) / 2 };
-
-        releasedText.draw( releasedOffset.x + textOffset.x, releasedOffset.y + textOffset.y, released );
-        pressedText.draw( pressedOffset.x + textOffset.x, pressedOffset.y + textOffset.y, pressed );
+        makeButtonSprites( released, pressed, info, buttonWidth, isEvilInterface );
 
         return { 0, 0, released, pressed };
     }

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -157,7 +157,7 @@ namespace
         fheroes2::Sprite released;
         fheroes2::Sprite pressed;
 
-        makeButtonSprites( released, pressed, info, buttonWidth, isEvilInterface );
+        makeButtonSprites( released, pressed, info, buttonWidth, isEvilInterface, false );
 
         return { 0, 0, released, pressed };
     }


### PR DESCRIPTION
This PR adds the button "..." to dialogs with editable fields:
- Save Game dialog;
- Player Name.

This button will allow to open the Virtual keyboard on any system.

![image](https://user-images.githubusercontent.com/113276641/229888715-0d036372-a088-4eb2-9c9a-9b0895118d0a.png)

![изображение](https://user-images.githubusercontent.com/113276641/230104742-57ab9966-1f9b-4b57-9d24-ae3ece1e2c37.png)

This PR also fixes high CPU usage in name input dialog.
