### PR TITLE
Add the ability to cancel waiting for the end of the pre-battle sound

### DIFF
--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -213,7 +213,7 @@ namespace
     }
 
     // Returns sound Channel ID, when error - returns `-1`.
-    int32_t PlaySoundImp( const int32_t m82, const int32_t soundVolume );
+    int PlaySoundImp( const int m82, const int soundVolume );
     void PlayMusicImp( const int trackId, const MusicSource musicType, const Music::PlaybackMode playbackMode );
     void playLoopSoundsImp( std::map<M82::SoundType, std::vector<AudioManager::AudioLoopEffectInfo>> soundEffects, const int soundVolume, const bool is3DAudioEnabled );
 
@@ -472,7 +472,7 @@ namespace
 
     AsyncSoundManager g_asyncSoundManager;
 
-    int32_t PlaySoundImp( const int32_t m82, const int32_t soundVolume )
+    int PlaySoundImp( const int m82, const int soundVolume )
     {
         std::scoped_lock<std::recursive_mutex> lock( g_asyncSoundManager.resourceMutex() );
 
@@ -857,7 +857,7 @@ namespace AudioManager
         g_asyncSoundManager.pushLoopSound( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
     }
 
-    int32_t PlaySound( const int32_t m82 )
+    int PlaySound( const int m82 )
     {
         if ( m82 == M82::UNKNOWN ) {
             return -1;

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "audio_manager.h"
+
 #include <algorithm>
 #include <array>
 #include <atomic>
@@ -33,7 +35,6 @@
 #include <utility>
 
 #include "agg_file.h"
-#include "audio_manager.h"
 #include "dir.h"
 #include "logging.h"
 #include "m82.h"
@@ -211,7 +212,8 @@ namespace
         return v;
     }
 
-    void PlaySoundImp( const int m82, const int soundVolume );
+    // Returns sound Channel ID, when error - returns `-1`.
+    int32_t PlaySoundImp( const int32_t m82, const int32_t soundVolume );
     void PlayMusicImp( const int trackId, const MusicSource musicType, const Music::PlaybackMode playbackMode );
     void playLoopSoundsImp( std::map<M82::SoundType, std::vector<AudioManager::AudioLoopEffectInfo>> soundEffects, const int soundVolume, const bool is3DAudioEnabled );
 
@@ -470,7 +472,7 @@ namespace
 
     AsyncSoundManager g_asyncSoundManager;
 
-    void PlaySoundImp( const int m82, const int soundVolume )
+    int32_t PlaySoundImp( const int32_t m82, const int32_t soundVolume )
     {
         std::scoped_lock<std::recursive_mutex> lock( g_asyncSoundManager.resourceMutex() );
 
@@ -478,18 +480,19 @@ namespace
 
         const std::vector<uint8_t> & v = GetWAV( m82 );
         if ( v.empty() ) {
-            return;
+            return -1;
         }
 
         const int channelId = Mixer::Play( &v[0], static_cast<uint32_t>( v.size() ), -1, false );
         if ( channelId < 0 ) {
             // Failed to get a free channel.
-            return;
+            return -1;
         }
 
         Mixer::Pause( channelId );
         Mixer::setVolume( channelId, 100 * soundVolume / 10 );
         Mixer::Resume( channelId );
+        return channelId;
     }
 
     uint64_t getMusicUID( const int trackId, const MusicSource musicType )
@@ -854,19 +857,19 @@ namespace AudioManager
         g_asyncSoundManager.pushLoopSound( std::move( soundEffects ), conf.SoundVolume(), conf.is3DAudioEnabled() );
     }
 
-    void PlaySound( const int m82 )
+    int32_t PlaySound( const int32_t m82 )
     {
         if ( m82 == M82::UNKNOWN ) {
-            return;
+            return -1;
         }
 
         if ( !Audio::isValid() ) {
-            return;
+            return -1;
         }
 
         g_asyncSoundManager.removeSoundTasks();
 
-        PlaySoundImp( m82, Settings::Get().SoundVolume() );
+        return PlaySoundImp( m82, Settings::Get().SoundVolume() );
     }
 
     void PlaySoundAsync( const int m82 )

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -492,6 +492,7 @@ namespace
         Mixer::Pause( channelId );
         Mixer::setVolume( channelId, 100 * soundVolume / 10 );
         Mixer::Resume( channelId );
+
         return channelId;
     }
 

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022                                                    *
+ *   Copyright (C) 2022 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -89,7 +89,7 @@ namespace AudioManager
 
     void playLoopSoundsAsync( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects );
 
-    void PlaySound( const int m82 );
+    int32_t PlaySound( const int32_t m82 );
     void PlaySoundAsync( const int m82 );
 
     void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode );

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -89,6 +89,7 @@ namespace AudioManager
 
     void playLoopSoundsAsync( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects );
 
+    // Returns the ID of the channel occupied by the sound being played, or a negative value (-1) in case of failure.
     int PlaySound( const int m82 );
     void PlaySoundAsync( const int m82 );
 

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -89,7 +89,7 @@ namespace AudioManager
 
     void playLoopSoundsAsync( std::map<M82::SoundType, std::vector<AudioLoopEffectInfo>> soundEffects );
 
-    int32_t PlaySound( const int32_t m82 );
+    int PlaySound( const int m82 );
     void PlaySoundAsync( const int m82 );
 
     void PlayMusic( const int trackId, const Music::PlaybackMode playbackMode );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -398,7 +398,10 @@ Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const
         // Wait for the end of M82::PREBATTL playback. Make sure that we check the music status first as HandleEvents() call is not instant.
         LocalEvent & le = LocalEvent::Get();
         while ( Mixer::isPlaying( -1 ) && le.HandleEvents() ) {
-            // Do nothing.
+            if ( le.KeyPress(fheroes2::Key::KEY_ESCAPE) || le.MouseClickMiddle() || le.MouseClickRight() ) {
+                // Cancel waiting for M82::PREBATTL to over and start the battle.
+                break;
+            }
         }
     }
 }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -398,7 +398,7 @@ Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const
         // Wait for the end of M82::PREBATTL playback. Make sure that we check the music status first as HandleEvents() call is not instant.
         LocalEvent & le = LocalEvent::Get();
         while ( Mixer::isPlaying( -1 ) && le.HandleEvents() ) {
-            if ( le.KeyPress(fheroes2::Key::KEY_ESCAPE) || le.MouseClickMiddle() || le.MouseClickRight() ) {
+            if ( le.KeyPress( fheroes2::Key::KEY_ESCAPE ) || le.MouseClickMiddle() || le.MouseClickRight() ) {
                 // Cancel waiting for M82::PREBATTL to over and start the battle.
                 break;
             }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1321,7 +1321,7 @@ void Battle::Interface::Redraw()
     // by new sounds if they are played (one way or another) after the end of the pre-battle sound, but before calling
     // this method. Although in this case here it will not lead to serious problems as in the worst case, the launch of
     // battle music will be postponed for some time.
-    if ( ( _preBattleSoundChannelId != -2 ) && ( _preBattleSoundChannelId == -1 ) || !Mixer::isPlaying( _preBattleSoundChannelId ) && !Music::isPlaying() ) {
+    if ( ( _preBattleSoundChannelId != -2 ) && ( _preBattleSoundChannelId == -1 || !Mixer::isPlaying( _preBattleSoundChannelId ) ) && !Music::isPlaying() ) {
         // Set `_preBattleSoundChannelId` to `-2` to skip `isPlaying()` checks in future as these checks could freeze
         // the game for some time in certain cases (e.g. slow MIDI backend).
         _preBattleSoundChannelId = -2;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1316,6 +1316,10 @@ void Battle::Interface::fullRedraw()
 
 void Battle::Interface::Redraw()
 {
+    // Check that the pre-battle sound is over to start playing the battle music.
+    // IMPORTANT: This implementation may suffer from the race condition as the pre-battle sound channel may be reused by new sounds using 'playSoundAsync()':
+    // such a playback is performed in the background thread so it may take this channel before this check is performed.
+    // Although in this case here it will not lead to serious problems as in the worst case, the launch of battle music will be postponed for some time.
     if ( ( _preBattleSoundChannelId != -1 ) && !Music::isPlaying() && !Mixer::isPlaying( _preBattleSoundChannelId ) ) {
         _preBattleSoundChannelId = -1;
         AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1255,7 +1255,7 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
 
     // Don't waste time playing the pre-battle sound if the game sounds are turned off
     if ( conf.SoundVolume() > 0 ) {
-        AudioManager::PlaySound( M82::PREBATTL );
+        _preBattleSoundChannelId = AudioManager::PlaySound( M82::PREBATTL );
     }
 }
 
@@ -1316,6 +1316,11 @@ void Battle::Interface::fullRedraw()
 
 void Battle::Interface::Redraw()
 {
+    if ( ( _preBattleSoundChannelId != -1 ) && !Music::isPlaying() && !Mixer::isPlaying( _preBattleSoundChannelId ) ) {
+        _preBattleSoundChannelId = -1;
+        AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
+    }
+
     RedrawPartialStart();
     RedrawPartialFinish();
 }
@@ -3333,10 +3338,6 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
 
 void Battle::Interface::RedrawActionNewTurn() const
 {
-    if ( !Music::isPlaying() ) {
-        AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
-    }
-
     if ( listlog == nullptr ) {
         return;
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1321,8 +1321,10 @@ void Battle::Interface::Redraw()
     // by new sounds if they are played (one way or another) after the end of the pre-battle sound, but before calling
     // this method. Although in this case here it will not lead to serious problems as in the worst case, the launch of
     // battle music will be postponed for some time.
-    if ( ( _preBattleSoundChannelId == -1 || !Mixer::isPlaying( _preBattleSoundChannelId ) ) && !Music::isPlaying() ) {
-        _preBattleSoundChannelId = -1;
+    if ( ( _preBattleSoundChannelId != -2 ) && !Mixer::isPlaying( _preBattleSoundChannelId ) && !Music::isPlaying() ) {
+        // Set `_preBattleSoundChannelId` to `-2` to skip `isPlaying()` checks in future as these checks could freeze
+        // the game for some time in certain cases (e.g. slow MIDI backend).
+        _preBattleSoundChannelId = -2;
 
         AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1321,7 +1321,7 @@ void Battle::Interface::Redraw()
     // by new sounds if they are played (one way or another) after the end of the pre-battle sound, but before calling
     // this method. Although in this case here it will not lead to serious problems as in the worst case, the launch of
     // battle music will be postponed for some time.
-    if ( _preBattleSoundChannelId && ( _preBattleSoundChannelId == -1 || !Mixer::isPlaying( _preBattleSoundChannelId.value() ) ) && !Music::isPlaying() ) {
+    if ( _preBattleSoundChannelId && ( _preBattleSoundChannelId < 0 || !Mixer::isPlaying( _preBattleSoundChannelId.value() ) ) && !Music::isPlaying() ) {
         // Reset the value of _preBattleSoundChannelId to skip isPlaying() checks in future as these checks could freeze
         // the game for some time in certain cases (e.g. slow MIDI backend).
         _preBattleSoundChannelId.reset();

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1321,7 +1321,7 @@ void Battle::Interface::Redraw()
     // by new sounds if they are played (one way or another) after the end of the pre-battle sound, but before calling
     // this method. Although in this case here it will not lead to serious problems as in the worst case, the launch of
     // battle music will be postponed for some time.
-    if ( ( _preBattleSoundChannelId != -2 ) && !Mixer::isPlaying( _preBattleSoundChannelId ) && !Music::isPlaying() ) {
+    if ( ( _preBattleSoundChannelId != -2 ) && ( _preBattleSoundChannelId == -1 ) || !Mixer::isPlaying( _preBattleSoundChannelId ) && !Music::isPlaying() ) {
         // Set `_preBattleSoundChannelId` to `-2` to skip `isPlaying()` checks in future as these checks could freeze
         // the game for some time in certain cases (e.g. slow MIDI backend).
         _preBattleSoundChannelId = -2;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1317,9 +1317,10 @@ void Battle::Interface::fullRedraw()
 void Battle::Interface::Redraw()
 {
     // Check that the pre-battle sound is over to start playing the battle music.
-    // IMPORTANT: This implementation may suffer from the race condition as the pre-battle sound channel may be reused by new sounds using 'playSoundAsync()':
-    // such a playback is performed in the background thread so it may take this channel before this check is performed.
-    // Although in this case here it will not lead to serious problems as in the worst case, the launch of battle music will be postponed for some time.
+    // IMPORTANT: This implementation may suffer from the race condition as the pre-battle sound channel may be reused
+    // by new sounds if they are played (one way or another) after the end of the pre-battle sound, but before calling
+    // this method. Although in this case here it will not lead to serious problems as in the worst case, the launch of
+    // battle music will be postponed for some time.
     if ( ( _preBattleSoundChannelId != -1 ) && !Music::isPlaying() && !Mixer::isPlaying( _preBattleSoundChannelId ) ) {
         _preBattleSoundChannelId = -1;
         AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1321,10 +1321,10 @@ void Battle::Interface::Redraw()
     // by new sounds if they are played (one way or another) after the end of the pre-battle sound, but before calling
     // this method. Although in this case here it will not lead to serious problems as in the worst case, the launch of
     // battle music will be postponed for some time.
-    if ( ( _preBattleSoundChannelId != -2 ) && ( _preBattleSoundChannelId == -1 || !Mixer::isPlaying( _preBattleSoundChannelId ) ) && !Music::isPlaying() ) {
-        // Set `_preBattleSoundChannelId` to `-2` to skip `isPlaying()` checks in future as these checks could freeze
+    if ( _preBattleSoundChannelId && ( _preBattleSoundChannelId == -1 || !Mixer::isPlaying( _preBattleSoundChannelId.value() ) ) && !Music::isPlaying() ) {
+        // Reset the value of _preBattleSoundChannelId to skip isPlaying() checks in future as these checks could freeze
         // the game for some time in certain cases (e.g. slow MIDI backend).
-        _preBattleSoundChannelId = -2;
+        _preBattleSoundChannelId.reset();
 
         AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1321,8 +1321,9 @@ void Battle::Interface::Redraw()
     // by new sounds if they are played (one way or another) after the end of the pre-battle sound, but before calling
     // this method. Although in this case here it will not lead to serious problems as in the worst case, the launch of
     // battle music will be postponed for some time.
-    if ( ( _preBattleSoundChannelId != -1 ) && !Music::isPlaying() && !Mixer::isPlaying( _preBattleSoundChannelId ) ) {
+    if ( ( _preBattleSoundChannelId == -1 || !Mixer::isPlaying( _preBattleSoundChannelId ) ) && !Music::isPlaying() ) {
         _preBattleSoundChannelId = -1;
+
         AudioManager::PlayMusicAsync( MUS::GetBattleRandom(), Music::PlaybackMode::REWIND_AND_PLAY_INFINITE );
     }
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -426,8 +426,8 @@ namespace Battle
 
         int _interruptAutoBattleForColor;
 
-        // The Channel ID of pre-battle sound. Used to check it is over to start the music.
-        int32_t _preBattleSoundChannelId{ -1 };
+        // The Channel ID of pre-battle sound. Used to check it is over to start the battle music.
+        int _preBattleSoundChannelId{ -1 };
 
         uint8_t _contourColor;
         bool _brightLandType; // used to determine current monster contour cycling colors

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -26,6 +26,7 @@
 
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -427,7 +428,7 @@ namespace Battle
         int _interruptAutoBattleForColor;
 
         // The Channel ID of pre-battle sound. Used to check it is over to start the battle music.
-        int _preBattleSoundChannelId{ -1 };
+        std::optional<int> _preBattleSoundChannelId{ -1 };
 
         uint8_t _contourColor;
         bool _brightLandType; // used to determine current monster contour cycling colors

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -426,6 +426,9 @@ namespace Battle
 
         int _interruptAutoBattleForColor;
 
+        // The Channel ID of pre-battle sound. Used to check it is over to start the music.
+        int32_t _preBattleSoundChannelId{ -1 };
+
         uint8_t _contourColor;
         bool _brightLandType; // used to determine current monster contour cycling colors
         uint32_t _contourCycle;


### PR DESCRIPTION
This PR adds the ability to skip waiting for pre-battle sound to over and start the battle by pressing ESC, right mouse or middle mouse button. This does not interrupt the pre-battle sound playback.