### PR TITLE
Fix extra fade when switching heroes by interface buttons, fix hero dismiss UI bugs

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -234,36 +234,40 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */, con
         result = ( *it )->OpenDialog( openConstructionWindow, false, renderBackgroundDialog );
     }
 
-    Interface::Basic & basicInterface = Interface::Basic::Get();
+    // If Castle dialog background was not rendered than we have opened it from other dialog (Kingdom Overview)
+    // and there is no need update Adventure map interface at this time.
+    if ( renderBackgroundDialog ) {
+        Interface::Basic & basicInterface = Interface::Basic::Get();
 
-    if ( updateFocus ) {
-        if ( heroCountBefore < myKingdom.GetHeroes().size() ) {
-            basicInterface.SetFocus( myKingdom.GetHeroes()[heroCountBefore], false );
-        }
-        else if ( it != myCastles.end() ) {
-            Heroes * heroInCastle = world.GetTiles( ( *it )->GetIndex() ).GetHeroes();
-            if ( heroInCastle == nullptr ) {
-                basicInterface.SetFocus( *it );
+        if ( updateFocus ) {
+            if ( heroCountBefore < myKingdom.GetHeroes().size() ) {
+                basicInterface.SetFocus( myKingdom.GetHeroes()[heroCountBefore], false );
+            }
+            else if ( it != myCastles.end() ) {
+                Heroes * heroInCastle = world.GetTiles( ( *it )->GetIndex() ).GetHeroes();
+                if ( heroInCastle == nullptr ) {
+                    basicInterface.SetFocus( *it );
+                }
+                else {
+                    basicInterface.SetFocus( heroInCastle, false );
+                }
             }
             else {
-                basicInterface.SetFocus( heroInCastle, false );
+                basicInterface.ResetFocus( GameFocus::HEROES, false );
             }
         }
         else {
-            basicInterface.ResetFocus( GameFocus::HEROES, false );
+            // If we don't update focus, we still have to restore environment sounds and terrain music theme
+            restoreSoundsForCurrentFocus();
         }
-    }
-    else {
-        // If we don't update focus, we still have to restore environment sounds and terrain music theme
-        restoreSoundsForCurrentFocus();
-    }
 
-    // The castle garrison can change
-    basicInterface.RedrawFocus();
+        // The castle garrison can change
+        basicInterface.RedrawFocus();
 
-    // Fade-in game screen only for 640x480 resolution.
-    if ( fheroes2::Display::instance().isDefaultSize() ) {
-        setDisplayFadeIn();
+        // Fade-in game screen only for 640x480 resolution.
+        if ( fheroes2::Display::instance().isDefaultSize() ) {
+            setDisplayFadeIn();
+        }
     }
 }
 
@@ -337,21 +341,25 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
         }
     }
 
-    if ( updateFocus ) {
-        if ( it != myHeroes.end() ) {
-            basicInterface.SetFocus( *it, false );
+    // If Hero dialog background was not rendered than we have opened it from other dialog (Kingdom Overview or Castle dialog)
+    // and there is no need update Adventure map interface at this time.
+    if ( renderBackgroundDialog ) {
+        if ( updateFocus ) {
+            if ( it != myHeroes.end() ) {
+                basicInterface.SetFocus( *it, false );
+            }
+            else {
+                basicInterface.ResetFocus( GameFocus::HEROES, false );
+            }
         }
-        else {
-            basicInterface.ResetFocus( GameFocus::HEROES, false );
+
+        // The hero's army can change
+        basicInterface.RedrawFocus();
+
+        // Fade-in game screen only for 640x480 resolution.
+        if ( needFade && renderBackgroundDialog && isDefaultScreenSize ) {
+            setDisplayFadeIn();
         }
-    }
-
-    // The hero's army can change
-    basicInterface.RedrawFocus();
-
-    // Fade-in game screen only for 640x480 resolution.
-    if ( needFade && renderBackgroundDialog && isDefaultScreenSize ) {
-        setDisplayFadeIn();
     }
 }
 

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -131,7 +131,7 @@ namespace
             return;
         }
 
-        const CursorRestorer cursorRestorer( true, Cursor::POINTER );
+        Cursor::Get().SetThemes( Cursor::POINTER );
 
         fheroes2::Display & display = fheroes2::Display::instance();
 

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -33,6 +33,7 @@
 #include <string>
 #include <utility>
 
+#include "cursor.h"
 #include "game_delays.h"
 #include "image_palette.h"
 #include "localevent.h"
@@ -129,6 +130,8 @@ namespace
         if ( frameCount < 2 || roi.height <= 0 || roi.width <= 0 ) {
             return;
         }
+
+        const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
         fheroes2::Display & display = fheroes2::Display::instance();
 

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -289,6 +289,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() ) {
             // Fade-out hero dialog.
             fheroes2::fadeOutDisplay( fadeRoi, !isDefaultScreenSize );
+
             return Dialog::CANCEL;
         }
 
@@ -337,6 +338,9 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         // dismiss
         if ( buttonDismiss.isEnabled() && buttonDismiss.isVisible() && le.MouseClickLeft( buttonDismiss.area() )
              && Dialog::YES == Dialog::Message( GetName(), _( "Are you sure you want to dismiss this Hero?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
+            // Fade-out hero dialog.
+            fheroes2::fadeOutDisplay( fadeRoi, !isDefaultScreenSize );
+
             return Dialog::DISMISS;
         }
 


### PR DESCRIPTION
fix #7255

This PR also fixes a bug when dismissing hero after opening hero dialog from the castle:

https://github.com/ihhub/fheroes2/assets/113276641/9ad6ce7b-623b-44f3-86ad-d90adfb3aad1
