### PR TITLE
Improve AI heroes interaction with castles and heroes in dangerous areas

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -36,7 +36,6 @@
 #include "resource.h"
 #include "world_pathfinding.h"
 
-class Army;
 class Castle;
 class HeroBase;
 class Heroes;

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -261,7 +261,6 @@ namespace AI
         bool recruitHero( Castle & castle, bool buyArmy, bool underThreat );
         void reinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget );
         void evaluateRegionSafety();
-        std::set<int> findCastlesInDanger( const KingdomCastles & castles, const std::vector<std::pair<int, const Army *>> & enemyArmies, int myColor );
         std::vector<AICastle> getSortedCastleList( const KingdomCastles & castles, const std::set<int> & castlesInDanger );
 
         double getObjectValue( const Heroes & hero, const int index, const int objectType, const double valueToIgnore, const uint32_t distanceToObject ) const;
@@ -288,6 +287,23 @@ namespace AI
         }
 
     private:
+        struct EnemyArmy
+        {
+            EnemyArmy() = default;
+
+            EnemyArmy( const int index_, const double strength_, const uint32_t movePoints_ )
+                : index( index_ )
+                , strength( strength_ )
+                , movePoints( movePoints_ )
+            {
+                // Do nothing.
+            }
+
+            int index{ -1 };
+            double strength{ 0 };
+            uint32_t movePoints{ 0 };
+        };
+
         // following data won't be saved/serialized
         double _combinedHeroStrength = 0;
         std::vector<IndexObject> _mapActionObjects;
@@ -324,6 +340,8 @@ namespace AI
         }
 
         void updateMapActionObjectCache( const int mapIndex );
+
+        std::set<int> findCastlesInDanger( const KingdomCastles & castles, const std::vector<EnemyArmy> & enemyArmies, int myColor );
     };
 }
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1706,12 +1706,12 @@ namespace AI
 
             const Maps::Tiles & destinationTile = world.GetTiles( destination );
 
-            // TODO: check nearby enemy heroes and distance to them instead of relying on a region.
+            // TODO: check nearby enemy heroes and distance to them instead of relying on region stats.
             const RegionStats & regionStats = _regions[destinationTile.GetRegion()];
 
             const bool isObjectReachableAtThisTurn = ( distance <= leftMovePoints );
 
-            // Go into "coward" mode only if the treat is real. Equal by strength heroes rarely attack each other.
+            // Go into "coward" mode only if the threat is real. Equal by strength heroes rarely attack each other.
             if ( heroStrength * AI::ARMY_ADVANTAGE_SMALL < regionStats.highestThreat ) {
                 switch ( type ) {
                 case MP2::OBJ_CASTLE: {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1728,6 +1728,8 @@ namespace AI
                     if ( anotherHero != nullptr && anotherHero->GetColor() != hero.GetColor() ) {
                         value -= dangerousTaskPenalty / 2;
                     }
+
+                    // Meeting friendly heroes usually increases defense of the army so no penalty of doing such.
                     break;
                 }
                 default:

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1707,6 +1707,7 @@ namespace AI
             const Maps::Tiles & destinationTile = world.GetTiles( destination );
             const MP2::MapObjectType objectType = destinationTile.GetObject();
 
+            // TODO: use nearby enemy heroes as a treat instead of a region.
             const RegionStats & regionStats = _regions[destinationTile.GetRegion()];
 
             if ( heroStrength < regionStats.highestThreat ) {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1710,13 +1710,15 @@ namespace AI
             // TODO: use nearby enemy heroes as a treat instead of a region.
             const RegionStats & regionStats = _regions[destinationTile.GetRegion()];
 
+            const bool isObjectReachableAtThisTurn = ( distance > leftMovePoints );
+
             // Go into scared mode only if the treat is real. Equal by strength heroes rarely attack each other.
             if ( heroStrength * AI::ARMY_ADVANTAGE_SMALL < regionStats.highestThreat ) {
                 switch ( objectType ) {
                 case MP2::OBJ_CASTLE: {
                     const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
                     assert( castle != nullptr );
-                    if ( castle != nullptr && castle->GetColor() != hero.GetColor() && castle->GetGarrisonStrength( &hero ) > 0.1 ) {
+                    if ( castle != nullptr && castle->GetColor() != hero.GetColor() && ( castle->GetGarrisonStrength( &hero ) > 0.1 || !isObjectReachableAtThisTurn ) ) {
                         // This is a non-empty enemy castle.
                         value -= dangerousTaskPenalty / 4;
                     }
@@ -1727,7 +1729,7 @@ namespace AI
                 case MP2::OBJ_HEROES: {
                     const Heroes * anotherHero = destinationTile.GetHeroes();
                     assert( anotherHero != nullptr );
-                    if ( anotherHero != nullptr && anotherHero->GetColor() != hero.GetColor() ) {
+                    if ( anotherHero != nullptr && anotherHero->GetColor() != hero.GetColor() && !isObjectReachableAtThisTurn ) {
                         value -= dangerousTaskPenalty / 2;
                     }
 
@@ -1741,7 +1743,7 @@ namespace AI
                 }
             }
 
-            if ( distance > leftMovePoints ) {
+            if ( isObjectReachableAtThisTurn ) {
                 // Distant object which is out of reach for the current turn must have lower priority.
                 distance = leftMovePoints + ( distance - leftMovePoints ) * 2;
             }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1711,7 +1711,7 @@ namespace AI
 
             const bool isObjectReachableAtThisTurn = ( distance <= leftMovePoints );
 
-            // Go into scared mode only if the treat is real. Equal by strength heroes rarely attack each other.
+            // Go into "coward" mode only if the treat is real. Equal by strength heroes rarely attack each other.
             if ( heroStrength * AI::ARMY_ADVANTAGE_SMALL < regionStats.highestThreat ) {
                 switch ( type ) {
                 case MP2::OBJ_CASTLE: {
@@ -1738,7 +1738,7 @@ namespace AI
                         }
                     }
 
-                    // Friendly castles as well as empty enemy castles are good stuff to capture.
+                    // Friendly castles are always the priority so no penalty for them.
                     break;
                 }
                 case MP2::OBJ_HEROES: {
@@ -1768,7 +1768,7 @@ namespace AI
                     break;
                 }
                 default:
-                    // It is better to avoid all other objects if the current hero under a big threat.
+                    // It is better to avoid all other objects if the current hero is under a big threat.
                     value -= dangerousTaskPenalty;
                     break;
                 }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1704,14 +1704,34 @@ namespace AI
                 }
             }
 
-            const RegionStats & regionStats = _regions[world.GetTiles( destination ).GetRegion()];
+            const Maps::Tiles & destinationTile = world.GetTiles( destination );
+            const MP2::MapObjectType objectType = destinationTile.GetObject();
+
+            const RegionStats & regionStats = _regions[destinationTile.GetRegion()];
 
             if ( heroStrength < regionStats.highestThreat ) {
-                const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
-                if ( castle != nullptr ) {
-                    if ( castle->GetColor() != hero.GetColor() && castle->GetGarrisonStrength( &hero ) > 0.1 ) {
+                switch ( objectType ) {
+                case MP2::OBJ_CASTLE: {
+                    const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
+                    assert( castle != nullptr );
+                    if ( castle != nullptr && castle->GetColor() != hero.GetColor() && castle->GetGarrisonStrength( &hero ) > 0.1 ) {
+                        // This is a non-empty enemy castle.
                         value -= dangerousTaskPenalty / 4;
                     }
+
+                    break;
+                }
+                case MP2::OBJ_HEROES: {
+                    const Heroes* anotherHero = destinationTile.GetHeroes();
+                    assert( anotherHero != nullptr );
+                    if ( anotherHero != nullptr && anotherHero->GetColor() != hero.GetColor() ) {
+                        value -= dangerousTaskPenalty / 4;
+                    }
+                    break;
+                }
+                default:
+                    value -= dangerousTaskPenalty / 4;
+                    break;
                 }
             }
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1708,11 +1708,11 @@ namespace AI
 
             if ( heroStrength < regionStats.highestThreat ) {
                 const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
-
-                if ( castle && ( castle->GetGarrisonStrength( &hero ) <= 0 || castle->GetColor() == hero.GetColor() ) )
-                    value -= dangerousTaskPenalty / 2;
-                else
-                    value -= dangerousTaskPenalty;
+                if ( castle != nullptr ) {
+                    if ( castle->GetColor() != hero.GetColor() && castle->GetGarrisonStrength( &hero ) > 0.1 ) {
+                        value -= dangerousTaskPenalty / 4;
+                    }
+                }
             }
 
             if ( distance > leftMovePoints ) {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1705,7 +1705,6 @@ namespace AI
             }
 
             const Maps::Tiles & destinationTile = world.GetTiles( destination );
-            const MP2::MapObjectType objectType = destinationTile.GetObject();
 
             // TODO: use nearby enemy heroes as a treat instead of a region.
             const RegionStats & regionStats = _regions[destinationTile.GetRegion()];
@@ -1714,7 +1713,7 @@ namespace AI
 
             // Go into scared mode only if the treat is real. Equal by strength heroes rarely attack each other.
             if ( heroStrength * AI::ARMY_ADVANTAGE_SMALL < regionStats.highestThreat ) {
-                switch ( objectType ) {
+                switch ( type ) {
                 case MP2::OBJ_CASTLE: {
                     const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
                     assert( castle != nullptr );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1710,7 +1710,8 @@ namespace AI
             // TODO: use nearby enemy heroes as a treat instead of a region.
             const RegionStats & regionStats = _regions[destinationTile.GetRegion()];
 
-            if ( heroStrength < regionStats.highestThreat ) {
+            // Go into scared mode only if the treat is real. Equal by strength heroes rarely attack each other.
+            if ( heroStrength * AI::ARMY_ADVANTAGE_SMALL < regionStats.highestThreat ) {
                 switch ( objectType ) {
                 case MP2::OBJ_CASTLE: {
                     const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
@@ -1720,6 +1721,7 @@ namespace AI
                         value -= dangerousTaskPenalty / 4;
                     }
 
+                    // Friendly castles as well as empty enemy castles are good opportunity to stay there.
                     break;
                 }
                 case MP2::OBJ_HEROES: {
@@ -1733,7 +1735,8 @@ namespace AI
                     break;
                 }
                 default:
-                    value -= dangerousTaskPenalty / 2;
+                    // It is better to avoid all other objects if the current hero under a big threat.
+                    value -= dangerousTaskPenalty;
                     break;
                 }
             }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1718,11 +1718,11 @@ namespace AI
                     const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
                     assert( castle != nullptr );
 
-                    if ( castle != nullptr && ( castle->GetColor() != hero.GetColor() ) &&
-                         ( ( castle->GetGarrisonStrength( &hero ) > heroStrength / 2 ) || !isObjectReachableAtThisTurn ) ) {
+                    if ( castle != nullptr && ( castle->GetColor() != hero.GetColor() )
+                         && ( ( castle->GetGarrisonStrength( &hero ) > heroStrength / 2 ) || !isObjectReachableAtThisTurn ) ) {
                         // If the castle is not reachable within a single turn or it has more or less powerful army
                         // then the priority should be lower for the castle.
-                        value -= dangerousTaskPenalty / 4;
+                        value -= dangerousTaskPenalty / 3;
                     }
 
                     // Friendly castles as well as empty enemy castles are good stuff to capture.
@@ -1740,14 +1740,7 @@ namespace AI
                 }
                 default:
                     // It is better to avoid all other objects if the current hero under a big threat.
-                    if ( distance > leftMovePoints / 3 && leftMovePoints > hero.GetMaxMovePoints() / 2 ) {
-                        // Since this object is reachable within a third of the turn for the hero we reduce the threat.
-                        // This is done because the hero can do something and still run away.
-                        value -= dangerousTaskPenalty / 2;
-                    }
-                    else {
-                        value -= dangerousTaskPenalty;
-                    }
+                    value -= dangerousTaskPenalty;
                     break;
                 }
             }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1722,15 +1722,15 @@ namespace AI
                     break;
                 }
                 case MP2::OBJ_HEROES: {
-                    const Heroes* anotherHero = destinationTile.GetHeroes();
+                    const Heroes * anotherHero = destinationTile.GetHeroes();
                     assert( anotherHero != nullptr );
                     if ( anotherHero != nullptr && anotherHero->GetColor() != hero.GetColor() ) {
-                        value -= dangerousTaskPenalty / 4;
+                        value -= dangerousTaskPenalty / 2;
                     }
                     break;
                 }
                 default:
-                    value -= dangerousTaskPenalty / 4;
+                    value -= dangerousTaskPenalty / 2;
                     break;
                 }
             }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1721,24 +1721,26 @@ namespace AI
                         break;
                     }
 
-                    if ( ( castle->GetColor() != hero.GetColor() ) ) {
-                        if ( isObjectReachableAtThisTurn ) {
-                            if ( castle->GetGarrisonStrength( &hero ) > heroStrength / 2 ) {
-                                value -= dangerousTaskPenalty / 4;
-                            }
-                            else {
-                                value -= dangerousTaskPenalty / 10;
-                            }
-                        }
-                        else if ( castle->GetGarrisonStrength( &hero ) > heroStrength / 2 ) {
-                            value -= dangerousTaskPenalty / 2;
-                        }
-                        else {
-                            value -= dangerousTaskPenalty / 3;
-                        }
+                    if ( castle->GetColor() == hero.GetColor() ) {
+                        // Friendly castles are always the priority so no penalty for them.
+                        break;
                     }
 
-                    // Friendly castles are always the priority so no penalty for them.
+                    if ( isObjectReachableAtThisTurn ) {
+                        if ( castle->GetGarrisonStrength( &hero ) > heroStrength / 2 ) {
+                            value -= dangerousTaskPenalty / 4;
+                        }
+                        else {
+                            value -= dangerousTaskPenalty / 10;
+                        }
+                    }
+                    else if ( castle->GetGarrisonStrength( &hero ) > heroStrength / 2 ) {
+                        value -= dangerousTaskPenalty / 2;
+                    }
+                    else {
+                        value -= dangerousTaskPenalty / 3;
+                    }
+
                     break;
                 }
                 case MP2::OBJ_HEROES: {
@@ -1748,12 +1750,12 @@ namespace AI
                         break;
                     }
 
-                    if ( anotherHero->GetColor() != hero.GetColor() ) {
+                    if ( anotherHero->GetColor() == hero.GetColor() ) {
                         if ( isObjectReachableAtThisTurn ) {
                             value -= dangerousTaskPenalty / 8;
                         }
                         else {
-                            value -= dangerousTaskPenalty / 2;
+                            value -= dangerousTaskPenalty / 4;
                         }
                     }
                     else {
@@ -1761,7 +1763,7 @@ namespace AI
                             value -= dangerousTaskPenalty / 8;
                         }
                         else {
-                            value -= dangerousTaskPenalty / 4;
+                            value -= dangerousTaskPenalty / 2;
                         }
                     }
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -423,6 +423,9 @@ namespace AI
                     continue;
                 }
 
+                // TODO: if a hero (even a weak one) is blocking the path then the function call below will return 0.
+                // TODO: For example if a friendly hero stands just below the castle entrance then the distance will be 0.
+                // TODO: Which is not the case as an enemy hero can be very powerful to kill the hero and capture the castle.
                 const uint32_t dist = _pathfinder.getDistance( enemyIndex, castleIndex, myColor, attackerStrength );
                 if ( dist == 0 || dist >= threatDistanceLimit ) {
                     continue;

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -417,7 +417,7 @@ namespace AI
                     continue;
                 }
 
-                int32_t daysToReach = ( dist + enemyArmy.movePoints - 1 ) / enemyArmy.movePoints;
+                uint32_t daysToReach = ( dist + enemyArmy.movePoints - 1 ) / enemyArmy.movePoints;
                 if ( daysToReach > 3 ) {
                     // It is too far away. Ignore it.
                     continue;
@@ -427,8 +427,8 @@ namespace AI
 
                 --daysToReach;
                 while ( daysToReach > 0 ) {
-                    // Each day reduces enemy strength by 33%. If an enemy is too far away then there is no reason to panic.
-                    enemyStrength = enemyStrength * 2 / 3;
+                    // Each day reduces enemy strength by 50%. If an enemy is too far away then there is no reason to panic.
+                    enemyStrength /= 2;
                     --daysToReach;
                 }
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -247,7 +247,7 @@ namespace AI
                 do {
                     Troop * weakestTroop = heroArmy.GetWeakestTroop();
                     const double weakestTroopStrength = weakestTroop->GetStrength();
-                    uint32_t count = std::max( weakestTroop->GetCount() / 2, 1u );
+                    uint32_t count = std::max( weakestTroop->GetCount() / 2, 1U );
                     if ( weakestTroopStrength < heroStrength * 0.1 ) {
                         count = weakestTroop->GetCount();
                     }

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -567,7 +567,7 @@ namespace AI
                         continue;
 
                     if ( !castle->isCastle() ) {
-                        // If it is just a town the opponent cannot hire heroes and do any damage.
+                        // If it is just a town then there is no way to hire heroes which can be a threat.
                         continue;
                     }
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -284,7 +284,6 @@ namespace AI
 
                     heroStrength = heroArmy.GetStrength();
                     castleStrength = garrison.GetStrength();
-
                 } while ( castleStrength < minStrength );
 
                 if ( castleStrength >= minStrength ) {

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -646,8 +646,8 @@ namespace AI
                     if ( !castle )
                         continue;
 
-                    if ( !castle->isCastle() ) {
-                        // If it is just a town then there is no way to hire heroes which can be a threat.
+                    if ( !castle->isCastle() && !castle->AllowBuyBuilding( BUILD_CASTLE ) ) {
+                        // If it is just a town with no possibility to build a castle then there is no way to hire heroes which can be a threat.
                         continue;
                     }
 

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -652,6 +652,7 @@ namespace AI
                     }
 
                     const double castleThreat = castle->GetArmy().GetStrength();
+                    // 1500 is slightly more than a fresh hero's maximum move points hired in a castle.
                     enemyArmies.emplace_back( idx, castleThreat, 1500 );
 
                     if ( stats.highestThreat < castleThreat ) {

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -287,7 +287,7 @@ namespace AI
                 } while ( castleStrength < minStrength );
 
                 if ( castleStrength >= minStrength ) {
-                    _priorityTargets.erase( castleIndex );
+                    _priorityTargets.erase( defenseTask );
                 }
                 else {
                     // Failed to secure the castle. Rearrange the army back.

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -244,8 +244,7 @@ namespace AI
 
                 const double minStrength = defenseTask->second.threatLevel * AI::ARMY_ADVANTAGE_DESPERATE;
 
-                do
-                {
+                do {
                     Troop * weakestTroop = heroArmy.GetWeakestTroop();
                     const double weakestTroopStrength = weakestTroop->GetStrength();
                     uint32_t count = std::max( weakestTroop->GetCount() / 2, 1u );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -118,11 +118,12 @@ public:
 
     void splitWeakestTroopsIfPossible();
 
+    // Combines all stacks consisting of identical monsters
+    void MergeSameMonsterTroops();
+
 protected:
     void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver );
 
-    // Combines all stacks consisting of identical monsters
-    void MergeSameMonsterTroops();
     // Combines two stacks consisting of identical monsters. Returns true if there was something to combine, otherwise returns false.
     bool MergeSameMonsterOnce();
     // Returns an optimized version of this Troops instance, i.e. all stacks of identical monsters are combined and there are no empty slots


### PR DESCRIPTION
This pull request fixes multiple things in AI behavior:
- move to a castle and stay there the hero cannot defeat the treat (close #7082). This is important to stay in the castle if the hero is too weak
- capture empty castles even if the area is under treat (close #7193). Also be afraid only of heroes which are really more powerful that the hero
