### PR TITLE
Do not allow to access overprotected tiles using the Dimension Door spell

### DIFF
--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -1010,8 +1010,7 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
         return {};
     }
 
-    const MapsIndexes & monsters = Maps::getMonstersProtectingTile( targetIndex );
-    for ( const int32_t monsterIndex : monsters ) {
+    for ( const int32_t monsterIndex : Maps::getMonstersProtectingTile( targetIndex ) ) {
         // Target tile is guarded by an overly strong nearby monster
         if ( isTileProtectedForAI( monsterIndex, _armyStrength, _advantage ) ) {
             return {};

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -1005,14 +1005,16 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
             return {};
     }
 
-    // The object requires to stand on it. In this case we need to check if it is protected by monsters.
-    if ( !MP2::isNeedStayFront( objectType ) ) {
-        const MapsIndexes & monsters = Maps::getMonstersProtectingTile( targetIndex );
-        for ( const int32_t monsterIndex : monsters ) {
-            if ( isTileProtectedForAI( monsterIndex, _armyStrength, _advantage ) ) {
-                // The tile is protected by monsters. No reason to try to get it.
-                return {};
-            }
+    // Target tile is guarded by an overly strong army
+    if ( isTileProtectedForAI( targetIndex, _armyStrength, _advantage ) ) {
+        return {};
+    }
+
+    const MapsIndexes & monsters = Maps::getMonstersProtectingTile( targetIndex );
+    for ( const int32_t monsterIndex : monsters ) {
+        // Target tile is guarded by an overly strong nearby monster
+        if ( isTileProtectedForAI( monsterIndex, _armyStrength, _advantage ) ) {
+            return {};
         }
     }
 


### PR DESCRIPTION
Related to #6959

Should fix an inability to access some tiles that require to stand in front of them (i.e. overprotected tiles that has too strong army of wandering monsters on them). "Too strong army" is detected using the same rules as `AIWorldPathfinder` uses for the "normal" movement. This change still allows to "steal" pickupable objects from under the nose of guardians:

https://user-images.githubusercontent.com/32623900/230740334-0f082bff-f1e7-4319-b39b-a3227ed05f80.mp4

Hi @ihhub could you please verify this change in regard to #6959? Does it resolve the corresponding issues?