### PR TITLE
Fix monster upgrade logic when AI was wasting resources for nothing

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -445,22 +445,28 @@ void Troops::Clean()
 void Troops::UpgradeTroops( const Castle & castle )
 {
     for ( Troop * troop : *this ) {
-        if ( troop->isValid() && troop->isAllowUpgrade() ) {
-            Kingdom & kingdom = castle.GetKingdom();
-            if ( castle.GetRace() != troop->GetRace() ) {
-                continue;
-            }
+        assert( troop != nullptr );
+        if ( !troop->isValid() ) {
+            continue;
+        }
 
-            if ( !castle.isBuild( troop->GetUpgrade().GetDwelling() ) ) {
-                continue;
-            }
+        if ( !troop->isAllowUpgrade() ) {
+            continue;
+        }
 
-            const payment_t payment = troop->GetTotalUpgradeCost();
+        Kingdom & kingdom = castle.GetKingdom();
+        if ( castle.GetRace() != troop->GetRace() ) {
+            continue;
+        }
 
-            if ( kingdom.AllowPayment( payment ) ) {
-                kingdom.OddFundsResource( payment );
-                troop->Upgrade();
-            }
+        if ( !castle.isBuild( troop->GetUpgrade().GetDwelling() ) ) {
+            continue;
+        }
+
+        const payment_t payment = troop->GetTotalUpgradeCost();
+        if ( kingdom.AllowPayment( payment ) ) {
+            kingdom.OddFundsResource( payment );
+            troop->Upgrade();
         }
     }
 }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -444,16 +444,25 @@ void Troops::Clean()
 
 void Troops::UpgradeTroops( const Castle & castle )
 {
-    for ( iterator it = begin(); it != end(); ++it )
-        if ( ( *it )->isValid() ) {
-            payment_t payment = ( *it )->GetTotalUpgradeCost();
+    for ( Troop * troop : *this ) {
+        if ( troop->isValid() && troop->isAllowUpgrade() ) {
             Kingdom & kingdom = castle.GetKingdom();
+            if ( castle.GetRace() != troop->GetRace() ) {
+                continue;
+            }
 
-            if ( castle.GetRace() == ( *it )->GetRace() && castle.isBuild( ( *it )->GetUpgrade().GetDwelling() ) && kingdom.AllowPayment( payment ) ) {
+            if ( !castle.isBuild( troop->GetUpgrade().GetDwelling() ) ) {
+                continue;
+            }
+
+            const payment_t payment = troop->GetTotalUpgradeCost();
+
+            if ( kingdom.AllowPayment( payment ) ) {
                 kingdom.OddFundsResource( payment );
-                ( *it )->Upgrade();
+                troop->Upgrade();
             }
         }
+    }
 }
 
 Troop * Troops::GetFirstValid()

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -442,7 +442,7 @@ void Troops::Clean()
     std::for_each( begin(), end(), []( Troop * troop ) { troop->Reset(); } );
 }
 
-void Troops::UpgradeTroops( const Castle & castle )
+void Troops::UpgradeTroops( const Castle & castle ) const
 {
     for ( Troop * troop : *this ) {
         assert( troop != nullptr );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -94,7 +94,7 @@ public:
     uint32_t getTotalHP() const;
 
     void Clean();
-    void UpgradeTroops( const Castle & );
+    void UpgradeTroops( const Castle & castle ) const;
 
     Troop * GetFirstValid();
     Troop * GetWeakestTroop() const;

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -554,6 +554,9 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
 
         switch ( Dialog::ArmyInfo( troop, flags, false, _troopWindowOffsetY ) ) {
         case Dialog::UPGRADE:
+            // If this assertion blows up then you are executing this code for a monster which has no upgrades.
+            assert( troop.isAllowUpgrade() );
+
             world.GetKingdom( _army->GetColor() ).OddFundsResource( troop.GetTotalUpgradeCost() );
             troop.Upgrade();
             break;

--- a/src/fheroes2/army/army_troop.h
+++ b/src/fheroes2/army/army_troop.h
@@ -58,6 +58,9 @@ public:
     uint32_t GetDamageMax() const;
 
     payment_t GetTotalCost() const;
+
+    // Returns the cost of an upgrade if a monster has an upgrade. Otherwise returns no resources.
+    // IMPORTANT!!! Make sure that you call this method after checking by isAllowUpgrade() method.
     payment_t GetTotalUpgradeCost() const;
 
     bool isEmpty() const;

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -644,10 +644,17 @@ double Castle::getVisitValue( const Heroes & hero ) const
 
     for ( size_t i = 0; i < futureArmy.Size(); ++i ) {
         Troop * troop = futureArmy.GetTroop( i );
-        if ( troop != nullptr && troop->isValid() ) {
-            const payment_t payment = troop->GetTotalUpgradeCost();
+        if ( troop != nullptr && troop->isValid() && troop->isAllowUpgrade() ) {
+            if ( GetRace() != troop->GetRace() ) {
+                continue;
+            }
 
-            if ( GetRace() == troop->GetRace() && isBuild( troop->GetUpgrade().GetDwelling() ) && potentialFunds >= payment ) {
+            if ( !isBuild( troop->GetUpgrade().GetDwelling() ) ) {
+                continue;
+            }
+
+            const payment_t payment = troop->GetTotalUpgradeCost();
+            if ( potentialFunds >= payment ) {
                 potentialFunds -= payment;
                 troop->Upgrade();
             }
@@ -2442,7 +2449,7 @@ double Castle::GetGarrisonStrength( const Heroes * attackingHero ) const
     }
 
     // Add castle bonuses if there are any troops defending the castle
-    if ( isCastle() && totalStrength > 1 ) {
+    if ( isCastle() && totalStrength > 0.1 ) {
         const Battle::Tower tower( *this, Battle::TowerType::TWR_CENTER, Rand::DeterministicRandomGenerator( 0 ), 0 );
         const double towerStr = tower.GetStrengthWithBonus( tower.GetAttackBonus(), 0 );
 

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -570,6 +570,9 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
         le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
 
         if ( buttonUpgrade.isEnabled() && ( le.MouseClickLeft( buttonUpgrade.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::ARMY_UPGRADE_TROOP ) ) ) {
+            // If this assertion blows up then you are executing this code for a monster which has no upgrades.
+            assert( troop.isAllowUpgrade() );
+
             if ( UPGRADE_DISABLE & flags ) {
                 const fheroes2::Text description( _( "You can't afford to upgrade your troops!" ), fheroes2::FontType::normalWhite() );
                 fheroes2::showResourceMessage( fheroes2::Text( "", {} ), description, Dialog::OK, troop.GetTotalUpgradeCost() );

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -821,9 +821,11 @@ int Monster::ICNMonh() const
 payment_t Monster::GetUpgradeCost() const
 {
     const Monster upgr = GetUpgrade();
-    const payment_t pay = ( id != upgr.id ) ? ( upgr.GetCost() - GetCost() ) * 2 : GetCost();
+    if ( id == upgr.id ) {
+        return {};
+    }
 
-    return pay;
+    return ( upgr.GetCost() - GetCost() ) * 2;
 }
 
 uint32_t Monster::GetCountFromHitPoints( const Monster & mons, uint32_t hp )

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -288,7 +288,6 @@ public:
         return payment_t( fheroes2::getMonsterData( id ).generalStats.cost );
     }
 
-    payment_t GetUpgradeCost() const;
     uint32_t GetDwelling() const;
 
     int GetMonsterSprite() const
@@ -303,6 +302,9 @@ public:
     static uint32_t GetMissileICN( uint32_t monsterID );
 
 protected:
+    // Returns the cost of an upgrade if a monster has an upgrade. Otherwise returns no resources.
+    payment_t GetUpgradeCost() const;
+
     static Monster FromDwelling( int race, uint32_t dw );
 
     int id;


### PR DESCRIPTION
Previously `GetUpgradeCost()` method was returning a normal cost of a monster if no upgrade is available. This causes a problem in `Troops::UpgradeTroops()` method which was deducting resources from the kingdom but no upgrade was done. On top of this the method didn't even have a check whether the monster can be upgraded.

During AI turn when a hero is in a castle we execute `reinforceHeroInCastle()` function which internally executes the code to upgrade monsters. This of course didn't work for monsters like Wolves which don't even have any upgrades.

This is a save file where a Yellow player has a hero in a castle and their money just disappear every turn because the "upgrade" of Wolves costs 1200 gold while the kingdom has only 1250 per day leaving the AI with 50 gold (on **master** branch):
[ai_doesnt_upgrade.zip](https://github.com/ihhub/fheroes2/files/11631813/ai_doesnt_upgrade.zip)
