### PR TITLE
Fix the rendering of the number of units during the castle siege

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1556,7 +1556,7 @@ void Battle::Interface::RedrawArmies()
             }
 
             for ( const Unit * unit : troopCounterAfterWall ) {
-                RedrawTroopSprite( *unit );
+                RedrawTroopCount( *unit );
             }
 
             for ( const Unit * unit : movingTroopAfterWall ) {


### PR DESCRIPTION
Regression after #7209, minor (copy+paste?) typo.

`master` branch:

![screen_master](https://github.com/ihhub/fheroes2/assets/32623900/1d5f3482-32d5-40e4-935f-4f2c635ec562)

This PR:

![screen_pr](https://github.com/ihhub/fheroes2/assets/32623900/e408ca5a-9daa-4d08-b654-9950d9c1e185)
