### PR TITLE
Standartize metadata for all objects on Adventure Map

### DIFF
--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -207,7 +207,7 @@ public:
         return *this;
     }
 
-   template <class Type, size_t Count>
+    template <class Type, size_t Count>
     StreamBase & operator<<( const std::array<Type, Count> & data )
     {
         put32( static_cast<uint32_t>( data.size() ) );

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -32,6 +32,7 @@
 #include <list>
 #include <map>
 #include <string>
+#include <tuple>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -25,6 +25,7 @@
 #define H2SERIALIZE_H
 
 #include <algorithm>
+#include <array>
 #include <cstdint>
 #include <cstdio>
 #include <iterator>
@@ -112,25 +113,25 @@ public:
         put8( ch );
     }
 
-    StreamBase & operator>>( bool & );
-    StreamBase & operator>>( char & );
-    StreamBase & operator>>( uint8_t & );
-    StreamBase & operator>>( uint16_t & );
-    StreamBase & operator>>( int16_t & );
-    StreamBase & operator>>( uint32_t & );
-    StreamBase & operator>>( int32_t & );
-    StreamBase & operator>>( std::string & );
+    StreamBase & operator>>( bool & v );
+    StreamBase & operator>>( char & v );
+    StreamBase & operator>>( uint8_t & v );
+    StreamBase & operator>>( uint16_t & v );
+    StreamBase & operator>>( int16_t & v );
+    StreamBase & operator>>( uint32_t & v );
+    StreamBase & operator>>( int32_t & v );
+    StreamBase & operator>>( std::string & v );
 
     StreamBase & operator>>( fheroes2::Point & point_ );
 
-    StreamBase & operator<<( const bool );
-    StreamBase & operator<<( const char );
-    StreamBase & operator<<( const uint8_t );
-    StreamBase & operator<<( const uint16_t );
-    StreamBase & operator<<( const int16_t );
-    StreamBase & operator<<( const uint32_t );
-    StreamBase & operator<<( const int32_t );
-    StreamBase & operator<<( const std::string & );
+    StreamBase & operator<<( const bool v );
+    StreamBase & operator<<( const char v );
+    StreamBase & operator<<( const uint8_t v );
+    StreamBase & operator<<( const uint16_t v );
+    StreamBase & operator<<( const int16_t v );
+    StreamBase & operator<<( const uint32_t v );
+    StreamBase & operator<<( const int32_t v );
+    StreamBase & operator<<( const std::string & v );
 
     StreamBase & operator<<( const fheroes2::Point & point_ );
 
@@ -203,6 +204,16 @@ public:
         put32( static_cast<uint32_t>( v.size() ) );
         for ( typename std::map<Type1, Type2>::const_iterator it = v.begin(); it != v.end(); ++it )
             *this << *it;
+        return *this;
+    }
+
+   template <class Type, size_t Count>
+    StreamBase & operator<<( const std::array<Type, Count> & data )
+    {
+        put32( static_cast<uint32_t>( data.size() ) );
+        for ( const auto & value : data ) {
+            *this << value;
+        }
         return *this;
     }
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -529,7 +529,10 @@ namespace
     void AIToTreasureChest( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        uint32_t gold = getFundsFromTile( tile ).gold;
+        const Funds funds = getFundsFromTile( tile );
+
+        assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
+        uint32_t gold = funds.gold;
 
         Kingdom & kingdom = hero.GetKingdom();
 
@@ -1072,7 +1075,10 @@ namespace
     void AIToPoorMoraleObject( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        uint32_t gold = getFundsFromTile( tile ).gold;
+        const Funds funds = getFundsFromTile( tile );
+        assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
+
+        uint32_t gold = funds.gold;
         bool complete = false;
 
         if ( gold ) {

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -57,7 +57,6 @@
 #include "math_base.h"
 #include "monster.h"
 #include "mp2.h"
-#include "pairs.h"
 #include "payment.h"
 #include "players.h"
 #include "puzzle.h"

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1398,6 +1398,7 @@ namespace
                 }
             }
             else if ( condition == Maps::ArtifactCaptureCondition::HAVE_WISDOM_SKILL || condition == Maps::ArtifactCaptureCondition::HAVE_LEADERSHIP_SKILL ) {
+                // TODO: do we need to check this condition?
                 result = true;
             }
             else if ( condition >= Maps::ArtifactCaptureCondition::FIGHT_50_ROGUES && condition <= Maps::ArtifactCaptureCondition::FIGHT_1_BONE_DRAGON ) {

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -609,7 +609,9 @@ namespace
         if ( !hero.isFriends( getColorFromTile( tile ) ) ) {
             auto removeObjectProtection = [&tile]() {
                 // Clear any metadata related to spells
-                removeMineSpellFromTile( tile );
+                if ( tile.GetObject( false ) == MP2::OBJ_MINES ) {
+                    removeMineSpellFromTile( tile );
+                }
             };
 
             auto captureObject = [&hero, &tile, &removeObjectProtection]() {

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -505,8 +505,9 @@ namespace
         }
 
         if ( destroy ) {
-            tile.RemoveObjectSprite();
             setMonsterCountOnTile( tile, 0 );
+
+            tile.RemoveObjectSprite();
             tile.setAsEmpty();
         }
     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -923,7 +923,10 @@ namespace AI
                 return 1000.0 * art.getArtifactValue();
             }
 
-            return getFundsFromTile( tile ).gold;
+            const Funds funds = getFundsFromTile( tile );
+            assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
+
+            return funds.gold;
         }
 
         case MP2::OBJ_DAEMON_CAVE:

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -923,7 +923,7 @@ namespace AI
                 return 1000.0 * art.getArtifactValue();
             }
 
-            return getGoldAmountFromTile( tile );
+            return getFundsFromTile( tile ).gold;
         }
 
         case MP2::OBJ_DAEMON_CAVE:

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -237,7 +237,7 @@ namespace
 
             if ( condition == Maps::ArtifactCaptureCondition::PAY_2000_GOLD || condition == Maps::ArtifactCaptureCondition::PAY_2500_GOLD_AND_3_RESOURCES
                  || condition == Maps::ArtifactCaptureCondition::PAY_3000_GOLD_AND_5_RESOURCES ) {
-                return kingdom.AllowPayment( getFundsFromTile( tile ) );
+                return kingdom.AllowPayment( getArtifactResourceRequirement( tile ) );
             }
 
             if ( condition == Maps::ArtifactCaptureCondition::HAVE_WISDOM_SKILL || condition == Maps::ArtifactCaptureCondition::HAVE_LEADERSHIP_SKILL ) {
@@ -325,9 +325,9 @@ namespace
 
         case MP2::OBJ_TREE_OF_KNOWLEDGE:
             if ( !hero.isVisited( tile ) ) {
-                const ResourceCount & rc = getResourcesFromTile( tile );
+                const Funds & rc = getTreeOfKnowledgeRequirement( tile );
                 // If the payment is required do not waste all resources from the kingdom. Use them wisely.
-                if ( !rc.isValid() || kingdom.AllowPayment( Funds( rc ) * 5 ) ) {
+                if ( rc.GetValidItemsCount() == 0 || kingdom.AllowPayment( rc * 5 ) ) {
                     return true;
                 }
             }
@@ -504,7 +504,7 @@ namespace
             break;
 
         case MP2::OBJ_DAEMON_CAVE:
-            if ( doesTileContainValuableItems( tile ) && getDaemonCaveBonus( tile ) != Maps::DaemonCaveCaptureBonus::PAY_2500_GOLD ) {
+            if ( doesTileContainValuableItems( tile ) && getDaemonCaveBonusType( tile ) != Maps::DaemonCaveCaptureBonus::PAY_2500_GOLD ) {
                 return isHeroStrongerThan( tile, objectType, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_MEDIUM );
             }
             break;
@@ -888,7 +888,7 @@ namespace AI
             if ( getColorFromTile( tile ) == hero.GetColor() ) {
                 return -dangerousTaskPenalty; // don't even attempt to go here
             }
-            return ( getResourcesFromTile( tile ).first == Resource::GOLD ) ? 4000.0 : 2000.0;
+            return ( getDailyIncomeObjectResources( tile ).gold > 0 ) ? 4000.0 : 2000.0;
         }
         case MP2::OBJ_ABANDONED_MINE: {
             return 3000.0;
@@ -1303,7 +1303,7 @@ namespace AI
             if ( getColorFromTile( tile ) == hero.GetColor() ) {
                 return -dangerousTaskPenalty; // don't even attempt to go here
             }
-            return ( getResourcesFromTile( tile ).first == Resource::GOLD ) ? 3000.0 : 1500.0;
+            return ( getDailyIncomeObjectResources( tile ).gold > 0 ) ? 3000.0 : 1500.0;
         }
         case MP2::OBJ_ABANDONED_MINE: {
             return 5000.0;
@@ -1465,7 +1465,7 @@ namespace AI
             if ( getColorFromTile( tile ) == hero.GetColor() ) {
                 return -dangerousTaskPenalty; // don't even attempt to go here
             }
-            return ( getResourcesFromTile( tile ).first == Resource::GOLD ) ? tenTiles : fiveTiles;
+            return ( getDailyIncomeObjectResources( tile ).gold > 0 ) ? tenTiles : fiveTiles;
         }
         case MP2::OBJ_CAMPFIRE:
         case MP2::OBJ_FLOTSAM:

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -941,20 +941,20 @@ void Army::setFromTile( const Maps::Tiles & tile )
     case MP2::OBJ_SHIPWRECK: {
         uint32_t count = 0;
 
-        switch ( tile.QuantityVariant() ) {
-        case 0:
+        switch ( getShipwrechCaptureCondition( tile ) ) {
+        case Maps::ShipwreckCaptureCondition::NO_BONUS:
             // Shipwreck guardians were defeated.
             return;
-        case 1:
+        case Maps::ShipwreckCaptureCondition::FIGHT_10_GHOSTS_AND_GET_1000_GOLD:
             count = 10;
             break;
-        case 2:
+        case Maps::ShipwreckCaptureCondition::FIGHT_15_GHOSTS_AND_GET_2000_GOLD:
             count = 15;
             break;
-        case 3:
+        case Maps::ShipwreckCaptureCondition::FIGHT_25_GHOSTS_AND_GET_5000_GOLD:
             count = 25;
             break;
-        case 4:
+        case Maps::ShipwreckCaptureCondition::FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT:
             count = 50;
             break;
         default:
@@ -972,29 +972,29 @@ void Army::setFromTile( const Maps::Tiles & tile )
         break;
 
     case MP2::OBJ_ARTIFACT:
-        switch ( tile.QuantityVariant() ) {
-        case 6:
+        switch ( getArtifactCaptureCondition( tile ) ) {
+        case Maps::ArtifactCaptureCondition::FIGHT_50_ROGUES:
             ArrangeForBattle( Monster::ROGUE, 50, tile.GetIndex(), false );
             break;
-        case 7:
+        case Maps::ArtifactCaptureCondition::FIGHT_1_GENIE:
             ArrangeForBattle( Monster::GENIE, 1, tile.GetIndex(), false );
             break;
-        case 8:
+        case Maps::ArtifactCaptureCondition::FIGHT_1_PALADIN:
             ArrangeForBattle( Monster::PALADIN, 1, tile.GetIndex(), false );
             break;
-        case 9:
+        case Maps::ArtifactCaptureCondition::FIGHT_1_CYCLOP:
             ArrangeForBattle( Monster::CYCLOPS, 1, tile.GetIndex(), false );
             break;
-        case 10:
+        case Maps::ArtifactCaptureCondition::FIGHT_1_PHOENIX:
             ArrangeForBattle( Monster::PHOENIX, 1, tile.GetIndex(), false );
             break;
-        case 11:
+        case Maps::ArtifactCaptureCondition::FIGHT_1_GREEN_DRAGON:
             ArrangeForBattle( Monster::GREEN_DRAGON, 1, tile.GetIndex(), false );
             break;
-        case 12:
+        case Maps::ArtifactCaptureCondition::FIGHT_1_TITAN:
             ArrangeForBattle( Monster::TITAN, 1, tile.GetIndex(), false );
             break;
-        case 13:
+        case Maps::ArtifactCaptureCondition::FIGHT_1_BONE_DRAGON:
             ArrangeForBattle( Monster::BONE_DRAGON, 1, tile.GetIndex(), false );
             break;
         default:

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -982,7 +982,7 @@ void Army::setFromTile( const Maps::Tiles & tile )
         case Maps::ArtifactCaptureCondition::FIGHT_1_PALADIN:
             ArrangeForBattle( Monster::PALADIN, 1, tile.GetIndex(), false );
             break;
-        case Maps::ArtifactCaptureCondition::FIGHT_1_CYCLOP:
+        case Maps::ArtifactCaptureCondition::FIGHT_1_CYCLOPS:
             ArrangeForBattle( Monster::CYCLOPS, 1, tile.GetIndex(), false );
             break;
         case Maps::ArtifactCaptureCondition::FIGHT_1_PHOENIX:

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -942,7 +942,7 @@ void Army::setFromTile( const Maps::Tiles & tile )
         uint32_t count = 0;
 
         switch ( getShipwrechCaptureCondition( tile ) ) {
-        case Maps::ShipwreckCaptureCondition::NO_BONUS:
+        case Maps::ShipwreckCaptureCondition::EMPTY:
             // Shipwreck guardians were defeated.
             return;
         case Maps::ShipwreckCaptureCondition::FIGHT_10_GHOSTS_AND_GET_1000_GOLD:

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -941,7 +941,7 @@ void Army::setFromTile( const Maps::Tiles & tile )
     case MP2::OBJ_SHIPWRECK: {
         uint32_t count = 0;
 
-        switch ( getShipwrechCaptureCondition( tile ) ) {
+        switch ( getShipwreckCaptureCondition( tile ) ) {
         case Maps::ShipwreckCaptureCondition::EMPTY:
             // Shipwreck guardians were defeated.
             return;

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -1069,7 +1069,7 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdo
     auto drawGoldMsg = [cost, &kingdom, &btnAccept]() {
         std::string str = _( "Not enough gold (%{gold})" );
 
-        StringReplace( str, "%{gold}", cost - kingdom.GetFunds().Get( Resource::GOLD ) );
+        StringReplace( str, "%{gold}", cost - kingdom.GetFunds().gold );
 
         const Text text( str, Font::SMALL );
         const fheroes2::Rect rect = btnAccept.area();

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -27,6 +27,7 @@
 #include <cstdlib>
 #include <ostream>
 #include <string>
+#include <utility>
 
 #include "agg_image.h"
 #include "army.h"
@@ -54,7 +55,6 @@
 #include "maps_tiles_helper.h"
 #include "math_base.h"
 #include "mp2.h"
-#include "pairs.h"
 #include "payment.h"
 #include "profit.h"
 #include "resource.h"

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -265,7 +265,7 @@ namespace
         std::string str = MP2::StringObject( tile.GetObject( false ) );
 
         if ( isVisited ) {
-            const Skill::Secondary & skill = getSecondarySkillFromTile( tile );
+            const Skill::Secondary & skill = getSecondarySkillFromWitchsHut( tile );
 
             str.append( "\n(" );
             str.append( Skill::Secondary::String( skill.Skill() ) );
@@ -452,7 +452,7 @@ namespace
             return showObjectVisitInfo( objectType, kingdom.isVisited( objectType ) );
 
         case MP2::OBJ_RESOURCE:
-            return Resource::String( tile.GetQuantity1() );
+            return Resource::String( getResourcesFromTile( tile ).first );
 
         case MP2::OBJ_MINES:
             return showMineInfo( tile, playerColor == getColorFromTile( tile ) );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -150,6 +150,7 @@ namespace
         std::string objectInfo = Maps::GetMinesName( resourceType );
 
         if ( isOwned ) {
+            // TODO: we should use the value from funds.
             objectInfo.append( getMinesIncomeString( resourceType ) );
         }
 
@@ -468,6 +469,7 @@ namespace
                 const Funds funds = getDailyIncomeObjectResources( tile );
                 assert( funds.GetValidItemsCount() == 1 );
 
+                // TODO: we should use the value from funds.
                 objectInfo.append( getMinesIncomeString( funds.getFirstValidResource().first ) );
             }
             return objectInfo;

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -146,7 +146,7 @@ namespace
 
     std::string showMineInfo( const Maps::Tiles & tile, const bool isOwned )
     {
-        const int32_t resourceType = getResourcesFromTile( tile ).first;
+        const int32_t resourceType = getDailyIncomeObjectResources( tile ).getFirstValidResource().first;
         std::string objectInfo = Maps::GetMinesName( resourceType );
 
         if ( isOwned ) {
@@ -452,7 +452,7 @@ namespace
             return showObjectVisitInfo( objectType, kingdom.isVisited( objectType ) );
 
         case MP2::OBJ_RESOURCE:
-            return Resource::String( getResourcesFromTile( tile ).first );
+            return Resource::String( getFundsFromTile( tile ).getFirstValidResource().first );
 
         case MP2::OBJ_MINES:
             return showMineInfo( tile, playerColor == getColorFromTile( tile ) );
@@ -461,7 +461,7 @@ namespace
         case MP2::OBJ_SAWMILL: {
             std::string objectInfo = MP2::StringObject( objectType );
             if ( playerColor == getColorFromTile( tile ) ) {
-                objectInfo.append( getMinesIncomeString( getResourcesFromTile( tile ).first ) );
+                objectInfo.append( getMinesIncomeString( getDailyIncomeObjectResources( tile ).getFirstValidResource().first ) );
             }
             return objectInfo;
         }

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -451,8 +451,12 @@ namespace
         case MP2::OBJ_MAGELLANS_MAPS:
             return showObjectVisitInfo( objectType, kingdom.isVisited( objectType ) );
 
-        case MP2::OBJ_RESOURCE:
-            return Resource::String( getFundsFromTile( tile ).getFirstValidResource().first );
+        case MP2::OBJ_RESOURCE: {
+            const Funds funds = getFundsFromTile( tile );
+            assert( funds.GetValidItemsCount() == 1 );
+
+            return Resource::String( funds.getFirstValidResource().first );
+        }
 
         case MP2::OBJ_MINES:
             return showMineInfo( tile, playerColor == getColorFromTile( tile ) );
@@ -461,7 +465,10 @@ namespace
         case MP2::OBJ_SAWMILL: {
             std::string objectInfo = MP2::StringObject( objectType );
             if ( playerColor == getColorFromTile( tile ) ) {
-                objectInfo.append( getMinesIncomeString( getDailyIncomeObjectResources( tile ).getFirstValidResource().first ) );
+                const Funds funds = getDailyIncomeObjectResources( tile );
+                assert( funds.GetValidItemsCount() == 1 );
+
+                objectInfo.append( getMinesIncomeString( funds.getFirstValidResource().first ) );
             }
             return objectInfo;
         }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -896,12 +896,12 @@ namespace
         const Spell & spell = getSpellFromTile( world.GetTiles( dst_index ) );
         assert( spell.isValid() );
 
-        const uint32_t spell_level = spell.Level();
+        const int spellLevel = spell.Level();
 
         std::string head;
         std::string body;
 
-        switch ( spell_level ) {
+        switch ( spellLevel ) {
         case 1:
             head = _( "Shrine of the 1st Circle" );
             body = _(
@@ -927,7 +927,7 @@ namespace
 
         if ( hero.HaveSpellBook() ) {
             // check valid level spell and wisdom skill
-            if ( 3 == spell_level && Skill::Level::NONE == hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) {
+            if ( 3 == spellLevel && Skill::Level::NONE == hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) {
                 body += _( "\nUnfortunately, you do not have the wisdom to understand the spell, and you are unable to learn it." );
                 Dialog::Message( head, body, Font::BIG, Dialog::OK );
             }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -688,32 +688,32 @@ namespace
     void ActionToObjectResource( const Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        Funds rc = getFundsFromTile( tile );
+        Funds funds = getFundsFromTile( tile );
 
         std::string msg;
         const std::string & caption = MP2::StringObject( objectType );
 
         switch ( objectType ) {
         case MP2::OBJ_WINDMILL:
-            msg = rc.GetValidItemsCount() > 0
+            msg = funds.GetValidItemsCount() > 0
                       ? _(
                           "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
                       : _( "The keeper of the mill announces:\n\"Milord, I am sorry, there are no resources currently available. Please try again next week.\"" );
             break;
 
         case MP2::OBJ_WATER_WHEEL:
-            msg = rc.GetValidItemsCount() > 0
+            msg = funds.GetValidItemsCount() > 0
                       ? _( "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with this gold, come back next week for more.\"" )
                       : _( "The keeper of the mill announces:\n\"Milord, I am sorry, there is no gold currently available. Please try again next week.\"" );
             break;
 
         case MP2::OBJ_LEAN_TO:
-            msg = rc.GetValidItemsCount() > 0 ? _( "You've found an abandoned lean-to.\nPoking about, you discover some resources hidden nearby." )
-                                              : _( "The lean-to is long abandoned. There is nothing of value here." );
+            msg = funds.GetValidItemsCount() > 0 ? _( "You've found an abandoned lean-to.\nPoking about, you discover some resources hidden nearby." )
+                                                 : _( "The lean-to is long abandoned. There is nothing of value here." );
             break;
 
         case MP2::OBJ_MAGIC_GARDEN:
-            msg = rc.GetValidItemsCount() > 0
+            msg = funds.GetValidItemsCount() > 0
                       ? _(
                           "You catch a leprechaun foolishly sleeping amidst a cluster of magic mushrooms.\nIn exchange for his freedom, he guides you to a small pot filled with precious things." )
                       : _(
@@ -724,8 +724,7 @@ namespace
             break;
         }
 
-        if ( rc.GetValidItemsCount() > 0 ) {
-            const Funds funds( rc );
+        if ( funds.GetValidItemsCount() > 0 ) {
 
             {
                 const MusicalEffectPlayer musicalEffectPlayer;
@@ -866,7 +865,7 @@ namespace
 
         const Funds & funds = getFundsFromTile( tile );
 
-        if ( 0 < funds.GetValidItemsCount() ) {
+        if ( funds.GetValidItemsCount() > 0 ) {
             msg = funds.wood && funds.gold ? _( "You search through the flotsam, and find some wood and some gold." )
                                            : _( "You search through the flotsam, and find some wood." );
 
@@ -1254,7 +1253,7 @@ namespace
         const Funds funds = getFundsFromTile( tile );
         assert( funds.GetValidItemsCount() == 0 || ( funds.GetValidItemsCount() == 1 && funds.gold > 0 ) );
 
-        uint32_t gold = getFundsFromTile( tile ).gold;
+        uint32_t gold = funds.gold;
         std::string ask;
         std::string msg;
         std::string win;
@@ -1703,7 +1702,10 @@ namespace
         const std::string & hdr = MP2::StringObject( objectType );
 
         std::string msg;
-        uint32_t gold = getFundsFromTile( tile ).gold;
+        const Funds funds = getFundsFromTile( tile );
+        assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
+
+        uint32_t gold = funds.gold;
 
         // dialog
         if ( tile.isWater() ) {
@@ -2906,7 +2908,10 @@ namespace
                 return Outcome::Experience;
             }
             case Maps::DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_2500_GOLD: {
-                const uint32_t gold = getFundsFromTile( tile ).gold;
+                const Funds funds = getFundsFromTile( tile );
+                assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
+
+                const uint32_t gold = funds.gold;
 
                 std::string msg = _(
                     "The Demon screams its challenge and attacks! After a short, desperate battle, you slay the monster and receive %{exp} experience points and %{count} gold." );
@@ -3009,7 +3014,10 @@ namespace
 
                     break;
                 case Outcome::ExperienceAndGold: {
-                    const uint32_t gold = getFundsFromTile( tile ).gold;
+                    const Funds funds = getFundsFromTile( tile );
+                    assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
+
+                    const uint32_t gold = funds.gold;
 
                     hero.IncreaseExperience( demonSlayingExperience );
                     kingdom.AddFundsResource( Funds( Resource::GOLD, gold ) );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -403,10 +403,10 @@ namespace
         if ( destroy ) {
             AudioManager::PlaySound( M82::KILLFADE );
 
+            setMonsterCountOnTile( tile, 0 );
+
             Interface::Basic::Get().GetGameArea().runSingleObjectAnimation(
                 std::make_shared<Interface::ObjectFadingOutInfo>( tile.GetObjectUID(), tile.GetIndex(), tile.GetObject() ) );
-
-            setMonsterCountOnTile( tile, 0 );
         }
 
         // Clear the hero's attacked monster tile index

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2990,10 +2990,8 @@ namespace
                     if ( res.AttackerWins() ) {
                         hero.IncreaseExperience( res.GetExperienceAttacker() );
 
-                        const Funds funds = getFundsFromTile( tile );
-                        assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
-
-                        const uint32_t gold = funds.gold;
+                        // Daemon Cave always gives 2500 Gold after a battle.
+                        const uint32_t gold = 2500;
 
                         std::string msg = _( "Upon defeating the daemon's servants, you find a hidden cache with %{count} gold." );
                         StringReplace( msg, "%{count}", gold );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2875,12 +2875,13 @@ namespace
 
             const Maps::DaemonCaveCaptureBonus originalDaemonBonus = getDaemonCaveBonus( tile );
 
-            const Maps::DaemonCaveCaptureBonus bonus =
-                ( originalDaemonBonus == Maps::DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_ARTIFACT && hero.IsFullBagArtifacts() ) ?
-                    Maps::DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_2500_GOLD : originalDaemonBonus;
+            const Maps::DaemonCaveCaptureBonus bonus
+                = ( originalDaemonBonus == Maps::DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_ARTIFACT && hero.IsFullBagArtifacts() )
+                      ? Maps::DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_2500_GOLD
+                      : originalDaemonBonus;
 
             switch ( bonus ) {
-            case Maps::DaemonCaveCaptureBonus::GET_1000_EXPERIENCE : {
+            case Maps::DaemonCaveCaptureBonus::GET_1000_EXPERIENCE: {
                 std::string msg
                     = _( "The Demon screams its challenge and attacks! After a short, desperate battle, you slay the monster and receive %{exp} experience points." );
                 StringReplace( msg, "%{exp}", std::to_string( demonSlayingExperience ) );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <initializer_list>
 #include <memory>
 #include <ostream>
 #include <string>
@@ -64,7 +65,6 @@
 #include "monster.h"
 #include "mp2.h"
 #include "mus.h"
-#include "pairs.h"
 #include "payment.h"
 #include "players.h"
 #include "profit.h"
@@ -2960,6 +2960,8 @@ namespace
 
                 return Outcome::Death;
             }
+            case Maps::DaemonCaveCaptureBonus::EMPTY:
+                break;
             default:
                 // This condition should never happen.
                 assert( 0 );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1953,7 +1953,9 @@ namespace
 
             auto removeObjectProtection = [&tile]() {
                 // Clear any metadata related to spells
-                removeMineSpellFromTile( tile );
+                if ( tile.GetObject( false ) == MP2::OBJ_MINES ) {
+                    removeMineSpellFromTile( tile );
+                }
             };
 
             auto captureObject = [&hero, objectType, &tile, &updateRadar, &removeObjectProtection]() {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -725,7 +725,6 @@ namespace
         }
 
         if ( funds.GetValidItemsCount() > 0 ) {
-
             {
                 const MusicalEffectPlayer musicalEffectPlayer;
 
@@ -2991,7 +2990,10 @@ namespace
                     if ( res.AttackerWins() ) {
                         hero.IncreaseExperience( res.GetExperienceAttacker() );
 
-                        const uint32_t gold = 2500;
+                        const Funds funds = getFundsFromTile( tile );
+                        assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
+
+                        const uint32_t gold = funds.gold;
 
                         std::string msg = _( "Upon defeating the daemon's servants, you find a hidden cache with %{count} gold." );
                         StringReplace( msg, "%{count}", gold );
@@ -3014,13 +3016,8 @@ namespace
 
                     break;
                 case Outcome::ExperienceAndGold: {
-                    const Funds funds = getFundsFromTile( tile );
-                    assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
-
-                    const uint32_t gold = funds.gold;
-
                     hero.IncreaseExperience( demonSlayingExperience );
-                    kingdom.AddFundsResource( Funds( Resource::GOLD, gold ) );
+                    kingdom.AddFundsResource( getFundsFromTile( tile ) );
 
                     break;
                 }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2958,6 +2958,10 @@ namespace
 
                 return Outcome::Death;
             }
+            default:
+                // This condition should never happen.
+                assert( 0 );
+                break;
             }
 
             return Outcome::Invalid;

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -695,10 +695,10 @@ namespace
 
         switch ( objectType ) {
         case MP2::OBJ_WINDMILL:
-            msg = rc.GetValidItemsCount() > 0 ? _(
-                      "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
-                               : _(
-                                   "The keeper of the mill announces:\n\"Milord, I am sorry, there are no resources currently available. Please try again next week.\"" );
+            msg = rc.GetValidItemsCount() > 0
+                      ? _(
+                          "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
+                      : _( "The keeper of the mill announces:\n\"Milord, I am sorry, there are no resources currently available. Please try again next week.\"" );
             break;
 
         case MP2::OBJ_WATER_WHEEL:

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1542,7 +1542,7 @@ namespace
                         const uint32_t count = payment.Get( res );
                         if ( count > 0 ) {
                             StringReplace( msg, "%{res}", Resource::String( res ) );
-                            StringReplace( msg, "%{count}", count );
+                            StringReplace( msg, "%{count}", static_cast<int>( count ) );
                             break;
                         }
                     }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -221,10 +221,10 @@ namespace
                 if ( remove && recruit == troop.GetCount() ) {
                     Game::PlayPickupSound();
 
+                    setMonsterCountOnTile( tile, 0 );
+
                     Interface::Basic::Get().GetGameArea().runSingleObjectAnimation(
                         std::make_shared<Interface::ObjectFadingOutInfo>( tile.GetObjectUID(), tile.GetIndex(), tile.GetObject() ) );
-
-                    setMonsterCountOnTile( tile, 0 );
                 }
                 else {
                     setMonsterCountOnTile( tile, troop.GetCount() - recruit );

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -484,7 +484,7 @@ bool Kingdom::isValidKingdomObject( const Maps::Tiles & tile, const MP2::MapObje
     if ( MP2::isCaptureObject( objectType ) )
         return !Players::isFriends( color, getColorFromTile( tile ) );
 
-    if ( MP2::isQuantityObject( objectType ) )
+    if ( MP2::isValuableResourceObject( objectType ) )
         return doesTileContainValuableItems( tile );
 
     return true;

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -408,7 +408,7 @@ namespace
                             const uint32_t colorOffset = colorToOffsetICN( getColorFromTile( tile ) );
                             // Do not render an unknown color.
                             if ( colorOffset != unknownIndex ) {
-                                renderResourceIcon( colorOffset, getResourcesFromTile( tile ).first, posX, posY );
+                                renderResourceIcon( colorOffset, getDailyIncomeObjectResources( tile ).getFirstValidResource().first, posX, posY );
                             }
                         }
                         break;
@@ -421,7 +421,7 @@ namespace
 
                     case MP2::OBJ_RESOURCE:
                         if ( revealResources || !tile.isFog( color ) ) {
-                            renderResourceIcon( 13, getResourcesFromTile( tile ).first, posX, posY );
+                            renderResourceIcon( 13, getFundsFromTile( tile ).getFirstValidResource().first, posX, posY );
                         }
                         break;
 

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -421,7 +421,7 @@ namespace
 
                     case MP2::OBJ_RESOURCE:
                         if ( revealResources || !tile.isFog( color ) ) {
-                            renderResourceIcon( 13, tile.GetQuantity1(), posX, posY );
+                            renderResourceIcon( 13, getResourcesFromTile( tile ).first, posX, posY );
                         }
                         break;
 

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
+#include <utility>
 
 #include "agg_image.h"
 #include "castle.h"
@@ -44,7 +45,6 @@
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"
 #include "mp2.h"
-#include "pairs.h"
 #include "resource.h"
 #include "screen.h"
 #include "settings.h"

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -424,7 +424,7 @@ namespace
 
                     case MP2::OBJ_RESOURCE:
                         if ( revealResources || !tile.isFog( color ) ) {
-                            const Funds funds = getDailyIncomeObjectResources( tile );
+                            const Funds funds = getFundsFromTile( tile );
                             assert( funds.GetValidItemsCount() == 1 );
 
                             renderResourceIcon( 13, funds.getFirstValidResource().first, posX, posY );

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -408,7 +408,10 @@ namespace
                             const uint32_t colorOffset = colorToOffsetICN( getColorFromTile( tile ) );
                             // Do not render an unknown color.
                             if ( colorOffset != unknownIndex ) {
-                                renderResourceIcon( colorOffset, getDailyIncomeObjectResources( tile ).getFirstValidResource().first, posX, posY );
+                                const Funds funds = getDailyIncomeObjectResources( tile );
+                                assert( funds.GetValidItemsCount() == 1 );
+
+                                renderResourceIcon( colorOffset, funds.getFirstValidResource().first, posX, posY );
                             }
                         }
                         break;
@@ -421,7 +424,10 @@ namespace
 
                     case MP2::OBJ_RESOURCE:
                         if ( revealResources || !tile.isFog( color ) ) {
-                            renderResourceIcon( 13, getFundsFromTile( tile ).getFirstValidResource().first, posX, posY );
+                            const Funds funds = getDailyIncomeObjectResources( tile );
+                            assert( funds.GetValidItemsCount() == 1 );
+
+                            renderResourceIcon( 13, funds.getFirstValidResource().first, posX, posY );
                         }
                         break;
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3268,7 +3268,6 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
             _metadata[1] = quantityValue2;
         }
 
-        _metadata[1] = quantityValue2;
         _metadata[2] = additionalMetadata;
         assert( _metadata[1] > 0 );
         break;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3278,10 +3278,17 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         break;
 
     // Abandoned mine was mixed with Mines in the old save formats.
-    // TODO: verify we convert data for Abandoned Mines properly before 1.0.3 and after.
     case MP2::OBJ_ABANDONED_MINE:
-        _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
-        _metadata[2] = additionalMetadata;
+        if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1003_RELEASE ) {
+            _metadata[0] = quantityValue1;
+            _metadata[1] = quantityValue2;
+            _metadata[2] = additionalMetadata;
+        }
+        else {
+            _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
+            _metadata[2] = additionalMetadata;
+        }
+        
         break;
 
     // Monster dwellings always store only one value - the number of monsters.

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3391,7 +3391,6 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         break;
 
     // Campfire contains some random resources and gold which has the same value as resource but multiplied by 100.
-    // TODO: verify that the amount of gold is always an equivalent of the amount of other resources multipled by 100.
     case MP2::OBJ_CAMPFIRE:
         _metadata[0] = quantityValue1;
         _metadata[1] = quantityValue2;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3270,7 +3270,7 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
 
         if ( _metadata[1] == 0 ) {
             // This is a broken mine from old saves. Let's try to correct income.
-            if ( Funds{ static_cast<int>( _metadata[0] ), 1 }.GetValidItemsCount() == 1 ) { 
+            if ( Funds{ static_cast<int>( _metadata[0] ), 1 }.GetValidItemsCount() == 1 ) {
                 const payment_t income = ProfitConditions::FromMine( static_cast<int>( _metadata[0] ) );
                 _metadata[1] = income.Get( static_cast<int>( _metadata[0] ) );
             }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3294,7 +3294,6 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
             _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
             _metadata[2] = additionalMetadata;
         }
-        
         break;
 
     // Monster dwellings always store only one value - the number of monsters.

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3416,13 +3416,14 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         _metadata[1] = quantityValue2 * 100;
         break;
 
-    // Derelict Ship always have only Gold.
+    // Derelict Ship always has only Gold.
     case MP2::OBJ_DERELICT_SHIP:
         _metadata[0] = quantityValue1;
         if ( quantityValue1 == Resource::GOLD ) {
             _metadata[1] = quantityValue2 * 100;
         }
         else {
+            assert( 0 );
             _metadata[1] = quantityValue2;
         }
         break;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3463,10 +3463,32 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         _metadata[0] = quantityValue1;
         break;
 
-    // Shipwreck contains Gold and Artifact. However, old format did not store the amount of Gold.
+    // Shipwreck contains Gold, Artifact and winning conditions. However, old format did not store the amount of Gold, we need to add it.
     case MP2::OBJ_SHIPWRECK:
         _metadata[0] = quantityValue1;
         _metadata[2] = ( quantityValue2 >> 4 );
+        switch ( static_cast<ShipwreckCaptureCondition>( _metadata[2] ) ) {
+        case ShipwreckCaptureCondition::EMPTY:
+            assert( _metadata[0] == Artifact::UNKNOWN );
+            break;
+        case ShipwreckCaptureCondition::FIGHT_10_GHOSTS_AND_GET_1000_GOLD:
+            _metadata[1] = 1000;
+            break;
+        case ShipwreckCaptureCondition::FIGHT_15_GHOSTS_AND_GET_2000_GOLD:
+            _metadata[1] = 2000;
+            break;
+        case ShipwreckCaptureCondition::FIGHT_25_GHOSTS_AND_GET_5000_GOLD:
+            _metadata[1] = 5000;
+            break;
+        case ShipwreckCaptureCondition::FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT:
+            _metadata[1] = 2000;
+            break;
+        default:
+            // This is an invalid case!
+            assert( 0 );
+            break;
+        }
+
         break;
 
     // These objects should not have any metadata.

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3269,9 +3269,15 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         }
 
         if ( _metadata[1] == 0 ) {
-            // This is a broken mine from old saves. Let's set the correct income.
-            const payment_t income = ProfitConditions::FromMine( static_cast<int>( _metadata[0] ) );
-            _metadata[1] = income.Get( static_cast<int>( _metadata[0] ) );
+            // This is a broken mine from old saves. Let's try to correct income.
+            if ( Funds{ static_cast<int>( _metadata[0] ), 1 }.GetValidItemsCount() == 1 ) { 
+                const payment_t income = ProfitConditions::FromMine( static_cast<int>( _metadata[0] ) );
+                _metadata[1] = income.Get( static_cast<int>( _metadata[0] ) );
+            }
+            else {
+                // This is definitely not a mine.
+                SetObject( MP2::OBJ_NONE );
+            }
         }
 
         _metadata[2] = additionalMetadata;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -696,7 +696,7 @@ void Maps::Tiles::Init( int32_t index, const MP2::mp2tile_t & mp2 )
     SetObject( static_cast<MP2::MapObjectType>( mp2.mapObjectType ) );
 
     if ( !MP2::doesObjectContainMetadata( _mainObjectType ) ) {
-        // No metadata should exit for this object!
+        // No metadata should exist for this object!
         assert( ( ( ( mp2.quantity2 << 8 ) + mp2.quantity1 ) >> 3 ) == 0 );
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -39,6 +39,7 @@
 #include "agg_image.h"
 #include "army.h"
 #include "army_troop.h"
+#include "artifact.h"
 #include "castle.h"
 #include "game.h"
 #include "game_io.h"
@@ -3247,14 +3248,13 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
 
     // The object could be under a hero.
     const MP2::MapObjectType objectType = GetObject( false );
-
     if ( !MP2::isActionObject( objectType ) ) {
         // A non-action object have no metadata.
         return;
     }
 
     switch ( objectType ) {
-    // Alchemist Lab and Mines have first value as a resource type and the second value as resource value per day.
+    // Alchemist Lab, Sawmill and Mines have first value as a resource type and the second value as resource count per day.
     case MP2::OBJ_ALCHEMIST_LAB:
     case MP2::OBJ_MINES:
     case MP2::OBJ_SAWMILL:

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3246,10 +3246,11 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
 {
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1004_RELEASE, "Remove this method." );
 
-    // The object could be under a hero.
+    // The object could be under a hero so ignore hero.
     const MP2::MapObjectType objectType = GetObject( false );
+
     if ( !MP2::isActionObject( objectType ) ) {
-        // A non-action object have no metadata.
+        // A non-action object has no metadata.
         return;
     }
 
@@ -3595,7 +3596,7 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         break;
 
     default:
-        // Did you add a new object on Adventure Map? Add the logic!
+        // Did you add a new action object on Adventure Map? Add the logic!
         assert( 0 );
         break;
     }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -685,9 +685,7 @@ void Maps::Tiles::Init( int32_t index, const MP2::mp2tile_t & mp2 )
     tilePassable = DIRECTION_ALL;
 
     _layerType = mp2.quantity1 & 0x03;
-    quantity1 = mp2.quantity1;
-    quantity2 = mp2.quantity2;
-    additionalMetadata = 0;
+    _metadata[0] = ( ( ( mp2.quantity2 << 8 ) + mp2.quantity1 ) >> 3 );
     _fogColors = Color::ALL;
     _terrainImageIndex = mp2.terrainImageIndex;
     _terrainFlags = mp2.terrainFlags;
@@ -695,6 +693,11 @@ void Maps::Tiles::Init( int32_t index, const MP2::mp2tile_t & mp2 )
 
     SetIndex( index );
     SetObject( static_cast<MP2::MapObjectType>( mp2.mapObjectType ) );
+
+    if ( !MP2::doesObjectContainMetadata( _mainObjectType ) ) {
+        // No metadata should exit for this object!
+        assert( ( ( ( mp2.quantity2 << 8 ) + mp2.quantity1 ) >> 3 ) == 0 );
+    }
 
     addons_level1.clear();
     addons_level2.clear();
@@ -1296,7 +1299,7 @@ void Maps::Tiles::renderMainObject( fheroes2::Image & output, const Interface::G
 
     // Render possible animation image.
     // TODO: quantity2 is used in absolutely incorrect way! Fix all the logic for it. As of now (quantity2 != 0) expression is used only for Magic Garden.
-    const uint32_t mainObjectAnimationIndex = ICN::AnimationFrame( mainObjectIcn, _imageIndex, Game::getAdventureMapAnimationIndex(), quantity2 != 0 );
+    const uint32_t mainObjectAnimationIndex = ICN::AnimationFrame( mainObjectIcn, _imageIndex, Game::getAdventureMapAnimationIndex(), metadata()[1] != 0 );
     if ( mainObjectAnimationIndex > 0 ) {
         const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( mainObjectIcn, mainObjectAnimationIndex );
 
@@ -1598,9 +1601,9 @@ std::string Maps::Tiles::String() const
        << "passable from   : " << ( tilePassable ? Direction::String( tilePassable ) : "nowhere" );
 
     os << std::endl
-       << "quantity 1      : " << static_cast<int>( quantity1 ) << std::endl
-       << "quantity 2      : " << static_cast<int>( quantity2 ) << std::endl
-       << "add. metadata   : " << additionalMetadata << std::endl;
+       << "metadata value 1: " << _metadata[0] << std::endl
+       << "metadata value 2: " << _metadata[1] << std::endl
+       << "metadata value 3: " << _metadata[2] << std::endl;
 
     if ( objectType == MP2::OBJ_BOAT )
         os << "boat owner color: " << Color::String( _boatOwnerColor ) << std::endl;
@@ -2019,6 +2022,8 @@ void Maps::Tiles::fixTileObjectType( Tiles & tile )
     case MP2::OBJ_NON_ACTION_EXPANSION_OBJECT:
     case MP2::OBJ_EXPANSION_DWELLING:
     case MP2::OBJ_EXPANSION_OBJECT: {
+        // The type of expansion action object or dwelling is stored in object metadata.
+        // However, we just ignore it.
         MP2::MapObjectType objectType = getLoyaltyObject( tile._objectIcnType, tile._imageIndex );
         if ( objectType != MP2::OBJ_NONE ) {
             tile.SetObject( objectType );
@@ -3069,7 +3074,7 @@ StreamBase & Maps::operator<<( StreamBase & msg, const Tiles & tile )
 
     return msg << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile.tilePassable << tile._uid
                << static_cast<ObjectIcnTypeUnderlyingType>( tile._objectIcnType ) << tile._hasObjectAnimation << tile._isMarkedAsRoad << tile._imageIndex
-               << static_cast<MainObjectTypeUnderlyingType>( tile._mainObjectType ) << tile._fogColors << tile.quantity1 << tile.quantity2 << tile.additionalMetadata
+               << static_cast<MainObjectTypeUnderlyingType>( tile._mainObjectType ) << tile._fogColors << tile._metadata
                << tile.heroID << tile.tileIsRoad << tile.addons_level1 << tile.addons_level2 << tile._layerType << tile._boatOwnerColor;
 }
 
@@ -3124,76 +3129,37 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1001_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1001_RELEASE ) {
-        if ( mainObjectType == 128 ) {
-            // This is an old Sea Chest object type.
-            mainObjectType = MP2::OBJ_SEA_CHEST;
-        }
-        else if ( mainObjectType == 235 ) {
-            // This is an old non-action Stables object type.
-            mainObjectType = MP2::OBJ_NON_ACTION_STABLES;
-        }
-        else if ( mainObjectType == 241 ) {
-            // This is an old action Stables object type.
-            mainObjectType = MP2::OBJ_STABLES;
-        }
-        else if ( mainObjectType == 234 ) {
-            // This is an old non-action Alchemist Tower object type.
-            mainObjectType = MP2::OBJ_NON_ACTION_ALCHEMIST_TOWER;
-        }
-        else if ( mainObjectType == 240 ) {
-            // This is an old action Alchemist Tower object type.
-            mainObjectType = MP2::OBJ_ALCHEMIST_TOWER;
-        }
-        else if ( mainObjectType == 118 ) {
-            // This is an old non-action The Hut of Magi object type.
-            mainObjectType = MP2::OBJ_NON_ACTION_HUT_OF_MAGI;
-        }
-        else if ( mainObjectType == 238 ) {
-            // This is an old action The Hut of Magi object type.
-            mainObjectType = MP2::OBJ_HUT_OF_MAGI;
-        }
-        else if ( mainObjectType == 119 ) {
-            // This is an old non-action The Eye of Magi object type.
-            mainObjectType = MP2::OBJ_NON_ACTION_EYE_OF_MAGI;
-        }
-        else if ( mainObjectType == 239 ) {
-            // This is an old action The Eye of Magi object type.
-            mainObjectType = MP2::OBJ_EYE_OF_MAGI;
-        }
-        else if ( mainObjectType == 233 ) {
-            // This is an old non-action Reefs object type.
-            mainObjectType = MP2::OBJ_REEFS;
-        }
-        else if ( mainObjectType == 65 ) {
-            // This is an old non-action Thatched Hut object type.
-            mainObjectType = MP2::OBJ_NON_ACTION_PEASANT_HUT;
-        }
-        else if ( mainObjectType == 193 ) {
-            // This is an old action Thatched Hut object type.
-            mainObjectType = MP2::OBJ_PEASANT_HUT;
-        }
-        else if ( mainObjectType == 117 ) {
-            // This is an old non-action Sirens object type.
-            mainObjectType = MP2::OBJ_NON_ACTION_SIRENS;
-        }
-        else if ( mainObjectType == 237 ) {
-            // This is an old action Sirens object type.
-            mainObjectType = MP2::OBJ_SIRENS;
-        }
-        else if ( mainObjectType == 116 ) {
-            // This is an old non-action Mermaid object type.
-            mainObjectType = MP2::OBJ_NON_ACTION_MERMAID;
-        }
-        else if ( mainObjectType == 236 ) {
-            // This is an old non-action Mermaid object type.
-            mainObjectType = MP2::OBJ_MERMAID;
-        }
+        mainObjectType = Tiles::convertOldMainObjectType( mainObjectType );
     }
 
     tile._mainObjectType = static_cast<MP2::MapObjectType>( mainObjectType );
 
-    msg >> tile._fogColors >> tile.quantity1 >> tile.quantity2 >> tile.additionalMetadata >> tile.heroID >> tile.tileIsRoad >> tile.addons_level1 >> tile.addons_level2
-        >> tile._layerType;
+    msg >> tile._fogColors;
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1004_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1004_RELEASE ) {
+        uint8_t quantity1 = 0;
+        uint8_t quantity2 = 0;
+        uint32_t additionalMetadata = 0;
+
+        msg >> quantity1 >> quantity2 >> additionalMetadata;
+
+        tile.quantityIntoMetadata( quantity1, quantity2, additionalMetadata );
+    }
+    else {
+        // We want to verify the size of array being present in the file.
+        std::vector<uint32_t> temp;
+        msg >> temp;
+
+        if ( tile._metadata.size() != temp.size() ) {
+            // This is a corrupted file!
+            assert( 0 );
+        }
+        else {
+            std::copy_n( temp.begin(), tile._metadata.size(), tile._metadata.begin() );
+        }
+    }
+
+    msg >> tile.heroID >> tile.tileIsRoad >> tile.addons_level1 >> tile.addons_level2 >> tile._layerType;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1002_RELEASE, "Remove the check below." );
     if ( Game::GetVersionOfCurrentSaveFile() >= FORMAT_VERSION_1002_RELEASE ) {
@@ -3203,22 +3169,347 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
     return msg;
 }
 
-int Maps::getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
+uint8_t Maps::Tiles::convertOldMainObjectType( const uint8_t mainObjectType )
 {
-    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 60 <= icnIndex && 102 >= icnIndex ) {
-        // 60, 66, 72, 78, 84, 90, 96, 102
-        return ( ( icnIndex - 60 ) / 6 ) + 1;
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1001_RELEASE, "Remove this method." );
+
+    if ( mainObjectType == 128 ) {
+        // This is an old Sea Chest object type.
+        return MP2::OBJ_SEA_CHEST;
+    }
+    if ( mainObjectType == 235 ) {
+        // This is an old non-action Stables object type.
+        return MP2::OBJ_NON_ACTION_STABLES;
+    }
+    if ( mainObjectType == 241 ) {
+        // This is an old action Stables object type.
+        return MP2::OBJ_STABLES;
+    }
+    if ( mainObjectType == 234 ) {
+        // This is an old non-action Alchemist Tower object type.
+        return MP2::OBJ_NON_ACTION_ALCHEMIST_TOWER;
+    }
+    if ( mainObjectType == 240 ) {
+        // This is an old action Alchemist Tower object type.
+        return MP2::OBJ_ALCHEMIST_TOWER;
+    }
+    if ( mainObjectType == 118 ) {
+        // This is an old non-action The Hut of Magi object type.
+        return MP2::OBJ_NON_ACTION_HUT_OF_MAGI;
+    }
+    if ( mainObjectType == 238 ) {
+        // This is an old action The Hut of Magi object type.
+        return MP2::OBJ_HUT_OF_MAGI;
+    }
+    if ( mainObjectType == 119 ) {
+        // This is an old non-action The Eye of Magi object type.
+        return MP2::OBJ_NON_ACTION_EYE_OF_MAGI;
+    }
+    if ( mainObjectType == 239 ) {
+        // This is an old action The Eye of Magi object type.
+        return MP2::OBJ_EYE_OF_MAGI;
+    }
+    if ( mainObjectType == 233 ) {
+        // This is an old non-action Reefs object type.
+        return MP2::OBJ_REEFS;
+    }
+    if ( mainObjectType == 65 ) {
+        // This is an old non-action Thatched Hut object type.
+        return MP2::OBJ_NON_ACTION_PEASANT_HUT;
+    }
+    if ( mainObjectType == 193 ) {
+        // This is an old action Thatched Hut object type.
+        return MP2::OBJ_PEASANT_HUT;
+    }
+    if ( mainObjectType == 117 ) {
+        // This is an old non-action Sirens object type.
+        return MP2::OBJ_NON_ACTION_SIRENS;
+    }
+    if ( mainObjectType == 237 ) {
+        // This is an old action Sirens object type.
+        return MP2::OBJ_SIRENS;
+    }
+    if ( mainObjectType == 116 ) {
+        // This is an old non-action Mermaid object type.
+        return MP2::OBJ_NON_ACTION_MERMAID;
+    }
+    if ( mainObjectType == 236 ) {
+        // This is an old non-action Mermaid object type.
+        return MP2::OBJ_MERMAID;
     }
 
-    return 0;
+    return mainObjectType;
 }
 
-int Maps::getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
+void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint8_t quantityValue2, const uint32_t additionalMetadata )
 {
-    if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 110 <= icnIndex && 138 >= icnIndex ) {
-        // 110, 114, 118, 122, 126, 130, 134, 138
-        return ( ( icnIndex - 110 ) / 4 ) + 1;
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1004_RELEASE, "Remove this method." );
+
+    // The object could be under a hero.
+    const MP2::MapObjectType objectType = GetObject( false );
+
+    if ( !MP2::isActionObject( objectType ) ) {
+        // A non-action object have no metadata.
+        return;
     }
 
-    return 0;
+    switch ( objectType ) {
+    // Alchemist Lab and Mines have first value as a resource type and the second value as resource value per day.
+    case MP2::OBJ_ALCHEMIST_LAB:
+    case MP2::OBJ_MINES:
+    case MP2::OBJ_SAWMILL:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        _metadata[2] = additionalMetadata;
+        assert( _metadata[1] > 0 );
+    break;
+
+    // Monster dwellings always store only one value - the number of monsters.
+    case MP2::OBJ_ABANDONED_MINE:
+    case MP2::OBJ_AIR_ALTAR:
+    case MP2::OBJ_ARCHER_HOUSE:
+    case MP2::OBJ_BARROW_MOUNDS:
+    case MP2::OBJ_CAVE:
+    case MP2::OBJ_CITY_OF_DEAD:
+    case MP2::OBJ_DESERT_TENT:
+    case MP2::OBJ_DRAGON_CITY:
+    case MP2::OBJ_DWARF_COTTAGE:
+    case MP2::OBJ_EARTH_ALTAR:
+    case MP2::OBJ_EXCAVATION:
+    case MP2::OBJ_FIRE_ALTAR:
+    case MP2::OBJ_GOBLIN_HUT:
+    case MP2::OBJ_HALFLING_HOLE:
+    case MP2::OBJ_PEASANT_HUT:
+    case MP2::OBJ_RUINS:
+    case MP2::OBJ_TREE_CITY:
+    case MP2::OBJ_TREE_HOUSE:
+    case MP2::OBJ_TROLL_BRIDGE:
+    case MP2::OBJ_WAGON_CAMP:
+    case MP2::OBJ_WATCH_TOWER:
+    case MP2::OBJ_WATER_ALTAR:
+        _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
+        break;
+
+    // Genie's Lamp must have some monsters inside otherwise this object should not exist on Adventure Map.
+    case MP2::OBJ_GENIE_LAMP:
+        _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
+        assert( 0 );
+        break;
+
+    // Shrines as well as Pyramid always contain one type of spell.
+    case MP2::OBJ_SHRINE_FIRST_CIRCLE:
+    case MP2::OBJ_SHRINE_SECOND_CIRCLE:
+    case MP2::OBJ_SHRINE_THIRD_CIRCLE:
+    case MP2::OBJ_PYRAMID:
+        _metadata[0] = quantityValue1;
+        break;
+
+    // Monster object store the number of monsters (which must be bigger than 0) and join condition type.
+    case MP2::OBJ_MONSTER:
+        _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
+        _metadata[2] = additionalMetadata;
+        break;
+
+    // Resource contains the type and the amount.
+    case MP2::OBJ_RESOURCE:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Barrier and Traveler's Tent contain color.
+    case MP2::OBJ_BARRIER:
+    case MP2::OBJ_TRAVELLER_TENT:
+        _metadata[0] = quantityValue1;
+        break;
+
+    // Tree of Knowledge contains either nothing for free level up or the amount of required resources.
+    case MP2::OBJ_TREE_OF_KNOWLEDGE:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Witch's Hut contains a basic level of  a secondary skill.
+    case MP2::OBJ_WITCHS_HUT:
+        _metadata[0] = quantityValue1;
+        break;
+
+    // Magic Garden and Water Wheel either contain nothing when it was visited or some resources.
+    case MP2::OBJ_MAGIC_GARDEN:
+    case MP2::OBJ_WATER_WHEEL:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Skeleton contains an artifact.
+    case MP2::OBJ_SKELETON:
+        _metadata[0] = quantityValue1;
+        break;
+
+    // Lean-To contains one resource type and it amount.
+    case MP2::OBJ_LEAN_TO:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Wagon can contain either an artifact or a resource.
+    case MP2::OBJ_WAGON:
+        if ( quantityValue2 > 0 ) {
+            _metadata[0] = Artifact::UNKNOWN;
+            _metadata[1] = quantityValue1;
+            _metadata[2] = quantityValue2;
+        }
+        else {
+            _metadata[0] = quantityValue1;
+        }
+        break;
+
+    // Flotsam can contain Wood and Gold.
+    case MP2::OBJ_FLOTSAM:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Treasure and Sea Chests can contain an artifact and gold.
+    case MP2::OBJ_GRAVEYARD:
+    case MP2::OBJ_SEA_CHEST:
+    case MP2::OBJ_TREASURE_CHEST:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Derelict Ship always have only Gold.
+    case MP2::OBJ_DERELICT_SHIP:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Daemon Cave is tricky: it can contain experience, gold and artifact.
+    // However, we store only artifact and a variation of a prize.
+    case MP2::OBJ_DAEMON_CAVE:
+        _metadata[0] = quantityValue1;
+        _metadata[2] = ( quantityValue2 >> 4 );
+        break;
+
+    // Campfire contains some random resources and gold which has the same value as resource but multiplied by 100.
+    // TODO: verify that the amount of gold is always an equivalent of the amount of other resources multipled by 100.
+    case MP2::OBJ_CAMPFIRE:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Windmill contains some resources.
+    case MP2::OBJ_WINDMILL:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = quantityValue2;
+        break;
+
+    // Artifact contains artifact ID, possible resources and condition to grab it.
+    case MP2::OBJ_ARTIFACT:
+        _metadata[0] = quantityValue1;
+        _metadata[1] = ( 0x0f & quantityValue2 );
+        _metadata[2] = ( quantityValue2 >> 4 );
+        break;
+
+    // Shipwreck Survivor has an artifact.
+    case MP2::OBJ_SHIPWRECK_SURVIVOR:
+        _metadata[2] = quantityValue1;
+        break;
+
+    // Shipwreck contains Gold and Artifact. However, we store only artifact and a variation of a prize.
+    case MP2::OBJ_SHIPWRECK:
+        _metadata[0] = quantityValue1;
+        _metadata[2] = ( quantityValue2 >> 4 );
+        break;
+
+    // These objects should not have any metadata.
+    case MP2::OBJ_ACTION_CACTUS:
+    case MP2::OBJ_ACTION_COAST:
+    case MP2::OBJ_ACTION_CRATER:
+    case MP2::OBJ_ACTION_DEAD_TREE:
+    case MP2::OBJ_ACTION_DUNE:
+    case MP2::OBJ_ACTION_FLOWERS:
+    case MP2::OBJ_ACTION_LAVAPOOL:
+    case MP2::OBJ_ACTION_MANDRAKE:
+    case MP2::OBJ_ACTION_MOSSY_ROCK:
+    case MP2::OBJ_ACTION_MOUND:
+    case MP2::OBJ_ACTION_MOUNTAINS:
+    case MP2::OBJ_ACTION_NOTHING_SPECIAL:
+    case MP2::OBJ_ACTION_REEFS:
+    case MP2::OBJ_ACTION_ROCK:
+    case MP2::OBJ_ACTION_SHRUB:
+    case MP2::OBJ_ACTION_STUMP:
+    case MP2::OBJ_ACTION_TAR_PIT:
+    case MP2::OBJ_ACTION_TREES:
+    case MP2::OBJ_ACTION_VOLCANO:
+    case MP2::OBJ_ACTION_WATER_LAKE:
+    case MP2::OBJ_ALCHEMIST_TOWER:
+    case MP2::OBJ_ARENA:
+    case MP2::OBJ_ARTESIAN_SPRING:
+    case MP2::OBJ_BOAT:
+    case MP2::OBJ_BUOY:
+    case MP2::OBJ_EYE_OF_MAGI:
+    case MP2::OBJ_FAERIE_RING:
+    case MP2::OBJ_FORT:
+    case MP2::OBJ_FOUNTAIN:
+    case MP2::OBJ_FREEMANS_FOUNDRY:
+    case MP2::OBJ_GAZEBO:
+    case MP2::OBJ_HILL_FORT:
+    case MP2::OBJ_HUT_OF_MAGI:
+    case MP2::OBJ_IDOL:
+    case MP2::OBJ_LIGHTHOUSE:
+    case MP2::OBJ_MAGELLANS_MAPS:
+    case MP2::OBJ_MAGIC_WELL:
+    case MP2::OBJ_MERCENARY_CAMP:
+    case MP2::OBJ_MERMAID:
+    case MP2::OBJ_OASIS:
+    case MP2::OBJ_OBELISK:
+    case MP2::OBJ_OBSERVATION_TOWER:
+    case MP2::OBJ_ORACLE:
+    case MP2::OBJ_SIRENS:
+    case MP2::OBJ_STABLES:
+    case MP2::OBJ_STANDING_STONES:
+    case MP2::OBJ_STONE_LITHS:
+    case MP2::OBJ_TEMPLE:
+    case MP2::OBJ_TRADING_POST:
+    case MP2::OBJ_WATERING_HOLE:
+    case MP2::OBJ_WHIRLPOOL:
+    case MP2::OBJ_WITCH_DOCTORS_HUT:
+    case MP2::OBJ_XANADU:
+        break;
+
+    // Metadata for these objects is stored outside this class.
+    case MP2::OBJ_BOTTLE:
+    case MP2::OBJ_CASTLE:
+    case MP2::OBJ_EVENT:
+    case MP2::OBJ_HEROES:
+    case MP2::OBJ_JAIL:
+    case MP2::OBJ_SIGN:
+    case MP2::OBJ_SPHINX:
+        assert( MP2::doesObjectNeedExtendedMetadata( objectType ) );
+        break;
+
+    // These objects must not even exist in a save file.
+    case MP2::OBJ_EXPANSION_DWELLING:
+    case MP2::OBJ_EXPANSION_OBJECT:
+    case MP2::OBJ_RANDOM_ARTIFACT:
+    case MP2::OBJ_RANDOM_ARTIFACT_MAJOR:
+    case MP2::OBJ_RANDOM_ARTIFACT_MINOR:
+    case MP2::OBJ_RANDOM_ARTIFACT_TREASURE:
+    case MP2::OBJ_RANDOM_CASTLE:
+    case MP2::OBJ_RANDOM_MONSTER:
+    case MP2::OBJ_RANDOM_MONSTER_MEDIUM:
+    case MP2::OBJ_RANDOM_MONSTER_STRONG:
+    case MP2::OBJ_RANDOM_MONSTER_VERY_STRONG:
+    case MP2::OBJ_RANDOM_MONSTER_WEAK:
+    case MP2::OBJ_RANDOM_RESOURCE:
+    case MP2::OBJ_RANDOM_TOWN:
+    case MP2::OBJ_RANDOM_ULTIMATE_ARTIFACT:
+        assert( 0 );
+        break;
+
+    default:
+        // Did you add a new object on Adventure Map? Add the logic!
+        assert( 0 );
+        break;
+    }
 }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3384,9 +3384,9 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         break;
 
     // Daemon Cave is tricky: it can contain experience, gold and artifact.
-    // However, we store only artifact and a variation of a prize.
     case MP2::OBJ_DAEMON_CAVE:
         _metadata[0] = quantityValue1;
+        _metadata[1] = ( 0x0f & quantityValue2 );
         _metadata[2] = ( quantityValue2 >> 4 );
         break;
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3268,8 +3268,13 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
             _metadata[1] = quantityValue2;
         }
 
+        if ( _metadata[1] == 0 ) {
+            // This is a broken mine from old saves. Let's set the correct income.
+            const payment_t income = ProfitConditions::FromMine( static_cast<int>( _metadata[0] ) );
+            _metadata[1] = income.Get( static_cast<int>( _metadata[0] ) );
+        }
+
         _metadata[2] = additionalMetadata;
-        assert( _metadata[1] > 0 );
         break;
 
     // Abandoned mine was mixed with Mines in the old save formats.
@@ -3423,7 +3428,6 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
             _metadata[1] = quantityValue2 * 100;
         }
         else {
-            assert( 0 );
             _metadata[1] = quantityValue2;
         }
         break;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3273,11 +3273,14 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         assert( _metadata[1] > 0 );
         break;
 
-    // Monster dwellings always store only one value - the number of monsters.
+    // Abandoned mine was mixed with Mines in the old save formats.
+    // TODO: verify we convert data for Abandoned Mines properly before 1.0.3 and after.
     case MP2::OBJ_ABANDONED_MINE:
         _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
         _metadata[2] = additionalMetadata;
         break;
+
+    // Monster dwellings always store only one value - the number of monsters.
     case MP2::OBJ_AIR_ALTAR:
     case MP2::OBJ_ARCHER_HOUSE:
     case MP2::OBJ_BARROW_MOUNDS:

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3074,8 +3074,8 @@ StreamBase & Maps::operator<<( StreamBase & msg, const Tiles & tile )
 
     return msg << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile.tilePassable << tile._uid
                << static_cast<ObjectIcnTypeUnderlyingType>( tile._objectIcnType ) << tile._hasObjectAnimation << tile._isMarkedAsRoad << tile._imageIndex
-               << static_cast<MainObjectTypeUnderlyingType>( tile._mainObjectType ) << tile._fogColors << tile._metadata
-               << tile.heroID << tile.tileIsRoad << tile.addons_level1 << tile.addons_level2 << tile._layerType << tile._boatOwnerColor;
+               << static_cast<MainObjectTypeUnderlyingType>( tile._mainObjectType ) << tile._fogColors << tile._metadata << tile.heroID << tile.tileIsRoad
+               << tile.addons_level1 << tile.addons_level2 << tile._layerType << tile._boatOwnerColor;
 }
 
 StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
@@ -3262,7 +3262,7 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         _metadata[1] = quantityValue2;
         _metadata[2] = additionalMetadata;
         assert( _metadata[1] > 0 );
-    break;
+        break;
 
     // Monster dwellings always store only one value - the number of monsters.
     case MP2::OBJ_ABANDONED_MINE:

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3461,7 +3461,7 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
 
     // Shipwreck Survivor has an artifact.
     case MP2::OBJ_SHIPWRECK_SURVIVOR:
-        _metadata[2] = quantityValue1;
+        _metadata[0] = quantityValue1;
         break;
 
     // Shipwreck contains Gold and Artifact. However, old format did not store the amount of Gold.

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -3253,12 +3253,21 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         return;
     }
 
+    // Old format contained Gold values divided by 100 due to uint8_t limitation. We don't have such limitation anymore.
+
     switch ( objectType ) {
     // Alchemist Lab, Sawmill and Mines have first value as a resource type and the second value as resource count per day.
     case MP2::OBJ_ALCHEMIST_LAB:
     case MP2::OBJ_MINES:
     case MP2::OBJ_SAWMILL:
         _metadata[0] = quantityValue1;
+        if ( quantityValue1 == Resource::GOLD ) {
+            _metadata[1] = quantityValue2 * 100;
+        }
+        else {
+            _metadata[1] = quantityValue2;
+        }
+
         _metadata[1] = quantityValue2;
         _metadata[2] = additionalMetadata;
         assert( _metadata[1] > 0 );
@@ -3266,6 +3275,9 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
 
     // Monster dwellings always store only one value - the number of monsters.
     case MP2::OBJ_ABANDONED_MINE:
+        _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
+        _metadata[2] = additionalMetadata;
+        break;
     case MP2::OBJ_AIR_ALTAR:
     case MP2::OBJ_ARCHER_HOUSE:
     case MP2::OBJ_BARROW_MOUNDS:
@@ -3293,7 +3305,7 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
     // Genie's Lamp must have some monsters inside otherwise this object should not exist on Adventure Map.
     case MP2::OBJ_GENIE_LAMP:
         _metadata[0] = ( static_cast<uint32_t>( quantityValue1 ) << 8 ) + quantityValue2;
-        assert( 0 );
+        assert( _metadata[0] > 0 );
         break;
 
     // Shrines as well as Pyramid always contain one type of spell.
@@ -3313,7 +3325,12 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
     // Resource contains the type and the amount.
     case MP2::OBJ_RESOURCE:
         _metadata[0] = quantityValue1;
-        _metadata[1] = quantityValue2;
+        if ( quantityValue1 == Resource::GOLD ) {
+            _metadata[1] = quantityValue2 * 100;
+        }
+        else {
+            _metadata[1] = quantityValue2;
+        }
         break;
 
     // Barrier and Traveler's Tent contain color.
@@ -3325,7 +3342,12 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
     // Tree of Knowledge contains either nothing for free level up or the amount of required resources.
     case MP2::OBJ_TREE_OF_KNOWLEDGE:
         _metadata[0] = quantityValue1;
-        _metadata[1] = quantityValue2;
+        if ( quantityValue1 == Resource::GOLD ) {
+            _metadata[1] = quantityValue2 * 100;
+        }
+        else {
+            _metadata[1] = quantityValue2;
+        }
         break;
 
     // Witch's Hut contains a basic level of  a secondary skill.
@@ -3337,7 +3359,12 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
     case MP2::OBJ_MAGIC_GARDEN:
     case MP2::OBJ_WATER_WHEEL:
         _metadata[0] = quantityValue1;
-        _metadata[1] = quantityValue2;
+        if ( quantityValue1 == Resource::GOLD ) {
+            _metadata[1] = quantityValue2 * 100;
+        }
+        else {
+            _metadata[1] = quantityValue2;
+        }
         break;
 
     // Skeleton contains an artifact.
@@ -3345,10 +3372,15 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         _metadata[0] = quantityValue1;
         break;
 
-    // Lean-To contains one resource type and it amount.
+    // Lean-To contains one resource type and its amount.
     case MP2::OBJ_LEAN_TO:
         _metadata[0] = quantityValue1;
-        _metadata[1] = quantityValue2;
+        if ( quantityValue1 == Resource::GOLD ) {
+            _metadata[1] = quantityValue2 * 100;
+        }
+        else {
+            _metadata[1] = quantityValue2;
+        }
         break;
 
     // Wagon can contain either an artifact or a resource.
@@ -3356,7 +3388,12 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         if ( quantityValue2 > 0 ) {
             _metadata[0] = Artifact::UNKNOWN;
             _metadata[1] = quantityValue1;
-            _metadata[2] = quantityValue2;
+            if ( quantityValue1 == Resource::GOLD ) {
+                _metadata[2] = quantityValue2 * 100;
+            }
+            else {
+                _metadata[2] = quantityValue2;
+            }
         }
         else {
             _metadata[0] = quantityValue1;
@@ -3366,7 +3403,7 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
     // Flotsam can contain Wood and Gold.
     case MP2::OBJ_FLOTSAM:
         _metadata[0] = quantityValue1;
-        _metadata[1] = quantityValue2;
+        _metadata[1] = quantityValue2 * 100;
         break;
 
     // Treasure and Sea Chests can contain an artifact and gold.
@@ -3374,19 +3411,24 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
     case MP2::OBJ_SEA_CHEST:
     case MP2::OBJ_TREASURE_CHEST:
         _metadata[0] = quantityValue1;
-        _metadata[1] = quantityValue2;
+        _metadata[1] = quantityValue2 * 100;
         break;
 
     // Derelict Ship always have only Gold.
     case MP2::OBJ_DERELICT_SHIP:
         _metadata[0] = quantityValue1;
-        _metadata[1] = quantityValue2;
+        if ( quantityValue1 == Resource::GOLD ) {
+            _metadata[1] = quantityValue2 * 100;
+        }
+        else {
+            _metadata[1] = quantityValue2;
+        }
         break;
 
     // Daemon Cave is tricky: it can contain experience, gold and artifact.
     case MP2::OBJ_DAEMON_CAVE:
         _metadata[0] = quantityValue1;
-        _metadata[1] = ( 0x0f & quantityValue2 );
+        _metadata[1] = ( 0x0f & quantityValue2 ) * 100;
         _metadata[2] = ( quantityValue2 >> 4 );
         break;
 
@@ -3399,7 +3441,12 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
     // Windmill contains some resources.
     case MP2::OBJ_WINDMILL:
         _metadata[0] = quantityValue1;
-        _metadata[1] = quantityValue2;
+        if ( quantityValue1 == Resource::GOLD ) {
+            _metadata[1] = quantityValue2 * 100;
+        }
+        else {
+            _metadata[1] = quantityValue2;
+        }
         break;
 
     // Artifact contains artifact ID, possible resources and condition to grab it.
@@ -3414,7 +3461,7 @@ void Maps::Tiles::quantityIntoMetadata( const uint8_t quantityValue1, const uint
         _metadata[2] = quantityValue1;
         break;
 
-    // Shipwreck contains Gold and Artifact. However, we store only artifact and a variation of a prize.
+    // Shipwreck contains Gold and Artifact. However, old format did not store the amount of Gold.
     case MP2::OBJ_SHIPWRECK:
         _metadata[0] = quantityValue1;
         _metadata[2] = ( quantityValue2 >> 4 );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -404,7 +404,7 @@ namespace Maps
 
         static uint8_t convertOldMainObjectType( const uint8_t mainObjectType );
 
-        // The old code was using a weird quantity based values which were very hard to understand.
+        // The old code was using weird quantity based values which were very hard to understand.
         // Since we must have backwards compatibility we need to do the conversion.
         void quantityIntoMetadata( const uint8_t quantityValue1, const uint8_t quantityValue2, const uint32_t additionalMetadata );
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -399,11 +399,6 @@ namespace Maps
         friend StreamBase & operator<<( StreamBase &, const Tiles & );
         friend StreamBase & operator>>( StreamBase &, Tiles & );
 
-        friend bool operator<( const Tiles & l, const Tiles & r )
-        {
-            return l.GetIndex() < r.GetIndex();
-        }
-
         static void renderAddonObject( fheroes2::Image & output, const Interface::GameArea & area, const fheroes2::Point & offset, const TilesAddon & addon );
         void renderMainObject( fheroes2::Image & output, const Interface::GameArea & area, const fheroes2::Point & offset ) const;
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -23,6 +23,7 @@
 #ifndef H2TILES_H
 #define H2TILES_H
 
+#include <array>
 #include <cstdint>
 #include <list>
 #include <string>
@@ -332,67 +333,16 @@ namespace Maps
         // (castle has a hero or garrison, dwelling has creatures, etc)
         bool isCaptureObjectProtected() const;
 
-        // Get Tile metadata field #1 (used for things like monster count or resource amount)
-        uint8_t GetQuantity1() const
-        {
-            return quantity1;
-        }
-
-        void setQuantity1( const uint8_t value )
-        {
-            quantity1 = value;
-        }
-
-        void setQuantity2( const uint8_t value )
-        {
-            quantity2 = value;
-        }
-
-        // Get Tile metadata field #2 (used for things like animations or resource type )
-        uint8_t GetQuantity2() const
-        {
-            return quantity2;
-        }
-
-        int QuantityVariant() const
-        {
-            return quantity2 >> 4;
-        }
-
-        int QuantityExt() const
-        {
-            return 0x0f & quantity2;
-        }
-
-        void QuantitySetVariant( const int variant )
-        {
-            quantity2 &= 0x0f;
-            quantity2 |= variant << 4;
-        }
-
-        void QuantitySetExt( int ext )
-        {
-            quantity2 &= 0xf0;
-            quantity2 |= ( 0x0f & ext );
-        }
-
         void SetObjectPassable( bool );
 
-        // Get additional metadata.
-        int32_t getAdditionalMetadata() const
+        const std::array<uint32_t, 3> & metadata() const
         {
-            return additionalMetadata;
+            return _metadata;
         }
 
-        // Set Tile additional metadata field.
-        void setAdditionalMetadata( const uint32_t value )
+        std::array<uint32_t, 3> & metadata()
         {
-            additionalMetadata = value;
-        }
-
-        void clearAdditionalMetadata()
-        {
-            additionalMetadata = 0;
+            return _metadata;
         }
 
         Heroes * GetHeroes() const;
@@ -457,6 +407,12 @@ namespace Maps
         static void renderAddonObject( fheroes2::Image & output, const Interface::GameArea & area, const fheroes2::Point & offset, const TilesAddon & addon );
         void renderMainObject( fheroes2::Image & output, const Interface::GameArea & area, const fheroes2::Point & offset ) const;
 
+        static uint8_t convertOldMainObjectType( const uint8_t mainObjectType );
+
+        // The old code was using a weird quantity based values which were very hard to understand.
+        // Since we must have backwards compatibility we need to do the conversion.
+        void quantityIntoMetadata( const uint8_t quantityValue1, const uint8_t quantityValue2, const uint32_t additionalMetadata );
+
         Addons addons_level1; // bottom layer
         Addons addons_level2; // top layer
 
@@ -493,12 +449,7 @@ namespace Maps
 
         uint8_t heroID = 0;
 
-        // TODO: Combine quantity1 and quantity2 into a single 16/32-bit variable except first 2 bits of quantity1 which are used for level type of an object.
-        uint8_t quantity1 = 0;
-        uint8_t quantity2 = 0;
-
-        // Additional metadata is not set from map's information but during runtime like spells or monster joining conditions.
-        int32_t additionalMetadata = 0;
+        std::array<uint32_t, 3> _metadata{ 0 };
 
         bool tileIsRoad = false;
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -509,7 +509,7 @@ namespace Maps
         return { Resource::GOLD, tile.metadata()[1] };
     }
 
-    ShipwreckCaptureCondition getShipwrechCaptureCondition( const Tiles & tile )
+    ShipwreckCaptureCondition getShipwreckCaptureCondition( const Tiles & tile )
     {
         if ( tile.GetObject( false ) != MP2::OBJ_SHIPWRECK ) {
             // Why are you calling this for an unsupported object type?
@@ -922,7 +922,7 @@ namespace Maps
             if ( art == Artifact::SPELL_SCROLL ) {
                 static_assert( Spell::FIREBALL < Spell::SETWGUARDIAN, "The order of spell IDs has been changed, check the logic below" );
 
-                // Spell ID is by 1 bigger than in the original game.
+                // Spell ID has a value of 1 bigger than in the original game.
                 const uint32_t spell = std::clamp( tile.metadata()[0] + 1, static_cast<uint32_t>( Spell::FIREBALL ), static_cast<uint32_t>( Spell::SETWGUARDIAN ) );
 
                 tile.metadata()[1] = spell;
@@ -1024,7 +1024,7 @@ namespace Maps
                 res = Resource::Rand( false );
             }
 
-            // 2 pieces of random resource.
+            // 2 pieces of random resources.
             setResourceOnTile( tile, res, 2 );
             break;
         }
@@ -1032,7 +1032,7 @@ namespace Maps
         case MP2::OBJ_LEAN_TO:
             assert( isFirstLoad );
 
-            // 1-4 pieces of random resource.
+            // 1-4 pieces of random resources.
             setResourceOnTile( tile, Resource::Rand( false ), Rand::Get( 1, 4 ) );
             break;
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -557,6 +557,9 @@ namespace Maps
         case MP2::OBJ_WATER_WHEEL:
             return { static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] };
 
+        case MP2::OBJ_WAGON:
+            return { static_cast<int>( tile.metadata()[1] ), tile.metadata()[2] };
+
         default:
             break;
         }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -947,8 +947,8 @@ namespace Maps
 
                 tile.metadata()[2] = cond;
 
-                if ( cond == static_cast<uint32_t>( ArtifactCaptureCondition::PAY_2500_GOLD_AND_3_RESOURCES ) ||
-                     cond == static_cast<uint32_t>( ArtifactCaptureCondition::PAY_3000_GOLD_AND_5_RESOURCES ) ) {
+                if ( cond == static_cast<uint32_t>( ArtifactCaptureCondition::PAY_2500_GOLD_AND_3_RESOURCES )
+                     || cond == static_cast<uint32_t>( ArtifactCaptureCondition::PAY_3000_GOLD_AND_5_RESOURCES ) ) {
                     // TODO: why do we use icon ICN index instead of map ICN index?
                     tile.metadata()[1] = Resource::getIconIcnIndex( Resource::Rand( false ) ) + 1;
                 }
@@ -1195,7 +1195,8 @@ namespace Maps
             const int cond = percents.Get();
 
             tile.metadata()[0] = ( cond == static_cast<int>( ShipwreckCaptureCondition::FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT ) )
-                                 ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL ) : Artifact::UNKNOWN;
+                                     ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL )
+                                     : Artifact::UNKNOWN;
             tile.metadata()[2] = cond;
             break;
         }
@@ -1223,9 +1224,9 @@ namespace Maps
             // 1000 exp or 1000 exp + 2500 gold or 1000 exp + art or (-2500 or remove hero)
             const uint32_t cond = Rand::Get( 1, 4 );
 
-
             tile.metadata()[0] = ( cond == static_cast<uint32_t>( DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_ARTIFACT ) )
-                                 ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL ) : Artifact::UNKNOWN;
+                                     ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL )
+                                     : Artifact::UNKNOWN;
             tile.metadata()[2] = cond;
             break;
         }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -214,6 +214,8 @@ namespace Maps
                 return { static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] * 100 };
             }
             return { static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] };
+        default:
+            break;
         }
 
         // Why are you calling this function for an unsupported object type?
@@ -546,10 +548,10 @@ namespace Maps
     {
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_CAMPFIRE:
-            return Funds( tile.metadata()[0], tile.metadata()[1] ) + Funds( Resource::GOLD, tile.metadata()[1] * 100 );
+            return Funds{ static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] } + Funds{ Resource::GOLD, tile.metadata()[1] * 100 };
 
         case MP2::OBJ_FLOTSAM:
-            return Funds( Resource::WOOD, tile.metadata()[0] ) + Funds( Resource::GOLD, tile.metadata()[1] * 100 );
+            return Funds{ Resource::WOOD, tile.metadata()[0] } + Funds{ Resource::GOLD, tile.metadata()[1] * 100 };
 
         case MP2::OBJ_DAEMON_CAVE:
         case MP2::OBJ_GRAVEYARD:

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -639,7 +639,7 @@ namespace Maps
         return false;
     }
 
-    void resetObjectInfoOnTile( Tiles & tile )
+    void resetObjectMetadata( Tiles & tile )
     {
         for ( uint32_t & value : tile.metadata() ) {
             value = 0;
@@ -663,7 +663,13 @@ namespace Maps
         default:
             break;
         }
+    }
 
+    void resetObjectInfoOnTile( Tiles & tile )
+    {
+        resetObjectMetadata( tile );
+
+        const MP2::MapObjectType objectType = tile.GetObject( false );
         if ( MP2::isPickupObject( objectType ) ) {
             tile.setAsEmpty();
         }
@@ -860,7 +866,7 @@ namespace Maps
         case MP2::OBJ_WAGON: {
             assert( isFirstLoad );
 
-            resetObjectInfoOnTile( tile );
+            resetObjectMetadata( tile );
 
             Rand::Queue percents( 3 );
             // 20%: empty
@@ -1416,9 +1422,16 @@ namespace Maps
         case MP2::OBJ_WATER_ALTAR:
             updateDwellingPopulationOnTile( tile, isFirstLoad );
             break;
+
+        case MP2::OBJ_EVENT:
+            assert( isFirstLoad );
+            // Event should be invisible on Adventure Map.
+            tile.resetObjectSprite();
+            break;
+
         default:
             if ( isFirstLoad ) {
-                tile.resetObjectSprite();
+                resetObjectMetadata( tile );
             }
             break;
         }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -210,7 +210,7 @@ namespace Maps
         case MP2::OBJ_MINES:
         case MP2::OBJ_SAWMILL:
             if ( tile.metadata()[0] == Resource::GOLD ) {
-                return { static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] * 100 };
+                return { static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] };
             }
             return { static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] };
         default:

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -39,7 +39,6 @@
 #include "maps_tiles.h"
 #include "monster.h"
 #include "mp2.h"
-#include "pairs.h"
 #include "payment.h"
 #include "profit.h"
 #include "rand.h"

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -419,9 +419,9 @@ namespace Maps
 
         switch ( static_cast<ArtifactCaptureCondition>( tile.metadata()[2] ) ) {
         case ArtifactCaptureCondition::HAVE_WISDOM_SKILL:
-            return { Skill::Secondary::LEADERSHIP, Skill::Level::BASIC };
-        case ArtifactCaptureCondition::HAVE_LEADERSHIP_SKILL:
             return { Skill::Secondary::WISDOM, Skill::Level::BASIC };
+        case ArtifactCaptureCondition::HAVE_LEADERSHIP_SKILL:
+            return { Skill::Secondary::LEADERSHIP, Skill::Level::BASIC };
         default:
             break;
         }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1226,7 +1226,6 @@ namespace Maps
                 tile.metadata()[1] = 0;
                 break;
             }
-            
             break;
         }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -528,6 +528,11 @@ namespace Maps
             return {};
         }
 
+        if ( tile.metadata()[0] == 0 && tile.metadata()[1] == 0 ) {
+            // No requirements.
+            return {};
+        }
+
         return { static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] };
     }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -472,7 +472,7 @@ namespace Maps
         if ( tile.GetObject( false ) != MP2::OBJ_DAEMON_CAVE ) {
             // Why are you calling this for an unsupported object type?
             assert( 0 );
-            return DaemonCaveCaptureBonus::NO_BONUS;
+            return DaemonCaveCaptureBonus::EMPTY;
         }
 
         return static_cast<DaemonCaveCaptureBonus>( tile.metadata()[2] );
@@ -500,7 +500,7 @@ namespace Maps
         if ( tile.GetObject( false ) != MP2::OBJ_SHIPWRECK ) {
             // Why are you calling this for an unsupported object type?
             assert( 0 );
-            return ShipwreckCaptureCondition::NO_BONUS;
+            return ShipwreckCaptureCondition::EMPTY;
         }
 
         return static_cast<ShipwreckCaptureCondition>( tile.metadata()[2] );

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -528,11 +528,6 @@ namespace Maps
             return {};
         }
 
-        if ( tile.metadata()[0] == 0 && tile.metadata()[1] == 0 ) {
-            // No requirements.
-            return {};
-        }
-
         return { static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] };
     }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -876,6 +876,9 @@ namespace Maps
             if ( percents.Get() ) {
                 tile.metadata()[0] = Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL );
             }
+            else {
+                tile.metadata()[0] = Artifact::UNKNOWN;
+            }
             break;
         }
 
@@ -1115,6 +1118,9 @@ namespace Maps
             default:
                 // Check your logic above!
                 assert( 0 );
+
+                tile.metadata()[0] = Artifact::UNKNOWN;
+                tile.metadata()[1] = 0;
                 break;
             }
             break;

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1316,6 +1316,8 @@ namespace Maps
                 break;
             }
             default:
+                // This is an unknown mine type. Most likely it was added by some hex editing.
+                tile.SetObject( MP2::OBJ_NONE );
                 break;
             }
             break;

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -21,6 +21,7 @@
 #include "maps_tiles_helper.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstdint>
 #include <limits>
@@ -178,7 +179,7 @@ namespace Maps
             return Spell::NONE;
         }
 
-        return tile.metadata()[2];
+        return static_cast<int32_t>( tile.metadata()[2] );
     }
 
     void setMineSpellOnTile( Tiles & tile, const int32_t spellId )
@@ -269,7 +270,7 @@ namespace Maps
         return false;
     }
 
-    int Maps::getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
+    int getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
     {
         // The color of the barrier is actually being stored in tile metadata but as of now we use sprite information.
 
@@ -283,7 +284,7 @@ namespace Maps
         return 0;
     }
 
-    int Maps::getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
+    int getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
     {
         // The color of the barrier is actually being stored in tile metadata but as of now we use sprite information.
 
@@ -375,7 +376,7 @@ namespace Maps
         case MP2::OBJ_ARTIFACT:
             if ( tile.metadata()[2] == static_cast<uint32_t>( ArtifactCaptureCondition::CONTAINS_SPELL ) ) {
                 Artifact art( Artifact::SPELL_SCROLL );
-                art.SetSpell( tile.metadata()[1] );
+                art.SetSpell( static_cast<int32_t>( tile.metadata()[1] ) );
                 return art;
             }
             else {
@@ -617,7 +618,7 @@ namespace Maps
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_BARRIER:
         case MP2::OBJ_TRAVELLER_TENT:
-            return tile.metadata()[0];
+            return static_cast<int>( tile.metadata()[0] );
         default:
             return world.ColorCapturedObject( tile.GetIndex() );
         }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -113,6 +113,7 @@ namespace
         if ( !art.isValid() ) {
             DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set an artifact over a random artifact on tile " << tile.GetIndex() )
             resetObjectMetadata( tile );
+            tile.setAsEmpty();
             return;
         }
 
@@ -167,6 +168,7 @@ namespace
         if ( !mons.isValid() ) {
             DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set a monster over a random monster on tile " << tile.GetIndex() )
             resetObjectMetadata( tile );
+            tile.setAsEmpty();
             return;
         }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1055,7 +1055,9 @@ namespace Maps
                 tile.metadata()[0] = Artifact::Rand( Artifact::ART_LEVEL_MAJOR );
                 break;
             default:
+                // Check your logic above!
                 assert( 0 );
+                tile.metadata()[0] = Artifact::UNKNOWN;
                 break;
             }
             break;
@@ -1072,23 +1074,24 @@ namespace Maps
             // 10% - 1000 gold + art
             percents.Push( 2, 10 );
 
-            int art = Artifact::UNKNOWN;
-            uint32_t gold = 0;
-
             switch ( percents.Get() ) {
+            case 0:
+                tile.metadata()[0] = Artifact::UNKNOWN;
+                tile.metadata()[1] = 0;
+                break;
             case 1:
-                gold = 1500;
+                tile.metadata()[0] = Artifact::UNKNOWN;
+                tile.metadata()[1] = 1500;
                 break;
             case 2:
-                gold = 1000;
-                art = Artifact::Rand( Artifact::ART_LEVEL_TREASURE );
+                tile.metadata()[0] = Artifact::Rand( Artifact::ART_LEVEL_TREASURE );
+                tile.metadata()[1] = 1000;
                 break;
             default:
+                // Check your logic above!
+                assert( 0 );
                 break;
             }
-
-            tile.metadata()[0] = art;
-            tile.metadata()[1] = gold;
             break;
         }
 
@@ -1112,27 +1115,30 @@ namespace Maps
                 // 5% - art
                 percents.Push( 4, 5 );
 
-                int art = Artifact::UNKNOWN;
-                uint32_t gold = 0;
-
-                // variant
                 switch ( percents.Get() ) {
                 case 1:
-                    gold = 2000;
+                    tile.metadata()[0] = Artifact::UNKNOWN;
+                    tile.metadata()[1] = 2000;
                     break;
                 case 2:
-                    gold = 1500;
+                    tile.metadata()[0] = Artifact::UNKNOWN;
+                    tile.metadata()[1] = 1500;
                     break;
                 case 3:
-                    gold = 1000;
+                    tile.metadata()[0] = Artifact::UNKNOWN;
+                    tile.metadata()[1] = 1000;
+                    break;
+                case 4:
+                    tile.metadata()[0] = Artifact::Rand( Artifact::ART_LEVEL_TREASURE );
+                    tile.metadata()[1] = 0;
                     break;
                 default:
-                    art = Artifact::Rand( Artifact::ART_LEVEL_TREASURE );
+                    // Check your logic above!
+                    tile.metadata()[0] = Artifact::UNKNOWN;
+                    tile.metadata()[1] = 0;
+                    assert( 0 );
                     break;
                 }
-
-                tile.metadata()[0] = art;
-                tile.metadata()[1] = gold;
             }
             break;
 
@@ -1175,6 +1181,8 @@ namespace Maps
                 tile.metadata()[1] = 2000;
                 break;
             default:
+                // Check your logic above!
+                assert( 0 );
                 tile.metadata()[0] = Artifact::UNKNOWN;
                 tile.metadata()[1] = 0;
                 break;
@@ -1221,6 +1229,8 @@ namespace Maps
                 tile.metadata()[1] = 2500;
                 break;
             default:
+                // Check your logic above!
+                assert( 0 );
                 tile.metadata()[0] = Artifact::UNKNOWN;
                 tile.metadata()[1] = 0;
                 break;

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1203,8 +1203,8 @@ namespace Maps
             tile.metadata()[0] = ( cond == static_cast<uint32_t>( DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_ARTIFACT ) )
                                      ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL )
                                      : Artifact::UNKNOWN;
-            tile.metadata()[1] = ( cond == static_cast<uint32_t>( DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_2500_GOLD ) ) ||
-                                 ( cond == static_cast<uint32_t>( DaemonCaveCaptureBonus::PAY_2500_GOLD ) )
+            tile.metadata()[1] = ( cond == static_cast<uint32_t>( DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_2500_GOLD ) )
+                                         || ( cond == static_cast<uint32_t>( DaemonCaveCaptureBonus::PAY_2500_GOLD ) )
                                      ? 25
                                      : 0;
             tile.metadata()[2] = cond;

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1427,6 +1427,7 @@ namespace Maps
             assert( isFirstLoad );
             // Event should be invisible on Adventure Map.
             tile.resetObjectSprite();
+            resetObjectMetadata( tile );
             break;
 
         default:

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -67,6 +67,8 @@ namespace
 
     void updateRandomResource( Maps::Tiles & tile )
     {
+        assert( tile.GetObject() == MP2::OBJ_RANDOM_RESOURCE );
+
         tile.SetObject( MP2::OBJ_RESOURCE );
 
         const uint8_t resourceSprite = Resource::GetIndexSprite( Resource::Rand( true ) );
@@ -103,11 +105,14 @@ namespace
             art = Artifact::Rand( Artifact::ART_LEVEL_MAJOR );
             break;
         default:
+            // Did you add another random artifact type? Add the logic above!
+            assert( 0 );
             return;
         }
 
         if ( !art.isValid() ) {
             DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set an artifact over a random artifact on tile " << tile.GetIndex() )
+            resetObjectMetadata( tile );
             return;
         }
 
@@ -154,7 +159,15 @@ namespace
             mons = Monster::Rand( Monster::LevelType::LEVEL_4 );
             break;
         default:
+            // Did you add another random monster type? Add the logic above!
+            assert( 0 );
             break;
+        }
+
+        if ( !mons.isValid() ) {
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set a monster over a random monster on tile " << tile.GetIndex() )
+            resetObjectMetadata( tile );
+            return;
         }
 
         tile.SetObject( MP2::OBJ_MONSTER );
@@ -537,6 +550,7 @@ namespace Maps
     {
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_CAMPFIRE:
+            // Campfire contains N of non-Gold resources and (N * 100) Gold.
             return Funds{ static_cast<int>( tile.metadata()[0] ), tile.metadata()[1] } + Funds{ Resource::GOLD, tile.metadata()[1] * 100 };
 
         case MP2::OBJ_FLOTSAM:

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -49,34 +49,171 @@
 #include "week.h"
 #include "world.h"
 
+namespace
+{
+    void updateMonsterPopulationOnTile( Maps::Tiles & tile )
+    {
+        const Troop & troop = getTroopFromTile( tile );
+        const uint32_t troopCount = troop.GetCount();
+
+        if ( troopCount == 0 ) {
+            Maps::setMonsterCountOnTile( tile, troop.GetRNDSize() );
+        }
+        else {
+            const uint32_t bonusUnit = ( Rand::Get( 1, 7 ) <= ( troopCount % 7 ) ) ? 1 : 0;
+            Maps::setMonsterCountOnTile( tile, troopCount * 8 / 7 + bonusUnit );
+        }
+    }
+
+    void updateRandomResource( Maps::Tiles & tile )
+    {
+        tile.SetObject( MP2::OBJ_RESOURCE );
+
+        const uint8_t resourceSprite = Resource::GetIndexSprite( Resource::Rand( true ) );
+
+        uint32_t uidResource = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNRSRC );
+        if ( uidResource == 0 ) {
+            uidResource = tile.GetObjectUID();
+        }
+
+        Maps::Tiles::updateTileById( tile, uidResource, resourceSprite );
+
+        // Replace shadow of the resource.
+        if ( Maps::isValidDirection( tile.GetIndex(), Direction::LEFT ) ) {
+            assert( resourceSprite > 0 );
+            Maps::Tiles::updateTileById( world.GetTiles( Maps::GetDirectionIndex( tile.GetIndex(), Direction::LEFT ) ), uidResource, resourceSprite - 1 );
+        }
+    }
+
+    void updateRandomArtifact( Maps::Tiles & tile )
+    {
+        Artifact art;
+
+        switch ( tile.GetObject() ) {
+        case MP2::OBJ_RANDOM_ARTIFACT:
+            art = Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL );
+            break;
+        case MP2::OBJ_RANDOM_ARTIFACT_TREASURE:
+            art = Artifact::Rand( Artifact::ART_LEVEL_TREASURE );
+            break;
+        case MP2::OBJ_RANDOM_ARTIFACT_MINOR:
+            art = Artifact::Rand( Artifact::ART_LEVEL_MINOR );
+            break;
+        case MP2::OBJ_RANDOM_ARTIFACT_MAJOR:
+            art = Artifact::Rand( Artifact::ART_LEVEL_MAJOR );
+            break;
+        default:
+            return;
+        }
+
+        if ( !art.isValid() ) {
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set an artifact over a random artifact on tile " << tile.GetIndex() )
+            return;
+        }
+
+        tile.SetObject( MP2::OBJ_ARTIFACT );
+
+        uint32_t uidArtifact = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNARTI );
+        if ( uidArtifact == 0 ) {
+            uidArtifact = tile.GetObjectUID();
+        }
+
+        static_assert( std::is_same_v<decltype( Maps::Tiles::updateTileById ), void( Maps::Tiles &, uint32_t, uint8_t )>,
+                       "Type of updateTileById() has been changed, check the logic below" );
+
+        const uint32_t artSpriteIndex = art.IndexSprite();
+        assert( artSpriteIndex > std::numeric_limits<uint8_t>::min() && artSpriteIndex <= std::numeric_limits<uint8_t>::max() );
+
+        Maps::Tiles::updateTileById( tile, uidArtifact, static_cast<uint8_t>( artSpriteIndex ) );
+
+        // replace artifact shadow
+        if ( Maps::isValidDirection( tile.GetIndex(), Direction::LEFT ) ) {
+            Maps::Tiles::updateTileById( world.GetTiles( Maps::GetDirectionIndex( tile.GetIndex(), Direction::LEFT ) ), uidArtifact,
+                                         static_cast<uint8_t>( artSpriteIndex - 1 ) );
+        }
+    }
+
+    void updateRandomMonster( Maps::Tiles & tile )
+    {
+        Monster mons;
+
+        switch ( tile.GetObject() ) {
+        case MP2::OBJ_RANDOM_MONSTER:
+            mons = Monster::Rand( Monster::LevelType::LEVEL_ANY );
+            break;
+        case MP2::OBJ_RANDOM_MONSTER_WEAK:
+            mons = Monster::Rand( Monster::LevelType::LEVEL_1 );
+            break;
+        case MP2::OBJ_RANDOM_MONSTER_MEDIUM:
+            mons = Monster::Rand( Monster::LevelType::LEVEL_2 );
+            break;
+        case MP2::OBJ_RANDOM_MONSTER_STRONG:
+            mons = Monster::Rand( Monster::LevelType::LEVEL_3 );
+            break;
+        case MP2::OBJ_RANDOM_MONSTER_VERY_STRONG:
+            mons = Monster::Rand( Monster::LevelType::LEVEL_4 );
+            break;
+        default:
+            break;
+        }
+
+        tile.SetObject( MP2::OBJ_MONSTER );
+
+        using TileImageIndexType = decltype( tile.GetObjectSpriteIndex() );
+        static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of GetObjectSpriteIndex() has been changed, check the logic below" );
+
+        assert( mons.GetID() > std::numeric_limits<TileImageIndexType>::min() && mons.GetID() <= std::numeric_limits<TileImageIndexType>::max() );
+
+        tile.setObjectSpriteIndex( static_cast<TileImageIndexType>( mons.GetID() - 1 ) ); // ICN::MONS32 starts from PEASANT
+    }
+}
+
 namespace Maps
 {
     int32_t getMineSpellIdFromTile( const Tiles & tile )
     {
-        return tile.getAdditionalMetadata();
+        if ( tile.GetObject( false ) != MP2::OBJ_MINES ) {
+            // Why are you calling this function for an unsupported object type?
+            assert( 0 );
+            return Spell::NONE;
+        }
+
+        return tile.metadata()[2];
     }
 
     void setMineSpellOnTile( Tiles & tile, const int32_t spellId )
     {
-        tile.setAdditionalMetadata( spellId );
+        if ( tile.GetObject( false ) != MP2::OBJ_MINES ) {
+            // Why are you calling this function for an unsupported object type?
+            assert( 0 );
+            return;
+        }
+
+        tile.metadata()[2] = spellId;
+    }
+
+    void removeMineSpellFromTile( Tiles & tile )
+    {
+        if ( tile.GetObject( false ) != MP2::OBJ_MINES ) {
+            // Why are you calling this function for an unsupported object type?
+            assert( 0 );
+            return;
+        }
+
+        tile.metadata()[2] = 0;
     }
 
     Spell getSpellFromTile( const Tiles & tile )
     {
         switch ( tile.GetObject( false ) ) {
-        case MP2::OBJ_ARTIFACT:
-            if ( tile.QuantityVariant() == 15 ) {
-                return { tile.GetQuantity1() };
-            }
-            return { Spell::NONE };
-
         case MP2::OBJ_SHRINE_FIRST_CIRCLE:
         case MP2::OBJ_SHRINE_SECOND_CIRCLE:
         case MP2::OBJ_SHRINE_THIRD_CIRCLE:
         case MP2::OBJ_PYRAMID:
-            return { tile.GetQuantity1() };
-
+            return { static_cast<int>( tile.metadata()[0] ) };
         default:
+            // Why are you calling this function for an unsupported object type?
+            assert( 0 );
             break;
         }
 
@@ -85,38 +222,79 @@ namespace Maps
 
     void setSpellOnTile( Tiles & tile, const int spellId )
     {
-        using Quantity1Type = decltype( tile.GetQuantity1() );
-        static_assert( std::is_same_v<Quantity1Type, uint8_t>, "Type of GetQuantity1() has been changed, check the logic below" );
-
         switch ( tile.GetObject( false ) ) {
-        case MP2::OBJ_ARTIFACT:
         case MP2::OBJ_SHRINE_FIRST_CIRCLE:
         case MP2::OBJ_SHRINE_SECOND_CIRCLE:
         case MP2::OBJ_SHRINE_THIRD_CIRCLE:
         case MP2::OBJ_PYRAMID:
-            assert( spellId >= std::numeric_limits<Quantity1Type>::min() && spellId <= std::numeric_limits<Quantity1Type>::max() );
-
-            tile.setQuantity1( static_cast<Quantity1Type>( spellId ) );
+            tile.metadata()[0] = spellId;
             break;
-
         default:
+            // Why are you calling this function for an unsupported object type?
+            assert( 0 );
             break;
         }
     }
 
     void setMonsterOnTileJoinCondition( Tiles & tile, const int32_t condition )
     {
-        tile.setAdditionalMetadata( condition );
+        if ( tile.GetObject() == MP2::OBJ_MONSTER ) {
+            tile.metadata()[2] = condition;
+        }
+        else {
+            // Why are you calling this function for an unsupported object type?
+            assert( 0 );
+        }
     }
 
     bool isMonsterOnTileJoinConditionSkip( const Tiles & tile )
     {
-        return tile.GetObject() == MP2::OBJ_MONSTER && tile.getAdditionalMetadata() == Monster::JOIN_CONDITION_SKIP;
+        if ( tile.GetObject() == MP2::OBJ_MONSTER ) {
+            return ( tile.metadata()[2] == Monster::JOIN_CONDITION_SKIP );
+        }
+
+        // Why are you calling this function for an unsupported object type?
+        assert( 0 );
+        return false;
     }
 
     bool isMonsterOnTileJoinConditionFree( const Tiles & tile )
     {
-        return tile.GetObject() == MP2::OBJ_MONSTER && tile.getAdditionalMetadata() == Monster::JOIN_CONDITION_FREE;
+        if ( tile.GetObject() == MP2::OBJ_MONSTER ) {
+            return ( tile.metadata()[2] == Monster::JOIN_CONDITION_FREE );
+        }
+
+        // Why are you calling this function for an unsupported object type?
+        assert( 0 );
+        return false;
+    }
+
+    int Maps::getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
+    {
+        // The color of the barrier is actually being stored in tile metadata but as of now we use sprite information.
+
+        if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 60 <= icnIndex && 102 >= icnIndex ) {
+            // 60, 66, 72, 78, 84, 90, 96, 102
+            return ( ( icnIndex - 60 ) / 6 ) + 1;
+        }
+
+        // Why are you calling this function for an unsupported object type?
+        assert( 0 );
+        return 0;
+    }
+
+    int Maps::getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex )
+    {
+        // The color of the barrier is actually being stored in tile metadata but as of now we use sprite information.
+
+        if ( MP2::OBJ_ICN_TYPE_X_LOC3 == objectIcnType && 110 <= icnIndex && 138 >= icnIndex ) {
+            // 110, 114, 118, 122, 126, 130, 134, 138
+            return ( ( icnIndex - 110 ) / 4 ) + 1;
+        }
+
+        // Why are you calling this function for an unsupported object type?
+        assert( 0 );
+        return 0;
     }
 
     Monster getMonsterFromTile( const Tiles & tile )
@@ -158,7 +336,6 @@ namespace Maps
             return { Monster::GENIE };
         case MP2::OBJ_ABANDONED_MINE:
             return { Monster::GHOST };
-        // Price of Loyalty
         case MP2::OBJ_WATER_ALTAR:
             return { Monster::WATER_ELEMENT };
         case MP2::OBJ_AIR_ALTAR:
@@ -169,7 +346,6 @@ namespace Maps
             return { Monster::EARTH_ELEMENT };
         case MP2::OBJ_BARROW_MOUNDS:
             return { Monster::GHOST };
-
         case MP2::OBJ_MONSTER:
             return { tile.GetObjectSpriteIndex() + 1 };
         default:
@@ -186,26 +362,25 @@ namespace Maps
     Artifact getArtifactFromTile( const Tiles & tile )
     {
         switch ( tile.GetObject( false ) ) {
-        case MP2::OBJ_WAGON:
-            return { tile.GetQuantity2() ? static_cast<int>( Artifact::UNKNOWN ) : tile.GetQuantity1() };
-
-        case MP2::OBJ_SKELETON:
         case MP2::OBJ_DAEMON_CAVE:
-        case MP2::OBJ_SEA_CHEST:
-        case MP2::OBJ_TREASURE_CHEST:
-        case MP2::OBJ_SHIPWRECK_SURVIVOR:
-        case MP2::OBJ_SHIPWRECK:
         case MP2::OBJ_GRAVEYARD:
-            return { tile.GetQuantity1() };
+        case MP2::OBJ_SEA_CHEST:
+        case MP2::OBJ_SHIPWRECK:
+        case MP2::OBJ_SHIPWRECK_SURVIVOR:
+        case MP2::OBJ_SKELETON:
+        case MP2::OBJ_TREASURE_CHEST:
+        case MP2::OBJ_WAGON:
+            return { static_cast<int>( tile.metadata()[0] ) };
 
         case MP2::OBJ_ARTIFACT:
-            if ( tile.QuantityVariant() == 15 ) {
+            if ( tile.metadata()[2] == static_cast<uint32_t>( ArtifactCaptureCondition::CONTAINS_SPELL ) ) {
                 Artifact art( Artifact::SPELL_SCROLL );
-                art.SetSpell( getSpellFromTile( tile ).GetID() );
+                art.SetSpell( tile.metadata()[1] );
                 return art;
             }
-            else
-                return { tile.GetQuantity1() };
+            else {
+                return { static_cast<int>( tile.metadata()[0] ) };
+            }
 
         default:
             break;
@@ -216,24 +391,19 @@ namespace Maps
 
     void setArtifactOnTile( Tiles & tile, const int artifactId )
     {
-        using Quantity1Type = decltype( tile.GetQuantity1() );
-        static_assert( std::is_same_v<Quantity1Type, uint8_t>, "Type of GetQuantity1() has been changed, check the logic below" );
-
-        assert( artifactId >= std::numeric_limits<Quantity1Type>::min() && artifactId <= std::numeric_limits<Quantity1Type>::max() );
-
-        tile.setQuantity1( static_cast<Quantity1Type>( artifactId ) );
+        tile.metadata()[0] = artifactId;
     }
 
     uint32_t getGoldAmountFromTile( const Tiles & tile )
     {
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_ARTIFACT:
-            switch ( tile.QuantityVariant() ) {
-            case 1:
+            switch ( static_cast<ArtifactCaptureCondition>( tile.metadata()[2] ) ) {
+            case ArtifactCaptureCondition::PAY_2000_GOLD:
                 return 2000;
-            case 2:
+            case ArtifactCaptureCondition::PAY_2500_GOLD_AND_3_RESOURCES:
                 return 2500;
-            case 3:
+            case ArtifactCaptureCondition::PAY_3000_GOLD_AND_5_RESOURCES:
                 return 3000;
             default:
                 break;
@@ -244,7 +414,10 @@ namespace Maps
         case MP2::OBJ_MAGIC_GARDEN:
         case MP2::OBJ_WATER_WHEEL:
         case MP2::OBJ_TREE_OF_KNOWLEDGE:
-            return tile.GetQuantity1() == Resource::GOLD ? 100 * tile.GetQuantity2() : 0;
+            if ( tile.metadata()[0] == Resource::GOLD ) {
+                return ( 100 * tile.metadata()[1] );
+            }
+            return 0;
 
         case MP2::OBJ_FLOTSAM:
         case MP2::OBJ_CAMPFIRE:
@@ -252,12 +425,12 @@ namespace Maps
         case MP2::OBJ_TREASURE_CHEST:
         case MP2::OBJ_DERELICT_SHIP:
         case MP2::OBJ_GRAVEYARD:
-            return 100 * tile.GetQuantity2();
+            return 100 * tile.metadata()[1];
 
         case MP2::OBJ_DAEMON_CAVE:
-            switch ( tile.QuantityVariant() ) {
-            case 2:
-            case 4:
+            switch ( static_cast<DaemonCaveCaptureBonus>( tile.metadata()[2] ) ) {
+            case DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_2500_GOLD:
+            case DaemonCaveCaptureBonus::PAY_2500_GOLD:
                 return 2500;
             default:
                 break;
@@ -265,14 +438,14 @@ namespace Maps
             break;
 
         case MP2::OBJ_SHIPWRECK:
-            switch ( tile.QuantityVariant() ) {
-            case 1:
+            switch ( static_cast<ShipwreckCaptureCondition>( tile.metadata()[2] ) ) {
+            case ShipwreckCaptureCondition::FIGHT_10_GHOSTS_AND_GET_1000_GOLD:
                 return 1000;
-            case 2:
-            case 4:
+            case ShipwreckCaptureCondition::FIGHT_15_GHOSTS_AND_GET_2000_GOLD:
+            case ShipwreckCaptureCondition::FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT:
                 // Case 4 gives 2000 gold and an artifact.
                 return 2000;
-            case 3:
+            case ShipwreckCaptureCondition::FIGHT_25_GHOSTS_AND_GET_5000_GOLD:
                 return 5000;
             default:
                 break;
@@ -286,58 +459,83 @@ namespace Maps
         return 0;
     }
 
-    Skill::Secondary getSecondarySkillFromTile( const Tiles & tile )
+    Skill::Secondary getArtifactSecondarySkillRequirement( const Tiles & tile )
     {
-        switch ( tile.GetObject( false ) ) {
-        case MP2::OBJ_ARTIFACT:
-            switch ( tile.QuantityVariant() ) {
-            case 4:
-                return { Skill::Secondary::LEADERSHIP, Skill::Level::BASIC };
-            case 5:
-                return { Skill::Secondary::WISDOM, Skill::Level::BASIC };
-            default:
-                break;
-            }
-            break;
+        if ( tile.GetObject( false ) != MP2::OBJ_ARTIFACT ) {
+            // Why are you calling this for an unsupported object type?
+            assert( 0 );
+            return {};
+        }
 
-        case MP2::OBJ_WITCHS_HUT:
-            return { tile.GetQuantity1(), Skill::Level::BASIC };
-
+        switch ( static_cast<ArtifactCaptureCondition>( tile.metadata()[2] ) ) {
+        case ArtifactCaptureCondition::HAVE_WISDOM_SKILL:
+            return { Skill::Secondary::LEADERSHIP, Skill::Level::BASIC };
+        case ArtifactCaptureCondition::HAVE_LEADERSHIP_SKILL:
+            return { Skill::Secondary::WISDOM, Skill::Level::BASIC };
         default:
             break;
         }
 
+        // Why are you calling this for invalid conditions?
+        assert( 0 );
         return {};
     }
 
-    void setSecondarySkillOnTile( Tiles & tile, const int skillId )
+    ArtifactCaptureCondition getArtifactCaptureCondition( const Tiles & tile )
     {
-        using Quantity1Type = decltype( tile.GetQuantity1() );
-        static_assert( std::is_same_v<Quantity1Type, uint8_t>, "Type of GetQuantity1() has been changed, check the logic below" );
-
-        switch ( tile.GetObject( false ) ) {
-        case MP2::OBJ_WITCHS_HUT:
-            assert( skillId >= std::numeric_limits<Quantity1Type>::min() && skillId <= std::numeric_limits<Quantity1Type>::max() );
-
-            tile.setQuantity1( static_cast<Quantity1Type>( skillId ) );
-            break;
-
-        default:
-            break;
+        if ( tile.GetObject( false ) != MP2::OBJ_ARTIFACT ) {
+            // Why are you calling this for an unsupported object type?
+            assert( 0 );
+            return ArtifactCaptureCondition::NO_CONDITIONS;
         }
+
+        return static_cast<ArtifactCaptureCondition>( tile.metadata()[2] );
+    }
+
+    DaemonCaveCaptureBonus getDaemonCaveBonus( const Tiles & tile )
+    {
+        if ( tile.GetObject( false ) != MP2::OBJ_DAEMON_CAVE ) {
+            // Why are you calling this for an unsupported object type?
+            assert( 0 );
+            return DaemonCaveCaptureBonus::NO_BONUS;
+        }
+
+        return static_cast<DaemonCaveCaptureBonus>( tile.metadata()[2] );
+    }
+
+    ShipwreckCaptureCondition getShipwrechCaptureCondition( const Tiles & tile )
+    {
+        if ( tile.GetObject( false ) != MP2::OBJ_SHIPWRECK ) {
+            // Why are you calling this for an unsupported object type?
+            assert( 0 );
+            return ShipwreckCaptureCondition::NO_BONUS;
+        }
+
+        return static_cast<ShipwreckCaptureCondition>( tile.metadata()[2] );
+    }
+
+    Skill::Secondary getSecondarySkillFromWitchsHut( const Tiles & tile )
+    {
+        if ( tile.GetObject( false ) != MP2::OBJ_WITCHS_HUT ) {
+            // Why are you calling this for an unsupported object type?
+            assert( 0 );
+            return {};
+        }
+
+        return { static_cast<int>( tile.metadata()[0] ), Skill::Level::BASIC };
     }
 
     ResourceCount getResourcesFromTile( const Tiles & tile )
     {
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_ARTIFACT:
-            switch ( tile.QuantityVariant() ) {
-            case 1:
+            switch ( static_cast<ArtifactCaptureCondition>( tile.metadata()[2] ) ) {
+            case ArtifactCaptureCondition::PAY_2000_GOLD:
                 return { Resource::GOLD, getGoldAmountFromTile( tile ) };
-            case 2:
-                return { Resource::getResourceTypeFromIconIndex( tile.QuantityExt() - 1 ), 3 };
-            case 3:
-                return { Resource::getResourceTypeFromIconIndex( tile.QuantityExt() - 1 ), 5 };
+            case ArtifactCaptureCondition::PAY_2500_GOLD_AND_3_RESOURCES:
+                return { Resource::getResourceTypeFromIconIndex( tile.metadata()[1] - 1 ), 3 };
+            case ArtifactCaptureCondition::PAY_3000_GOLD_AND_5_RESOURCES:
+                return { Resource::getResourceTypeFromIconIndex( tile.metadata()[1] - 1 ), 5 };
             default:
                 break;
             }
@@ -348,33 +546,26 @@ namespace Maps
             return { Resource::GOLD, getGoldAmountFromTile( tile ) };
 
         case MP2::OBJ_FLOTSAM:
-            return { Resource::WOOD, tile.GetQuantity1() };
+            return { Resource::WOOD, tile.metadata()[0] };
 
         default:
             break;
         }
 
-        return { tile.GetQuantity1(), Resource::GOLD == tile.GetQuantity1() ? getGoldAmountFromTile( tile ) : tile.GetQuantity2() };
+        // TODO: check all types of objects!
+        return { static_cast<int>( tile.metadata()[0] ), ( Resource::GOLD == tile.metadata()[0] ) ? getGoldAmountFromTile( tile ) : tile.metadata()[1] };
     }
 
     void setResourceOnTile( Tiles & tile, const int resourceType, uint32_t value )
     {
-        using Quantity1Type = decltype( tile.GetQuantity1() );
-        using Quantity2Type = decltype( tile.GetQuantity2() );
-        static_assert( std::is_same_v<Quantity1Type, uint8_t> && std::is_same_v<Quantity2Type, uint8_t>,
-                       "Types of tile's quantities have been changed, check the logic below" );
-
-        assert( resourceType >= std::numeric_limits<Quantity1Type>::min() && resourceType <= std::numeric_limits<Quantity1Type>::max() );
-
-        tile.setQuantity1( static_cast<Quantity1Type>( resourceType ) );
+        tile.metadata()[0] = resourceType;
 
         if ( resourceType == Resource::GOLD ) {
-            value = value / 100;
+            tile.metadata()[1] = value / 100;
         }
-
-        assert( value >= std::numeric_limits<Quantity2Type>::min() && value <= std::numeric_limits<Quantity2Type>::max() );
-
-        tile.setQuantity2( static_cast<Quantity2Type>( value ) );
+        else {
+            tile.metadata()[1] = value;
+        }
     }
 
     Funds getFundsFromTile( const Tiles & tile )
@@ -383,11 +574,11 @@ namespace Maps
 
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_ARTIFACT:
-            switch ( tile.QuantityVariant() ) {
-            case 1:
+            switch ( static_cast<ArtifactCaptureCondition>( tile.metadata()[2] ) ) {
+            case ArtifactCaptureCondition::PAY_2000_GOLD:
                 return Funds( rc );
-            case 2:
-            case 3:
+            case ArtifactCaptureCondition::PAY_2500_GOLD_AND_3_RESOURCES:
+            case ArtifactCaptureCondition::PAY_3000_GOLD_AND_5_RESOURCES:
                 return Funds( Resource::GOLD, getGoldAmountFromTile( tile ) ) + Funds( rc );
             default:
                 break;
@@ -398,7 +589,7 @@ namespace Maps
             return Funds( Resource::GOLD, getGoldAmountFromTile( tile ) ) + Funds( rc );
 
         case MP2::OBJ_FLOTSAM:
-            return Funds( Resource::GOLD, getGoldAmountFromTile( tile ) ) + Funds( Resource::WOOD, tile.GetQuantity1() );
+            return Funds( Resource::GOLD, getGoldAmountFromTile( tile ) ) + Funds( Resource::WOOD, tile.metadata()[0] );
 
         case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_TREASURE_CHEST:
@@ -426,8 +617,7 @@ namespace Maps
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_BARRIER:
         case MP2::OBJ_TRAVELLER_TENT:
-            return tile.GetQuantity1();
-
+            return tile.metadata()[0];
         default:
             return world.ColorCapturedObject( tile.GetIndex() );
         }
@@ -435,17 +625,11 @@ namespace Maps
 
     void setColorOnTile( Tiles & tile, const int color )
     {
-        using Quantity1Type = decltype( tile.GetQuantity1() );
-        static_assert( std::is_same_v<Quantity1Type, uint8_t>, "Type of GetQuantity1() has been changed, check the logic below" );
-
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_BARRIER:
         case MP2::OBJ_TRAVELLER_TENT:
-            assert( color >= std::numeric_limits<Quantity1Type>::min() && color <= std::numeric_limits<Quantity1Type>::max() );
-
-            tile.setQuantity1( static_cast<Quantity1Type>( color ) );
+            tile.metadata()[0] = color;
             break;
-
         default:
             world.CaptureObject( tile.GetIndex(), color );
             break;
@@ -474,16 +658,16 @@ namespace Maps
         case MP2::OBJ_WINDMILL:
         case MP2::OBJ_LEAN_TO:
         case MP2::OBJ_MAGIC_GARDEN:
-            return tile.GetQuantity2() != 0;
+            return tile.metadata()[1] > 0;
 
         case MP2::OBJ_SKELETON:
             return getArtifactFromTile( tile ) != Artifact::UNKNOWN;
 
         case MP2::OBJ_WAGON:
-            return getArtifactFromTile( tile ) != Artifact::UNKNOWN || tile.GetQuantity2() != 0;
+            return getArtifactFromTile( tile ) != Artifact::UNKNOWN || tile.metadata()[2] != 0;
 
         case MP2::OBJ_DAEMON_CAVE:
-            return tile.QuantityVariant() != 0;
+            return tile.metadata()[2] != 0;
 
         default:
             break;
@@ -494,9 +678,9 @@ namespace Maps
 
     void resetObjectInfoOnTile( Tiles & tile )
     {
-        // TODO: don't modify first 2 bits of quantity1.
-        tile.setQuantity1( 0 );
-        tile.setQuantity2( 0 );
+        for ( uint32_t & value : tile.metadata() ) {
+            value = 0;
+        }
 
         const MP2::MapObjectType objectType = tile.GetObject( false );
 
@@ -524,44 +708,78 @@ namespace Maps
 
     uint32_t getMonsterCountFromTile( const Tiles & tile )
     {
-        static_assert( std::is_same_v<decltype( tile.GetQuantity1() ), uint8_t> && std::is_same_v<decltype( tile.GetQuantity2() ), uint8_t>,
-                       "Types of tile's quantities have been changed, check the logic below" );
+        switch ( tile.GetObject( false ) ) {
+        case MP2::OBJ_ABANDONED_MINE:
+        case MP2::OBJ_AIR_ALTAR:
+        case MP2::OBJ_ARCHER_HOUSE:
+        case MP2::OBJ_BARROW_MOUNDS:
+        case MP2::OBJ_CAVE:
+        case MP2::OBJ_CITY_OF_DEAD:
+        case MP2::OBJ_DESERT_TENT:
+        case MP2::OBJ_DRAGON_CITY:
+        case MP2::OBJ_DWARF_COTTAGE:
+        case MP2::OBJ_EARTH_ALTAR:
+        case MP2::OBJ_EXCAVATION:
+        case MP2::OBJ_FIRE_ALTAR:
+        case MP2::OBJ_GENIE_LAMP:
+        case MP2::OBJ_GOBLIN_HUT:
+        case MP2::OBJ_HALFLING_HOLE:
+        case MP2::OBJ_MONSTER:
+        case MP2::OBJ_PEASANT_HUT:
+        case MP2::OBJ_RUINS:
+        case MP2::OBJ_TREE_CITY:
+        case MP2::OBJ_TREE_HOUSE:
+        case MP2::OBJ_TROLL_BRIDGE:
+        case MP2::OBJ_WAGON_CAMP:
+        case MP2::OBJ_WATCH_TOWER:
+        case MP2::OBJ_WATER_ALTAR:
+            return tile.metadata()[0];
+        default:
+            // Why are you calling this function for an unsupported object type?
+            assert( 0 );
+            break;
+        }
 
-        // TODO: avoid this hacky way of storing data.
-        return ( static_cast<uint32_t>( tile.GetQuantity1() ) << 8 ) + tile.GetQuantity2();
+        return 0;
     }
 
     void setMonsterCountOnTile( Tiles & tile, uint32_t count )
     {
-        static_assert( std::is_same_v<decltype( tile.GetQuantity1() ), uint8_t> && std::is_same_v<decltype( tile.GetQuantity2() ), uint8_t>,
-                       "Types of tile's quantities have been changed, check the logic below" );
-
-        if ( count > UINT16_MAX ) {
-            DEBUG_LOG( DBG_GAME, DBG_WARN, "The number of monsters for tile " << tile.GetIndex() << " is " << count << ", which is more than " << UINT16_MAX )
-
-            count = UINT16_MAX;
+        switch ( tile.GetObject( false ) ) {
+        case MP2::OBJ_ABANDONED_MINE:
+        case MP2::OBJ_AIR_ALTAR:
+        case MP2::OBJ_ARCHER_HOUSE:
+        case MP2::OBJ_BARROW_MOUNDS:
+        case MP2::OBJ_CAVE:
+        case MP2::OBJ_CITY_OF_DEAD:
+        case MP2::OBJ_DESERT_TENT:
+        case MP2::OBJ_DRAGON_CITY:
+        case MP2::OBJ_DWARF_COTTAGE:
+        case MP2::OBJ_EARTH_ALTAR:
+        case MP2::OBJ_EXCAVATION:
+        case MP2::OBJ_FIRE_ALTAR:
+        case MP2::OBJ_GENIE_LAMP:
+        case MP2::OBJ_GOBLIN_HUT:
+        case MP2::OBJ_HALFLING_HOLE:
+        case MP2::OBJ_MONSTER:
+        case MP2::OBJ_PEASANT_HUT:
+        case MP2::OBJ_RUINS:
+        case MP2::OBJ_TREE_CITY:
+        case MP2::OBJ_TREE_HOUSE:
+        case MP2::OBJ_TROLL_BRIDGE:
+        case MP2::OBJ_WAGON_CAMP:
+        case MP2::OBJ_WATCH_TOWER:
+        case MP2::OBJ_WATER_ALTAR:
+            tile.metadata()[0] = count;
+            return;
+        default:
+            // Why are you calling this function for an unsupported object type?
+            assert( 0 );
+            break;
         }
-
-        // TODO: avoid this hacky way of storing data.
-        tile.setQuantity1( ( count >> 8 ) & 0xFF );
-        tile.setQuantity2( count & 0xFF );
     }
 
-    void updateMonsterPopulationOnTile( Tiles & tile )
-    {
-        const Troop & troop = getTroopFromTile( tile );
-        const uint32_t troopCount = troop.GetCount();
-
-        if ( troopCount == 0 ) {
-            setMonsterCountOnTile( tile, troop.GetRNDSize() );
-        }
-        else {
-            const uint32_t bonusUnit = ( Rand::Get( 1, 7 ) <= ( troopCount % 7 ) ) ? 1 : 0;
-            setMonsterCountOnTile( tile, troopCount * 8 / 7 + bonusUnit );
-        }
-    }
-
-    void updateDwellingPopulationOnTile( Tiles & tile, bool isFirstLoad )
+    void updateDwellingPopulationOnTile( Tiles & tile, const bool isFirstLoad )
     {
         uint32_t count = isFirstLoad ? 0 : getMonsterCountFromTile( tile );
         const MP2::MapObjectType objectType = tile.GetObject( false );
@@ -625,50 +843,61 @@ namespace Maps
             break;
 
         default:
+            // Did you add a new dwelling on Adventure Map? Add the logic above!
+            assert( 0 );
             break;
         }
 
-        if ( count ) {
-            setMonsterCountOnTile( tile, count );
-        }
+        assert( count > 0 );
+        setMonsterCountOnTile( tile, count );
     }
 
     void updateObjectInfoTile( Tiles & tile, const bool isFirstLoad )
     {
-        // TODO: don't modify first 2 bits of quantity1.
         switch ( tile.GetObject( false ) ) {
         case MP2::OBJ_WITCHS_HUT:
-            setSecondarySkillOnTile( tile, Skill::Secondary::RandForWitchsHut() );
+            assert( isFirstLoad );
+
+            tile.metadata()[0] = Skill::Secondary::RandForWitchsHut();
             break;
 
         case MP2::OBJ_SHRINE_FIRST_CIRCLE:
-            setSpellOnTile( tile, Rand::Get( 1 ) ? Spell::RandCombat( 1 ).GetID() : Spell::RandAdventure( 1 ).GetID() );
+            assert( isFirstLoad );
+
+            tile.metadata()[0] = Rand::Get( 1 ) ? Spell::RandCombat( 1 ).GetID() : Spell::RandAdventure( 1 ).GetID();
             break;
 
         case MP2::OBJ_SHRINE_SECOND_CIRCLE:
-            setSpellOnTile( tile, Rand::Get( 1 ) ? Spell::RandCombat( 2 ).GetID() : Spell::RandAdventure( 2 ).GetID() );
+            assert( isFirstLoad );
+
+            tile.metadata()[0] = Rand::Get( 1 ) ? Spell::RandCombat( 2 ).GetID() : Spell::RandAdventure( 2 ).GetID();
             break;
 
         case MP2::OBJ_SHRINE_THIRD_CIRCLE:
-            setSpellOnTile( tile, Rand::Get( 1 ) ? Spell::RandCombat( 3 ).GetID() : Spell::RandAdventure( 3 ).GetID() );
+            assert( isFirstLoad );
+
+            tile.metadata()[0] = Rand::Get( 1 ) ? Spell::RandCombat( 3 ).GetID() : Spell::RandAdventure( 3 ).GetID();
             break;
 
         case MP2::OBJ_SKELETON: {
+            assert( isFirstLoad );
+
             Rand::Queue percents( 2 );
             // 80%: empty
             percents.Push( 0, 80 );
             // 20%: artifact 1 or 2 or 3
             percents.Push( 1, 20 );
 
-            if ( percents.Get() )
-                setArtifactOnTile( tile, Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL ) );
-            else
-                resetObjectInfoOnTile( tile );
+            if ( percents.Get() ) {
+                tile.metadata()[0] = Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL );
+            }
             break;
         }
 
         case MP2::OBJ_WAGON: {
-            tile.setQuantity2( 0 );
+            assert( isFirstLoad );
+
+            resetObjectInfoOnTile( tile );
 
             Rand::Queue percents( 3 );
             // 20%: empty
@@ -680,55 +909,59 @@ namespace Maps
 
             switch ( percents.Get() ) {
             case 1:
-                setArtifactOnTile( tile, Artifact::Rand( Rand::Get( 1 ) ? Artifact::ART_LEVEL_TREASURE : Artifact::ART_LEVEL_MINOR ) );
+                tile.metadata()[0] = Artifact::Rand( Rand::Get( 1 ) ? Artifact::ART_LEVEL_TREASURE : Artifact::ART_LEVEL_MINOR );
                 break;
             case 2:
-                setResourceOnTile( tile, Resource::Rand( false ), Rand::Get( 2, 5 ) );
+                tile.metadata()[1] = Resource::Rand( false );
+                tile.metadata()[2] = Rand::Get( 2, 5 );
                 break;
             default:
-                resetObjectInfoOnTile( tile );
                 break;
             }
             break;
         }
 
         case MP2::OBJ_ARTIFACT: {
+            assert( isFirstLoad );
+
             const int art = Artifact::FromMP2IndexSprite( tile.GetObjectSpriteIndex() ).GetID();
+            if ( Artifact::UNKNOWN == art ) {
+                // This is an unknown artifact. Did you add a new one?
+                assert( 0 );
+                return;
+            }
 
-            if ( Artifact::UNKNOWN != art ) {
-                if ( art == Artifact::SPELL_SCROLL ) {
-                    static_assert( std::is_same_v<decltype( tile.GetQuantity1() ), uint8_t> && std::is_same_v<decltype( tile.GetQuantity2() ), uint8_t>,
-                                   "Types of tile's quantities have been changed, check the bitwise arithmetic below" );
-                    static_assert( Spell::FIREBALL < Spell::SETWGUARDIAN, "The order of spell IDs has been changed, check the logic below" );
+            if ( art == Artifact::SPELL_SCROLL ) {
+                static_assert( Spell::FIREBALL < Spell::SETWGUARDIAN, "The order of spell IDs has been changed, check the logic below" );
 
-                    // Spell id of a spell scroll is represented by 2 low-order bits of quantity2 and 5 high-order bits of quantity1 plus one, and cannot be random
-                    const int spell = std::clamp( ( ( tile.GetQuantity2() & 0x03 ) << 5 ) + ( tile.GetQuantity1() >> 3 ) + 1, static_cast<int>( Spell::FIREBALL ),
-                                                  static_cast<int>( Spell::SETWGUARDIAN ) );
+                // Spell ID is by 1 bigger than in the original game.
+                const uint32_t spell = std::clamp( tile.metadata()[0] + 1, static_cast<uint32_t>( Spell::FIREBALL ), static_cast<uint32_t>( Spell::SETWGUARDIAN ) );
 
-                    tile.QuantitySetVariant( 15 );
-                    setSpellOnTile( tile, spell );
-                }
-                else {
-                    // 0: 70% none
-                    // 1,2,3 - 2000g, 2500g+3res, 3000g+5res,
-                    // 4,5 - need to have skill wisdom or leadership,
-                    // 6 - 50 rogues, 7 - 1 gin, 8,9,10,11,12,13 - 1 monster level4,
-                    // 15 - spell
-                    const int cond = Rand::Get( 1, 10 ) < 4 ? Rand::Get( 1, 13 ) : 0;
+                tile.metadata()[1] = spell;
+                tile.metadata()[2] = static_cast<uint32_t>( ArtifactCaptureCondition::CONTAINS_SPELL );
+            }
+            else {
+                // 70% chance of no conditions.
+                // Refer to ArtifactCaptureCondition enumeration.
+                const uint32_t cond = Rand::Get( 1, 10 ) < 4 ? Rand::Get( 1, 13 ) : 0;
 
-                    tile.QuantitySetVariant( cond );
-                    setArtifactOnTile( tile, art );
+                tile.metadata()[2] = cond;
 
-                    if ( cond == 2 || cond == 3 ) {
-                        // TODO: why do we use icon ICN index instead of map ICN index?
-                        tile.QuantitySetExt( Resource::getIconIcnIndex( Resource::Rand( false ) ) + 1 );
-                    }
+                if ( cond == static_cast<uint32_t>( ArtifactCaptureCondition::PAY_2500_GOLD_AND_3_RESOURCES ) ||
+                     cond == static_cast<uint32_t>( ArtifactCaptureCondition::PAY_3000_GOLD_AND_5_RESOURCES ) ) {
+                    // TODO: why do we use icon ICN index instead of map ICN index?
+                    tile.metadata()[1] = Resource::getIconIcnIndex( Resource::Rand( false ) ) + 1;
                 }
             }
+
+            tile.metadata()[0] = art;
+
             break;
         }
 
         case MP2::OBJ_RESOURCE: {
+            assert( isFirstLoad );
+
             int resourceType = Resource::UNKNOWN;
 
             if ( tile.getObjectIcnType() == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
@@ -747,8 +980,8 @@ namespace Maps
                     }
                 }
             }
-            uint32_t count = 0;
 
+            uint32_t count = 0;
             switch ( resourceType ) {
             case Resource::GOLD:
                 count = 100 * Rand::Get( 5, 10 );
@@ -778,7 +1011,9 @@ namespace Maps
         }
 
         case MP2::OBJ_CAMPFIRE:
-            // 4-6 rnd resource and + 400-600 gold
+            assert( isFirstLoad );
+
+            // 4-6 random resource and + 400-600 gold
             setResourceOnTile( tile, Resource::Rand( false ), Rand::Get( 4, 6 ) );
             break;
 
@@ -801,49 +1036,54 @@ namespace Maps
                 res = Resource::Rand( false );
             }
 
-            // 2 rnd resource
+            // 2 pieces of random resource.
             setResourceOnTile( tile, res, 2 );
             break;
         }
 
         case MP2::OBJ_LEAN_TO:
-            // 1-4 rnd resource
+            assert( isFirstLoad );
+
+            // 1-4 pieces of random resource.
             setResourceOnTile( tile, Resource::Rand( false ), Rand::Get( 1, 4 ) );
             break;
 
         case MP2::OBJ_FLOTSAM: {
+            assert( isFirstLoad );
+
             switch ( Rand::Get( 1, 4 ) ) {
             // 25%: empty
             default:
                 break;
             // 25%: 500 gold + 10 wood
             case 1:
-                setResourceOnTile( tile, Resource::GOLD, 500 );
-                tile.setQuantity1( 10 );
+                tile.metadata()[0] = 10;
+                tile.metadata()[1] = 5;
                 break;
             // 25%: 200 gold + 5 wood
             case 2:
-                setResourceOnTile( tile, Resource::GOLD, 200 );
-                tile.setQuantity1( 5 );
+                tile.metadata()[0] = 5;
+                tile.metadata()[1] = 2;
                 break;
             // 25%: 5 wood
             case 3:
-                tile.setQuantity1( 5 );
+                tile.metadata()[0] = 5;
                 break;
             }
             break;
         }
 
         case MP2::OBJ_SHIPWRECK_SURVIVOR: {
+            assert( isFirstLoad );
+
             Rand::Queue percents( 3 );
             // 55%: artifact 1
             percents.Push( 1, 55 );
             // 30%: artifact 2
-            percents.Push( 1, 30 );
+            percents.Push( 2, 30 );
             // 15%: artifact 3
-            percents.Push( 1, 15 );
+            percents.Push( 3, 15 );
 
-            // variant
             switch ( percents.Get() ) {
             case 1:
                 setArtifactOnTile( tile, Artifact::Rand( Artifact::ART_LEVEL_TREASURE ) );
@@ -859,6 +1099,8 @@ namespace Maps
         }
 
         case MP2::OBJ_SEA_CHEST: {
+            assert( isFirstLoad );
+
             Rand::Queue percents( 3 );
             // 20% - empty
             percents.Push( 0, 20 );
@@ -870,10 +1112,7 @@ namespace Maps
             int art = Artifact::UNKNOWN;
             uint32_t gold = 0;
 
-            // variant
             switch ( percents.Get() ) {
-            default:
-                break; // empty
             case 1:
                 gold = 1500;
                 break;
@@ -881,14 +1120,18 @@ namespace Maps
                 gold = 1000;
                 art = Artifact::Rand( Artifact::ART_LEVEL_TREASURE );
                 break;
+            default:
+                break;
             }
 
-            setResourceOnTile( tile, Resource::GOLD, gold );
-            setArtifactOnTile( tile, art );
+            tile.metadata()[0] = art;
+            tile.metadata()[1] = gold / 100;
             break;
         }
 
         case MP2::OBJ_TREASURE_CHEST:
+            assert( isFirstLoad );
+
             if ( tile.isWater() ) {
                 tile.SetObject( MP2::OBJ_SEA_CHEST );
                 updateObjectInfoTile( tile, isFirstLoad );
@@ -925,16 +1168,20 @@ namespace Maps
                     break;
                 }
 
-                setResourceOnTile( tile, Resource::GOLD, gold );
-                setArtifactOnTile( tile, art );
+                tile.metadata()[0] = art;
+                tile.metadata()[1] = gold / 100;
             }
             break;
 
         case MP2::OBJ_DERELICT_SHIP:
+            assert( isFirstLoad );
+
             setResourceOnTile( tile, Resource::GOLD, 5000 );
             break;
 
         case MP2::OBJ_SHIPWRECK: {
+            assert( isFirstLoad );
+
             Rand::Queue percents( 4 );
             // 40% - 10ghost(1000g)
             percents.Push( 1, 40 );
@@ -947,18 +1194,23 @@ namespace Maps
 
             const int cond = percents.Get();
 
-            tile.QuantitySetVariant( cond );
-            setArtifactOnTile( tile, cond == 4 ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL ) : Artifact::UNKNOWN );
+            tile.metadata()[0] = ( cond == static_cast<int>( ShipwreckCaptureCondition::FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT ) )
+                                 ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL ) : Artifact::UNKNOWN;
+            tile.metadata()[2] = cond;
             break;
         }
 
         case MP2::OBJ_GRAVEYARD:
+            assert( isFirstLoad );
+
             // 1000 gold + art
             setResourceOnTile( tile, Resource::GOLD, 1000 );
             setArtifactOnTile( tile, Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL ) );
             break;
 
         case MP2::OBJ_PYRAMID: {
+            assert( isFirstLoad );
+
             // random spell level 5
             const Spell & spell = Rand::Get( 1 ) ? Spell::RandCombat( 5 ) : Spell::RandAdventure( 5 );
             setSpellOnTile( tile, spell.GetID() );
@@ -966,14 +1218,21 @@ namespace Maps
         }
 
         case MP2::OBJ_DAEMON_CAVE: {
+            assert( isFirstLoad );
+
             // 1000 exp or 1000 exp + 2500 gold or 1000 exp + art or (-2500 or remove hero)
-            const int cond = Rand::Get( 1, 4 );
-            tile.QuantitySetVariant( cond );
-            setArtifactOnTile( tile, cond == 3 ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL ) : Artifact::UNKNOWN );
+            const uint32_t cond = Rand::Get( 1, 4 );
+
+
+            tile.metadata()[0] = ( cond == static_cast<uint32_t>( DaemonCaveCaptureBonus::GET_1000_EXPERIENCE_AND_ARTIFACT ) )
+                                 ? Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL ) : Artifact::UNKNOWN;
+            tile.metadata()[2] = cond;
             break;
         }
 
         case MP2::OBJ_TREE_OF_KNOWLEDGE:
+            assert( isFirstLoad );
+
             // variant: 10 gems, 2000 gold or free
             switch ( Rand::Get( 1, 3 ) ) {
             case 1:
@@ -988,14 +1247,20 @@ namespace Maps
             break;
 
         case MP2::OBJ_BARRIER:
+            assert( isFirstLoad );
+
             setColorOnTile( tile, getColorFromBarrierSprite( tile.getObjectIcnType(), tile.GetObjectSpriteIndex() ) );
             break;
 
         case MP2::OBJ_TRAVELLER_TENT:
+            assert( isFirstLoad );
+
             setColorOnTile( tile, getColorFromTravellerTentSprite( tile.getObjectIcnType(), tile.GetObjectSpriteIndex() ) );
             break;
 
         case MP2::OBJ_ALCHEMIST_LAB: {
+            assert( isFirstLoad );
+
             const auto resourceCount = fheroes2::checkedCast<uint32_t>( ProfitConditions::FromMine( Resource::MERCURY ).mercury );
             assert( resourceCount.has_value() && resourceCount > 0U );
 
@@ -1004,6 +1269,8 @@ namespace Maps
         }
 
         case MP2::OBJ_SAWMILL: {
+            assert( isFirstLoad );
+
             const auto resourceCount = fheroes2::checkedCast<uint32_t>( ProfitConditions::FromMine( Resource::WOOD ).wood );
             assert( resourceCount.has_value() && resourceCount > 0U );
 
@@ -1012,6 +1279,8 @@ namespace Maps
         }
 
         case MP2::OBJ_MINES: {
+            assert( isFirstLoad );
+
             switch ( tile.GetObjectSpriteIndex() ) {
             case 0: {
                 const auto resourceCount = fheroes2::checkedCast<uint32_t>( ProfitConditions::FromMine( Resource::ORE ).ore );
@@ -1055,20 +1324,18 @@ namespace Maps
         }
 
         case MP2::OBJ_ABANDONED_MINE:
-            // The number of Ghosts is set when loading the map and does not change anymore
+            // The number of Ghosts is set only when loading the map and does not change anymore.
             if ( isFirstLoad ) {
                 setMonsterCountOnTile( tile, Rand::Get( 30, 60 ) );
             }
             break;
 
         case MP2::OBJ_BOAT:
+            assert( isFirstLoad );
+
             // This is a special case. Boats are different in the original editor.
             tile.setObjectIcnType( MP2::OBJ_ICN_TYPE_BOAT32 );
             tile.setObjectSpriteIndex( 18 );
-            break;
-
-        case MP2::OBJ_EVENT:
-            tile.resetObjectSprite();
             break;
 
         case MP2::OBJ_RANDOM_ARTIFACT:
@@ -1113,151 +1380,41 @@ namespace Maps
             }
             break;
 
-        case MP2::OBJ_WATCH_TOWER:
-        case MP2::OBJ_EXCAVATION:
-        case MP2::OBJ_CAVE:
-        case MP2::OBJ_TREE_HOUSE:
+        case MP2::OBJ_AIR_ALTAR:
         case MP2::OBJ_ARCHER_HOUSE:
-        case MP2::OBJ_GOBLIN_HUT:
+        case MP2::OBJ_BARROW_MOUNDS:
+        case MP2::OBJ_CAVE:
+        case MP2::OBJ_CITY_OF_DEAD:
+        case MP2::OBJ_DESERT_TENT:
+        case MP2::OBJ_DRAGON_CITY:
         case MP2::OBJ_DWARF_COTTAGE:
+        case MP2::OBJ_EARTH_ALTAR:
+        case MP2::OBJ_EXCAVATION:
+        case MP2::OBJ_FIRE_ALTAR:
+        case MP2::OBJ_GOBLIN_HUT:
         case MP2::OBJ_HALFLING_HOLE:
         case MP2::OBJ_PEASANT_HUT:
-        // recruit dwelling
         case MP2::OBJ_RUINS:
         case MP2::OBJ_TREE_CITY:
-        case MP2::OBJ_WAGON_CAMP:
-        case MP2::OBJ_DESERT_TENT:
+        case MP2::OBJ_TREE_HOUSE:
         case MP2::OBJ_TROLL_BRIDGE:
-        case MP2::OBJ_DRAGON_CITY:
-        case MP2::OBJ_CITY_OF_DEAD:
+        case MP2::OBJ_WAGON_CAMP:
+        case MP2::OBJ_WATCH_TOWER:
         case MP2::OBJ_WATER_ALTAR:
-        case MP2::OBJ_AIR_ALTAR:
-        case MP2::OBJ_FIRE_ALTAR:
-        case MP2::OBJ_EARTH_ALTAR:
-        case MP2::OBJ_BARROW_MOUNDS:
             updateDwellingPopulationOnTile( tile, isFirstLoad );
             break;
         default:
+            if ( isFirstLoad ) {
+                tile.resetObjectSprite();
+            }
             break;
         }
-    }
-
-    void updateRandomArtifact( Tiles & tile )
-    {
-        Artifact art;
-
-        switch ( tile.GetObject() ) {
-        case MP2::OBJ_RANDOM_ARTIFACT:
-            art = Artifact::Rand( Artifact::ART_LEVEL_ALL_NORMAL );
-            break;
-        case MP2::OBJ_RANDOM_ARTIFACT_TREASURE:
-            art = Artifact::Rand( Artifact::ART_LEVEL_TREASURE );
-            break;
-        case MP2::OBJ_RANDOM_ARTIFACT_MINOR:
-            art = Artifact::Rand( Artifact::ART_LEVEL_MINOR );
-            break;
-        case MP2::OBJ_RANDOM_ARTIFACT_MAJOR:
-            art = Artifact::Rand( Artifact::ART_LEVEL_MAJOR );
-            break;
-        default:
-            return;
-        }
-
-        if ( !art.isValid() ) {
-            DEBUG_LOG( DBG_GAME, DBG_WARN, "Failed to set an artifact over a random artifact on tile " << tile.GetIndex() )
-            return;
-        }
-
-        tile.SetObject( MP2::OBJ_ARTIFACT );
-
-        uint32_t uidArtifact = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNARTI );
-        if ( uidArtifact == 0 ) {
-            uidArtifact = tile.GetObjectUID();
-        }
-
-        static_assert( std::is_same_v<decltype( Maps::Tiles::updateTileById ), void( Tiles &, uint32_t, uint8_t )>,
-                       "Type of updateTileById() has been changed, check the logic below" );
-
-        const uint32_t artSpriteIndex = art.IndexSprite();
-        assert( artSpriteIndex > std::numeric_limits<uint8_t>::min() && artSpriteIndex <= std::numeric_limits<uint8_t>::max() );
-
-        Maps::Tiles::updateTileById( tile, uidArtifact, static_cast<uint8_t>( artSpriteIndex ) );
-
-        // replace artifact shadow
-        if ( Maps::isValidDirection( tile.GetIndex(), Direction::LEFT ) ) {
-            Maps::Tiles::updateTileById( world.GetTiles( Maps::GetDirectionIndex( tile.GetIndex(), Direction::LEFT ) ), uidArtifact,
-                                         static_cast<uint8_t>( artSpriteIndex - 1 ) );
-        }
-    }
-
-    void updateRandomResource( Tiles & tile )
-    {
-        tile.SetObject( MP2::OBJ_RESOURCE );
-
-        const uint8_t resourceSprite = Resource::GetIndexSprite( Resource::Rand( true ) );
-
-        uint32_t uidResource = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_OBJNRSRC );
-        if ( uidResource == 0 ) {
-            uidResource = tile.GetObjectUID();
-        }
-
-        Maps::Tiles::updateTileById( tile, uidResource, resourceSprite );
-
-        // Replace shadow of the resource.
-        if ( Maps::isValidDirection( tile.GetIndex(), Direction::LEFT ) ) {
-            assert( resourceSprite > 0 );
-            Maps::Tiles::updateTileById( world.GetTiles( Maps::GetDirectionIndex( tile.GetIndex(), Direction::LEFT ) ), uidResource, resourceSprite - 1 );
-        }
-    }
-
-    void updateRandomMonster( Tiles & tile )
-    {
-        Monster mons;
-
-        switch ( tile.GetObject() ) {
-        case MP2::OBJ_RANDOM_MONSTER:
-            mons = Monster::Rand( Monster::LevelType::LEVEL_ANY );
-            break;
-        case MP2::OBJ_RANDOM_MONSTER_WEAK:
-            mons = Monster::Rand( Monster::LevelType::LEVEL_1 );
-            break;
-        case MP2::OBJ_RANDOM_MONSTER_MEDIUM:
-            mons = Monster::Rand( Monster::LevelType::LEVEL_2 );
-            break;
-        case MP2::OBJ_RANDOM_MONSTER_STRONG:
-            mons = Monster::Rand( Monster::LevelType::LEVEL_3 );
-            break;
-        case MP2::OBJ_RANDOM_MONSTER_VERY_STRONG:
-            mons = Monster::Rand( Monster::LevelType::LEVEL_4 );
-            break;
-        default:
-            break;
-        }
-
-        tile.SetObject( MP2::OBJ_MONSTER );
-
-        using TileImageIndexType = decltype( tile.GetObjectSpriteIndex() );
-        static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of GetObjectSpriteIndex() has been changed, check the logic below" );
-
-        assert( mons.GetID() > std::numeric_limits<TileImageIndexType>::min() && mons.GetID() <= std::numeric_limits<TileImageIndexType>::max() );
-
-        tile.setObjectSpriteIndex( static_cast<TileImageIndexType>( mons.GetID() - 1 ) ); // ICN::MONS32 starts from PEASANT
     }
 
     void updateMonsterInfoOnTile( Tiles & tile )
     {
         const Monster mons = Monster( tile.GetObjectSpriteIndex() + 1 ); // ICN::MONS32 start from PEASANT
-        uint32_t count = 0;
-
-        // update count (mp2 format)
-        if ( tile.GetQuantity1() || tile.GetQuantity2() ) {
-            count = tile.GetQuantity2();
-            count <<= 8;
-            count |= tile.GetQuantity1();
-            count >>= 3;
-        }
-
-        setMonsterOnTile( tile, mons, count );
+        setMonsterOnTile( tile, mons, tile.metadata()[0] );
     }
 
     void setMonsterOnTile( Tiles & tile, const Monster & mons, const uint32_t count )

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -35,12 +35,53 @@ namespace Maps
 {
     class Tiles;
 
+    enum class ArtifactCaptureCondition : uint32_t
+    {
+        NO_CONDITIONS = 0,
+        PAY_2000_GOLD = 1,
+        PAY_2500_GOLD_AND_3_RESOURCES = 2,
+        PAY_3000_GOLD_AND_5_RESOURCES = 3,
+        HAVE_WISDOM_SKILL = 4,
+        HAVE_LEADERSHIP_SKILL = 5,
+        FIGHT_50_ROGUES = 6,
+        FIGHT_1_GENIE = 7,
+        FIGHT_1_PALADIN = 8,
+        FIGHT_1_CYCLOP = 9,
+        FIGHT_1_PHOENIX = 10,
+        FIGHT_1_GREEN_DRAGON = 11,
+        FIGHT_1_TITAN = 12,
+        FIGHT_1_BONE_DRAGON = 13,
+        CONTAINS_SPELL = 15
+    };
+
+    enum class DaemonCaveCaptureBonus : uint32_t
+    {
+        NO_BONUS = 0,
+        GET_1000_EXPERIENCE = 1,
+        GET_1000_EXPERIENCE_AND_2500_GOLD = 2,
+        GET_1000_EXPERIENCE_AND_ARTIFACT = 3,
+        PAY_2500_GOLD = 4
+    };
+
+    enum class ShipwreckCaptureCondition : uint32_t
+    {
+        NO_BONUS = 0,
+        FIGHT_10_GHOSTS_AND_GET_1000_GOLD = 1,
+        FIGHT_15_GHOSTS_AND_GET_2000_GOLD = 2,
+        FIGHT_25_GHOSTS_AND_GET_5000_GOLD = 3,
+        FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT = 4
+    };
+
+    // Only for MP2::OBJ_MINES.
     int32_t getMineSpellIdFromTile( const Tiles & tile );
     void setMineSpellOnTile( Tiles & tile, const int32_t spellId );
+    void removeMineSpellFromTile( Tiles & tile );
 
+    // Only for objects which always have spell(s).
     Spell getSpellFromTile( const Tiles & tile );
     void setSpellOnTile( Tiles & tile, const int spellId );
 
+    // Only for MP2::OBJ_MONSTER.
     void setMonsterOnTileJoinCondition( Tiles & tile, const int32_t condition );
     bool isMonsterOnTileJoinConditionSkip( const Tiles & tile );
     bool isMonsterOnTileJoinConditionFree( const Tiles & tile );
@@ -56,8 +97,15 @@ namespace Maps
 
     uint32_t getGoldAmountFromTile( const Tiles & tile );
 
-    Skill::Secondary getSecondarySkillFromTile( const Tiles & tile );
-    void setSecondarySkillOnTile( Tiles & tile, const int skillId );
+    Skill::Secondary getArtifactSecondarySkillRequirement( const Tiles & tile );
+    ArtifactCaptureCondition getArtifactCaptureCondition( const Tiles & tile );
+
+    DaemonCaveCaptureBonus getDaemonCaveBonus( const Tiles & tile );
+
+    ShipwreckCaptureCondition getShipwrechCaptureCondition( const Tiles & tile );
+
+    // Only for MP2::OBJ_WITCHS_HUT.
+    Skill::Secondary getSecondarySkillFromWitchsHut( const Tiles & tile );
 
     ResourceCount getResourcesFromTile( const Tiles & tile );
     void setResourceOnTile( Tiles & tile, const int resourceType, uint32_t value );
@@ -76,17 +124,9 @@ namespace Maps
     uint32_t getMonsterCountFromTile( const Tiles & tile );
     void setMonsterCountOnTile( Tiles & tile, uint32_t count );
 
-    void updateMonsterPopulationOnTile( Tiles & tile );
-
-    void updateDwellingPopulationOnTile( Tiles & tile, bool isFirstLoad );
+    void updateDwellingPopulationOnTile( Tiles & tile, const bool isFirstLoad );
 
     void updateObjectInfoTile( Tiles & tile, const bool isFirstLoad );
-
-    void updateRandomArtifact( Tiles & tile );
-
-    void updateRandomResource( Tiles & tile );
-
-    void updateRandomMonster( Tiles & tile );
 
     void updateMonsterInfoOnTile( Tiles & tile );
 

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -24,7 +24,6 @@
 #include "army_troop.h"
 #include "artifact.h"
 #include "mp2.h"
-#include "pairs.h"
 #include "resource.h"
 #include "skill.h"
 
@@ -34,6 +33,9 @@ class Spell;
 namespace Maps
 {
     class Tiles;
+
+    // ATTENTION: If you add any new enumeration make sure that value 0 corresponds to empty / visited object
+    //            so we don't need to write special logic in resetObjectInfoOnTile().
 
     enum class ArtifactCaptureCondition : uint32_t
     {
@@ -56,7 +58,7 @@ namespace Maps
 
     enum class DaemonCaveCaptureBonus : uint32_t
     {
-        NO_BONUS = 0,
+        EMPTY = 0,
         GET_1000_EXPERIENCE = 1,
         GET_1000_EXPERIENCE_AND_2500_GOLD = 2,
         GET_1000_EXPERIENCE_AND_ARTIFACT = 3,
@@ -65,7 +67,7 @@ namespace Maps
 
     enum class ShipwreckCaptureCondition : uint32_t
     {
-        NO_BONUS = 0,
+        EMPTY = 0,
         FIGHT_10_GHOSTS_AND_GET_1000_GOLD = 1,
         FIGHT_15_GHOSTS_AND_GET_2000_GOLD = 2,
         FIGHT_25_GHOSTS_AND_GET_5000_GOLD = 3,

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -48,7 +48,7 @@ namespace Maps
         FIGHT_50_ROGUES = 6,
         FIGHT_1_GENIE = 7,
         FIGHT_1_PALADIN = 8,
-        FIGHT_1_CYCLOP = 9,
+        FIGHT_1_CYCLOPS = 9,
         FIGHT_1_PHOENIX = 10,
         FIGHT_1_GREEN_DRAGON = 11,
         FIGHT_1_TITAN = 12,

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -122,6 +122,8 @@ namespace Maps
 
     bool doesTileContainValuableItems( const Tiles & tile );
 
+    void resetObjectMetadata( Tiles & tile );
+
     void resetObjectInfoOnTile( Tiles & tile );
 
     uint32_t getMonsterCountFromTile( const Tiles & tile );

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -77,7 +77,9 @@ namespace Maps
     void setMineSpellOnTile( Tiles & tile, const int32_t spellId );
     void removeMineSpellFromTile( Tiles & tile );
 
-    // Only for objects which always have spell(s).
+    Funds getDailyIncomeObjectResources( const Tiles & tile );
+
+    // Only for objects which always have spell(s): Shrine and Pyramid.
     Spell getSpellFromTile( const Tiles & tile );
     void setSpellOnTile( Tiles & tile, const int spellId );
 
@@ -93,21 +95,20 @@ namespace Maps
 
     Artifact getArtifactFromTile( const Tiles & tile );
 
-    void setArtifactOnTile( Tiles & tile, const int artifactId );
-
-    uint32_t getGoldAmountFromTile( const Tiles & tile );
-
     Skill::Secondary getArtifactSecondarySkillRequirement( const Tiles & tile );
     ArtifactCaptureCondition getArtifactCaptureCondition( const Tiles & tile );
+    Funds getArtifactResourceRequirement( const Tiles & tile );
 
-    DaemonCaveCaptureBonus getDaemonCaveBonus( const Tiles & tile );
+    DaemonCaveCaptureBonus getDaemonCaveBonusType( const Tiles & tile );
+    Funds getDaemonPaymentCondition( const Tiles & tile );
 
     ShipwreckCaptureCondition getShipwrechCaptureCondition( const Tiles & tile );
+
+    Funds getTreeOfKnowledgeRequirement( const Tiles & tile );
 
     // Only for MP2::OBJ_WITCHS_HUT.
     Skill::Secondary getSecondarySkillFromWitchsHut( const Tiles & tile );
 
-    ResourceCount getResourcesFromTile( const Tiles & tile );
     void setResourceOnTile( Tiles & tile, const int resourceType, uint32_t value );
 
     Funds getFundsFromTile( const Tiles & tile );

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -104,7 +104,7 @@ namespace Maps
     DaemonCaveCaptureBonus getDaemonCaveBonusType( const Tiles & tile );
     Funds getDaemonPaymentCondition( const Tiles & tile );
 
-    ShipwreckCaptureCondition getShipwrechCaptureCondition( const Tiles & tile );
+    ShipwreckCaptureCondition getShipwreckCaptureCondition( const Tiles & tile );
 
     Funds getTreeOfKnowledgeRequirement( const Tiles & tile );
 

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -1006,6 +1006,8 @@ bool MP2::doesObjectContainMetadata( const MP2::MapObjectType type )
     // Ultimate artifact contains radius value to be placed by the engine.
     case OBJ_RANDOM_ULTIMATE_ARTIFACT:
         return true;
+    default:
+        break;
     }
 
     return false;

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -640,7 +640,7 @@ MP2::MapObjectType MP2::getBaseActionObjectType( const MapObjectType objectType 
     return static_cast<MapObjectType>( objectType | OBJ_ACTION_OBJECT_TYPE );
 }
 
-bool MP2::isQuantityObject( const MapObjectType objectType )
+bool MP2::isValuableResourceObject( const MapObjectType objectType )
 {
     // Sort things in alphabetical order for better readability.
     switch ( objectType ) {
@@ -958,4 +958,55 @@ bool MP2::isDiggingHoleSprite( const int terrainType, const ObjectIcnType object
     }
 
     return ( objectIcnType == terrainObjectIcnType ) && ( index == correctIndex );
+}
+
+bool MP2::doesObjectNeedExtendedMetadata( const MP2::MapObjectType type )
+{
+    switch ( type ) {
+    case OBJ_BOTTLE:
+    case OBJ_CASTLE:
+    case OBJ_EVENT:
+    case OBJ_HEROES:
+    case OBJ_JAIL:
+    case OBJ_RANDOM_CASTLE:
+    case OBJ_RANDOM_TOWN:
+    case OBJ_SIGN:
+    case OBJ_SPHINX:
+        return true;
+    default:
+        break;
+    }
+
+    return false;
+}
+
+bool MP2::doesObjectContainMetadata( const MP2::MapObjectType type )
+{
+    if ( doesObjectNeedExtendedMetadata( type ) ) {
+        // UID for an extended metadata data chunk which should be read outside Tiles object.
+        return true;
+    }
+
+    switch ( type ) {
+    // Only spell scrolls require additional metadata to store spell ID.
+    case OBJ_ARTIFACT:
+    // Traveller's tent and barriers contain a color of the object. As of now we don't use it at all.
+    case OBJ_BARRIER:
+    case OBJ_TRAVELLER_TENT:
+    // Expansion object and dwellings contain ID to identify object type. As of now we don't use it at all.
+    case OBJ_EXPANSION_DWELLING:
+    case OBJ_EXPANSION_OBJECT:
+    // The number of monsters.
+    case OBJ_MONSTER:
+    case OBJ_RANDOM_MONSTER:
+    case OBJ_RANDOM_MONSTER_MEDIUM:
+    case OBJ_RANDOM_MONSTER_STRONG:
+    case OBJ_RANDOM_MONSTER_VERY_STRONG:
+    case OBJ_RANDOM_MONSTER_WEAK:
+    // Ultimate artifact contains radius value to be placed by the engine.
+    case OBJ_RANDOM_ULTIMATE_ARTIFACT:
+        return true;
+    }
+
+    return false;
 }

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -481,7 +481,7 @@ namespace MP2
 
     bool isWaterActionObject( const MapObjectType objectType );
 
-    bool isQuantityObject( const MapObjectType objectType );
+    bool isValuableResourceObject( const MapObjectType objectType );
     bool isCaptureObject( const MapObjectType objectType );
     bool isPickupObject( const MapObjectType objectType );
     bool isArtifactObject( const MapObjectType objectType );
@@ -501,6 +501,13 @@ namespace MP2
 
     bool getDiggingHoleSprite( const int terrainType, ObjectIcnType & objectIcnType, uint8_t & index );
     bool isDiggingHoleSprite( const int terrainType, const ObjectIcnType objectIcnType, const uint8_t index );
+
+    // Only specific objects from the original MP2 format require extended metadata.
+    // These objects store a UID in their initial metadata (quantity1 and quantity2 values).
+    bool doesObjectNeedExtendedMetadata( const MP2::MapObjectType type );
+
+    // Only specific objects from the original MP2 format contain metadata (quantity1 and quantity2 values).
+    bool doesObjectContainMetadata( const MP2::MapObjectType type );
 }
 
 #endif

--- a/src/fheroes2/maps/pairs.h
+++ b/src/fheroes2/maps/pairs.h
@@ -28,7 +28,6 @@
 
 #include "color.h"
 #include "mp2.h"
-#include "resource.h"
 
 class IndexObject : public std::pair<int32_t, int>
 {
@@ -66,21 +65,6 @@ public:
     bool isColor( int colors ) const
     {
         return ( colors & second ) != 0;
-    }
-};
-
-class ResourceCount : public std::pair<int, uint32_t>
-{
-public:
-    ResourceCount() = delete;
-
-    ResourceCount( int res, uint32_t count )
-        : std::pair<int, uint32_t>( res, count )
-    {}
-
-    bool isValid() const
-    {
-        return ( first & Resource::ALL ) && second;
     }
 };
 

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -574,27 +574,27 @@ std::pair<int, int32_t> Funds::getFirstValidResource() const
     }
 
     if ( ore > 0 ) {
-        return { Resource::ORE, wood };
+        return { Resource::ORE, ore };
     }
 
     if ( mercury > 0 ) {
-        return { Resource::MERCURY, wood };
+        return { Resource::MERCURY, mercury };
     }
 
     if ( sulfur > 0 ) {
-        return { Resource::SULFUR, wood };
+        return { Resource::SULFUR, sulfur };
     }
 
     if ( crystal > 0 ) {
-        return { Resource::CRYSTAL, wood };
+        return { Resource::CRYSTAL, crystal };
     }
 
     if ( gems > 0 ) {
-        return { Resource::GEMS, wood };
+        return { Resource::GEMS, gems };
     }
 
     if ( gold > 0 ) {
-        return { Resource::GOLD, wood };
+        return { Resource::GOLD, gold };
     }
 
     // We shouldn't reach this point. Make sure that you are calling this method for valid Funds.

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -110,20 +110,6 @@ Funds::Funds( const cost_t & cost )
     , gold( cost.gold )
 {}
 
-Funds::Funds( const ResourceCount & rs )
-    : wood( 0 )
-    , mercury( 0 )
-    , ore( 0 )
-    , sulfur( 0 )
-    , crystal( 0 )
-    , gems( 0 )
-    , gold( 0 )
-{
-    int32_t * ptr = GetPtr( rs.first );
-    if ( ptr )
-        *ptr = rs.second;
-}
-
 int Resource::Rand( const bool includeGold )
 {
     switch ( Rand::Get( 1, ( includeGold ? 7 : 6 ) ) ) {

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -35,7 +35,6 @@
 #include "icn.h"
 #include "image.h"
 #include "logging.h"
-#include "pairs.h"
 #include "rand.h"
 #include "screen.h"
 #include "serialize.h"

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -567,6 +567,41 @@ void Funds::Trim()
         gold = 0;
 }
 
+std::pair<int, int32_t> Funds::getFirstValidResource() const
+{
+    if ( wood > 0 ) {
+        return { Resource::WOOD, wood };
+    }
+
+    if ( ore > 0 ) {
+        return { Resource::ORE, wood };
+    }
+
+    if ( mercury > 0 ) {
+        return { Resource::MERCURY, wood };
+    }
+
+    if ( sulfur > 0 ) {
+        return { Resource::SULFUR, wood };
+    }
+
+    if ( crystal > 0 ) {
+        return { Resource::CRYSTAL, wood };
+    }
+
+    if ( gems > 0 ) {
+        return { Resource::GEMS, wood };
+    }
+
+    if ( gold > 0 ) {
+        return { Resource::GOLD, wood };
+    }
+
+    // We shouldn't reach this point. Make sure that you are calling this method for valid Funds.
+    assert( 0 );
+    return { Resource::UNKNOWN, 0 };
+}
+
 void Funds::Reset()
 {
     wood = 0;

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -94,7 +94,9 @@ Funds::Funds( int rs, uint32_t count )
         break;
 
     default:
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown resource" )
+        if ( count > 0 ) {
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown resource is being added to Funds class. Ignore it." )
+        }
         break;
     }
 }

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -25,7 +25,7 @@
 
 #include <cstdint>
 #include <string>
-#include <vector>
+#include <utility>
 
 #include "math_base.h"
 

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -47,8 +47,6 @@ struct cost_t
         0, 0, 0, 0, 0, 0, 0                                                                                                                                              \
     }
 
-class ResourceCount;
-
 namespace Resource
 {
     enum
@@ -72,7 +70,6 @@ public:
     Funds( int32_t _ore, int32_t _wood, int32_t _mercury, int32_t _sulfur, int32_t _crystal, int32_t _gems, int32_t _gold );
     Funds( int rs, uint32_t count );
     explicit Funds( const cost_t & );
-    explicit Funds( const ResourceCount & );
 
     Funds operator+( const Funds & ) const;
     Funds operator*( uint32_t mul ) const;

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -25,6 +25,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 #include "math_base.h"
 
@@ -96,6 +97,8 @@ public:
     int GetValidItems() const;
     uint32_t GetValidItemsCount() const;
     void Trim(); // set all values to be >= 0
+
+    std::pair<int, int32_t> getFirstValidResource() const;
 
     void Reset();
     std::string String() const;

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -28,6 +28,7 @@ enum SaveFileFormat : uint16_t
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
+    FORMAT_VERSION_1004_RELEASE = 10008,
     FORMAT_VERSION_1003_RELEASE = 10007,
     FORMAT_VERSION_1002_RELEASE = 10006,
     FORMAT_VERSION_PRE2_1002_RELEASE = 10005,
@@ -39,5 +40,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_1000_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1003_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1004_RELEASE
 };

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1411,7 +1411,7 @@ StreamBase & operator>>( StreamBase & msg, World & w )
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1003_RELEASE ) {
         for ( Maps::Tiles & tile : w.vec_tiles ) {
             if ( tile.GetObject( false ) == MP2::OBJ_ABANDONED_MINE ) {
-                const int32_t spellId = Maps::getMineSpellIdFromTile( tile );
+                const int32_t spellId = tile.metadata()[2];
 
                 if ( spellId == Spell::HAUNT ) {
                     const Funds rc = getDailyIncomeObjectResources( tile );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1414,8 +1414,8 @@ StreamBase & operator>>( StreamBase & msg, World & w )
                 const int32_t spellId = Maps::getMineSpellIdFromTile( tile );
 
                 if ( spellId == Spell::HAUNT ) {
-                    const ResourceCount rc = getResourcesFromTile( tile );
-                    const int resource = rc.isValid() ? rc.first : Resource::GOLD;
+                    const Funds rc = getDailyIncomeObjectResources( tile );
+                    const int resource = ( rc.GetValidItemsCount() > 0 ) ? rc.getFirstValidResource().first : Resource::GOLD;
 
                     Maps::Tiles::RestoreAbandonedMine( tile, resource );
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -370,7 +370,6 @@ void World::Reset()
     _seed = 0;
 }
 
-/* new maps */
 void World::NewMaps( int32_t sw, int32_t sh )
 {
     Reset();

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1414,7 +1414,7 @@ StreamBase & operator>>( StreamBase & msg, World & w )
                 const int32_t spellId = static_cast<int32_t>( tile.metadata()[2] );
 
                 if ( spellId == Spell::HAUNT ) {
-                    const Funds rc = getDailyIncomeObjectResources( tile );
+                    const Funds rc{ static_cast<int32_t>( tile.metadata()[0] ), 1 };
                     const int resource = ( rc.GetValidItemsCount() > 0 ) ? rc.getFirstValidResource().first : Resource::GOLD;
 
                     Maps::Tiles::RestoreAbandonedMine( tile, resource );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1411,7 +1411,7 @@ StreamBase & operator>>( StreamBase & msg, World & w )
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1003_RELEASE ) {
         for ( Maps::Tiles & tile : w.vec_tiles ) {
             if ( tile.GetObject( false ) == MP2::OBJ_ABANDONED_MINE ) {
-                const int32_t spellId = tile.metadata()[2];
+                const int32_t spellId = static_cast<int32_t>( tile.metadata()[2] );
 
                 if ( spellId == Spell::HAUNT ) {
                     const Funds rc = getDailyIncomeObjectResources( tile );

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -360,6 +360,8 @@ private:
     bool ProcessNewMap( const std::string & filename, const bool checkPoLObjects );
     void PostLoad( const bool setTilePassabilities );
 
+    bool updateTileMetadata( Maps::Tiles & tile, const MP2::MapObjectType objectType, const bool checkPoLObjects );
+
     bool isValidCastleEntrance( const fheroes2::Point & tilePosition ) const;
 
     friend class Radar;

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -722,6 +722,7 @@ bool World::ProcessNewMap( const std::string & filename, const bool checkPoLObje
     // There is a tile with a predefined Ultimate Artifact, pick a tile nearby in the radius specified in the artifact's properties
     else {
         const int32_t radius = static_cast<int32_t>( ultArtTileIter->metadata()[0] );
+        resetObjectMetadata( *ultArtTileIter );
 
         // Remove the predefined Ultimate Artifact object
         ultArtTileIter->Remove( ultArtTileIter->GetObjectUID() );
@@ -849,6 +850,7 @@ bool World::updateTileMetadata( Maps::Tiles & tile, const MP2::MapObjectType obj
     case MP2::OBJ_WITCHS_HUT:
         updateObjectInfoTile( tile, true );
         break;
+
     case MP2::OBJ_AIR_ALTAR:
     case MP2::OBJ_BARROW_MOUNDS:
     case MP2::OBJ_EARTH_ALTAR:
@@ -857,6 +859,10 @@ bool World::updateTileMetadata( Maps::Tiles & tile, const MP2::MapObjectType obj
         // We need to clear metadata because it is being stored as a part of an MP2 object.
         resetObjectInfoOnTile( tile );
         updateObjectInfoTile( tile, true );
+        break;
+
+    case MP2::OBJ_RANDOM_ULTIMATE_ARTIFACT:
+        // We need information from an Ultimate artifact for later use. We will reset metadata later.
         break;
 
     case MP2::OBJ_HEROES: {

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -829,7 +829,6 @@ bool World::ProcessNewMap( const std::string & filename, const bool checkPoLObje
     }
     // There is a tile with a predefined Ultimate Artifact, pick a tile nearby in the radius specified in the artifact's properties
     else {
-        // The radius can be in the range 0 - 127, it is represented by 2 low-order bits of quantity2 and 5 high-order bits of quantity1
         const int32_t radius = static_cast<int32_t>( ultArtTileIter->metadata()[0] );
 
         // Remove the predefined Ultimate Artifact object

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -758,6 +758,8 @@ bool World::ProcessNewMap( const std::string & filename, const bool checkPoLObje
         }
 
         default:
+            // Remove any metadata from other objects.
+            resetObjectInfoOnTile( tile );
             break;
         }
     }

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -890,7 +890,7 @@ bool World::updateTileMetadata( Maps::Tiles & tile, const MP2::MapObjectType obj
 
     default:
         // Remove any metadata from other objects.
-        resetObjectInfoOnTile( tile );
+        resetObjectMetadata( tile );
         break;
     }
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -864,7 +864,7 @@ bool World::updateTileMetadata( Maps::Tiles & tile, const MP2::MapObjectType obj
         if ( tile.getObjectIcnType() == MP2::OBJ_ICN_TYPE_MINIHERO )
             tile.Remove( tile.GetObjectUID() );
 
-        Heroes* chosenHero = GetHeroes( Maps::GetPoint( tile.GetIndex() ) );
+        Heroes * chosenHero = GetHeroes( Maps::GetPoint( tile.GetIndex() ) );
         assert( chosenHero != nullptr );
 
         tile.SetHeroes( chosenHero );

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
@@ -829,7 +830,7 @@ bool World::ProcessNewMap( const std::string & filename, const bool checkPoLObje
     // There is a tile with a predefined Ultimate Artifact, pick a tile nearby in the radius specified in the artifact's properties
     else {
         // The radius can be in the range 0 - 127, it is represented by 2 low-order bits of quantity2 and 5 high-order bits of quantity1
-        const int32_t radius = ultArtTileIter->metadata()[0];
+        const int32_t radius = static_cast<int32_t>( ultArtTileIter->metadata()[0] );
 
         // Remove the predefined Ultimate Artifact object
         ultArtTileIter->Remove( ultArtTileIter->GetObjectUID() );

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -30,7 +30,6 @@
 #include <ostream>
 #include <set>
 #include <string>
-#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -125,8 +125,14 @@ namespace
         }
 
         // Monster or artifact guarded by a monster
-        if ( objectType == MP2::OBJ_MONSTER || ( objectType == MP2::OBJ_ARTIFACT && tile.QuantityVariant() > 5 ) )
+        if ( objectType == MP2::OBJ_MONSTER ) {
             return Army( tile ).GetStrength() > armyStrength;
+        }
+
+        if ( objectType == MP2::OBJ_ARTIFACT && getArtifactCaptureCondition( tile ) >= Maps::ArtifactCaptureCondition::FIGHT_50_ROGUES &&
+             getArtifactCaptureCondition( tile ) <= Maps::ArtifactCaptureCondition::FIGHT_1_BONE_DRAGON ) {
+            return Army( tile ).GetStrength() > armyStrength;
+        }
 
         // Check if AI has the key for the barrier
         if ( objectType == MP2::OBJ_BARRIER && world.GetKingdom( color ).IsVisitTravelersTent( getColorFromTile( tile ) ) )

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -129,8 +129,8 @@ namespace
             return Army( tile ).GetStrength() > armyStrength;
         }
 
-        if ( objectType == MP2::OBJ_ARTIFACT && getArtifactCaptureCondition( tile ) >= Maps::ArtifactCaptureCondition::FIGHT_50_ROGUES &&
-             getArtifactCaptureCondition( tile ) <= Maps::ArtifactCaptureCondition::FIGHT_1_BONE_DRAGON ) {
+        if ( objectType == MP2::OBJ_ARTIFACT && getArtifactCaptureCondition( tile ) >= Maps::ArtifactCaptureCondition::FIGHT_50_ROGUES
+             && getArtifactCaptureCondition( tile ) <= Maps::ArtifactCaptureCondition::FIGHT_1_BONE_DRAGON ) {
             return Army( tile ).GetStrength() > armyStrength;
         }
 


### PR DESCRIPTION
- remove cryptic quantity1 and quantity2 values everywhere in the code and replace them with human-readable **metadata** array
- avoid hardcoded values for many object conditions like Artifact, Daemon Cave or Shipwreck
- fix AI pathfinding when Spell Scroll was considered as an artifact which requires to defeat an army
- fix Shipwreck Survivor bonuses. It always contained artifact of level 1
- add many checks in the code to prevent calling functions for unsupported objects
- add specialized functions to get information about objects. We have to avoid generic functions

relates to #6845 

**ATTENTION**
This pull request changes almost every object interaction on Adventure Map in relation to conditions and resources. Also I added a conversion code from old save format to a new one. As a result, it is important to test all objects for new maps as well as objects on maps loaded from old saves.

The best strategy for testing by developers is to enable debug mode and see metadata values on objects. Now it is easily readable.