### PR TITLE
Rework the search algorithm for available scaled resolutions

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -134,7 +134,7 @@ namespace
             const fheroes2::ResolutionInfo lowestResolution = *( resolutions.begin() );
 
             for ( const fheroes2::ResolutionInfo & resolution : possibleResolutions ) {
-                if ( lowestResolution < resolution || lowestResolution == resolution ) {
+                if ( lowestResolution.gameWidth < resolution.gameWidth || lowestResolution.gameHeight < resolution.gameHeight || lowestResolution == resolution ) {
                     continue;
                 }
 


### PR DESCRIPTION
Related to #7046

Use the reverse logic to search the available scaled resolutions: do not search for bigger resolutions for existing smaller ones (640x480 -> 1280x960) but add lower "pseudo-resolutions" for existing bigger resolutions instead (1280x1024 -> 640x512x2).

![resolutions](https://user-images.githubusercontent.com/32623900/233808084-ba5f7d60-e747-4b16-a095-36ff9d01e958.jpg)
