### PR TITLE
Use try_emplace() from C++17 instead of emplace()

### DIFF
--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -160,13 +160,13 @@ namespace
             }
 
             // Place the path to the cache
-            musicTrackIdToFilePath.emplace( musicTrackId, filePath );
+            musicTrackIdToFilePath.try_emplace( musicTrackId, filePath );
 
             return filePath;
         }
 
         // Place the negative result to the cache
-        musicTrackIdToFilePath.emplace( musicTrackId, std::string{} );
+        musicTrackIdToFilePath.try_emplace( musicTrackId, std::string{} );
 
         return {};
     }


### PR DESCRIPTION
Fix minor code smells recently introduced by #7183.