### PR TITLE
Fix adventure map fog reveal on campaign scenario restart and when loading a Hot Seat save made in the first game day.

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1525,6 +1525,9 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
 
             Players & players = conf.GetPlayers();
             players.SetStartGame();
+
+            assert( players.current_color != -1);
+
             if ( Settings::isFadeEffectEnabled() )
                 fheroes2::FadeDisplay();
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1525,9 +1525,6 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
 
             Players & players = conf.GetPlayers();
             players.SetStartGame();
-
-            assert( players.current_color != -1);
-
             if ( Settings::isFadeEffectEnabled() )
                 fheroes2::FadeDisplay();
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -636,7 +636,9 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
     const bool isHotSeatGame = conf.IsGameType( Game::TYPE_HOTSEAT );
     if ( !isHotSeatGame ) {
-        assert( currentColor != -1 );
+        // It is not a Hot Seat (multiplayer) game so we set current color to the only human player.
+        conf.SetCurrentColor( Players::HumanColors() );
+
         // Fully update fog directions if there will be only one human player.
         Interface::GameArea::updateMapFogDirections();
     }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -706,8 +706,8 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                     conf.SetCurrentColor( playerColor );
 
-                    // Reveal fog to be compatible with the old pre 1.0.2 saves.
-                    if ( isHotSeatGame ) {
+                    // Reveal fog on the first day to be compatible with the old pre 1.0.2 saves.
+                    if ( world.CountDay() == 1 ) {
                         world.ClearFog( playerColor );
                     }
 
@@ -749,11 +749,13 @@ fheroes2::GameMode Interface::Basic::StartGame()
                     Redraw();
                     display.render();
 
+                    // Reveal fog on the first day to be compatible with the old pre 1.0.2 saves.
+                    if ( world.CountDay() == 1 ) {
+                        world.ClearFog( playerColor );
+                    }
+
                     // In Hot Seat mode there could be different alliances so we have to update fog directions for some cases.
                     if ( isHotSeatGame ) {
-                        // Reveal fog to be compatible with the old pre 1.0.2 saves.
-                        world.ClearFog( playerColor );
-
                         Maps::Tiles::updateFogDirectionsInArea( { 0, 0 }, { world.w(), world.h() }, hotSeatAIFogColors( player ) );
                     }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -606,10 +606,17 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
     radar.Build();
     radar.SetHide( true );
+
+    // Hide the world map at the first drawing
+    const int currentColor = conf.CurrentColor();
+    conf.SetCurrentColor( -1 );
+
     iconsPanel.HideIcons( ICON_ANY );
     statusWindow.Reset();
 
-    SetRedraw( REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_ICONS | REDRAW_BUTTONS | REDRAW_STATUS | REDRAW_BORDER );
+    Redraw( REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_ICONS | REDRAW_BUTTONS | REDRAW_STATUS | REDRAW_BORDER );
+
+    conf.SetCurrentColor( currentColor );
 
     bool loadedFromSave = conf.LoadedGameVersion();
     bool skipTurns = loadedFromSave;
@@ -799,9 +806,9 @@ fheroes2::GameMode Interface::Basic::StartGame()
         }
 
         // don't carry the current color from the last player to the next turn
-        if ( res == fheroes2::GameMode::END_TURN ) {
-            conf.SetCurrentColor( -1 );
-        }
+        // if ( res == fheroes2::GameMode::END_TURN ) {
+        conf.SetCurrentColor( -1 );
+        //}
     }
 
     // if we are here, the res value should never be fheroes2::GameMode::END_TURN

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -660,9 +660,9 @@ fheroes2::GameMode Interface::Basic::StartGame()
         for ( const Player * player : sortedPlayers ) {
             assert( player != nullptr );
 
-            int playerColor = player->GetColor();
+            const int playerColor = player->GetColor();
 
-            Kingdom & kingdom = world.GetKingdom( player->GetColor() );
+            Kingdom & kingdom = world.GetKingdom( playerColor );
 
             if ( skipTurns && !player->isColor( conf.CurrentColor() ) ) {
                 continue;
@@ -672,7 +672,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
             skipTurns = false;
 
             if ( kingdom.isPlay() ) {
-                DEBUG_LOG( DBG_GAME, DBG_INFO, world.DateString() << ", color: " << Color::String( player->GetColor() ) << ", resource: " << kingdom.GetFunds().String() )
+                DEBUG_LOG( DBG_GAME, DBG_INFO, world.DateString() << ", color: " << Color::String( playerColor ) << ", resource: " << kingdom.GetFunds().String() )
 
                 radar.SetHide( true );
                 radar.SetRedraw( REDRAW_RADAR_CURSOR );
@@ -701,14 +701,14 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                         AudioManager::PlayMusic( MUS::NEW_MONTH, Music::PlaybackMode::PLAY_ONCE );
 
-                        Game::DialogPlayers( player->GetColor(), _( "%{color} player's turn." ) );
+                        Game::DialogPlayers( playerColor, _( "%{color} player's turn." ) );
                     }
 
-                    conf.SetCurrentColor( player->GetColor() );
+                    conf.SetCurrentColor( playerColor );
 
-                    // Update fog data to be compatible with the old pre 1.0.2 saves.
+                    // Reveal fog to be compatible with the old pre 1.0.2 saves.
                     if ( isHotSeatGame ) {
-                        world.ClearFog( player->GetColor() );
+                        world.ClearFog( playerColor );
                     }
 
                     kingdom.ActionBeforeTurn();
@@ -733,7 +733,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                     Cursor::Get().SetThemes( Cursor::WAIT );
 
-                    conf.SetCurrentColor( player->GetColor() );
+                    conf.SetCurrentColor( playerColor );
 
                     statusWindow.Reset();
                     statusWindow.SetState( StatusType::STATUS_AITURN );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -798,10 +798,8 @@ fheroes2::GameMode Interface::Basic::StartGame()
             res = fheroes2::GameMode::MAIN_MENU;
         }
 
-        // don't carry the current color from the last player to the next turn
-        if ( res == fheroes2::GameMode::END_TURN ) {
-            conf.SetCurrentColor( Color::NONE );
-        }
+        // Don't carry the current player color to the next turn.
+        conf.SetCurrentColor( Color::NONE );
     }
 
     // if we are here, the res value should never be fheroes2::GameMode::END_TURN

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -751,6 +751,9 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                     // In Hot Seat mode there could be different alliances so we have to update fog directions for some cases.
                     if ( isHotSeatGame ) {
+                        // Reveal fog to be compatible with the old pre 1.0.2 saves.
+                        world.ClearFog( player->GetColor() );
+
                         Maps::Tiles::updateFogDirectionsInArea( { 0, 0 }, { world.w(), world.h() }, hotSeatAIFogColors( player ) );
                     }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -606,17 +606,10 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
     radar.Build();
     radar.SetHide( true );
-
-    // Hide the world map at the first drawing
-    const int currentColor = conf.CurrentColor();
-    conf.SetCurrentColor( -1 );
-
     iconsPanel.HideIcons( ICON_ANY );
     statusWindow.Reset();
 
-    Redraw( REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_ICONS | REDRAW_BUTTONS | REDRAW_STATUS | REDRAW_BORDER );
-
-    conf.SetCurrentColor( currentColor );
+    SetRedraw( REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_ICONS | REDRAW_BUTTONS | REDRAW_STATUS | REDRAW_BORDER );
 
     bool loadedFromSave = conf.LoadedGameVersion();
     bool skipTurns = loadedFromSave;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -806,9 +806,9 @@ fheroes2::GameMode Interface::Basic::StartGame()
         }
 
         // don't carry the current color from the last player to the next turn
-        // if ( res == fheroes2::GameMode::END_TURN ) {
-        conf.SetCurrentColor( -1 );
-        //}
+        if ( res == fheroes2::GameMode::END_TURN ) {
+            conf.SetCurrentColor( -1 );
+        }
     }
 
     // if we are here, the res value should never be fheroes2::GameMode::END_TURN

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -694,7 +694,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                         AudioManager::PlayMusic( MUS::NEW_MONTH, Music::PlaybackMode::PLAY_ONCE );
 
-                        Game::DialogPlayers( playerColor, _( "%{color} player's turn." ) );
+                        Game::DialogPlayers( playerColor, "", _( "%{color} player's turn." ) );
                     }
 
                     conf.SetCurrentColor( playerColor );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -660,6 +660,8 @@ fheroes2::GameMode Interface::Basic::StartGame()
         for ( const Player * player : sortedPlayers ) {
             assert( player != nullptr );
 
+            int playerColor = player->GetColor();
+
             Kingdom & kingdom = world.GetKingdom( player->GetColor() );
 
             if ( skipTurns && !player->isColor( conf.CurrentColor() ) ) {
@@ -703,6 +705,11 @@ fheroes2::GameMode Interface::Basic::StartGame()
                     }
 
                     conf.SetCurrentColor( player->GetColor() );
+
+                    // Update fog data to be compatible with the old pre 1.0.2 saves.
+                    if ( isHotSeatGame ) {
+                        world.ClearFog( player->GetColor() );
+                    }
 
                     kingdom.ActionBeforeTurn();
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -636,6 +636,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
     const bool isHotSeatGame = conf.IsGameType( Game::TYPE_HOTSEAT );
     if ( !isHotSeatGame ) {
+        assert( currentColor != -1 );
         // Fully update fog directions if there will be only one human player.
         Interface::GameArea::updateMapFogDirections();
     }
@@ -803,7 +804,9 @@ fheroes2::GameMode Interface::Basic::StartGame()
         }
 
         // don't carry the current color from the last player to the next turn
-        conf.SetCurrentColor( -1 );
+        if ( res == fheroes2::GameMode::END_TURN ) {
+            conf.SetCurrentColor( -1 );
+        }
     }
 
     // if we are here, the res value should never be fheroes2::GameMode::END_TURN

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -752,7 +752,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
                     // In Hot Seat mode there could be different alliances so we have to update fog directions for some cases.
                     if ( isHotSeatGame ) {
                         // Reveal fog to be compatible with the old pre 1.0.2 saves.
-                        world.ClearFog( player->GetColor() );
+                        world.ClearFog( playerColor );
 
                         Maps::Tiles::updateFogDirectionsInArea( { 0, 0 }, { world.w(), world.h() }, hotSeatAIFogColors( player ) );
                     }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -606,17 +606,11 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
     radar.Build();
     radar.SetHide( true );
-
-    // Hide the world map at the first drawing
-    const int currentColor = conf.CurrentColor();
-    conf.SetCurrentColor( -1 );
-
     iconsPanel.HideIcons( ICON_ANY );
     statusWindow.Reset();
 
+    // Prepare for render the whole game interface with adventure map filled with fog as it was not uncovered by 'updateMapFogDirections()'.
     Redraw( REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_ICONS | REDRAW_BUTTONS | REDRAW_STATUS | REDRAW_BORDER );
-
-    conf.SetCurrentColor( currentColor );
 
     bool loadedFromSave = conf.LoadedGameVersion();
     bool skipTurns = loadedFromSave;
@@ -683,9 +677,6 @@ fheroes2::GameMode Interface::Basic::StartGame()
                     AudioManager::ResetAudio();
 
                     if ( isHotSeatGame ) {
-                        // we need to hide the world map in hot seat mode
-                        conf.SetCurrentColor( -1 );
-
                         iconsPanel.HideIcons( ICON_ANY );
                         statusWindow.Reset();
 
@@ -809,7 +800,7 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
         // don't carry the current color from the last player to the next turn
         if ( res == fheroes2::GameMode::END_TURN ) {
-            conf.SetCurrentColor( -1 );
+            conf.SetCurrentColor( Color::NONE );
         }
     }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -627,8 +627,8 @@ fheroes2::GameMode Interface::Basic::StartGame()
     std::vector<Player *> sortedPlayers = conf.GetPlayers().getVector();
     std::sort( sortedPlayers.begin(), sortedPlayers.end(), SortPlayers );
 
-    if ( !loadedFromSave ) {
-        // Clear fog around heroes, castles and mines for all players when starting a new map.
+    if ( !loadedFromSave || world.CountDay() == 1 ) {
+        // Clear fog around heroes, castles and mines for all players when starting a new map or if the save was done at the first day.
         for ( const Player * player : sortedPlayers ) {
             world.ClearFog( player->GetColor() );
         }
@@ -706,11 +706,6 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                     conf.SetCurrentColor( playerColor );
 
-                    // Reveal fog on the first day to be compatible with the old pre 1.0.2 saves.
-                    if ( world.CountDay() == 1 ) {
-                        world.ClearFog( playerColor );
-                    }
-
                     kingdom.ActionBeforeTurn();
 
                     iconsPanel.ShowIcons( ICON_ANY );
@@ -748,11 +743,6 @@ fheroes2::GameMode Interface::Basic::StartGame()
 
                     Redraw();
                     display.render();
-
-                    // Reveal fog on the first day to be compatible with the old pre 1.0.2 saves.
-                    if ( world.CountDay() == 1 ) {
-                        world.ClearFog( playerColor );
-                    }
 
                     // In Hot Seat mode there could be different alliances so we have to update fog directions for some cases.
                     if ( isHotSeatGame ) {

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -460,18 +460,21 @@ int Players::HumanColors()
 
 int Players::FriendColors()
 {
-    int colors = 0;
     const Players & players = Settings::Get().GetPlayers();
+    const int playerColor = players.current_color;
 
-    if ( players.current_color & Players::HumanColors() ) {
+    assert( playerColor >= 0 );
+
+    const int humanColors = Players::HumanColors();
+
+    if ( playerColor & humanColors ) {
         const Player * player = players.GetCurrent();
-        if ( player )
-            colors = player->GetFriends();
+        if ( player ) {
+            return player->GetFriends();
+        }
     }
-    else
-        colors = Players::HumanColors();
 
-    return colors;
+    return humanColors;
 }
 
 std::string Players::String() const

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -460,21 +460,12 @@ int Players::HumanColors()
 
 int Players::FriendColors()
 {
-    const Players & players = Settings::Get().GetPlayers();
-    const int playerColor = players.current_color;
-
-    assert( playerColor >= 0 );
-
-    const int humanColors = Players::HumanColors();
-
-    if ( playerColor & humanColors ) {
-        const Player * player = players.GetCurrent();
-        if ( player ) {
-            return player->GetFriends();
-        }
+    const Player * player = Settings::Get().GetPlayers().GetCurrent();
+    if ( player ) {
+        return player->GetFriends();
     }
 
-    return humanColors;
+    return 0;
 }
 
 std::string Players::String() const

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -455,6 +455,7 @@ int Players::HumanColors()
     if ( humanColors == Color::NONE ) {
         humanColors = Settings::Get().GetPlayers().GetColors( CONTROL_HUMAN, true );
     }
+
     return humanColors;
 }
 
@@ -468,10 +469,11 @@ int Players::FriendColors()
     return 0;
 }
 
-void Players::setCurrentColor( int color )
+void Players::setCurrentColor( const int color )
 {
     // We can set only one of 6 player colors ( BLUE | GREEN | RED | YELLOW | ORANGE | PURPLE ) or NONE (neutral player).
     assert( Color::Count( color ) == 1 || color == Color::NONE );
+
     _currentColor = color;
 }
 

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -251,7 +251,16 @@ public:
     // Return current player friends colors, if player does not exist he has no friends (returns 0).
     static int FriendColors();
 
-    int current_color;
+    int getCurrentColor() const
+    {
+        return _currentColor;
+    }
+
+    // The color should belong to one player or be NONE (neutral player).
+    void setCurrentColor( int color );
+
+private:
+    int _currentColor{ Color::NONE };
 };
 
 StreamBase & operator<<( StreamBase &, const Players & );

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -248,6 +248,7 @@ public:
     static void SetPlayerControl( int color, int ctrl );
     static void SetPlayerInGame( int color, bool );
     static int HumanColors();
+    // Return current player friends colors, if player does not exist he has no friends (returns 0).
     static int FriendColors();
 
     int current_color;

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -257,7 +257,7 @@ public:
     }
 
     // The color should belong to one player or be NONE (neutral player).
-    void setCurrentColor( int color );
+    void setCurrentColor( const int color );
 
 private:
     int _currentColor{ Color::NONE };

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -314,7 +314,7 @@ public:
     }
 
     // The color should belong to one player or be NONE (neutral player).
-    void SetCurrentColor( int color )
+    void SetCurrentColor( const int color )
     {
         players.setCurrentColor( color );
     }

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -310,12 +310,13 @@ public:
 
     int CurrentColor() const
     {
-        return players.current_color;
+        return players.getCurrentColor();
     }
 
+    // The color should belong to one player or be NONE (neutral player).
     void SetCurrentColor( int color )
     {
-        players.current_color = color;
+        players.setCurrentColor( color );
     }
 
     int PreferablyCountPlayers() const


### PR DESCRIPTION
The issue was found by **Stisen11** on Discord channel: "When I restart Good Campaign level 2, the adventure map is ALL black! That is until I click and move a hero. Then the fog of war renders wierdly..."

This PR does these fixes:
- do not force set player color to -1 when you end current player turn not by "ending" it (i.e. restarting a campaign scenario);
- set the the only human player color before updating adventure map fog directions for Single player games;
- rework of `Players::FriendColors()` to return return current friends player colors, if player does not exist - return 0.
