### PR TITLE
Russian translation: "Succession Wars" as "Войны Престолонаследия", not "войны за престол"

### DIFF
--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -3209,7 +3209,7 @@ msgid "Map Type:\n"
 msgstr "Тип карты:\n"
 
 msgid "The Succession Wars"
-msgstr "Война за престол"
+msgstr "Войны Престолонаследия"
 
 msgid "Lose all your heroes and towns."
 msgstr "Потерять всех героев и все города."
@@ -3314,7 +3314,7 @@ msgid ""
 "Indicates whether the map is made for \"The Succession Wars\" or \"The Price "
 "of Loyalty\" version of the game."
 msgstr ""
-"Указывает, создана ли карта для версии игры \"Война за престол\" или \"Цена "
+"Указывает, создана ли карта для версии игры \"Войны Престолонаследия\" или \"Цена "
 "верности\"."
 
 msgid "Map Type"


### PR DESCRIPTION
Extracted a part of #7207 into a separate PR.

As discussed in #7207, all first letters in this case are capitalized [according to the rules of Russian language](https://orfogrammka.ru/OGL03/70091346.html#id-3Названияупотреблениепрописныхбуквкавычекслитноедефисноераздельноенаписание-3234Собственныеназваниявойн), because it is [the name of the war](https://mightandmagic.fandom.com/wiki/Second_War_of_Enrothian_Succession).