### PR TITLE
Do not use fade effect when switching campaign scenario

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1430,7 +1430,9 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
     LocalEvent & le = LocalEvent::Get();
 
     // Fade-in campaign scenario info.
-    fheroes2::fadeInDisplay( { top.x, top.y, backgroundImage.width(), backgroundImage.height() }, false );
+    if ( validateDisplayFadeIn() ) {
+        fheroes2::fadeInDisplay( { top.x, top.y, backgroundImage.width(), backgroundImage.height() }, false );
+    }
 
     std::vector<fheroes2::Rect> choiceArea( bonusChoiceCount );
     for ( uint32_t i = 0; i < bonusChoiceCount; ++i ) {

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -248,5 +248,7 @@ fheroes2::GameMode Game::DisplayLoadGameDialog()
     // We are loading a game so fade-out main menu screen.
     fheroes2::fadeOutDisplay();
 
+    setDisplayFadeIn();
+
     return returnValue;
 }

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -212,12 +212,15 @@ fheroes2::GameMode Game::CampaignSelection()
         le.MousePressLeft( buttonPriceOfLoyalty.area() ) ? buttonPriceOfLoyalty.drawOnPress() : buttonPriceOfLoyalty.drawOnRelease();
         le.MousePressLeft( buttonCancelGame.area() ) ? buttonCancelGame.drawOnPress() : buttonCancelGame.drawOnRelease();
 
-        if ( le.MouseClickLeft( buttonSuccessionWars.area() ) || HotKeyPressEvent( HotKeyEvent::MAIN_MENU_NEW_ORIGINAL_CAMPAIGN ) )
+        if ( le.MouseClickLeft( buttonSuccessionWars.area() ) || HotKeyPressEvent( HotKeyEvent::MAIN_MENU_NEW_ORIGINAL_CAMPAIGN ) ) {
             return fheroes2::GameMode::NEW_SUCCESSION_WARS_CAMPAIGN;
-        if ( le.MouseClickLeft( buttonPriceOfLoyalty.area() ) || HotKeyPressEvent( HotKeyEvent::MAIN_MENU_NEW_EXPANSION_CAMPAIGN ) )
+        }
+        if ( le.MouseClickLeft( buttonPriceOfLoyalty.area() ) || HotKeyPressEvent( HotKeyEvent::MAIN_MENU_NEW_EXPANSION_CAMPAIGN ) ) {
             return fheroes2::GameMode::NEW_PRICE_OF_LOYALTY_CAMPAIGN;
-        if ( HotKeyPressEvent( HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( buttonCancelGame.area() ) )
+        }
+        if ( HotKeyPressEvent( HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( buttonCancelGame.area() ) ) {
             return fheroes2::GameMode::MAIN_MENU;
+        }
 
         if ( le.MousePressRight( buttonSuccessionWars.area() ) ) {
             Dialog::Message( _( "Original Campaign" ), _( "Either Roland's or Archibald's campaign from the original Heroes of Might and Magic II." ), Font::BIG );
@@ -325,8 +328,12 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
 
     screenRestorer.changePalette( nullptr );
 
+    // Update the frame but do not render it.
     display.fill( 0 );
-    display.render();
+    display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
+
+    // Set the fade-in for the Campaign scenario info.
+    setDisplayFadeIn();
 
     return fheroes2::GameMode::SELECT_CAMPAIGN_SCENARIO;
 }
@@ -452,6 +459,9 @@ fheroes2::GameMode Game::NewPriceOfLoyaltyCampaign()
     // Update the frame but do not render it.
     display.fill( 0 );
     display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
+
+    // Set the fade-in for the Campaign scenario info.
+    setDisplayFadeIn();
 
     return gameChoice;
 }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -356,8 +356,9 @@ fheroes2::GameMode Interface::Basic::EventScenarioInformation()
         fheroes2::Display & display = fheroes2::Display::instance();
         fheroes2::ImageRestorer saver( display, 0, 0, display.width(), display.height() );
 
-        // We are opening campaign scenario info. It is a full screen image change. So do th Adventure map screen fade-out.
+        // We are opening campaign scenario info. It is a full screen image change. So do fade-out and set the fade-in.
         fheroes2::fadeOutDisplay();
+        Game::setDisplayFadeIn();
 
         AudioManager::ResetAudio();
 


### PR DESCRIPTION
Remove fade when switching between the scenarios in campaign scenario info dialog.

master build:

https://github.com/ihhub/fheroes2/assets/113276641/652090e5-f8e9-434e-8e59-7ae2bf8f07c3

this PR:

https://github.com/ihhub/fheroes2/assets/113276641/07a243f3-fd6a-4001-87a8-000dea6bfee6

