### PR TITLE
Speedup Homebrew on macOS

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -48,10 +48,9 @@ jobs:
     - name: Install dependencies (macOS)
       if: ${{ startsWith( matrix.config.os, 'macos-' ) }}
       run: |
-        brew update
         brew install ${{ matrix.config.dependencies }}
       env:
-        # TODO: remove this temporary setting
+        # Do not update outdated dependencies of installed packages
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: ON
     - name: Build
       run: |

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -256,8 +256,10 @@ jobs:
     - name: Install dependencies (macOS)
       if: ${{ startsWith( matrix.config.os, 'macos-' ) }}
       run: |
-        brew update
         brew install ${{ matrix.config.dependencies }}
+      env:
+        # Do not update outdated dependencies of installed packages
+        HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: ON
     - name: Build
       run: |
         make -j 2


### PR DESCRIPTION
At the moment, installing Homebrew packages on GitHub macOS VMs is very slow (sometimes this process does not even fit into the 30-minute limit). This PR aims to fix this with the following changes:

* Do not run a separate `brew update` step. `brew install` performs "lightweight" update (using `brew update --auto-update`).
* Do not update outdated dependencies of installed packages (using the `HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK` environment variable). This can be a bit dangerous if some installed package expects a newer version of its dependency, but this leads to a good acceleration of the package installation process.