### PR TITLE
Use an older version of the Android Gradle Plugin

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -80,8 +80,7 @@ android {
 }
 
 dependencies {
-    // TODO: version 2.0.3 does not emulate java.nio properly on Android 7 and below
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.2'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.0.3'
 
     implementation project(':isotools')
     implementation project(':sdl2')

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.0.1'
+        // TODO: AGP 8.0 has issues with desugar_jdk_libs_nio, which leads to problems with
+        // TODO: java.nio emulation in release builds on Android 7 and below
+        classpath 'com.android.tools.build:gradle:7.4.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
fix #7187

https://issuetracker.google.com/issues/279034662
https://issuetracker.google.com/issues/282544786

This issue was introduced in the Android Gradle Plugin 8.0 and should be fixed in 8.1 (currently in beta, will be available along with the new version of Android Studio). As a workaround, I rolled back to an older AGP version (7.4.2). With older AGP version, there are warnings during the desugaring stage:

```
Warning: Desugared library: Cannot amend library reference java.nio.file.Path java.nio.file.Path.of(java.net.URI) because the holder is not a library class.
Warning: Desugared library: Cannot amend library reference java.nio.file.Path java.nio.file.Path.of(java.lang.String, java.lang.String[]) because the holder is not a library class.
```

but it seems that everything works fine both in debug and release builds on Android 6 tablet that I temporarily borrowed.