### PR TITLE
Remove extra fade-in and redundant Castle row 'Init()' in Kingdom Overview

### DIFF
--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -493,9 +493,12 @@ void StatsCastlesList::ActionListSingleClick( CstlRow & row, const fheroes2::Poi
         // click hero icon
         else if ( fheroes2::Rect( ox + 82, oy + 19, Interface::IconsBar::GetItemWidth(), Interface::IconsBar::GetItemHeight() ) & cursor ) {
             Heroes * hero = row.castle->GetHero();
-            if ( hero ) {
-                Game::OpenHeroesDialog( *hero, false, false );
+
+            if ( !hero ) {
+                return;
             }
+
+            Game::OpenHeroesDialog( *hero, false, false );
         }
         else {
             return;


### PR DESCRIPTION
Fix extra fade-in and redundant Castle `row.Init()` in Kingdom Overview dialog when clicking on an empty hero or castle captain icon.

Master build:

https://github.com/ihhub/fheroes2/assets/113276641/6c78a0ee-c788-4fef-b947-eeb6b1e6e0cd

In this PR the first 3 extra fades (when no new dialog is not opened) are disabled.