### PR TITLE
Optimize CPU load while Battlefield rendering

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1261,7 +1261,7 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     _mainSurface.resize( area.width, battlefieldHeight );
     _battleGround.resize( area.width, battlefieldHeight );
 
-    // As `_battleGround` and '_mainSurface' are used to prepare battlefield screen to render on display they does not need to have a transform layer.
+    // As `_battleGround` and '_mainSurface' are used to prepare battlefield screen to render on display they do not need to have a transform layer.
     _battleGround._disableTransformLayer();
     _mainSurface._disableTransformLayer();
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1273,7 +1273,7 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     _mainSurface._disableTransformLayer();
 
     // Prepare the Battlefield ground.
-    _redrawBattleGround( conf );
+    _redrawBattleGround();
 
     AudioManager::ResetAudio();
 
@@ -1890,9 +1890,7 @@ void Battle::Interface::RedrawTroopCount( const Unit & unit )
 
 void Battle::Interface::RedrawCover()
 {
-    const Settings & conf = Settings::Get();
-
-    _redrawCoverStatic( conf );
+    _redrawCoverStatic();
 
     const Bridge * bridge = Arena::GetBridge();
     if ( bridge && ( bridge->isDown() || _bridgeAnimation.animationIsRequired ) ) {
@@ -1909,7 +1907,7 @@ void Battle::Interface::RedrawCover()
     const Cell * cell = Board::GetCell( index_pos );
     const int cursorType = Cursor::Get().Themes();
 
-    if ( cell && _currentUnit && conf.BattleShowMouseShadow() ) {
+    if ( cell && _currentUnit && Settings::Get().BattleShowMouseShadow() ) {
         std::set<const Cell *> highlightedCells;
 
         if ( humanturn_spell.isValid() ) {
@@ -2089,7 +2087,7 @@ void Battle::Interface::RedrawCover()
     }
 }
 
-void Battle::Interface::_redrawBattleGround( const Settings & conf )
+void Battle::Interface::_redrawBattleGround()
 {
     // Battlefield background image.
     if ( icn_cbkg != ICN::UNKNOWN ) {
@@ -2150,7 +2148,7 @@ void Battle::Interface::_redrawBattleGround( const Settings & conf )
     }
 
     // Battlefield grid.
-    if ( conf.BattleShowGrid() ) {
+    if ( Settings::Get().BattleShowGrid() ) {
         const Board & board = *Arena::GetBoard();
 
         for ( const Cell & cell : board ) {
@@ -2170,9 +2168,11 @@ void Battle::Interface::_redrawBattleGround( const Settings & conf )
     }
 }
 
-void Battle::Interface::_redrawCoverStatic( const Settings & conf )
+void Battle::Interface::_redrawCoverStatic()
 {
     fheroes2::Copy( _battleGround, _mainSurface );
+
+    const Settings & conf = Settings::Get();
 
     // Movement shadow.
     if ( !_movingUnit && conf.BattleShowMoveShadow() && _currentUnit && !( _currentUnit->GetCurrentControl() & CONTROL_AI ) ) {
@@ -3060,7 +3060,7 @@ void Battle::Interface::_openBattleSettingsDialog()
 
     if ( showGrid != conf.BattleShowGrid() ) {
         // The grid setting has changed. Update for the Battlefield ground.
-        _redrawBattleGround( conf );
+        _redrawBattleGround();
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1355,9 +1355,6 @@ void Battle::Interface::RedrawPartialStart()
 
 void Battle::Interface::RedrawPartialFinish()
 {
-    fheroes2::Time counter;
-    counter.reset();
-
     fheroes2::Display & display = fheroes2::Display::instance();
 
     if ( Settings::Get().BattleShowArmyOrder() ) {
@@ -1378,9 +1375,6 @@ void Battle::Interface::RedrawPartialFinish()
 
     fheroes2::Copy( _mainSurface, 0, 0, display, _interfacePosition.x, _interfacePosition.y, _mainSurface.width(), _mainSurface.height() );
 
-    double tmp = counter.getS() * 1000;
-    COUT( "RedrawPartialFinish render: " << tmp << " ms." )
-
     RedrawInterface();
 
     display.render();
@@ -1388,9 +1382,6 @@ void Battle::Interface::RedrawPartialFinish()
 
 void Battle::Interface::RedrawInterface()
 {
-    fheroes2::Time counter;
-    counter.reset();
-
     status.Redraw( fheroes2::Display::instance() );
 
     btn_auto.draw();
@@ -1402,16 +1393,10 @@ void Battle::Interface::RedrawInterface()
     if ( listlog && listlog->isOpenLog() ) {
         listlog->Redraw();
     }
-
-    double tmp = counter.getS() * 1000;
-    COUT( "RedrawInterface render: " << tmp << " ms." )
 }
 
 void Battle::Interface::RedrawArmies()
 {
-    fheroes2::Time counter;
-    counter.reset();
-
     // Continue the idle animation for all troops on the battlefield: update idle animation frames before rendering the troops.
     IdleTroopsAnimation();
 
@@ -1669,8 +1654,6 @@ void Battle::Interface::RedrawArmies()
     if ( _flyingUnit ) {
         RedrawTroopSprite( *_flyingUnit );
     }
-    double tmp = counter.getS() * 1000;
-    COUT( "RedrawArmies render: " << tmp << " ms." )
 }
 
 void Battle::Interface::RedrawOpponents()
@@ -1903,17 +1886,10 @@ void Battle::Interface::RedrawTroopCount( const Unit & unit )
 
 void Battle::Interface::RedrawCover()
 {
-    fheroes2::Time counter;
-    counter.reset();
-
     const Settings & conf = Settings::Get();
     const Board & board = *Arena::GetBoard();
 
     RedrawCoverStatic( conf, board );
-
-    double tmp = counter.getS() * 1000;
-    COUT( "RedrawCoverStatic render: " << tmp << " ms." )
-    counter.reset();
 
     const Bridge * bridge = Arena::GetBridge();
     if ( bridge && ( bridge->isDown() || _bridgeAnimation.animationIsRequired ) ) {
@@ -2112,9 +2088,6 @@ void Battle::Interface::RedrawCover()
             }
         }
     }
-
-    tmp = counter.getS() * 1000;
-    COUT( "RedrawCover render: " << tmp << " ms." )
 }
 
 void Battle::Interface::redrawBattleGround( const Settings & conf, const Board & board )

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -332,8 +332,8 @@ namespace Battle
         void HumanCastSpellTurn( const Unit & /* unused */, Actions & actions, std::string & msg );
 
         void RedrawCover();
-        void _redrawBattleGround( const Settings & conf );
-        void _redrawCoverStatic( const Settings & conf );
+        void _redrawBattleGround();
+        void _redrawCoverStatic();
         void RedrawLowObjects( const int32_t cellId );
         void RedrawHighObjects( const int32_t cellId );
         void RedrawCastle( const Castle & castle, const int32_t cellId );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -46,7 +46,6 @@ class Castle;
 class HeroBase;
 class Kingdom;
 class LocalEvent;
-class Settings;
 
 namespace fheroes2
 {

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -293,7 +293,6 @@ namespace Battle
 
         void SetStatus( const std::string &, bool = false );
         void SetOrderOfUnits( const std::shared_ptr<const Units> & units );
-
         void FadeArena( bool clearMessageLog );
 
         void RedrawActionNewTurn() const;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -293,6 +293,7 @@ namespace Battle
 
         void SetStatus( const std::string &, bool = false );
         void SetOrderOfUnits( const std::shared_ptr<const Units> & units );
+
         void FadeArena( bool clearMessageLog );
 
         void RedrawActionNewTurn() const;
@@ -332,6 +333,7 @@ namespace Battle
         void HumanCastSpellTurn( const Unit &, Actions &, std::string & );
 
         void RedrawCover();
+        void redrawBattleGround( const Settings & conf, const Board & board );
         void RedrawCoverStatic( const Settings & conf, const Board & board );
         void RedrawLowObjects( int32_t );
         void RedrawHighObjects( int32_t );
@@ -403,10 +405,13 @@ namespace Battle
         fheroes2::Rect _interfacePosition;
         fheroes2::Rect _surfaceInnerArea;
         fheroes2::Image _mainSurface;
+        fheroes2::Image _battleGround;
         fheroes2::Image _hexagonGrid;
         fheroes2::Image _hexagonShadow;
         fheroes2::Image _hexagonGridShadow;
         fheroes2::Image _hexagonCursorShadow;
+
+        bool _updateBattleGround{ true };
 
         int icn_cbkg;
         int icn_frng;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -332,8 +332,8 @@ namespace Battle
         void HumanCastSpellTurn( const Unit &, Actions &, std::string & );
 
         void RedrawCover();
-        void redrawBattleGround( const Settings & conf, const Board & board );
-        void RedrawCoverStatic( const Settings & conf, const Board & board );
+        void _redrawBattleGround( const Settings & conf );
+        void _redrawCoverStatic( const Settings & conf );
         void RedrawLowObjects( int32_t );
         void RedrawHighObjects( int32_t );
         void RedrawCastle( const Castle &, int32_t );
@@ -388,6 +388,7 @@ namespace Battle
 
         void EventAutoSwitch( const Unit &, Actions & );
         void EventAutoFinish( Actions & a );
+        void _openBattleSettingsDialog();
         void EventShowOptions();
         void ButtonAutoAction( const Unit &, Actions & );
         void ButtonSettingsAction();
@@ -409,8 +410,6 @@ namespace Battle
         fheroes2::Image _hexagonShadow;
         fheroes2::Image _hexagonGridShadow;
         fheroes2::Image _hexagonCursorShadow;
-
-        bool _updateBattleGround{ true };
 
         int icn_cbkg;
         int icn_frng;


### PR DESCRIPTION
This PR relates to #7176 issue and optimizes the Battlefield render:
- render Battlefield background only when it is changed (grid on/off) and cache it;
- use `fheroes2::Copy()` instead of `fheroes2::Blit()` where possible:
  - when preparing the Battlefield background;
  - on every render when drawing the rectangle images without transparency (count background, status bar background, ...);
  - during DeathWave and EarthQuake spell effects.

Full render time for the Castle battlefield: 1.5 -> 0.85 ms
Full render time for the "Ship" battlefield, used in Battle only" mode: 1.0 -> 0.6 ms. 
<details><summary>Render time for optimized parts for the "Ship" battlefield</summary> 

```
RedrawCoverStatic render time:   0.2916 ms. -> 0.0443 ms.
RedrawPartialFinish render time: 0.1684 ms. -> 0.0142 ms.
RedrawInterface render time:     0.0159 ms. -> 0.0052 ms.
```

</details>