### PR TITLE
Fix not returning to load menu while switching between campaign scenarios

### DIFF
--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -166,7 +166,7 @@ void Game::mainGameLoop( bool isFirstGameRun )
             break;
         case fheroes2::GameMode::COMPLETE_CAMPAIGN_SCENARIO_FROM_LOAD_FILE:
             result = Game::CompleteCampaignScenario( true );
-            if ( result == fheroes2::GameMode::SELECT_CAMPAIGN_SCENARIO ) {
+            while ( result == fheroes2::GameMode::SELECT_CAMPAIGN_SCENARIO ) {
                 result = Game::SelectCampaignScenario( fheroes2::GameMode::LOAD_CAMPAIGN, false );
             }
             break;


### PR DESCRIPTION
close #6037