### PR TITLE
Do not render hero/boat over the bottom map border. Adventure map.

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -165,6 +165,7 @@ namespace
         const bool isHeroInCastle = ( castle != nullptr && castle->GetCenter() == heroPos );
 
         const uint8_t heroAlphaValue = hero->getAlphaValue();
+        const int32_t worldHeight = world.h();
 
         auto spriteInfo = hero->getHeroSpritesPerTile();
         auto spriteShadowInfo = hero->getHeroShadowSpritesPerTile();
@@ -228,7 +229,12 @@ namespace
             }
 
             if ( imagePos.y > 0 && !isHeroInCastle ) {
-                // The very bottom part of hero (or hero on boat) image should not be rendered before it's fog so we place it in the extra deque.
+                // Hero horse or boat should not be rendered over the bottom map border.
+                if ( ( heroPos.y + imagePos.y ) >= worldHeight ) {
+                    continue;
+                }
+
+                // The very bottom part of hero (or hero on boat) image should not be rendered before it's shadow so we place it in the extra deque.
                 if ( imagePos.x < 0 ) {
                     tileUnfit.heroBackgroundImages[imagePos + heroPos].emplace_front( objectInfo );
                 }
@@ -258,7 +264,7 @@ namespace
             const fheroes2::Point imagePos = objectInfo.tileOffset + heroPos;
 
             // Shadows outside the game area should not be rendered.
-            if ( imagePos.x < 0 || imagePos.y < 0 ) {
+            if ( imagePos.x < 0 || imagePos.y < 0 || imagePos.y >= worldHeight ) {
                 continue;
             }
 


### PR DESCRIPTION
This PR fixes a bug of hero/boat rendering over the bottom map border.

Current master build:
![bug](https://user-images.githubusercontent.com/113276641/231814086-5ca857bf-6fea-464d-9555-9ec45c4bd14b.png)

This PR:
![fheroes2 2023-04-13 18-16-25-761](https://user-images.githubusercontent.com/113276641/231813856-9425e8dc-e499-4ea2-9924-57ec8149d4c6.gif)
