### PR TITLE
Fill main menu with background when we do not stretch the main menu main image

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3621,21 +3621,23 @@ namespace fheroes2
             const double scaleFactorY = static_cast<double>( display.height() ) / Display::DEFAULT_HEIGHT;
 
             const double scaleFactor = std::min( scaleFactorX, scaleFactorY );
-            const int32_t resizedWidth = std::lround( originalIcn.width() * scaleFactor );
-            const int32_t resizedHeight = std::lround( originalIcn.height() * scaleFactor );
-            const int32_t offsetX = std::lround( display.width() - Display::DEFAULT_WIDTH * scaleFactor ) / 2;
-            const int32_t offsetY = std::lround( display.height() - Display::DEFAULT_HEIGHT * scaleFactor ) / 2;
+            const int32_t resizedWidth = static_cast<int32_t>( std::lround( originalIcn.width() * scaleFactor ) );
+            const int32_t resizedHeight = static_cast<int32_t>( std::lround( originalIcn.height() * scaleFactor ) );
+            const int32_t offsetX = static_cast<int32_t>( std::lround( display.width() - Display::DEFAULT_WIDTH * scaleFactor ) ) / 2;
+            const int32_t offsetY = static_cast<int32_t>( std::lround( display.height() - Display::DEFAULT_HEIGHT * scaleFactor ) ) / 2;
             assert( offsetX >= 0 && offsetY >= 0 );
 
             // Resize only if needed
             if ( resizedIcn.height() != resizedHeight || resizedIcn.width() != resizedWidth ) {
                 resizedIcn.resize( resizedWidth, resizedHeight );
-                resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) + offsetY );
+                resizedIcn.setPosition( static_cast<int32_t>( std::lround( originalIcn.x() * scaleFactor ) ) + offsetX,
+                                        static_cast<int32_t>( std::lround( originalIcn.y() * scaleFactor ) ) + offsetY );
                 Resize( originalIcn, resizedIcn, false );
             }
             else {
                 // No need to resize but we have to update the offset.
-                resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) + offsetY );
+                resizedIcn.setPosition( static_cast<int32_t>( std::lround( originalIcn.x() * scaleFactor ) ) + offsetX,
+                                        static_cast<int32_t>( std::lround( originalIcn.y() * scaleFactor ) ) + offsetY );
             }
 
             return resizedIcn;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -23,8 +23,8 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cstring>
 #include <cmath>
+#include <cstring>
 #include <initializer_list>
 #include <map>
 #include <memory>

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3596,16 +3596,17 @@ namespace fheroes2
         }
 
         // We have few ICNs which we need to scale like some related to main screen
-        bool IsScalableICN( int id )
+        bool IsScalableICN( const int id )
         {
             return id == ICN::HEROES || id == ICN::BTNSHNGL || id == ICN::SHNGANIM;
         }
 
-        const Sprite & GetScaledICN( int icnId, uint32_t index )
+        const Sprite & GetScaledICN( const int icnId, const uint32_t index )
         {
             const Sprite & originalIcn = _icnVsSprite[icnId][index];
+            const Display & display = Display::instance();
 
-            if ( Display::DEFAULT_WIDTH == Display::instance().width() && Display::DEFAULT_HEIGHT == Display::instance().height() ) {
+            if ( display.width() == Display::DEFAULT_WIDTH && display.height() == Display::DEFAULT_HEIGHT ) {
                 return originalIcn;
             }
 
@@ -3615,16 +3616,22 @@ namespace fheroes2
 
             Sprite & resizedIcn = _icnVsScaledSprite[icnId][index];
 
-            const double scaleFactorX = static_cast<double>( Display::instance().width() ) / Display::DEFAULT_WIDTH;
-            const double scaleFactorY = static_cast<double>( Display::instance().height() ) / Display::DEFAULT_HEIGHT;
+            const double scaleFactor = static_cast<double>( display.height() ) / Display::DEFAULT_HEIGHT;
+            const int32_t resizedWidth = static_cast<int32_t>( originalIcn.width() * scaleFactor + 0.5 );
+            const int32_t resizedHeight = static_cast<int32_t>( originalIcn.height() * scaleFactor + 0.5 );
+            const int32_t offsetX = static_cast<int32_t>( display.width() - Display::DEFAULT_WIDTH * scaleFactor ) / 2;
 
-            const int32_t resizedWidth = static_cast<int32_t>( originalIcn.width() * scaleFactorX + 0.5 );
-            const int32_t resizedHeight = static_cast<int32_t>( originalIcn.height() * scaleFactorY + 0.5 );
             // Resize only if needed
-            if ( resizedIcn.width() != resizedWidth || resizedIcn.height() != resizedHeight ) {
+            if ( resizedIcn.height() != resizedHeight ) {
                 resizedIcn.resize( resizedWidth, resizedHeight );
-                resizedIcn.setPosition( static_cast<int32_t>( originalIcn.x() * scaleFactorX + 0.5 ), static_cast<int32_t>( originalIcn.y() * scaleFactorY + 0.5 ) );
+                resizedIcn.setPosition( static_cast<int32_t>( originalIcn.x() * scaleFactor + 0.5 ) + offsetX,
+                                        static_cast<int32_t>( originalIcn.y() * scaleFactor + 0.5 ) );
                 Resize( originalIcn, resizedIcn, false );
+            }
+            else if ( resizedIcn.width() != resizedWidth ) {
+                // No need to resize but we have to update the offset.
+                resizedIcn.setPosition( static_cast<int32_t>( originalIcn.x() * scaleFactor + 0.5 ) + offsetX,
+                                        static_cast<int32_t>( originalIcn.y() * scaleFactor + 0.5 ) );
             }
 
             return resizedIcn;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -24,6 +24,7 @@
 #include <array>
 #include <cassert>
 #include <cstring>
+#include <cmath>
 #include <initializer_list>
 #include <map>
 #include <memory>
@@ -3617,21 +3618,19 @@ namespace fheroes2
             Sprite & resizedIcn = _icnVsScaledSprite[icnId][index];
 
             const double scaleFactor = static_cast<double>( display.height() ) / Display::DEFAULT_HEIGHT;
-            const int32_t resizedWidth = static_cast<int32_t>( originalIcn.width() * scaleFactor + 0.5 );
-            const int32_t resizedHeight = static_cast<int32_t>( originalIcn.height() * scaleFactor + 0.5 );
+            const int32_t resizedWidth = std::lround( originalIcn.width() * scaleFactor );
+            const int32_t resizedHeight = std::lround( originalIcn.height() * scaleFactor );
             const int32_t offsetX = static_cast<int32_t>( display.width() - Display::DEFAULT_WIDTH * scaleFactor ) / 2;
 
             // Resize only if needed
             if ( resizedIcn.height() != resizedHeight ) {
                 resizedIcn.resize( resizedWidth, resizedHeight );
-                resizedIcn.setPosition( static_cast<int32_t>( originalIcn.x() * scaleFactor + 0.5 ) + offsetX,
-                                        static_cast<int32_t>( originalIcn.y() * scaleFactor + 0.5 ) );
+                resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) );
                 Resize( originalIcn, resizedIcn, false );
             }
             else if ( resizedIcn.width() != resizedWidth ) {
                 // No need to resize but we have to update the offset.
-                resizedIcn.setPosition( static_cast<int32_t>( originalIcn.x() * scaleFactor + 0.5 ) + offsetX,
-                                        static_cast<int32_t>( originalIcn.y() * scaleFactor + 0.5 ) );
+                resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) );
             }
 
             return resizedIcn;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3617,20 +3617,25 @@ namespace fheroes2
 
             Sprite & resizedIcn = _icnVsScaledSprite[icnId][index];
 
-            const double scaleFactor = static_cast<double>( display.height() ) / Display::DEFAULT_HEIGHT;
+            const double scaleFactorX = static_cast<double>( display.width() ) / Display::DEFAULT_WIDTH;
+            const double scaleFactorY = static_cast<double>( display.height() ) / Display::DEFAULT_HEIGHT;
+
+            const double scaleFactor = std::min( scaleFactorX, scaleFactorY );
             const int32_t resizedWidth = std::lround( originalIcn.width() * scaleFactor );
             const int32_t resizedHeight = std::lround( originalIcn.height() * scaleFactor );
-            const int32_t offsetX = static_cast<int32_t>( display.width() - Display::DEFAULT_WIDTH * scaleFactor ) / 2;
+            const int32_t offsetX = std::lround( display.width() - Display::DEFAULT_WIDTH * scaleFactor ) / 2;
+            const int32_t offsetY = std::lround( display.height() - Display::DEFAULT_HEIGHT * scaleFactor ) / 2;
+            assert( offsetX >= 0 && offsetY >= 0 );
 
             // Resize only if needed
-            if ( resizedIcn.height() != resizedHeight ) {
+            if ( resizedIcn.height() != resizedHeight || resizedIcn.width() != resizedWidth ) {
                 resizedIcn.resize( resizedWidth, resizedHeight );
-                resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) );
+                resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) + offsetY );
                 Resize( originalIcn, resizedIcn, false );
             }
             else {
                 // No need to resize but we have to update the offset.
-                resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) );
+                resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) + offsetY );
             }
 
             return resizedIcn;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3628,7 +3628,7 @@ namespace fheroes2
                 resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) );
                 Resize( originalIcn, resizedIcn, false );
             }
-            else if ( resizedIcn.width() != resizedWidth ) {
+            else {
                 // No need to resize but we have to update the offset.
                 resizedIcn.setPosition( std::lround( originalIcn.x() * scaleFactor ) + offsetX, std::lround( originalIcn.y() * scaleFactor ) );
             }

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -30,7 +30,6 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "cursor.h"
@@ -41,9 +40,9 @@
 #include "game_mainmenu_ui.h"
 #include "game_mode.h"
 #include "icn.h"
-#include "image.h"
 #include "localevent.h"
 #include "logging.h"
+#include "math_base.h"
 #include "mus.h"
 #include "screen.h"
 #include "settings.h"

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "game.h"
+
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -34,7 +36,6 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "dir.h"
-#include "game.h"
 #include "game_hotkeys.h"
 #include "game_io.h"
 #include "game_mainmenu_ui.h"
@@ -43,7 +44,6 @@
 #include "image.h"
 #include "localevent.h"
 #include "logging.h"
-#include "game_mainmenu_ui.h"
 #include "mus.h"
 #include "screen.h"
 #include "settings.h"

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -43,6 +43,7 @@
 #include "image.h"
 #include "localevent.h"
 #include "logging.h"
+#include "game_mainmenu_ui.h"
 #include "mus.h"
 #include "screen.h"
 #include "settings.h"
@@ -52,6 +53,8 @@
 
 namespace
 {
+    const int32_t buttonYStep = 66;
+
     void outputLoadGameInTextSupportMode()
     {
         START_TEXT_SUPPORT_MODE
@@ -85,24 +88,13 @@ fheroes2::GameMode Game::LoadMulti()
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     // image background
-    const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
     fheroes2::drawMainMenuScreen();
 
-    const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
-    const int32_t panelOffset = fheroes2::Display::DEFAULT_HEIGHT - panel.height();
-    const int32_t panelXPos = back.width() - ( panel.width() + panelOffset );
-    fheroes2::Blit( panel, display, panelXPos, panelOffset );
+    const fheroes2::Point buttonPos = fheroes2::drawButtonPanel();
 
-    const int32_t buttonMiddlePos = panelXPos + SHADOWWIDTH + ( panel.width() - SHADOWWIDTH ) / 2;
-    const fheroes2::Sprite & buttonSample = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 0 );
-    const int32_t buttonWidth = buttonSample.width();
-    const int32_t buttonXPos = buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
-    const int32_t buttonYPos = 46;
-    const int32_t buttonYStep = 66;
-
-    fheroes2::Button buttonHotSeat( buttonXPos, buttonYPos, ICN::BUTTON_HOT_SEAT, 0, 1 );
-    fheroes2::Button buttonNetwork( buttonXPos, buttonYPos + buttonYStep * 1, ICN::BTNMP, 2, 3 );
-    fheroes2::Button buttonCancelGame( buttonXPos, buttonYPos + buttonYStep * 5, ICN::BUTTON_LARGE_CANCEL, 0, 1 );
+    fheroes2::Button buttonHotSeat( buttonPos.x, buttonPos.y, ICN::BUTTON_HOT_SEAT, 0, 1 );
+    fheroes2::Button buttonNetwork( buttonPos.x, buttonPos.y + buttonYStep * 1, ICN::BTNMP, 2, 3 );
+    fheroes2::Button buttonCancelGame( buttonPos.x, buttonPos.y + buttonYStep * 5, ICN::BUTTON_LARGE_CANCEL, 0, 1 );
 
     buttonHotSeat.draw();
     buttonCancelGame.draw();
@@ -155,17 +147,9 @@ fheroes2::GameMode Game::LoadGame()
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
     fheroes2::drawMainMenuScreen();
 
-    const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
-    const int32_t panelOffset = fheroes2::Display::DEFAULT_HEIGHT - panel.height();
-    const int32_t panelXPos = back.width() - ( panel.width() + panelOffset );
-    fheroes2::Blit( panel, display, panelXPos, panelOffset );
-
-    const int32_t buttonMiddlePos = panelXPos + SHADOWWIDTH + ( panel.width() - SHADOWWIDTH ) / 2;
-    const fheroes2::Sprite & buttonSample = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 0 );
-    const int32_t buttonWidth = buttonSample.width();
+    const fheroes2::Point buttonPos = fheroes2::drawButtonPanel();
 
     std::vector<fheroes2::Button> buttons( 4 );
     const size_t buttonCount = buttons.size();
@@ -175,17 +159,13 @@ fheroes2::GameMode Game::LoadGame()
     buttons[2].setICNInfo( ICN::BUTTON_MULTIPLAYER_GAME, 0, 1 );
     buttons[3].setICNInfo( ICN::BUTTON_LARGE_CANCEL, 0, 1 );
 
-    const int32_t buttonXPos = buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
-    const int32_t buttonYPos = 46;
-    const int32_t buttonYStep = 66;
-
     for ( size_t i = 0; i < buttonCount - 1; ++i ) {
-        buttons[i].setPosition( buttonXPos, buttonYPos + buttonYStep * static_cast<int32_t>( i ) );
+        buttons[i].setPosition( buttonPos.x, buttonPos.y + buttonYStep * static_cast<int32_t>( i ) );
         buttons[i].draw();
     }
 
     // following the cancel button in newgame
-    buttons.back().setPosition( buttonXPos, buttonYPos + buttonYStep * 5 );
+    buttons.back().setPosition( buttonPos.x, buttonPos.y + buttonYStep * 5 );
     buttons.back().draw();
 
     display.render();

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include <algorithm>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <memory>

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -253,8 +253,8 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
     const double scaleY = static_cast<double>( display.height() ) / fheroes2::Display::DEFAULT_HEIGHT;
 
     const double scale = std::min( scaleX, scaleY );
-    const int32_t offsetX = std::lround( display.width() - fheroes2::Display::DEFAULT_WIDTH * scale ) / 2;
-    const int32_t offsetY = std::lround( display.height() - fheroes2::Display::DEFAULT_HEIGHT * scale ) / 2;
+    const int32_t offsetX = static_cast<int32_t>( std::lround( display.width() - fheroes2::Display::DEFAULT_WIDTH * scale ) ) / 2;
+    const int32_t offsetY = static_cast<int32_t>( std::lround( display.height() - fheroes2::Display::DEFAULT_HEIGHT * scale ) ) / 2;
 
     const fheroes2::Rect settingsArea( static_cast<int32_t>( 63 * scale ) + offsetX, static_cast<int32_t>( 202 * scale ) + offsetY, static_cast<int32_t>( 90 * scale ),
                                        static_cast<int32_t>( 160 * scale ) );

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -249,9 +249,14 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 
     display.render();
 
-    const double scale = static_cast<double>( display.height() ) / fheroes2::Display::DEFAULT_HEIGHT;
-    const int32_t offsetX = static_cast<int32_t>( display.width() - fheroes2::Display::DEFAULT_WIDTH * scale ) / 2;
-    const fheroes2::Rect settingsArea( static_cast<int32_t>( 63 * scale ) + offsetX, static_cast<int32_t>( 202 * scale ), static_cast<int32_t>( 90 * scale ),
+    const double scaleX = static_cast<double>( display.width() ) / fheroes2::Display::DEFAULT_WIDTH;
+    const double scaleY = static_cast<double>( display.height() ) / fheroes2::Display::DEFAULT_HEIGHT;
+
+    const double scale = std::min( scaleX, scaleY );
+    const int32_t offsetX = std::lround( display.width() - fheroes2::Display::DEFAULT_WIDTH * scale ) / 2;
+    const int32_t offsetY = std::lround( display.height() - fheroes2::Display::DEFAULT_HEIGHT * scale ) / 2;
+
+    const fheroes2::Rect settingsArea( static_cast<int32_t>( 63 * scale ) + offsetX, static_cast<int32_t>( 202 * scale ) + offsetY, static_cast<int32_t>( 90 * scale ),
                                        static_cast<int32_t>( 160 * scale ) );
 
     uint32_t lantern_frame = 0;
@@ -358,8 +363,9 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
             ++lantern_frame;
             fheroes2::Blit( lantern12, display, lantern12.x(), lantern12.y() );
             if ( le.MouseCursor( settingsArea ) ) {
-                const int32_t offsetY = static_cast<int32_t>( 55 * scale );
-                fheroes2::Blit( highlightDoor, 0, offsetY, display, highlightDoor.x(), highlightDoor.y() + offsetY, highlightDoor.width(), highlightDoor.height() );
+                const int32_t doorOffsetY = static_cast<int32_t>( 55 * scale ) + offsetY;
+                fheroes2::Blit(
+                    highlightDoor, 0, doorOffsetY, display, highlightDoor.x(), highlightDoor.y() + doorOffsetY, highlightDoor.width(), highlightDoor.height() );
             }
 
             display.render();

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -364,8 +364,8 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
             fheroes2::Blit( lantern12, display, lantern12.x(), lantern12.y() );
             if ( le.MouseCursor( settingsArea ) ) {
                 const int32_t doorOffsetY = static_cast<int32_t>( 55 * scale ) + offsetY;
-                fheroes2::Blit(
-                    highlightDoor, 0, doorOffsetY, display, highlightDoor.x(), highlightDoor.y() + doorOffsetY, highlightDoor.width(), highlightDoor.height() );
+                fheroes2::Blit( highlightDoor, 0, doorOffsetY, display, highlightDoor.x(), highlightDoor.y() + doorOffsetY, highlightDoor.width(),
+                                highlightDoor.height() );
             }
 
             display.render();

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -249,10 +249,10 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 
     display.render();
 
-    const double scaleX = static_cast<double>( display.width() ) / fheroes2::Display::DEFAULT_WIDTH;
-    const double scaleY = static_cast<double>( display.height() ) / fheroes2::Display::DEFAULT_HEIGHT;
-    const fheroes2::Rect settingsArea( static_cast<int32_t>( 63 * scaleX ), static_cast<int32_t>( 202 * scaleY ), static_cast<int32_t>( 90 * scaleX ),
-                                       static_cast<int32_t>( 160 * scaleY ) );
+    const double scale = static_cast<double>( display.height() ) / fheroes2::Display::DEFAULT_HEIGHT;
+    const int32_t offsetX = static_cast<int32_t>( display.width() - fheroes2::Display::DEFAULT_WIDTH * scale ) / 2;
+    const fheroes2::Rect settingsArea( static_cast<int32_t>( 63 * scale ) + offsetX, static_cast<int32_t>( 202 * scale ), static_cast<int32_t>( 90 * scale ),
+                                       static_cast<int32_t>( 160 * scale ) );
 
     uint32_t lantern_frame = 0;
 
@@ -270,7 +270,6 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
     fheroes2::Sprite highlightDoor = fheroes2::AGG::GetICN( ICN::SHNGANIM, 18 );
     fheroes2::ApplyPalette( highlightDoor, 8 );
 
-    // mainmenu loop
     while ( true ) {
         if ( !le.HandleEvents( true, true ) ) {
             if ( Interface::Basic::EventExit() == fheroes2::GameMode::QUIT_GAME ) {
@@ -359,7 +358,7 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
             ++lantern_frame;
             fheroes2::Blit( lantern12, display, lantern12.x(), lantern12.y() );
             if ( le.MouseCursor( settingsArea ) ) {
-                const int32_t offsetY = static_cast<int32_t>( 55 * scaleY );
+                const int32_t offsetY = static_cast<int32_t>( 55 * scale );
                 fheroes2::Blit( highlightDoor, 0, offsetY, display, highlightDoor.x(), highlightDoor.y() + offsetY, highlightDoor.width(), highlightDoor.height() );
             }
 

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -95,8 +95,8 @@ namespace fheroes2
             assert( mainMenuBackground.x() == 0 );
 
             renderWindowBackground( display, { 0, 0, display.width(), mainMenuBackground.y() } );
-            renderWindowBackground( display, { 0, mainMenuBackground.y() + mainMenuBackground.height(),
-                                               display.width(), display.height() - mainMenuBackground.y() - mainMenuBackground.height() } );
+            renderWindowBackground( display, { 0, mainMenuBackground.y() + mainMenuBackground.height(), display.width(),
+                                               display.height() - mainMenuBackground.y() - mainMenuBackground.height() } );
         }
     }
 }

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -85,6 +85,6 @@ namespace fheroes2
 
         renderWindowBackground( display, { 0, 0, mainMenuBackground.x(), display.height() } );
         renderWindowBackground( display, { mainMenuBackground.x() + mainMenuBackground.width(), 0, display.width() - mainMenuBackground.x() - mainMenuBackground.width(),
-                                display.height() } );
+                                           display.height() } );
     }
 }

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -21,6 +21,7 @@
 #include "game_mainmenu_ui.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 
 #include "agg_image.h"
@@ -85,8 +86,17 @@ namespace fheroes2
         drawSprite( display, ICN::BTNSHNGL, 13 );
         drawSprite( display, ICN::BTNSHNGL, 17 );
 
-        renderWindowBackground( display, { 0, 0, mainMenuBackground.x(), display.height() } );
-        renderWindowBackground( display, { mainMenuBackground.x() + mainMenuBackground.width(), 0, display.width() - mainMenuBackground.x() - mainMenuBackground.width(),
-                                           display.height() } );
+        if ( mainMenuBackground.y() == 0 ) {
+            renderWindowBackground( display, { 0, 0, mainMenuBackground.x(), display.height() } );
+            renderWindowBackground( display, { mainMenuBackground.x() + mainMenuBackground.width(), 0,
+                                               display.width() - mainMenuBackground.x() - mainMenuBackground.width(), display.height() } );
+        }
+        else {
+            assert( mainMenuBackground.x() == 0 );
+
+            renderWindowBackground( display, { 0, 0, display.width(), mainMenuBackground.y() } );
+            renderWindowBackground( display, { 0, mainMenuBackground.y() + mainMenuBackground.height(),
+                                               display.width(), display.height() - mainMenuBackground.y() - mainMenuBackground.height() } );
+        }
     }
 }

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 
 #include "agg_image.h"
+#include "dialog.h"
 #include "icn.h"
 #include "image.h"
 #include "math_base.h"
@@ -98,5 +99,24 @@ namespace fheroes2
             renderWindowBackground( display, { 0, mainMenuBackground.y() + mainMenuBackground.height(), display.width(),
                                                display.height() - mainMenuBackground.y() - mainMenuBackground.height() } );
         }
+    }
+
+    Point drawButtonPanel()
+    {
+        const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
+        const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
+
+        const uint32_t panelOffset = fheroes2::Display::DEFAULT_HEIGHT - panel.height();
+        const uint32_t panelXPos = back.width() + back.x() - ( panel.width() + panelOffset );
+        fheroes2::Blit( panel, fheroes2::Display::instance(), panelXPos, panelOffset + back.y() );
+
+        const int32_t buttonMiddlePos = panelXPos + SHADOWWIDTH + ( panel.width() - SHADOWWIDTH ) / 2;
+
+        const fheroes2::Sprite & buttonSample = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 0 );
+        const int32_t buttonWidth = buttonSample.width();
+        const int32_t buttonXPos = buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
+        const int32_t buttonYPos = 46 + back.y();
+
+        return { buttonXPos, buttonYPos };
     }
 }

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -20,11 +20,13 @@
 
 #include "game_mainmenu_ui.h"
 
+#include <algorithm>
 #include <cstdint>
 
 #include "agg_image.h"
 #include "icn.h"
 #include "image.h"
+#include "math_base.h"
 #include "screen.h"
 #include "settings.h"
 

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -26,25 +26,65 @@
 #include "icn.h"
 #include "image.h"
 #include "screen.h"
+#include "settings.h"
+
+namespace
+{
+    void drawSprite( fheroes2::Image & output, const int icnId, const uint32_t index )
+    {
+        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icnId, index );
+        fheroes2::Blit( sprite, 0, 0, output, sprite.x(), sprite.y(), sprite.width(), sprite.height() );
+    }
+
+    void renderWindowBackground( fheroes2::Image & output, const fheroes2::Rect roi )
+    {
+        if ( roi.width == 0 || roi.height == 0 ) {
+            // Nothing to render.
+            return;
+        }
+
+        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
+
+        const fheroes2::Sprite & background = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+
+        const int32_t stepX = ( roi.width + background.width() ) / background.width();
+        const int32_t stepY = ( roi.height + background.height() ) / background.height();
+
+        fheroes2::Point offset{ roi.x, roi.y };
+
+        for ( int y = 0; y < stepY; ++y ) {
+            offset.x = roi.x;
+
+            const int32_t height = std::min( background.height(), roi.height - y * background.height() );
+
+            for ( int x = 0; x < stepY; ++x ) {
+                fheroes2::Copy( background, 0, 0, output, offset.x, offset.y, std::min( background.width(), roi.width - x * background.width() ), height );
+
+                offset.x += background.width();
+            }
+
+            offset.y += background.height();
+        }
+    }
+}
 
 namespace fheroes2
 {
-    void drawSprite( Display & display, const int icnId, const uint32_t index )
-    {
-        const Sprite & sprite = AGG::GetICN( icnId, index );
-        Blit( sprite, 0, 0, display, sprite.x(), sprite.y(), sprite.width(), sprite.height() );
-    }
-
     void drawMainMenuScreen()
     {
         Display & display = Display::instance();
 
-        Copy( AGG::GetICN( ICN::HEROES, 0 ), display );
+        const Sprite & mainMenuBackground = AGG::GetICN( ICN::HEROES, 0 );
+        Copy( mainMenuBackground, 0, 0, display, mainMenuBackground.x(), mainMenuBackground.y(), mainMenuBackground.width(), mainMenuBackground.height() );
 
         drawSprite( display, ICN::BTNSHNGL, 1 );
         drawSprite( display, ICN::BTNSHNGL, 5 );
         drawSprite( display, ICN::BTNSHNGL, 9 );
         drawSprite( display, ICN::BTNSHNGL, 13 );
         drawSprite( display, ICN::BTNSHNGL, 17 );
+
+        renderWindowBackground( display, { 0, 0, mainMenuBackground.x(), display.height() } );
+        renderWindowBackground( display, { mainMenuBackground.x() + mainMenuBackground.width(), 0, display.width() - mainMenuBackground.x() - mainMenuBackground.width(),
+                                display.height() } );
     }
 }

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -57,7 +57,7 @@ namespace
 
             const int32_t height = std::min( background.height(), roi.height - y * background.height() );
 
-            for ( int x = 0; x < stepY; ++x ) {
+            for ( int x = 0; x < stepX; ++x ) {
                 fheroes2::Copy( background, 0, 0, output, offset.x, offset.y, std::min( background.width(), roi.width - x * background.width() ), height );
 
                 offset.x += background.width();

--- a/src/fheroes2/game/game_mainmenu_ui.h
+++ b/src/fheroes2/game/game_mainmenu_ui.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_mainmenu_ui.h
+++ b/src/fheroes2/game/game_mainmenu_ui.h
@@ -20,7 +20,11 @@
 
 #pragma once
 
+#include "math_base.h"
+
 namespace fheroes2
 {
     void drawMainMenuScreen();
+
+    Point drawButtonPanel();
 }

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -77,7 +77,7 @@ namespace
         const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
 
         const uint32_t panelOffset = fheroes2::Display::DEFAULT_HEIGHT - panel.height();
-        const uint32_t panelXPos = back.width() - ( panel.width() + panelOffset );
+        const uint32_t panelXPos = back.width() + back.x() - ( panel.width() + panelOffset );
         fheroes2::Blit( panel, fheroes2::Display::instance(), panelXPos, panelOffset );
 
         const int32_t buttonMiddlePos = panelXPos + SHADOWWIDTH + ( panel.width() - SHADOWWIDTH ) / 2;

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -52,7 +52,6 @@
 #include "image.h"
 #include "localevent.h"
 #include "logging.h"
-#include "game_mainmenu_ui.h"
 #include "maps_fileinfo.h"
 #include "math_base.h"
 #include "mus.h"

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -52,6 +52,7 @@
 #include "image.h"
 #include "localevent.h"
 #include "logging.h"
+#include "game_mainmenu_ui.h"
 #include "maps_fileinfo.h"
 #include "math_base.h"
 #include "mus.h"
@@ -69,26 +70,6 @@
 namespace
 {
     const int32_t buttonYStep = 66;
-
-    // Draw button panel and return the position for a button.
-    fheroes2::Point drawButtonPanel()
-    {
-        const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
-        const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
-
-        const uint32_t panelOffset = fheroes2::Display::DEFAULT_HEIGHT - panel.height();
-        const uint32_t panelXPos = back.width() + back.x() - ( panel.width() + panelOffset );
-        fheroes2::Blit( panel, fheroes2::Display::instance(), panelXPos, panelOffset );
-
-        const int32_t buttonMiddlePos = panelXPos + SHADOWWIDTH + ( panel.width() - SHADOWWIDTH ) / 2;
-
-        const fheroes2::Sprite & buttonSample = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 0 );
-        const int32_t buttonWidth = buttonSample.width();
-        const int32_t buttonXPos = buttonMiddlePos - buttonWidth / 2 - 3; // 3 is button shadow
-        const int32_t buttonYPos = 46;
-
-        return fheroes2::Point( buttonXPos, buttonYPos );
-    }
 
     std::unique_ptr<SMKVideoSequence> getVideo( const std::string & fileName )
     {
@@ -210,7 +191,7 @@ fheroes2::GameMode Game::CampaignSelection()
     outputNewCampaignSelectionInTextSupportMode();
 
     fheroes2::drawMainMenuScreen();
-    const fheroes2::Point buttonPos = drawButtonPanel();
+    const fheroes2::Point buttonPos = fheroes2::drawButtonPanel();
 
     fheroes2::Button buttonSuccessionWars( buttonPos.x, buttonPos.y, ICN::BUTTON_ORIGINAL_CAMPAIGN, 0, 1 );
     fheroes2::Button buttonPriceOfLoyalty( buttonPos.x, buttonPos.y + buttonYStep * 1, ICN::BUTTON_EXPANSION_CAMPAIGN, 0, 1 );
@@ -479,7 +460,7 @@ fheroes2::GameMode Game::NewNetwork()
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     fheroes2::drawMainMenuScreen();
-    const fheroes2::Point buttonPos = drawButtonPanel();
+    const fheroes2::Point buttonPos = fheroes2::drawButtonPanel();
 
     fheroes2::Button buttonHost( buttonPos.x, buttonPos.y, ICN::BTNNET, 0, 1 );
     fheroes2::Button buttonGuest( buttonPos.x, buttonPos.y + buttonYStep, ICN::BTNNET, 2, 3 );
@@ -532,7 +513,7 @@ fheroes2::GameMode Game::NewGame()
     fheroes2::Display & display = fheroes2::Display::instance();
 
     fheroes2::drawMainMenuScreen();
-    const fheroes2::Point buttonPos = drawButtonPanel();
+    const fheroes2::Point buttonPos = fheroes2::drawButtonPanel();
 
     fheroes2::Button buttonStandardGame( buttonPos.x, buttonPos.y, ICN::BUTTON_STANDARD_GAME, 0, 1 );
     fheroes2::ButtonSprite buttonCampaignGame( buttonPos.x, buttonPos.y + buttonYStep * 1, fheroes2::AGG::GetICN( ICN::BUTTON_CAMPAIGN_GAME, 0 ),
@@ -612,7 +593,7 @@ fheroes2::GameMode Game::NewMulti()
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     fheroes2::drawMainMenuScreen();
-    const fheroes2::Point buttonPos = drawButtonPanel();
+    const fheroes2::Point buttonPos = fheroes2::drawButtonPanel();
 
     fheroes2::Button buttonHotSeat( buttonPos.x, buttonPos.y, ICN::BUTTON_HOT_SEAT, 0, 1 );
     fheroes2::Button buttonNetwork( buttonPos.x, buttonPos.y + buttonYStep * 1, ICN::BTNMP, 2, 3 );
@@ -653,7 +634,7 @@ uint32_t Game::SelectCountPlayers()
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     fheroes2::drawMainMenuScreen();
-    const fheroes2::Point buttonPos = drawButtonPanel();
+    const fheroes2::Point buttonPos = fheroes2::drawButtonPanel();
 
     fheroes2::Button button2Players( buttonPos.x, buttonPos.y, ICN::BUTTON_2_PLAYERS, 0, 1 );
     fheroes2::Button button3Players( buttonPos.x, buttonPos.y + buttonYStep * 1, ICN::BUTTON_3_PLAYERS, 0, 1 );


### PR DESCRIPTION
This change might be not the best approach we could do but it does not stretch the main menu, avoiding button shifting issues and also serves as an indicator for widscreen resolutions.

![image](https://user-images.githubusercontent.com/19829520/236610978-c0df9d69-b686-42d6-be77-c76fbc5ad7ed.png)

![image](https://user-images.githubusercontent.com/19829520/236615231-a763f020-e52b-4b5a-bd37-751f6e418a42.png)

![image](https://user-images.githubusercontent.com/19829520/236636181-c3b5b350-615d-4918-9f7c-779f68567459.png)


close #7045
close #7014
relates to #4384