### PR TITLE
WIP: Support for 32bit images

### DIFF
--- a/src/engine/h2d_file.cpp
+++ b/src/engine/h2d_file.cpp
@@ -190,7 +190,13 @@ namespace fheroes2
 
         const size_t size = static_cast<size_t>( width * height );
         image.resize( width, height );
-        memcpy( image.image(), data.data() + 4 + 4 + 4 + 4, size );
+
+        //memcpy( image.image(), data.data() + 4 + 4 + 4 + 4, size * 4 );
+        uint32_t * imageData = image.image();
+        const uint8_t * pixelData = data.data() + 4 + 4 + 4 + 4;
+        for ( size_t j = 0; j < size; ++j, ++imageData, ++pixelData ) {
+            *imageData = *pixelData;
+        }
         memcpy( image.transform(), data.data() + 4 + 4 + 4 + 4 + size, size );
 
         image.setPosition( x, y );

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -1019,7 +1019,7 @@ namespace fheroes2
                     for ( ; imageOutX != imageOutXEnd; --imageInX, --transformInX, ++imageOutX ) {
                         if ( *transformInX > 0 ) { // apply a transformation
                             if ( *transformInX != 1 ) { // skip pixel
-                                //*imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                                *imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                             }
                         }
                         else { // copy a pixel
@@ -1044,7 +1044,7 @@ namespace fheroes2
                         }
 
                         if ( *transformInX > 0 && *transformOutX == 0 ) { // apply a transformation
-                            //*imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                            *imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                         }
                         else { // copy a pixel
                             *transformOutX = *transformInX;
@@ -1074,7 +1074,7 @@ namespace fheroes2
                     for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX ) {
                         if ( *transformInX > 0 ) { // apply a transformation
                             if ( *transformInX != 1 ) { // skip pixel
-                                //*imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                                *imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                             }
                         }
                         else { // copy a pixel
@@ -1099,7 +1099,7 @@ namespace fheroes2
                         }
 
                         if ( *transformInX > 0 && *transformOutX == 0 ) { // apply a transformation
-                            //*imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                            *imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                         }
                         else { // copy a pixel
                             *transformOutX = *transformInX;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -378,16 +378,16 @@ namespace
         const int32_t widthIn = in.width();
         const int32_t widthOut = out.width();
 
-        const uint8_t * imageInY = in.image() + inY * widthIn + inX;
-        uint8_t * imageOutY = out.image() + outY * widthOut + outX;
-        const uint8_t * imageInYEnd = imageInY + height * widthIn;
+        const uint32_t * imageInY = in.image() + inY * widthIn + inX;
+        uint32_t * imageOutY = out.image() + outY * widthOut + outX;
+        const uint32_t * imageInYEnd = imageInY + height * widthIn;
 
         if ( in.singleLayer() ) {
             // All pixels in a single layer image do not have any transform values so there is no need to check for them.
             for ( ; imageInY != imageInYEnd; imageInY += widthIn, imageOutY += widthOut ) {
-                const uint8_t * imageInX = imageInY;
-                uint8_t * imageOutX = imageOutY;
-                const uint8_t * imageInXEnd = imageInX + width;
+                const uint32_t * imageInX = imageInY;
+                uint32_t * imageOutX = imageOutY;
+                const uint32_t * imageInXEnd = imageInX + width;
 
                 for ( ; imageInX != imageInXEnd; ++imageInX, ++imageOutX ) {
                     *imageOutX = palette[*imageInX];
@@ -398,10 +398,10 @@ namespace
             const uint8_t * transformInY = in.transform() + inY * widthIn + inX;
 
             for ( ; imageInY != imageInYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
-                const uint8_t * imageInX = imageInY;
+                const uint32_t * imageInX = imageInY;
                 const uint8_t * transformInX = transformInY;
-                uint8_t * imageOutX = imageOutY;
-                const uint8_t * imageInXEnd = imageInX + width;
+                uint32_t * imageOutX = imageOutY;
+                const uint32_t * imageInXEnd = imageInX + width;
 
                 for ( ; imageInX != imageInXEnd; ++imageInX, ++imageOutX, ++transformInX ) {
                     if ( *transformInX == 0 ) { // only modify pixels with data
@@ -475,12 +475,12 @@ namespace fheroes2
         return *this;
     }
 
-    uint8_t * Image::image()
+    uint32_t * Image::image()
     {
         return _data.get();
     }
 
-    const uint8_t * Image::image() const
+    const uint32_t * Image::image() const
     {
         return _data.get();
     }
@@ -517,7 +517,7 @@ namespace fheroes2
 
         const size_t size = static_cast<size_t>( width_ * height_ );
 
-        _data.reset( new uint8_t[size] );
+        _data.reset( new uint32_t[size] );
         _dataTransform.reset( new uint8_t[size] );
 
         _width = width_;
@@ -528,7 +528,7 @@ namespace fheroes2
     {
         if ( !empty() ) {
             const size_t totalSize = static_cast<size_t>( _width * _height );
-            std::fill( image(), image() + totalSize, static_cast<uint8_t>( 0 ) );
+            std::fill( image(), image() + totalSize, static_cast<uint32_t>( 0 ) );
             std::fill( transform(), transform() + totalSize, static_cast<uint8_t>( 1 ) ); // skip all data
         }
     }
@@ -547,14 +547,14 @@ namespace fheroes2
         const size_t size = static_cast<size_t>( image._width * image._height );
 
         if ( image._width != _width || image._height != _height ) {
-            _data.reset( new uint8_t[size] );
+            _data.reset( new uint32_t[size] );
             _dataTransform.reset( new uint8_t[size] );
 
             _width = image._width;
             _height = image._height;
         }
 
-        memcpy( _data.get(), image._data.get(), size );
+        memcpy( _data.get(), image._data.get(), size * 4 );
         memcpy( _dataTransform.get(), image._dataTransform.get(), size );
     }
 
@@ -798,25 +798,25 @@ namespace fheroes2
 
         if ( flip ) {
             const int32_t offsetInY = inY * widthIn + widthIn - 1 - inX;
-            const uint8_t * imageInY = in.image() + offsetInY;
+            const uint32_t * imageInY = in.image() + offsetInY;
             const uint8_t * transformInY = in.transform() + offsetInY;
 
             const int32_t offsetOutY = outY * widthOut + outX;
-            uint8_t * imageOutY = out.image() + offsetOutY;
-            const uint8_t * imageOutYEnd = imageOutY + height * widthOut;
+            uint32_t * imageOutY = out.image() + offsetOutY;
+            const uint32_t * imageOutYEnd = imageOutY + height * widthOut;
 
             for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
-                const uint8_t * imageInX = imageInY;
+                const uint32_t * imageInX = imageInY;
                 const uint8_t * transformInX = transformInY;
-                uint8_t * imageOutX = imageOutY;
-                const uint8_t * imageOutXEnd = imageOutX + width;
+                uint32_t * imageOutX = imageOutY;
+                const uint32_t * imageOutXEnd = imageOutX + width;
 
                 for ( ; imageOutX != imageOutXEnd; --imageInX, --transformInX, ++imageOutX ) {
                     if ( *transformInX == 1 ) { // skip pixel
                         continue;
                     }
 
-                    uint8_t inValue = *imageInX;
+                    uint32_t inValue = *imageInX;
                     if ( *transformInX > 1 ) {
                         inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                     }
@@ -833,24 +833,24 @@ namespace fheroes2
         }
         else {
             const int32_t offsetInY = inY * widthIn + inX;
-            const uint8_t * imageInY = in.image() + offsetInY;
+            const uint32_t * imageInY = in.image() + offsetInY;
             const uint8_t * transformInY = in.transform() + offsetInY;
 
-            uint8_t * imageOutY = out.image() + outY * widthOut + outX;
-            const uint8_t * imageInYEnd = imageInY + height * widthIn;
+            uint32_t * imageOutY = out.image() + outY * widthOut + outX;
+            const uint32_t * imageInYEnd = imageInY + height * widthIn;
 
             for ( ; imageInY != imageInYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
-                const uint8_t * imageInX = imageInY;
+                const uint32_t * imageInX = imageInY;
                 const uint8_t * transformInX = transformInY;
-                uint8_t * imageOutX = imageOutY;
-                const uint8_t * imageInXEnd = imageInX + width;
+                uint32_t * imageOutX = imageOutY;
+                const uint32_t * imageInXEnd = imageInX + width;
 
                 for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX ) {
                     if ( *transformInX == 1 ) { // skip pixel
                         continue;
                     }
 
-                    uint8_t inValue = *imageInX;
+                    uint32_t inValue = *imageInX;
                     if ( *transformInX > 1 ) {
                         inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                     }
@@ -945,13 +945,13 @@ namespace fheroes2
 
         const int32_t imageWidth = image.width();
 
-        uint8_t * imageY = image.image() + y * imageWidth + x;
-        const uint8_t * imageYEnd = imageY + height * imageWidth;
+        uint32_t * imageY = image.image() + y * imageWidth + x;
+        const uint32_t * imageYEnd = imageY + height * imageWidth;
 
         if ( image.singleLayer() ) {
             for ( ; imageY != imageYEnd; imageY += imageWidth ) {
-                uint8_t * imageX = imageY;
-                const uint8_t * imageXEnd = imageX + width;
+                uint32_t * imageX = imageY;
+                const uint32_t * imageXEnd = imageX + width;
 
                 for ( ; imageX != imageXEnd; ++imageX ) {
                     *imageX = *( transformTable + transformId * 256 + *imageX );
@@ -962,9 +962,9 @@ namespace fheroes2
             const uint8_t * transformY = image.transform() + y * imageWidth + x;
 
             for ( ; imageY != imageYEnd; imageY += imageWidth, transformY += imageWidth ) {
-                uint8_t * imageX = imageY;
+                uint32_t * imageX = imageY;
                 const uint8_t * transformX = transformY;
-                const uint8_t * imageXEnd = imageX + width;
+                const uint32_t * imageXEnd = imageX + width;
 
                 for ( ; imageX != imageXEnd; ++imageX, ++transformX ) {
                     if ( *transformX == 0 ) {
@@ -1001,20 +1001,20 @@ namespace fheroes2
 
         if ( flip ) {
             const int32_t offsetInY = inY * widthIn + widthIn - 1 - inX;
-            const uint8_t * imageInY = in.image() + offsetInY;
+            const uint32_t * imageInY = in.image() + offsetInY;
             const uint8_t * transformInY = in.transform() + offsetInY;
 
             const int32_t offsetOutY = outY * widthOut + outX;
-            uint8_t * imageOutY = out.image() + offsetOutY;
-            const uint8_t * imageOutYEnd = imageOutY + height * widthOut;
+            uint32_t * imageOutY = out.image() + offsetOutY;
+            const uint32_t * imageOutYEnd = imageOutY + height * widthOut;
 
             if ( out.singleLayer() ) {
                 assert( !in.singleLayer() );
                 for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
-                    const uint8_t * imageInX = imageInY;
+                    const uint32_t * imageInX = imageInY;
                     const uint8_t * transformInX = transformInY;
-                    uint8_t * imageOutX = imageOutY;
-                    const uint8_t * imageOutXEnd = imageOutX + width;
+                    uint32_t * imageOutX = imageOutY;
+                    const uint32_t * imageOutXEnd = imageOutX + width;
 
                     for ( ; imageOutX != imageOutXEnd; --imageInX, --transformInX, ++imageOutX ) {
                         if ( *transformInX > 0 ) { // apply a transformation
@@ -1032,11 +1032,11 @@ namespace fheroes2
                 uint8_t * transformOutY = out.transform() + offsetOutY;
 
                 for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut, transformOutY += widthOut ) {
-                    const uint8_t * imageInX = imageInY;
+                    const uint32_t * imageInX = imageInY;
                     const uint8_t * transformInX = transformInY;
-                    uint8_t * imageOutX = imageOutY;
+                    uint32_t * imageOutX = imageOutY;
                     uint8_t * transformOutX = transformOutY;
-                    const uint8_t * imageOutXEnd = imageOutX + width;
+                    const uint32_t * imageOutXEnd = imageOutX + width;
 
                     for ( ; imageOutX != imageOutXEnd; --imageInX, --transformInX, ++imageOutX, ++transformOutX ) {
                         if ( *transformInX == 1 ) { // skip pixel
@@ -1056,20 +1056,20 @@ namespace fheroes2
         }
         else {
             const int32_t offsetInY = inY * widthIn + inX;
-            const uint8_t * imageInY = in.image() + offsetInY;
+            const uint32_t * imageInY = in.image() + offsetInY;
             const uint8_t * transformInY = in.transform() + offsetInY;
 
             const int32_t offsetOutY = outY * widthOut + outX;
-            uint8_t * imageOutY = out.image() + offsetOutY;
-            const uint8_t * imageInYEnd = imageInY + height * widthIn;
+            uint32_t * imageOutY = out.image() + offsetOutY;
+            const uint32_t * imageInYEnd = imageInY + height * widthIn;
 
             if ( out.singleLayer() ) {
                 assert( !in.singleLayer() );
                 for ( ; imageInY != imageInYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
-                    const uint8_t * imageInX = imageInY;
+                    const uint32_t * imageInX = imageInY;
                     const uint8_t * transformInX = transformInY;
-                    uint8_t * imageOutX = imageOutY;
-                    const uint8_t * imageInXEnd = imageInX + width;
+                    uint32_t * imageOutX = imageOutY;
+                    const uint32_t * imageInXEnd = imageInX + width;
 
                     for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX ) {
                         if ( *transformInX > 0 ) { // apply a transformation
@@ -1087,11 +1087,11 @@ namespace fheroes2
                 uint8_t * transformOutY = out.transform() + offsetOutY;
 
                 for ( ; imageInY != imageInYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut, transformOutY += widthOut ) {
-                    const uint8_t * imageInX = imageInY;
+                    const uint32_t * imageInX = imageInY;
                     const uint8_t * transformInX = transformInY;
-                    uint8_t * imageOutX = imageOutY;
+                    uint32_t * imageOutX = imageOutY;
                     uint8_t * transformOutX = transformOutY;
-                    const uint8_t * imageInXEnd = imageInX + width;
+                    const uint32_t * imageInXEnd = imageInX + width;
 
                     for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX, ++transformOutX ) {
                         if ( *transformInX == 1 ) { // skip pixel
@@ -1135,22 +1135,22 @@ namespace fheroes2
         const int32_t widthOut = out.width();
 
         const int32_t offsetInY = inY * widthIn + inX;
-        const uint8_t * imageInY = in.image() + offsetInY;
+        const uint32_t * imageInY = in.image() + offsetInY;
 
         const int32_t offsetOutY = outY * widthOut + outX;
-        uint8_t * imageOutY = out.image() + offsetOutY;
-        const uint8_t * imageOutYEnd = imageOutY + height * widthOut;
+        uint32_t * imageOutY = out.image() + offsetOutY;
+        const uint32_t * imageOutYEnd = imageOutY + height * widthOut;
 
         if ( out.singleLayer() ) {
             for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, imageOutY += widthOut ) {
-                memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
+                memcpy( imageOutY, imageInY, static_cast<size_t>( width * 4 ) );
             }
         }
         else if ( in.singleLayer() ) {
             uint8_t * transformOutY = out.transform() + offsetOutY;
 
             for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, imageOutY += widthOut, transformOutY += widthOut ) {
-                memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
+                memcpy( imageOutY, imageInY, static_cast<size_t>( width * 4 ) );
                 std::fill( transformOutY, transformOutY + width, static_cast<uint8_t>( 0 ) );
             }
         }
@@ -1159,7 +1159,7 @@ namespace fheroes2
             uint8_t * transformOutY = out.transform() + offsetOutY;
 
             for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut, transformOutY += widthOut ) {
-                memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
+                memcpy( imageOutY, imageInY, static_cast<size_t>( width * 4 ) );
                 memcpy( transformOutY, transformInY, static_cast<size_t>( width ) );
             }
         }
@@ -1188,7 +1188,7 @@ namespace fheroes2
         assert( !contour.empty() );
 
         const uint8_t * inY = image.transform();
-        uint8_t * outImageY = contour.image();
+        uint32_t * outImageY = contour.image();
         uint8_t * outTransformY = contour.transform();
 
         const int32_t reducedWidth = width - 1;
@@ -1223,22 +1223,22 @@ namespace fheroes2
 
         const int32_t widthIn = in.width();
         const int32_t offsetIn = inY * widthIn + inX;
-        const uint8_t * imageIn = in.image() + offsetIn;
+        const uint32_t * imageIn = in.image() + offsetIn;
         const uint8_t * transformIn = in.transform() + offsetIn;
 
         const int32_t widthOut = out.width();
         const int32_t offsetOut = outY * widthOut + outX;
-        uint8_t * imageOut = out.image() + offsetOut;
+        uint32_t * imageOut = out.image() + offsetOut;
         uint8_t * transformOut = out.transform() + offsetOut;
 
         const bool isInNonSinglelayerToOutSinglelayer = !in.singleLayer() && out.singleLayer();
 
         if ( isVertical ) {
             // We also go in a loop from the right part of the image to its center.
-            const uint8_t * imageInRightPoint = imageIn + width - 1;
+            const uint32_t * imageInRightPoint = imageIn + width - 1;
             const uint8_t * transformInRightPoint = transformIn + width - 1;
 
-            uint8_t * imageOutRightPoint = imageOut + width - 1;
+            uint32_t * imageOutRightPoint = imageOut + width - 1;
             uint8_t * transformOutRightPoint = transformOut + width - 1;
 
             const int32_t halfWidth = width / 2;
@@ -1330,11 +1330,11 @@ namespace fheroes2
         else {
             // We also go in a loop from the bottom part of the image to its center.
             const int32_t offsetInBottomOffset = ( height - 1 ) * widthIn;
-            const uint8_t * imageInBottomPoint = imageIn + offsetInBottomOffset;
+            const uint32_t * imageInBottomPoint = imageIn + offsetInBottomOffset;
             const uint8_t * transformInBottomPoint = transformIn + offsetInBottomOffset;
 
             const int32_t offsetOutYBottomOffset = ( height - 1 ) * widthOut;
-            uint8_t * imageOutBottomPoint = imageOut + offsetOutYBottomOffset;
+            uint32_t * imageOutBottomPoint = imageOut + offsetOutYBottomOffset;
             uint8_t * transformOutBottomPoint = transformOut + offsetOutYBottomOffset;
 
             const int32_t halfHeight = height / 2;
@@ -1479,9 +1479,9 @@ namespace fheroes2
 
         if ( skipFactor < 2 ) {
             // top side
-            uint8_t * data = image.image();
+            uint32_t * data = image.image();
             uint8_t * transform = image.transform();
-            const uint8_t * dataEnd = data + width;
+            const uint32_t * dataEnd = data + width;
             for ( ; data != dataEnd; ++data, ++transform ) {
                 *data = value;
                 *transform = 0;
@@ -1518,9 +1518,9 @@ namespace fheroes2
             uint32_t counter = 0;
 
             // top side
-            uint8_t * data = image.image();
+            uint32_t * data = image.image();
             uint8_t * transform = image.transform();
-            const uint8_t * dataEnd = data + width;
+            const uint32_t * dataEnd = data + width;
             for ( ; data != dataEnd; ++data, ++transform ) {
                 if ( counter != skipFactor ) {
                     *data = value;
@@ -1611,7 +1611,7 @@ namespace fheroes2
         if ( maxY >= height )
             maxY = height;
 
-        uint8_t * data = image.image();
+        uint32_t * data = image.image();
         uint8_t * transform = image.transform();
 
         if ( dx > dy ) {
@@ -1726,7 +1726,7 @@ namespace fheroes2
                 return Image();
         }
 
-        std::vector<const uint8_t *> imageIn( input.size() );
+        std::vector<const uint32_t *> imageIn( input.size() );
         std::vector<const uint8_t *> transformIn( input.size() );
 
         for ( size_t i = 0; i < input.size(); ++i ) {
@@ -1737,9 +1737,9 @@ namespace fheroes2
         Image out( input[0]->width(), input[0]->height() );
         out.reset();
 
-        uint8_t * imageOut = out.image();
+        uint32_t * imageOut = out.image();
         uint8_t * transformOut = out.transform();
-        const uint8_t * imageOutEnd = imageOut + out.width() * out.height();
+        const uint32_t * imageOutEnd = imageOut + out.width() * out.height();
 
         bool isEqual = false;
 
@@ -1779,9 +1779,9 @@ namespace fheroes2
 
         const int32_t imageWidth = image.width();
 
-        uint8_t * imageY = image.image() + y * imageWidth + x;
+        uint32_t * imageY = image.image() + y * imageWidth + x;
         uint8_t * transformY = image.transform() + y * imageWidth + x;
-        const uint8_t * imageYEnd = imageY + height * imageWidth;
+        const uint32_t * imageYEnd = imageY + height * imageWidth;
 
         for ( ; imageY != imageYEnd; imageY += imageWidth, transformY += imageWidth ) {
             std::fill( imageY, imageY + width, colorId );
@@ -1796,9 +1796,9 @@ namespace fheroes2
 
         const int32_t imageWidth = image.width();
 
-        uint8_t * imageY = image.image() + y * imageWidth + x;
+        uint32_t * imageY = image.image() + y * imageWidth + x;
         uint8_t * transformY = image.transform() + y * imageWidth + x;
-        const uint8_t * imageYEnd = imageY + height * imageWidth;
+        const uint32_t * imageYEnd = imageY + height * imageWidth;
 
         for ( ; imageY != imageYEnd; imageY += imageWidth, transformY += imageWidth ) {
             std::fill( imageY, imageY + width, static_cast<uint8_t>( 0 ) );
@@ -1818,10 +1818,10 @@ namespace fheroes2
         Image output( width, height );
         output.reset();
 
-        const uint8_t * imageInY = input.image();
+        const uint32_t * imageInY = input.image();
         const uint8_t * transformInY = input.transform();
 
-        uint8_t * imageOutY = output.image();
+        uint32_t * imageOutY = output.image();
         uint8_t * transformOutY = output.transform();
 
         for ( int32_t y = 0; y < height; ++y ) {
@@ -1897,19 +1897,19 @@ namespace fheroes2
         const int32_t offsetOut = outY * widthOut + outX;
         const int32_t offsetIn = inY * widthIn + inX;
 
-        uint8_t * imageOutY = out.image() + offsetOut;
+        uint32_t * imageOutY = out.image() + offsetOut;
         uint8_t * transformOutY = out.transform() + offsetOut;
-        const uint8_t * imageOutYEnd = imageOutY + widthOut * height;
+        const uint32_t * imageOutYEnd = imageOutY + widthOut * height;
 
         if ( horizontally && !vertically ) {
-            const uint8_t * imageInY = in.image() + offsetIn + width - 1;
+            const uint32_t * imageInY = in.image() + offsetIn + width - 1;
             const uint8_t * transformInY = in.transform() + offsetIn + width - 1;
 
             for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY += widthIn, transformInY += widthIn ) {
-                uint8_t * imageOutX = imageOutY;
+                uint32_t * imageOutX = imageOutY;
                 uint8_t * transformOutX = transformOutY;
-                const uint8_t * imageOutXEnd = imageOutX + width;
-                const uint8_t * imageInX = imageInY;
+                const uint32_t * imageOutXEnd = imageOutX + width;
+                const uint32_t * imageInX = imageInY;
                 const uint8_t * transformInX = transformInY;
 
                 for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++transformOutX, --imageInX, --transformInX ) {
@@ -1919,23 +1919,23 @@ namespace fheroes2
             }
         }
         else if ( !horizontally && vertically ) {
-            const uint8_t * imageInY = in.image() + offsetIn + ( height - 1 ) * widthIn;
+            const uint32_t * imageInY = in.image() + offsetIn + ( height - 1 ) * widthIn;
             const uint8_t * transformInY = in.transform() + offsetIn + ( height - 1 ) * widthIn;
 
             for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY -= widthIn, transformInY -= widthIn ) {
-                memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
+                memcpy( imageOutY, imageInY, static_cast<size_t>( width * 4 ) );
                 memcpy( transformOutY, transformInY, static_cast<size_t>( width ) );
             }
         }
         else {
-            const uint8_t * imageInY = in.image() + offsetIn + ( height - 1 ) * widthIn + widthIn - 1;
+            const uint32_t * imageInY = in.image() + offsetIn + ( height - 1 ) * widthIn + widthIn - 1;
             const uint8_t * transformInY = in.transform() + offsetIn + ( height - 1 ) * widthIn + widthIn - 1;
 
             for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY -= widthIn, transformInY -= widthIn ) {
-                uint8_t * imageOutX = imageOutY;
+                uint32_t * imageOutX = imageOutY;
                 uint8_t * transformOutX = transformOutY;
-                const uint8_t * imageOutXEnd = imageOutX + width;
-                const uint8_t * imageInX = imageInY;
+                const uint32_t * imageOutXEnd = imageOutX + width;
+                const uint32_t * imageInX = imageInY;
                 const uint8_t * transformInX = transformInY;
 
                 for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++transformOutX, --imageInX, --transformInX ) {
@@ -2050,18 +2050,18 @@ namespace fheroes2
 
         const int32_t offset = y * imageWidth + x;
 
-        const uint8_t * imageInY = in.image() + offset;
-        const uint8_t * imageInYEnd = imageInY + height * imageWidth;
-        const uint8_t * imageOutY = out.image() + offset;
+        const uint32_t * imageInY = in.image() + offset;
+        const uint32_t * imageInYEnd = imageInY + height * imageWidth;
+        const uint32_t * imageOutY = out.image() + offset;
         const uint8_t * transformInY = in.transform() + offset;
         const uint8_t * transformOutY = out.transform() + offset;
 
         for ( ; imageInY != imageInYEnd; imageInY += imageWidth, transformInY += imageWidth, imageOutY += imageWidth, transformOutY += imageWidth ) {
-            const uint8_t * imageInX = imageInY;
+            const uint32_t * imageInX = imageInY;
             const uint8_t * transformInX = transformInY;
-            const uint8_t * imageOutX = imageOutY;
+            const uint32_t * imageOutX = imageOutY;
             const uint8_t * transformOutX = transformOutY;
-            const uint8_t * imageInXEnd = imageInX + width;
+            const uint32_t * imageInXEnd = imageInX + width;
 
             for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX, ++transformOutX ) {
                 if ( *transformInX != *transformOutX ) {
@@ -2072,7 +2072,7 @@ namespace fheroes2
                     continue;
                 }
 
-                table[*imageInX] = *imageOutX;
+                table[*imageInX] = static_cast<uint8_t>(*imageOutX);
             }
         }
 
@@ -2145,8 +2145,8 @@ namespace fheroes2
         if ( image.empty() )
             return;
 
-        uint8_t * data = image.image();
-        const uint8_t * dataEnd = data + image.width() * image.height();
+        uint32_t * data = image.image();
+        const uint32_t * dataEnd = data + image.width() * image.height();
 
         for ( ; data != dataEnd; ++data ) {
             if ( *data == oldColorId ) {
@@ -2163,9 +2163,9 @@ namespace fheroes2
         const int32_t width = image.width();
         const int32_t height = image.height();
 
-        const uint8_t * imageIn = image.image();
+        const uint32_t * imageIn = image.image();
         uint8_t * transformIn = image.transform();
-        const uint8_t * imageInEnd = imageIn + height * width;
+        const uint32_t * imageInEnd = imageIn + height * width;
         for ( ; imageIn != imageInEnd; ++imageIn, ++transformIn ) {
             if ( *transformIn == 0 && *imageIn == colorId ) { // modify pixels with transform value 0
                 *transformIn = transformId;
@@ -2199,8 +2199,8 @@ namespace fheroes2
         const int32_t offsetInY = inY * widthIn + inX;
         const int32_t offsetOutY = outY * widthOut + outX;
 
-        const uint8_t * imageInY = in.image() + offsetInY;
-        uint8_t * imageOutY = out.image() + offsetOutY;
+        const uint32_t * imageInY = in.image() + offsetInY;
+        uint32_t * imageOutY = out.image() + offsetOutY;
 
         if ( isSubpixelAccuracy ) {
             std::vector<double> positionX( widthRoiOut );
@@ -2218,14 +2218,14 @@ namespace fheroes2
                     const int32_t startY = static_cast<int32_t>( posY );
                     const double coeffY = posY - startY;
 
-                    uint8_t * imageOutX = imageOutY;
+                    uint32_t * imageOutX = imageOutY;
 
                     for ( int32_t x = 0; x < widthRoiOut; ++x, ++imageOutX ) {
                         const double posX = positionX[x];
                         const int32_t startX = static_cast<int32_t>( posX );
                         const int32_t offsetIn = startY * widthIn + startX;
 
-                        const uint8_t * imageInX = imageInY + offsetIn;
+                        const uint32_t * imageInX = imageInY + offsetIn;
 
                         if ( posX < widthRoiIn - 1 && posY < heightRoiIn - 1 ) {
                             const double coeffX = posX - startX;
@@ -2260,7 +2260,7 @@ namespace fheroes2
                     const int32_t startY = static_cast<int32_t>( posY );
                     const double coeffY = posY - startY;
 
-                    uint8_t * imageOutX = imageOutY;
+                    uint32_t * imageOutX = imageOutY;
                     uint8_t * transformOutX = transformOutY;
 
                     for ( int32_t x = 0; x < widthRoiOut; ++x, ++imageOutX, ++transformOutX ) {
@@ -2268,7 +2268,7 @@ namespace fheroes2
                         const int32_t startX = static_cast<int32_t>( posX );
                         const int32_t offsetIn = startY * widthIn + startX;
 
-                        const uint8_t * imageInX = imageInY + offsetIn;
+                        const uint32_t * imageInX = imageInY + offsetIn;
                         const uint8_t * transformInX = transformInY + offsetIn;
 
                         if ( posX < widthIn - 1 && posY < heightRoiIn - 1 ) {
@@ -2304,7 +2304,7 @@ namespace fheroes2
             }
         }
         else {
-            const uint8_t * imageOutYEnd = imageOutY + widthOut * heightRoiOut;
+            const uint32_t * imageOutYEnd = imageOutY + widthOut * heightRoiOut;
             int32_t idY = 0;
 
             // Precalculation of X position
@@ -2314,11 +2314,11 @@ namespace fheroes2
 
             if ( in.singleLayer() && out.singleLayer() ) {
                 for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, ++idY ) {
-                    uint8_t * imageOutX = imageOutY;
-                    const uint8_t * imageOutXEnd = imageOutX + widthRoiOut;
+                    uint32_t * imageOutX = imageOutY;
+                    const uint32_t * imageOutXEnd = imageOutX + widthRoiOut;
 
                     const int32_t offset = ( ( idY * heightRoiIn ) / heightRoiOut ) * widthIn;
-                    const uint8_t * imageInX = imageInY + offset;
+                    const uint32_t * imageInX = imageInY + offset;
                     const int32_t * idX = positionX.data();
 
                     for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++idX ) {
@@ -2331,12 +2331,12 @@ namespace fheroes2
                 uint8_t * transformOutY = out.transform() + offsetOutY;
 
                 for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, ++idY ) {
-                    uint8_t * imageOutX = imageOutY;
+                    uint32_t * imageOutX = imageOutY;
                     uint8_t * transformOutX = transformOutY;
-                    const uint8_t * imageOutXEnd = imageOutX + widthRoiOut;
+                    const uint32_t * imageOutXEnd = imageOutX + widthRoiOut;
 
                     const int32_t offset = ( ( idY * heightRoiIn ) / heightRoiOut ) * widthIn;
-                    const uint8_t * imageInX = imageInY + offset;
+                    const uint32_t * imageInX = imageInY + offset;
                     const uint8_t * transformInX = transformInY + offset;
                     const int32_t * idX = positionX.data();
 
@@ -2463,17 +2463,17 @@ namespace fheroes2
         const int32_t width = in.width();
         const int32_t height = in.height();
 
-        const uint8_t * imageInY = in.image();
-        const uint8_t * imageInYEnd = imageInY + width * height;
-        uint8_t * imageOutX = out.image();
+        const uint32_t * imageInY = in.image();
+        const uint32_t * imageInYEnd = imageInY + width * height;
+        uint32_t * imageOutX = out.image();
 
         const uint8_t * transformInY = in.transform();
         uint8_t * transformOutX = out.transform();
 
         for ( ; imageInY != imageInYEnd; imageInY += width, transformInY += width, ++imageOutX, ++transformOutX ) {
-            const uint8_t * imageInX = imageInY;
-            const uint8_t * imageInXEnd = imageInX + width;
-            uint8_t * imageOutY = imageOutX;
+            const uint32_t * imageInX = imageInY;
+            const uint32_t * imageInXEnd = imageInX + width;
+            uint32_t * imageOutY = imageOutX;
 
             const uint8_t * transformInX = transformInY;
             uint8_t * transformOutY = transformOutX;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -855,8 +855,8 @@ namespace fheroes2
                         inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                     }
 
-                    const uint8_t * inPAL = gamePalette + inValue * 3;
-                    const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+                    const uint8_t * inPAL = gamePalette + static_cast<uint8_t>(inValue) * 3;
+                    const uint8_t * outPAL = gamePalette + static_cast<uint8_t>( *imageOutX ) * 3;
 
                     const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
                     const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
@@ -1019,7 +1019,7 @@ namespace fheroes2
                     for ( ; imageOutX != imageOutXEnd; --imageInX, --transformInX, ++imageOutX ) {
                         if ( *transformInX > 0 ) { // apply a transformation
                             if ( *transformInX != 1 ) { // skip pixel
-                                *imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                                //*imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                             }
                         }
                         else { // copy a pixel
@@ -1044,7 +1044,7 @@ namespace fheroes2
                         }
 
                         if ( *transformInX > 0 && *transformOutX == 0 ) { // apply a transformation
-                            *imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                            //*imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                         }
                         else { // copy a pixel
                             *transformOutX = *transformInX;
@@ -1074,7 +1074,7 @@ namespace fheroes2
                     for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX ) {
                         if ( *transformInX > 0 ) { // apply a transformation
                             if ( *transformInX != 1 ) { // skip pixel
-                                *imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                                //*imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                             }
                         }
                         else { // copy a pixel
@@ -1099,7 +1099,7 @@ namespace fheroes2
                         }
 
                         if ( *transformInX > 0 && *transformOutX == 0 ) { // apply a transformation
-                            *imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                            //*imageOutX = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
                         }
                         else { // copy a pixel
                             *transformOutX = *transformInX;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -443,6 +443,7 @@ namespace fheroes2
         : _width( 0 )
         , _height( 0 )
         , _data( std::move( image_._data ) )
+        , _dataTransform( std::move( image_._dataTransform ) )
         , _singleLayer( false )
     {
         std::swap( _singleLayer, image_._singleLayer );
@@ -468,6 +469,7 @@ namespace fheroes2
             std::swap( _width, image_._width );
             std::swap( _height, image_._height );
             std::swap( _data, image_._data );
+            std::swap( _dataTransform, image_._dataTransform );
         }
 
         return *this;
@@ -486,6 +488,7 @@ namespace fheroes2
     void Image::clear()
     {
         _data.reset();
+        _dataTransform.reset();
 
         _width = 0;
         _height = 0;
@@ -514,7 +517,8 @@ namespace fheroes2
 
         const size_t size = static_cast<size_t>( width_ * height_ );
 
-        _data.reset( new uint8_t[size * 2] );
+        _data.reset( new uint8_t[size] );
+        _dataTransform.reset( new uint8_t[size] );
 
         _width = width_;
         _height = height_;
@@ -543,13 +547,15 @@ namespace fheroes2
         const size_t size = static_cast<size_t>( image._width * image._height );
 
         if ( image._width != _width || image._height != _height ) {
-            _data.reset( new uint8_t[size * 2] );
+            _data.reset( new uint8_t[size] );
+            _dataTransform.reset( new uint8_t[size] );
 
             _width = image._width;
             _height = image._height;
         }
 
-        memcpy( _data.get(), image._data.get(), size * 2 );
+        memcpy( _data.get(), image._data.get(), size );
+        memcpy( _dataTransform.get(), image._dataTransform.get(), size );
     }
 
     Sprite::Sprite()

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -57,8 +57,8 @@ namespace fheroes2
             return _height;
         }
 
-        virtual uint8_t * image();
-        virtual const uint8_t * image() const;
+        virtual uint32_t * image();
+        virtual const uint32_t * image() const;
 
         uint8_t * transform()
         {
@@ -99,7 +99,7 @@ namespace fheroes2
 
         int32_t _width;
         int32_t _height;
-        std::unique_ptr<uint8_t[]> _data; // holds 1 image layer
+        std::unique_ptr<uint32_t[]> _data; // holds 1 image layer
         std::unique_ptr<uint8_t[]> _dataTransform; // holds 1 image layer
 
         bool _singleLayer; // only for images which are not used for any other operations except displaying on screen. Non-copyable member.

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -62,12 +62,12 @@ namespace fheroes2
 
         uint8_t * transform()
         {
-            return _data.get() + width() * height();
+            return _dataTransform.get();
         }
 
         const uint8_t * transform() const
         {
-            return _data.get() + width() * height();
+            return _dataTransform.get();
         }
 
         bool empty() const
@@ -99,7 +99,8 @@ namespace fheroes2
 
         int32_t _width;
         int32_t _height;
-        std::unique_ptr<uint8_t[]> _data; // holds 2 image layers
+        std::unique_ptr<uint8_t[]> _data; // holds 1 image layer
+        std::unique_ptr<uint8_t[]> _dataTransform; // holds 1 image layer
 
         bool _singleLayer; // only for images which are not used for any other operations except displaying on screen. Non-copyable member.
     };

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -109,7 +109,7 @@ namespace
 #endif
 
         if ( surface->pitch != width ) {
-            const uint8_t * imageIn = image.image();
+            const uint32_t * imageIn = image.image();
 
             for ( int32_t i = 0; i < height; ++i ) {
                 memcpy( static_cast<uint8_t *>( surface->pixels ) + surface->pitch * i, imageIn + width * i, static_cast<size_t>( width ) );
@@ -182,14 +182,14 @@ namespace fheroes2
             image.resize( surface->w, surface->h );
 
             const uint8_t * inY = reinterpret_cast<uint8_t *>( surface->pixels );
-            uint8_t * outY = image.image();
+            uint32_t * outY = image.image();
             uint8_t * transformY = image.transform();
 
             const uint8_t * inYEnd = inY + surface->h * surface->pitch;
 
             for ( ; inY != inYEnd; inY += surface->pitch, outY += surface->w, transformY += surface->w ) {
                 const uint8_t * inX = inY;
-                uint8_t * outX = outY;
+                uint32_t * outX = outY;
                 uint8_t * transformX = transformY;
                 const uint8_t * inXEnd = inX + surface->w;
 
@@ -228,13 +228,13 @@ namespace fheroes2
             memset( image.transform(), 0, surface->w * surface->h );
 
             const uint8_t * inY = reinterpret_cast<uint8_t *>( surface->pixels );
-            uint8_t * outY = image.image();
+            uint32_t * outY = image.image();
 
             const uint8_t * inYEnd = inY + surface->h * surface->pitch;
 
             for ( ; inY != inYEnd; inY += surface->pitch, outY += surface->w ) {
                 const uint8_t * inX = inY;
-                uint8_t * outX = outY;
+                uint32_t * outX = outY;
                 const uint8_t * inXEnd = inX + surface->w * 3;
 
                 for ( ; inX != inXEnd; inX += 3, ++outX ) {
@@ -247,14 +247,14 @@ namespace fheroes2
             image.reset();
 
             const uint8_t * inY = reinterpret_cast<uint8_t *>( surface->pixels );
-            uint8_t * outY = image.image();
+            uint32_t * outY = image.image();
             uint8_t * transformY = image.transform();
 
             const uint8_t * inYEnd = inY + surface->h * surface->pitch;
 
             for ( ; inY != inYEnd; inY += surface->pitch, outY += surface->w, transformY += surface->w ) {
                 const uint8_t * inX = inY;
-                uint8_t * outX = outY;
+                uint32_t * outX = outY;
                 uint8_t * transformX = transformY;
                 const uint8_t * inXEnd = inX + surface->w * 4;
 
@@ -296,7 +296,7 @@ namespace fheroes2
         Sprite sprite( width, height, offsetX, offsetY );
         sprite.reset();
 
-        uint8_t * imageData = sprite.image();
+        uint32_t * imageData = sprite.image();
         uint8_t * imageTransform = sprite.transform();
 
         uint32_t posX = 0;

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -108,15 +108,16 @@ namespace
         SDL_SetPalette( surface, SDL_LOGPAL | SDL_PHYSPAL, paletteSDL.data(), 0, 256 );
 #endif
 
+        // TODO: test the changes in memcpy (multiplication by 4)
         if ( surface->pitch != width ) {
             const uint32_t * imageIn = image.image();
 
             for ( int32_t i = 0; i < height; ++i ) {
-                memcpy( static_cast<uint8_t *>( surface->pixels ) + surface->pitch * i, imageIn + width * i, static_cast<size_t>( width ) );
+                memcpy( static_cast<uint8_t *>( surface->pixels ) + surface->pitch * i, imageIn + width * i, static_cast<size_t>( width * 4) );
             }
         }
         else {
-            memcpy( surface->pixels, image.image(), static_cast<size_t>( width * height ) );
+            memcpy( surface->pixels, image.image(), static_cast<size_t>( width * height * 4 ) );
         }
 
 #if defined( ENABLE_PNG )
@@ -393,7 +394,12 @@ namespace fheroes2
             Image & tilImage = output[i];
             tilImage.resize( width, height );
             tilImage._disableTransformLayer();
-            memcpy( tilImage.image(), data + i * imageSize, imageSize );
+
+            // memcpy( tilImage.image(), data + i * imageSize, imageSize ); // this doesn't work
+            uint32_t * imageData = tilImage.image(); 
+            for ( size_t j = 0; j < imageSize; ++j, ++imageData, ++data ) {
+                *imageData = *data;
+            }
             std::fill( tilImage.transform(), tilImage.transform() + imageSize, static_cast<uint8_t>( 0 ) );
         }
     }

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -283,8 +283,18 @@ namespace
                     const uint32_t * in = imageIn;
                     const uint32_t * transform = _palette32Bit.data();
 
-                    for ( ; out != outEnd; ++out, ++in )
-                        *out = *( transform + *in ); 
+                    for ( ; out != outEnd; ++out, ++in ) {
+                        // We assume that any uint32 value that is lower than 256 is in fact a uint8 (normal sprite).
+                        // The downside is that we won't be able to use pure-blue (e.g. [0-255]-0-0-0) pixels in our 32bit assets.
+                        // Maybe in the future we'll discriminate between the two by using a special flag in transform.
+                        if ( *in < 256 ) {
+                            *out = *( transform + *in ); 
+                        }
+                        else {
+                            *out = *in; 
+                        }
+                    }
+                        
                 }
                 else if ( surface->format->BitsPerPixel == 8 ) {
                     if ( surface->pixels != imageIn ) {
@@ -312,8 +322,16 @@ namespace
                         const uint32_t * outXEnd = outX + roi.width;
                         const uint32_t * inX = inY;
 
-                        for ( ; outX != outXEnd; ++outX, ++inX )
-                            *outX = *( transform + *inX );
+                        for ( ; outX != outXEnd; ++outX, ++inX ) {
+                            // As mentioned above, we assume that any uint32 value that is lower than 256 is in fact a uint8 (normal sprite).
+                            if ( *inX < 256 ) {
+                                *outX = *( transform + *inX );
+                            }
+                            else {
+                                *outX = *inX;
+                            }
+                        }
+                            
                     }
                 }
                 else if ( surface->format->BitsPerPixel == 8 ) {

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -274,17 +274,17 @@ namespace
 
             const bool fullFrame = ( roi.width == imageWidth ) && ( roi.height == imageHeight );
 
-            const uint8_t * imageIn = image.image();
+            const uint32_t * imageIn = image.image();
 
             if ( fullFrame ) {
                 if ( surface->format->BitsPerPixel == 32 ) {
                     uint32_t * out = static_cast<uint32_t *>( surface->pixels );
                     const uint32_t * outEnd = out + imageWidth * imageHeight;
-                    const uint8_t * in = imageIn;
+                    const uint32_t * in = imageIn;
                     const uint32_t * transform = _palette32Bit.data();
 
                     for ( ; out != outEnd; ++out, ++in )
-                        *out = *( transform + *in );
+                        *out = *( transform + *in ); 
                 }
                 else if ( surface->format->BitsPerPixel == 8 ) {
                     if ( surface->pixels != imageIn ) {
@@ -304,13 +304,13 @@ namespace
                 if ( surface->format->BitsPerPixel == 32 ) {
                     uint32_t * outY = static_cast<uint32_t *>( surface->pixels );
                     const uint32_t * outYEnd = outY + imageWidth * roi.height;
-                    const uint8_t * inY = imageIn + roi.x + roi.y * imageWidth;
+                    const uint32_t * inY = imageIn + roi.x + roi.y * imageWidth;
                     const uint32_t * transform = _palette32Bit.data();
 
                     for ( ; outY != outYEnd; outY += imageWidth, inY += imageWidth ) {
                         uint32_t * outX = outY;
                         const uint32_t * outXEnd = outX + roi.width;
-                        const uint8_t * inX = inY;
+                        const uint32_t * inX = inY;
 
                         for ( ; outX != outXEnd; ++outX, ++inX )
                             *outX = *( transform + *inX );
@@ -383,13 +383,13 @@ namespace
 
             uint32_t * out = static_cast<uint32_t *>( surface->pixels );
             const uint32_t * outEnd = out + width * height;
-            const uint8_t * in = icon.image();
+            const uint32_t * in = icon.image();
             const uint8_t * transform = icon.transform();
 
             if ( surface->format->Amask > 0 ) {
                 for ( ; out != outEnd; ++out, ++in, ++transform ) {
                     if ( *transform == 0 ) {
-                        const uint8_t * value = currentPalette + *in * 3;
+                        const uint8_t * value = currentPalette + static_cast<uint8_t>( *in ) * 3;
                         *out = SDL_MapRGBA( surface->format, *value, *( value + 1 ), *( value + 2 ), 255 );
                     }
                 }
@@ -397,7 +397,7 @@ namespace
             else {
                 for ( ; out != outEnd; ++out, ++in, ++transform ) {
                     if ( *transform == 0 ) {
-                        const uint8_t * value = currentPalette + *in * 3;
+                        const uint8_t * value = currentPalette + static_cast<uint8_t>( *in ) * 3;
                         *out = SDL_MapRGB( surface->format, *value, *( value + 1 ), *( value + 2 ) );
                     }
                     else {
@@ -468,7 +468,7 @@ namespace
 
             uint32_t * out = static_cast<uint32_t *>( surface->pixels );
             const uint32_t * outEnd = out + width * height;
-            const uint8_t * in = image.image();
+            const uint32_t * in = image.image();
             const uint8_t * transform = image.transform();
 
             if ( surface->format->Amask > 0 ) {
@@ -1225,7 +1225,7 @@ namespace
 
                     // Display class doesn't have support for image pitch so we mustn't link display to surface if width is not divisible by 4.
                     if ( _surface->w % 4 == 0 ) {
-                        linkRenderSurface( static_cast<uint8_t *>( _surface->pixels ) );
+                        linkRenderSurface( static_cast<uint32_t *>( _surface->pixels ) );
                     }
                 }
             }
@@ -1545,7 +1545,7 @@ namespace
 
 namespace fheroes2
 {
-    void BaseRenderEngine::linkRenderSurface( uint8_t * surface ) const
+    void BaseRenderEngine::linkRenderSurface( uint32_t * surface ) const
     {
         Display::instance().linkRenderSurface( surface );
     }
@@ -1669,12 +1669,12 @@ namespace fheroes2
         }
     }
 
-    uint8_t * Display::image()
+    uint32_t * Display::image()
     {
         return _renderSurface != nullptr ? _renderSurface : Image::image();
     }
 
-    const uint8_t * Display::image() const
+    const uint32_t * Display::image() const
     {
         return _renderSurface != nullptr ? _renderSurface : Image::image();
     }

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -172,7 +172,7 @@ namespace fheroes2
             // Do nothing.
         }
 
-        void linkRenderSurface( uint8_t * surface ) const; // declaration of this method is in source file
+        void linkRenderSurface( uint32_t * surface ) const; // declaration of this method is in source file
 
     private:
         bool _isFullScreen;
@@ -227,8 +227,8 @@ namespace fheroes2
         }
 
         // For 8-bit mode we return a pointer to direct surface which we draw on screen
-        uint8_t * image() override;
-        const uint8_t * image() const override;
+        uint32_t * image() override;
+        const uint32_t * image() const override;
 
         void release(); // to release all allocated resources. Should be used at the end of the application
 
@@ -250,7 +250,7 @@ namespace fheroes2
         PreRenderProcessing _preprocessing;
         PostRenderProcessing _postprocessing;
 
-        uint8_t * _renderSurface;
+        uint32_t * _renderSurface;
 
         // Previous area drawn on the screen.
         Rect _prevRoi;
@@ -258,7 +258,7 @@ namespace fheroes2
         Size _screenSize;
 
         // Only for cases of direct drawing on rendered 8-bit image.
-        void linkRenderSurface( uint8_t * surface )
+        void linkRenderSurface( uint32_t * surface )
         {
             _renderSurface = surface;
         }

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -235,8 +235,8 @@ void SMKVideoSequence::getNextFrame( fheroes2::Image & image, const int32_t x, c
             assert( ( height % _heightScaleFactor ) == 0 );
 
             const uint8_t * inY = data;
-            uint8_t * outY = image.image();
-            const uint8_t * outYEnd = outY + height * _width;
+            uint32_t * outY = image.image();
+            const uint32_t * outYEnd = outY + height * _width;
 
             for ( ; outY != outYEnd; outY += _heightScaleFactor * _width, inY += _width ) {
                 std::copy( inY, inY + width, outY );
@@ -257,8 +257,8 @@ void SMKVideoSequence::getNextFrame( fheroes2::Image & image, const int32_t x, c
         const uint8_t * inY = data;
 
         const int32_t imageWidth = image.width();
-        uint8_t * outY = image.image() + x + y * imageWidth;
-        const uint8_t * outYEnd = outY + ( height / _heightScaleFactor ) * _heightScaleFactor * imageWidth;
+        uint32_t * outY = image.image() + x + y * imageWidth;
+        const uint32_t * outYEnd = outY + ( height / _heightScaleFactor ) * _heightScaleFactor * imageWidth;
 
         if ( _heightScaleFactor == 2 ) {
             assert( ( height % _heightScaleFactor ) == 0 );

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -210,12 +210,11 @@ fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_
 
     fheroes2::Image out( width, height );
 
-    std::memcpy( out.image(), uncompressedData.data(), uncompressedSize );
-    if ( doubleLayer ) {
-        std::memcpy( out.transform(), uncompressedData.data() + uncompressedSize, uncompressedSize );
-    }
-    else {
-        std::fill( out.transform(), out.transform() + uncompressedSize, static_cast<uint8_t>( 0 ) );
+    uint32_t * outImage = out.image(); 
+    uint8_t * outTransform = out.transform();
+    for ( size_t i = 0; i < uncompressedSize; ++i, ++outImage, ++outTransform ) {
+        *outImage = static_cast<uint32_t>( uncompressedData.data()[i] );
+        *outTransform = static_cast<uint8_t>( doubleLayer ? uncompressedData.data()[i + uncompressedSize] : 0 );
     }
     return out;
 }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -260,8 +260,8 @@ namespace
         output.reset();
 
         const uint8_t * input = data.data() + 6;
-        uint8_t * image = output.image();
-        const uint8_t * imageEnd = image + width * height;
+        uint32_t * image = output.image();
+        const uint32_t * imageEnd = image + width * height;
         uint8_t * transform = output.transform();
 
         for ( ; image != imageEnd; ++image, ++transform, ++input ) {
@@ -1439,7 +1439,7 @@ namespace fheroes2
                     // clean the button.
                     const int32_t pixelPosition = 5 * 132;
                     if ( pixelPosition < ( out.width() * out.height() ) ) {
-                        Fill( out, 4, 3 + i, 132 - i, 16, out.image()[pixelPosition] );
+                        Fill( out, 4, 3 + i, 132 - i, 16, static_cast<uint8_t>(out.image()[pixelPosition] ));
                     }
                 }
 

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -52,9 +52,9 @@ namespace
 
         assert( !out.singleLayer() );
 
-        uint8_t * image = out.image();
+        uint32_t * image = out.image();
         const uint8_t * transform = out.transform();
-        const uint8_t * imageEnd = image + out.width() * out.height();
+        const uint32_t * imageEnd = image + out.width() * out.height();
 
         for ( ; image != imageEnd; ++image, ++transform ) {
             if ( *transform == 0 ) {

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -275,7 +275,7 @@ void Interface::Radar::RedrawObjects( const int32_t playerColor, const ViewWorld
     const bool revealAll = flags == ViewWorldMode::ViewAll;
 #endif
 
-    uint8_t * radarImage = _map.image();
+    uint32_t * radarImage = _map.image();
 
     assert( _roi.x >= 0 && _roi.y >= 0 && ( _roi.width + _roi.x ) <= world.w() && ( _roi.height + _roi.y ) <= world.h() );
 
@@ -299,7 +299,7 @@ void Interface::Radar::RedrawObjects( const int32_t playerColor, const ViewWorld
     const int32_t maxRoiY = _roi.height + _roi.y;
 
     for ( int32_t y = _roi.y; y < maxRoiY; ++y ) {
-        uint8_t * radarY = radarImage + static_cast<ptrdiff_t>( y * _zoom ) * radarWidth;
+        uint32_t * radarY = radarImage + static_cast<ptrdiff_t>( y * _zoom ) * radarWidth;
         const ptrdiff_t radarYStep = isZoomIn ? ( static_cast<ptrdiff_t>( ( y + 1 ) * _zoom ) * radarWidth ) : 0;
 
         for ( int32_t x = _roi.x; x < maxRoiX; ++x ) {
@@ -383,10 +383,10 @@ void Interface::Radar::RedrawObjects( const int32_t playerColor, const ViewWorld
                 }
             }
 
-            uint8_t * radarX = radarY + static_cast<ptrdiff_t>( x * _zoom );
+            uint32_t * radarX = radarY + static_cast<ptrdiff_t>( x * _zoom );
             if ( isZoomIn ) {
-                const uint8_t * radarYEnd = radarImage + radarYStep + static_cast<ptrdiff_t>( x * _zoom );
-                uint8_t * radarXEnd = radarY + static_cast<ptrdiff_t>( ( x + 1 ) * _zoom );
+                const uint32_t * radarYEnd = radarImage + radarYStep + static_cast<ptrdiff_t>( x * _zoom );
+                uint32_t * radarXEnd = radarY + static_cast<ptrdiff_t>( ( x + 1 ) * _zoom );
 
                 for ( ; radarX != radarYEnd; radarX += radarWidth, radarXEnd += radarWidth ) {
                     std::fill( radarX, radarXEnd, fillColor );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -63,13 +63,13 @@ namespace
 
         const int32_t imageWidth = output.width();
 
-        uint8_t * imageOutY = output.image() + imageWidth * contourOffset.y;
+        uint32_t * imageOutY = output.image() + imageWidth * contourOffset.y;
         const uint8_t * transformInY = input.transform() - contourOffset.x;
         uint8_t * transformOutY = output.transform() + imageWidth * contourOffset.y;
         const uint8_t * transformOutYEnd = transformOutY + imageWidth * height;
 
         for ( ; transformOutY != transformOutYEnd; transformInY += imageWidth, transformOutY += imageWidth, imageOutY += imageWidth ) {
-            uint8_t * imageOutX = imageOutY;
+            uint32_t * imageOutX = imageOutY;
             const uint8_t * transformInX = transformInY;
             uint8_t * transformOutX = transformOutY;
             const uint8_t * transformOutXEnd = transformOutX + width;
@@ -1265,7 +1265,7 @@ namespace
             font[198 - 32].reset();
             fheroes2::Copy( font[56], 1, 0, font[198 - 32], 1, 0, 8, 11 );
             fheroes2::Copy( font[56], 9, 0, font[198 - 32], 10, 0, 6, 11 );
-            fheroes2::Fill( font[198 - 32], 9, 1, 1, 9, font[198 - 32].image()[1 + font[198 - 32].width()] );
+            fheroes2::Fill( font[198 - 32], 9, 1, 1, 9, static_cast<uint8_t>(font[198 - 32].image()[1 + font[198 - 32].width()]) );
             font[198 - 32].setPosition( font[56].x(), font[56].y() );
             updateNormalFontLetterShadow( font[198 - 32] );
 
@@ -1482,7 +1482,7 @@ namespace
             font[230 - 32].reset();
             fheroes2::Copy( font[88], 0, 0, font[230 - 32], 0, 0, 6, 7 );
             fheroes2::Copy( font[88], 5, 0, font[230 - 32], 7, 0, 5, 7 );
-            fheroes2::Fill( font[230 - 32], 6, 1, 1, 5, font[230 - 32].image()[3 + font[230 - 32].width()] );
+            fheroes2::Fill( font[230 - 32], 6, 1, 1, 5, static_cast<uint8_t>(font[230 - 32].image()[3 + font[230 - 32].width()]) );
             font[230 - 32].setPosition( font[88].x(), font[88].y() );
             updateNormalFontLetterShadow( font[230 - 32] );
 

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -357,9 +357,9 @@ namespace fheroes2
 
         // Set the input image horizontal offset from where to draw the wave.
         const int32_t offsetX = x < waveLength ? 0 : x - waveLength;
-        const uint8_t * inImageX = in.image() + offsetX;
+        const uint32_t * inImageX = in.image() + offsetX;
 
-        uint8_t * outImageX = out.image();
+        uint32_t * outImageX = out.image();
 
         // Set pointers to the start and the end of the death wave curve.
         std::vector<int32_t>::const_iterator pntX = deathWaveCurve.begin() + ( x < waveLength ? waveLength - x : 0 );
@@ -372,11 +372,11 @@ namespace fheroes2
                 continue;
             }
 
-            const uint8_t * outImageYEnd = outImageX + static_cast<ptrdiff_t>( inHeight + *pntX ) * outWidth;
-            const uint8_t * inImageY = inImageX - static_cast<ptrdiff_t>( *pntX + 1 ) * inWidth;
+            const uint32_t * outImageYEnd = outImageX + static_cast<ptrdiff_t>( inHeight + *pntX ) * outWidth;
+            const uint32_t * inImageY = inImageX - static_cast<ptrdiff_t>( *pntX + 1 ) * inWidth;
 
             // A loop to shift all horizontal pixels vertically.
-            uint8_t * outImageY = outImageX;
+            uint32_t * outImageY = outImageX;
             for ( ; outImageY != outImageYEnd; outImageY += outWidth ) {
                 inImageY += inWidth;
                 *outImageY = *inImageY;
@@ -412,8 +412,8 @@ namespace fheroes2
         Image out( width, height );
         std::fill( out.transform(), out.transform() + static_cast<size_t>( width * height ), static_cast<uint8_t>( 0 ) );
 
-        uint8_t * imageOutX = out.image();
-        const uint8_t * imageIn = in.image();
+        uint32_t * imageOutX = out.image();
+        const uint32_t * imageIn = in.image();
 
         const uint8_t * gamePalette = getGamePalette();
 
@@ -422,8 +422,8 @@ namespace fheroes2
         for ( int32_t y = 0; y < height; ++y ) {
             const int32_t startY = std::max( y - blurRadius, 0 );
             const int32_t rangeY = std::min( y + blurRadius + 1, height ) - startY;
-            const uint8_t * imageInXStart = imageIn + static_cast<ptrdiff_t>( y ) * width;
-            const uint8_t * imageInYStart = imageIn + static_cast<ptrdiff_t>( startY ) * width;
+            const uint32_t * imageInXStart = imageIn + static_cast<ptrdiff_t>( y ) * width;
+            const uint32_t * imageInYStart = imageIn + static_cast<ptrdiff_t>( startY ) * width;
 
             for ( int32_t x = 0; x < width; ++x, ++imageOutX ) {
                 const int32_t startX = std::max( x - blurRadius, 0 );
@@ -433,8 +433,8 @@ namespace fheroes2
                 uint32_t sumGreen = 0;
                 uint32_t sumBlue = 0;
 
-                const uint8_t * imageInX = imageInXStart + startX;
-                const uint8_t * imageInXEnd = imageInX + rangeX;
+                const uint32_t * imageInX = imageInXStart + startX;
+                const uint32_t * imageInXEnd = imageInX + rangeX;
 
                 for ( ; imageInX != imageInXEnd; ++imageInX ) {
                     const uint8_t * palette = gamePalette + static_cast<ptrdiff_t>( *imageInX ) * 3;
@@ -444,9 +444,9 @@ namespace fheroes2
                     sumBlue += *( palette + 2 );
                 }
 
-                const uint8_t * imageInY = imageInYStart + x;
-                const uint8_t * imageInYEnd = imageInY + static_cast<ptrdiff_t>( rangeY ) * width;
-                const uint8_t * currentPixel = imageInXStart + x;
+                const uint32_t * imageInY = imageInYStart + x;
+                const uint32_t * imageInYEnd = imageInY + static_cast<ptrdiff_t>( rangeY ) * width;
+                const uint32_t * currentPixel = imageInXStart + x;
 
                 for ( ; imageInY != imageInYEnd; imageInY += width ) {
                     if ( imageInY != currentPixel ) {
@@ -488,10 +488,10 @@ namespace fheroes2
 
         const int32_t widthOut = out.width();
 
-        uint8_t * outImageY = out.image();
+        uint32_t * outImageY = out.image();
         uint8_t * outTransformY = out.transform();
 
-        const uint8_t * inImageY = in.image();
+        const uint32_t * inImageY = in.image();
         const uint8_t * inTransformY = in.transform();
 
         for ( int32_t y = 0; y < height; ++y, inImageY += widthIn, inTransformY += widthIn, outImageY += widthOut, outTransformY += widthOut ) {

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -499,7 +499,7 @@ namespace fheroes2
             const double sinYEffect = sin( ( y % limitY ) / waveFrequency ) * 2.0 - 1;
             const int32_t offset = static_cast<int32_t>( rippleXModifier * sinYEffect ) + offsetX;
 
-            memcpy( outImageY + offset, inImageY, widthIn );
+            memcpy( outImageY + offset, inImageY, widthIn * 4 );
             memcpy( outTransformY + offset, inTransformY, widthIn );
         }
 

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -270,8 +270,8 @@ namespace
 
             assert( ( width > 0 ) && ( height > 0 ) && ( x >= 0 ) && ( y >= 0 ) && ( ( x + width ) < displayWidth ) && ( ( y + height ) < display.height() ) );
 
-            uint8_t * imageY = display.image() + static_cast<ptrdiff_t>( y ) * displayWidth + x;
-            const uint8_t * imageYEnd = imageY + static_cast<ptrdiff_t>( height ) * displayWidth;
+            uint32_t * imageY = display.image() + static_cast<ptrdiff_t>( y ) * displayWidth + x;
+            const uint32_t * imageYEnd = imageY + static_cast<ptrdiff_t>( height ) * displayWidth;
 
             for ( ; imageY != imageYEnd; imageY += displayWidth ) {
                 std::fill( imageY, imageY + width, static_cast<uint8_t>( 0 ) );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -303,7 +303,7 @@ namespace
             const uint8_t leftColor = ( ( passable & Direction::LEFT ) != 0 ) ? green : red;
             const uint8_t rightColor = ( ( passable & Direction::RIGHT ) != 0 ) ? green : red;
 
-            uint8_t * image = sf.image();
+            uint32_t * image = sf.image();
             uint8_t * transform = sf.transform();
 
             // Horizontal


### PR DESCRIPTION
The type of `image()` has been converted from `uint8_t` to `uint32_t`.
With this change, normal RGBA images can be rendered:
![image](https://user-images.githubusercontent.com/2912123/235470706-30b1520d-464b-4218-98c7-ebdbc96b4b27.png)
This should usher a bright new future for fheroes2 :).

Some notes:
- My strategy was as follows: change the type and then fix every new error that Visual Studio throws. In 80% of the case the fix was straightforward (just adapt the types). The most troublesome were the `memcpy()`, but were eventually fixed.
- Some extensive testing is needed. I just entered a few games and clicked some menus to see if anything crashes.
- This change is a milestone to another Pull Request that I'll submit in the coming days, where we allow the user to place unpacked png files next to the agg archives and they'll be dynamically loaded in game, overriding the old assets.
- SDL1 no longer works due to this change. From my understanding, you were already thinking of deleting it from the source code.
- I have close to zero experience with C++, so please be kind.
