### PR TITLE
Fix idle animation lag while casting a spell on the Battlefield

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1382,6 +1382,9 @@ void Battle::Interface::RedrawInterface()
 
 void Battle::Interface::RedrawArmies()
 {
+    // Continue the idle animation for all troops on the battlefield: update idle animation frames before rendering the troops.
+    IdleTroopsAnimation();
+
     const Castle * castle = Arena::GetCastle();
 
     const int32_t wallCellIds[ARENAH]
@@ -1636,9 +1639,6 @@ void Battle::Interface::RedrawArmies()
     if ( _flyingUnit ) {
         RedrawTroopSprite( *_flyingUnit );
     }
-
-    // Continue the idle animation for all troops on the battlefield.
-    IdleTroopsAnimation();
 }
 
 void Battle::Interface::RedrawOpponents()
@@ -3240,15 +3240,13 @@ void Battle::Interface::AnimateOpponents( OpponentSprite * target )
 
     LocalEvent & le = LocalEvent::Get();
 
-    // Do not wait to render the first frame of hero animation as previous one is already rendered.
-    Game::passAnimationDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
+    // We need to wait the delay before rendering the first frame of hero animation.
+    Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
 
+    // 'BATTLE_OPPONENTS_DELAY' is more than 2 times the value of 'BATTLE_IDLE_DELAY', so we need to handle the idle animation separately in this loop.
     while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_OPPONENTS_DELAY, Game::BATTLE_IDLE_DELAY } ) ) ) {
         // Animate the idling units.
-        if ( Game::validateAnimationDelay( Game::BATTLE_IDLE_DELAY ) ) {
-            // 'validateAnimationDelay()' resets the delay. We pass it as the same check is done during `Redraw()` and we need to do IDLE animation.
-            Game::passAnimationDelay( Game::DelayType::BATTLE_IDLE_DELAY );
-
+        if ( IdleTroopsAnimation() ) {
             Redraw();
         }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3240,7 +3240,7 @@ void Battle::Interface::AnimateOpponents( OpponentSprite * target )
 
     LocalEvent & le = LocalEvent::Get();
 
-    // We need to wait the delay before rendering the first frame of hero animation.
+    // We need to wait this delay before rendering the first frame of hero animation.
     Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
 
     // 'BATTLE_OPPONENTS_DELAY' is more than 2 times the value of 'BATTLE_IDLE_DELAY', so we need to handle the idle animation separately in this loop.
@@ -3251,7 +3251,7 @@ void Battle::Interface::AnimateOpponents( OpponentSprite * target )
         }
 
         if ( Game::validateAnimationDelay( Game::BATTLE_OPPONENTS_DELAY ) ) {
-            // Render the first frame before waiting any delay.
+            // Render before switching to the next frame.
             Redraw();
 
             if ( target->isFinishFrame() ) {


### PR DESCRIPTION
This PR fixes the idle animation lag while hero is moving his arm to cast a spell and after casting it.

Master build:

https://user-images.githubusercontent.com/113276641/236998990-31d6ec52-2c9c-4b0d-b455-edf2b1529c7b.mp4


This PR:

https://user-images.githubusercontent.com/113276641/236998614-e8abdea6-9390-4497-aeec-3842c2c5ae2e.mp4

