### PR TITLE
Use 22050 sound sample rate for PS Vita to fix high CPU load

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -55,8 +55,13 @@ namespace
 {
     struct AudioSpec
     {
+#if defined( TARGET_PS_VITA )
+        // Notice: The PS Vita sound resampler is CPU intensive if the value is not 22050.
+        int frequency = 22050;
+#else
         // Notice: Value 22050 causes music distortion on Windows.
         int frequency = 44100;
+#endif
         uint16_t format = AUDIO_S16;
         // Stereo audio support
         int channels = 2;


### PR DESCRIPTION
Fix #7176
On the battlefield on high speed the move sound is played for every cell move which ends in multiple simultaneous sound playbacks. The PS Vita sound resampler loads the CPU to resample and play these sounds. This result in game lags and jerky animation.