### PR TITLE
Fix the "unused variable" warning on release builds

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -57,7 +57,6 @@ namespace
     {
         // Notice: Value 22050 causes music distortion on Windows.
         int frequency = 44100;
-
         uint16_t format = AUDIO_S16;
         // Stereo audio support
         int channels = 2;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -2502,8 +2502,10 @@ void Maps::Tiles::updateFogDirectionsInArea( const fheroes2::Point & minPos, con
     // Set the 'fogData' index offset from the tile index for the TOP LEFT direction from the tile.
     const int32_t topLeftDirectionOffset = -1 - fogDataWidth;
 
+#ifndef NDEBUG
     // Cache the maximum border for fogDataIndex corresponding the "CENTER" tile to use in assertion. Should be removed if assertion is removed.
     const int32_t centerfogDataIndexLimit = fogDataSize + topLeftDirectionOffset;
+#endif
 
     // Calculate fog directions using the cached 'isFog' data.
     for ( int32_t y = minY; y < maxY; ++y ) {


### PR DESCRIPTION
Fix the warning:

```
/home/runner/work/fheroes2/fheroes2/android/app/jni/main/../../../../src/fheroes2/maps/maps_tiles.cpp:2506:19: warning: unused variable 'centerfogDataIndexLimit' [-Wunused-variable]
     const int32_t centerfogDataIndexLimit = fogDataSize + topLeftDirectionOffset;
                   ^
```

when app was built with the `NDEBUG` macro defined.