### PR TITLE
Expand wide screen support

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -166,7 +166,8 @@ namespace
                 assert( resolutions[biggerId].gameWidth > 0 && resolutions[biggerId].gameHeight > 0 );
 
                 if ( resolutions[biggerId].screenWidth != resolutions[biggerId].gameWidth || resolutions[biggerId].screenHeight != resolutions[biggerId].gameHeight ) {
-                    assert( resolutions[biggerId].screenWidth >= resolutions[biggerId].gameWidth && resolutions[biggerId].screenHeight >= resolutions[biggerId].gameHeight );
+                    assert( resolutions[biggerId].screenWidth >= resolutions[biggerId].gameWidth
+                            && resolutions[biggerId].screenHeight >= resolutions[biggerId].gameHeight );
                     // This resolution has scaling. Ignore it.
                     continue;
                 }

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -705,7 +705,7 @@ namespace
             vita2d_texture_set_alloc_memblock_type( SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW );
             _texBuffer = vita2d_create_empty_texture_format( resolutionInfo.width, resolutionInfo.height, SCE_GXM_TEXTURE_FORMAT_P8_ABGR );
             _palettedTexturePointer = static_cast<uint8_t *>( vita2d_texture_get_datap( _texBuffer ) );
-            memset( _palettedTexturePointer, 0, resolutionInfo.width * resolutionInfo.height * sizeof( uint8_t ) );
+            memset( _palettedTexturePointer, 0, resolutionInfo.gameWidth * resolutionInfo.gameHeight * sizeof( uint8_t ) );
             _createPalette();
 
             _calculateScreenScaling( resolutionInfo.width, resolutionInfo.height, isFullScreen );

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -148,8 +148,9 @@ namespace
 
         // Wide screen devices support much higher resolutions but items on such resolutions are too tiny.
         // In order to improve user experience on these devices we are adding a special non-standard resolution.
-        resolutions.emplace_back( resolutions.back().gameWidth * fheroes2::Display::DEFAULT_HEIGHT / resolutions.back().gameHeight, fheroes2::Display::DEFAULT_HEIGHT,
-                                  resolutions.back().gameWidth, resolutions.back().gameHeight );
+        const fheroes2::ResolutionInfo biggestResolution = resolutions.back();
+        resolutions.emplace_back( biggestResolution.gameWidth * fheroes2::Display::DEFAULT_HEIGHT / biggestResolution.gameHeight, fheroes2::Display::DEFAULT_HEIGHT,
+                                  biggestResolution.gameWidth, biggestResolution.gameHeight );
         std::sort( resolutions.begin(), resolutions.end() );
 
         // Add resolutions with scale factor. No need to run through the newly added elements so we remember the size of the array.

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -148,9 +148,9 @@ namespace
 
         // Wide screen devices support much higher resolutions but items on such resolutions are too tiny.
         // In order to improve user experience on these devices we are adding a special non-standard resolution.
-        const fheroes2::ResolutionInfo biggestResolution = resolutions.back();
-        resolutions.emplace_back( biggestResolution.gameWidth * fheroes2::Display::DEFAULT_HEIGHT / biggestResolution.gameHeight, fheroes2::Display::DEFAULT_HEIGHT,
-                                  biggestResolution.gameWidth, biggestResolution.gameHeight );
+        const fheroes2::Size biggestResolution{ resolutions.back().gameWidth, resolutions.back().gameHeight };
+        resolutions.emplace_back( biggestResolution.width * fheroes2::Display::DEFAULT_HEIGHT / biggestResolution.height, fheroes2::Display::DEFAULT_HEIGHT,
+                                  biggestResolution.width, biggestResolution.height );
         std::sort( resolutions.begin(), resolutions.end() );
 
         // Add resolutions with scale factor. No need to run through the newly added elements so we remember the size of the array.

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -122,6 +122,7 @@ namespace
             return { { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } };
         }
 
+        // TODO: add resolutions which are close to the current screen aspect ratio.
         // Some operating systems do not work well with SDL so they return very limited number of high resolutions.
         // Populate missing resolutions into the list.
         const std::set<fheroes2::ResolutionInfo> possibleResolutions

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -689,7 +689,7 @@ namespace
 
             vita2d_init();
 
-            _window = SDL_CreateWindow( "", 0, 0, resolutionInfo.width, resolutionInfo.height, 0 );
+            _window = SDL_CreateWindow( "", 0, 0, resolutionInfo.gameWidth, resolutionInfo.gameHeight, 0 );
             if ( _window == nullptr ) {
                 clear();
                 return false;
@@ -703,12 +703,12 @@ namespace
             }
 
             vita2d_texture_set_alloc_memblock_type( SCE_KERNEL_MEMBLOCK_TYPE_USER_CDRAM_RW );
-            _texBuffer = vita2d_create_empty_texture_format( resolutionInfo.width, resolutionInfo.height, SCE_GXM_TEXTURE_FORMAT_P8_ABGR );
+            _texBuffer = vita2d_create_empty_texture_format( resolutionInfo.gameWidth, resolutionInfo.gameHeight, SCE_GXM_TEXTURE_FORMAT_P8_ABGR );
             _palettedTexturePointer = static_cast<uint8_t *>( vita2d_texture_get_datap( _texBuffer ) );
             memset( _palettedTexturePointer, 0, resolutionInfo.gameWidth * resolutionInfo.gameHeight * sizeof( uint8_t ) );
             _createPalette();
 
-            _calculateScreenScaling( resolutionInfo.width, resolutionInfo.height, isFullScreen );
+            _calculateScreenScaling( resolutionInfo.gameWidth, resolutionInfo.gameHeight, isFullScreen );
 
             return true;
         }

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -629,9 +629,9 @@ namespace
         {
             static const std::vector<fheroes2::ResolutionInfo> filteredResolutions = []() {
                 std::set<fheroes2::ResolutionInfo> resolutionSet;
-                resolutionSet.emplace( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, 1 );
-                resolutionSet.emplace( VITA_ASPECT_CORRECTED_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, 1 );
-                resolutionSet.emplace( VITA_FULLSCREEN_WIDTH, VITA_FULLSCREEN_HEIGHT, 1 );
+                resolutionSet.emplace( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
+                resolutionSet.emplace( VITA_ASPECT_CORRECTED_WIDTH, fheroes2::Display::DEFAULT_HEIGHT );
+                resolutionSet.emplace( VITA_FULLSCREEN_WIDTH, VITA_FULLSCREEN_HEIGHT );
                 resolutionSet = FilterResolutions( resolutionSet );
 
                 return std::vector<fheroes2::ResolutionInfo>{ resolutionSet.rbegin(), resolutionSet.rend() };
@@ -895,7 +895,7 @@ namespace
 #if defined( TARGET_NINTENDO_SWITCH )
                 // Nintendo Switch supports arbitrary resolutions via the HW scaler
                 // 848x480 is the smallest resolution supported by fheroes2
-                resolutionSet.emplace( 848, 480, 1 );
+                resolutionSet.emplace( 848, 480 );
 #endif
                 resolutionSet = FilterResolutions( resolutionSet );
 

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -63,20 +63,31 @@ namespace
             return resolutionInfo;
         }
 
-        if ( resolutionInfo.width < 1 )
-            resolutionInfo.width = 1;
-        if ( resolutionInfo.height < 1 )
-            resolutionInfo.height = 1;
-        if ( resolutionInfo.scale < 1 )
-            resolutionInfo.scale = 1;
+        if ( resolutionInfo.gameWidth < 1 ) {
+            resolutionInfo.gameWidth = 1;
+        }
 
-        const double x = resolutionInfo.width;
-        const double y = resolutionInfo.height;
-        const double scale = resolutionInfo.scale;
+        if ( resolutionInfo.gameHeight < 1 ) {
+            resolutionInfo.gameHeight = 1;
+        }
+
+        if ( resolutionInfo.screenWidth < resolutionInfo.gameWidth ) {
+            resolutionInfo.screenWidth = resolutionInfo.gameWidth;
+        }
+
+        if ( resolutionInfo.screenHeight < resolutionInfo.gameHeight ) {
+            resolutionInfo.screenHeight = resolutionInfo.gameHeight;
+        }
+
+        const double gameX = resolutionInfo.gameWidth;
+        const double gameY = resolutionInfo.gameHeight;
+        const double screenX = resolutionInfo.screenWidth;
+        const double screenY = resolutionInfo.screenHeight;
 
         std::vector<double> similarity( resolutions.size(), 0 );
         for ( size_t i = 0; i < resolutions.size(); ++i ) {
-            similarity[i] = std::fabs( resolutions[i].width - x ) / x + std::fabs( resolutions[i].height - y ) / y + std::fabs( resolutions[i].scale - scale ) / scale;
+            similarity[i] = std::fabs( resolutions[i].gameWidth - gameX ) / gameX + std::fabs( resolutions[i].gameHeight - gameY ) / gameY +
+                            std::fabs( resolutions[i].screenWidth - screenX ) / screenX + std::fabs( resolutions[i].screenHeight - screenY ) / screenY;
         }
 
         const std::vector<double>::difference_type id = std::distance( similarity.begin(), std::min_element( similarity.begin(), similarity.end() ) );
@@ -86,7 +97,7 @@ namespace
 
     bool IsLowerThanDefaultRes( const fheroes2::ResolutionInfo & value )
     {
-        return value.width < fheroes2::Display::DEFAULT_WIDTH || value.height < fheroes2::Display::DEFAULT_HEIGHT;
+        return value.gameWidth < fheroes2::Display::DEFAULT_WIDTH || value.gameHeight < fheroes2::Display::DEFAULT_HEIGHT;
     }
 
     std::set<fheroes2::ResolutionInfo> FilterResolutions( const std::set<fheroes2::ResolutionInfo> & resolutionSet )
@@ -94,7 +105,7 @@ namespace
         static_assert( fheroes2::Display::DEFAULT_WIDTH == 640 && fheroes2::Display::DEFAULT_HEIGHT == 480, "Default resolution must be 640 x 480" );
 
         if ( resolutionSet.empty() ) {
-            return { { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, 1 } };
+            return { { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } };
         }
 
         std::vector<fheroes2::ResolutionInfo> resolutions;
@@ -108,20 +119,20 @@ namespace
         }
 
         if ( resolutions.empty() ) {
-            return { { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, 1 } };
+            return { { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } };
         }
 
         // Some operating systems do not work well with SDL so they return very limited number of high resolutions.
         // Populate missing resolutions into the list.
         const std::set<fheroes2::ResolutionInfo> possibleResolutions
-            = { { 640, 480, 1 },   { 800, 600, 1 },  { 1024, 768, 1 },  { 1152, 864, 1 }, { 1280, 600, 1 }, { 1280, 720, 1 },  { 1280, 768, 1 }, { 1280, 960, 1 },
-                { 1280, 1024, 1 }, { 1360, 768, 1 }, { 1400, 1050, 1 }, { 1440, 900, 1 }, { 1600, 900, 1 }, { 1680, 1050, 1 }, { 1920, 1080, 1 } };
+            = { { 640, 480 },   { 800, 600 },  { 1024, 768 },  { 1152, 864 }, { 1280, 600 }, { 1280, 720 },  { 1280, 768 }, { 1280, 960 },
+                { 1280, 1024 }, { 1360, 768 }, { 1400, 1050 }, { 1440, 900 }, { 1600, 900 }, { 1680, 1050 }, { 1920, 1080 } };
 
         const fheroes2::ResolutionInfo lowestResolution = resolutions.front();
         assert( *std::min_element( resolutions.begin(), resolutions.end() ) == resolutions.front() );
 
         for ( const fheroes2::ResolutionInfo & resolution : possibleResolutions ) {
-            if ( lowestResolution.width < resolution.width || lowestResolution.height < resolution.height || resolution == lowestResolution ) {
+            if ( lowestResolution.gameWidth < resolution.gameWidth || lowestResolution.gameHeight < resolution.gameHeight || resolution == lowestResolution ) {
                 continue;
             }
             resolutions.emplace_back( resolution );
@@ -135,23 +146,28 @@ namespace
 
         std::sort( resolutions.begin(), resolutions.end() );
 
+        // Wide screen devices support much higher resolutions but items on such resolutions are too tiny.
+        // In order to improve user experience on these devices we are adding a special non-standard resolution.
+        resolutions.emplace_back( resolutions.back().gameWidth * fheroes2::Display::DEFAULT_HEIGHT / resolutions.back().gameHeight, fheroes2::Display::DEFAULT_HEIGHT,
+                                  resolutions.back().gameWidth, resolutions.back().gameHeight );
+        std::sort( resolutions.begin(), resolutions.end() );
+
         // Add resolutions with scale factor. No need to run through the newly added elements so we remember the size of the array.
         const size_t resolutionCountBefore = resolutions.size();
 
         // Since all resolutions are sorted then the last resolution (which is the highest) cannot have any scale factor.
         for ( size_t currentId = 0; currentId < resolutionCountBefore - 1; ++currentId ) {
-            assert( resolutions[currentId].width > 0 && resolutions[currentId].height > 0 );
+            assert( resolutions[currentId].gameWidth > 0 && resolutions[currentId].gameHeight > 0 );
 
             for ( size_t biggerId = currentId + 1; biggerId < resolutionCountBefore; ++biggerId ) {
-                assert( resolutions[biggerId].width > 0 && resolutions[biggerId].height > 0 );
+                assert( resolutions[biggerId].gameWidth > 0 && resolutions[biggerId].gameHeight > 0 );
 
-                if ( ( resolutions[biggerId].width % resolutions[currentId].width ) == 0 && ( resolutions[biggerId].height % resolutions[currentId].height ) == 0
-                     && ( resolutions[biggerId].width / resolutions[currentId].width ) == ( resolutions[biggerId].height / resolutions[currentId].height ) ) {
+                if ( ( resolutions[biggerId].gameWidth % resolutions[currentId].gameWidth ) == 0 && ( resolutions[biggerId].gameHeight % resolutions[currentId].gameHeight ) == 0
+                     && ( resolutions[biggerId].gameWidth / resolutions[currentId].gameWidth ) == ( resolutions[biggerId].gameHeight / resolutions[currentId].gameHeight ) ) {
                     // IMPORTANT: we MUST do a copy of a vector element if we want to emplace it to the same vector.
                     const fheroes2::ResolutionInfo currentResolution = resolutions[currentId];
-                    const int32_t scaleFactor = resolutions[biggerId].width / currentResolution.width;
 
-                    resolutions.emplace_back( currentResolution.width, currentResolution.height, scaleFactor );
+                    resolutions.emplace_back( currentResolution.gameWidth, currentResolution.gameHeight, resolutions[biggerId].gameWidth, resolutions[biggerId].gameHeight );
                 }
             }
         }
@@ -823,8 +839,8 @@ namespace
 
                 const fheroes2::Display & display = fheroes2::Display::instance();
                 if ( display.width() != 0 && display.height() != 0 ) {
-                    assert( display.scale() > 0 );
-                    SDL_SetWindowSize( _window, display.width() * display.scale(), display.height() * display.scale() );
+                    assert( display.screenSize().width >= display.width() && display.screenSize().height >= display.height() );
+                    SDL_SetWindowSize( _window, display.screenSize().width, display.screenSize().height );
                 }
             }
 
@@ -868,7 +884,7 @@ namespace
                             ERROR_LOG( "Failed to get display mode. The error value: " << returnCode << ", description: " << SDL_GetError() )
                         }
                         else {
-                            resolutionSet.emplace( videoMode.w, videoMode.h, 1 );
+                            resolutionSet.emplace( videoMode.w, videoMode.h );
                         }
                     }
                 }
@@ -1076,10 +1092,10 @@ namespace
 
             flags |= SDL_WINDOW_RESIZABLE;
 
-            _window = SDL_CreateWindow( _previousWindowTitle.data(), _prevWindowPos.x, _prevWindowPos.y, resolutionInfo.width * resolutionInfo.scale,
-                                        resolutionInfo.height * resolutionInfo.scale, flags );
+            _window = SDL_CreateWindow( _previousWindowTitle.data(), _prevWindowPos.x, _prevWindowPos.y, resolutionInfo.screenWidth,
+                                        resolutionInfo.screenHeight, flags );
             if ( _window == nullptr ) {
-                ERROR_LOG( "Failed to create an application window of " << resolutionInfo.width << " x " << resolutionInfo.height
+                ERROR_LOG( "Failed to create an application window of " << resolutionInfo.screenWidth << " x " << resolutionInfo.screenHeight
                                                                         << " size. The error: " << SDL_GetError() )
                 clear();
                 return false;
@@ -1124,21 +1140,21 @@ namespace
                 }
             }
 
-            _surface = SDL_CreateRGBSurface( 0, resolutionInfo.width, resolutionInfo.height, isPaletteModeSupported ? 8 : 32, 0, 0, 0, 0 );
+            _surface = SDL_CreateRGBSurface( 0, resolutionInfo.gameWidth, resolutionInfo.gameHeight, isPaletteModeSupported ? 8 : 32, 0, 0, 0, 0 );
             if ( _surface == nullptr ) {
-                ERROR_LOG( "Failed to create a surface of " << resolutionInfo.width << " x " << resolutionInfo.height << " size. The error: " << SDL_GetError() )
+                ERROR_LOG( "Failed to create a surface of " << resolutionInfo.gameWidth << " x " << resolutionInfo.gameHeight << " size. The error: " << SDL_GetError() )
                 clear();
                 return false;
             }
 
-            if ( _surface->w <= 0 || _surface->h <= 0 || _surface->w != resolutionInfo.width || _surface->h != resolutionInfo.height ) {
+            if ( _surface->w <= 0 || _surface->h <= 0 || _surface->w != resolutionInfo.gameWidth || _surface->h != resolutionInfo.gameHeight ) {
                 clear();
                 return false;
             }
 
             _createPalette();
 
-            return _createRenderer( resolutionInfo.width, resolutionInfo.height );
+            return _createRenderer( resolutionInfo.gameWidth, resolutionInfo.gameHeight );
         }
 
         void updatePalette( const std::vector<uint8_t> & colorIds ) override
@@ -1360,7 +1376,7 @@ namespace
                 SDL_Rect ** modes = SDL_ListModes( nullptr, SDL_FULLSCREEN | SDL_HWSURFACE );
                 if ( modes != nullptr && modes != reinterpret_cast<SDL_Rect **>( -1 ) ) {
                     for ( int i = 0; modes[i]; ++i ) {
-                        resolutionSet.emplace( modes[i]->w, modes[i]->h, 1 );
+                        resolutionSet.emplace( modes[i]->w, modes[i]->h );
                     }
                 }
 
@@ -1439,14 +1455,14 @@ namespace
             if ( isFullScreen )
                 flags |= SDL_FULLSCREEN;
 
-            _surface = SDL_SetVideoMode( resolutionInfo.width, resolutionInfo.height, _bitDepth, flags );
+            _surface = SDL_SetVideoMode( resolutionInfo.gameWidth, resolutionInfo.gameHeight, _bitDepth, flags );
             if ( _surface == nullptr ) {
                 return false;
             }
 
             _syncFullScreen();
 
-            if ( _surface->w <= 0 || _surface->h <= 0 || _surface->w != resolutionInfo.width || _surface->h != resolutionInfo.height ) {
+            if ( _surface->w <= 0 || _surface->h <= 0 || _surface->w != resolutionInfo.gameWidth || _surface->h != resolutionInfo.gameHeight ) {
                 clear();
                 return false;
             }
@@ -1533,7 +1549,6 @@ namespace fheroes2
         , _preprocessing( nullptr )
         , _postprocessing( nullptr )
         , _renderSurface( nullptr )
-        , _scale( 1 )
     {
         _disableTransformLayer();
     }
@@ -1550,7 +1565,8 @@ namespace fheroes2
 
     void Display::setResolution( ResolutionInfo info )
     {
-        if ( width() > 0 && height() > 0 && info.width == width() && info.height == height() && info.scale == _scale ) // nothing to resize
+        if ( width() > 0 && height() > 0 && info.gameWidth == width() && info.gameHeight == height() && info.screenWidth == _screenSize.width &&
+             info.screenHeight == _screenSize.height ) // nothing to resize
             return;
 
         const bool isFullScreen = _engine->isFullScreen();
@@ -1565,8 +1581,8 @@ namespace fheroes2
             clear();
         }
 
-        Image::resize( info.width, info.height );
-        _scale = info.scale;
+        Image::resize( info.gameWidth, info.gameHeight );
+        _screenSize = { info.screenWidth, info.screenHeight };
 
         // To detect some UI artifacts by invalid code let's put all transform data into pixel skipping mode.
         std::fill( transform(), transform() + width() * height(), static_cast<uint8_t>( 1 ) );

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -86,8 +86,8 @@ namespace
 
         std::vector<double> similarity( resolutions.size(), 0 );
         for ( size_t i = 0; i < resolutions.size(); ++i ) {
-            similarity[i] = std::fabs( resolutions[i].gameWidth - gameX ) / gameX + std::fabs( resolutions[i].gameHeight - gameY ) / gameY +
-                            std::fabs( resolutions[i].screenWidth - screenX ) / screenX + std::fabs( resolutions[i].screenHeight - screenY ) / screenY;
+            similarity[i] = std::fabs( resolutions[i].gameWidth - gameX ) / gameX + std::fabs( resolutions[i].gameHeight - gameY ) / gameY
+                            + std::fabs( resolutions[i].screenWidth - screenX ) / screenX + std::fabs( resolutions[i].screenHeight - screenY ) / screenY;
         }
 
         const std::vector<double>::difference_type id = std::distance( similarity.begin(), std::min_element( similarity.begin(), similarity.end() ) );
@@ -162,12 +162,15 @@ namespace
             for ( size_t biggerId = currentId + 1; biggerId < resolutionCountBefore; ++biggerId ) {
                 assert( resolutions[biggerId].gameWidth > 0 && resolutions[biggerId].gameHeight > 0 );
 
-                if ( ( resolutions[biggerId].gameWidth % resolutions[currentId].gameWidth ) == 0 && ( resolutions[biggerId].gameHeight % resolutions[currentId].gameHeight ) == 0
-                     && ( resolutions[biggerId].gameWidth / resolutions[currentId].gameWidth ) == ( resolutions[biggerId].gameHeight / resolutions[currentId].gameHeight ) ) {
+                if ( ( resolutions[biggerId].gameWidth % resolutions[currentId].gameWidth ) == 0
+                     && ( resolutions[biggerId].gameHeight % resolutions[currentId].gameHeight ) == 0
+                     && ( resolutions[biggerId].gameWidth / resolutions[currentId].gameWidth )
+                            == ( resolutions[biggerId].gameHeight / resolutions[currentId].gameHeight ) ) {
                     // IMPORTANT: we MUST do a copy of a vector element if we want to emplace it to the same vector.
                     const fheroes2::ResolutionInfo currentResolution = resolutions[currentId];
 
-                    resolutions.emplace_back( currentResolution.gameWidth, currentResolution.gameHeight, resolutions[biggerId].gameWidth, resolutions[biggerId].gameHeight );
+                    resolutions.emplace_back( currentResolution.gameWidth, currentResolution.gameHeight, resolutions[biggerId].gameWidth,
+                                              resolutions[biggerId].gameHeight );
                 }
             }
         }
@@ -1092,8 +1095,7 @@ namespace
 
             flags |= SDL_WINDOW_RESIZABLE;
 
-            _window = SDL_CreateWindow( _previousWindowTitle.data(), _prevWindowPos.x, _prevWindowPos.y, resolutionInfo.screenWidth,
-                                        resolutionInfo.screenHeight, flags );
+            _window = SDL_CreateWindow( _previousWindowTitle.data(), _prevWindowPos.x, _prevWindowPos.y, resolutionInfo.screenWidth, resolutionInfo.screenHeight, flags );
             if ( _window == nullptr ) {
                 ERROR_LOG( "Failed to create an application window of " << resolutionInfo.screenWidth << " x " << resolutionInfo.screenHeight
                                                                         << " size. The error: " << SDL_GetError() )
@@ -1565,8 +1567,8 @@ namespace fheroes2
 
     void Display::setResolution( ResolutionInfo info )
     {
-        if ( width() > 0 && height() > 0 && info.gameWidth == width() && info.gameHeight == height() && info.screenWidth == _screenSize.width &&
-             info.screenHeight == _screenSize.height ) // nothing to resize
+        if ( width() > 0 && height() > 0 && info.gameWidth == width() && info.gameHeight == height() && info.screenWidth == _screenSize.width
+             && info.screenHeight == _screenSize.height ) // nothing to resize
             return;
 
         const bool isFullScreen = _engine->isFullScreen();

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -166,6 +166,7 @@ namespace
                 assert( resolutions[biggerId].gameWidth > 0 && resolutions[biggerId].gameHeight > 0 );
 
                 if ( resolutions[biggerId].screenWidth != resolutions[biggerId].gameWidth || resolutions[biggerId].screenHeight != resolutions[biggerId].gameHeight ) {
+                    assert( resolutions[biggerId].screenWidth >= resolutions[biggerId].gameWidth && resolutions[biggerId].screenHeight >= resolutions[biggerId].gameHeight );
                     // This resolution has scaling. Ignore it.
                     continue;
                 }

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -140,18 +140,20 @@ namespace
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
         // Scaling is available only on SDL 2.
-        if ( resolutions.size() < 2 ) {
-            return { resolutions.begin(), resolutions.end() };
-        }
-
         std::sort( resolutions.begin(), resolutions.end() );
 
         // Wide screen devices support much higher resolutions but items on such resolutions are too tiny.
         // In order to improve user experience on these devices we are adding a special non-standard resolution.
         const fheroes2::Size biggestResolution{ resolutions.back().gameWidth, resolutions.back().gameHeight };
-        resolutions.emplace_back( biggestResolution.width * fheroes2::Display::DEFAULT_HEIGHT / biggestResolution.height, fheroes2::Display::DEFAULT_HEIGHT,
-                                  biggestResolution.width, biggestResolution.height );
-        std::sort( resolutions.begin(), resolutions.end() );
+        if ( biggestResolution.width > fheroes2::Display::DEFAULT_WIDTH && biggestResolution.height > fheroes2::Display::DEFAULT_HEIGHT ) {
+            resolutions.emplace_back( biggestResolution.width * fheroes2::Display::DEFAULT_HEIGHT / biggestResolution.height, fheroes2::Display::DEFAULT_HEIGHT,
+                                      biggestResolution.width, biggestResolution.height );
+            std::sort( resolutions.begin(), resolutions.end() );
+        }
+
+        if ( resolutions.size() < 2 ) {
+            return { resolutions.begin(), resolutions.end() };
+        }
 
         // Add resolutions with scale factor. No need to run through the newly added elements so we remember the size of the array.
         const size_t resolutionCountBefore = resolutions.size();
@@ -162,6 +164,11 @@ namespace
 
             for ( size_t biggerId = currentId + 1; biggerId < resolutionCountBefore; ++biggerId ) {
                 assert( resolutions[biggerId].gameWidth > 0 && resolutions[biggerId].gameHeight > 0 );
+
+                if ( resolutions[biggerId].screenWidth != resolutions[biggerId].gameWidth || resolutions[biggerId].screenHeight != resolutions[biggerId].gameHeight ) {
+                    // This resolution has scaling. Ignore it.
+                    continue;
+                }
 
                 if ( ( resolutions[biggerId].gameWidth % resolutions[currentId].gameWidth ) == 0
                      && ( resolutions[biggerId].gameHeight % resolutions[currentId].gameHeight ) == 0

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -38,17 +38,27 @@ namespace fheroes2
     {
         ResolutionInfo() = default;
 
-        ResolutionInfo( const int32_t width_, const int32_t height_, const int32_t scale_ )
-            : width( width_ )
-            , height( height_ )
-            , scale( scale_ )
+        ResolutionInfo( const int32_t gameWidth_, const int32_t gameHeight_ )
+            : gameWidth( gameWidth_ )
+            , gameHeight( gameHeight_ )
+            , screenWidth( gameWidth_ )
+            , screenHeight( gameHeight_ )
+        {
+            // Do nothing.
+        }
+
+        ResolutionInfo( const int32_t gameWidth_, const int32_t gameHeight_, const int32_t screenWidth_, const int32_t screenHeight_ )
+            : gameWidth( gameWidth_ )
+            , gameHeight( gameHeight_ )
+            , screenWidth( screenWidth_ )
+            , screenHeight( screenHeight_ )
         {
             // Do nothing.
         }
 
         bool operator==( const ResolutionInfo & info ) const
         {
-            return width == info.width && height == info.height && scale == info.scale;
+            return gameWidth == info.gameWidth && gameHeight == info.gameHeight && screenWidth == info.screenWidth && screenHeight == info.screenHeight;
         }
 
         bool operator!=( const ResolutionInfo & info ) const
@@ -58,14 +68,16 @@ namespace fheroes2
 
         bool operator<( const ResolutionInfo & info ) const
         {
-            return std::tie( width, height, scale ) < std::tie( info.width, info.height, info.scale );
+            return std::tie( gameWidth, gameHeight, screenWidth, screenHeight ) < std::tie( info.gameWidth, info.gameHeight, info.screenWidth, info.screenHeight );
         }
 
-        int32_t width{ 0 };
+        int32_t gameWidth{ 0 };
 
-        int32_t height{ 0 };
+        int32_t gameHeight{ 0 };
 
-        int32_t scale{ 1 };
+        int32_t screenWidth{ 0 };
+
+        int32_t screenHeight{ 0 };
     };
 
     class BaseRenderEngine
@@ -224,9 +236,9 @@ namespace fheroes2
         // nullptr input parameter is used to reset palette to default one.
         void changePalette( const uint8_t * palette = nullptr, const bool forceDefaultPaletteUpdate = false ) const;
 
-        int32_t scale() const
+        Size screenSize() const
         {
-            return _scale;
+            return _screenSize;
         }
 
         friend BaseRenderEngine & engine();
@@ -243,7 +255,7 @@ namespace fheroes2
         // Previous area drawn on the screen.
         Rect _prevRoi;
 
-        int32_t _scale;
+        Size _screenSize;
 
         // Only for cases of direct drawing on rendered 8-bit image.
         void linkRenderSurface( uint8_t * surface )

--- a/src/engine/tinyconfig.h
+++ b/src/engine/tinyconfig.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -28,6 +28,7 @@
 #include <string>
 
 #include "math_base.h"
+#include "screen.h"
 
 class TinyConfig : private std::multimap<std::string, std::string>
 {
@@ -43,6 +44,9 @@ public:
     // Tries to find and return a Point-type struct stored as a string "[ x, y ]" for a given key.
     // In case of any error, the fallback value is returned.
     fheroes2::Point PointParams( const std::string & key, const fheroes2::Point & fallbackValue ) const;
+    // Tries to find and return a ResolutionInfo-type struct (multiple formats are supported, see the implementation for details)
+    // for a given key. In case of any error, the fallback value is returned.
+    fheroes2::ResolutionInfo ResolutionParams( const std::string & key, const fheroes2::ResolutionInfo & fallbackValue ) const;
 
 private:
     char separator;

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -69,8 +69,8 @@ namespace
             const int32_t integer = display.screenSize().width / display.width();
             const int32_t fraction = display.screenSize().width * 10 / display.width() - 10 * integer;
 
-            resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() ) + " (x" + std::to_string( integer ) + '.' +
-                             std::to_string( fraction ) + ')';
+            resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() ) + " (x" + std::to_string( integer ) + '.'
+                             + std::to_string( fraction ) + ')';
         }
         else {
             resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -65,8 +65,12 @@ namespace
     {
         const fheroes2::Display & display = fheroes2::Display::instance();
         std::string resolutionName;
-        if ( display.scale() > 1 ) {
-            resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() ) + " (x" + std::to_string( display.scale() ) + ')';
+        if ( display.screenSize().width != display.width() || display.screenSize().height != display.height() ) {
+            const int32_t integer = display.screenSize().width / display.width();
+            const int32_t fraction = display.screenSize().width * 10 / display.width() - 10 * integer;
+
+            resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() ) + " (x" + std::to_string( integer ) + '.' +
+                             std::to_string( fraction ) + ')';
         }
         else {
             resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );

--- a/src/fheroes2/dialog/dialog_resolution.cpp
+++ b/src/fheroes2/dialog/dialog_resolution.cpp
@@ -53,11 +53,15 @@ namespace
 
     std::pair<std::string, std::string> getResolutionStrings( const fheroes2::ResolutionInfo & resolution )
     {
-        if ( resolution.scale > 1 ) {
-            return std::make_pair( std::to_string( resolution.width ), std::to_string( resolution.height ) + " (x" + std::to_string( resolution.scale ) + ")" );
+        if ( resolution.screenWidth != resolution.gameWidth && resolution.screenHeight != resolution.gameHeight ) {
+            const int32_t integer = resolution.screenWidth / resolution.gameWidth;
+            const int32_t fraction = resolution.screenWidth * 10 / resolution.gameWidth - 10 * integer;
+
+            return std::make_pair( std::to_string( resolution.gameWidth ), std::to_string( resolution.gameHeight ) + " (x" + std::to_string( integer ) +
+                                   "." + std::to_string( fraction ) + ')' );
         }
 
-        return std::make_pair( std::to_string( resolution.width ), std::to_string( resolution.height ) );
+        return std::make_pair( std::to_string( resolution.gameWidth ), std::to_string( resolution.gameHeight ) );
     }
 
     class ResolutionList : public Interface::ListBox<fheroes2::ResolutionInfo>
@@ -135,7 +139,7 @@ namespace
         fheroes2::Text text( _( "Select Game Resolution:" ), fheroes2::FontType::normalYellow() );
         text.draw( dst.x + ( 377 - text.width() ) / 2, dst.y + 32, output );
 
-        if ( resolution.width > 0 && resolution.height > 0 ) {
+        if ( resolution.gameWidth > 0 && resolution.gameHeight > 0 ) {
             const fheroes2::FontType fontType = fheroes2::FontType::normalYellow();
 
             const auto [leftText, rightText] = getResolutionStrings( resolution );
@@ -194,7 +198,7 @@ namespace Dialog
 
         resList.SetListContent( resolutions );
 
-        const fheroes2::ResolutionInfo currentResolution{ display.width(), display.height(), display.scale() };
+        const fheroes2::ResolutionInfo currentResolution{ display.width(), display.height(), display.screenSize().width, display.screenSize().height };
 
         fheroes2::ResolutionInfo selectedResolution;
         for ( size_t i = 0; i < resolutions.size(); ++i ) {
@@ -257,7 +261,8 @@ namespace Dialog
             display.render();
         }
 
-        if ( selectedResolution.width > 0 && selectedResolution.height > 0 && selectedResolution.scale > 0 && selectedResolution != currentResolution ) {
+        if ( selectedResolution.gameWidth > 0 && selectedResolution.gameHeight > 0 && selectedResolution.screenWidth >= selectedResolution.gameWidth &&
+             selectedResolution.screenHeight >= selectedResolution.gameHeight && selectedResolution != currentResolution ) {
             display.setResolution( selectedResolution );
 
 #if !defined( MACOS_APP_BUNDLE )

--- a/src/fheroes2/dialog/dialog_resolution.cpp
+++ b/src/fheroes2/dialog/dialog_resolution.cpp
@@ -57,8 +57,8 @@ namespace
             const int32_t integer = resolution.screenWidth / resolution.gameWidth;
             const int32_t fraction = resolution.screenWidth * 10 / resolution.gameWidth - 10 * integer;
 
-            return std::make_pair( std::to_string( resolution.gameWidth ), std::to_string( resolution.gameHeight ) + " (x" + std::to_string( integer ) +
-                                   "." + std::to_string( fraction ) + ')' );
+            return std::make_pair( std::to_string( resolution.gameWidth ),
+                                   std::to_string( resolution.gameHeight ) + " (x" + std::to_string( integer ) + "." + std::to_string( fraction ) + ')' );
         }
 
         return std::make_pair( std::to_string( resolution.gameWidth ), std::to_string( resolution.gameHeight ) );
@@ -261,8 +261,8 @@ namespace Dialog
             display.render();
         }
 
-        if ( selectedResolution.gameWidth > 0 && selectedResolution.gameHeight > 0 && selectedResolution.screenWidth >= selectedResolution.gameWidth &&
-             selectedResolution.screenHeight >= selectedResolution.gameHeight && selectedResolution != currentResolution ) {
+        if ( selectedResolution.gameWidth > 0 && selectedResolution.gameHeight > 0 && selectedResolution.screenWidth >= selectedResolution.gameWidth
+             && selectedResolution.screenHeight >= selectedResolution.gameHeight && selectedResolution != currentResolution ) {
             display.setResolution( selectedResolution );
 
 #if !defined( MACOS_APP_BUNDLE )

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -28,6 +28,7 @@
 #include <memory>
 #include <set>
 #include <string>
+#include <vector>
 
 #include <SDL_events.h>
 #include <SDL_main.h> // IWYU pragma: keep

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -129,8 +129,23 @@ namespace
             const Settings & conf = Settings::Get();
 
             fheroes2::Display & display = fheroes2::Display::instance();
+            if ( conf.isFirstGameRun() && System::isHandheldDevice() ) {
+                // We do not show resolution dialog for first run on handheld devices. In this case it is wise to set 'widest' resolution by default.
+                const std::vector<fheroes2::ResolutionInfo> resolutions = fheroes2::engine().getAvailableResolutions();
+                fheroes2::ResolutionInfo bestResolution{ conf.currentResolutionInfo() };
 
-            display.setResolution( conf.currentResolutionInfo() );
+                for ( const fheroes2::ResolutionInfo & info : resolutions ) {
+                    if ( info.gameWidth > bestResolution.gameWidth && info.gameHeight == bestResolution.gameHeight ) {
+                        bestResolution = info;
+                    }
+                }
+
+                display.setResolution( bestResolution );
+            }
+            else {
+                display.setResolution( conf.currentResolutionInfo() );
+            }
+
             display.fill( 0 ); // start from a black screen
 
             fheroes2::engine().setTitle( GetCaption() );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -88,7 +88,7 @@ std::string Settings::GetVersion()
 }
 
 Settings::Settings()
-    : _resolutionInfo( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, 1 )
+    : _resolutionInfo( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT )
     , game_difficulty( Difficulty::NORMAL )
     , sound_volume( 6 )
     , music_volume( 6 )
@@ -255,24 +255,33 @@ bool Settings::Read( const std::string & filePath )
         size_t pos = value.find( 'x' );
 
         if ( pos != std::string::npos ) {
-            _resolutionInfo.width = GetInt( value.substr( 0, pos ) );
+            _resolutionInfo.gameWidth = GetInt( value.substr( 0, pos ) );
 
-            const size_t prevXPos = pos;
-            pos = value.find( 'x', prevXPos + 1 );
+            size_t prevXPos = pos;
+            pos = value.find( ':', prevXPos + 1 );
             if ( pos != std::string::npos ) {
-                _resolutionInfo.height = GetInt( value.substr( prevXPos + 1, pos - prevXPos - 1 ) );
-                _resolutionInfo.scale = GetInt( value.substr( pos + 1, value.length() - pos - 1 ) );
+                _resolutionInfo.gameHeight = GetInt( value.substr( prevXPos + 1, pos - prevXPos - 1 ) );
+
+                prevXPos = pos;
+                pos = value.find( 'x', prevXPos + 1 );
+                if ( pos != std::string::npos ) {
+                    _resolutionInfo.screenWidth = GetInt( value.substr( prevXPos + 1, pos - prevXPos - 1 ) );
+                    _resolutionInfo.screenHeight = GetInt( value.substr( pos + 1, value.length() - pos - 1 ) );
+                }
+                else {
+                    _resolutionInfo.screenWidth = _resolutionInfo.gameWidth;
+                    _resolutionInfo.screenHeight = _resolutionInfo.gameHeight;
+                }
             }
             else {
                 // This is old video mode setting without scale.
-                _resolutionInfo.height = GetInt( value.substr( prevXPos + 1, value.length() - prevXPos - 1 ) );
-                _resolutionInfo.scale = 1;
+                _resolutionInfo.gameHeight = GetInt( value.substr( prevXPos + 1, value.length() - prevXPos - 1 ) );
+                _resolutionInfo.screenWidth = _resolutionInfo.gameWidth;
+                _resolutionInfo.screenHeight = _resolutionInfo.gameHeight;
             }
         }
         else {
-            _resolutionInfo.width = fheroes2::Display::DEFAULT_WIDTH;
-            _resolutionInfo.height = fheroes2::Display::DEFAULT_HEIGHT;
-            _resolutionInfo.scale = 1;
+            _resolutionInfo = { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT };
             DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown video mode: " << value )
         }
     }
@@ -389,7 +398,7 @@ std::string Settings::String() const
     const fheroes2::Display & display = fheroes2::Display::instance();
 
     os << std::endl << "# video mode (game resolution)" << std::endl;
-    os << "videomode = " << display.width() << "x" << display.height() << "x" << display.scale() << std::endl;
+    os << "videomode = " << display.width() << "x" << display.height() << ":" << display.screenSize().width << "x" << display.screenSize().height << std::endl;
 
     os << std::endl << "# music: original, expansion, external" << std::endl;
     os << "music = " << musicType << std::endl;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -41,7 +41,6 @@
 #include "settings.h"
 #include "system.h"
 #include "tinyconfig.h"
-#include "tools.h"
 #include "translations.h"
 #include "ui_language.h"
 #include "version.h"
@@ -248,45 +247,10 @@ bool Settings::Read( const std::string & filePath )
         pos_stat = config.PointParams( "status window position", { -1, -1 } );
     }
 
-    // videomode
-    sval = config.StrParams( "videomode" );
-    if ( !sval.empty() ) {
-        const std::string value = StringLower( sval );
-        size_t pos = value.find( 'x' );
-
-        if ( pos != std::string::npos ) {
-            _resolutionInfo.gameWidth = GetInt( value.substr( 0, pos ) );
-
-            size_t prevXPos = pos;
-            pos = value.find( ':', prevXPos + 1 );
-            if ( pos != std::string::npos ) {
-                _resolutionInfo.gameHeight = GetInt( value.substr( prevXPos + 1, pos - prevXPos - 1 ) );
-
-                prevXPos = pos;
-                pos = value.find( 'x', prevXPos + 1 );
-                if ( pos != std::string::npos ) {
-                    _resolutionInfo.screenWidth = GetInt( value.substr( prevXPos + 1, pos - prevXPos - 1 ) );
-                    _resolutionInfo.screenHeight = GetInt( value.substr( pos + 1, value.length() - pos - 1 ) );
-                }
-                else {
-                    _resolutionInfo.screenWidth = _resolutionInfo.gameWidth;
-                    _resolutionInfo.screenHeight = _resolutionInfo.gameHeight;
-                }
-            }
-            else {
-                // This is old video mode setting without scale.
-                _resolutionInfo.gameHeight = GetInt( value.substr( prevXPos + 1, value.length() - prevXPos - 1 ) );
-                _resolutionInfo.screenWidth = _resolutionInfo.gameWidth;
-                _resolutionInfo.screenHeight = _resolutionInfo.gameHeight;
-            }
-        }
-        else {
-            _resolutionInfo = { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT };
-            DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown video mode: " << value )
-        }
+    if ( config.Exists( "videomode" ) ) {
+        _resolutionInfo = config.ResolutionParams( "videomode", { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } );
     }
 
-    // full screen
     if ( config.Exists( "fullscreen" ) ) {
         setFullScreen( config.StrParams( "fullscreen" ) == "on" );
     }
@@ -397,7 +361,7 @@ std::string Settings::String() const
 
     const fheroes2::Display & display = fheroes2::Display::instance();
 
-    os << std::endl << "# video mode (game resolution)" << std::endl;
+    os << std::endl << "# video mode: in-game width x in-game height : on-screen width x on-screen height" << std::endl;
     os << "videomode = " << display.width() << "x" << display.height() << ":" << display.screenSize().width << "x" << display.screenSize().height << std::endl;
 
     os << std::endl << "# music: original, expansion, external" << std::endl;


### PR DESCRIPTION
Add a special resolution for devices to support wide screens which are prevalent in modern devices. Only for SDL 2. The newly added resolution is extremely useful for mobile phones where we have to keep resolution as low as possible but avoid the game being rendered only on half of the phone's screen. This resolution is set by default for the first application run.

![image](https://user-images.githubusercontent.com/19829520/232307125-051fbd7b-d40f-490d-803a-e1ee588e5fe0.png)

relates to #5373

I am open for suggestions, corrections how to improve user experience in this field.