### PR TITLE
Move jobless AI heroes into castles on a last day of a week

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -287,16 +287,6 @@ namespace AI
             return iter->second.type == PriorityTaskType::ATTACK || iter->second.type == PriorityTaskType::DEFEND;
         }
 
-        bool isNonCriticalTask( const int index ) const
-        {
-            const auto iter = _priorityTargets.find( index );
-            if ( iter == _priorityTargets.end() ) {
-                return false;
-            }
-
-            return iter->second.type == PriorityTaskType::REINFORCE;
-        }
-
     private:
         // following data won't be saved/serialized
         double _combinedHeroStrength = 0;

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -272,9 +272,29 @@ namespace AI
 
         double getTargetArmyStrength( const Maps::Tiles & tile, const MP2::MapObjectType objectType );
 
-        bool isCriticalTask( const int index ) const
+        bool isPriorityTask( const int index ) const
         {
             return _priorityTargets.find( index ) != _priorityTargets.end();
+        }
+
+        bool isCriticalTask( const int index ) const
+        {
+            const auto iter = _priorityTargets.find( index );
+            if ( iter == _priorityTargets.end() ) {
+                return false;
+            }
+
+            return iter->second.type == PriorityTaskType::ATTACK || iter->second.type == PriorityTaskType::DEFEND;
+        }
+
+        bool isNonCriticalTask( const int index ) const
+        {
+            const auto iter = _priorityTargets.find( index );
+            if ( iter == _priorityTargets.end() ) {
+                return false;
+            }
+
+            return iter->second.type == PriorityTaskType::REINFORCE;
         }
 
     private:
@@ -292,6 +312,8 @@ namespace AI
         std::map<int32_t, double> _neutralMonsterStrengthCache;
 
         void CastleTurn( Castle & castle, const bool defensiveStrategy );
+
+        // Returns true if heroes can still do tasks but they have no move points.
         bool HeroesTurn( VecHeroes & heroes, const uint32_t startProgressValue, const uint32_t endProgressValue );
 
         double getGeneralObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
@@ -303,8 +325,8 @@ namespace AI
         void updatePriorityTargets( Heroes & hero, const int32_t tileIndex, const MP2::MapObjectType objectType );
         void updateKingdomBudget( const Kingdom & kingdom );
 
-        bool purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, int32_t availableHeroCount,
-                                bool moreTasksForHeroes );
+        bool purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, const int32_t availableHeroCount,
+                                const bool moreTasksForHeroes );
 
         static bool isMonsterStrengthCacheable( const MP2::MapObjectType objectType )
         {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1842,7 +1842,6 @@ namespace AI
 
             _priorityTargets.erase( tileIndex );
             break;
-
         }
         case PriorityTaskType::ATTACK: {
             // check if battle was actually won or attacker still there

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1833,7 +1833,8 @@ namespace AI
         const PriorityTask & task = it->second;
 
         switch ( task.type ) {
-        case PriorityTaskType::DEFEND: {
+        case PriorityTaskType::DEFEND:
+        case PriorityTaskType::REINFORCE: {
             // TODO: sort the army between the castle and hero to have maximum movement points for the next day
             // TODO: but also have enough army to defend the castle.
             if ( objectType == MP2::OBJ_CASTLE ) {
@@ -1870,15 +1871,6 @@ namespace AI
 
             break;
         }
-        case PriorityTaskType::REINFORCE:
-            // TODO: sort the army between the castle and hero to have maximum movement points for the next day
-            // TODO: but also have enough army to defend the castle.
-            if ( objectType == MP2::OBJ_CASTLE ) {
-                hero.SetModes( Heroes::SLEEPER );
-            }
-
-            _priorityTargets.erase( tileIndex );
-            break;
         default:
             // Did you add a new type of priority task? Add the logic above!
             assert( 0 );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -607,7 +607,6 @@ namespace AI
                         const auto [dummy, inserted] = _priorityTargets.emplace( castle->GetIndex(), PriorityTask{ PriorityTaskType::REINFORCE, 0 } );
                         if ( inserted ) {
                             moreTaskForHeroes = true;
-                            VERBOSE_LOG( Color::String( myColor ) << " heroes have nothing to go so move them into castles." )
                         }
                     }
                 }

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -601,7 +601,7 @@ namespace AI
 
             if ( !moreTaskForHeroes && world.LastDay() ) {
                 // Heroes have nothing to do. In this case it is wise to move heroes to castles especially if it is the last day of a week.
-                // So for the next day a hero with a maximum amount of spell points as well as new troops can explore the surroundings.
+                // So for the next day a hero will have a maximum amount of spell points as well as new troops.
                 for ( Castle * castle : castles ) {
                     if ( castle->GetHero() == nullptr ) {
                         const auto [dummy, inserted] = _priorityTargets.emplace( castle->GetIndex(), PriorityTask{ PriorityTaskType::REINFORCE, 0 } );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -610,13 +610,11 @@ namespace AI
                         }
                     }
                 }
-
-                if ( moreTaskForHeroes ) {
-                    continue;
-                }
             }
 
-            break;
+            if ( !moreTaskForHeroes ) {
+                break;
+            }
         }
 
         status.DrawAITurnProgress( 9 );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -610,11 +610,13 @@ namespace AI
                         }
                     }
                 }
+
+                if ( moreTaskForHeroes ) {
+                    continue;
+                }
             }
 
-            if ( !moreTaskForHeroes ) {
-                break;
-            }
+            break;
         }
 
         status.DrawAITurnProgress( 9 );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -478,7 +478,7 @@ namespace AI
 
         const int mapSize = world.w() * world.h();
         _priorityTargets.clear();
-        _mapObjects.clear();
+        _mapActionObjects.clear();
         _regions.clear();
         _regions.resize( world.getRegionCount() );
 
@@ -499,11 +499,11 @@ namespace AI
                 continue;
             }
 
-            if ( objectType == MP2::OBJ_NONE || objectType == MP2::OBJ_COAST )
+            if ( !MP2::isActionObject( objectType ) ) {
                 continue;
+            }
 
-            stats.validObjects.emplace_back( idx, objectType );
-            _mapObjects.emplace_back( idx, objectType );
+            _mapActionObjects.emplace_back( idx, objectType );
 
             if ( objectType == MP2::OBJ_HEROES ) {
                 const Heroes * hero = tile.GetHeroes();
@@ -561,7 +561,7 @@ namespace AI
 
         updateKingdomBudget( kingdom );
 
-        DEBUG_LOG( DBG_AI, DBG_TRACE, Color::String( myColor ) << " found " << _mapObjects.size() << " valid objects" )
+        DEBUG_LOG( DBG_AI, DBG_TRACE, Color::String( myColor ) << " found " << _mapActionObjects.size() << " valid objects" )
 
         uint32_t progressStatus = 1;
         status.DrawAITurnProgress( progressStatus );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -602,9 +602,9 @@ namespace AI
             if ( !moreTaskForHeroes && world.LastDay() ) {
                 // Heroes have nothing to do. In this case it is wise to move heroes to castles especially if it is the last day of a week.
                 // So for the next day a hero will have a maximum amount of spell points as well as new troops.
-                for ( Castle * castle : castles ) {
+                for ( const Castle * castle : castles ) {
                     if ( castle->GetHero() == nullptr ) {
-                        const auto [dummy, inserted] = _priorityTargets.emplace( castle->GetIndex(), PriorityTask{ PriorityTaskType::REINFORCE, 0 } );
+                        const auto [dummy, inserted] = _priorityTargets.try_emplace( castle->GetIndex(), PriorityTask{ PriorityTaskType::REINFORCE, 0 } );
                         if ( inserted ) {
                             moreTaskForHeroes = true;
                         }


### PR DESCRIPTION
There are situations when AI heroes have literally nothing to do. If it is a last day of week then it is wise to move to objects which will give something on the next day.

This is a save file where Yellow player heroes have no tasks so it is wise to move one of them to the castle for reinforcement. This save is done on day 6 so see what happens on day 7.
[AI_does_not_merge_army.zip](https://github.com/ihhub/fheroes2/files/11641662/AI_does_not_merge_army.zip)
