### PR TITLE
Do not recalculate the hero path on focus change if player is controlled by AI

### DIFF
--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <vector>
 
 #include "audio.h"

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -48,6 +48,8 @@ void Interface::Basic::SetFocus( Heroes * hero, const bool retainScrollBarPositi
         return;
     }
 
+    assert( player->isControlHuman() || ( player->isControlAI() && player->isAIAutoControlMode() ) );
+
     Focus & focus = player->GetFocus();
 
     if ( focus.GetHeroes() && focus.GetHeroes() != hero ) {
@@ -55,7 +57,8 @@ void Interface::Basic::SetFocus( Heroes * hero, const bool retainScrollBarPositi
         focus.GetHeroes()->ShowPath( false );
     }
 
-    if ( !hero->isMoveEnabled() ) {
+    // Heroes::calculatePath() uses PlayerWorldPathfinder and should not be used for an AI-controlled hero
+    if ( !hero->isMoveEnabled() && hero->isControlHuman() ) {
         hero->calculatePath( -1 );
     }
 
@@ -85,6 +88,8 @@ void Interface::Basic::SetFocus( Castle * castle )
     if ( player == nullptr ) {
         return;
     }
+
+    assert( player->isControlHuman() );
 
     Focus & focus = player->GetFocus();
 

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -43,13 +43,14 @@
 
 void Interface::Basic::SetFocus( Heroes * hero, const bool retainScrollBarPosition )
 {
-    Player * player = Settings::Get().GetPlayers().GetCurrent();
+    assert( hero != nullptr );
 
+    Player * player = Settings::Get().GetPlayers().GetCurrent();
     if ( player == nullptr ) {
         return;
     }
 
-    assert( player->isControlHuman() || ( player->isControlAI() && player->isAIAutoControlMode() ) );
+    assert( player->GetColor() == hero->GetColor() && ( player->isControlHuman() || ( player->isControlAI() && player->isAIAutoControlMode() ) ) );
 
     Focus & focus = player->GetFocus();
 
@@ -84,13 +85,14 @@ void Interface::Basic::SetFocus( Heroes * hero, const bool retainScrollBarPositi
 
 void Interface::Basic::SetFocus( Castle * castle )
 {
-    Player * player = Settings::Get().GetPlayers().GetCurrent();
+    assert( castle != nullptr );
 
+    Player * player = Settings::Get().GetPlayers().GetCurrent();
     if ( player == nullptr ) {
         return;
     }
 
-    assert( player->isControlHuman() );
+    assert( player->GetColor() == castle->GetColor() && player->isControlHuman() );
 
     Focus & focus = player->GetFocus();
 


### PR DESCRIPTION
Fix issue observed after #7228 on debug builds when a developer grants AI temporary control over a human-controlled player. Here is a save file:

[AI_Crash.zip](https://github.com/ihhub/fheroes2/files/11625209/AI_Crash.zip)

On this video game crashes on failed assertion in the `AIToTeleports()` because the hero's path is not empty on the teleport tile, which should not be under normal conditions:

https://github.com/ihhub/fheroes2/assets/32623900/a1c23b54-c261-41e3-810b-433945d90ac9

Usually, `SetFocus()` should be called for a human-controlled player only, but in debug builds we have `AIAutoControlMode` and `SetFocus()` may be called for a hero in this mode - for example, it is called on the teleport tile before performing the action, which leads to invalid hero's path due to its recalculation on focus change after #7228 using the wrong pathfinder.

With this PR:

https://github.com/ihhub/fheroes2/assets/32623900/74d57688-2a34-40f8-9d28-a3030a698de1
