### PR TITLE
Redraw the status window after the amount of kingdom resources has changed at the beginning of the day, fix recurring events

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -857,6 +857,10 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
             }
         } );
 
+        // The amount of the kingdom resources has changed, the status window needs to be updated
+        Redraw( REDRAW_STATUS );
+        display.render();
+
         if ( conf.isAutoSaveAtBeginningOfTurnEnabled() ) {
             Game::AutoSave();
         }

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1578,7 +1578,7 @@ bool EventDate::isAllow( const int col, const uint32_t date ) const
         return false;
     }
 
-    if ( firstOccurrenceDay < date ) {
+    if ( firstOccurrenceDay > date ) {
         // The date has not come.
         return false;
     }


### PR DESCRIPTION
fix #7002