### PR TITLE
Fix AI heroes behavior ignoring empty castles with commanders

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1197,7 +1197,7 @@ double Army::GetStrength() const
         result += strength;
     }
 
-    if ( commander ) {
+    if ( commander != nullptr && result > 0.1 ) {
         result += commander->GetMagicStrategicValue( result );
     }
 

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1175,12 +1175,16 @@ double Army::GetStrength() const
     const int armyMorale = GetMorale();
     const int armyLuck = GetLuck();
 
+    bool troopsExist = false;
+
     for ( const Troop * troop : *this ) {
         assert( troop != nullptr );
 
         if ( troop->isEmpty() ) {
             continue;
         }
+
+        troopsExist = true;
 
         double strength = troop->GetStrengthWithBonus( bonusAttack, bonusDefense );
 
@@ -1197,7 +1201,7 @@ double Army::GetStrength() const
         result += strength;
     }
 
-    if ( commander != nullptr && result > 0.1 ) {
+    if ( commander != nullptr && troopsExist ) {
         result += commander->GetMagicStrategicValue( result );
     }
 


### PR DESCRIPTION
close #6095

We should not calculate commander magical impact if an army does not have any creatures.