### PR TITLE
Improve AI retreat logic during battles

### DIFF
--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -32,6 +32,7 @@
 #include "payment.h"
 #include "rand.h"
 #include "resource.h"
+#include "settings.h"
 
 namespace AI
 {
@@ -139,6 +140,21 @@ namespace AI
 
     bool CanPurchaseHero( const Kingdom & kingdom )
     {
-        return kingdom.GetCountCastle() > 0 && kingdom.AllowRecruitHero( true );
+        if ( kingdom.GetCountCastle() == 0 ) {
+            return false;
+        }
+
+        if ( kingdom.GetColor() == Settings::Get().CurrentColor() ) {
+            // This is the AI's current turn.
+            return kingdom.AllowRecruitHero( true );
+        }
+
+        // This is not the current turn for the AI so we need to calculate the possible future income on the next day.
+        if ( !kingdom.AllowRecruitHero( false ) ) {
+            return false;
+        }
+
+        // This is a very rough estimation of the next kingdom resources but we can't predict the whole future at the moment.
+        return kingdom.AllowPayment( PaymentConditions::RecruitHero() - kingdom.GetIncome() );
     }
 }

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -121,7 +121,7 @@ public:
     {
         return resource;
     }
-    Funds GetIncome( int = INCOME_ALL ) const;
+    Funds GetIncome( int type = INCOME_ALL ) const;
 
     double GetArmiesStrength() const;
 


### PR DESCRIPTION
AI should sometimes should take into an account the future.

The previous conditions work only for the current AI turn but not for the next one which is not always the case.