### PR TITLE
Reset battlefield grid cursor position after using the Spell Book

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6109,6 +6109,10 @@ void Battle::Interface::ProcessingHeroDialogResult( int res, Actions & a )
                     };
 
                     const Spell spell = hero->OpenSpellBook( SpellBook::Filter::CMBT, true, true, &statusCallback );
+
+                    // Reset battlefield grid cursor position after closing the spell book.
+                    index_pos = -1;
+
                     if ( spell.isValid() ) {
                         assert( spell.isCombat() );
 


### PR DESCRIPTION
The bug was found by **drevoborod** on Discord.
If your cursor pointer is not _WAR_NONE_ (X) and you call the Spell Book by hotkey ("C") and try to use the **Teleport** spell you will encounter an assertion that checks that the cursor type is not _WAR_NONE_ or _SP_TELEPORT_.
You can just simple point your creature and call the Spell Book:
![cursor](https://user-images.githubusercontent.com/113276641/232277938-87d0960f-dc15-40f3-82f4-68f07a2c00e6.png)

This happens as the cursor position and type were not updated from the state before opening the Spell Book.

This PR resets the battlefield cursor position on battlefield after using the Spell Book.