### PR TITLE
Improve army distribution in castles for AI players

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -240,8 +240,10 @@ namespace AI
     void Normal::CastleTurn( Castle & castle, const bool defensiveStrategy )
     {
         if ( defensiveStrategy ) {
-            // Avoid building monster dwellings when defensive as they will likely fall into enemy's hands
+            // Avoid building monster dwellings when defensive as they might fall into enemy's hands, unless we have a lot of resources.
             const Kingdom & kingdom = castle.GetKingdom();
+
+            // TODO: check if we can upgrade monsters. It is much cheaper (except Giants into Titans) to upgrade monsters than buy new ones.
 
             Troops possibleReinforcement = castle.getAvailableArmy( kingdom.GetFunds() );
             double possibleReinforcementStrength = possibleReinforcement.GetStrength();

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -217,7 +217,15 @@ namespace AI
         Army & heroArmy = hero.GetArmy();
         Army & garrison = castle.GetArmy();
 
+        // Merge all troops in the castle to have the best army.
+        heroArmy.JoinStrongestFromArmy( garrison );
+
+        // Upgrade troops and try to merge them again.
         heroArmy.UpgradeTroops( castle );
+        garrison.UpgradeTroops( castle );
+        heroArmy.JoinStrongestFromArmy( garrison );
+
+        // Recruit more troops and also merge them.
         castle.recruitBestAvailable( budget );
         heroArmy.JoinStrongestFromArmy( garrison );
 
@@ -253,6 +261,7 @@ namespace AI
                     }
                 }
             }
+
             if ( unitToSwap ) {
                 const uint32_t count = unitToSwap->GetCount();
                 const uint32_t toMove = onlyHalf ? count / 2 : count;
@@ -263,14 +272,18 @@ namespace AI
                     else {
                         unitToSwap->SetCount( count - toMove );
                     }
-
-                    // TODO: redistribute troops properly.
-                    OptimizeTroopsOrder( garrison );
                 }
             }
         }
 
         OptimizeTroopsOrder( heroArmy );
+
+        if ( garrison.GetOccupiedSlotCount() == 1 ) {
+            garrison.splitWeakestTroopsIfPossible();
+        }
+        else {
+            OptimizeTroopsOrder( garrison );
+        }
     }
 
     void Normal::evaluateRegionSafety()

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -685,7 +685,7 @@ void Troops::JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotFor
     }
 
     if ( !keepAtLeastOneSlotForGiver || giverArmy.isValid() ) {
-        // Either the giver army does no need extra army or it already has some.
+        // Either the giver army does not need an extra army or it already has some.
         return;
     }
 
@@ -732,22 +732,7 @@ void Troops::JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotFor
     }
 
     // Make sure that this hero can survive an attack by splitting a single stack of monsters into multiple.
-    Troop * firstValidStack = giverArmy.GetFirstValid();
-    assert( firstValidStack != nullptr );
-
-    if ( firstValidStack->GetCount() > 1 ) {
-        const uint32_t stackCount = std::min( static_cast<uint32_t>( giverArmy.size() ), firstValidStack->GetCount() );
-
-        Troop temp( *firstValidStack );
-        firstValidStack->Reset();
-
-        giverArmy.addNewTroopsToFreeSlots( temp, stackCount );
-    }
-
-    // Make it less predictable to guess where troops would be. It makes human players to suffer by constantly adjusting the position of their troops.
-    if ( giverArmy.GetOccupiedSlotCount() < giverArmy.size() ) {
-        Rand::Shuffle( giverArmy );
-    }
+    splitWeakestTroopsIfPossible();
 }
 
 void Troops::SplitTroopIntoFreeSlots( const Troop & troop, const Troop & selectedSlot, const uint32_t slots )
@@ -860,6 +845,31 @@ bool Troops::mergeWeakestTroopsIfNeeded()
     addNewTroopsToFreeSlots( Troop( weakestMonsterToMerge, monsterCount ), monsterIdVsSlotCount[weakestMonsterToMerge] - 1 );
 
     return true;
+}
+
+void Troops::splitWeakestTroopsIfPossible()
+{
+    if ( GetOccupiedSlotCount() == size() ) {
+        // Nothing to do as all slots are being occupied.
+        return;
+    }
+
+    Troop * weakestStack = GetWeakestTroop();
+    assert( weakestStack != nullptr );
+
+    if ( weakestStack->GetCount() > 1 ) {
+        const uint32_t stackCount = std::min( static_cast<uint32_t>( size() + 1 - GetOccupiedSlotCount() ), weakestStack->GetCount() );
+
+        Troop temp( *weakestStack );
+        weakestStack->Reset();
+
+        addNewTroopsToFreeSlots( temp, stackCount );
+    }
+
+    // Make it less predictable to guess where troops would be. It makes human players to suffer by constantly adjusting the position of their troops.
+    if ( GetOccupiedSlotCount() < size() ) {
+        Rand::Shuffle( *this );
+    }
 }
 
 void Troops::AssignToFirstFreeSlot( const Troop & troopToAssign, const uint32_t count ) const

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -116,6 +116,8 @@ public:
     // If the army has no slot find 2 or more slots of the same monster which is the weakest and merge them releasing one slot in troops.
     bool mergeWeakestTroopsIfNeeded();
 
+    void splitWeakestTroopsIfPossible();
+
 protected:
     void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver );
 

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -205,8 +205,9 @@ public:
     // Returns the correct dwelling type available in the castle. BUILD_NOTHING is returned if this is not a dwelling.
     uint32_t GetActualDwelling( const uint32_t buildId ) const;
 
-    bool RecruitMonsterFromDwelling( uint32_t dw, uint32_t count, bool force = false );
+    // Returns true in case of successful recruitment.
     bool RecruitMonster( const Troop & troop, bool showDialog = true );
+
     void recruitBestAvailable( Funds budget );
     uint32_t getRecruitLimit( const Monster & monster, const Funds & budget ) const;
 
@@ -306,6 +307,8 @@ private:
     void WellRedrawInfoArea( const fheroes2::Point & cur_pt, const std::vector<fheroes2::RandomMonsterAnimation> & monsterAnimInfo ) const;
     void JoinRNDArmy();
     void PostLoad();
+
+    bool RecruitMonsterFromDwelling( uint32_t dw, uint32_t count, bool force = false );
 
     friend StreamBase & operator<<( StreamBase &, const Castle & );
     friend StreamBase & operator>>( StreamBase &, Castle & );


### PR DESCRIPTION
The current AI behavior does not cover possible scenarios:
- army is not distributed evenly after visiting by a hero. In most cases a hero grabs the most of the army and leaves just one stack of weak monsters. There is no perfect rule how to distribute an army of weak monsters but it is proven that having 5 stacks of monsters is better than 1 stack as there is a higher chance of shooting towers
- monsters were not upgraded if they were initially in a castle (use [AI_does_not_merge_army.zip](https://github.com/ihhub/fheroes2/files/11666182/AI_does_not_merge_army.zip) save, wait for the 7th day when a Yellow hero moves to the castle)
- if monsters are present in the castle no army shuffling was done (use [ai_castle_army_distribution.zip](https://github.com/ihhub/fheroes2/files/11666209/ai_castle_army_distribution.zip) save and just end the turn. Red hero will move to the castle)
