### PR TITLE
Android Toolset: implement animation extraction from HOMM2.GOG

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -57,6 +57,13 @@ IncludeCategories:
 IndentCaseLabels: false
 IndentWidth: 4
 IndentWrappedFunctionNames: true
+JavaImportGroups:
+  - 'java'
+  - 'android'
+  - 'androidx'
+  - 'org.apache'
+  - 'org.libsdl'
+  - 'com.github.stephenc'
 KeepEmptyLinesAtTheStartOfBlocks: false
 MaxEmptyLinesToKeep: 1
 NamespaceIndentation: All

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -63,12 +63,17 @@ jobs:
       if: ${{ github.event_name == 'pull_request' }}
       run: |
         cd android
-        ./gradlew app:lint
+        ./gradlew app:lint isotools:lint
     - uses: actions/upload-artifact@v3
       if: ${{ github.event_name == 'pull_request' && ( success() || failure() ) }}
       with:
-        name: android-lint-report
+        name: android-app-lint-report
         path: android/app/build/reports/
+    - uses: actions/upload-artifact@v3
+      if: ${{ github.event_name == 'pull_request' && ( success() || failure() ) }}
+      with:
+        name: android-isotools-lint-report
+        path: android/isotools/build/reports/
     - name: Create package
       run: |
         7z a -bb1 -tzip -- fheroes2_android.zip LICENSE changelog.txt fheroes2.aab fheroes2.apk ./docs/README.txt ./docs/README_android.md

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,7 +80,7 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.3'
 
     implementation project(':isotools')
     implementation project(':sdl2')

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,8 +82,11 @@ android {
 dependencies {
     coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs:2.0.3'
 
+    implementation project(':isotools')
     implementation project(':sdl2')
+
     implementation group: 'commons-io', name: 'commons-io', version: '2.11.0'
+
     implementation 'com.google.android.material:material:1.8.0'
 }
 

--- a/android/app/src/main/java/org/fheroes2/GameActivity.java
+++ b/android/app/src/main/java/org/fheroes2/GameActivity.java
@@ -94,7 +94,7 @@ public final class GameActivity extends SDLActivity
 
                 final File outFileDir = outFile.getParentFile();
                 if ( outFileDir != null ) {
-                    outFileDir.mkdirs();
+                    Files.createDirectories( outFileDir.toPath() );
                 }
 
                 try ( final OutputStream out = Files.newOutputStream( outFile.toPath() ) ) {

--- a/android/app/src/main/java/org/fheroes2/GameActivity.java
+++ b/android/app/src/main/java/org/fheroes2/GameActivity.java
@@ -74,6 +74,7 @@ public final class GameActivity extends SDLActivity
         System.exit( 0 );
     }
 
+    @SuppressWarnings( "IOStreamConstructor" ) // Files.newOutputStream() requires API level 26
     private void extractAssets( final String srcPath, final File dstDir )
     {
         final ArrayList<String> assetsPaths;

--- a/android/app/src/main/java/org/fheroes2/GameActivity.java
+++ b/android/app/src/main/java/org/fheroes2/GameActivity.java
@@ -26,6 +26,7 @@ import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.file.Files;
 import java.util.ArrayList;
+import java.util.List;
 
 import android.content.Intent;
 import android.os.Bundle;
@@ -76,7 +77,7 @@ public final class GameActivity extends SDLActivity
 
     private void extractAssets( final String srcPath, final File dstDir )
     {
-        final ArrayList<String> assetsPaths;
+        final List<String> assetsPaths;
 
         try {
             assetsPaths = getAssetsPaths( srcPath );
@@ -106,9 +107,9 @@ public final class GameActivity extends SDLActivity
         }
     }
 
-    private ArrayList<String> getAssetsPaths( final String path ) throws IOException
+    private List<String> getAssetsPaths( final String path ) throws IOException
     {
-        final ArrayList<String> result = new ArrayList<>();
+        final List<String> result = new ArrayList<>();
 
         final String[] assets = getAssets().list( path );
 

--- a/android/app/src/main/java/org/fheroes2/GameActivity.java
+++ b/android/app/src/main/java/org/fheroes2/GameActivity.java
@@ -20,16 +20,19 @@
 
 package org.fheroes2;
 
-import android.content.Intent;
-import android.os.Bundle;
-import android.util.Log;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.ArrayList;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+
 import org.apache.commons.io.IOUtils;
+
 import org.libsdl.app.SDLActivity;
 
 public final class GameActivity extends SDLActivity

--- a/android/app/src/main/java/org/fheroes2/GameActivity.java
+++ b/android/app/src/main/java/org/fheroes2/GameActivity.java
@@ -21,10 +21,10 @@
 package org.fheroes2;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.ArrayList;
 
 import android.content.Intent;
@@ -74,7 +74,6 @@ public final class GameActivity extends SDLActivity
         System.exit( 0 );
     }
 
-    @SuppressWarnings( "IOStreamConstructor" ) // Files.newOutputStream() requires API level 26
     private void extractAssets( final String srcPath, final File dstDir )
     {
         final ArrayList<String> assetsPaths;
@@ -97,7 +96,7 @@ public final class GameActivity extends SDLActivity
                     outFileDir.mkdirs();
                 }
 
-                try ( final OutputStream out = new FileOutputStream( outFile ) ) {
+                try ( final OutputStream out = Files.newOutputStream( outFile.toPath() ) ) {
                     IOUtils.copy( in, out );
                 }
             }

--- a/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
+++ b/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
@@ -31,6 +31,8 @@ import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import android.util.Log;
+
 import org.apache.commons.io.IOUtils;
 
 import com.github.stephenc.javaisotools.loopfs.iso9660.Iso9660FileEntry;
@@ -234,6 +236,10 @@ final class HoMM2AssetManagement
             else {
                 isoStream.write( chunk, 16, 2048 );
             }
+        }
+
+        if ( chunkOffset != 0 ) {
+            Log.w( "fheroes2", "The last chunk of the GOG file was ignored due to the wrong size." );
         }
     }
 }

--- a/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
+++ b/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
@@ -116,6 +116,7 @@ final class HoMM2AssetManagement
         return result;
     }
 
+    // Returns true if at least one animation was found and extracted, otherwise returns false
     private static boolean extractAnimationsFromISO( final File externalFilesDir, final File isoFile ) throws IOException
     {
         // It is allowed to extract only files located in these subdirectories

--- a/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
+++ b/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
@@ -21,10 +21,10 @@
 package org.fheroes2;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.nio.file.Files;
 import java.util.HashSet;
 import java.util.Locale;
 import java.util.Set;
@@ -46,7 +46,6 @@ final class HoMM2AssetManagement
     }
 
     // Returns true if at least one asset was found and extracted, otherwise returns false
-    @SuppressWarnings( "IOStreamConstructor" ) // Files.newOutputStream() requires API level 26
     static boolean extractHoMM2AssetsFromZip( final File externalFilesDir, final File cacheDir, final InputStream iStream ) throws IOException
     {
         // It is allowed to extract only files located in these subdirectories
@@ -79,7 +78,7 @@ final class HoMM2AssetManagement
                 final File isoFile = new File( cacheDir, "homm2.iso" );
 
                 try {
-                    try ( final OutputStream iso = new FileOutputStream( isoFile ) ) {
+                    try ( final OutputStream iso = Files.newOutputStream( isoFile.toPath() ) ) {
                         gogToISO( zStream, iso );
                     }
 
@@ -111,7 +110,7 @@ final class HoMM2AssetManagement
                 outFileDir.mkdirs();
             }
 
-            try ( final OutputStream out = new FileOutputStream( outFile ) ) {
+            try ( final OutputStream out = Files.newOutputStream( outFile.toPath() ) ) {
                 IOUtils.copy( zStream, out );
             }
 
@@ -122,7 +121,6 @@ final class HoMM2AssetManagement
     }
 
     // Returns true if at least one animation was found and extracted, otherwise returns false
-    @SuppressWarnings( "IOStreamConstructor" ) // Files.newOutputStream() requires API level 26
     private static boolean extractAnimationsFromISO( final File externalFilesDir, final File isoFile ) throws IOException
     {
         // It is allowed to extract only files located in these subdirectories
@@ -162,7 +160,7 @@ final class HoMM2AssetManagement
                     outFileDir.mkdirs();
                 }
 
-                try ( final InputStream in = isoFileSystem.getInputStream( isoEntry ); final OutputStream out = new FileOutputStream( outFile ) ) {
+                try ( final InputStream in = isoFileSystem.getInputStream( isoEntry ); final OutputStream out = Files.newOutputStream( outFile.toPath() ) ) {
                     IOUtils.copy( in, out );
                 }
 

--- a/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
+++ b/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
@@ -92,7 +92,7 @@ final class HoMM2AssetManagement
                     result = result || res;
                 }
                 finally {
-                    isoFile.delete();
+                    Files.deleteIfExists( isoFile.toPath() );
                 }
 
                 continue;

--- a/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
+++ b/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
@@ -20,8 +20,6 @@
 
 package org.fheroes2;
 
-import com.github.stephenc.javaisotools.loopfs.iso9660.Iso9660FileEntry;
-import com.github.stephenc.javaisotools.loopfs.iso9660.Iso9660FileSystem;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -32,7 +30,11 @@ import java.util.Locale;
 import java.util.Set;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
+
 import org.apache.commons.io.IOUtils;
+
+import com.github.stephenc.javaisotools.loopfs.iso9660.Iso9660FileEntry;
+import com.github.stephenc.javaisotools.loopfs.iso9660.Iso9660FileSystem;
 
 final class HoMM2AssetManagement
 {

--- a/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
+++ b/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
@@ -112,7 +112,7 @@ final class HoMM2AssetManagement
 
             final File outFileDir = outFile.getParentFile();
             if ( outFileDir != null ) {
-                outFileDir.mkdirs();
+                Files.createDirectories( outFileDir.toPath() );
             }
 
             try ( final OutputStream out = Files.newOutputStream( outFile.toPath() ) ) {
@@ -162,7 +162,7 @@ final class HoMM2AssetManagement
 
                 final File outFileDir = outFile.getParentFile();
                 if ( outFileDir != null ) {
-                    outFileDir.mkdirs();
+                    Files.createDirectories( outFileDir.toPath() );
                 }
 
                 try ( final InputStream in = isoFileSystem.getInputStream( isoEntry ); final OutputStream out = Files.newOutputStream( outFile.toPath() ) ) {

--- a/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
+++ b/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
@@ -46,6 +46,7 @@ final class HoMM2AssetManagement
     }
 
     // Returns true if at least one asset was found and extracted, otherwise returns false
+    @SuppressWarnings( "IOStreamConstructor" ) // Files.newOutputStream() requires API level 26
     static boolean extractHoMM2AssetsFromZip( final File externalFilesDir, final File cacheDir, final InputStream iStream ) throws IOException
     {
         // It is allowed to extract only files located in these subdirectories
@@ -121,6 +122,7 @@ final class HoMM2AssetManagement
     }
 
     // Returns true if at least one animation was found and extracted, otherwise returns false
+    @SuppressWarnings( "IOStreamConstructor" ) // Files.newOutputStream() requires API level 26
     private static boolean extractAnimationsFromISO( final File externalFilesDir, final File isoFile ) throws IOException
     {
         // It is allowed to extract only files located in these subdirectories
@@ -194,6 +196,7 @@ final class HoMM2AssetManagement
         return "";
     }
 
+    @SuppressWarnings( "BooleanMethodIsAlwaysInverted" )
     private static boolean isValidHoMM2AssetPath( final File path, final Set<File> allowedSubdirs ) throws IOException
     {
         for ( File dir = path.getCanonicalFile().getParentFile(); dir != null; dir = dir.getParentFile() ) {

--- a/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
+++ b/android/app/src/main/java/org/fheroes2/HoMM2AssetManagement.java
@@ -40,6 +40,11 @@ import com.github.stephenc.javaisotools.loopfs.iso9660.Iso9660FileSystem;
 
 final class HoMM2AssetManagement
 {
+    private HoMM2AssetManagement()
+    {
+        throw new IllegalStateException( "Instantiation is not allowed" );
+    }
+
     static boolean isHoMM2AssetsPresent( final File externalFilesDir )
     {
         return ( new File( externalFilesDir, "data" + File.separator + "heroes2.agg" ) ).exists();

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -23,6 +23,7 @@ package org.fheroes2;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 import java.util.Objects;
 
 import android.app.AlertDialog;
@@ -48,9 +49,9 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         private static final class Status
         {
             public boolean isBackgroundTaskExecuting;
-            public final ArrayList<String> saveFileNames;
+            public final List<String> saveFileNames;
 
-            Status( final boolean isBackgroundTaskExecuting, final ArrayList<String> saveFileNames )
+            Status( final boolean isBackgroundTaskExecuting, final List<String> saveFileNames )
             {
                 this.isBackgroundTaskExecuting = isBackgroundTaskExecuting;
                 this.saveFileNames = saveFileNames;
@@ -72,7 +73,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             return liveStatus;
         }
 
-        public void updateSaveFileList( final File saveFileDir, final ArrayList<String> allowedSaveFileExtensions )
+        public void updateSaveFileList( final File saveFileDir, final List<String> allowedSaveFileExtensions )
         {
             final Status status = Objects.requireNonNull( liveStatus.getValue() );
 
@@ -90,7 +91,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             } ).start();
         }
 
-        public void deleteSaveFiles( final File saveFileDir, final ArrayList<String> allowedSaveFileExtensions, final ArrayList<String> saveFileNames )
+        public void deleteSaveFiles( final File saveFileDir, final List<String> allowedSaveFileExtensions, final List<String> saveFileNames )
         {
             final Status status = Objects.requireNonNull( liveStatus.getValue() );
 
@@ -126,9 +127,9 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             } ).start();
         }
 
-        private ArrayList<String> getSaveFileList( final File saveFileDir, final ArrayList<String> allowedSaveFileExtensions )
+        private List<String> getSaveFileList( final File saveFileDir, final List<String> allowedSaveFileExtensions )
         {
-            final ArrayList<String> saveFileNames = new ArrayList<>();
+            final List<String> saveFileNames = new ArrayList<>();
 
             final File[] saveFilesList = saveFileDir.listFiles( ( dir, name ) -> {
                 if ( !dir.equals( saveFileDir ) ) {
@@ -254,7 +255,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             .setMessage( res.getQuantityString( R.plurals.activity_save_file_manager_delete_confirmation_message, selectedSaveFilesCount, selectedSaveFilesCount ) )
             .setPositiveButton( R.string.activity_save_file_manager_delete_confirmation_positive_btn_text,
                                 ( dialog, which ) -> {
-                                    final ArrayList<String> saveFileNames = new ArrayList<>();
+                                    final List<String> saveFileNames = new ArrayList<>();
 
                                     for ( int i = 0; i < saveFileListView.getCount(); ++i ) {
                                         if ( saveFileListView.isItemChecked( i ) ) {
@@ -271,9 +272,9 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             .show();
     }
 
-    private ArrayList<String> getAllowedSaveFileExtensions()
+    private List<String> getAllowedSaveFileExtensions()
     {
-        final ArrayList<String> allowedSaveFileExtensions = new ArrayList<>();
+        final List<String> allowedSaveFileExtensions = new ArrayList<>();
 
         if ( filterStandardToggleButton.isChecked() ) {
             allowedSaveFileExtensions.add( ".sav" );
@@ -293,7 +294,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         viewModel.updateSaveFileList( saveFileDir, getAllowedSaveFileExtensions() );
     }
 
-    private void deleteSaveFiles( final ArrayList<String> saveFileNames )
+    private void deleteSaveFiles( final List<String> saveFileNames )
     {
         if ( saveFileNames.isEmpty() ) {
             return;

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -20,6 +20,11 @@
 
 package org.fheroes2;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Objects;
+
 import android.app.AlertDialog;
 import android.content.res.Resources;
 import android.os.Bundle;
@@ -29,15 +34,12 @@ import android.widget.ArrayAdapter;
 import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.ToggleButton;
+
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Objects;
 
 public final class SaveFileManagerActivity extends AppCompatActivity
 {

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -21,6 +21,7 @@
 package org.fheroes2;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -102,13 +103,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                     for ( final String saveFileName : saveFileNames ) {
                         final File saveFile = new File( saveFileDir, saveFileName );
 
-                        if ( !saveFile.isFile() ) {
-                            continue;
-                        }
-
-                        if ( !saveFile.delete() ) {
-                            Log.e( "fheroes2", "Unable to delete save file " + saveFile.getCanonicalPath() );
-                        }
+                        Files.deleteIfExists( saveFile.toPath() );
                     }
                 }
                 catch ( final Exception ex ) {

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -56,6 +56,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                 this.saveFileNames = saveFileNames;
             }
 
+            @SuppressWarnings( "SameParameterValue" )
             Status setIsBackgroundTaskExecuting( final boolean isBackgroundTaskExecuting )
             {
                 this.isBackgroundTaskExecuting = isBackgroundTaskExecuting;

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -73,6 +73,7 @@ public final class ToolsetActivity extends AppCompatActivity
                 return this;
             }
 
+            @SuppressWarnings( "SameParameterValue" )
             Status setIsBackgroundTaskExecuting( final boolean isBackgroundTaskExecuting )
             {
                 this.isBackgroundTaskExecuting = isBackgroundTaskExecuting;

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -20,6 +20,10 @@
 
 package org.fheroes2;
 
+import java.io.File;
+import java.io.InputStream;
+import java.util.Objects;
+
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
@@ -29,6 +33,7 @@ import android.view.View;
 import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
+
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
@@ -36,9 +41,6 @@ import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
-import java.io.File;
-import java.io.InputStream;
-import java.util.Objects;
 
 public final class ToolsetActivity extends AppCompatActivity
 {

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -93,7 +93,7 @@ public final class ToolsetActivity extends AppCompatActivity
             liveStatus.setValue( status.setIsHoMM2AssetsPresent( HoMM2AssetManagement.isHoMM2AssetsPresent( externalFilesDir ) ) );
         }
 
-        public void extractAssets( final File externalFilesDir, final Uri zipFileUri, final ContentResolver contentResolver )
+        public void extractAssets( final File externalFilesDir, final File cacheDir, final Uri zipFileUri, final ContentResolver contentResolver )
         {
             final Status status = Objects.requireNonNull( liveStatus.getValue() );
 
@@ -101,7 +101,7 @@ public final class ToolsetActivity extends AppCompatActivity
 
             new Thread( () -> {
                 try ( final InputStream iStream = contentResolver.openInputStream( zipFileUri ) ) {
-                    if ( HoMM2AssetManagement.extractHoMM2AssetsFromZip( externalFilesDir, iStream ) ) {
+                    if ( HoMM2AssetManagement.extractHoMM2AssetsFromZip( externalFilesDir, cacheDir, iStream ) ) {
                         liveStatus.postValue( new Status( HoMM2AssetManagement.isHoMM2AssetsPresent( externalFilesDir ), false, RESULT_SUCCESS, "" ) );
                     }
                     else {
@@ -125,7 +125,7 @@ public final class ToolsetActivity extends AppCompatActivity
             return;
         }
 
-        viewModel.extractAssets( getExternalFilesDir( null ), result, getContentResolver() );
+        viewModel.extractAssets( getExternalFilesDir( null ), getCacheDir(), result, getContentResolver() );
     } );
 
     @Override

--- a/android/isotools/LICENSE
+++ b/android/isotools/LICENSE
@@ -1,0 +1,458 @@
+            GNU LESSER GENERAL PUBLIC LICENSE
+		          Version 2.1, February 1999
+
+Copyright (C) 1991, 1999 Free Software Foundation, Inc.
+  51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+Everyone is permitted to copy and distribute verbatim copies
+of this license document, but changing it is not allowed.
+
+[This is the first released version of the Lesser GPL.  It also counts
+as the successor of the GNU Library Public License, version 2, hence
+the version number 2.1.]
+
+                        Preamble
+
+  The licenses for most software are designed to take away your
+freedom to share and change it.  By contrast, the GNU General Public
+Licenses are intended to guarantee your freedom to share and change
+free software--to make sure the software is free for all its users.
+
+  This license, the Lesser General Public License, applies to some
+specially designated software packages--typically libraries--of the
+Free Software Foundation and other authors who decide to use it.  You
+can use it too, but we suggest you first think carefully about whether
+this license or the ordinary General Public License is the better
+strategy to use in any particular case, based on the explanations below.
+
+  When we speak of free software, we are referring to freedom of use,
+not price.  Our General Public Licenses are designed to make sure that
+you have the freedom to distribute copies of free software (and charge
+for this service if you wish); that you receive source code or can get
+it if you want it; that you can change the software and use pieces of
+it in new free programs; and that you are informed that you can do
+these things.
+
+  To protect your rights, we need to make restrictions that forbid
+distributors to deny you these rights or to ask you to surrender these
+rights.  These restrictions translate to certain responsibilities for
+you if you distribute copies of the library or if you modify it.
+
+  For example, if you distribute copies of the library, whether gratis
+or for a fee, you must give the recipients all the rights that we gave
+you.  You must make sure that they, too, receive or can get the source
+code.  If you link other code with the library, you must provide
+complete object files to the recipients, so that they can relink them
+with the library after making changes to the library and recompiling
+it.  And you must show them these terms so they know their rights.
+
+  We protect your rights with a two-step method: (1) we copyright the
+library, and (2) we offer you this license, which gives you legal
+permission to copy, distribute and/or modify the library.
+
+  To protect each distributor, we want to make it very clear that
+there is no warranty for the free library.  Also, if the library is
+modified by someone else and passed on, the recipients should know
+that what they have is not the original version, so that the original
+author's reputation will not be affected by problems that might be
+introduced by others.
+
+  Finally, software patents pose a constant threat to the existence of
+any free program.  We wish to make sure that a company cannot
+effectively restrict the users of a free program by obtaining a
+restrictive license from a patent holder.  Therefore, we insist that
+any patent license obtained for a version of the library must be
+consistent with the full freedom of use specified in this license.
+
+  Most GNU software, including some libraries, is covered by the
+ordinary GNU General Public License.  This license, the GNU Lesser
+General Public License, applies to certain designated libraries, and
+is quite different from the ordinary General Public License.  We use
+this license for certain libraries in order to permit linking those
+libraries into non-free programs.
+
+  When a program is linked with a library, whether statically or using
+a shared library, the combination of the two is legally speaking a
+combined work, a derivative of the original library.  The ordinary
+General Public License therefore permits such linking only if the
+entire combination fits its criteria of freedom.  The Lesser General
+Public License permits more lax criteria for linking other code with
+the library.
+
+  We call this license the "Lesser" General Public License because it
+does Less to protect the user's freedom than the ordinary General
+Public License.  It also provides other free software developers Less
+of an advantage over competing non-free programs.  These disadvantages
+are the reason we use the ordinary General Public License for many
+libraries.  However, the Lesser license provides advantages in certain
+special circumstances.
+
+  For example, on rare occasions, there may be a special need to
+encourage the widest possible use of a certain library, so that it becomes
+a de-facto standard.  To achieve this, non-free programs must be
+allowed to use the library.  A more frequent case is that a free
+library does the same job as widely used non-free libraries.  In this
+case, there is little to gain by limiting the free library to free
+software only, so we use the Lesser General Public License.
+
+  In other cases, permission to use a particular library in non-free
+programs enables a greater number of people to use a large body of
+free software.  For example, permission to use the GNU C Library in
+non-free programs enables many more people to use the whole GNU
+operating system, as well as its variant, the GNU/Linux operating
+system.
+
+  Although the Lesser General Public License is Less protective of the
+users' freedom, it does ensure that the user of a program that is
+linked with the Library has the freedom and the wherewithal to run
+that program using a modified version of the Library.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.  Pay close attention to the difference between a
+"work based on the library" and a "work that uses the library".  The
+former contains code derived from the library, whereas the latter must
+be combined with the library in order to run.
+
+        		  GNU LESSER GENERAL PUBLIC LICENSE
+   TERMS AND CONDITIONS FOR COPYING, DISTRIBUTION AND MODIFICATION
+
+  0. This License Agreement applies to any software library or other
+program which contains a notice placed by the copyright holder or
+other authorized party saying it may be distributed under the terms of
+this Lesser General Public License (also called "this License").
+Each licensee is addressed as "you".
+
+  A "library" means a collection of software functions and/or data
+prepared so as to be conveniently linked with application programs
+(which use some of those functions and data) to form executables.
+
+  The "Library", below, refers to any such software library or work
+which has been distributed under these terms.  A "work based on the
+Library" means either the Library or any derivative work under
+copyright law: that is to say, a work containing the Library or a
+portion of it, either verbatim or with modifications and/or translated
+straightforwardly into another language.  (Hereinafter, translation is
+included without limitation in the term "modification".)
+
+  "Source code" for a work means the preferred form of the work for
+making modifications to it.  For a library, complete source code means
+all the source code for all modules it contains, plus any associated
+interface definition files, plus the scripts used to control compilation
+and installation of the library.
+
+  Activities other than copying, distribution and modification are not
+covered by this License; they are outside its scope.  The act of
+running a program using the Library is not restricted, and output from
+such a program is covered only if its contents constitute a work based
+on the Library (independent of the use of the Library in a tool for
+writing it).  Whether that is true depends on what the Library does
+and what the program that uses the Library does.
+
+  1. You may copy and distribute verbatim copies of the Library's
+complete source code as you receive it, in any medium, provided that
+you conspicuously and appropriately publish on each copy an
+appropriate copyright notice and disclaimer of warranty; keep intact
+all the notices that refer to this License and to the absence of any
+warranty; and distribute a copy of this License along with the
+Library.
+
+  You may charge a fee for the physical act of transferring a copy,
+and you may at your option offer warranty protection in exchange for a
+fee.
+
+  2. You may modify your copy or copies of the Library or any portion
+of it, thus forming a work based on the Library, and copy and
+distribute such modifications or work under the terms of Section 1
+above, provided that you also meet all of these conditions:
+
+    a) The modified work must itself be a software library.
+
+    b) You must cause the files modified to carry prominent notices
+    stating that you changed the files and the date of any change.
+
+    c) You must cause the whole of the work to be licensed at no
+    charge to all third parties under the terms of this License.
+
+    d) If a facility in the modified Library refers to a function or a
+    table of data to be supplied by an application program that uses
+    the facility, other than as an argument passed when the facility
+    is invoked, then you must make a good faith effort to ensure that,
+    in the event an application does not supply such function or
+    table, the facility still operates, and performs whatever part of
+    its purpose remains meaningful.
+
+    (For example, a function in a library to compute square roots has
+    a purpose that is entirely well-defined independent of the
+    application.  Therefore, Subsection 2d requires that any
+    application-supplied function or table used by this function must
+    be optional: if the application does not supply it, the square
+    root function must still compute square roots.)
+
+These requirements apply to the modified work as a whole.  If
+identifiable sections of that work are not derived from the Library,
+and can be reasonably considered independent and separate works in
+themselves, then this License, and its terms, do not apply to those
+sections when you distribute them as separate works.  But when you
+distribute the same sections as part of a whole which is a work based
+on the Library, the distribution of the whole must be on the terms of
+this License, whose permissions for other licensees extend to the
+entire whole, and thus to each and every part regardless of who wrote
+it.
+
+Thus, it is not the intent of this section to claim rights or contest
+your rights to work written entirely by you; rather, the intent is to
+exercise the right to control the distribution of derivative or
+collective works based on the Library.
+
+In addition, mere aggregation of another work not based on the Library
+with the Library (or with a work based on the Library) on a volume of
+a storage or distribution medium does not bring the other work under
+the scope of this License.
+
+  3. You may opt to apply the terms of the ordinary GNU General Public
+License instead of this License to a given copy of the Library.  To do
+this, you must alter all the notices that refer to this License, so
+that they refer to the ordinary GNU General Public License, version 2,
+instead of to this License.  (If a newer version than version 2 of the
+ordinary GNU General Public License has appeared, then you can specify
+that version instead if you wish.)  Do not make any other change in
+these notices.
+
+  Once this change is made in a given copy, it is irreversible for
+that copy, so the ordinary GNU General Public License applies to all
+subsequent copies and derivative works made from that copy.
+
+  This option is useful when you wish to copy part of the code of
+the Library into a program that is not a library.
+
+  4. You may copy and distribute the Library (or a portion or
+derivative of it, under Section 2) in object code or executable form
+under the terms of Sections 1 and 2 above provided that you accompany
+it with the complete corresponding machine-readable source code, which
+must be distributed under the terms of Sections 1 and 2 above on a
+medium customarily used for software interchange.
+
+  If distribution of object code is made by offering access to copy
+from a designated place, then offering equivalent access to copy the
+source code from the same place satisfies the requirement to
+distribute the source code, even though third parties are not
+compelled to copy the source along with the object code.
+
+  5. A program that contains no derivative of any portion of the
+Library, but is designed to work with the Library by being compiled or
+linked with it, is called a "work that uses the Library".  Such a
+work, in isolation, is not a derivative work of the Library, and
+therefore falls outside the scope of this License.
+
+  However, linking a "work that uses the Library" with the Library
+creates an executable that is a derivative of the Library (because it
+contains portions of the Library), rather than a "work that uses the
+library".  The executable is therefore covered by this License.
+Section 6 states terms for distribution of such executables.
+
+  When a "work that uses the Library" uses material from a header file
+that is part of the Library, the object code for the work may be a
+derivative work of the Library even though the source code is not.
+Whether this is true is especially significant if the work can be
+linked without the Library, or if the work is itself a library.  The
+threshold for this to be true is not precisely defined by law.
+
+  If such an object file uses only numerical parameters, data
+structure layouts and accessors, and small macros and small inline
+functions (ten lines or less in length), then the use of the object
+file is unrestricted, regardless of whether it is legally a derivative
+work.  (Executables containing this object code plus portions of the
+Library will still fall under Section 6.)
+
+  Otherwise, if the work is a derivative of the Library, you may
+distribute the object code for the work under the terms of Section 6.
+Any executables containing that work also fall under Section 6,
+whether or not they are linked directly with the Library itself.
+
+  6. As an exception to the Sections above, you may also combine or
+link a "work that uses the Library" with the Library to produce a
+work containing portions of the Library, and distribute that work
+under terms of your choice, provided that the terms permit
+modification of the work for the customer's own use and reverse
+engineering for debugging such modifications.
+
+  You must give prominent notice with each copy of the work that the
+Library is used in it and that the Library and its use are covered by
+this License.  You must supply a copy of this License.  If the work
+during execution displays copyright notices, you must include the
+copyright notice for the Library among them, as well as a reference
+directing the user to the copy of this License.  Also, you must do one
+of these things:
+
+    a) Accompany the work with the complete corresponding
+    machine-readable source code for the Library including whatever
+    changes were used in the work (which must be distributed under
+    Sections 1 and 2 above); and, if the work is an executable linked
+    with the Library, with the complete machine-readable "work that
+    uses the Library", as object code and/or source code, so that the
+    user can modify the Library and then relink to produce a modified
+    executable containing the modified Library.  (It is understood
+    that the user who changes the contents of definitions files in the
+    Library will not necessarily be able to recompile the application
+    to use the modified definitions.)
+
+    b) Use a suitable shared library mechanism for linking with the
+    Library.  A suitable mechanism is one that (1) uses at run time a
+    copy of the library already present on the user's computer system,
+    rather than copying library functions into the executable, and (2)
+    will operate properly with a modified version of the library, if
+    the user installs one, as long as the modified version is
+    interface-compatible with the version that the work was made with.
+
+    c) Accompany the work with a written offer, valid for at
+    least three years, to give the same user the materials
+    specified in Subsection 6a, above, for a charge no more
+    than the cost of performing this distribution.
+
+    d) If distribution of the work is made by offering access to copy
+    from a designated place, offer equivalent access to copy the above
+    specified materials from the same place.
+
+    e) Verify that the user has already received a copy of these
+    materials or that you have already sent this user a copy.
+
+  For an executable, the required form of the "work that uses the
+Library" must include any data and utility programs needed for
+reproducing the executable from it.  However, as a special exception,
+the materials to be distributed need not include anything that is
+normally distributed (in either source or binary form) with the major
+components (compiler, kernel, and so on) of the operating system on
+which the executable runs, unless that component itself accompanies
+the executable.
+
+  It may happen that this requirement contradicts the license
+restrictions of other proprietary libraries that do not normally
+accompany the operating system.  Such a contradiction means you cannot
+use both them and the Library together in an executable that you
+distribute.
+
+  7. You may place library facilities that are a work based on the
+Library side-by-side in a single library together with other library
+facilities not covered by this License, and distribute such a combined
+library, provided that the separate distribution of the work based on
+the Library and of the other library facilities is otherwise
+permitted, and provided that you do these two things:
+
+    a) Accompany the combined library with a copy of the same work
+    based on the Library, uncombined with any other library
+    facilities.  This must be distributed under the terms of the
+    Sections above.
+
+    b) Give prominent notice with the combined library of the fact
+    that part of it is a work based on the Library, and explaining
+    where to find the accompanying uncombined form of the same work.
+
+  8. You may not copy, modify, sublicense, link with, or distribute
+the Library except as expressly provided under this License.  Any
+attempt otherwise to copy, modify, sublicense, link with, or
+distribute the Library is void, and will automatically terminate your
+rights under this License.  However, parties who have received copies,
+or rights, from you under this License will not have their licenses
+terminated so long as such parties remain in full compliance.
+
+  9. You are not required to accept this License, since you have not
+signed it.  However, nothing else grants you permission to modify or
+distribute the Library or its derivative works.  These actions are
+prohibited by law if you do not accept this License.  Therefore, by
+modifying or distributing the Library (or any work based on the
+Library), you indicate your acceptance of this License to do so, and
+all its terms and conditions for copying, distributing or modifying
+the Library or works based on it.
+
+  10. Each time you redistribute the Library (or any work based on the
+Library), the recipient automatically receives a license from the
+original licensor to copy, distribute, link with or modify the Library
+subject to these terms and conditions.  You may not impose any further
+restrictions on the recipients' exercise of the rights granted herein.
+You are not responsible for enforcing compliance by third parties with
+this License.
+
+  11. If, as a consequence of a court judgment or allegation of patent
+infringement or for any other reason (not limited to patent issues),
+conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot
+distribute so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you
+may not distribute the Library at all.  For example, if a patent
+license would not permit royalty-free redistribution of the Library by
+all those who receive copies directly or indirectly through you, then
+the only way you could satisfy both it and this License would be to
+refrain entirely from distribution of the Library.
+
+If any portion of this section is held invalid or unenforceable under any
+particular circumstance, the balance of the section is intended to apply,
+and the section as a whole is intended to apply in other circumstances.
+
+It is not the purpose of this section to induce you to infringe any
+patents or other property right claims or to contest validity of any
+such claims; this section has the sole purpose of protecting the
+integrity of the free software distribution system which is
+implemented by public license practices.  Many people have made
+generous contributions to the wide range of software distributed
+through that system in reliance on consistent application of that
+system; it is up to the author/donor to decide if he or she is willing
+to distribute software through any other system and a licensee cannot
+impose that choice.
+
+This section is intended to make thoroughly clear what is believed to
+be a consequence of the rest of this License.
+
+  12. If the distribution and/or use of the Library is restricted in
+certain countries either by patents or by copyrighted interfaces, the
+original copyright holder who places the Library under this License may add
+an explicit geographical distribution limitation excluding those countries,
+so that distribution is permitted only in or among countries not thus
+excluded.  In such case, this License incorporates the limitation as if
+written in the body of this License.
+
+  13. The Free Software Foundation may publish revised and/or new
+versions of the Lesser General Public License from time to time.
+Such new versions will be similar in spirit to the present version,
+but may differ in detail to address new problems or concerns.
+
+Each version is given a distinguishing version number.  If the Library
+specifies a version number of this License which applies to it and
+"any later version", you have the option of following the terms and
+conditions either of that version or of any later version published by
+the Free Software Foundation.  If the Library does not specify a
+license version number, you may choose any version ever published by
+the Free Software Foundation.
+
+  14. If you wish to incorporate parts of the Library into other free
+programs whose distribution conditions are incompatible with these,
+write to the author to ask for permission.  For software which is
+copyrighted by the Free Software Foundation, write to the Free
+Software Foundation; we sometimes make exceptions for this.  Our
+decision will be guided by the two goals of preserving the free status
+of all derivatives of our free software and of promoting the sharing
+and reuse of software generally.
+
+                            NO WARRANTY
+
+  15. BECAUSE THE LIBRARY IS LICENSED FREE OF CHARGE, THERE IS NO
+WARRANTY FOR THE LIBRARY, TO THE EXTENT PERMITTED BY APPLICABLE LAW.
+EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR
+OTHER PARTIES PROVIDE THE LIBRARY "AS IS" WITHOUT WARRANTY OF ANY
+KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE
+LIBRARY IS WITH YOU.  SHOULD THE LIBRARY PROVE DEFECTIVE, YOU ASSUME
+THE COST OF ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN
+WRITING WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY
+AND/OR REDISTRIBUTE THE LIBRARY AS PERMITTED ABOVE, BE LIABLE TO YOU
+FOR DAMAGES, INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OR INABILITY TO USE THE
+LIBRARY (INCLUDING BUT NOT LIMITED TO LOSS OF DATA OR DATA BEING
+RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD PARTIES OR A
+FAILURE OF THE LIBRARY TO OPERATE WITH ANY OTHER SOFTWARE), EVEN IF
+SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGES.
+
+                      END OF TERMS AND CONDITIONS

--- a/android/isotools/build.gradle
+++ b/android/isotools/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'com.android.library'
+
+android {
+    namespace 'com.github.stephenc.javaisotools'
+
+    compileSdkVersion 33
+
+    defaultConfig {
+        minSdkVersion 19
+        targetSdkVersion 33
+    }
+}

--- a/android/isotools/src/main/AndroidManifest.xml
+++ b/android/isotools/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<manifest />

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/FileEntry.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/FileEntry.java
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.api;
+
+public interface FileEntry {
+    String getName();
+    String getPath();
+
+    boolean isDirectory();
+
+    long getSize();
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/FileEntry.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/FileEntry.java
@@ -23,7 +23,8 @@
 
 package com.github.stephenc.javaisotools.loopfs.api;
 
-public interface FileEntry {
+public interface FileEntry
+{
     String getName();
     String getPath();
 

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/FileSystem.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/FileSystem.java
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.api;
+
+import java.io.Closeable;
+import java.io.InputStream;
+
+public interface FileSystem<T extends FileEntry> extends Iterable<T>, Closeable {
+    InputStream getInputStream( T entry );
+
+    boolean isClosed();
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/FileSystem.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/FileSystem.java
@@ -26,7 +26,8 @@ package com.github.stephenc.javaisotools.loopfs.api;
 import java.io.Closeable;
 import java.io.InputStream;
 
-public interface FileSystem<T extends FileEntry> extends Iterable<T>, Closeable {
+public interface FileSystem<T extends FileEntry> extends Iterable<T>, Closeable
+{
     InputStream getInputStream( T entry );
 
     boolean isClosed();

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/LoopFileSystemException.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/api/LoopFileSystemException.java
@@ -1,0 +1,34 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.api;
+
+import java.io.IOException;
+
+public class LoopFileSystemException extends IOException
+{
+    public LoopFileSystemException( final String message )
+    {
+        super( message );
+    }
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Constants.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Constants.java
@@ -23,7 +23,8 @@
 
 package com.github.stephenc.javaisotools.loopfs.iso9660;
 
-public interface Constants {
+public interface Constants
+{
     int DEFAULT_BLOCK_SIZE = 2 * 1024;
     int RESERVED_SECTORS = 16;
 

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Constants.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Constants.java
@@ -1,0 +1,31 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.iso9660;
+
+public interface Constants {
+    int DEFAULT_BLOCK_SIZE = 2 * 1024;
+    int RESERVED_SECTORS = 16;
+
+    String DEFAULT_ENCODING = "US-ASCII";
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/EntryInputStream.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/EntryInputStream.java
@@ -1,0 +1,151 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.iso9660;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+class EntryInputStream extends InputStream
+{
+    // entry within the file system
+    private Iso9660FileEntry entry;
+
+    // the parent file system
+    private Iso9660FileSystem fileSystem;
+
+    // current position within entry data
+    private long pos;
+
+    // number of remaining bytes within entry
+    private long rem;
+
+    EntryInputStream( final Iso9660FileEntry entry, final Iso9660FileSystem fileSystem )
+    {
+        this.fileSystem = fileSystem;
+        this.entry = entry;
+        this.pos = 0;
+        this.rem = entry.getSize();
+    }
+
+    public int read( final byte[] b, final int off, final int len ) throws IOException
+    {
+        ensureOpen();
+
+        if ( this.rem <= 0 ) {
+            return -1;
+        }
+        if ( len <= 0 ) {
+            return 0;
+        }
+
+        int toRead = len;
+
+        if ( toRead > this.rem ) {
+            // down cast is safe as toRead is int and greater than this.rem
+            toRead = (int)this.rem;
+        }
+
+        int read;
+
+        synchronized ( this.fileSystem )
+        {
+            if ( this.fileSystem.isClosed() ) {
+                throw new IOException( "ISO file closed." );
+            }
+
+            read = this.fileSystem.readBytes( this.entry, this.pos, b, off, toRead );
+        }
+
+        if ( read > 0 ) {
+            this.pos += read;
+            this.rem -= read;
+        }
+
+        return read;
+    }
+
+    public int read() throws IOException
+    {
+        ensureOpen();
+
+        final byte[] b = new byte[1];
+
+        if ( read( b, 0, 1 ) == 1 ) {
+            return b[0] & 0xff;
+        }
+        else {
+            return -1;
+        }
+    }
+
+    public long skip( final long n )
+    {
+        ensureOpen();
+
+        final long len = Math.min( n, this.rem );
+
+        this.pos += len;
+        this.rem -= len;
+
+        if ( this.rem <= 0 ) {
+            close();
+        }
+
+        return len;
+    }
+
+    public int available()
+    {
+        if ( this.rem > Integer.MAX_VALUE ) {
+            return Integer.MAX_VALUE;
+        }
+        else if ( this.rem < 0 ) {
+            return 0;
+        }
+        else {
+            return (int)this.rem;
+        }
+    }
+
+    public long size()
+    {
+        ensureOpen();
+
+        return this.entry.getSize();
+    }
+
+    public void close()
+    {
+        this.rem = 0;
+        this.entry = null;
+        this.fileSystem = null;
+    }
+
+    private void ensureOpen()
+    {
+        if ( null == this.entry ) {
+            throw new IllegalStateException( "stream has been closed" );
+        }
+    }
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/EntryInputStream.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/EntryInputStream.java
@@ -68,8 +68,7 @@ class EntryInputStream extends InputStream
 
         int read;
 
-        synchronized ( this.fileSystem )
-        {
+        synchronized ( this.fileSystem ) {
             if ( this.fileSystem.isClosed() ) {
                 throw new IOException( "ISO file closed." );
             }

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/EntryIterator.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/EntryIterator.java
@@ -1,0 +1,103 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.iso9660;
+
+import com.github.stephenc.javaisotools.loopfs.util.LittleEndian;
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.NoSuchElementException;
+
+class EntryIterator implements Iterator<Iso9660FileEntry>
+{
+    private final Iso9660FileSystem fileSystem;
+    private final List<Iso9660FileEntry> queue;
+
+    public EntryIterator( final Iso9660FileSystem fileSystem, final Iso9660FileEntry rootEntry )
+    {
+        this.fileSystem = fileSystem;
+        this.queue = new LinkedList<>();
+        if ( rootEntry != null )
+            this.queue.add( rootEntry );
+    }
+
+    public boolean hasNext()
+    {
+        return !this.queue.isEmpty();
+    }
+
+    public Iso9660FileEntry next()
+    {
+        if ( !hasNext() ) {
+            throw new NoSuchElementException();
+        }
+
+        // pop next entry from the queue
+        final Iso9660FileEntry entry = this.queue.remove( 0 );
+
+        // if the entry is a directory, queue all its children
+        if ( entry.isDirectory() ) {
+            final byte[] content;
+
+            try {
+                content = this.fileSystem.getBytes( entry );
+            }
+            catch ( IOException ex ) {
+                throw new RuntimeException( ex );
+            }
+
+            int offset = 0;
+            boolean paddingMode = false;
+
+            while ( offset < content.length ) {
+                if ( LittleEndian.getUInt8( content, offset ) <= 0 ) {
+                    paddingMode = true;
+                    offset += 2;
+                    continue;
+                }
+
+                Iso9660FileEntry child = new Iso9660FileEntry( this.fileSystem, entry.getPath(), content, offset + 1 );
+
+                if ( paddingMode && child.getSize() < 0 ) {
+                    continue;
+                }
+
+                offset += child.getEntryLength();
+
+                // It doesn't seem useful to include the . and .. entries
+                if ( !".".equals( child.getName() ) && !"..".equals( child.getName() ) ) {
+                    this.queue.add( child );
+                }
+            }
+        }
+
+        return entry;
+    }
+
+    public void remove()
+    {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/EntryIterator.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/EntryIterator.java
@@ -23,12 +23,13 @@
 
 package com.github.stephenc.javaisotools.loopfs.iso9660;
 
-import com.github.stephenc.javaisotools.loopfs.util.LittleEndian;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.NoSuchElementException;
+
+import com.github.stephenc.javaisotools.loopfs.util.LittleEndian;
 
 class EntryIterator implements Iterator<Iso9660FileEntry>
 {

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660FileEntry.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660FileEntry.java
@@ -1,0 +1,131 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.iso9660;
+
+import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
+
+public final class Iso9660FileEntry implements FileEntry
+{
+    public static final char ID_SEPARATOR = ';';
+
+    private final Iso9660FileSystem fileSystem;
+    private final String parentPath;
+    private final int entryLength;
+    private final long startSector;
+    private final long dataLength;
+    private final int flags;
+    private final String identifier;
+
+    public Iso9660FileEntry( final Iso9660FileSystem fileSystem, final byte[] block, final int pos )
+    {
+        this( fileSystem, null, block, pos );
+    }
+
+    public Iso9660FileEntry( final Iso9660FileSystem fileSystem, final String parentPath, final byte[] block, final int startPos )
+    {
+        this.fileSystem = fileSystem;
+        this.parentPath = parentPath;
+
+        final int offset = startPos - 1;
+
+        this.entryLength = Util.getUInt8( block, offset + 1 );
+        this.startSector = Util.getUInt32LE( block, offset + 3 );
+        this.dataLength = Util.getUInt32LE( block, offset + 11 );
+        this.flags = Util.getUInt8( block, offset + 26 );
+        this.identifier = getFileIdentifier( block, offset, isDirectory() );
+    }
+
+    private String getFileIdentifier( final byte[] block, final int offset, final boolean isDir )
+    {
+        final int fidLength = Util.getUInt8( block, offset + 33 );
+
+        if ( isDir ) {
+            final int buff34 = Util.getUInt8( block, offset + 34 );
+
+            if ( ( fidLength == 1 ) && ( buff34 == 0x00 ) ) {
+                return ".";
+            }
+            else if ( ( fidLength == 1 ) && ( buff34 == 0x01 ) ) {
+                return "..";
+            }
+        }
+
+        final String id = Util.getDChars( block, offset + 34, fidLength, this.fileSystem.getEncoding() );
+
+        final int sepIdx = id.indexOf( ID_SEPARATOR );
+
+        if ( sepIdx >= 0 ) {
+            return id.substring( 0, sepIdx );
+        }
+        else {
+            return id;
+        }
+    }
+
+    public String getName()
+    {
+        return this.identifier;
+    }
+
+    public String getPath()
+    {
+        if ( ".".equals( this.getName() ) ) {
+            return "";
+        }
+
+        StringBuilder buf = new StringBuilder();
+
+        if ( null != this.parentPath ) {
+            buf.append( this.parentPath );
+        }
+
+        buf.append( getName() );
+
+        if ( isDirectory() ) {
+            buf.append( "/" );
+        }
+
+        return buf.toString();
+    }
+
+    public boolean isDirectory()
+    {
+        return ( this.flags & 0x02 ) != 0;
+    }
+
+    public long getSize()
+    {
+        return this.dataLength;
+    }
+
+    public long getStartBlock()
+    {
+        return this.startSector;
+    }
+
+    public int getEntryLength()
+    {
+        return this.entryLength;
+    }
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660FileSystem.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660FileSystem.java
@@ -23,14 +23,15 @@
 
 package com.github.stephenc.javaisotools.loopfs.iso9660;
 
-import com.github.stephenc.javaisotools.loopfs.spi.AbstractBlockFileSystem;
-import com.github.stephenc.javaisotools.loopfs.spi.SeekableInput;
-import com.github.stephenc.javaisotools.loopfs.spi.SeekableInputFile;
-import com.github.stephenc.javaisotools.loopfs.spi.VolumeDescriptorSet;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Iterator;
+
+import com.github.stephenc.javaisotools.loopfs.spi.AbstractBlockFileSystem;
+import com.github.stephenc.javaisotools.loopfs.spi.SeekableInput;
+import com.github.stephenc.javaisotools.loopfs.spi.SeekableInputFile;
+import com.github.stephenc.javaisotools.loopfs.spi.VolumeDescriptorSet;
 
 public class Iso9660FileSystem extends AbstractBlockFileSystem<Iso9660FileEntry>
 {

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660FileSystem.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660FileSystem.java
@@ -1,0 +1,87 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.iso9660;
+
+import com.github.stephenc.javaisotools.loopfs.spi.AbstractBlockFileSystem;
+import com.github.stephenc.javaisotools.loopfs.spi.SeekableInput;
+import com.github.stephenc.javaisotools.loopfs.spi.SeekableInputFile;
+import com.github.stephenc.javaisotools.loopfs.spi.VolumeDescriptorSet;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Iterator;
+
+public class Iso9660FileSystem extends AbstractBlockFileSystem<Iso9660FileEntry>
+{
+    public Iso9660FileSystem( File file, boolean readOnly ) throws IOException
+    {
+        this( new SeekableInputFile( file ), readOnly );
+    }
+
+    public Iso9660FileSystem( SeekableInput seekable, boolean readOnly ) throws IOException
+    {
+        super( seekable, readOnly, Constants.DEFAULT_BLOCK_SIZE, Constants.RESERVED_SECTORS );
+    }
+
+    public String getEncoding()
+    {
+        return ( (Iso9660VolumeDescriptorSet)getVolumeDescriptorSet() ).getEncoding();
+    }
+
+    public InputStream getInputStream( Iso9660FileEntry entry )
+    {
+        ensureOpen();
+        return new EntryInputStream( entry, this );
+    }
+
+    byte[] getBytes( Iso9660FileEntry entry ) throws IOException
+    {
+        if ( entry.getSize() > Integer.MAX_VALUE ) {
+            throw new IOException( "Entry too large" );
+        }
+        int size = (int)entry.getSize();
+
+        byte[] buf = new byte[size];
+
+        readBytes( entry, 0, buf, 0, size );
+
+        return buf;
+    }
+
+    int readBytes( Iso9660FileEntry entry, long entryOffset, byte[] buffer, int bufferOffset, int len ) throws IOException
+    {
+        long startPos = ( entry.getStartBlock() * Constants.DEFAULT_BLOCK_SIZE ) + entryOffset;
+        return readData( startPos, buffer, bufferOffset, len );
+    }
+
+    protected Iterator<Iso9660FileEntry> iterator( Iso9660FileEntry rootEntry )
+    {
+        return new EntryIterator( this, rootEntry );
+    }
+
+    protected VolumeDescriptorSet<Iso9660FileEntry> createVolumeDescriptorSet()
+    {
+        return new Iso9660VolumeDescriptorSet( this );
+    }
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660VolumeDescriptorSet.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660VolumeDescriptorSet.java
@@ -1,0 +1,171 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.iso9660;
+
+import com.github.stephenc.javaisotools.loopfs.api.LoopFileSystemException;
+import com.github.stephenc.javaisotools.loopfs.spi.VolumeDescriptorSet;
+import java.io.IOException;
+
+public class Iso9660VolumeDescriptorSet implements VolumeDescriptorSet<Iso9660FileEntry>
+{
+    public static final int TYPE_BOOTRECORD = 0;
+    public static final int TYPE_PRIMARY_DESCRIPTOR = 1;
+    public static final int TYPE_SUPPLEMENTARY_DESCRIPTOR = 2;
+    public static final int TYPE_PARTITION_DESCRIPTOR = 3;
+    public static final int TYPE_TERMINATOR = 255;
+
+    private final Iso9660FileSystem isoFile;
+
+    private String application;
+    private Iso9660FileEntry rootDirectoryEntry;
+
+    public String encoding = Constants.DEFAULT_ENCODING;
+    public String escapeSequences;
+
+    private boolean hasPrimary = false;
+    private boolean hasSupplementary = false;
+
+    public Iso9660VolumeDescriptorSet( Iso9660FileSystem fileSystem )
+    {
+        this.isoFile = fileSystem;
+    }
+
+    public boolean deserialize( byte[] descriptor ) throws IOException
+    {
+        final int type = Util.getUInt8( descriptor, 1 );
+
+        boolean terminator = false;
+
+        switch ( type ) {
+        case TYPE_TERMINATOR:
+            if ( !this.hasPrimary ) {
+                throw new LoopFileSystemException( "No primary volume descriptor found" );
+            }
+            terminator = true;
+            break;
+        case TYPE_PRIMARY_DESCRIPTOR:
+            deserializePrimary( descriptor );
+            break;
+        case TYPE_SUPPLEMENTARY_DESCRIPTOR:
+            deserializeSupplementary( descriptor );
+            break;
+        case TYPE_BOOTRECORD:
+        case TYPE_PARTITION_DESCRIPTOR:
+        default:
+            break;
+        }
+
+        return terminator;
+    }
+
+    private void deserializePrimary( byte[] descriptor ) throws IOException
+    {
+        // according to the spec, some ISO 9660 file systems can contain multiple identical primary
+        // volume descriptors
+        if ( this.hasPrimary ) {
+            return;
+        }
+
+        validateBlockSize( descriptor );
+
+        if ( !this.hasSupplementary ) {
+            deserializeCommon( descriptor );
+        }
+
+        this.application = Util.getDChars( descriptor, 575, 128 );
+
+        this.hasPrimary = true;
+    }
+
+    private void deserializeSupplementary( byte[] descriptor ) throws IOException
+    {
+        // for now, only recognize one supplementary descriptor
+        if ( this.hasSupplementary ) {
+            return;
+        }
+
+        validateBlockSize( descriptor );
+
+        String escapeSequences = Util.getDChars( descriptor, 89, 32 );
+
+        String enc = getEncoding( escapeSequences );
+
+        if ( null != enc ) {
+            this.encoding = enc;
+            this.escapeSequences = escapeSequences;
+
+            deserializeCommon( descriptor );
+
+            this.hasSupplementary = true;
+        }
+    }
+
+    private void deserializeCommon( byte[] descriptor )
+    {
+        this.rootDirectoryEntry = new Iso9660FileEntry( this.isoFile, descriptor, 157 );
+    }
+
+    private void validateBlockSize( byte[] descriptor ) throws IOException
+    {
+        int blockSize = Util.getUInt16Both( descriptor, 129 );
+        if ( blockSize != Constants.DEFAULT_BLOCK_SIZE ) {
+            throw new LoopFileSystemException( "Invalid block size: " + blockSize );
+        }
+    }
+
+    private String getEncoding( String escapeSequences )
+    {
+        String encoding = null;
+
+        switch ( escapeSequences ) {
+        case "%/@":
+            // UCS-2 level 1
+        case "%/C":
+            // UCS-2 level 2
+        case "%/E":
+            // UCS-2 level 3
+            encoding = "UTF-16BE";
+            break;
+        default:
+            break;
+        }
+
+        return encoding;
+    }
+
+    public String getApplication()
+    {
+        return this.application;
+    }
+
+    public Iso9660FileEntry getRootEntry()
+    {
+        return this.rootDirectoryEntry;
+    }
+
+    public String getEncoding()
+    {
+        return this.encoding;
+    }
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660VolumeDescriptorSet.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Iso9660VolumeDescriptorSet.java
@@ -23,9 +23,10 @@
 
 package com.github.stephenc.javaisotools.loopfs.iso9660;
 
+import java.io.IOException;
+
 import com.github.stephenc.javaisotools.loopfs.api.LoopFileSystemException;
 import com.github.stephenc.javaisotools.loopfs.spi.VolumeDescriptorSet;
-import java.io.IOException;
 
 public class Iso9660VolumeDescriptorSet implements VolumeDescriptorSet<Iso9660FileEntry>
 {

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Util.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Util.java
@@ -23,8 +23,9 @@
 
 package com.github.stephenc.javaisotools.loopfs.iso9660;
 
-import com.github.stephenc.javaisotools.loopfs.util.LittleEndian;
 import java.io.UnsupportedEncodingException;
+
+import com.github.stephenc.javaisotools.loopfs.util.LittleEndian;
 
 public final class Util
 {

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Util.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/iso9660/Util.java
@@ -1,0 +1,62 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.iso9660;
+
+import com.github.stephenc.javaisotools.loopfs.util.LittleEndian;
+import java.io.UnsupportedEncodingException;
+
+public final class Util
+{
+    public static int getUInt8( byte[] block, int pos )
+    {
+        return LittleEndian.getUInt8( block, pos - 1 );
+    }
+
+    public static int getUInt16Both( byte[] block, int pos )
+    {
+        return LittleEndian.getUInt16( block, pos - 1 );
+    }
+
+    public static long getUInt32LE( byte[] block, int pos )
+    {
+        return LittleEndian.getUInt32( block, pos - 1 );
+    }
+
+    public static String getDChars( byte[] block, int pos, int length )
+    {
+        return new String( block, pos - 1, length ).trim();
+    }
+
+    public static String getDChars( byte[] block, int pos, int length, String encoding )
+    {
+        try {
+            return new String( block, pos - 1, length, encoding ).trim();
+        }
+        catch ( UnsupportedEncodingException ex ) {
+            throw new RuntimeException( ex );
+        }
+    }
+
+    private Util() {}
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/AbstractBlockFileSystem.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/AbstractBlockFileSystem.java
@@ -1,0 +1,111 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.spi;
+
+import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
+import java.io.IOException;
+import java.util.Iterator;
+
+public abstract class AbstractBlockFileSystem<T extends FileEntry> extends AbstractFileSystem<T>
+{
+    private final int blockSize;
+    private final int reservedBlocks;
+    private VolumeDescriptorSet<T> volumeDescriptorSet;
+
+    protected AbstractBlockFileSystem( final SeekableInput seekable, final boolean readOnly, final int blockSize, final int reservedBlocks ) throws IOException
+    {
+        super( seekable, readOnly );
+
+        if ( blockSize <= 0 ) {
+            throw new IllegalArgumentException( "'blockSize' must be > 0" );
+        }
+        if ( reservedBlocks < 0 ) {
+            throw new IllegalArgumentException( "'reservedBlocks' must be >= 0" );
+        }
+
+        this.blockSize = blockSize;
+        this.reservedBlocks = reservedBlocks;
+    }
+
+    public final Iterator<T> iterator()
+    {
+        ensureOpen();
+
+        // load the volume descriptors if necessary
+        if ( null == this.volumeDescriptorSet ) {
+            try {
+                loadVolumeDescriptors();
+            }
+            catch ( IOException ex ) {
+                throw new RuntimeException( ex );
+            }
+        }
+
+        return iterator( this.volumeDescriptorSet.getRootEntry() );
+    }
+
+    protected void loadVolumeDescriptors() throws IOException
+    {
+        final byte[] buffer = new byte[this.blockSize];
+
+        this.volumeDescriptorSet = createVolumeDescriptorSet();
+
+        // skip the reserved blocks, then read volume descriptor blocks sequentially and add them
+        // to the VolumeDescriptorSet
+        int block = this.reservedBlocks;
+        while ( readBlock( block, buffer ) && !this.volumeDescriptorSet.deserialize( buffer ) ) {
+            block++;
+        }
+    }
+
+    protected final boolean readBlock( final long block, final byte[] buffer ) throws IOException
+    {
+        final int bytesRead = readData( block * this.blockSize, buffer, 0, this.blockSize );
+
+        if ( bytesRead <= 0 ) {
+            return false;
+        }
+
+        if ( this.blockSize != bytesRead ) {
+            throw new IOException( "Could not deserialize a complete block" );
+        }
+
+        return true;
+    }
+
+    protected final synchronized int readData( final long startPos, final byte[] buffer, final int offset, final int len ) throws IOException
+    {
+        seek( startPos );
+        return read( buffer, offset, len );
+    }
+
+    protected final VolumeDescriptorSet<T> getVolumeDescriptorSet()
+    {
+        return this.volumeDescriptorSet;
+    }
+
+    protected abstract Iterator<T> iterator( T root );
+
+    protected abstract VolumeDescriptorSet<T> createVolumeDescriptorSet();
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/AbstractBlockFileSystem.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/AbstractBlockFileSystem.java
@@ -23,9 +23,10 @@
 
 package com.github.stephenc.javaisotools.loopfs.spi;
 
-import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
 import java.io.IOException;
 import java.util.Iterator;
+
+import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
 
 public abstract class AbstractBlockFileSystem<T extends FileEntry> extends AbstractFileSystem<T>
 {

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/AbstractFileSystem.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/AbstractFileSystem.java
@@ -1,0 +1,93 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.spi;
+
+import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
+import com.github.stephenc.javaisotools.loopfs.api.FileSystem;
+import java.io.IOException;
+
+public abstract class AbstractFileSystem<T extends FileEntry> implements FileSystem<T>
+{
+    private SeekableInput channel;
+
+    protected AbstractFileSystem( final SeekableInput seekable, final boolean readOnly )
+    {
+        if ( !readOnly ) {
+            throw new IllegalArgumentException( "Currently, only read-only is supported" );
+        }
+        this.channel = seekable;
+    }
+
+    // TODO: close open streams automatically
+
+    public synchronized void close() throws IOException
+    {
+        if ( isClosed() ) {
+            return;
+        }
+        try {
+            this.channel.close();
+        }
+        finally {
+            this.channel = null;
+        }
+    }
+
+    public synchronized boolean isClosed()
+    {
+        return ( null == this.channel );
+    }
+
+    protected final void ensureOpen() throws IllegalStateException
+    {
+        if ( isClosed() ) {
+            throw new IllegalStateException( "File has been closed" );
+        }
+    }
+
+    protected final void seek( long pos ) throws IOException
+    {
+        ensureOpen();
+        this.channel.seek( pos );
+    }
+
+    protected final int read( byte[] buffer, int offset, int length ) throws IOException
+    {
+        ensureOpen();
+        return readFully( buffer, offset, length );
+    }
+
+    private int readFully( byte[] buffer, int offset, int length ) throws IOException
+    {
+        int bytesRead;
+        int remaining = length;
+
+        // read doesn't guarantee a full buffer is read. Reading until we have a full buffer or end of stream
+        while ( remaining != 0 && ( bytesRead = this.channel.read( buffer, offset, remaining ) ) != -1 ) {
+            offset += bytesRead;
+            remaining -= bytesRead;
+        }
+        return length - remaining;
+    }
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/AbstractFileSystem.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/AbstractFileSystem.java
@@ -23,9 +23,10 @@
 
 package com.github.stephenc.javaisotools.loopfs.spi;
 
+import java.io.IOException;
+
 import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
 import com.github.stephenc.javaisotools.loopfs.api.FileSystem;
-import java.io.IOException;
 
 public abstract class AbstractFileSystem<T extends FileEntry> implements FileSystem<T>
 {

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/SeekableInput.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/SeekableInput.java
@@ -1,0 +1,34 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.spi;
+
+import java.io.IOException;
+
+public interface SeekableInput {
+    void seek( long pos ) throws IOException;
+
+    int read( byte[] b, int off, int len ) throws IOException;
+
+    void close() throws IOException;
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/SeekableInput.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/SeekableInput.java
@@ -25,7 +25,8 @@ package com.github.stephenc.javaisotools.loopfs.spi;
 
 import java.io.IOException;
 
-public interface SeekableInput {
+public interface SeekableInput
+{
     void seek( long pos ) throws IOException;
 
     int read( byte[] b, int off, int len ) throws IOException;

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/SeekableInputFile.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/SeekableInputFile.java
@@ -1,0 +1,57 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.spi;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+
+public class SeekableInputFile implements SeekableInput
+{
+    private final RandomAccessFile channel;
+
+    public SeekableInputFile( File file ) throws IOException
+    {
+        if ( !file.exists() ) {
+            throw new FileNotFoundException( "File does not exist: " + file );
+        }
+        this.channel = new RandomAccessFile( file, "r" );
+    }
+
+    public void seek( long pos ) throws IOException
+    {
+        this.channel.seek( pos );
+    }
+
+    public int read( byte[] b, int off, int len ) throws IOException
+    {
+        return this.channel.read( b, off, len );
+    }
+
+    public void close() throws IOException
+    {
+        this.channel.close();
+    }
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/VolumeDescriptorSet.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/VolumeDescriptorSet.java
@@ -1,0 +1,33 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.spi;
+
+import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
+import java.io.IOException;
+
+public interface VolumeDescriptorSet<T extends FileEntry> {
+    boolean deserialize( byte[] volumeDescriptor ) throws IOException;
+
+    T getRootEntry();
+}

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/VolumeDescriptorSet.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/VolumeDescriptorSet.java
@@ -23,8 +23,9 @@
 
 package com.github.stephenc.javaisotools.loopfs.spi;
 
-import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
 import java.io.IOException;
+
+import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
 
 public interface VolumeDescriptorSet<T extends FileEntry>
 {

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/VolumeDescriptorSet.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/spi/VolumeDescriptorSet.java
@@ -26,7 +26,8 @@ package com.github.stephenc.javaisotools.loopfs.spi;
 import com.github.stephenc.javaisotools.loopfs.api.FileEntry;
 import java.io.IOException;
 
-public interface VolumeDescriptorSet<T extends FileEntry> {
+public interface VolumeDescriptorSet<T extends FileEntry>
+{
     boolean deserialize( byte[] volumeDescriptor ) throws IOException;
 
     T getRootEntry();

--- a/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/util/LittleEndian.java
+++ b/android/isotools/src/main/java/com/github/stephenc/javaisotools/loopfs/util/LittleEndian.java
@@ -1,0 +1,48 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2023                                                    *
+ *                                                                         *
+ *   Copyright (c) 2010 Stephen Connolly.                                  *
+ *   Copyright (c) 2006-2007 loopy project (http://loopy.sourceforge.net)  *
+ *                                                                         *
+ *   This library is free software; you can redistribute it and/or         *
+ *   modify it under the terms of the GNU Lesser General Public            *
+ *   License as published by the Free Software Foundation; either          *
+ *   version 2.1 of the License, or (at your option) any later version.    *
+ *                                                                         *
+ *   This library is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU     *
+ *   Lesser General Public License for more details.                       *
+ *                                                                         *
+ *   You should have received a copy of the GNU Lesser General Public      *
+ *   License along with this program; if not, write to the                 *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package com.github.stephenc.javaisotools.loopfs.util;
+
+public class LittleEndian
+{
+    public static int getUInt8( byte[] src, int offset )
+    {
+        return src[offset] & 0xFF;
+    }
+
+    public static int getUInt16( byte[] src, int offset )
+    {
+        final int v0 = src[offset] & 0xFF;
+        final int v1 = src[offset + 1] & 0xFF;
+        return ( ( v1 << 8 ) | v0 );
+    }
+
+    public static long getUInt32( byte[] src, int offset )
+    {
+        final long v0 = src[offset] & 0xFF;
+        final long v1 = src[offset + 1] & 0xFF;
+        final long v2 = src[offset + 2] & 0xFF;
+        final long v3 = src[offset + 3] & 0xFF;
+        return ( ( v3 << 24 ) | ( v2 << 16 ) | ( v1 << 8 ) | v0 );
+    }
+}

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':sdl2'
+include ':app', ':isotools', ':sdl2'


### PR DESCRIPTION
If `HOMM2.GOG` is present in a ZIP archive with HoMM2 assets. On request from people writing reviews on Google Play.

ISO9660 module was mostly taken from [stephenc/java-iso-tools](https://github.com/stephenc/java-iso-tools) repo (LGPL license, currently unmaintained). I removed a lot of unnecessary code that did nothing useful for us but require unnecessary dependencies (including natural monsters like [Apache Hadoop](https://github.com/stephenc/java-iso-tools/blob/334caa435f58ebaa8a5f69eefc2e5ac247c0d6c2/loop-fs-spi/pom.xml#L50-L54)), fixed a few bugs (for instance, the original code treated files with the `Hidden` attribute in the ISO image as directories and caused a crash), modernized the original code a bit, formatted it according to our standards and added our copyright strings above the original ones.