### PR TITLE
Improve the destination indication for Teleport spell

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1145,7 +1145,7 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     , _flyingUnit( nullptr )
     , b_current_sprite( nullptr )
     , index_pos( -1 )
-    , teleport_src( -1 )
+    , _teleportSpellSrcIdx( -1 )
     , listlog( nullptr )
     , _cursorRestorer( true, Cursor::WAR_POINTER )
     , _bridgeAnimation( { false, BridgeMovementAnimation::UP_POSITION } )
@@ -1922,8 +1922,8 @@ void Battle::Interface::RedrawCover()
                     highlightedCells.emplace( cell );
                     break;
                 case Cursor::SP_TELEPORT:
-                    if ( Board::isValidIndex( teleport_src ) ) {
-                        const Unit * unitToTeleport = arena.GetTroopBoard( teleport_src );
+                    if ( Board::isValidIndex( _teleportSpellSrcIdx ) ) {
+                        const Unit * unitToTeleport = arena.GetTroopBoard( _teleportSpellSrcIdx );
                         assert( unitToTeleport != nullptr );
 
                         const Position pos = Position::GetPosition( *unitToTeleport, index_pos );
@@ -2565,8 +2565,8 @@ int Battle::Interface::GetBattleSpellCursor( std::string & statusMsg ) const
         }
 
         // Check the Teleport spell first
-        if ( Board::isValidIndex( teleport_src ) ) {
-            const Unit * unitToTeleport = arena.GetTroopBoard( teleport_src );
+        if ( Board::isValidIndex( _teleportSpellSrcIdx ) ) {
+            const Unit * unitToTeleport = arena.GetTroopBoard( _teleportSpellSrcIdx );
             assert( unitToTeleport != nullptr );
 
             if ( unitOnCell == nullptr && cell->isPassableForUnit( *unitToTeleport ) ) {
@@ -2925,7 +2925,7 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /*b*/, Actions & a, std
     // reset cast
     if ( le.MousePressRight() || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
         humanturn_spell = Spell::NONE;
-        teleport_src = -1;
+        _teleportSpellSrcIdx = -1;
     }
     else if ( le.MouseCursor( _interfacePosition ) && humanturn_spell.isValid() ) {
         const int themes = GetBattleSpellCursor( msg );
@@ -2952,13 +2952,13 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /*b*/, Actions & a, std
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, humanturn_spell.GetName() << ", dst: " << index_pos )
 
             if ( Cursor::SP_TELEPORT == cursor.Themes() ) {
-                if ( 0 > teleport_src )
-                    teleport_src = index_pos;
+                if ( 0 > _teleportSpellSrcIdx )
+                    _teleportSpellSrcIdx = index_pos;
                 else {
-                    a.emplace_back( CommandType::MSG_BATTLE_CAST, Spell::TELEPORT, teleport_src, index_pos );
+                    a.emplace_back( CommandType::MSG_BATTLE_CAST, Spell::TELEPORT, _teleportSpellSrcIdx, index_pos );
                     humanturn_spell = Spell::NONE;
                     humanturn_exit = true;
-                    teleport_src = -1;
+                    _teleportSpellSrcIdx = -1;
                 }
             }
             else if ( Cursor::SP_MIRRORIMAGE == cursor.Themes() ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1875,12 +1875,11 @@ void Battle::Interface::RedrawCover()
         fheroes2::Blit( bridgeImage, _mainSurface, bridgeImage.x(), bridgeImage.y() );
     }
 
-    // cursor
     const Cell * cell = Board::GetCell( index_pos );
     const int cursorType = Cursor::Get().Themes();
 
     if ( cell && _currentUnit && conf.BattleShowMouseShadow() ) {
-        std::set<const Cell *> highlightCells;
+        std::set<const Cell *> highlightedCells;
 
         if ( humanturn_spell.isValid() ) {
             switch ( humanturn_spell.GetID() ) {
@@ -1889,37 +1888,37 @@ void Battle::Interface::RedrawCover()
                 for ( size_t i = 0; i < around.size(); ++i ) {
                     const Cell * nearbyCell = Board::GetCell( around[i] );
                     if ( nearbyCell != nullptr ) {
-                        highlightCells.emplace( nearbyCell );
+                        highlightedCells.emplace( nearbyCell );
                     }
                 }
                 break;
             }
             case Spell::FIREBALL:
             case Spell::METEORSHOWER: {
-                highlightCells.emplace( cell );
+                highlightedCells.emplace( cell );
                 const Indexes around = Board::GetAroundIndexes( index_pos );
                 for ( size_t i = 0; i < around.size(); ++i ) {
                     const Cell * nearbyCell = Board::GetCell( around[i] );
                     if ( nearbyCell != nullptr ) {
-                        highlightCells.emplace( nearbyCell );
+                        highlightedCells.emplace( nearbyCell );
                     }
                 }
                 break;
             }
             case Spell::FIREBLAST: {
-                highlightCells.emplace( cell );
+                highlightedCells.emplace( cell );
                 const Indexes around = Board::GetDistanceIndexes( index_pos, 2 );
                 for ( size_t i = 0; i < around.size(); ++i ) {
                     const Cell * nearbyCell = Board::GetCell( around[i] );
                     if ( nearbyCell != nullptr ) {
-                        highlightCells.emplace( nearbyCell );
+                        highlightedCells.emplace( nearbyCell );
                     }
                 }
                 break;
             }
             case Spell::TELEPORT: {
                 if ( cursorType == Cursor::WAR_NONE ) {
-                    highlightCells.emplace( cell );
+                    highlightedCells.emplace( cell );
                 }
                 else if ( cursorType == Cursor::SP_TELEPORT ) {
                     if ( Board::isValidIndex( teleport_src ) ) {
@@ -1929,16 +1928,16 @@ void Battle::Interface::RedrawCover()
                         const Position pos = Position::GetPosition( *unitToTeleport, index_pos );
                         assert( pos.GetHead() != nullptr );
 
-                        highlightCells.emplace( pos.GetHead() );
+                        highlightedCells.emplace( pos.GetHead() );
 
                         if ( unitToTeleport->isWide() ) {
                             assert( pos.GetTail() != nullptr );
 
-                            highlightCells.emplace( pos.GetTail() );
+                            highlightedCells.emplace( pos.GetTail() );
                         }
                     }
                     else {
-                        highlightCells.emplace( cell );
+                        highlightedCells.emplace( cell );
                     }
                 }
                 else {
@@ -1947,17 +1946,17 @@ void Battle::Interface::RedrawCover()
                 break;
             }
             default:
-                highlightCells.emplace( cell );
+                highlightedCells.emplace( cell );
             }
         }
         else if ( _currentUnit->isAbilityPresent( fheroes2::MonsterAbilityType::AREA_SHOT )
                   && ( cursorType == Cursor::WAR_ARROW || cursorType == Cursor::WAR_BROKENARROW ) ) {
-            highlightCells.emplace( cell );
+            highlightedCells.emplace( cell );
             const Indexes around = Board::GetAroundIndexes( index_pos );
             for ( size_t i = 0; i < around.size(); ++i ) {
                 const Cell * nearbyCell = Board::GetCell( around[i] );
                 if ( nearbyCell != nullptr ) {
-                    highlightCells.emplace( nearbyCell );
+                    highlightedCells.emplace( nearbyCell );
                 }
             }
         }
@@ -1967,12 +1966,12 @@ void Battle::Interface::RedrawCover()
             assert( pos.GetHead() != nullptr );
             assert( pos.GetTail() != nullptr );
 
-            highlightCells.emplace( pos.GetHead() );
-            highlightCells.emplace( pos.GetTail() );
+            highlightedCells.emplace( pos.GetHead() );
+            highlightedCells.emplace( pos.GetTail() );
         }
         else if ( cursorType == Cursor::SWORD_TOPLEFT || cursorType == Cursor::SWORD_TOPRIGHT || cursorType == Cursor::SWORD_BOTTOMLEFT
                   || cursorType == Cursor::SWORD_BOTTOMRIGHT || cursorType == Cursor::SWORD_LEFT || cursorType == Cursor::SWORD_RIGHT ) {
-            highlightCells.emplace( cell );
+            highlightedCells.emplace( cell );
 
             int direction = 0;
             if ( cursorType == Cursor::SWORD_TOPLEFT ) {
@@ -2000,19 +1999,19 @@ void Battle::Interface::RedrawCover()
             const Position pos = Position::GetReachable( *_currentUnit, Board::GetIndexDirection( index_pos, direction ) );
             assert( pos.GetHead() != nullptr );
 
-            highlightCells.emplace( pos.GetHead() );
+            highlightedCells.emplace( pos.GetHead() );
 
             if ( _currentUnit->isWide() ) {
                 assert( pos.GetTail() != nullptr );
 
-                highlightCells.emplace( pos.GetTail() );
+                highlightedCells.emplace( pos.GetTail() );
             }
 
             if ( _currentUnit->isDoubleCellAttack() ) {
                 const Cell * secondAttackedCell = Board::GetCell( index_pos, Board::GetReflectDirection( direction ) );
 
                 if ( secondAttackedCell ) {
-                    highlightCells.emplace( secondAttackedCell );
+                    highlightedCells.emplace( secondAttackedCell );
                 }
             }
             else if ( _currentUnit->isAllAdjacentCellsAttack() ) {
@@ -2028,32 +2027,32 @@ void Battle::Interface::RedrawCover()
                     const Unit * nearbyUnit = nearbyCell->GetUnit();
 
                     if ( nearbyUnit && nearbyUnit->GetColor() != _currentUnit->GetCurrentColor() ) {
-                        highlightCells.emplace( nearbyCell );
+                        highlightedCells.emplace( nearbyCell );
                     }
                 }
             }
         }
         else {
-            highlightCells.emplace( cell );
+            highlightedCells.emplace( cell );
         }
 
-        assert( !highlightCells.empty() );
+        assert( !highlightedCells.empty() );
 
         const HeroBase * currentCommander = arena.GetCurrentCommander();
-        const int spellPower = ( currentCommander == nullptr ) ? 0 : currentCommander->GetPower();
 
-        for ( const Cell * highlightCell : highlightCells ) {
-            bool isApplicable = highlightCell->isPassable( false );
+        for ( const Cell * highlightedCell : highlightedCells ) {
+            assert( highlightedCell != nullptr );
+
+            bool isApplicable = highlightedCell->isPassable( false );
 
             if ( isApplicable ) {
-                const Unit * highlightedUnit = highlightCell->GetUnit();
+                const Unit * highlightedUnit = highlightedCell->GetUnit();
 
-                isApplicable
-                    = highlightedUnit == nullptr || !humanturn_spell.isValid() || !highlightedUnit->isMagicResist( humanturn_spell, spellPower, currentCommander );
+                isApplicable = highlightedUnit == nullptr || !humanturn_spell.isValid() || highlightedUnit->AllowApplySpell( humanturn_spell, currentCommander );
             }
 
             if ( isApplicable ) {
-                fheroes2::Blit( _hexagonCursorShadow, _mainSurface, highlightCell->GetPos().x, highlightCell->GetPos().y );
+                fheroes2::Blit( _hexagonCursorShadow, _mainSurface, highlightedCell->GetPos().x, highlightedCell->GetPos().y );
             }
         }
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2550,18 +2550,7 @@ int Battle::Interface::GetBattleSpellCursor( std::string & statusMsg ) const
         // Cursor is over some dead unit that we can resurrect
         if ( unitOnCell == nullptr && arena.GraveyardAllowResurrect( index_pos, spell ) ) {
             unitOnCell = arena.GraveyardLastTroop( index_pos );
-            assert( unitOnCell != nullptr );
-
-            if ( unitOnCell->isWide() ) {
-                const Cell * headCell = Board::GetCell( unitOnCell->GetHeadIndex() );
-                const Cell * tailCell = Board::GetCell( unitOnCell->GetTailIndex() );
-                assert( headCell != nullptr && tailCell != nullptr );
-
-                // This dead unit is partially covered by an alive unit
-                if ( headCell->GetUnit() || tailCell->GetUnit() ) {
-                    unitOnCell = nullptr;
-                }
-            }
+            assert( unitOnCell != nullptr && !unitOnCell->isValid() );
         }
 
         // Check the Teleport spell first

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1917,10 +1917,11 @@ void Battle::Interface::RedrawCover()
                 break;
             }
             case Spell::TELEPORT: {
-                if ( cursorType == Cursor::WAR_NONE ) {
+                switch ( cursorType ) {
+                case Cursor::WAR_NONE:
                     highlightedCells.emplace( cell );
-                }
-                else if ( cursorType == Cursor::SP_TELEPORT ) {
+                    break;
+                case Cursor::SP_TELEPORT:
                     if ( Board::isValidIndex( teleport_src ) ) {
                         const Unit * unitToTeleport = arena.GetTroopBoard( teleport_src );
                         assert( unitToTeleport != nullptr );
@@ -1939,14 +1940,17 @@ void Battle::Interface::RedrawCover()
                     else {
                         highlightedCells.emplace( cell );
                     }
-                }
-                else {
+                    break;
+                default:
+                    // This should never happen
                     assert( 0 );
+                    break;
                 }
                 break;
             }
             default:
                 highlightedCells.emplace( cell );
+                break;
             }
         }
         else if ( _currentUnit->isAbilityPresent( fheroes2::MonsterAbilityType::AREA_SHOT )

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2565,7 +2565,7 @@ int Battle::Interface::GetBattleSpellCursor( std::string & statusMsg ) const
             const Unit * unitToTeleport = arena.GetTroopBoard( teleport_src );
             assert( unitToTeleport != nullptr );
 
-            if ( !unitOnCell && cell->isPassableForUnit( *unitToTeleport ) ) {
+            if ( unitOnCell == nullptr && cell->isPassableForUnit( *unitToTeleport ) ) {
                 statusMsg = _( "Teleport here" );
 
                 return Cursor::SP_TELEPORT;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -438,7 +438,8 @@ namespace Battle
         fheroes2::Point _flyingPos;
 
         int32_t index_pos;
-        int32_t teleport_src;
+        // Index of the cell selected as the source for the Teleport spell
+        int32_t _teleportSpellSrcIdx;
         fheroes2::Rect main_tower;
 
         std::unique_ptr<StatusListBox> listlog;

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -776,12 +776,15 @@ bool Battle::Unit::AllowApplySpell( const Spell & spell, const HeroBase * hero, 
         return false;
     }
 
-    if ( hero && spell.isApplyToFriends() && GetColor() != hero->GetColor() )
+    if ( hero && spell.isApplyToFriends() && GetColor() != hero->GetColor() ) {
         return false;
-    if ( hero && spell.isApplyToEnemies() && GetColor() == hero->GetColor() && !forceApplyToAlly )
+    }
+    if ( hero && spell.isApplyToEnemies() && GetColor() == hero->GetColor() && !forceApplyToAlly ) {
         return false;
-    if ( isMagicResist( spell, ( hero ? hero->GetPower() : 0 ), hero ) )
+    }
+    if ( GetMagicResist( spell, ( hero ? hero->GetPower() : 0 ), hero ) >= 100 ) {
         return false;
+    }
 
     const HeroBase * myhero = GetCommander();
     if ( !myhero )

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -271,11 +271,6 @@ namespace Battle
         AnimationState animation;
 
     private:
-        bool isMagicResist( const Spell & spell, const uint32_t attackingArmySpellPower, const HeroBase * attackingHero ) const
-        {
-            return 100 <= GetMagicResist( spell, attackingArmySpellPower, attackingHero );
-        }
-
         // Add a temporary affection (usually a spell effect) with the specified duration. Only one affection can be added.
         void addAffection( const uint32_t mode, const uint32_t duration );
 

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -117,11 +117,6 @@ namespace Battle
 
         bool isHaveDamage() const;
 
-        bool isMagicResist( const Spell & spell, const uint32_t attackingArmySpellPower, const HeroBase * attackingHero ) const
-        {
-            return 100 <= GetMagicResist( spell, attackingArmySpellPower, attackingHero );
-        }
-
         bool OutOfWalls() const;
         bool canReach( int index ) const;
         bool canReach( const Unit & unit ) const;
@@ -276,6 +271,11 @@ namespace Battle
         AnimationState animation;
 
     private:
+        bool isMagicResist( const Spell & spell, const uint32_t attackingArmySpellPower, const HeroBase * attackingHero ) const
+        {
+            return 100 <= GetMagicResist( spell, attackingArmySpellPower, attackingHero );
+        }
+
         // Add a temporary affection (usually a spell effect) with the specified duration. Only one affection can be added.
         void addAffection( const uint32_t mode, const uint32_t duration );
 


### PR DESCRIPTION
close #6941

Also, this PR fixes the issue when cells are highlighted, even if the current spell does not apply to units on these cells. Currently on the `master` branch:

https://user-images.githubusercontent.com/32623900/229931766-7bfca010-d673-42ae-8d60-fa9bcf6f06e4.mp4

With this PR:

https://user-images.githubusercontent.com/32623900/229931819-4463921c-0218-46c8-96b6-364beba7429d.mp4

This change may be controversial, but I believe that since we do not highlight the cells with dragons in this video, we should not also highlight the cells with other units on which this spell does not work. Empty cells will continue to be highlighted as before.