### PR TITLE
Fix cases when AI ignores some objects during path evaluation

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -46,8 +46,11 @@ namespace AI
     void Normal::revealFog( const Maps::Tiles & tile )
     {
         const MP2::MapObjectType object = tile.GetObject();
-        if ( object != MP2::OBJ_NONE )
-            _mapObjects.emplace_back( tile.GetIndex(), object );
+        if ( object != MP2::OBJ_NONE ) {
+            const IndexObject indexObject{ tile.GetIndex(), static_cast<int>( object ) };
+
+            _mapObjects.emplace( std::upper_bound( _mapObjects.begin(), _mapObjects.end(), indexObject ), indexObject );
+        }
     }
 
     double Normal::getTargetArmyStrength( const Maps::Tiles & tile, const MP2::MapObjectType objectType )

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -49,6 +49,8 @@ namespace AI
         if ( object != MP2::OBJ_NONE ) {
             const IndexObject indexObject{ tile.GetIndex(), static_cast<int>( object ) };
 
+            // _mapObjects must in a sorted ascending order as we use std::binary_search later in the code.
+            // std::upper_bound is used in order to find the correct spot for insertion in a sorted array.
             _mapObjects.emplace( std::upper_bound( _mapObjects.begin(), _mapObjects.end(), indexObject ), indexObject );
         }
     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1673,6 +1673,8 @@ namespace AI
             if ( !isDimensionDoor ) {
                 // Dimension door path does not include any objects on the way.
                 std::vector<IndexObject> list = _pathfinder.getObjectsOnTheWay( destination );
+                std::sort( list.begin(), list.end() );
+
                 for ( IndexObject & pair : list ) {
                     if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) ) {
                         const double extraValue = valueStorage.value( pair, 0 ); // object is on the way, we don't loose any movement points.

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1658,6 +1658,9 @@ namespace AI
         maxPriority = lowestPossibleValue;
 #ifdef WITH_DEBUG
         MP2::MapObjectType objectType = MP2::OBJ_NONE;
+
+        // If this assertion blows up then the array is not sorted and the logic below will not work as intended.
+        assert( std::is_sorted( _mapObjects.begin(), _mapObjects.end() ) );
 #endif
 
         // pre-cache the pathfinder

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1673,8 +1673,6 @@ namespace AI
             if ( !isDimensionDoor ) {
                 // Dimension door path does not include any objects on the way.
                 std::vector<IndexObject> list = _pathfinder.getObjectsOnTheWay( destination );
-                std::sort( list.begin(), list.end() );
-
                 for ( IndexObject & pair : list ) {
                     if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapObjects.begin(), _mapObjects.end(), pair ) ) {
                         const double extraValue = valueStorage.value( pair, 0 ); // object is on the way, we don't loose any movement points.


### PR DESCRIPTION
std::binary_search works only if an array is partially sorted in respect to value - https://en.cppreference.com/w/cpp/algorithm/binary_search

~~Since **getObjectsOnTheWay()** method returns unsorted array we have to sort it in order to fulfill binary search requirements.~~
**_mapObjects** wasn't been completely sorted during fog revealing events.