### PR TITLE
Fix AI capturing a dwelling protected by monsters

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1292,7 +1292,8 @@ namespace
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
 
-                setColorOnTile( tile, hero.GetColor() );
+                // Set ownership of the dwelling to a Neutral (gray) player so that any player can recruit troops without a fight.
+                setColorOnTile( tile, Color::UNUSED );
                 tile.SetObjectPassable( true );
             }
             else {

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -801,11 +801,23 @@ namespace Maps
 
         case MP2::OBJ_TROLL_BRIDGE:
         case MP2::OBJ_CITY_OF_DEAD:
-            count = isFirstLoad ? Rand::Get( 4, 6 ) : ( Color::NONE == getColorFromTile( tile ) ) ? count : count + Rand::Get( 1, 3 );
+            if ( isFirstLoad ) {
+                count = Rand::Get( 4, 6 );
+            }
+            else if ( getColorFromTile( tile ) != Color::NONE || count == 0 ) {
+                // If the Troll Bridge or City of Dead has been captured or has 0 creatures, its population is increased by 1-3 creature per week.
+                count += Rand::Get( 1, 3 );
+            }
             break;
 
         case MP2::OBJ_DRAGON_CITY:
-            count = isFirstLoad ? 2 : ( Color::NONE == getColorFromTile( tile ) ) ? count : count + 1;
+            if ( isFirstLoad ) {
+                count = 2;
+            }
+            else if ( getColorFromTile( tile ) != Color::NONE || count == 0 ) {
+                // If the Dragon City has been captured or has 0 creatures, its population is increased by 1 dragon per week.
+                ++count;
+            }
             break;
 
         default:

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -44,6 +44,7 @@
 #include "race.h"
 #include "rand.h"
 #include "resource.h"
+#include "save_format_version.h"
 #include "skill.h"
 #include "spell.h"
 #include "tools.h"
@@ -804,20 +805,34 @@ namespace Maps
             if ( isFirstLoad ) {
                 count = Rand::Get( 4, 6 );
             }
-            else if ( getColorFromTile( tile ) != Color::NONE || count == 0 ) {
-                // If the Troll Bridge or City of Dead has been captured or has 0 creatures, its population is increased by 1-3 creature per week.
+            else if ( getColorFromTile( tile ) != Color::NONE ) {
+                // If the Troll Bridge or City of Dead has been captured, its population is increased by 1-3 creature per week.
                 count += Rand::Get( 1, 3 );
             }
+
+            static_assert( LAST_SUPPORTED_FORMAT_VERSION <= FORMAT_VERSION_1005_RELEASE, "Remove the check below." );
+            if ( count == 0 ) {
+                // The fix for the case when the Troll Bridge or City of Dead with NONE tile color, has 0 creatures (fixed in PR #7246).
+                count += Rand::Get( 1, 3 );
+            }
+
             break;
 
         case MP2::OBJ_DRAGON_CITY:
             if ( isFirstLoad ) {
                 count = 2;
             }
-            else if ( getColorFromTile( tile ) != Color::NONE || count == 0 ) {
+            else if ( getColorFromTile( tile ) != Color::NONE ) {
                 // If the Dragon City has been captured or has 0 creatures, its population is increased by 1 dragon per week.
                 ++count;
             }
+
+            static_assert( LAST_SUPPORTED_FORMAT_VERSION <= FORMAT_VERSION_1005_RELEASE, "Remove the check below." );
+            if ( count == 0 ) {
+                // The fix for the case when the Dragon City with NONE tile color, has 0 creatures (fixed in PR #7246).
+                ++count;
+            }
+
             break;
 
         default:


### PR DESCRIPTION
Fix #7245

In master build it possible that AI captures the Dragon City (or Troll Bridge, or City of Dead), byes all creatures and is vanquished. So the dwelling's color is reset to NONE and we have 0 creatures count.

This PR makes AI logic as for non-AI heroes: Set ownership of the dwelling to a Neutral (gray) player.
Also to fix such cases (with 0 creatures and NONE color after AI vanquish) the dwelling population is increased like the dwelling was captured.