### PR TITLE
Fix loading campaign save made at the end of scenario

### DIFF
--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -39,6 +39,7 @@
 #include "normal/ai_normal.h"
 #include "race.h"
 #include "rand.h"
+#include "save_format_version.h"
 #include "serialize.h"
 #include "settings.h"
 #include "world.h"
@@ -529,6 +530,13 @@ StreamBase & operator>>( StreamBase & msg, Players & players )
     int colors;
     int current;
     msg >> colors >> current;
+
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1004_RELEASE, "Remove the logic below." );
+    // The old save files made at the end of a campaign scenario has player color set to '-1' which is not supported now.
+    // So we change the incorrect color '-1' to 'Color::NONE'.
+    if ( current == -1 ) {
+        current = Color::NONE;
+    }
 
     players.clear();
     players.setCurrentColor( current );


### PR DESCRIPTION
relates to #7109
This PR fixes loading a save made at the end of a campaign scenario.
Such old saves store '-1' as the current player color.
Recently we decided not to use negative numbers for player colors as in some cases it produces bugs.
All places in the engine that were setting player color to '-1' were changed to 'Color::NONE' in https://github.com/ihhub/fheroes2/pull/7080