### PR TITLE
Update the translation documentation

### DIFF
--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -45,27 +45,42 @@ language abbreviations. Then to have font support, you will have to specify what
 the language to the font generation code found in `src/fheroes2/gui/ui_font.cpp`. If a compatible font encoding has not currently
 been implemented, then code for that will need to be written.
 
-## Editing translations
+
+## Editing translations - Before you start
+
+Before start, you will have to prepare your working environment: fork the fheroes2 repository and prepare an application where you
+will edit your translation. Then you will have to create a branch. Now you can provide the translation. After you finish your work,
+and you are happy to share it, you will have to prepare a Pull Request.
+
+
+### Fork the fheroes2 repository
+
+https://docs.github.com/en/get-started/quickstart/fork-a-repo
+
+
+### Software to edit translation files
 
 We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](https://wiki.gnome.org/Apps/Gtranslator) to
-edit translations.
+edit translations. Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
 
-Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
 
-NOTE: The fheroes2 team has set a maximum of 400 total modified lines for any Pull Request (PR) for translations. For contributors wanting to
-add translated lines to a new language this has a maximum of 30 total modified lines for that first PR.
+## Editing translations - Your first/next translation
 
-These limitations have been set because every PR needs to be reviewed by our team, and so changing too many lines at once will only slow this
-process down. In addition, GitHub becomes increasingly difficult to navigate once too many changes, comments and so on are present within the
-same PR page, further slowing down the process of reviewing it.
+### Sync your fork
 
-Furthermore, we have decided on a minimum amount of 15 changed strings for a translation PR. For languages that have translations that are more
-or less complete, less than this amount can be accepted.
+Before you start working on the first/next translation, make sure that your fork has recent changes. To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 
-Preferably a PR should contain a small amount of changes, about 100 lines, all focused on translating a specific part of the game - for
-example creature names or castle buildings.
+### Create a branch
 
-## Build binary translation files
+Now you will create a space for your work. Brach is a special place . Read more [about branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
+
+To create a branch, please follow the GitHub's instruction about [creating a branch within your repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository)
+
+### Now provide your changes
+
+Now it is time to use your favorive software, that allows you to update the translation and suits you best.
+
+### Test your changes
 
 Once the translation files have been modified, for Linux/MacOS run the `make` command below in the `files/lang` subdirectory to create
 machine object (MO) binary files which can be used by the fheroes2 engine.
@@ -88,6 +103,38 @@ set to.
 
 For example, for German you will have to set font encoding to CP1252, while for Russian this would be CP1251. Later when submitting
 a PR with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
+
+
+### Share your work with the team
+
+When you are happy about your work, share it. The first step is to commit it into your repository. Then, create a pull request.
+
+How to [commit](https://github.com/git-guides/git-commit). 
+
+How to [create a pull request from your form your fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
+
+Try to add a meaningfull PR title, this will allow the team to quickly identify the scope of your work, ie. "Update Slovak translation".
+
+
+<details>
+
+<summary>PR restrictions</summary>
+
+The fheroes2 team has set a maximum of 400 total modified lines for any Pull Request (PR) for translations. For contributors wanting to
+add translated lines to a new language this has a maximum of 30 total modified lines for that first PR.
+
+These limitations have been set because every PR needs to be reviewed by our team, and so changing too many lines at once will only slow this
+process down. In addition, GitHub becomes increasingly difficult to navigate once too many changes, comments and so on are present within the
+same PR page, further slowing down the process of reviewing it.
+
+Furthermore, we have decided on a minimum amount of 15 changed strings for a translation PR. For languages that have translations that are more
+or less complete, less than this amount can be accepted.
+
+Preferably a PR should contain a small amount of changes, about 100 lines, all focused on translating a specific part of the game - for
+example creature names or castle buildings.
+
+</details>
+
 
 ## Updating PO templates and translatable strings in PO files
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -27,15 +27,6 @@ subdirectory of the project source tree. The current instruction is designed for
 ![Ukrainian](https://img.shields.io/endpoint?url=https://ihhub.github.io/fheroes2/json/lang_uk.json)
 ![Vietnamese](https://img.shields.io/endpoint?url=https://ihhub.github.io/fheroes2/json/lang_vi.json)
 
-## Finding translatable strings in the codebase
-
-Translatable strings can be found in the source code as arguments to the `_` function (a short name for `gettext`),
-`_n` function (a short name for `ngettext`) and `gettext_noop` function used only as indicator for the future string
-translation. The string below, for example, can be translated in PO files:
-
-```cpp
-_( "Are you sure you want to quit?" )
-```
 
 ## Adding new translations/localizations
 
@@ -72,13 +63,24 @@ Before you start working on the first/next translation, make sure that your fork
 
 ### Create a branch
 
-Now you will create a space for your work. Brach is a special place . Read more [about branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
+Now you will create a space for your work. Brach is a special place where you can safely prepare, test and share your changes. Read more [about branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
 
-To create a branch, please follow the GitHub's instruction about [creating a branch within your repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository)
+To create a branch, please follow the GitHub's instruction about [creating a branch within your repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
 
 ### Now provide your changes
 
-Now it is time to use your favorive software, that allows you to update the translation and suits you best.
+Now it is time to use your favourite software, which allows you to update the translation and suits you best.
+
+
+#### Finding translatable strings in the codebase
+
+Translatable strings can be found in the source code as arguments to the `_` function (a short name for `gettext`),
+`_n` function (a short name for `ngettext`) and `gettext_noop` function used only as indicator for the future string
+translation. The string below, for example, can be translated in PO files:
+
+```cpp
+_( "Are you sure you want to quit?" )
+```
 
 ### Test your changes
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -108,7 +108,8 @@ a PR with your changes, you will have to save the PO file in UTF-8 encoding beca
 
 ### Share your work with the team
 
-When you are happy about your work, share it. The first step is to commit it into your repository. Then, create a pull request.
+When you are happy about your work, share it. The first step is to commit your work into your fork. Then, create a pull request that 
+introduces your changes into the fheroes2 repository.
 
 How to [commit](https://github.com/git-guides/git-commit). 
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -105,7 +105,7 @@ a pull request with your changes, you will have to save the PO file in UTF-8 enc
 ### Sharing your translation work
 
 When you are satisfied with your work, you can proceed with sharing it. The first step is to commit your work into the branch you made of 
-your own fheroes2 fork. Then, create a PR that proposes to introduce your changes into the fheroes2 repository.
+your own fheroes2 fork. Then, create a pull request that proposes to introduce your changes into the fheroes2 repository.
 
 How to [**commit**](https://github.com/git-guides/git-commit). 
 
@@ -116,19 +116,19 @@ your work, I.E. "Update the Slovak translation".
 
 <details>
 
-<summary>Pull request (PR) restrictions</summary>
+<summary>Pull request restrictions</summary>
 
-The fheroes2 team has set a maximum of 400 total modified lines for any PR for translations. For contributors wanting to
-add translated lines to a new language this has a maximum of 30 total modified lines for that first PR.
+The fheroes2 team has set a maximum of 400 total modified lines for any pull request for translations. For contributors wanting to
+add translated lines to a new language this has a maximum of 30 total modified lines for that first pull request.
 
-These limitations have been set because every PR needs to be reviewed by our team, and so changing too many lines at once will only slow this
+These limitations have been set because every pull request needs to be reviewed by our team, and so changing too many lines at once will only slow this
 process down. In addition, GitHub becomes increasingly difficult to navigate once too many changes, comments and so on are present within the
-same PR page, further slowing down the process of reviewing it.
+same pull request page, further slowing down the process of reviewing it.
 
-Furthermore, we have decided on a minimum amount of 15 changed strings for a translation PR. For languages that have translations that are more
+Furthermore, we have decided on a minimum amount of 15 changed strings for a translation pull request. For languages that have translations that are more
 or less complete, less than this amount can be accepted.
 
-Preferably a PR should contain a small amount of changes, about 100 lines, all focused on translating a specific part of the game - for
+Preferably a pull request should contain a small amount of changes, about 100 lines, all focused on translating a specific part of the game - for
 example creature names or castle buildings.
 
 </details>

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -3,7 +3,7 @@
 This project uses portable object (PO) files to handle localization in various languages. The PO files are located in the `files/lang`
 subdirectory of the project source tree. The current instruction is designed for Linux, MacOS and Windows users.
 
-# Current status
+## Current status
 
 ![Belarusian](https://img.shields.io/endpoint?url=https://ihhub.github.io/fheroes2/json/lang_be.json)
 ![Bulgarian](https://img.shields.io/endpoint?url=https://ihhub.github.io/fheroes2/json/lang_bg.json)
@@ -28,7 +28,7 @@ subdirectory of the project source tree. The current instruction is designed for
 ![Vietnamese](https://img.shields.io/endpoint?url=https://ihhub.github.io/fheroes2/json/lang_vi.json)
 
 
-# Adding new translations/localizations
+## Adding new translations/localizations
 
 If you want to add a new localization, you will first need to add it to the `SupportedLanguage` list/enumeration in the source code.
 Afterwards, a new PO file for it will need to be added. It will have to be named according to the ISO standard's two-character
@@ -37,51 +37,51 @@ the language to the font generation code found in `src/fheroes2/gui/ui_font.cpp`
 been implemented, then code for that will need to be written.
 
 
-# Editing translations - Before you start
+## Editing translations - Before you start
 
 Before start, you will have to prepare your working environment: fork the fheroes2 repository and prepare an application where you
 will edit your translation. Then you will have to create a branch. Now you can provide the translation. After you finish your work,
-and you are happy to share it, you will have to prepare a Pull Request.
+and you are happy to share it, you will have to prepare a pull request.
 
 
-## Fork the fheroes2 repository
+### Fork the fheroes2 repository
 
-A fork is your copy of the fheroes2 repository. It gives you a safe space to prepare and test your changes. You can read here how to [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+A fork is your copy of the fheroes2 repository. It gives you a safe space to prepare and test your changes.
+You can read here how to [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 
-## Software to edit translation files
+### Software to edit translation files
 
 We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](https://wiki.gnome.org/Apps/Gtranslator) to
 edit translations. Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
 
 
-# Editing translations - Your first or next translation
+## Editing translations - Your first or next translation
 
-## Sync your fork
+### Sync your fork
 
 Before you start working on the first or next translation, make sure that your fork has all recent changes for the fhereos2 repo. To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 
-## Create a branch
+### Create a branch
 
-Now create a space for your work where you can safely prepare, test and share your changes. Read more [about branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
+Now create a space for your work where you can safely prepare, test and share your changes. Read more [**about branches**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
 
-To create a branch, please follow the GitHub's instruction about [creating a branch within your repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
+To create a branch, please follow the GitHub's instruction about [**creating a branch within your repo**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
 
-## Now provide your changes
+### Now provide your translations
 
 Now it is time to use your favourite software, which allows you to update the translation and suits you best.
 
-### Finding translatable strings in the codebase
+#### Finding translatable strings in the codebase
 
-Translatable strings can be found in the source code as arguments to the `_` function (a short name for `gettext`),
-`_n` function (a short name for `ngettext`) and `gettext_noop` function used only as indicator for the future string
-translation. The string below, for example, can be translated in PO files:
+All original translatable strings are located in the source code of the project. If you need to clarify where this string is being used
+you can search for it. The string below, for example, can be translated in PO files:
 
 ```cpp
 _( "Are you sure you want to quit?" )
 ```
 
-## Test your changes
+### Test your changes
 
 Once the translation files have been modified, for Linux/MacOS run the `make` command below in the `files/lang` subdirectory to create
 machine object (MO) binary files which can be used by the fheroes2 engine.
@@ -103,26 +103,26 @@ the program will need to be set to compile the MO file in the font encoding/Char
 set to.
 
 For example, for German you will have to set font encoding to CP1252, while for Russian this would be CP1251. Later when submitting
-a PR with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
+a pull request with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
 
 
-## Share your work with the team
+### Share your work with the team
 
 When you are happy about your work, share it. The first step is to commit your work into your fork. Then, create a pull request that 
 introduces your changes into the fheroes2 repository.
 
-How to [commit](https://github.com/git-guides/git-commit). 
+How to [**commit**](https://github.com/git-guides/git-commit). 
 
-How to [create a pull request from your form your fork](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
+How to [**create a pull request from your form your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
 
-Try to add a meaningfull PR title, this will allow the team to quickly identify the scope of your work, ie. "Update Slovak translation".
+Try to add a meaningfull pull request title, this will allow the team to quickly identify the scope of your work, ie. "Update Slovak translation".
 
 
 <details>
 
-<summary>PR restrictions</summary>
+<summary>Pull request (PR) restrictions</summary>
 
-The fheroes2 team has set a maximum of 400 total modified lines for any Pull Request (PR) for translations. For contributors wanting to
+The fheroes2 team has set a maximum of 400 total modified lines for any PR for translations. For contributors wanting to
 add translated lines to a new language this has a maximum of 30 total modified lines for that first PR.
 
 These limitations have been set because every PR needs to be reviewed by our team, and so changing too many lines at once will only slow this
@@ -138,12 +138,12 @@ example creature names or castle buildings.
 </details>
 
 
-# Updating PO templates and translatable strings in PO files
+## Updating PO templates and translatable strings in PO files
 
 Currently all PO files are automatically updated with new strings after each commit that brings changes to the ingame text. If for whatever
 reason you still need to update strings locally, this can be achieved by running the command below in `src/dist` to generate a new portable
 object template (POT) file. Windows users will need to setup an environment that lets them run `make`, like Windows Subsystem for Linux (WSL)
-or [Cygwin](https://www.cygwin.com/)/[MSYS2](https://www.msys2.org/).
+or [**Cygwin**](https://www.cygwin.com/)/[**MSYS2**](https://www.msys2.org/).
 
 ```bash
 make pot

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -60,18 +60,22 @@ edit translations. Currently all implemented languages adhere to a standardized 
 
 ### Sync your fork
 
-Before you start working on the first or next translation, make sure that your fork has all the recent changes from the fheroes2 repo. To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
+Before you start working on the first or next translation, make sure that your fork has all the recent changes from the fheroes2 repo.
+To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 
 ### Creating a branch
 
-Next you will set up an environment for working on your translation, in addition to testing and sharing your changes. Read more [**about branches**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
+Next you will set up an environment for working on your translation, in addition to testing and sharing your changes.
+Read more [**about branches**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
 
-To create a branch, please follow GitHub's instructions on [**creating a branch within your repo**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
+To create a branch, please follow GitHub's instructions on
+[**creating a branch within your repo**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
 
 ### Submitting translations
 
-Finally you will use your translation software of choice to make changes to the translation. All original translatable strings are located in the source code of the project. 
-If you need to clarify where this string is being used you can search for it. The string below, for example, can be translated in PO files:
+Finally you will use your translation software of choice to make changes to the translation. All original translatable strings are
+located in the source code of the project. If you need to clarify where this string is being used you can search for it.
+The string below, for example, can be translated in PO files:
 
 ```cpp
 _( "Are you sure you want to quit?" )

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -45,7 +45,7 @@ and you are ready to share it, you will have to prepare a pull request.
 
 ### Fork the fheroes2 repository
 
-A fork is your copy of the fheroes2 repository. It gives you a safe space to prepare and test your changes.
+A fork is your copy of the fheroes2 repository. It gives you a safe environment to prepare and test your changes.
 You can read here how to [**create a fork**](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -46,7 +46,7 @@ and you are happy to share it, you will have to prepare a Pull Request.
 
 ### Fork the fheroes2 repository
 
-https://docs.github.com/en/get-started/quickstart/fork-a-repo
+A fork is your copy of the fheroes2 repository. It gives you a safe space to prepare and test your changes. You can read here how to [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 
 ### Software to edit translation files
@@ -55,22 +55,21 @@ We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](h
 edit translations. Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
 
 
-## Editing translations - Your first/next translation
+## Editing translations - Your first or next translation
 
 ### Sync your fork
 
-Before you start working on the first/next translation, make sure that your fork has recent changes. To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
+Before you start working on the first or next translation, make sure that your fork has all recent changes for the fhereos2 repo. To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 
 ### Create a branch
 
-Now you will create a space for your work. Brach is a special place where you can safely prepare, test and share your changes. Read more [about branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
+Now create a space for your work where you can safely prepare, test and share your changes. Read more [about branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
 
 To create a branch, please follow the GitHub's instruction about [creating a branch within your repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
 
 ### Now provide your changes
 
 Now it is time to use your favourite software, which allows you to update the translation and suits you best.
-
 
 #### Finding translatable strings in the codebase
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -47,7 +47,7 @@ and you are happy to share it, you will have to prepare a pull request.
 ### Fork the fheroes2 repository
 
 A fork is your copy of the fheroes2 repository. It gives you a safe space to prepare and test your changes.
-You can read here how to [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
+You can read here how to [**create a fork**](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 
 ### Software to edit translation files
@@ -71,8 +71,6 @@ To create a branch, please follow the GitHub's instruction about [**creating a b
 ### Now provide your translations
 
 Now it is time to use your favourite software, which allows you to update the translation and suits you best.
-
-#### Finding translatable strings in the codebase
 
 All original translatable strings are located in the source code of the project. If you need to clarify where this string is being used
 you can search for it. The string below, for example, can be translated in PO files:

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -56,9 +56,9 @@ We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](h
 edit translations. Currently all implemented languages adhere to a standardized font encoding/charset.
 
 
-## Editing translations - Your first or next translation
+## Editing translations - For the first time or again
 
-### Sync your fork
+### Syncing your fork
 
 Before you start working on the first or next translation, make sure that your fork has all the recent changes from the fheroes2 repo.
 To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
@@ -91,15 +91,19 @@ For example, for the German PO file, `de.po`, the following would be the command
 make de.mo
 ```
 
-To have this MO file used by the engine, it should then be placed in the `files/lang` folder used by the fheroes2 executable.
-The exact location of this folder depends on the operating system. On Windows, it is usually located in the app installation
-directory. On Linux, it is usually located in the `/usr/share/fheroes2` or `/usr/local/share/fheroes2`. Currently for MacOS 
-users this location is dependent on what third-party package manager is used to install fheroes2. The Flatpak version of the 
-fheroes2 installation from Flathub is located in the `usr/.var/app/io.github.ihhub.Fheroes2` directory.
+To make the engine use this MO, the file should be placed in the `files/lang` folder used by the fheroes2 executable.
+The exact location of this folder depends on the operating system.
 
+On Windows, it is usually located in the app installation directory.
 
-For Windows users who use POEdit or a similar application, it is possible to compile the MO file using such a program. However, note that
-the program will need to be set to compile the MO file in the font encoding/Charset that the language that you are translating to has been
+On Linux, it is usually located in the `/usr/share/fheroes2` or `/usr/local/share/fheroes2`.
+
+Currently for MacOS users this location is dependent on what third-party package manager is used to install fheroes2.
+
+The Flatpak version of the fheroes2 installation from Flathub is located in the `usr/.var/app/io.github.ihhub.Fheroes2` directory.
+
+For Windows users who use POEdit or a similar application, it is possible to compile the MO file using said program. However, note that
+the program will need to be set to compile the MO file in the font encoding/charset that the language that you are translating to has been
 set to.
 
 For example, for German you will have to set font encoding to CP1252, while for Russian this would be CP1251. Later when submitting
@@ -120,7 +124,7 @@ your work, I.E. "Update the Slovak translation".
 
 <details>
 
-<summary>Pull request restrictions</summary>
+<summary>Pull request restrictions - Please read</summary>
 
 The fheroes2 team has set a maximum of 400 total modified lines for any pull request for translations. For contributors wanting to
 add translated lines to a new language this has a maximum of 30 total modified lines for that first pull request.
@@ -142,7 +146,7 @@ example creature names or castle buildings.
 
 Currently all PO files are automatically updated with new strings after each commit that brings changes to the ingame text. If for whatever
 reason you still need to update strings locally, this can be achieved by running the command below in `src/dist` to generate a new portable
-object template (POT) file. Windows users will need to setup an environment that lets them run `make`, like Windows Subsystem for Linux (WSL)
+object template (POT) file. Windows users will need to set up an environment that lets them run `make`, like Windows Subsystem for Linux (WSL)
 or [**Cygwin**](https://www.cygwin.com/)/[**MSYS2**](https://www.msys2.org/).
 
 ```bash
@@ -150,8 +154,9 @@ make pot
 ```
 
 Once the POT file has been created, go to the `files/lang` folder and run the command below to update translatable strings in the PO files.
-If you are using programs mentioned above like POEdit, then they have options to merge new strings from a POT file.
 
 ```bash
 make merge
 ```
+
+If you are using programs mentioned above like POEdit, then they have options to merge new strings from a POT file.

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -39,46 +39,45 @@ been implemented, then code for that will need to be written.
 
 ## Editing translations - Before you start
 
-Before starting, you will have to set up the necessary environment: fork the fheroes2 repository and install an application used for translating. When you have your own fork of fheroes2 you should create a branch. At this point you can start translating. After you finish your work,
-and you are ready to share it, you will have to prepare a pull request.
+Before starting, you will have to set up the necessary environment: fork the fheroes2 repository and install an application used 
+for translating. When you have your own fork of fheroes2 you should create a branch. At this point you can start translating. 
+After you finish your work, and you are ready to share it, you will have to prepare a pull request.
 
 
-### Fork the fheroes2 repository
+### Forking the fheroes2 repository
 
 A fork is your copy of the fheroes2 repository. It gives you a safe environment to prepare and test your changes.
 You can read here how to [**create a fork**](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 
-### Software to edit translation files
+### Translation editing software
 
 We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](https://wiki.gnome.org/Apps/Gtranslator) to
-edit translations. Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
+edit translations. Currently all implemented languages adhere to a standardized font encoding/charset.
 
 
 ## Editing translations - Your first or next translation
 
 ### Sync your fork
 
-Before you start working on the first or next translation, make sure that your fork has all recent changes for the fhereos2 repo. To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
+Before you start working on the first or next translation, make sure that your fork has all the recent changes from the fheroes2 repo. To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 
-### Create a branch
+### Creating a branch
 
-Now create a space for your work where you can safely prepare, test and share your changes. Read more [**about branches**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
+Next you will set up an environment for working on your translation, in addition to testing and sharing your changes. Read more [**about branches**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
 
-To create a branch, please follow the GitHub's instruction about [**creating a branch within your repo**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
+To create a branch, please follow GitHub's instructions on [**creating a branch within your repo**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
 
-### Now provide your translations
+### Submitting translations
 
-Now it is time to use your favourite software, which allows you to update the translation and suits you best.
-
-All original translatable strings are located in the source code of the project. If you need to clarify where this string is being used
-you can search for it. The string below, for example, can be translated in PO files:
+Finally you will use your translation software of choice to make changes to the translation. All original translatable strings are located in the source code of the project. 
+If you need to clarify where this string is being used you can search for it. The string below, for example, can be translated in PO files:
 
 ```cpp
 _( "Are you sure you want to quit?" )
 ```
 
-### Test your changes
+### Testing your changes
 
 Once the translation files have been modified, for Linux/MacOS run the `make` command below in the `files/lang` subdirectory to create
 machine object (MO) binary files which can be used by the fheroes2 engine.
@@ -103,17 +102,17 @@ For example, for German you will have to set font encoding to CP1252, while for 
 a pull request with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
 
 
-### Share your work with the team
+### Sharing your translation work
 
-When you are happy about your work, share it. The first step is to commit your work into your fork. Then, create a pull request that 
-introduces your changes into the fheroes2 repository.
+When you are satisfied with your work, you can proceed with sharing it. The first step is to commit your work into the branch you made of 
+your own fheroes2 fork. Then, create a PR that proposes to introduce your changes into the fheroes2 repository.
 
 How to [**commit**](https://github.com/git-guides/git-commit). 
 
 How to [**create a pull request from your form your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
 
-Try to add a meaningfull pull request title, this will allow the team to quickly identify the scope of your work, ie. "Update Slovak translation".
-
+The pull request title has to be something human-understandable. This allows the team to quickly identify the purpose of 
+your work, I.E. "Update the Slovak translation".
 
 <details>
 

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -3,7 +3,7 @@
 This project uses portable object (PO) files to handle localization in various languages. The PO files are located in the `files/lang`
 subdirectory of the project source tree. The current instruction is designed for Linux, MacOS and Windows users.
 
-## Current status
+# Current status
 
 ![Belarusian](https://img.shields.io/endpoint?url=https://ihhub.github.io/fheroes2/json/lang_be.json)
 ![Bulgarian](https://img.shields.io/endpoint?url=https://ihhub.github.io/fheroes2/json/lang_bg.json)
@@ -28,7 +28,7 @@ subdirectory of the project source tree. The current instruction is designed for
 ![Vietnamese](https://img.shields.io/endpoint?url=https://ihhub.github.io/fheroes2/json/lang_vi.json)
 
 
-## Adding new translations/localizations
+# Adding new translations/localizations
 
 If you want to add a new localization, you will first need to add it to the `SupportedLanguage` list/enumeration in the source code.
 Afterwards, a new PO file for it will need to be added. It will have to be named according to the ISO standard's two-character
@@ -37,41 +37,41 @@ the language to the font generation code found in `src/fheroes2/gui/ui_font.cpp`
 been implemented, then code for that will need to be written.
 
 
-## Editing translations - Before you start
+# Editing translations - Before you start
 
 Before start, you will have to prepare your working environment: fork the fheroes2 repository and prepare an application where you
 will edit your translation. Then you will have to create a branch. Now you can provide the translation. After you finish your work,
 and you are happy to share it, you will have to prepare a Pull Request.
 
 
-### Fork the fheroes2 repository
+## Fork the fheroes2 repository
 
 A fork is your copy of the fheroes2 repository. It gives you a safe space to prepare and test your changes. You can read here how to [create a fork](https://docs.github.com/en/get-started/quickstart/fork-a-repo).
 
 
-### Software to edit translation files
+## Software to edit translation files
 
 We encourage you to use [**poedit**](https://poedit.net/) or [**gtranslator**](https://wiki.gnome.org/Apps/Gtranslator) to
 edit translations. Currently all implemented languages, except French, adhere to a standardized font encoding/charset.
 
 
-## Editing translations - Your first or next translation
+# Editing translations - Your first or next translation
 
-### Sync your fork
+## Sync your fork
 
 Before you start working on the first or next translation, make sure that your fork has all recent changes for the fhereos2 repo. To do this, [**sync your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/working-with-forks/syncing-a-fork).
 
-### Create a branch
+## Create a branch
 
 Now create a space for your work where you can safely prepare, test and share your changes. Read more [about branches](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches).
 
 To create a branch, please follow the GitHub's instruction about [creating a branch within your repo](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-and-deleting-branches-within-your-repository).
 
-### Now provide your changes
+## Now provide your changes
 
 Now it is time to use your favourite software, which allows you to update the translation and suits you best.
 
-#### Finding translatable strings in the codebase
+### Finding translatable strings in the codebase
 
 Translatable strings can be found in the source code as arguments to the `_` function (a short name for `gettext`),
 `_n` function (a short name for `ngettext`) and `gettext_noop` function used only as indicator for the future string
@@ -81,7 +81,7 @@ translation. The string below, for example, can be translated in PO files:
 _( "Are you sure you want to quit?" )
 ```
 
-### Test your changes
+## Test your changes
 
 Once the translation files have been modified, for Linux/MacOS run the `make` command below in the `files/lang` subdirectory to create
 machine object (MO) binary files which can be used by the fheroes2 engine.
@@ -106,7 +106,7 @@ For example, for German you will have to set font encoding to CP1252, while for 
 a PR with your changes, you will have to save the PO file in UTF-8 encoding because this is what Github supports.
 
 
-### Share your work with the team
+## Share your work with the team
 
 When you are happy about your work, share it. The first step is to commit your work into your fork. Then, create a pull request that 
 introduces your changes into the fheroes2 repository.
@@ -138,7 +138,7 @@ example creature names or castle buildings.
 </details>
 
 
-## Updating PO templates and translatable strings in PO files
+# Updating PO templates and translatable strings in PO files
 
 Currently all PO files are automatically updated with new strings after each commit that brings changes to the ingame text. If for whatever
 reason you still need to update strings locally, this can be achieved by running the command below in `src/dist` to generate a new portable

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -109,7 +109,7 @@ your own fheroes2 fork. Then, create a PR that proposes to introduce your change
 
 How to [**commit**](https://github.com/git-guides/git-commit). 
 
-How to [**create a pull request from your form your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
+How to [**create a pull request from your fork**](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request-from-a-fork).
 
 The pull request title has to be something human-understandable. This allows the team to quickly identify the purpose of 
 your work, I.E. "Update the Slovak translation".

--- a/docs/TRANSLATION.md
+++ b/docs/TRANSLATION.md
@@ -39,9 +39,8 @@ been implemented, then code for that will need to be written.
 
 ## Editing translations - Before you start
 
-Before start, you will have to prepare your working environment: fork the fheroes2 repository and prepare an application where you
-will edit your translation. Then you will have to create a branch. Now you can provide the translation. After you finish your work,
-and you are happy to share it, you will have to prepare a pull request.
+Before starting, you will have to set up the necessary environment: fork the fheroes2 repository and install an application used for translating. When you have your own fork of fheroes2 you should create a branch. At this point you can start translating. After you finish your work,
+and you are ready to share it, you will have to prepare a pull request.
 
 
 ### Fork the fheroes2 repository


### PR DESCRIPTION
A step to update the TRANSLATION.md file.

The idea behind this change is to slightly reorganise the file into the following sections:
- Intro
- Current status
- Adding new translations/localizations
- Editing translations - Before you start
- Editing translations - Your first or next translation
- Other topics (currently Updating PO templates and translatable strings in PO files)

The second idea is to add few high-level instructions on cooperating and using the Github.

This change tackles (but does not resolve) second topic of #7089.