### PR TITLE
Resurrection spells are not a subset of restoration spells

### DIFF
--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1265,6 +1265,7 @@ void Battle::Unit::SpellModesAction( const Spell & spell, uint32_t duration, con
         break;
 
     default:
+        assert( 0 );
         break;
     }
 }
@@ -1496,6 +1497,7 @@ void Battle::Unit::SpellRestoreAction( const Spell & spell, const uint32_t spell
     }
 
     default:
+        assert( 0 );
         break;
     }
 }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -906,10 +906,12 @@ bool Battle::Unit::ApplySpell( const Spell & spell, const HeroBase * hero, Targe
 
     const uint32_t spoint = hero ? hero->GetPower() : DEFAULT_SPELL_DURATION;
 
-    if ( spell.isDamage() )
+    if ( spell.isDamage() ) {
         SpellApplyDamage( spell, spoint, hero, target );
-    else if ( spell.isRestore() )
+    }
+    else if ( spell.isRestore() || spell.isResurrect() ) {
         SpellRestoreAction( spell, spoint, hero );
+    }
     else {
         SpellModesAction( spell, spoint, hero );
     }
@@ -1267,7 +1269,7 @@ void Battle::Unit::SpellModesAction( const Spell & spell, uint32_t duration, con
     }
 }
 
-void Battle::Unit::SpellApplyDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, TargetInfo & target )
+void Battle::Unit::SpellApplyDamage( const Spell & spell, const uint32_t spellPoints, const HeroBase * hero, TargetInfo & target )
 {
     const uint32_t dmg = CalculateSpellDamage( spell, spellPoints, hero, target.damage, false /* ignore defending hero */ );
 
@@ -1453,7 +1455,7 @@ uint32_t Battle::Unit::CalculateSpellDamage( const Spell & spell, uint32_t spell
     return dmg;
 }
 
-void Battle::Unit::SpellRestoreAction( const Spell & spell, uint32_t spoint, const HeroBase * hero )
+void Battle::Unit::SpellRestoreAction( const Spell & spell, const uint32_t spellPoints, const HeroBase * hero )
 {
     switch ( spell.GetID() ) {
     case Spell::CURE:
@@ -1462,7 +1464,7 @@ void Battle::Unit::SpellRestoreAction( const Spell & spell, uint32_t spoint, con
         removeAffection( IS_BAD_MAGIC );
 
         // restore
-        hp += ( spell.Restore() * spoint );
+        hp += fheroes2::getHPRestorePoints( spell, spellPoints, hero );
         if ( hp > ArmyTroop::GetHitPoints() ) {
             hp = ArmyTroop::GetHitPoints();
         }
@@ -1478,7 +1480,7 @@ void Battle::Unit::SpellRestoreAction( const Spell & spell, uint32_t spoint, con
             graveyard->RemoveTroop( *this );
         }
 
-        const uint32_t restore = fheroes2::getResurrectPoints( spell, spoint, hero );
+        const uint32_t restore = fheroes2::getResurrectPoints( spell, spellPoints, hero );
         const uint32_t resurrect = Resurrect( restore, false, ( spell == Spell::RESURRECT ) );
 
         // Put the unit back on the board

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1272,6 +1272,8 @@ void Battle::Unit::SpellModesAction( const Spell & spell, uint32_t duration, con
 
 void Battle::Unit::SpellApplyDamage( const Spell & spell, const uint32_t spellPoints, const HeroBase * hero, TargetInfo & target )
 {
+    assert( spell.isDamage() );
+
     const uint32_t dmg = CalculateSpellDamage( spell, spellPoints, hero, target.damage, false /* ignore defending hero */ );
 
     // apply damage
@@ -1283,6 +1285,8 @@ void Battle::Unit::SpellApplyDamage( const Spell & spell, const uint32_t spellPo
 
 uint32_t Battle::Unit::CalculateSpellDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, uint32_t targetDamage, bool ignoreDefendingHero ) const
 {
+    assert( spell.isDamage() );
+
     // TODO: use fheroes2::getSpellDamage function to remove code duplication.
     uint32_t dmg = spell.Damage() * spellPoints;
 

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -183,10 +183,7 @@ namespace Battle
         std::vector<Spell> getCurrentSpellEffects() const;
         void PostAttackAction();
         void SetBlindAnswer( bool value );
-        void SpellModesAction( const Spell &, uint32_t, const HeroBase * );
-        void SpellApplyDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, TargetInfo & target );
         uint32_t CalculateSpellDamage( const Spell & spell, uint32_t spellPoints, const HeroBase * hero, uint32_t targetDamage, bool ignoreDefendingHero ) const;
-        void SpellRestoreAction( const Spell &, uint32_t, const HeroBase * );
 
         bool SwitchAnimation( int rule, bool reverse = false );
         bool SwitchAnimation( const std::vector<int> & animationList, bool reverse = false );
@@ -262,7 +259,7 @@ namespace Battle
             return idleTimer.checkDelay();
         }
 
-        // Remove temporary affection(s) (usually spell effect(s)). Multiple affections can be removed using a single call.
+        // Removes temporary affection(s) (usually spell effect(s)). Multiple affections can be removed using a single call.
         void removeAffection( const uint32_t mode );
 
         // TODO: find a better way to expose it without a million getters/setters
@@ -272,10 +269,17 @@ namespace Battle
         uint32_t ApplyDamage( const uint32_t dmg );
         uint32_t Resurrect( const uint32_t points, const bool allow_overflow, const bool skip_dead );
 
-        // Add a temporary affection (usually a spell effect) with the specified duration. Only one affection can be added.
+        // Applies a damage-causing spell to this unit
+        void SpellApplyDamage( const Spell & spell, const uint32_t spellPoints, const HeroBase * hero, TargetInfo & target );
+        // Applies a restoring or reviving spell to this unit
+        void SpellRestoreAction( const Spell & spell, const uint32_t spellPoints, const HeroBase * hero );
+        // Applies a spell to this unit that changes its parameters
+        void SpellModesAction( const Spell & spell, uint32_t duration, const HeroBase * hero );
+
+        // Adds a temporary affection (usually a spell effect) with the specified duration. Only one affection can be added.
         void addAffection( const uint32_t mode, const uint32_t duration );
 
-        // Replace some temporary affection(s) with another affection. Multiple affections can be replaced by a new one (but
+        // Replaces some temporary affection(s) with another affection. Multiple affections can be replaced by a new one (but
         // only one) with a single call.
         void replaceAffection( const uint32_t modeToReplace, const uint32_t replacementMode, const uint32_t duration );
 

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -432,7 +432,7 @@ uint32_t Spell::Restore() const
         break;
     }
 
-    return Resurrect();
+    return 0;
 }
 
 uint32_t Spell::Resurrect() const


### PR DESCRIPTION
fix #7214

![resurrect](https://github.com/ihhub/fheroes2/assets/32623900/e22a6f9b-ca24-4de0-9792-fdb6d7b387f9)
