### PR TITLE
Adjust battlefield Idle and Flag animation speed, avoid setting 0 animation delay

### DIFF
--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -187,8 +187,8 @@ void Game::UpdateGameSpeed()
     const int32_t battleSpeed = conf.BattleSpeed();
     // For the battle speed = 10 avoid the zero delay and set animation speed to the 1/3 of battleSpeedAdjustment step.
     const double adjustedBattleSpeed = ( battleSpeed < 10 ) ? ( ( 10 - battleSpeed ) * battleSpeedAdjustment ) : ( battleSpeedAdjustment / 3 );
-    // For the battle speed =  5 .. 10 adjust the Idle animation not to have insane high animation speed.
-    const double adjustedIdleAnimationSpeed = ( adjustedBattleSpeed < 1 ) ? ( adjustedBattleSpeed + 1 ) / 2 : adjustedBattleSpeed;
+    // Reduce the Idle animation adjustment interval to (0.5 .. 1).
+    const double adjustedIdleAnimationSpeed = ( 19 - battleSpeed ) / 18.0;
 
     delays[BATTLE_FRAME_DELAY].setDelay( static_cast<uint64_t>( 120 * adjustedBattleSpeed ) );
     delays[BATTLE_MISSILE_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -36,7 +36,7 @@ namespace
 
     static_assert( ( DEFAULT_BATTLE_SPEED >= 0 ) && ( DEFAULT_BATTLE_SPEED < 10 ) );
 
-    const double battleSpeedAdjustment = 1.0 / static_cast<double>( 10 - DEFAULT_BATTLE_SPEED );
+    constexpr double battleSpeedAdjustment = 1.0 / static_cast<double>( 10 - DEFAULT_BATTLE_SPEED );
 
     int humanHeroMultiplier = 1;
     int aiHeroMultiplier = 1;
@@ -185,7 +185,10 @@ void Game::UpdateGameSpeed()
     SetupHeroMovement( conf.AIMoveSpeed(), delays[CURRENT_AI_DELAY], aiHeroMultiplier );
 
     const int32_t battleSpeed = conf.BattleSpeed();
-    const double adjustedBattleSpeed = ( battleSpeed < 10 ) ? ( ( 10 - battleSpeed ) * battleSpeedAdjustment ) : ( battleSpeedAdjustment / 2 );
+    // For the battle speed = 10 avoid the zero delay and set animation speed to the 1/3 of battleSpeedAdjustment step.
+    const double adjustedBattleSpeed = ( battleSpeed < 10 ) ? ( ( 10 - battleSpeed ) * battleSpeedAdjustment ) : ( battleSpeedAdjustment / 3 );
+    // For the battle speed =  5 .. 10 adjust the Idle animation not to have insane high animation speed.
+    const double adjustedIdleAnimationSpeed = ( adjustedBattleSpeed < 1 ) ? ( adjustedBattleSpeed + 1 ) / 2 : adjustedBattleSpeed;
 
     delays[BATTLE_FRAME_DELAY].setDelay( static_cast<uint64_t>( 120 * adjustedBattleSpeed ) );
     delays[BATTLE_MISSILE_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
@@ -195,9 +198,9 @@ void Game::UpdateGameSpeed()
     delays[BATTLE_CATAPULT_BOULDER_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
     delays[BATTLE_CATAPULT_CLOUD_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
     delays[BATTLE_BRIDGE_DELAY].setDelay( static_cast<uint64_t>( 90 * adjustedBattleSpeed ) );
-    delays[BATTLE_IDLE_DELAY].setDelay( static_cast<uint64_t>( 150 * adjustedBattleSpeed ) );
+    delays[BATTLE_IDLE_DELAY].setDelay( static_cast<uint64_t>( 150 * adjustedIdleAnimationSpeed ) );
     delays[BATTLE_OPPONENTS_DELAY].setDelay( static_cast<uint64_t>( 350 * adjustedBattleSpeed ) );
-    delays[BATTLE_FLAGS_DELAY].setDelay( static_cast<uint64_t>( 250 * adjustedBattleSpeed ) );
+    delays[BATTLE_FLAGS_DELAY].setDelay( static_cast<uint64_t>( 250 * adjustedIdleAnimationSpeed ) );
 }
 
 int Game::HumanHeroAnimSkip()
@@ -212,7 +215,8 @@ int Game::AIHeroAnimSkip()
 
 uint32_t Game::ApplyBattleSpeed( uint32_t delay )
 {
-    return static_cast<uint32_t>( battleSpeedAdjustment * ( 10 - Settings::Get().BattleSpeed() ) * delay );
+    const uint32_t battleSpeed = static_cast<uint32_t>( battleSpeedAdjustment * ( 10 - Settings::Get().BattleSpeed() ) * delay );
+    return battleSpeed == 0 ? 1 : battleSpeed;
 }
 
 bool Game::hasEveryDelayPassed( const std::vector<Game::DelayType> & delayTypes )


### PR DESCRIPTION
Close #7125

This PR is a compromise between current idle animation speed setting implementation and constant idle animation speed.
The player has to visually understand the battle speed so the flag and idle animation IMHO should depend on the battle speed setting but not as much as movement animation.
The battle animation delay coefficient changes in the interval from 1.5 (for speed 1) to 0.05 (for speed 10).
This PR makes Idle/Flag animation delay coefficient to change in the interval from 1.0 (speed 1) to 0.5 (speed 10). With these delays animations does not look so awful.

Also this PR adds a fix to avoid adjusting the battle animation speed to 0 ms which can result in high CPU load. 1 ms delay is set instead.
