### PR TITLE
Fix missing logic for AI heroes to meet each other in the middle of a turn

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1586,6 +1586,9 @@ namespace AI
             break;
         case MP2::OBJ_COAST:
             AIToCoast( hero, dst_index );
+
+            // Coast is not an action object by definition.
+            isAction = false;
             break;
 
         case MP2::OBJ_MONSTER:

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1574,7 +1574,6 @@ namespace AI
 
         const Maps::Tiles & tile = world.GetTiles( dst_index );
         const MP2::MapObjectType objectType = tile.GetObject( dst_index != hero.GetIndex() );
-        bool isAction = true;
 
         const bool isActionObject = MP2::isActionObject( objectType, hero.isShipMaster() );
         if ( isActionObject )
@@ -1585,10 +1584,8 @@ namespace AI
             AIToBoat( hero, dst_index );
             break;
         case MP2::OBJ_COAST:
+            // Coast is not an action object by definition but we need to do hero's animation.
             AIToCoast( hero, dst_index );
-
-            // Coast is not an action object by definition.
-            isAction = false;
             break;
 
         case MP2::OBJ_MONSTER:
@@ -1827,8 +1824,8 @@ namespace AI
             AIToSirens( hero, objectType, dst_index );
             break;
         default:
-            assert( !isActionObject ); // AI should know what to do with this type of action object! Please add logic for it.
-            isAction = false;
+            // AI should know what to do with this type of action object! Please add logic for it.
+            assert( !isActionObject );
             break;
         }
 
@@ -1836,7 +1833,7 @@ namespace AI
             hero.GetPath().Reset();
 
         // ignore empty tiles
-        if ( isAction )
+        if ( isActionObject )
             AI::Get().HeroesActionComplete( hero, dst_index, objectType );
     }
 

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -51,8 +51,16 @@ namespace AI
             const IndexObject indexObject{ tile.GetIndex(), static_cast<int>( object ) };
 
             // _mapActionObjects must in a sorted ascending order as we use std::binary_search later in the code.
-            // std::upper_bound is used in order to find the correct spot for insertion in a sorted array.
-            _mapActionObjects.emplace( std::upper_bound( _mapActionObjects.begin(), _mapActionObjects.end(), indexObject ), indexObject );
+            // std::lower_bound is used in order to find the correct spot for insertion in a sorted array.
+            auto iter = std::lower_bound( _mapActionObjects.begin(), _mapActionObjects.end(), indexObject,
+                                          []( const IndexObject & left, const IndexObject & right ) { return left.first < right.first; } );
+            if ( iter != _mapActionObjects.end() && iter->first == indexObject.first ) {
+                // The object exist! Most likely because of View All spell.
+                iter->second = indexObject.second;
+            }
+            else {
+                _mapActionObjects.emplace( iter, indexObject );
+            }
         }
     }
 
@@ -161,7 +169,7 @@ namespace AI
             }
         }
         else if ( MP2::isActionObject( objectType ) ) {
-            _mapActionObjects.emplace( iter, IndexObject{ mapIndex, MP2::OBJ_HEROES } );
+            _mapActionObjects.emplace( iter, IndexObject{ mapIndex, objectType } );
         }
     }
 }

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -29,6 +29,7 @@
 #include "payment.h"
 #include "profit.h"
 #include "rand.h"
+#include "world.h"
 
 namespace AI
 {
@@ -46,12 +47,12 @@ namespace AI
     void Normal::revealFog( const Maps::Tiles & tile )
     {
         const MP2::MapObjectType object = tile.GetObject();
-        if ( object != MP2::OBJ_NONE ) {
+        if ( MP2::isActionObject( object ) ) {
             const IndexObject indexObject{ tile.GetIndex(), static_cast<int>( object ) };
 
-            // _mapObjects must in a sorted ascending order as we use std::binary_search later in the code.
+            // _mapActionObjects must in a sorted ascending order as we use std::binary_search later in the code.
             // std::upper_bound is used in order to find the correct spot for insertion in a sorted array.
-            _mapObjects.emplace( std::upper_bound( _mapObjects.begin(), _mapObjects.end(), indexObject ), indexObject );
+            _mapActionObjects.emplace( std::upper_bound( _mapActionObjects.begin(), _mapActionObjects.end(), indexObject ), indexObject );
         }
     }
 
@@ -142,5 +143,25 @@ namespace AI
         }
 
         return prio;
+    }
+
+    void Normal::updateMapActionObjectCache( const int mapIndex )
+    {
+        const Maps::Tiles & tile = world.GetTiles( mapIndex );
+        const MP2::MapObjectType objectType = tile.GetObject();
+        auto iter = std::lower_bound( _mapActionObjects.begin(), _mapActionObjects.end(), IndexObject{ mapIndex, objectType },
+                                      []( const IndexObject & left, const IndexObject & right ) { return left.first < right.first; } );
+
+        if ( iter != _mapActionObjects.end() && iter->first == mapIndex ) {
+            if ( MP2::isActionObject( objectType ) ) {
+                iter->second = objectType;
+            }
+            else {
+                _mapActionObjects.erase( iter );
+            }
+        }
+        else if ( MP2::isActionObject( objectType ) ) {
+            _mapActionObjects.emplace( iter, IndexObject{ mapIndex, MP2::OBJ_HEROES } );
+        }
     }
 }

--- a/src/fheroes2/ai/normal/ai_normal.cpp
+++ b/src/fheroes2/ai/normal/ai_normal.cpp
@@ -47,21 +47,11 @@ namespace AI
     void Normal::revealFog( const Maps::Tiles & tile )
     {
         const MP2::MapObjectType object = tile.GetObject();
-        if ( MP2::isActionObject( object ) ) {
-            const IndexObject indexObject{ tile.GetIndex(), static_cast<int>( object ) };
-
-            // _mapActionObjects must in a sorted ascending order as we use std::binary_search later in the code.
-            // std::lower_bound is used in order to find the correct spot for insertion in a sorted array.
-            auto iter = std::lower_bound( _mapActionObjects.begin(), _mapActionObjects.end(), indexObject,
-                                          []( const IndexObject & left, const IndexObject & right ) { return left.first < right.first; } );
-            if ( iter != _mapActionObjects.end() && iter->first == indexObject.first ) {
-                // The object exist! Most likely because of View All spell.
-                iter->second = indexObject.second;
-            }
-            else {
-                _mapActionObjects.emplace( iter, indexObject );
-            }
+        if ( !MP2::isActionObject( object ) ) {
+            return;
         }
+
+        updateMapActionObjectCache( tile.GetIndex() );
     }
 
     double Normal::getTargetArmyStrength( const Maps::Tiles & tile, const MP2::MapObjectType objectType )

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -78,7 +78,6 @@ namespace AI
         int fogCount = 0;
         int safetyFactor = 0;
         int spellLevel = 2;
-        std::vector<IndexObject> validObjects;
     };
 
     struct AICastle
@@ -265,7 +264,7 @@ namespace AI
         std::set<int> findCastlesInDanger( const KingdomCastles & castles, const std::vector<std::pair<int, const Army *>> & enemyArmies, int myColor );
         std::vector<AICastle> getSortedCastleList( const KingdomCastles & castles, const std::set<int> & castlesInDanger );
 
-        double getObjectValue( const Heroes & hero, const int index, int & objectType, const double valueToIgnore, const uint32_t distanceToObject ) const;
+        double getObjectValue( const Heroes & hero, const int index, const int objectType, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getPriorityTarget( const HeroToMove & heroInfo, double & maxPriority );
         void resetPathfinder() override;
 
@@ -281,7 +280,7 @@ namespace AI
     private:
         // following data won't be saved/serialized
         double _combinedHeroStrength = 0;
-        std::vector<IndexObject> _mapObjects;
+        std::vector<IndexObject> _mapActionObjects;
         std::map<int, PriorityTask> _priorityTargets;
         std::vector<RegionStats> _regions;
         std::array<BudgetEntry, 7> _budget = { Resource::WOOD, Resource::MERCURY, Resource::ORE, Resource::SULFUR, Resource::CRYSTAL, Resource::GEMS, Resource::GOLD };
@@ -311,6 +310,8 @@ namespace AI
         {
             return objectType == MP2::OBJ_MONSTER;
         }
+
+        void updateMapActionObjectCache( const int mapIndex );
     };
 }
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1545,8 +1545,7 @@ namespace AI
 
     double Normal::getObjectValue( const Heroes & hero, const int index, const int objectType, const double valueToIgnore, const uint32_t distanceToObject ) const
     {
-        const Maps::Tiles & tile = world.GetTiles( index );
-        assert( objectType == tile.GetObject() );
+        assert( objectType == world.GetTiles( index ).GetObject() );
 
         switch ( hero.getAIRole() ) {
         case Heroes::Role::HUNTER:

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1654,13 +1654,13 @@ namespace AI
 
         for ( const auto & actionObject : _mapActionObjects ) {
             if ( actionObject.second == MP2::OBJ_HEROES ) {
-                const Maps::Tiles & tile = world.GetTiles( actionObject.first );
-                const Heroes * tileHero = tile.GetHeroes();
-                assert( tileHero != nullptr );
+                assert( world.GetTiles( actionObject.first ).GetHeroes() != nullptr );
             }
 
-            assert( objectIndexes.count( actionObject.first ) == 0 );
-            objectIndexes.emplace( actionObject.first );
+            const auto [dummy, inserted] = objectIndexes.emplace( actionObject.first );
+            if ( !inserted ) {
+              assert( 0 );
+            }
         }
 #endif
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -170,12 +170,6 @@ namespace
         const Maps::Tiles & tile = world.GetTiles( index );
         const MP2::MapObjectType objectType = tile.GetObject();
 
-        if ( !MP2::isActionObject( objectType ) ) {
-            // TODO: add logic to verify if all parts of puzzle are opened and the location is known.
-            // TODO: once it is done, check if the tile does not have a hole. If it does not mark it as a valid object.
-            return false;
-        }
-
         // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player
         if ( MP2::isArtifactObject( objectType ) ) {
             const Artifact art = getArtifactFromTile( tile );
@@ -578,11 +572,6 @@ namespace
         case MP2::OBJ_TRADING_POST:
         // AI should never consider a whirlpool as a destination point. It uses them only to make a path.
         case MP2::OBJ_WHIRLPOOL:
-            return false;
-
-        case MP2::OBJ_COAST:
-            // Coast is not an action object. If this assertion blows up then something is wrong with the logic above.
-            assert( 0 );
             return false;
 
         default:
@@ -1660,6 +1649,19 @@ namespace AI
 
         // If this assertion blows up then the array is not sorted and the logic below will not work as intended.
         assert( std::is_sorted( _mapActionObjects.begin(), _mapActionObjects.end() ) );
+
+        std::set<int> objectIndexes;
+
+        for ( const auto & actionObject : _mapActionObjects ) {
+            if ( actionObject.second == MP2::OBJ_HEROES ) {
+                const Maps::Tiles & tile = world.GetTiles( actionObject.first );
+                const Heroes * tileHero = tile.GetHeroes();
+                assert( tileHero != nullptr );
+            }
+
+            assert( objectIndexes.count( actionObject.first ) == 0 );
+            objectIndexes.emplace( actionObject.first );
+        }
 #endif
 
         // pre-cache the pathfinder

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1659,7 +1659,7 @@ namespace AI
 
             const auto [dummy, inserted] = objectIndexes.emplace( actionObject.first );
             if ( !inserted ) {
-              assert( 0 );
+                assert( 0 );
             }
         }
 #endif

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -655,7 +655,7 @@ namespace
             , _ignoreValue( ignoreValue )
         {}
 
-        double value( std::pair<int, int> & objectInfo, const uint32_t distance )
+        double value( const std::pair<int, int> & objectInfo, const uint32_t distance )
         {
             auto iter = _objectValue.find( objectInfo );
             if ( iter != _objectValue.end() ) {
@@ -1677,7 +1677,7 @@ namespace AI
             if ( !isDimensionDoor ) {
                 // Dimension door path does not include any objects on the way.
                 std::vector<IndexObject> list = _pathfinder.getObjectsOnTheWay( destination );
-                for ( IndexObject & pair : list ) {
+                for ( const IndexObject & pair : list ) {
                     if ( objectValidator.isValid( pair.first ) && std::binary_search( _mapActionObjects.begin(), _mapActionObjects.end(), pair ) ) {
                         const double extraValue = valueStorage.value( pair, 0 ); // object is on the way, we don't loose any movement points.
                         if ( extraValue > 0 ) {
@@ -1726,7 +1726,7 @@ namespace AI
             }
         }
 
-        for ( IndexObject & node : _mapActionObjects ) {
+        for ( const IndexObject & node : _mapActionObjects ) {
             // Skip if hero in patrol mode and object outside of reach
             if ( heroInPatrolMode && Maps::GetApproximateDistance( node.first, heroInfo.patrolCenter ) > heroInfo.patrolDistance )
                 continue;

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -478,7 +478,7 @@ namespace AI
 
         const int mapSize = world.w() * world.h();
         _priorityTargets.clear();
-        _mapObjects.clear();
+        _mapActionObjects.clear();
         _regions.clear();
         _regions.resize( world.getRegionCount() );
 
@@ -499,11 +499,11 @@ namespace AI
                 continue;
             }
 
-            if ( objectType == MP2::OBJ_NONE || objectType == MP2::OBJ_COAST )
+            if ( !MP2::isActionObject( objectType ) ) {
                 continue;
+            }
 
-            stats.validObjects.emplace_back( idx, objectType );
-            _mapObjects.emplace_back( idx, objectType );
+            _mapActionObjects.emplace_back( idx, objectType );
 
             if ( objectType == MP2::OBJ_HEROES ) {
                 const Heroes * hero = tile.GetHeroes();
@@ -561,7 +561,7 @@ namespace AI
 
         updateKingdomBudget( kingdom );
 
-        DEBUG_LOG( DBG_AI, DBG_TRACE, Color::String( myColor ) << " found " << _mapObjects.size() << " valid objects" )
+        DEBUG_LOG( DBG_AI, DBG_TRACE, Color::String( myColor ) << " found " << _mapActionObjects.size() << " valid objects" )
 
         uint32_t progressStatus = 1;
         status.DrawAITurnProgress( progressStatus );
@@ -595,6 +595,10 @@ namespace AI
             if ( !purchaseNewHeroes( sortedCastleList, castlesInDanger, availableHeroCount, moreTaskForHeroes ) ) {
                 break;
             }
+
+            assert( !heroes.empty() && heroes.back() != nullptr );
+            updateMapActionObjectCache( heroes.back()->GetIndex() );
+
             ++availableHeroCount;
         }
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -459,7 +459,7 @@ void Kingdom::SetVisited( int32_t index, const MP2::MapObjectType objectType )
 
 bool Kingdom::isValidKingdomObject( const Maps::Tiles & tile, const MP2::MapObjectType objectType ) const
 {
-    if ( !MP2::isActionObject( objectType ) && objectType != MP2::OBJ_COAST )
+    if ( !MP2::isActionObject( objectType ) )
         return false;
 
     if ( isVisited( tile.GetIndex(), objectType ) )

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -343,7 +343,7 @@ double Artifact::getArtifactValue() const
         case fheroes2::ArtifactBonusType::NONE:
             break;
         default:
-            // Did you add a new artifact ? Add your logic here.
+            // Did you add a new artifact bonus? Add your logic here.
             assert( 0 );
             break;
         }
@@ -367,7 +367,7 @@ double Artifact::getArtifactValue() const
             artifactValue -= curse.value;
             break;
         default:
-            // Did you add a new artifact ? Add your logic here.
+            // Did you add a new artifact curse? Add your logic here.
             assert( 0 );
             break;
         }

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -969,10 +969,16 @@ uint32_t World::CountObeliskOnMaps()
 
 void World::ActionForMagellanMaps( int color )
 {
+    const bool isAIPlayer = world.GetKingdom( color ).isControlAI();
+
     const int alliedColors = Players::GetPlayerFriends( color );
 
     for ( Maps::Tiles & tile : vec_tiles ) {
         if ( tile.isWater() ) {
+            if ( isAIPlayer && tile.isFog( color ) ) {
+                AI::Get().revealFog( tile );
+            }
+
             tile.ClearFog( alliedColors );
         }
     }


### PR DESCRIPTION
- we did not update map object cache when a hero moves so other heroes were using the old cached data and failed to find the hero if there is a need to meet each other. Such behavior is really hard to catch so you can use this save to test the master branch and this branch (green AI hero moves to a castle and another hero ignores him in master branch):
[Great_War_II_0018_hero_inte.zip](https://github.com/ihhub/fheroes2/files/11612281/Great_War_II_0018_hero_inte.zip)
- fix Magellan's Maps visit by AI heroes when discovered objects were not being added for exploration
- fix duplication of object information from the fog discovery event when AI uses "View All" spell.
- reduce the amount of objects being processed for a possible movement. Only action objects should be considered as useful for any movement.