### PR TITLE
Do not reset castle or heroes scrollbars when hero moves

### DIFF
--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -179,9 +179,10 @@ namespace Interface
             return controlPanel;
         }
 
+        void SetFocus( Heroes *, const bool retainScrollBarPosition );
         void SetFocus( Heroes * );
         void SetFocus( Castle * );
-        void ResetFocus( const int priority, const bool resetScrollBarPosition );
+        void ResetFocus( const int priority, const bool retainScrollBarPosition );
         void RedrawFocus();
         void updateFocus();
 

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -181,7 +181,7 @@ namespace Interface
 
         void SetFocus( Heroes * );
         void SetFocus( Castle * );
-        void ResetFocus( int priority, const bool resetScrollBarPosition = true );
+        void ResetFocus( const int priority, const bool resetScrollBarPosition );
         void RedrawFocus();
         void updateFocus();
 

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -181,7 +181,7 @@ namespace Interface
 
         void SetFocus( Heroes * );
         void SetFocus( Castle * );
-        void ResetFocus( int );
+        void ResetFocus( int priority, const bool resetScrollBarPosition = true );
         void RedrawFocus();
         void updateFocus();
 

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -180,7 +180,6 @@ namespace Interface
         }
 
         void SetFocus( Heroes *, const bool retainScrollBarPosition );
-        void SetFocus( Heroes * );
         void SetFocus( Castle * );
         void ResetFocus( const int priority, const bool retainScrollBarPosition );
         void RedrawFocus();

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1159,7 +1159,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
                             Interface::Basic::RedrawLocker redrawLocker( Interface::Basic::Get() );
 
                             gameArea.SetCenter( hero->GetCenter() );
-                            ResetFocus( GameFocus::HEROES );
+                            ResetFocus( GameFocus::HEROES, false);
 
                             RedrawFocus();
 
@@ -1181,7 +1181,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
                                 gameArea.ShiftCenter( movement );
 
                                 Game::SetUpdateSoundsOnFocusUpdate( false );
-                                ResetFocus( GameFocus::HEROES );
+                                ResetFocus( GameFocus::HEROES, false );
                                 Game::SetUpdateSoundsOnFocusUpdate( true );
                                 heroAnimationFrameCount = 32 - heroMovementSkipValue;
                                 heroAnimationSpriteId = hero->GetSpriteIndex();

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -250,7 +250,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
             }
         }
         else {
-            basicInterface.ResetFocus( GameFocus::HEROES, true );
+            basicInterface.ResetFocus( GameFocus::HEROES, false );
         }
     }
     else {
@@ -322,7 +322,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameW
             basicInterface.SetFocus( *it );
         }
         else {
-            basicInterface.ResetFocus( GameFocus::HEROES, true );
+            basicInterface.ResetFocus( GameFocus::HEROES, false );
         }
     }
 
@@ -821,7 +821,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
         updateFocus();
     }
     else {
-        ResetFocus( GameFocus::FIRSTHERO, true );
+        ResetFocus( GameFocus::FIRSTHERO, false );
     }
 
     radar.SetHide( false );
@@ -1159,7 +1159,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
                             Interface::Basic::RedrawLocker redrawLocker( Interface::Basic::Get() );
 
                             gameArea.SetCenter( hero->GetCenter() );
-                            ResetFocus( GameFocus::HEROES, false );
+                            ResetFocus( GameFocus::HEROES, true );
 
                             RedrawFocus();
 
@@ -1181,7 +1181,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
                                 gameArea.ShiftCenter( movement );
 
                                 Game::SetUpdateSoundsOnFocusUpdate( false );
-                                ResetFocus( GameFocus::HEROES, false );
+                                ResetFocus( GameFocus::HEROES, true );
                                 Game::SetUpdateSoundsOnFocusUpdate( true );
                                 heroAnimationFrameCount = 32 - heroMovementSkipValue;
                                 heroAnimationSpriteId = hero->GetSpriteIndex();

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1159,7 +1159,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
                             Interface::Basic::RedrawLocker redrawLocker( Interface::Basic::Get() );
 
                             gameArea.SetCenter( hero->GetCenter() );
-                            ResetFocus( GameFocus::HEROES, false);
+                            ResetFocus( GameFocus::HEROES, false );
 
                             RedrawFocus();
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -250,7 +250,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
             }
         }
         else {
-            basicInterface.ResetFocus( GameFocus::HEROES );
+            basicInterface.ResetFocus( GameFocus::HEROES, true );
         }
     }
     else {
@@ -322,7 +322,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameW
             basicInterface.SetFocus( *it );
         }
         else {
-            basicInterface.ResetFocus( GameFocus::HEROES );
+            basicInterface.ResetFocus( GameFocus::HEROES, true );
         }
     }
 
@@ -821,7 +821,7 @@ fheroes2::GameMode Interface::Basic::HumanTurn( const bool isload )
         updateFocus();
     }
     else {
-        ResetFocus( GameFocus::FIRSTHERO );
+        ResetFocus( GameFocus::FIRSTHERO, true );
     }
 
     radar.SetHide( false );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -238,7 +238,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
 
     if ( updateFocus ) {
         if ( heroCountBefore < myKingdom.GetHeroes().size() ) {
-            basicInterface.SetFocus( myKingdom.GetHeroes()[heroCountBefore] );
+            basicInterface.SetFocus( myKingdom.GetHeroes()[heroCountBefore], false );
         }
         else if ( it != myCastles.end() ) {
             Heroes * heroInCastle = world.GetTiles( ( *it )->GetIndex() ).GetHeroes();
@@ -246,7 +246,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */ )
                 basicInterface.SetFocus( *it );
             }
             else {
-                basicInterface.SetFocus( heroInCastle );
+                basicInterface.SetFocus( heroInCastle, false );
             }
         }
         else {
@@ -319,7 +319,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, bool windowIsGameW
 
     if ( updateFocus ) {
         if ( it != myHeroes.end() ) {
-            basicInterface.SetFocus( *it );
+            basicInterface.SetFocus( *it, false );
         }
         else {
             basicInterface.ResetFocus( GameFocus::HEROES, false );
@@ -1300,7 +1300,7 @@ void Interface::Basic::MouseCursorAreaClickLeft( const int32_t index_maps )
         // focus change/open hero
         if ( nullptr != to_hero ) {
             if ( !from_hero || from_hero != to_hero ) {
-                SetFocus( to_hero );
+                SetFocus( to_hero, false );
                 CalculateHeroPath( to_hero, -1 );
                 RedrawFocus();
             }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -165,7 +165,7 @@ void Interface::Basic::EventNextHero()
             if ( it == myHeroes.end() )
                 it = myHeroes.begin();
             if ( ( *it )->MayStillMove( true, false ) ) {
-                SetFocus( *it );
+                SetFocus( *it, false );
                 CalculateHeroPath( *it, -1 );
                 break;
             }
@@ -174,7 +174,7 @@ void Interface::Basic::EventNextHero()
     else {
         for ( Heroes * hero : myHeroes ) {
             if ( hero->MayStillMove( true, false ) ) {
-                SetFocus( hero );
+                SetFocus( hero, false );
                 CalculateHeroPath( hero, -1 );
                 break;
             }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -217,7 +217,7 @@ void Interface::Basic::EventCastSpell()
 
         // The spell will consume the hero's spell points (and perhaps also movement points) and can move the
         // hero to another location, so we may have to update the terrain music theme and environment sounds
-        ResetFocus( GameFocus::HEROES );
+        ResetFocus( GameFocus::HEROES, true );
         RedrawFocus();
     }
 }
@@ -298,7 +298,7 @@ void Interface::Basic::EventNextTown()
             SetFocus( *it );
         }
         else
-            ResetFocus( GameFocus::CASTLE );
+            ResetFocus( GameFocus::CASTLE, true );
 
         RedrawFocus();
     }
@@ -467,7 +467,7 @@ fheroes2::GameMode Interface::Basic::EventDefaultAction( const fheroes2::GameMod
 
             // The action object can alter the status of the hero (e.g. Stables or Well) or
             // move it to another location (e.g. Stone Liths or Whirlpool)
-            ResetFocus( GameFocus::HEROES );
+            ResetFocus( GameFocus::HEROES, true );
             RedrawFocus();
 
             // If a hero completed an action we must verify the condition for the scenario.

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -116,7 +116,7 @@ void Interface::Basic::ShowPathOrStartMoveHero( Heroes * hero, int32_t destinati
     }
     // start move
     else if ( path.isValid() && hero->MayStillMove( false, true ) ) {
-        SetFocus( hero );
+        SetFocus( hero, true );
         RedrawFocus();
 
         hero->SetMove( true );
@@ -217,7 +217,7 @@ void Interface::Basic::EventCastSpell()
 
         // The spell will consume the hero's spell points (and perhaps also movement points) and can move the
         // hero to another location, so we may have to update the terrain music theme and environment sounds
-        ResetFocus( GameFocus::HEROES, true );
+        ResetFocus( GameFocus::HEROES, false );
         RedrawFocus();
     }
 }
@@ -298,7 +298,7 @@ void Interface::Basic::EventNextTown()
             SetFocus( *it );
         }
         else
-            ResetFocus( GameFocus::CASTLE, true );
+            ResetFocus( GameFocus::CASTLE, false );
 
         RedrawFocus();
     }
@@ -467,7 +467,7 @@ fheroes2::GameMode Interface::Basic::EventDefaultAction( const fheroes2::GameMod
 
             // The action object can alter the status of the hero (e.g. Stables or Well) or
             // move it to another location (e.g. Stone Liths or Whirlpool)
-            ResetFocus( GameFocus::HEROES, true );
+            ResetFocus( GameFocus::HEROES, false );
             RedrawFocus();
 
             // If a hero completed an action we must verify the condition for the scenario.

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -217,7 +217,7 @@ void Interface::Basic::EventCastSpell()
 
         // The spell will consume the hero's spell points (and perhaps also movement points) and can move the
         // hero to another location, so we may have to update the terrain music theme and environment sounds
-        ResetFocus( GameFocus::HEROES, false );
+        ResetFocus( GameFocus::HEROES, true );
         RedrawFocus();
     }
 }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -467,7 +467,7 @@ fheroes2::GameMode Interface::Basic::EventDefaultAction( const fheroes2::GameMod
 
             // The action object can alter the status of the hero (e.g. Stables or Well) or
             // move it to another location (e.g. Stone Liths or Whirlpool)
-            ResetFocus( GameFocus::HEROES, false );
+            ResetFocus( GameFocus::HEROES, true );
             RedrawFocus();
 
             // If a hero completed an action we must verify the condition for the scenario.

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -155,8 +155,12 @@ void Interface::Basic::ResetFocus( const int priority, const bool retainScrollBa
     case GameFocus::HEROES:
         if ( focus.GetHeroes() && focus.GetHeroes()->GetColor() == player->GetColor() )
             SetFocus( focus.GetHeroes(), retainScrollBarPosition );
-        else if ( !myKingdom.GetHeroes().empty() )
+        else if ( !myKingdom.GetHeroes().empty() ) {
+            // Reset scrollbar here because the current focused hero might have
+            // lost a battle and is not in the heroes list anymore.
+            iconsPanel.ResetIcons( ICON_HEROES );
             SetFocus( myKingdom.GetHeroes().front(), false );
+        }
         else if ( !myKingdom.GetCastles().empty() ) {
             iconsPanel.SetRedraw( ICON_HEROES );
             SetFocus( myKingdom.GetCastles().front() );
@@ -168,8 +172,10 @@ void Interface::Basic::ResetFocus( const int priority, const bool retainScrollBa
     case GameFocus::CASTLE:
         if ( focus.GetCastle() && focus.GetCastle()->GetColor() == player->GetColor() )
             SetFocus( focus.GetCastle() );
-        else if ( !myKingdom.GetCastles().empty() )
+        else if ( !myKingdom.GetCastles().empty() ) {
+            iconsPanel.ResetIcons( ICON_CASTLES );
             SetFocus( myKingdom.GetCastles().front() );
+        }
         else if ( !myKingdom.GetHeroes().empty() ) {
             iconsPanel.SetRedraw( ICON_CASTLES );
             SetFocus( myKingdom.GetHeroes().front(), false );

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -129,8 +129,8 @@ void Interface::Basic::ResetFocus( int priority, const bool resetScrollBarPositi
         Focus & focus = player->GetFocus();
         Kingdom & myKingdom = world.GetKingdom( player->GetColor() );
 
-        if (resetScrollBarPosition) {
-            iconsPanel.ResetIcons( ICON_ANY);
+        if ( resetScrollBarPosition ) {
+            iconsPanel.ResetIcons( ICON_ANY );
         }
 
         switch ( priority ) {

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -189,7 +189,7 @@ int Interface::GetFocusType()
 
         if ( focus.GetHeroes() )
             return GameFocus::HEROES;
-        else if ( focus.GetCastle() )
+        if ( focus.GetCastle() )
             return GameFocus::CASTLE;
     }
 
@@ -223,11 +223,7 @@ void Interface::Basic::RedrawFocus()
         iconsPanel.SetRedraw();
     }
 
-    if ( type != FOCUS_CASTLE && iconsPanel.IsSelected( ICON_CASTLES ) ) {
-        iconsPanel.ResetIcons( ICON_CASTLES );
-        iconsPanel.SetRedraw();
-    }
-    else if ( type == FOCUS_CASTLE && !iconsPanel.IsSelected( ICON_CASTLES ) ) {
+    if ( type == FOCUS_CASTLE && !iconsPanel.IsSelected( ICON_CASTLES ) ) {
         iconsPanel.Select( GetFocusCastle() );
         iconsPanel.SetRedraw();
     }

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -40,11 +40,6 @@
 #include "settings.h"
 #include "world.h"
 
-void Interface::Basic::SetFocus( Heroes * hero )
-{
-    SetFocus( hero, false );
-}
-
 void Interface::Basic::SetFocus( Heroes * hero, const bool retainScrollBarPosition )
 {
     Player * player = Settings::Get().GetPlayers().GetCurrent();
@@ -125,7 +120,7 @@ void Interface::Basic::updateFocus()
         Heroes * hero = GetFocusHeroes();
 
         if ( hero != nullptr ) {
-            SetFocus( hero );
+            SetFocus( hero, false );
         }
     }
 }
@@ -151,7 +146,7 @@ void Interface::Basic::ResetFocus( const int priority, const bool retainScrollBa
         KingdomHeroes::const_iterator it = std::find_if( heroes.begin(), heroes.end(), []( const Heroes * hero ) { return !hero->Modes( Heroes::SLEEPER ); } );
 
         if ( it != heroes.end() )
-            SetFocus( *it );
+            SetFocus( *it, false );
         else
             ResetFocus( GameFocus::CASTLE, retainScrollBarPosition );
         break;
@@ -161,7 +156,7 @@ void Interface::Basic::ResetFocus( const int priority, const bool retainScrollBa
         if ( focus.GetHeroes() && focus.GetHeroes()->GetColor() == player->GetColor() )
             SetFocus( focus.GetHeroes(), retainScrollBarPosition );
         else if ( !myKingdom.GetHeroes().empty() )
-            SetFocus( myKingdom.GetHeroes().front() );
+            SetFocus( myKingdom.GetHeroes().front(), false );
         else if ( !myKingdom.GetCastles().empty() ) {
             iconsPanel.SetRedraw( ICON_HEROES );
             SetFocus( myKingdom.GetCastles().front() );
@@ -177,7 +172,7 @@ void Interface::Basic::ResetFocus( const int priority, const bool retainScrollBa
             SetFocus( myKingdom.GetCastles().front() );
         else if ( !myKingdom.GetHeroes().empty() ) {
             iconsPanel.SetRedraw( ICON_CASTLES );
-            SetFocus( myKingdom.GetHeroes().front() );
+            SetFocus( myKingdom.GetHeroes().front(), false );
         }
         else
             focus.Reset();

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -57,7 +57,6 @@ void Interface::Basic::SetFocus( Heroes * hero )
 
         Redraw( REDRAW_BUTTONS );
 
-        iconsPanel.Select( hero );
         gameArea.SetCenter( hero->GetCenter() );
         statusWindow.SetState( StatusType::STATUS_ARMY );
 
@@ -122,7 +121,7 @@ void Interface::Basic::updateFocus()
     }
 }
 
-void Interface::Basic::ResetFocus( int priority )
+void Interface::Basic::ResetFocus( int priority, const bool resetScrollBarPosition /* = true */ )
 {
     Player * player = Settings::Get().GetPlayers().GetCurrent();
 
@@ -130,7 +129,7 @@ void Interface::Basic::ResetFocus( int priority )
         Focus & focus = player->GetFocus();
         Kingdom & myKingdom = world.GetKingdom( player->GetColor() );
 
-        iconsPanel.ResetIcons( ICON_ANY );
+        iconsPanel.ResetIcons( ICON_ANY, resetScrollBarPosition );
 
         switch ( priority ) {
         case GameFocus::FIRSTHERO: {
@@ -141,7 +140,7 @@ void Interface::Basic::ResetFocus( int priority )
             if ( it != heroes.end() )
                 SetFocus( *it );
             else
-                ResetFocus( GameFocus::CASTLE );
+                ResetFocus( GameFocus::CASTLE, resetScrollBarPosition );
             break;
         }
 

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -42,6 +42,11 @@
 
 void Interface::Basic::SetFocus( Heroes * hero )
 {
+    SetFocus( hero, false );
+}
+
+void Interface::Basic::SetFocus( Heroes * hero, const bool retainScrollBarPosition )
+{
     Player * player = Settings::Get().GetPlayers().GetCurrent();
 
     if ( player ) {
@@ -56,6 +61,10 @@ void Interface::Basic::SetFocus( Heroes * hero )
         focus.Set( hero );
 
         Redraw( REDRAW_BUTTONS );
+
+        if ( !retainScrollBarPosition ) {
+            iconsPanel.Select( hero );
+        }
 
         gameArea.SetCenter( hero->GetCenter() );
         statusWindow.SetState( StatusType::STATUS_ARMY );
@@ -121,7 +130,7 @@ void Interface::Basic::updateFocus()
     }
 }
 
-void Interface::Basic::ResetFocus( const int priority, const bool resetScrollBarPosition )
+void Interface::Basic::ResetFocus( const int priority, const bool retainScrollBarPosition )
 {
     Player * player = Settings::Get().GetPlayers().GetCurrent();
     if ( player == nullptr ) {
@@ -131,7 +140,7 @@ void Interface::Basic::ResetFocus( const int priority, const bool resetScrollBar
     Focus & focus = player->GetFocus();
     Kingdom & myKingdom = world.GetKingdom( player->GetColor() );
 
-    if ( resetScrollBarPosition ) {
+    if ( !retainScrollBarPosition ) {
         iconsPanel.ResetIcons( ICON_ANY );
     }
 
@@ -144,13 +153,13 @@ void Interface::Basic::ResetFocus( const int priority, const bool resetScrollBar
         if ( it != heroes.end() )
             SetFocus( *it );
         else
-            ResetFocus( GameFocus::CASTLE, resetScrollBarPosition );
+            ResetFocus( GameFocus::CASTLE, retainScrollBarPosition );
         break;
     }
 
     case GameFocus::HEROES:
         if ( focus.GetHeroes() && focus.GetHeroes()->GetColor() == player->GetColor() )
-            SetFocus( focus.GetHeroes() );
+            SetFocus( focus.GetHeroes(), retainScrollBarPosition );
         else if ( !myKingdom.GetHeroes().empty() )
             SetFocus( myKingdom.GetHeroes().front() );
         else if ( !myKingdom.GetCastles().empty() ) {
@@ -223,7 +232,11 @@ void Interface::Basic::RedrawFocus()
         iconsPanel.SetRedraw();
     }
 
-    if ( type == FOCUS_CASTLE && !iconsPanel.IsSelected( ICON_CASTLES ) ) {
+    if ( type != FOCUS_CASTLE && iconsPanel.IsSelected( ICON_CASTLES ) ) {
+        iconsPanel.ResetIcons( ICON_CASTLES );
+        iconsPanel.SetRedraw();
+    }
+    else if ( type == FOCUS_CASTLE && !iconsPanel.IsSelected( ICON_CASTLES ) ) {
         iconsPanel.Select( GetFocusCastle() );
         iconsPanel.SetRedraw();
     }

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -129,7 +129,9 @@ void Interface::Basic::ResetFocus( int priority, const bool resetScrollBarPositi
         Focus & focus = player->GetFocus();
         Kingdom & myKingdom = world.GetKingdom( player->GetColor() );
 
-        iconsPanel.ResetIcons( ICON_ANY, resetScrollBarPosition );
+        if (resetScrollBarPosition) {
+            iconsPanel.ResetIcons( ICON_ANY);
+        }
 
         switch ( priority ) {
         case GameFocus::FIRSTHERO: {

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -409,11 +409,11 @@ void Interface::IconsPanel::Select( Castle * const cs )
     castleIcons.SetCurrent( cs );
 }
 
-void Interface::IconsPanel::ResetIcons( const icons_t type )
+void Interface::IconsPanel::ResetIcons( const icons_t type, const bool resetScrollBarPosition /* = true */ )
 {
     Kingdom & kingdom = world.GetKingdom( Settings::Get().CurrentColor() );
 
-    if ( !kingdom.isControlAI() ) {
+    if ( !kingdom.isControlAI() && resetScrollBarPosition ) {
         const int icnscroll = Settings::Get().isEvilInterfaceEnabled() ? ICN::SCROLLE : ICN::SCROLL;
 
         const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -219,12 +219,12 @@ void Interface::HeroesIcons::RedrawBackground( const fheroes2::Point & pos )
 
 void Interface::HeroesIcons::ActionCurrentUp()
 {
-    Interface::Basic::Get().SetFocus( GetCurrent() );
+    Interface::Basic::Get().SetFocus( GetCurrent(), false );
 }
 
 void Interface::HeroesIcons::ActionCurrentDn()
 {
-    Interface::Basic::Get().SetFocus( GetCurrent() );
+    Interface::Basic::Get().SetFocus( GetCurrent(), false );
 }
 
 void Interface::HeroesIcons::ActionListDoubleClick( HEROES & item )
@@ -239,7 +239,7 @@ void Interface::HeroesIcons::ActionListSingleClick( HEROES & item )
     if ( item ) {
         Interface::Basic & I = Interface::Basic::Get();
 
-        I.SetFocus( item );
+        I.SetFocus( item, false );
         I.CalculateHeroPath( item, -1 );
         I.RedrawFocus();
     }

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2022                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -409,11 +409,11 @@ void Interface::IconsPanel::Select( Castle * const cs )
     castleIcons.SetCurrent( cs );
 }
 
-void Interface::IconsPanel::ResetIcons( const icons_t type, const bool resetScrollBarPosition /* = true */ )
+void Interface::IconsPanel::ResetIcons( const icons_t type )
 {
     Kingdom & kingdom = world.GetKingdom( Settings::Get().CurrentColor() );
 
-    if ( !kingdom.isControlAI() && resetScrollBarPosition ) {
+    if ( !kingdom.isControlAI() ) {
         const int icnscroll = Settings::Get().isEvilInterfaceEnabled() ? ICN::SCROLLE : ICN::SCROLL;
 
         const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );

--- a/src/fheroes2/gui/interface_icons.h
+++ b/src/fheroes2/gui/interface_icons.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -181,7 +181,7 @@ namespace Interface
         void Select( Castle * const );
 
         bool IsSelected( const icons_t type ) const;
-        void ResetIcons( const icons_t type );
+        void ResetIcons( const icons_t type, const bool resetScrollBarPosition = true );
         void HideIcons( const icons_t type );
         void ShowIcons( const icons_t type );
 

--- a/src/fheroes2/gui/interface_icons.h
+++ b/src/fheroes2/gui/interface_icons.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2022                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -181,7 +181,7 @@ namespace Interface
         void Select( Castle * const );
 
         bool IsSelected( const icons_t type ) const;
-        void ResetIcons( const icons_t type, const bool resetScrollBarPosition = true );
+        void ResetIcons( const icons_t type );
         void HideIcons( const icons_t type );
         void ShowIcons( const icons_t type );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3488,7 +3488,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
         {
             Interface::Basic & I = Interface::Basic::Get();
 
-            I.ResetFocus( GameFocus::HEROES, false );
+            I.ResetFocus( GameFocus::HEROES, true );
             I.RedrawFocus();
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3488,7 +3488,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
         {
             Interface::Basic & I = Interface::Basic::Get();
 
-            I.ResetFocus( GameFocus::HEROES );
+            I.ResetFocus( GameFocus::HEROES, false );
             I.RedrawFocus();
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3502,7 +3502,7 @@ void Heroes::Action( int tileIndex, bool isDestination )
         focusUpdater = std::make_unique<FocusUpdater>();
 
         if ( isAIControlledForHumanPlayer ) {
-            Interface::Basic::Get().SetFocus( this );
+            Interface::Basic::Get().SetFocus( this, false );
         }
     }
 


### PR DESCRIPTION
Solves https://github.com/ihhub/fheroes2/issues/6837. Now both castles and heroes scrollbars positions are retained when hero moves. Previously both of them were modified. Castle scrollbar always goes to the top and heroes scrollbar is either placed to the top or bottom of the scrollbar view depending on the hero's position on the list.