### PR TITLE
Add language support for highscores

### DIFF
--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -262,15 +262,14 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
             const Campaign::CampaignSaveData & campaignSaveData = Campaign::CampaignSaveData::Get();
             const uint32_t rating = getCampaignRating( campaignSaveData );
 
-            selectedEntryIndex = highScoreDataContainer.registerScoreCampaign( { std::move( lang ), player,
-                Campaign::getCampaignName( campaignSaveData.getCampaignID() ), completionTime, campaignSaveData.getDaysPassed(), rating, world.GetMapSeed() } );
+            selectedEntryIndex = highScoreDataContainer.registerScoreCampaign( { std::move( lang ), player, Campaign::getCampaignName( campaignSaveData.getCampaignID() ),
+                                                                                 completionTime, campaignSaveData.getDaysPassed(), rating, world.GetMapSeed() } );
         }
         else {
             const uint32_t rating = GetGameOverScores();
             const uint32_t days = world.CountDay();
-            selectedEntryIndex
-                = highScoreDataContainer.registerScoreStandard(
-                    { std::move( lang ), player, Settings::Get().CurrentFileInfo().name, completionTime, days, rating, world.GetMapSeed() } );
+            selectedEntryIndex = highScoreDataContainer.registerScoreStandard(
+                { std::move( lang ), player, Settings::Get().CurrentFileInfo().name, completionTime, days, rating, world.GetMapSeed() } );
         }
 
         highScoreDataContainer.save( highScoreDataPath );

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -191,6 +191,7 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
 
     if ( !highScoreDataContainer.load( highScoreDataPath ) ) {
         // Unable to load the file. Let's populate with the default values.
+        highScoreDataContainer.clear();
         highScoreDataContainer.populateStandardDefaultHighScores();
         highScoreDataContainer.populateCampaignDefaultHighScores();
     }

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -193,7 +193,6 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
         // Unable to load the file. Let's populate with the default values.
         highScoreDataContainer.populateStandardDefaultHighScores();
         highScoreDataContainer.populateCampaignDefaultHighScores();
-        highScoreDataContainer.save( highScoreDataPath );
     }
 
     const bool isAfterGameCompletion = ( ( gameResult.GetResult() & GameOver::WINS ) != 0 );

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -55,6 +55,7 @@
 #include "translations.h"
 #include "ui_button.h"
 #include "ui_dialog.h"
+#include "ui_language.h"
 #include "ui_text.h"
 #include "ui_window.h"
 #include "world.h"
@@ -95,6 +96,8 @@ namespace
 
         for ( const fheroes2::HighscoreData & data : highScores ) {
             const fheroes2::FontType font = ( scoreIndex == selectedScoreIndex ) ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
+
+            const fheroes2::LanguageSwitcher languageSwitcher( fheroes2::getLanguageFromAbbreviation( data.languageAbbreviation ) );
 
             text.set( data.playerName, font );
             text.draw( offsetX + playerNameOffset, offsetY + initialHighScoreEntryOffsetY, display );
@@ -253,18 +256,21 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
 
         const uint32_t completionTime = fheroes2::HighscoreData::generateCompletionTime();
 
+        std::string lang = fheroes2::getLanguageAbbreviation( fheroes2::getCurrentLanguage() );
+
         if ( isCampaign ) {
             const Campaign::CampaignSaveData & campaignSaveData = Campaign::CampaignSaveData::Get();
             const uint32_t rating = getCampaignRating( campaignSaveData );
 
-            selectedEntryIndex = highScoreDataContainer.registerScoreCampaign(
-                { player, Campaign::getCampaignName( campaignSaveData.getCampaignID() ), completionTime, campaignSaveData.getDaysPassed(), rating, world.GetMapSeed() } );
+            selectedEntryIndex = highScoreDataContainer.registerScoreCampaign( { std::move( lang ), player,
+                Campaign::getCampaignName( campaignSaveData.getCampaignID() ), completionTime, campaignSaveData.getDaysPassed(), rating, world.GetMapSeed() } );
         }
         else {
             const uint32_t rating = GetGameOverScores();
             const uint32_t days = world.CountDay();
             selectedEntryIndex
-                = highScoreDataContainer.registerScoreStandard( { player, Settings::Get().CurrentFileInfo().name, completionTime, days, rating, world.GetMapSeed() } );
+                = highScoreDataContainer.registerScoreStandard(
+                    { std::move( lang ), player, Settings::Get().CurrentFileInfo().name, completionTime, days, rating, world.GetMapSeed() } );
         }
 
         highScoreDataContainer.save( highScoreDataPath );

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -312,6 +312,7 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
         }
 
         if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+            // TODO: avoid redrawing the whole screen when only monster animation update is required.
             if ( isCampaign )
                 RedrawHighScoresCampaign( top.x, top.y, monsterAnimationFrameId, selectedEntryIndex );
             else

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -28,8 +28,8 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 #include "agg_image.h"
 #include "campaign_savedata.h"

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 #include "agg_image.h"
 #include "campaign_savedata.h"

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -111,7 +111,7 @@ namespace fheroes2
 
     void HighscoreData::loadV1( StreamBase & msg )
     {
-        languageAbbreviation = "en";
+        languageAbbreviation = fheroes2::getLanguageAbbreviation( fheroes2::SupportedLanguage::English );
 
         msg >> playerName >> scenarioName >> completionTime >> dayCount >> rating >> mapSeed;
     }

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -162,6 +162,12 @@ namespace fheroes2
             hdata >> _highScoresStandard >> _highScoresCampaign;
         }
 
+        if ( hdata.fail() ) {
+            _highScoresStandard.clear();
+            _highScoresCampaign.clear();
+            return false;
+        }
+
         // Since the introduction of campaign difficulty we need to calculate rating of a campaign completion.
         // Before the change rating for campaigns was always 0. We need to set it to the number of days.
         for ( fheroes2::HighscoreData & data : _highScoresCampaign ) {
@@ -184,7 +190,7 @@ namespace fheroes2
             _highScoresCampaign.resize( highscoreMaximumEntries );
         }
 
-        return !hdata.fail();
+        return true;
     }
 
     bool HighScoreDataContainer::save( const std::string & fileName ) const

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -25,6 +25,7 @@
 #include <ctime>
 #include <memory>
 
+#include "campaign_scenariodata.h"
 #include "serialize.h"
 #include "translations.h"
 #include "ui_language.h"
@@ -334,15 +335,15 @@ namespace fheroes2
 
         const std::string lang = fheroes2::getLanguageAbbreviation( fheroes2::getCurrentLanguage() );
 
-        registerScoreCampaign( { lang, _( "Antoine" ), "Roland", currentTime, 600, 600, 0 } );
-        registerScoreCampaign( { lang, _( "Astra" ), "Archibald", currentTime, 650, 650, 0 } );
-        registerScoreCampaign( { lang, _( "Agar" ), "Roland", currentTime, 700, 700, 0 } );
-        registerScoreCampaign( { lang, _( "Vatawna" ), "Archibald", currentTime, 750, 750, 0 } );
-        registerScoreCampaign( { lang, _( "Vesper" ), "Roland", currentTime, 800, 800, 0 } );
-        registerScoreCampaign( { lang, _( "Ambrose" ), "Archibald", currentTime, 850, 850, 0 } );
-        registerScoreCampaign( { lang, _( "Troyan" ), "Roland", currentTime, 900, 900, 0 } );
-        registerScoreCampaign( { lang, _( "Jojosh" ), "Archibald", currentTime, 1000, 1000, 0 } );
-        registerScoreCampaign( { lang, _( "Wrathmont" ), "Roland", currentTime, 2000, 2000, 0 } );
-        registerScoreCampaign( { lang, _( "Maximus" ), "Archibald", currentTime, 3000, 3000, 0 } );
+        registerScoreCampaign( { lang, _( "Antoine" ), Campaign::getCampaignName( Campaign::ROLAND_CAMPAIGN ), currentTime, 600, 600, 0 } );
+        registerScoreCampaign( { lang, _( "Astra" ), Campaign::getCampaignName( Campaign::ARCHIBALD_CAMPAIGN ), currentTime, 650, 650, 0 } );
+        registerScoreCampaign( { lang, _( "Agar" ), Campaign::getCampaignName( Campaign::ROLAND_CAMPAIGN ), currentTime, 700, 700, 0 } );
+        registerScoreCampaign( { lang, _( "Vatawna" ), Campaign::getCampaignName( Campaign::ARCHIBALD_CAMPAIGN ), currentTime, 750, 750, 0 } );
+        registerScoreCampaign( { lang, _( "Vesper" ), Campaign::getCampaignName( Campaign::ROLAND_CAMPAIGN ), currentTime, 800, 800, 0 } );
+        registerScoreCampaign( { lang, _( "Ambrose" ), Campaign::getCampaignName( Campaign::ARCHIBALD_CAMPAIGN ), currentTime, 850, 850, 0 } );
+        registerScoreCampaign( { lang, _( "Troyan" ), Campaign::getCampaignName( Campaign::ROLAND_CAMPAIGN ), currentTime, 900, 900, 0 } );
+        registerScoreCampaign( { lang, _( "Jojosh" ), Campaign::getCampaignName( Campaign::ARCHIBALD_CAMPAIGN ), currentTime, 1000, 1000, 0 } );
+        registerScoreCampaign( { lang, _( "Wrathmont" ), Campaign::getCampaignName( Campaign::ROLAND_CAMPAIGN ), currentTime, 2000, 2000, 0 } );
+        registerScoreCampaign( { lang, _( "Maximus" ), Campaign::getCampaignName( Campaign::ARCHIBALD_CAMPAIGN ), currentTime, 3000, 3000, 0 } );
     }
 }

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -163,8 +163,6 @@ namespace fheroes2
         }
 
         if ( hdata.fail() ) {
-            _highScoresStandard.clear();
-            _highScoresCampaign.clear();
             return false;
         }
 

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -18,12 +18,13 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "highscores.h"
+
 #include <algorithm>
 #include <array>
 #include <ctime>
 #include <memory>
 
-#include "highscores.h"
 #include "serialize.h"
 #include "translations.h"
 #include "ui_language.h"

--- a/src/fheroes2/game/highscores.h
+++ b/src/fheroes2/game/highscores.h
@@ -37,9 +37,10 @@ namespace fheroes2
     {
     public:
         HighscoreData() = default;
-        HighscoreData( std::string playerName_, std::string scenarioName_, const uint32_t completionTime_, const uint32_t dayCount_, const uint32_t rating_,
-                       const uint32_t mapSeed_ )
-            : playerName( std::move( playerName_ ) )
+        HighscoreData( std::string languageAbbreviation_, std::string playerName_, std::string scenarioName_, const uint32_t completionTime_, const uint32_t dayCount_,
+                       const uint32_t rating_, const uint32_t mapSeed_ )
+            : languageAbbreviation( std::move( languageAbbreviation_ ) )
+            , playerName( std::move( playerName_ ) )
             , scenarioName( std::move( scenarioName_ ) )
             , completionTime( completionTime_ )
             , dayCount( dayCount_ )
@@ -63,6 +64,7 @@ namespace fheroes2
             return scenarioName == other.scenarioName && dayCount == other.dayCount && rating == other.rating && mapSeed == other.mapSeed;
         }
 
+        std::string languageAbbreviation;
         std::string playerName;
         std::string scenarioName;
         uint32_t completionTime{ 0 };
@@ -75,6 +77,8 @@ namespace fheroes2
         uint32_t mapSeed{ 0 };
 
         static uint32_t generateCompletionTime();
+
+        void loadV1( StreamBase & msg );
 
     private:
         friend StreamBase & operator<<( StreamBase &, const HighscoreData & );

--- a/src/fheroes2/game/highscores.h
+++ b/src/fheroes2/game/highscores.h
@@ -111,6 +111,12 @@ namespace fheroes2
         static Monster getMonsterByRating( const size_t rating );
         static Monster getMonsterByDay( const size_t dayCount );
 
+        void clear()
+        {
+            _highScoresStandard.clear();
+            _highScoresCampaign.clear();
+        }
+
     private:
         std::vector<HighscoreData> _highScoresStandard;
         std::vector<HighscoreData> _highScoresCampaign;

--- a/src/fheroes2/game/highscores.h
+++ b/src/fheroes2/game/highscores.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022                                                    *
+ *   Copyright (C) 2022 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
close #6970

We save highscores file only when a player complete a single map / campaign. This is done to save data using the same language user chosen to use.