### PR TITLE
Improve dialog titles related to losing the game

### DIFF
--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -91,7 +91,7 @@ namespace Game
 
     int GetKingdomColors();
     int GetActualKingdomColors();
-    void DialogPlayers( int color, std::string );
+    void DialogPlayers( int color, std::string title, std::string message );
 
     uint32_t getAdventureMapAnimationIndex();
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -165,7 +165,7 @@ namespace
         AudioManager::PlayMusic( MUS::LOSTGAME, Music::PlaybackMode::PLAY_ONCE );
 
         if ( !body.empty() )
-            fheroes2::showStandardTextMessage( _("Defeat!"), body, Dialog::OK );
+            fheroes2::showStandardTextMessage( _( "Defeat!" ), body, Dialog::OK );
     }
 }
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -349,7 +349,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
     for ( const int color : Colors( colors ) ) {
         if ( !world.GetKingdom( color ).isPlay() ) {
             if ( !isSinglePlayer || ( color & humanColors ) == 0 ) {
-                Game::DialogPlayers( color, "", _( "%{color} player has been vanquished!" ) );
+                Game::DialogPlayers( color, _( "Major Event!" ), _( "%{color} player has been vanquished!" ) );
             }
             colors &= ( ~color );
         }

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -165,7 +165,7 @@ namespace
         AudioManager::PlayMusic( MUS::LOSTGAME, Music::PlaybackMode::PLAY_ONCE );
 
         if ( !body.empty() )
-            fheroes2::showStandardTextMessage( "", body, Dialog::OK );
+            fheroes2::showStandardTextMessage( _("Defeat!"), body, Dialog::OK );
     }
 }
 

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -349,7 +349,7 @@ fheroes2::GameMode GameOver::Result::LocalCheckGameOver()
     for ( const int color : Colors( colors ) ) {
         if ( !world.GetKingdom( color ).isPlay() ) {
             if ( !isSinglePlayer || ( color & humanColors ) == 0 ) {
-                Game::DialogPlayers( color, _( "%{color} player has been vanquished!" ) );
+                Game::DialogPlayers( color, "", _( "%{color} player has been vanquished!" ) );
             }
             colors &= ( ~color );
         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1278,7 +1278,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
                                          _( "%{color} player, you have lost your last town. If you do not conquer another town in next week, you will be eliminated." ) );
                 }
                 else if ( lostTownDays == 1 ) {
-                    Game::DialogPlayers( conf.CurrentColor(), _( "Beware!" ), _( "%{color} player, your heroes abandon you, and you are banished from this land." ) );
+                    Game::DialogPlayers( conf.CurrentColor(), _( "Defeat!" ), _( "%{color} player, your heroes abandon you, and you are banished from this land." ) );
                 }
             }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -155,10 +155,10 @@ fheroes2::GameMode Game::StartGame()
     return Interface::Basic::Get().StartGame();
 }
 
-void Game::DialogPlayers( int color, std::string str )
+void Game::DialogPlayers( int color, std::string title, std::string message )
 {
     const Player * player = Players::Get( color );
-    StringReplace( str, "%{color}", ( player ? player->GetName() : Color::String( color ) ) );
+    StringReplace( message, "%{color}", ( player ? player->GetName() : Color::String( color ) ) );
 
     const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::BRCREST, 6 );
     fheroes2::Sprite sign = border;
@@ -189,7 +189,8 @@ void Game::DialogPlayers( int color, std::string str )
     }
 
     const fheroes2::CustomImageDialogElement imageUI( std::move( sign ) );
-    fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( std::move( str ), fheroes2::FontType::normalWhite() ), Dialog::OK, { &imageUI } );
+    fheroes2::showMessage( fheroes2::Text( std::move( title ), fheroes2::FontType::normalYellow() ),
+                           fheroes2::Text( std::move( message ), fheroes2::FontType::normalWhite() ), Dialog::OK, { &imageUI } );
 }
 
 void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
@@ -375,12 +376,13 @@ void ShowWarningLostTownsDialog()
     const uint32_t lostTownDays = myKingdom.GetLostTownDays();
 
     if ( lostTownDays == 1 ) {
-        Game::DialogPlayers( myKingdom.GetColor(), _( "%{color} player, this is your last day to capture a town, or you will be banished from this land." ) );
+        Game::DialogPlayers( myKingdom.GetColor(), _( "Beware!" ),
+                             _( "%{color} player, this is your last day to capture a town, or you will be banished from this land." ) );
     }
     else if ( lostTownDays > 0 && lostTownDays <= Game::GetLostTownDays() ) {
         std::string str = _( "%{color} player, you only have %{day} days left to capture a town, or you will be banished from this land." );
         StringReplace( str, "%{day}", lostTownDays );
-        Game::DialogPlayers( myKingdom.GetColor(), str );
+        Game::DialogPlayers( myKingdom.GetColor(), _( "Beware!" ), str );
     }
 }
 
@@ -696,7 +698,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                         AudioManager::PlayMusic( MUS::NEW_MONTH, Music::PlaybackMode::PLAY_ONCE );
 
-                        Game::DialogPlayers( player->GetColor(), _( "%{color} player's turn." ) );
+                        Game::DialogPlayers( player->GetColor(), "", _( "%{color} player's turn." ) );
                     }
 
                     conf.SetCurrentColor( player->GetColor() );
@@ -1272,11 +1274,11 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
                 const uint32_t lostTownDays = myKingdom.GetLostTownDays();
 
                 if ( lostTownDays > Game::GetLostTownDays() ) {
-                    Game::DialogPlayers( conf.CurrentColor(),
+                    Game::DialogPlayers( conf.CurrentColor(), _( "Beware!" ),
                                          _( "%{color} player, you have lost your last town. If you do not conquer another town in next week, you will be eliminated." ) );
                 }
                 else if ( lostTownDays == 1 ) {
-                    Game::DialogPlayers( conf.CurrentColor(), _( "%{color} player, your heroes abandon you, and you are banished from this land." ) );
+                    Game::DialogPlayers( conf.CurrentColor(), _( "Beware!" ), _( "%{color} player, your heroes abandon you, and you are banished from this land." ) );
                 }
             }
 


### PR DESCRIPTION
Solves https://github.com/ihhub/fheroes2/issues/1561 and https://github.com/ihhub/fheroes2/issues/1649. Add title to following dialogs

![image](https://user-images.githubusercontent.com/11016113/232309836-d51822b7-1a22-40bd-94e2-1769d3c59cd7.png)

![image](https://user-images.githubusercontent.com/11016113/232307613-c7dd6deb-c80f-430b-b479-54ad45b99073.png)

![image](https://user-images.githubusercontent.com/11016113/232312241-57121228-75a4-44b1-84c2-29186bf31861.png)

This one you can see when it's your last day and you end you turn manually.

![image](https://user-images.githubusercontent.com/11016113/232312151-57aa9bf7-6450-4eea-a9a3-ce0c0f0cd6c7.png)

This one can been seen when you have more than one castle and then they are taken from you. When it's your turn and you end your turn manually.

![image](https://user-images.githubusercontent.com/11016113/232312625-f6ea2b90-6539-4f38-a6a2-1b9a55d8fbbe.png)



