### PR TITLE
Fix assertion in the Interface::Basic::SetFocus( Castle * )

### DIFF
--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -92,7 +92,7 @@ void Interface::Basic::SetFocus( Castle * castle )
         return;
     }
 
-    assert( player->GetColor() == castle->GetColor() && player->isControlHuman() );
+    assert( player->GetColor() == castle->GetColor() && ( player->isControlHuman() || ( player->isControlAI() && player->isAIAutoControlMode() ) ) );
 
     Focus & focus = player->GetFocus();
 


### PR DESCRIPTION
fix #7271

This method can also be called in the "AI auto control mode".