### PR TITLE
Fix an issue that caused an AI-controlled hero standing next to Stone Liths to block the path of another AI-controlled hero standing on these Stone Liths

### DIFF
--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -176,6 +176,12 @@ namespace Maps
             return _hasObjectAnimation;
         }
 
+        // Checks whether it is possible to move into this tile from the specified direction
+        bool isPassableFrom( const int direction ) const
+        {
+            return ( direction & tilePassable ) != 0;
+        }
+
         // Checks whether it is possible to move into this tile from the specified direction under the specified conditions
         bool isPassableFrom( const int direction, const bool fromWater, const bool skipFog, const int heroColor ) const;
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -912,6 +912,13 @@ bool AIWorldPathfinder::isHeroPossiblyBlockingWay( const Heroes & hero )
         return true;
     }
 
+    // Is the hero standing near the Stone Liths that are occupied by another hero?
+    for ( const int32_t idx : Maps::ScanAroundObject( heroIndex, MP2::OBJ_STONE_LITHS ) ) {
+        if ( world.GetTiles( idx ).GetObject() == MP2::OBJ_HEROES ) {
+            return true;
+        }
+    }
+
     // Is the hero standing on Stone Liths?
     return world.GetTiles( heroIndex ).GetObject( false ) == MP2::OBJ_STONE_LITHS;
 }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -774,8 +774,10 @@ int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero )
             continue;
         }
 
-        // Tile is reachable and the hero has enough army to defeat potential guards
-        if ( _cache[newIndex]._cost > 0 ) {
+        const WorldNode & node = _cache[newIndex];
+
+        // Tile is directly reachable (in one move) and the hero has enough army to defeat potential guards
+        if ( node._cost > 0 && node._from == start ) {
             return newIndex;
         }
     }

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -915,6 +915,13 @@ bool AIWorldPathfinder::isHeroPossiblyBlockingWay( const Heroes & hero )
 
     const Maps::Tiles & heroTile = world.GetTiles( heroIndex );
 
+    // Hero in the boat can neither occupy nor block the Stone Liths
+    if ( heroTile.isWater() ) {
+        assert( heroTile.GetObject( false ) != MP2::OBJ_STONE_LITHS );
+
+        return false;
+    }
+
     // Does the hero potentially block the exit from Stone Liths for another hero?
     for ( const int32_t idx : Maps::ScanAroundObject( heroIndex, MP2::OBJ_STONE_LITHS ) ) {
         const Maps::Tiles & tile = world.GetTiles( idx );


### PR DESCRIPTION
fix #7138
fix #7140

At first I thought to limit the case to checking only friendly heroes nearby, but then I decided that all AI-controlled heroes should behave "like a gentleman" with enemy ones and give way to them, if it turns out that neither of them has an advantage and does not dare to attack the other.