### PR TITLE
Adust spell info message when hero has zero (0) mana

### DIFF
--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -361,8 +361,17 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
     }
 
     if ( !HaveSpellPoints( spell ) ) {
-        if ( res ) {
+        const Heroes * hero = dynamic_cast<const Heroes *>( this );
+        assert( hero != nullptr );
+
+        if ( hero->GetSpellPoints() == 0 && res ) {
+            *res = _( "That spell costs %{mana} mana. You have no mana, so you can't cast the spell." );
+            StringReplace( *res, "%{mana}", spell.spellPoints( hero ) );
+        }
+        else if ( res ) {
             *res = _( "That spell costs %{mana} mana. You only have %{point} mana, so you can't cast the spell." );
+            StringReplace( *res, "%{mana}", spell.spellPoints( hero ) );
+            StringReplace( *res, "%{point}", hero->GetSpellPoints() );
         }
         return false;
     }

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -361,17 +361,14 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
     }
 
     if ( !HaveSpellPoints( spell ) ) {
-        const Heroes * hero = dynamic_cast<const Heroes *>( this );
-        assert( hero != nullptr );
-
-        if ( hero->GetSpellPoints() == 0 && res ) {
+        if ( GetSpellPoints() == 0 && res ) {
             *res = _( "That spell costs %{mana} mana. You have no mana, so you can't cast the spell." );
-            StringReplace( *res, "%{mana}", spell.spellPoints( hero ) );
+            StringReplace( *res, "%{mana}", spell.spellPoints( this ) );
         }
         else if ( res ) {
             *res = _( "That spell costs %{mana} mana. You only have %{point} mana, so you can't cast the spell." );
-            StringReplace( *res, "%{mana}", spell.spellPoints( hero ) );
-            StringReplace( *res, "%{point}", hero->GetSpellPoints() );
+            StringReplace( *res, "%{mana}", spell.spellPoints( this ) );
+            StringReplace( *res, "%{point}", GetSpellPoints() );
         }
         return false;
     }

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -361,11 +361,11 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
     }
 
     if ( !HaveSpellPoints( spell ) ) {
-        if ( GetSpellPoints() == 0 && res ) {
+        if ( GetSpellPoints() == 0 && res != nullptr ) {
             *res = _( "That spell costs %{mana} mana. You have no mana, so you can't cast the spell." );
             StringReplace( *res, "%{mana}", spell.spellPoints( this ) );
         }
-        else if ( res ) {
+        else if ( res != nullptr ) {
             *res = _( "That spell costs %{mana} mana. You only have %{point} mana, so you can't cast the spell." );
             StringReplace( *res, "%{mana}", spell.spellPoints( this ) );
             StringReplace( *res, "%{point}", GetSpellPoints() );

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -297,12 +297,8 @@ Spell SpellBook::Open( const HeroBase & hero, const Filter displayableSpells, co
                             curspell = *spell;
                             break;
                         }
-                        else {
-                            StringReplace( str, "%{mana}", ( *spell ).spellPoints( &hero ) );
-                            StringReplace( str, "%{point}", hero.GetSpellPoints() );
-                            Dialog::Message( spell->GetName(), str, Font::BIG, Dialog::OK );
-                            display.render();
-                        }
+                        Dialog::Message( spell->GetName(), str, Font::BIG, Dialog::OK );
+                        display.render();
                     }
                     else {
                         fheroes2::SpellDialogElement( *spell, &hero ).showPopup( Dialog::OK );


### PR DESCRIPTION
Solves https://github.com/ihhub/fheroes2/issues/5259 by changing the message to "You have no mana..." when hero has 0 mana points.

![image](https://user-images.githubusercontent.com/11016113/233849569-caf3bc69-2968-4b14-9354-24312e294959.png)
