### PR TITLE
Fix rating in campaign congratulations text in win video

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1256,7 +1256,7 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
 
         textBody = _( "Score: %{score}\n\nRating:\n%{rating}" );
         StringReplace( textBody, "%{score}", score );
-        StringReplace( textBody, "%{rating}", fheroes2::HighScoreDataContainer::getMonsterByDay( daysPassed ).GetName() );
+        StringReplace( textBody, "%{rating}", fheroes2::HighScoreDataContainer::getMonsterByDay( score ).GetName() );
         ratingText.add( { textBody, fheroes2::FontType::normalWhite() } );
 
         // Show results from the 5th second until end (forever) and set maximum width to 140 to fit the black area.


### PR DESCRIPTION
This PR fixes wrong display of Rating in congratulations text shown in WIN video. In 'master' build it was calculated without taking into account of campaign difficulty.