### PR TITLE
Improve image processing logic for single-layer images

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -198,29 +198,35 @@ namespace
         69,  69,  69,  69,  69,  69,  69,  69,  69,  69,  242, 243, 244, 245, 246, 247, 248, 249, 250, 251, 252, 253, 254, 255 // No cycle
     };
 
-    bool Validate( const fheroes2::Image & image, int32_t x, int32_t y, int32_t width, int32_t height )
+    bool Validate( const fheroes2::Image & image, const int32_t x, const int32_t y, const int32_t width, const int32_t height )
     {
-        if ( image.empty() || width <= 0 || height <= 0 ) // what's the reason to work with empty images?
+        if ( image.empty() || width <= 0 || height <= 0 ) {
+            // What's the reason to work with empty images?
             return false;
+        }
 
-        if ( x < 0 || y < 0 || x + width > image.width() || y + height > image.height() )
+        if ( x < 0 || y < 0 || x + width > image.width() || y + height > image.height() ) {
             return false;
+        }
 
         return true;
     }
 
     bool Verify( const fheroes2::Image & image, int32_t & x, int32_t & y, int32_t & width, int32_t & height )
     {
-        if ( image.empty() || width <= 0 || height <= 0 ) // what's the reason to work with empty images?
+        if ( image.empty() || width <= 0 || height <= 0 ) {
+            // What's the reason to work with empty images?
             return false;
+        }
 
         const int32_t widthOut = image.width();
         const int32_t heightOut = image.height();
 
         if ( x < 0 ) {
             const int32_t offsetX = -x;
-            if ( offsetX >= width )
+            if ( offsetX >= width ) {
                 return false;
+            }
 
             x = 0;
             width -= offsetX;
@@ -228,46 +234,54 @@ namespace
 
         if ( y < 0 ) {
             const int32_t offsetY = -y;
-            if ( offsetY >= height )
+            if ( offsetY >= height ) {
                 return false;
+            }
 
             y = 0;
             height -= offsetY;
         }
 
-        if ( x > widthOut || y > heightOut )
+        if ( x > widthOut || y > heightOut ) {
             return false;
+        }
 
         if ( x + width > widthOut ) {
             const int32_t offsetX = x + width - widthOut;
-            if ( offsetX >= width )
+            if ( offsetX >= width ) {
                 return false;
+            }
             width -= offsetX;
         }
 
         if ( y + height > heightOut ) {
             const int32_t offsetY = y + height - heightOut;
-            if ( offsetY >= height )
+            if ( offsetY >= height ) {
                 return false;
+            }
             height -= offsetY;
         }
 
         return true;
     }
 
-    bool Verify( int32_t & inX, int32_t & inY, int32_t & outX, int32_t & outY, int32_t & width, int32_t & height, int32_t widthIn, int32_t heightIn, int32_t widthOut,
-                 int32_t heightOut )
+    bool Verify( int32_t & inX, int32_t & inY, int32_t & outX, int32_t & outY, int32_t & width, int32_t & height, const int32_t widthIn, const int32_t heightIn,
+                 const int32_t widthOut, const int32_t heightOut )
     {
-        if ( widthIn <= 0 || heightIn <= 0 || widthOut <= 0 || heightOut <= 0 || width <= 0 || height <= 0 ) // what's the reason to work with empty images?
+        if ( widthIn <= 0 || heightIn <= 0 || widthOut <= 0 || heightOut <= 0 || width <= 0 || height <= 0 ) {
+            // What's the reason to work with empty images?
             return false;
+        }
 
-        if ( inX < 0 || inY < 0 || inX > widthIn || inY > heightIn )
+        if ( inX < 0 || inY < 0 || inX > widthIn || inY > heightIn ) {
             return false;
+        }
 
         if ( outX < 0 ) {
             const int32_t offsetX = -outX;
-            if ( offsetX >= width )
+            if ( offsetX >= width ) {
                 return false;
+            }
 
             inX += offsetX;
             outX = 0;
@@ -276,42 +290,48 @@ namespace
 
         if ( outY < 0 ) {
             const int32_t offsetY = -outY;
-            if ( offsetY >= height )
+            if ( offsetY >= height ) {
                 return false;
+            }
 
             inY += offsetY;
             outY = 0;
             height -= offsetY;
         }
 
-        if ( outX > widthOut || outY > heightOut )
+        if ( outX > widthOut || outY > heightOut ) {
             return false;
+        }
 
         if ( inX + width > widthIn ) {
             const int32_t offsetX = inX + width - widthIn;
-            if ( offsetX >= width )
+            if ( offsetX >= width ) {
                 return false;
+            }
             width -= offsetX;
         }
 
         if ( inY + height > heightIn ) {
             const int32_t offsetY = inY + height - heightIn;
-            if ( offsetY >= height )
+            if ( offsetY >= height ) {
                 return false;
+            }
             height -= offsetY;
         }
 
         if ( outX + width > widthOut ) {
             const int32_t offsetX = outX + width - widthOut;
-            if ( offsetX >= width )
+            if ( offsetX >= width ) {
                 return false;
+            }
             width -= offsetX;
         }
 
         if ( outY + height > heightOut ) {
             const int32_t offsetY = outY + height - heightOut;
-            if ( offsetY >= height )
+            if ( offsetY >= height ) {
                 return false;
+            }
             height -= offsetY;
         }
 
@@ -324,7 +344,7 @@ namespace
         return Verify( inX, inY, outX, outY, width, height, in.width(), in.height(), out.width(), out.height() );
     }
 
-    uint8_t GetPALColorId( uint8_t red, uint8_t green, uint8_t blue )
+    uint8_t GetPALColorId( const uint8_t red, const uint8_t green, const uint8_t blue )
     {
         static uint8_t rgbToId[64 * 64 * 64];
         static bool isInitialized = false;
@@ -385,7 +405,7 @@ namespace
         const uint8_t * imageInYEnd = imageInY + height * widthIn;
 
         if ( in.singleLayer() ) {
-            // All pixels in a single layer image do not have any transform values so there is no need to check for them.
+            // All pixels in a single-layer image do not have any transform values so there is no need to check for them.
             for ( ; imageInY != imageInYEnd; imageInY += widthIn, imageOutY += widthOut ) {
                 const uint8_t * imageInX = imageInY;
                 uint8_t * imageOutX = imageOutY;
@@ -417,35 +437,18 @@ namespace
 
 namespace fheroes2
 {
-    Image::Image()
-        : _width( 0 )
-        , _height( 0 )
-        , _singleLayer( false )
-    {
-        // Do nothing.
-    }
-
-    Image::Image( int32_t width_, int32_t height_ )
-        : _width( 0 )
-        , _height( 0 )
-        , _singleLayer( false )
+    Image::Image( const int32_t width_, const int32_t height_ )
     {
         Image::resize( width_, height_ );
     }
 
     Image::Image( const Image & image_ )
-        : _width( 0 )
-        , _height( 0 )
-        , _singleLayer( false )
     {
         copy( image_ );
     }
 
     Image::Image( Image && image_ ) noexcept
-        : _width( 0 )
-        , _height( 0 )
-        , _data( std::move( image_._data ) )
-        , _singleLayer( false )
+        : _data( std::move( image_._data ) )
     {
         std::swap( _singleLayer, image_._singleLayer );
         std::swap( _width, image_._width );
@@ -464,12 +467,10 @@ namespace fheroes2
     Image & Image::operator=( Image && image_ ) noexcept
     {
         if ( this != &image_ ) {
-            // We shouldn't copy or move different types of images.
-            assert( _singleLayer == image_._singleLayer );
-
             std::swap( _width, image_._width );
             std::swap( _height, image_._height );
             std::swap( _data, image_._data );
+            std::swap( _singleLayer, image_._singleLayer );
         }
 
         return *this;
@@ -493,16 +494,16 @@ namespace fheroes2
         _height = 0;
     }
 
-    void Image::fill( uint8_t value )
+    void Image::fill( const uint8_t value )
     {
         if ( !empty() ) {
-            const size_t totalSize = static_cast<size_t>( _width * _height );
+            const size_t totalSize = static_cast<size_t>( _width ) * _height;
             std::fill( image(), image() + totalSize, value );
             std::fill( transform(), transform() + totalSize, static_cast<uint8_t>( 0 ) );
         }
     }
 
-    void Image::resize( int32_t width_, int32_t height_ )
+    void Image::resize( const int32_t width_, const int32_t height_ )
     {
         if ( width_ == _width && height_ == _height ) {
             return;
@@ -514,7 +515,7 @@ namespace fheroes2
             return;
         }
 
-        const size_t size = static_cast<size_t>( width_ * height_ );
+        size_t size = static_cast<size_t>( width_ ) * height_;
 
         _data.reset( new uint8_t[size * 2] );
 
@@ -525,24 +526,22 @@ namespace fheroes2
     void Image::reset()
     {
         if ( !empty() ) {
-            const size_t totalSize = static_cast<size_t>( _width * _height );
+            const size_t totalSize = static_cast<size_t>( _width ) * _height;
             std::fill( image(), image() + totalSize, static_cast<uint8_t>( 0 ) );
-            std::fill( transform(), transform() + totalSize, static_cast<uint8_t>( 1 ) ); // skip all data
+            // Set the transform layer to skip all data.
+            std::fill( transform(), transform() + totalSize, static_cast<uint8_t>( 1 ) );
         }
     }
 
     void Image::copy( const Image & image )
     {
-        // We shouldn't copy or move different types of images.
-        assert( _singleLayer == image._singleLayer );
-
         if ( !image._data ) {
             clear();
 
             return;
         }
 
-        const size_t size = static_cast<size_t>( image._width * image._height );
+        const size_t size = static_cast<size_t>( image._width ) * image._height;
 
         if ( image._width != _width || image._height != _height ) {
             _data.reset( new uint8_t[size * 2] );
@@ -551,18 +550,12 @@ namespace fheroes2
             _height = image._height;
         }
 
+        _singleLayer = image._singleLayer;
+
         memcpy( _data.get(), image._data.get(), size * 2 );
     }
 
-    Sprite::Sprite()
-        : Image( 0, 0 )
-        , _x( 0 )
-        , _y( 0 )
-    {
-        // Do nothing.
-    }
-
-    Sprite::Sprite( int32_t width_, int32_t height_, int32_t x_, int32_t y_ )
+    Sprite::Sprite( const int32_t width_, const int32_t height_, const int32_t x_ /* = 0 */, const int32_t y_ /* = 0 */ )
         : Image( width_, height_ )
         , _x( x_ )
         , _y( y_ )
@@ -570,7 +563,7 @@ namespace fheroes2
         // Do nothing.
     }
 
-    Sprite::Sprite( const Image & image, int32_t x_, int32_t y_ )
+    Sprite::Sprite( const Image & image, const int32_t x_ /* = 0 */, const int32_t y_ /* = 0 */ )
         : Image( image )
         , _x( x_ )
         , _y( y_ )
@@ -578,18 +571,8 @@ namespace fheroes2
         // Do nothing.
     }
 
-    Sprite::Sprite( const Sprite & sprite )
-        : Image( sprite )
-        , _x( sprite._x )
-        , _y( sprite._y )
-    {
-        // Do nothing.
-    }
-
     Sprite::Sprite( Sprite && sprite ) noexcept
         : Image( std::move( sprite ) )
-        , _x( 0 )
-        , _y( 0 )
     {
         std::swap( _x, sprite._x );
         std::swap( _y, sprite._y );
@@ -619,7 +602,7 @@ namespace fheroes2
         return *this;
     }
 
-    void Sprite::setPosition( int32_t x_, int32_t y_ )
+    void Sprite::setPosition( const int32_t x_, const int32_t y_ )
     {
         _x = x_;
         _y = y_;
@@ -627,34 +610,36 @@ namespace fheroes2
 
     ImageRestorer::ImageRestorer( Image & image )
         : _image( image )
-        , _x( 0 )
-        , _y( 0 )
         , _width( image.width() )
         , _height( image.height() )
-        , _isRestored( false )
     {
         _updateRoi();
-        _copy.resize( _width, _height );
+
         if ( _image.singleLayer() ) {
+            // The restorer is used to restore the image without the transform layer so we make a single-layer copy.
             _copy._disableTransformLayer();
         }
 
-        Copy( _image, _x, _y, _copy, 0, 0, _width, _height );
+        _copy.resize( _width, _height );
+
+        Copy( _image, 0, 0, _copy, 0, 0, _width, _height );
     }
 
-    ImageRestorer::ImageRestorer( Image & image, int32_t x_, int32_t y_, int32_t width, int32_t height )
+    ImageRestorer::ImageRestorer( Image & image, const int32_t x_, const int32_t y_, const int32_t width, const int32_t height )
         : _image( image )
         , _x( x_ )
         , _y( y_ )
         , _width( width )
         , _height( height )
-        , _isRestored( false )
     {
         _updateRoi();
-        _copy.resize( _width, _height );
+
         if ( _image.singleLayer() ) {
+            // The restorer is used to restore the image without the transform layer so we make a single-layer copy.
             _copy._disableTransformLayer();
         }
+
+        _copy.resize( _width, _height );
 
         Copy( _image, _x, _y, _copy, 0, 0, _width, _height );
     }
@@ -666,7 +651,7 @@ namespace fheroes2
         }
     }
 
-    void ImageRestorer::update( int32_t x_, int32_t y_, int32_t width, int32_t height )
+    void ImageRestorer::update( const int32_t x_, const int32_t y_, const int32_t width, const int32_t height )
     {
         _isRestored = false;
         _x = x_;
@@ -685,18 +670,15 @@ namespace fheroes2
         Copy( _copy, 0, 0, _image, _x, _y, _width, _height );
     }
 
-    void ImageRestorer::reset()
-    {
-        _isRestored = true;
-    }
-
     void ImageRestorer::_updateRoi()
     {
-        if ( _width < 0 )
+        if ( _width < 0 ) {
             _width = 0;
+        }
 
-        if ( _height < 0 )
+        if ( _height < 0 ) {
             _height = 0;
+        }
 
         if ( _x < 0 ) {
             const int32_t offset = -_x;
@@ -792,18 +774,10 @@ namespace fheroes2
 
         const int32_t maxX = inWidth + absOffsetX;
         const int32_t maxY = inHeight + absOffsetY;
-        const bool isInNonSingleLayer = !in.singleLayer();
-        const bool isOutNonSingleLayer = !out.singleLayer();
+        const bool isOutDoubleLayer = !out.singleLayer();
 
-        const uint8_t * transformIn = nullptr;
-        if ( isInNonSingleLayer ) {
-            transformIn = in.transform();
-        }
-
-        uint8_t * transformOut = nullptr;
-        if ( isOutNonSingleLayer ) {
-            transformOut = out.transform() + outStartOffset;
-        }
+        const uint8_t * transformIn = in.singleLayer() ? nullptr : in.transform();
+        uint8_t * transformOut = isOutDoubleLayer ? ( out.transform() + outStartOffset ) : nullptr;
 
         uint8_t * imageOut = out.image() + outStartOffset;
 
@@ -846,7 +820,7 @@ namespace fheroes2
                 // The transformTableId is less than 6 so the shadow has to be applied.
                 const int32_t outOffset = x + y * outWidth;
 
-                if ( isOutNonSingleLayer ) {
+                if ( isOutDoubleLayer ) {
                     uint8_t * transformOutX = transformOut + outOffset;
 
                     if ( *transformOutX == 0 ) {
@@ -863,7 +837,7 @@ namespace fheroes2
                     }
                 }
                 else {
-                    // For single layer 'out' image apply shadow transform to the image data.
+                    // For single-layer 'out' image apply shadow transform to the image data.
                     uint8_t * imageOutX = imageOut + outOffset;
                     *imageOutX = *( transformTable + transformTableId * ptrdiff_t{ 256 } + *imageOutX );
                 }
@@ -873,8 +847,9 @@ namespace fheroes2
 
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId )
     {
-        if ( in.empty() || shadowOffset.x > 0 || shadowOffset.y < 0 )
+        if ( in.empty() || shadowOffset.x > 0 || shadowOffset.y < 0 ) {
             return in;
+        }
 
         Sprite out = makeShadow( in, shadowOffset, transformId );
         Blit( in, out, -shadowOffset.x, 0 );
@@ -882,24 +857,26 @@ namespace fheroes2
         return out;
     }
 
-    void AddTransparency( Image & image, uint8_t valueToReplace )
+    void AddTransparency( Image & image, const uint8_t valueToReplace )
     {
         ReplaceColorIdByTransformId( image, valueToReplace, 1 );
     }
 
-    void AlphaBlit( const Image & in, Image & out, uint8_t alphaValue, bool flip )
+    void AlphaBlit( const Image & in, Image & out, const uint8_t alphaValue, const bool flip /* = false */ )
     {
         AlphaBlit( in, 0, 0, out, 0, 0, in.width(), in.height(), alphaValue, flip );
     }
 
-    void AlphaBlit( const Image & in, Image & out, int32_t outX, int32_t outY, uint8_t alphaValue, bool flip )
+    void AlphaBlit( const Image & in, Image & out, int32_t outX, int32_t outY, const uint8_t alphaValue, const bool flip /* = false */ )
     {
         AlphaBlit( in, 0, 0, out, outX, outY, in.width(), in.height(), alphaValue, flip );
     }
 
-    void AlphaBlit( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, uint8_t alphaValue, bool flip )
+    void AlphaBlit( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const uint8_t alphaValue,
+                    const bool flip /* = false */ )
     {
-        if ( alphaValue == 0 ) { // there is nothing we need to do
+        if ( alphaValue == 0 ) {
+            // There is nothing we need to do.
             return;
         }
 
@@ -912,7 +889,6 @@ namespace fheroes2
             return;
         }
 
-        // Blitting one image onto another can be done only for image layer so we don't consider transform part of the output image
         const int32_t widthIn = in.width();
         const int32_t widthOut = out.width();
 
@@ -923,69 +899,109 @@ namespace fheroes2
         if ( flip ) {
             const int32_t offsetInY = inY * widthIn + widthIn - 1 - inX;
             const uint8_t * imageInY = in.image() + offsetInY;
-            const uint8_t * transformInY = in.transform() + offsetInY;
 
             const int32_t offsetOutY = outY * widthOut + outX;
             uint8_t * imageOutY = out.image() + offsetOutY;
             const uint8_t * imageOutYEnd = imageOutY + height * widthOut;
 
-            for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
-                const uint8_t * imageInX = imageInY;
-                const uint8_t * transformInX = transformInY;
-                uint8_t * imageOutX = imageOutY;
-                const uint8_t * imageOutXEnd = imageOutX + width;
+            if ( in.singleLayer() ) {
+                for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, imageOutY += widthOut ) {
+                    const uint8_t * imageInX = imageInY;
+                    uint8_t * imageOutX = imageOutY;
+                    const uint8_t * imageOutXEnd = imageOutX + width;
 
-                for ( ; imageOutX != imageOutXEnd; --imageInX, --transformInX, ++imageOutX ) {
-                    if ( *transformInX == 1 ) { // skip pixel
-                        continue;
+                    for ( ; imageOutX != imageOutXEnd; --imageInX, ++imageOutX ) {
+                        const uint8_t * inPAL = gamePalette + ( *imageInX ) * 3;
+                        const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+
+                        const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
+                        const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
+                        const uint32_t blue = static_cast<uint32_t>( *( inPAL + 2 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 2 ) ) * behindValue;
+                        *imageOutX = GetPALColorId( static_cast<uint8_t>( red / 255 ), static_cast<uint8_t>( green / 255 ), static_cast<uint8_t>( blue / 255 ) );
                     }
+                }
+            }
+            else {
+                const uint8_t * transformInY = in.transform() + offsetInY;
 
-                    uint8_t inValue = *imageInX;
-                    if ( *transformInX > 1 ) {
-                        inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
+                    const uint8_t * imageInX = imageInY;
+                    const uint8_t * transformInX = transformInY;
+                    uint8_t * imageOutX = imageOutY;
+                    const uint8_t * imageOutXEnd = imageOutX + width;
+
+                    for ( ; imageOutX != imageOutXEnd; --imageInX, --transformInX, ++imageOutX ) {
+                        if ( *transformInX == 1 ) { // skip pixel
+                            continue;
+                        }
+
+                        uint8_t inValue = *imageInX;
+                        if ( *transformInX > 1 ) {
+                            inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                        }
+
+                        const uint8_t * inPAL = gamePalette + inValue * 3;
+                        const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+
+                        const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
+                        const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
+                        const uint32_t blue = static_cast<uint32_t>( *( inPAL + 2 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 2 ) ) * behindValue;
+                        *imageOutX = GetPALColorId( static_cast<uint8_t>( red / 255 ), static_cast<uint8_t>( green / 255 ), static_cast<uint8_t>( blue / 255 ) );
                     }
-
-                    const uint8_t * inPAL = gamePalette + inValue * 3;
-                    const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
-
-                    const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
-                    const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
-                    const uint32_t blue = static_cast<uint32_t>( *( inPAL + 2 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 2 ) ) * behindValue;
-                    *imageOutX = GetPALColorId( static_cast<uint8_t>( red / 255 ), static_cast<uint8_t>( green / 255 ), static_cast<uint8_t>( blue / 255 ) );
                 }
             }
         }
         else {
             const int32_t offsetInY = inY * widthIn + inX;
             const uint8_t * imageInY = in.image() + offsetInY;
-            const uint8_t * transformInY = in.transform() + offsetInY;
 
             uint8_t * imageOutY = out.image() + outY * widthOut + outX;
             const uint8_t * imageInYEnd = imageInY + height * widthIn;
 
-            for ( ; imageInY != imageInYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
-                const uint8_t * imageInX = imageInY;
-                const uint8_t * transformInX = transformInY;
-                uint8_t * imageOutX = imageOutY;
-                const uint8_t * imageInXEnd = imageInX + width;
+            if ( in.singleLayer() ) {
+                for ( ; imageInY != imageInYEnd; imageInY += widthIn, imageOutY += widthOut ) {
+                    const uint8_t * imageInX = imageInY;
+                    uint8_t * imageOutX = imageOutY;
+                    const uint8_t * imageInXEnd = imageInX + width;
 
-                for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX ) {
-                    if ( *transformInX == 1 ) { // skip pixel
-                        continue;
+                    for ( ; imageInX != imageInXEnd; ++imageInX, ++imageOutX ) {
+                        const uint8_t * inPAL = gamePalette + ( *imageInX ) * 3;
+                        const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+
+                        const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
+                        const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
+                        const uint32_t blue = static_cast<uint32_t>( *( inPAL + 2 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 2 ) ) * behindValue;
+                        *imageOutX = GetPALColorId( static_cast<uint8_t>( red / 255 ), static_cast<uint8_t>( green / 255 ), static_cast<uint8_t>( blue / 255 ) );
                     }
+                }
+            }
+            else {
+                const uint8_t * transformInY = in.transform() + offsetInY;
 
-                    uint8_t inValue = *imageInX;
-                    if ( *transformInX > 1 ) {
-                        inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                for ( ; imageInY != imageInYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
+                    const uint8_t * imageInX = imageInY;
+                    const uint8_t * transformInX = transformInY;
+                    uint8_t * imageOutX = imageOutY;
+                    const uint8_t * imageInXEnd = imageInX + width;
+
+                    for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, ++imageOutX ) {
+                        if ( *transformInX == 1 ) { // skip pixel
+                            continue;
+                        }
+
+                        uint8_t inValue = *imageInX;
+                        if ( *transformInX > 1 ) {
+                            inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                        }
+
+                        const uint8_t * inPAL = gamePalette + inValue * 3;
+                        const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+
+                        const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
+                        const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
+                        const uint32_t blue = static_cast<uint32_t>( *( inPAL + 2 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 2 ) ) * behindValue;
+                        *imageOutX = GetPALColorId( static_cast<uint8_t>( red / 255 ), static_cast<uint8_t>( green / 255 ), static_cast<uint8_t>( blue / 255 ) );
                     }
-
-                    const uint8_t * inPAL = gamePalette + inValue * 3;
-                    const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
-
-                    const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
-                    const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
-                    const uint32_t blue = static_cast<uint32_t>( *( inPAL + 2 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 2 ) ) * behindValue;
-                    *imageOutX = GetPALColorId( static_cast<uint8_t>( red / 255 ), static_cast<uint8_t>( green / 255 ), static_cast<uint8_t>( blue / 255 ) );
                 }
             }
         }
@@ -1005,12 +1021,12 @@ namespace fheroes2
         ApplyRawPalette( in, 0, 0, out, 0, 0, in.width(), in.height(), palette.data() );
     }
 
-    void ApplyPalette( Image & image, uint8_t paletteId )
+    void ApplyPalette( Image & image, const uint8_t paletteId )
     {
         ApplyPalette( image, image, paletteId );
     }
 
-    void ApplyPalette( const Image & in, Image & out, uint8_t paletteId )
+    void ApplyPalette( const Image & in, Image & out, const uint8_t paletteId )
     {
         if ( paletteId > 15 ) {
             return;
@@ -1038,12 +1054,12 @@ namespace fheroes2
         ApplyRawPalette( in, inX, inY, out, outX, outY, width, height, palette.data() );
     }
 
-    void ApplyAlpha( const Image & in, Image & out, uint8_t alpha )
+    void ApplyAlpha( const Image & in, Image & out, const uint8_t alpha )
     {
         ApplyAlpha( in, 0, 0, out, 0, 0, in.width(), in.height(), alpha );
     }
 
-    void ApplyAlpha( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, uint8_t alpha )
+    void ApplyAlpha( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const uint8_t alpha )
     {
         std::vector<uint8_t> palette( 256 );
 
@@ -1062,10 +1078,11 @@ namespace fheroes2
         ApplyPalette( in, inX, inY, out, outX, outY, width, height, palette );
     }
 
-    void ApplyTransform( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, uint8_t transformId )
+    void ApplyTransform( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, const uint8_t transformId )
     {
-        if ( !Verify( image, x, y, width, height ) )
+        if ( !Verify( image, x, y, width, height ) ) {
             return;
+        }
 
         const int32_t imageWidth = image.width();
 
@@ -1099,19 +1116,19 @@ namespace fheroes2
         }
     }
 
-    void Blit( const Image & in, Image & out, bool flip )
+    void Blit( const Image & in, Image & out, const bool flip /* = false */ )
     {
         Blit( in, 0, 0, out, 0, 0, in.width(), in.height(), flip );
     }
 
-    void Blit( const Image & in, Image & out, int32_t outX, int32_t outY, bool flip )
+    void Blit( const Image & in, Image & out, int32_t outX, int32_t outY, const bool flip /* = false */ )
     {
         Blit( in, 0, 0, out, outX, outY, in.width(), in.height(), flip );
     }
 
-    void Blit( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, bool flip )
+    void Blit( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool flip /* = false */ )
     {
-        if ( in.singleLayer() && out.singleLayer() && !flip ) {
+        if ( in.singleLayer() && !flip ) {
             Copy( in, inX, inY, out, outX, outY, width, height );
             return;
         }
@@ -1235,10 +1252,11 @@ namespace fheroes2
         }
     }
 
-    void Blit( const Image & in, const Point & inPos, Image & out, const Point & outPos, const Size & size, bool flip )
+    void Blit( const Image & in, const Point & inPos, Image & out, const Point & outPos, const Size & size, const bool flip /* = false */ )
     {
-        if ( inPos.x < 0 || inPos.y < 0 )
+        if ( inPos.x < 0 || inPos.y < 0 ) {
             return;
+        }
 
         Blit( in, inPos.x, inPos.y, out, outPos.x, outPos.y, size.width, size.height, flip );
     }
@@ -1291,15 +1309,29 @@ namespace fheroes2
 
     void CopyTransformLayer( const Image & in, Image & out )
     {
-        if ( in.empty() || out.empty() || in.singleLayer() || out.singleLayer() || in.width() != out.width() || in.height() != out.height() ) {
+        if ( in.empty() || out.empty() || in.singleLayer() || in.width() != out.width() || in.height() != out.height() ) {
             assert( 0 );
             return;
         }
+
+        if ( out.singleLayer() ) {
+            // Add the transform layer.
+            Image temp;
+            Copy( out, temp );
+            out = std::move( temp );
+        }
+
         memcpy( out.transform(), in.transform(), in.width() * in.height() );
     }
 
-    Sprite CreateContour( const Image & image, uint8_t value )
+    Sprite CreateContour( const Image & image, const uint8_t value )
     {
+        if ( image.empty() || image.singleLayer() ) {
+            // A contour can be created only for non-empty images with the transform layer.
+            assert( 0 );
+            return {};
+        }
+
         const int32_t width = image.width();
         const int32_t height = image.height();
 
@@ -1308,8 +1340,6 @@ namespace fheroes2
         if ( width < 2 || height < 2 ) {
             return contour;
         }
-
-        assert( !contour.empty() );
 
         const uint8_t * inY = image.transform();
         uint8_t * outImageY = contour.image();
@@ -1348,22 +1378,22 @@ namespace fheroes2
         const int32_t widthIn = in.width();
         const int32_t offsetIn = inY * widthIn + inX;
         const uint8_t * imageIn = in.image() + offsetIn;
-        const uint8_t * transformIn = in.transform() + offsetIn;
+        const uint8_t * transformIn = in.singleLayer() ? nullptr : in.transform() + offsetIn;
 
         const int32_t widthOut = out.width();
         const int32_t offsetOut = outY * widthOut + outX;
         uint8_t * imageOut = out.image() + offsetOut;
-        uint8_t * transformOut = out.transform() + offsetOut;
+        uint8_t * transformOut = out.singleLayer() ? nullptr : out.transform() + offsetOut;
 
-        const bool isInNonSinglelayerToOutSinglelayer = !in.singleLayer() && out.singleLayer();
+        const bool isInDoubleLayerToOutSingleLayer = !in.singleLayer() && out.singleLayer();
 
         if ( isVertical ) {
             // We also go in a loop from the right part of the image to its center.
             const uint8_t * imageInRightPoint = imageIn + width - 1;
-            const uint8_t * transformInRightPoint = transformIn + width - 1;
-
             uint8_t * imageOutRightPoint = imageOut + width - 1;
-            uint8_t * transformOutRightPoint = transformOut + width - 1;
+
+            const uint8_t * transformInRightPoint = transformIn ? transformIn + width - 1 : nullptr;
+            uint8_t * transformOutRightPoint = transformOut ? transformOut + width - 1 : nullptr;
 
             const int32_t halfWidth = width / 2;
 
@@ -1371,15 +1401,25 @@ namespace fheroes2
             if ( ( width % 2 ) == 1 ) {
                 if ( isReverse ) {
                     --imageOutRightPoint;
-                    --transformOutRightPoint;
                     --imageInRightPoint;
-                    --transformInRightPoint;
+
+                    if ( transformOutRightPoint ) {
+                        --transformOutRightPoint;
+                    }
+                    if ( transformInRightPoint ) {
+                        --transformInRightPoint;
+                    }
                 }
                 else {
                     ++imageOut;
-                    ++transformOut;
                     ++imageIn;
-                    ++transformIn;
+
+                    if ( transformOut ) {
+                        ++transformOut;
+                    }
+                    if ( transformIn ) {
+                        ++transformIn;
+                    }
                 }
             }
 
@@ -1398,7 +1438,7 @@ namespace fheroes2
                     const int32_t offsetY = y % stepY;
 
                     if ( isReverse == ( patternPoint != offsetY ) ) {
-                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformIn + offsetInX ) == 1 ) ) {
+                        if ( isInDoubleLayerToOutSingleLayer && ( *( transformIn + offsetInX ) == 1 ) ) {
                             // Skip pixel.
                             continue;
                         }
@@ -1414,11 +1454,12 @@ namespace fheroes2
                             *( transformOut + offsetOutX ) = 0;
                         }
                         else {
+                            // 'in' and 'out' images have the transform layer.
                             *( transformOut + offsetOutX ) = *( transformIn + offsetInX );
                         }
                     }
                     else {
-                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformInRightPoint + offsetInX ) == 1 ) ) {
+                        if ( isInDoubleLayerToOutSingleLayer && ( *( transformInRightPoint + offsetInX ) == 1 ) ) {
                             // Skip pixel.
                             continue;
                         }
@@ -1435,6 +1476,7 @@ namespace fheroes2
                             *( transformOutRightPoint + offsetOutX ) = 0;
                         }
                         else {
+                            // 'in' and 'out' images have the transform layer.
                             *( transformOutRightPoint + offsetOutX ) = *( transformInRightPoint + offsetInX );
                         }
                     }
@@ -1442,24 +1484,29 @@ namespace fheroes2
 
                 ++imageOut;
                 --imageOutRightPoint;
-                ++transformOut;
-                --transformOutRightPoint;
-
                 ++imageIn;
                 --imageInRightPoint;
-                ++transformIn;
-                --transformInRightPoint;
+
+                if ( transformOut ) {
+                    ++transformOut;
+                    --transformOutRightPoint;
+                }
+
+                if ( transformIn ) {
+                    ++transformIn;
+                    --transformInRightPoint;
+                }
             }
         }
         else {
             // We also go in a loop from the bottom part of the image to its center.
             const int32_t offsetInBottomOffset = ( height - 1 ) * widthIn;
-            const uint8_t * imageInBottomPoint = imageIn + offsetInBottomOffset;
-            const uint8_t * transformInBottomPoint = transformIn + offsetInBottomOffset;
-
             const int32_t offsetOutYBottomOffset = ( height - 1 ) * widthOut;
+            const uint8_t * imageInBottomPoint = imageIn + offsetInBottomOffset;
             uint8_t * imageOutBottomPoint = imageOut + offsetOutYBottomOffset;
-            uint8_t * transformOutBottomPoint = transformOut + offsetOutYBottomOffset;
+
+            const uint8_t * transformInBottomPoint = transformIn ? transformIn + offsetInBottomOffset : nullptr;
+            uint8_t * transformOutBottomPoint = transformOut ? transformOut + offsetOutYBottomOffset : nullptr;
 
             const int32_t halfHeight = height / 2;
 
@@ -1467,15 +1514,25 @@ namespace fheroes2
             if ( ( height % 2 ) == 1 ) {
                 if ( isReverse ) {
                     imageOutBottomPoint -= widthOut;
-                    transformOutBottomPoint -= widthOut;
                     imageInBottomPoint -= widthIn;
-                    transformInBottomPoint -= widthIn;
+
+                    if ( transformOutBottomPoint ) {
+                        transformOutBottomPoint -= widthOut;
+                    }
+                    if ( transformInBottomPoint ) {
+                        transformInBottomPoint -= widthIn;
+                    }
                 }
                 else {
                     imageOut += widthOut;
-                    transformOut += widthOut;
                     imageIn += widthIn;
-                    transformIn += widthIn;
+
+                    if ( transformOut ) {
+                        transformOut += widthOut;
+                    }
+                    if ( transformIn ) {
+                        transformIn += widthIn;
+                    }
                 }
             }
 
@@ -1492,7 +1549,7 @@ namespace fheroes2
                     const int32_t offsetX = x % stepX;
 
                     if ( isReverse == ( patternPoint != offsetX ) ) {
-                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformIn + x ) == 1 ) ) {
+                        if ( isInDoubleLayerToOutSingleLayer && ( *( transformIn + x ) == 1 ) ) {
                             // Skip pixel.
                             continue;
                         }
@@ -1508,11 +1565,12 @@ namespace fheroes2
                             *( transformOut + x ) = 0;
                         }
                         else {
+                            // 'in' and 'out' images have the transform layer.
                             *( transformOut + x ) = *( transformIn + x );
                         }
                     }
                     else {
-                        if ( isInNonSinglelayerToOutSinglelayer && ( *( transformInBottomPoint + x ) == 1 ) ) {
+                        if ( isInDoubleLayerToOutSingleLayer && ( *( transformInBottomPoint + x ) == 1 ) ) {
                             // Skip pixel.
                             continue;
                         }
@@ -1520,7 +1578,7 @@ namespace fheroes2
                         // Second part of transition: we copy image excluding single pixels.
                         *( imageOutBottomPoint + x ) = *( imageInBottomPoint + x );
 
-                        if ( !out.singleLayer() ) {
+                        if ( out.singleLayer() ) {
                             continue;
                         }
                         if ( in.singleLayer() ) {
@@ -1528,6 +1586,7 @@ namespace fheroes2
                             *( transformOutBottomPoint + x ) = 0;
                         }
                         else {
+                            // 'in' and 'out' images have the transform layer.
                             *( transformOutBottomPoint + x ) = *( transformInBottomPoint + x );
                         }
                     }
@@ -1535,26 +1594,33 @@ namespace fheroes2
 
                 imageOut += widthOut;
                 imageOutBottomPoint -= widthOut;
-                transformOut += widthOut;
-                transformOutBottomPoint -= widthOut;
-
                 imageIn += widthIn;
                 imageInBottomPoint -= widthIn;
-                transformIn += widthIn;
-                transformInBottomPoint -= widthIn;
+
+                if ( transformOut ) {
+                    transformOut += widthOut;
+                    transformOutBottomPoint -= widthOut;
+                }
+
+                if ( transformIn ) {
+                    transformIn += widthIn;
+                    transformInBottomPoint -= widthIn;
+                }
             }
         }
     }
 
     Sprite Crop( const Image & image, int32_t x, int32_t y, int32_t width, int32_t height )
     {
-        if ( image.empty() || width <= 0 || height <= 0 )
-            return Sprite();
+        if ( image.empty() || width <= 0 || height <= 0 ) {
+            return {};
+        }
 
         if ( x < 0 ) {
             const int32_t offsetX = -x;
-            if ( offsetX >= width )
-                return Sprite();
+            if ( offsetX >= width ) {
+                return {};
+            }
 
             x = 0;
             width -= offsetX;
@@ -1562,15 +1628,17 @@ namespace fheroes2
 
         if ( y < 0 ) {
             const int32_t offsetY = -y;
-            if ( offsetY >= height )
-                return Sprite();
+            if ( offsetY >= height ) {
+                return {};
+            }
 
             y = 0;
             height -= offsetY;
         }
 
-        if ( x > image.width() || y > image.height() )
-            return Sprite();
+        if ( x > image.width() || y > image.height() ) {
+            return {};
+        }
 
         if ( x + width > image.width() ) {
             const int32_t offsetX = x + width - image.width();
@@ -1582,17 +1650,19 @@ namespace fheroes2
             height -= offsetY;
         }
 
-        Sprite out( width, height );
+        Sprite out;
         if ( image.singleLayer() ) {
+            // The result of Crop should have the same layers as the input image.
             out._disableTransformLayer();
         }
+        out.resize( width, height );
 
         Copy( image, x, y, out, 0, 0, width, height );
         out.setPosition( x, y );
         return out;
     }
 
-    void DrawBorder( Image & image, uint8_t value, uint32_t skipFactor )
+    void DrawBorder( Image & image, const uint8_t value, const uint32_t skipFactor /* =0 */ )
     {
         if ( image.empty() || image.width() < 2 || image.height() < 2 ) {
             return;
@@ -1600,121 +1670,182 @@ namespace fheroes2
 
         const int32_t width = image.width();
         const int32_t height = image.height();
+        const bool isSingleLayer = image.singleLayer();
+
+        uint8_t * dataPointer = image.image();
+        uint8_t * transformPointer = isSingleLayer ? nullptr : image.transform();
 
         if ( skipFactor < 2 ) {
             // top side
-            uint8_t * data = image.image();
-            uint8_t * transform = image.transform();
+            uint8_t * data = dataPointer;
+            uint8_t * transform = transformPointer;
             const uint8_t * dataEnd = data + width;
-            for ( ; data != dataEnd; ++data, ++transform ) {
-                *data = value;
-                *transform = 0;
+            if ( isSingleLayer ) {
+                for ( ; data != dataEnd; ++data ) {
+                    *data = value;
+                }
+            }
+            else {
+                for ( ; data != dataEnd; ++data, ++transform ) {
+                    *data = value;
+                    *transform = 0;
+                }
             }
 
             // bottom side
-            data = image.image() + width * ( height - 1 );
-            transform = image.transform() + width * ( height - 1 );
+            data = dataPointer + width * static_cast<ptrdiff_t>( height - 1 );
             dataEnd = data + width;
-            for ( ; data != dataEnd; ++data, ++transform ) {
-                *data = value;
-                *transform = 0;
+            if ( isSingleLayer ) {
+                for ( ; data != dataEnd; ++data ) {
+                    *data = value;
+                }
+            }
+            else {
+                transform = transformPointer + width * static_cast<ptrdiff_t>( height - 1 );
+                for ( ; data != dataEnd; ++data, ++transform ) {
+                    *data = value;
+                    *transform = 0;
+                }
             }
 
             // left side
-            data = image.image() + width;
-            transform = image.transform() + width;
+            data = dataPointer + width;
             dataEnd = data + width * ( height - 2 );
-            for ( ; data != dataEnd; data += width, transform += width ) {
-                *data = value;
-                *transform = 0;
+            if ( isSingleLayer ) {
+                for ( ; data != dataEnd; data += width ) {
+                    *data = value;
+                }
+            }
+            else {
+                transform = transformPointer + width;
+                for ( ; data != dataEnd; data += width, transform += width ) {
+                    *data = value;
+                    *transform = 0;
+                }
             }
 
             // right side
-            data = image.image() + width + width - 1;
-            transform = image.transform() + width + width - 1;
+            data = dataPointer + width + width - 1;
             dataEnd = data + width * ( height - 2 );
-            for ( ; data != dataEnd; data += width, transform += width ) {
-                *data = value;
-                *transform = 0;
+            if ( isSingleLayer ) {
+                for ( ; data != dataEnd; data += width ) {
+                    *data = value;
+                }
+            }
+            else {
+                transform = transformPointer + width + width - 1;
+                for ( ; data != dataEnd; data += width, transform += width ) {
+                    *data = value;
+                    *transform = 0;
+                }
             }
         }
         else {
-            uint32_t counter = 0;
+            uint32_t counter = 1;
 
             // top side
-            uint8_t * data = image.image();
-            uint8_t * transform = image.transform();
+            uint8_t * data = dataPointer;
+            uint8_t * transform = transformPointer;
             const uint8_t * dataEnd = data + width;
-            for ( ; data != dataEnd; ++data, ++transform ) {
-                if ( counter != skipFactor ) {
-                    *data = value;
-                    *transform = 0;
+            if ( isSingleLayer ) {
+                for ( ; data != dataEnd; ++data ) {
+                    if ( counter % skipFactor != 0 ) {
+                        *data = value;
+                    }
+                    ++counter;
                 }
-                else {
-                    counter = 0;
+            }
+            else {
+                for ( ; data != dataEnd; ++data, ++transform ) {
+                    if ( counter % skipFactor != 0 ) {
+                        *data = value;
+                        *transform = 0;
+                    }
+                    ++counter;
                 }
-                ++counter;
             }
 
             // right side
-            data = image.image() + width + width - 1;
-            transform = image.transform() + width + width - 1;
+            data = dataPointer + width + width - 1;
             dataEnd = data + width * ( height - 2 );
-            for ( ; data != dataEnd; data += width, transform += width ) {
-                if ( counter != skipFactor ) {
-                    *data = value;
-                    *transform = 0;
+            if ( isSingleLayer ) {
+                for ( ; data != dataEnd; data += width ) {
+                    if ( counter % skipFactor != 0 ) {
+                        *data = value;
+                    }
+                    ++counter;
                 }
-                else {
-                    counter = 0;
+            }
+            else {
+                transform = transformPointer + width + width - 1;
+                for ( ; data != dataEnd; data += width, transform += width ) {
+                    if ( counter % skipFactor != 0 ) {
+                        *data = value;
+                        *transform = 0;
+                    }
+                    ++counter;
                 }
-                ++counter;
             }
 
             // bottom side
-            data = image.image() + width * ( height - 1 ) + width - 1;
-            transform = image.transform() + width * ( height - 1 ) + width - 1;
+            data = dataPointer + width * static_cast<ptrdiff_t>( height - 1 ) + width - 1;
             dataEnd = data - width;
-            for ( ; data != dataEnd; --data, --transform ) {
-                if ( counter != skipFactor ) {
-                    *data = value;
-                    *transform = 0;
+            if ( isSingleLayer ) {
+                for ( ; data != dataEnd; --data ) {
+                    if ( counter % skipFactor != 0 ) {
+                        *data = value;
+                    }
+                    ++counter;
                 }
-                else {
-                    counter = 0;
+            }
+            else {
+                transform = transformPointer + width * static_cast<ptrdiff_t>( height - 1 ) + width - 1;
+                for ( ; data != dataEnd; --data, --transform ) {
+                    if ( counter % skipFactor != 0 ) {
+                        *data = value;
+                        *transform = 0;
+                    }
+                    ++counter;
                 }
-                ++counter;
             }
 
             // left side
-            data = image.image() + width * ( height - 2 );
-            transform = image.transform() + width * ( height - 2 );
-            dataEnd = image.image();
-            for ( ; data != dataEnd; data -= width, transform -= width ) {
-                if ( counter != skipFactor ) {
-                    *data = value;
-                    *transform = 0;
+            data = dataPointer + width * static_cast<ptrdiff_t>( height - 2 );
+            dataEnd = dataPointer;
+            if ( isSingleLayer ) {
+                for ( ; data != dataEnd; data -= width ) {
+                    if ( counter % skipFactor != 0 ) {
+                        *data = value;
+                    }
+                    ++counter;
                 }
-                else {
-                    counter = 0;
+            }
+            else {
+                transform = transformPointer + width * static_cast<ptrdiff_t>( height - 2 );
+                for ( ; data != dataEnd; data -= width, transform -= width ) {
+                    if ( counter % skipFactor != 0 ) {
+                        *data = value;
+                        *transform = 0;
+                    }
+                    ++counter;
                 }
-                ++counter;
             }
         }
     }
 
-    void DrawLine( Image & image, const Point & start, const Point & end, uint8_t value, const Rect & roi )
+    void DrawLine( Image & image, const Point & start, const Point & end, const uint8_t value, const Rect & roi /* = Rect() */ )
     {
-        if ( image.empty() )
+        if ( image.empty() ) {
             return;
+        }
 
         const int32_t width = image.width();
         const int32_t height = image.height();
 
         int32_t x1 = start.x;
         int32_t y1 = start.y;
-        int32_t x2 = end.x;
-        int32_t y2 = end.y;
+        const int32_t x2 = end.x;
+        const int32_t y2 = end.y;
 
         const int32_t dx = std::abs( x2 - x1 );
         const int32_t dy = std::abs( y2 - y1 );
@@ -1726,58 +1857,99 @@ namespace fheroes2
         int32_t maxX = isValidRoi ? roi.x + roi.width : width;
         int32_t maxY = isValidRoi ? roi.y + roi.height : height;
 
-        if ( minX >= width || minY >= height )
+        if ( minX >= width || minY >= height ) {
             return;
+        }
 
-        if ( maxX >= width )
+        if ( maxX >= width ) {
             maxX = width;
+        }
 
-        if ( maxY >= height )
+        if ( maxY >= height ) {
             maxY = height;
+        }
 
         uint8_t * data = image.image();
-        uint8_t * transform = image.transform();
 
-        if ( dx > dy ) {
-            int32_t ns = dx / 2;
+        if ( image.singleLayer() ) {
+            if ( dx >= dy ) {
+                int32_t ns = dx / 2;
 
-            for ( int32_t i = 0; i <= dx; ++i ) {
-                if ( x1 >= minX && x1 < maxX && y1 >= minY && y1 < maxY ) {
-                    const int32_t offset = x1 + y1 * width;
-                    *( data + offset ) = value;
-                    *( transform + offset ) = 0;
+                for ( int32_t i = 0; i <= dx; ++i ) {
+                    if ( x1 >= minX && x1 < maxX && y1 >= minY && y1 < maxY ) {
+                        const int32_t offset = x1 + y1 * width;
+                        *( data + offset ) = value;
+                    }
+                    x1 < x2 ? ++x1 : --x1;
+                    ns -= dy;
+                    if ( ns < 0 ) {
+                        y1 < y2 ? ++y1 : --y1;
+                        ns += dx;
+                    }
                 }
-                x1 < x2 ? ++x1 : --x1;
-                ns -= dy;
-                if ( ns < 0 ) {
+            }
+            else {
+                int32_t ns = dy / 2;
+
+                for ( int32_t i = 0; i <= dy; ++i ) {
+                    if ( x1 >= minX && x1 < maxX && y1 >= minY && y1 < maxY ) {
+                        const int32_t offset = x1 + y1 * width;
+                        *( data + offset ) = value;
+                    }
                     y1 < y2 ? ++y1 : --y1;
-                    ns += dx;
+                    ns -= dx;
+                    if ( ns < 0 ) {
+                        x1 < x2 ? ++x1 : --x1;
+                        ns += dy;
+                    }
                 }
             }
         }
         else {
-            int32_t ns = dy / 2;
+            uint8_t * transform = image.transform();
 
-            for ( int32_t i = 0; i <= dy; ++i ) {
-                if ( x1 >= minX && x1 < maxX && y1 >= minY && y1 < maxY ) {
-                    const int32_t offset = x1 + y1 * width;
-                    *( data + offset ) = value;
-                    *( transform + offset ) = 0;
-                }
-                y1 < y2 ? ++y1 : --y1;
-                ns -= dx;
-                if ( ns < 0 ) {
+            if ( dx >= dy ) {
+                int32_t ns = dx / 2;
+
+                for ( int32_t i = 0; i <= dx; ++i ) {
+                    if ( x1 >= minX && x1 < maxX && y1 >= minY && y1 < maxY ) {
+                        const int32_t offset = x1 + y1 * width;
+                        *( data + offset ) = value;
+                        *( transform + offset ) = 0;
+                    }
                     x1 < x2 ? ++x1 : --x1;
-                    ns += dy;
+                    ns -= dy;
+                    if ( ns < 0 ) {
+                        y1 < y2 ? ++y1 : --y1;
+                        ns += dx;
+                    }
+                }
+            }
+            else {
+                int32_t ns = dy / 2;
+
+                for ( int32_t i = 0; i <= dy; ++i ) {
+                    if ( x1 >= minX && x1 < maxX && y1 >= minY && y1 < maxY ) {
+                        const int32_t offset = x1 + y1 * width;
+                        *( data + offset ) = value;
+                        *( transform + offset ) = 0;
+                    }
+                    y1 < y2 ? ++y1 : --y1;
+                    ns -= dx;
+                    if ( ns < 0 ) {
+                        x1 < x2 ? ++x1 : --x1;
+                        ns += dy;
+                    }
                 }
             }
         }
     }
 
-    void DrawRect( Image & image, const Rect & roi, uint8_t value )
+    void DrawRect( Image & image, const Rect & roi, const uint8_t value )
     {
-        if ( image.empty() || roi.width < 1 || roi.height < 1 )
+        if ( image.empty() || roi.width < 1 || roi.height < 1 ) {
             return;
+        }
 
         DrawLine( image, { roi.x, roi.y }, { roi.x + roi.width, roi.y }, value, roi );
         DrawLine( image, { roi.x, roi.y }, { roi.x, roi.y + roi.height }, value, roi );
@@ -1832,8 +2004,9 @@ namespace fheroes2
 
     Image ExtractCommonPattern( const std::vector<const Image *> & input )
     {
-        if ( input.empty() )
-            return Image();
+        if ( input.empty() ) {
+            return {};
+        }
 
         assert( input.front() != nullptr );
 
@@ -1841,13 +2014,18 @@ namespace fheroes2
             return *input.front();
         }
 
-        if ( input[0]->empty() )
-            return Image();
+        if ( input.front()->empty() ) {
+            return {};
+        }
 
-        for ( size_t i = 1; i < input.size(); ++i ) {
-            assert( input[i] != nullptr );
-            if ( input[i]->width() != input[0]->width() || input[i]->height() != input[0]->height() )
-                return Image();
+        const int32_t inputFrontWidth = input.front()->width();
+        const int32_t inputFrontHeight = input.front()->height();
+
+        for ( const Image * image : input ) {
+            assert( image != nullptr );
+            if ( image->width() != inputFrontWidth || image->height() != inputFrontHeight ) {
+                return {};
+            }
         }
 
         std::vector<const uint8_t *> imageIn( input.size() );
@@ -1855,10 +2033,11 @@ namespace fheroes2
 
         for ( size_t i = 0; i < input.size(); ++i ) {
             imageIn[i] = input[i]->image();
-            transformIn[i] = input[i]->transform();
+
+            transformIn[i] = input[i]->singleLayer() ? nullptr : input[i]->transform();
         }
 
-        Image out( input[0]->width(), input[0]->height() );
+        Image out( inputFrontWidth, inputFrontHeight );
         out.reset();
 
         uint8_t * imageOut = out.image();
@@ -1871,7 +2050,7 @@ namespace fheroes2
             isEqual = true;
 
             for ( size_t i = 1; i < input.size(); ++i ) {
-                if ( *imageIn[0] != *imageIn[i] || *transformIn[0] != *transformIn[i] ) {
+                if ( *imageIn[0] != *imageIn[i] || ( transformIn[0] && transformIn[i] && ( *transformIn[0] != *transformIn[i] ) ) ) {
                     isEqual = false;
                     break;
                 }
@@ -1879,24 +2058,28 @@ namespace fheroes2
 
             if ( isEqual ) {
                 *imageOut = *imageIn[0];
-                *transformOut = *transformIn[0];
+                *transformOut = transformIn[0] ? *transformIn[0] : 0;
             }
 
             for ( size_t i = 0; i < input.size(); ++i ) {
                 ++imageIn[i];
-                ++transformIn[i];
+                if ( transformIn[i] ) {
+                    ++transformIn[i];
+                }
             }
         }
 
         return out;
     }
 
-    void Fill( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, uint8_t colorId )
+    void Fill( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, const uint8_t colorId )
     {
-        if ( !Verify( image, x, y, width, height ) )
+        if ( !Verify( image, x, y, width, height ) ) {
             return;
+        }
 
-        if ( image.width() == width && image.height() == height ) { // we need to fill whole image
+        if ( image.width() == width && image.height() == height ) {
+            // We fill the whole image.
             image.fill( colorId );
             return;
         }
@@ -1904,19 +2087,27 @@ namespace fheroes2
         const int32_t imageWidth = image.width();
 
         uint8_t * imageY = image.image() + y * imageWidth + x;
-        uint8_t * transformY = image.transform() + y * imageWidth + x;
         const uint8_t * imageYEnd = imageY + height * imageWidth;
 
-        for ( ; imageY != imageYEnd; imageY += imageWidth, transformY += imageWidth ) {
-            std::fill( imageY, imageY + width, colorId );
-            std::fill( transformY, transformY + width, static_cast<uint8_t>( 0 ) );
+        if ( image.singleLayer() ) {
+            for ( ; imageY != imageYEnd; imageY += imageWidth ) {
+                std::fill( imageY, imageY + width, colorId );
+            }
+        }
+        else {
+            uint8_t * transformY = image.transform() + static_cast<ptrdiff_t>( y ) * imageWidth + x;
+            for ( ; imageY != imageYEnd; imageY += imageWidth, transformY += imageWidth ) {
+                std::fill( imageY, imageY + width, colorId );
+                std::fill( transformY, transformY + width, static_cast<uint8_t>( 0 ) );
+            }
         }
     }
 
-    void FillTransform( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, uint8_t transformId )
+    void FillTransform( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, const uint8_t transformId )
     {
-        if ( !Verify( image, x, y, width, height ) )
+        if ( !Verify( image, x, y, width, height ) || image.singleLayer() ) {
             return;
+        }
 
         const int32_t imageWidth = image.width();
 
@@ -1938,34 +2129,54 @@ namespace fheroes2
 
         const int32_t width = input.width();
         const int32_t height = input.height();
+        const bool isSingleLayer = input.singleLayer();
 
-        Image output( width, height );
+        Image output;
+        if ( isSingleLayer ) {
+            output._disableTransformLayer();
+        }
+        output.resize( width, height );
         output.reset();
 
         const uint8_t * imageInY = input.image();
-        const uint8_t * transformInY = input.transform();
-
         uint8_t * imageOutY = output.image();
-        uint8_t * transformOutY = output.transform();
 
-        for ( int32_t y = 0; y < height; ++y ) {
-            const uint8_t * transformInX = transformInY;
-
-            for ( int32_t x = 0; x < width; ++x ) {
-                if ( *transformInX == 0 && ( x == 0 || x == width - 1 || *( transformInX - 1 ) == 0 || *( transformInX + 1 ) == 0 )
-                     && ( y == 0 || y == height - 1 || *( transformInX - width ) == 0 || *( transformInX + width ) == 0 ) ) {
-                    *( transformOutY + x ) = 0;
-                    *( imageOutY + x ) = *( imageInY + x );
+        if ( isSingleLayer ) {
+            for ( int32_t y = 0; y < height; ++y ) {
+                for ( int32_t x = 0; x < width; ++x ) {
+                    if ( ( x == 0 || x == width - 1 ) && ( y == 0 || y == height - 1 ) ) {
+                        *( imageOutY + x ) = *( imageInY + x );
+                    }
                 }
 
-                ++transformInX;
+                imageInY += width;
+
+                imageOutY += width;
             }
+        }
+        else {
+            const uint8_t * transformInY = input.transform();
+            uint8_t * transformOutY = output.transform();
 
-            imageInY += width;
-            transformInY += width;
+            for ( int32_t y = 0; y < height; ++y ) {
+                const uint8_t * transformInX = transformInY;
 
-            imageOutY += width;
-            transformOutY += width;
+                for ( int32_t x = 0; x < width; ++x ) {
+                    if ( *transformInX == 0 && ( x == 0 || x == width - 1 || *( transformInX - 1 ) == 0 || *( transformInX + 1 ) == 0 )
+                         && ( y == 0 || y == height - 1 || *( transformInX - width ) == 0 || *( transformInX + width ) == 0 ) ) {
+                        *( transformOutY + x ) = 0;
+                        *( imageOutY + x ) = *( imageInY + x );
+                    }
+
+                    ++transformInX;
+                }
+
+                imageInY += width;
+                transformInY += width;
+
+                imageOutY += width;
+                transformOutY += width;
+            }
         }
 
         return output;
@@ -1990,10 +2201,10 @@ namespace fheroes2
         return true;
     }
 
-    Image Flip( const Image & in, bool horizontally, bool vertically )
+    Image Flip( const Image & in, const bool horizontally, const bool vertically )
     {
         if ( in.empty() ) {
-            return Image();
+            return {};
         }
 
         const int32_t width = in.width();
@@ -2009,9 +2220,16 @@ namespace fheroes2
         return out;
     }
 
-    void Flip( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, bool horizontally, bool vertically )
+    void Flip( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool horizontally,
+               const bool vertically )
     {
         if ( !Verify( in, inX, inY, out, outX, outY, width, height ) ) {
+            return;
+        }
+
+        if ( !horizontally && !vertically ) {
+            // No flip is required.
+            Copy( in, inX, inY, out, outX, outY, width, height );
             return;
         }
 
@@ -2022,49 +2240,166 @@ namespace fheroes2
         const int32_t offsetIn = inY * widthIn + inX;
 
         uint8_t * imageOutY = out.image() + offsetOut;
-        uint8_t * transformOutY = out.transform() + offsetOut;
         const uint8_t * imageOutYEnd = imageOutY + widthOut * height;
+
+        const bool isOutSingleLayer = out.singleLayer();
+        uint8_t * transformOutY = isOutSingleLayer ? nullptr : out.transform() + offsetOut;
 
         if ( horizontally && !vertically ) {
             const uint8_t * imageInY = in.image() + offsetIn + width - 1;
-            const uint8_t * transformInY = in.transform() + offsetIn + width - 1;
 
-            for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY += widthIn, transformInY += widthIn ) {
-                uint8_t * imageOutX = imageOutY;
-                uint8_t * transformOutX = transformOutY;
-                const uint8_t * imageOutXEnd = imageOutX + width;
-                const uint8_t * imageInX = imageInY;
-                const uint8_t * transformInX = transformInY;
+            if ( in.singleLayer() ) {
+                for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, imageInY += widthIn ) {
+                    uint8_t * imageOutX = imageOutY;
+                    const uint8_t * imageOutXEnd = imageOutX + width;
+                    const uint8_t * imageInX = imageInY;
 
-                for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++transformOutX, --imageInX, --transformInX ) {
-                    *imageOutX = *imageInX;
-                    *transformOutX = *transformInX;
+                    if ( isOutSingleLayer ) {
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, --imageInX ) {
+                            *imageOutX = *imageInX;
+                        }
+                    }
+                    else {
+                        // 'in' image is single-layer, 'out' image is double-layer (with the  transform layer).
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, --imageInX ) {
+                            *imageOutX = *imageInX;
+                        }
+
+                        // Set 'in' image transform data not to skip image data.
+                        std::fill( transformOutY, transformOutY + width, static_cast<uint8_t>( 0 ) );
+
+                        transformOutY += widthOut;
+                    }
+                }
+            }
+            else {
+                const uint8_t * transformInY = in.transform() + offsetIn + width - 1;
+
+                for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY += widthIn, transformInY += widthIn ) {
+                    uint8_t * imageOutX = imageOutY;
+                    const uint8_t * imageOutXEnd = imageOutX + width;
+                    const uint8_t * imageInX = imageInY;
+                    const uint8_t * transformInX = transformInY;
+
+                    if ( isOutSingleLayer ) {
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, --imageInX, --transformInX ) {
+                            // Copy image data only for non-transparent pixels.
+                            if ( *transformInX == 0 ) {
+                                *imageOutX = *imageInX;
+                            }
+                        }
+                    }
+                    else {
+                        // 'in' and 'out' images are with transform layer.
+                        uint8_t * transformOutX = transformOutY;
+
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++transformOutX, --imageInX, --transformInX ) {
+                            *imageOutX = *imageInX;
+                            *transformOutX = *transformInX;
+                        }
+                    }
                 }
             }
         }
         else if ( !horizontally && vertically ) {
             const uint8_t * imageInY = in.image() + offsetIn + ( height - 1 ) * widthIn;
-            const uint8_t * transformInY = in.transform() + offsetIn + ( height - 1 ) * widthIn;
 
-            for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY -= widthIn, transformInY -= widthIn ) {
-                memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
-                memcpy( transformOutY, transformInY, static_cast<size_t>( width ) );
+            if ( in.singleLayer() ) {
+                if ( isOutSingleLayer ) {
+                    for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, imageInY -= widthIn ) {
+                        memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
+                    }
+                }
+                else {
+                    // 'in' image is single-layer, 'out' image is double-layer (with the  transform layer).
+                    for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY -= widthIn ) {
+                        memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
+
+                        // Set 'in' image transform data not to skip image data.
+                        std::fill( transformOutY, transformOutY + width, static_cast<uint8_t>( 0 ) );
+                    }
+                }
+            }
+            else {
+                const uint8_t * transformInY = in.transform() + offsetIn + static_cast<ptrdiff_t>( height - 1 ) * widthIn;
+
+                if ( isOutSingleLayer ) {
+                    for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, imageInY -= widthIn, transformInY -= widthIn ) {
+                        uint8_t * imageOutX = imageOutY;
+                        const uint8_t * imageOutXEnd = imageOutX + width;
+                        const uint8_t * imageInX = imageInY;
+                        const uint8_t * transformInX = transformInY;
+
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++imageInX, ++transformInX ) {
+                            // Copy image data only for non-transparent pixels.
+                            if ( *transformInX == 0 ) {
+                                *imageOutX = *imageInX;
+                            }
+                        }
+                    }
+                }
+                else {
+                    // 'in' and 'out' images are with transform layer.
+                    for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY -= widthIn, transformInY -= widthIn ) {
+                        memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
+                        memcpy( transformOutY, transformInY, static_cast<size_t>( width ) );
+                    }
+                }
             }
         }
         else {
-            const uint8_t * imageInY = in.image() + offsetIn + ( height - 1 ) * widthIn + widthIn - 1;
-            const uint8_t * transformInY = in.transform() + offsetIn + ( height - 1 ) * widthIn + widthIn - 1;
+            // Flip horizontally and vertically.
+            if ( in.singleLayer() ) {
+                const uint8_t * imageInY = in.image() + offsetIn + static_cast<ptrdiff_t>( height - 1 ) * widthIn + widthIn - 1;
 
-            for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY -= widthIn, transformInY -= widthIn ) {
-                uint8_t * imageOutX = imageOutY;
-                uint8_t * transformOutX = transformOutY;
-                const uint8_t * imageOutXEnd = imageOutX + width;
-                const uint8_t * imageInX = imageInY;
-                const uint8_t * transformInX = transformInY;
+                for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY -= widthIn ) {
+                    uint8_t * imageOutX = imageOutY;
+                    const uint8_t * imageOutXEnd = imageOutX + width;
+                    const uint8_t * imageInX = imageInY;
 
-                for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++transformOutX, --imageInX, --transformInX ) {
-                    *imageOutX = *imageInX;
-                    *transformOutX = *transformInX;
+                    if ( isOutSingleLayer ) {
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, --imageInX ) {
+                            *imageOutX = *imageInX;
+                        }
+                    }
+                    else {
+                        // 'in' image is single-layer, 'out' image is double-layer (with the  transform layer).
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, --imageInX ) {
+                            *imageOutX = *imageInX;
+                        }
+
+                        // Set 'in' image transform data not to skip image data.
+                        std::fill( transformOutY, transformOutY + width, static_cast<uint8_t>( 0 ) );
+                    }
+                }
+            }
+            else {
+                const uint8_t * imageInY = in.image() + offsetIn + static_cast<ptrdiff_t>( height - 1 ) * widthIn + widthIn - 1;
+                const uint8_t * transformInY = in.transform() + offsetIn + static_cast<ptrdiff_t>( height - 1 ) * widthIn + widthIn - 1;
+
+                for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, imageInY -= widthIn, transformInY -= widthIn ) {
+                    uint8_t * imageOutX = imageOutY;
+                    const uint8_t * imageOutXEnd = imageOutX + width;
+                    const uint8_t * imageInX = imageInY;
+                    const uint8_t * transformInX = transformInY;
+
+                    if ( isOutSingleLayer ) {
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, --imageInX, --transformInX ) {
+                            // Copy image data only for non-transparent pixels.
+                            if ( *transformInX == 0 ) {
+                                *imageOutX = *imageInX;
+                            }
+                        }
+                    }
+                    else {
+                        // 'in' and 'out' images are with transform layer.
+                        uint8_t * transformOutX = transformOutY;
+
+                        for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++transformOutX, --imageInX, --transformInX ) {
+                            *imageOutX = *imageInX;
+                            *transformOutX = *transformInX;
+                        }
+                    }
                 }
             }
         }
@@ -2072,8 +2407,9 @@ namespace fheroes2
 
     Rect GetActiveROI( const Image & image, const uint8_t minTransformValue )
     {
-        if ( image.empty() )
-            return Rect();
+        if ( image.empty() || image.singleLayer() ) {
+            return {};
+        }
 
         const int32_t width = image.width();
         const int32_t height = image.height();
@@ -2092,12 +2428,14 @@ namespace fheroes2
                 }
             }
 
-            if ( area.y >= 0 )
+            if ( area.y >= 0 ) {
                 break;
+            }
         }
 
-        if ( area.y < 0 )
-            return Rect();
+        if ( area.y < 0 ) {
+            return {};
+        }
 
         // Bottom border
         inY = image.transform() + width * ( height - 1 );
@@ -2111,8 +2449,9 @@ namespace fheroes2
                 }
             }
 
-            if ( area.height >= 0 )
+            if ( area.height >= 0 ) {
                 break;
+            }
         }
 
         // Left border
@@ -2127,8 +2466,9 @@ namespace fheroes2
                 }
             }
 
-            if ( area.x >= 0 )
+            if ( area.x >= 0 ) {
                 break;
+            }
         }
 
         // Right border
@@ -2143,14 +2483,15 @@ namespace fheroes2
                 }
             }
 
-            if ( area.width >= 0 )
+            if ( area.width >= 0 ) {
                 break;
+            }
         }
 
         return area;
     }
 
-    uint8_t GetColorId( uint8_t red, uint8_t green, uint8_t blue )
+    uint8_t GetColorId( const uint8_t red, const uint8_t green, const uint8_t blue )
     {
         return GetPALColorId( red / 4, green / 4, blue / 4 );
     }
@@ -2162,7 +2503,7 @@ namespace fheroes2
             table[i] = static_cast<uint8_t>( i );
         }
 
-        if ( !Verify( in, x, y, width, height ) ) {
+        if ( !Verify( in, x, y, width, height ) || in.singleLayer() || out.singleLayer() ) {
             return table;
         }
 
@@ -2205,8 +2546,9 @@ namespace fheroes2
 
     Sprite makeShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId )
     {
-        if ( in.empty() || shadowOffset.x > 0 || shadowOffset.y < 0 )
-            return Sprite();
+        if ( in.empty() || in.singleLayer() || shadowOffset.x > 0 || shadowOffset.y < 0 ) {
+            return {};
+        }
 
         const int32_t width = in.width();
         const int32_t height = in.height();
@@ -2240,7 +2582,7 @@ namespace fheroes2
 
     void MaskTransformLayer( const Image & mask, int32_t maskX, int32_t maskY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height )
     {
-        if ( !Verify( mask, maskX, maskY, out, outX, outY, width, height ) ) {
+        if ( !Verify( mask, maskX, maskY, out, outX, outY, width, height ) || mask.singleLayer() || out.singleLayer() ) {
             return;
         }
 
@@ -2264,10 +2606,11 @@ namespace fheroes2
         }
     }
 
-    void ReplaceColorId( Image & image, uint8_t oldColorId, uint8_t newColorId )
+    void ReplaceColorId( Image & image, const uint8_t oldColorId, const uint8_t newColorId )
     {
-        if ( image.empty() )
+        if ( image.empty() ) {
             return;
+        }
 
         uint8_t * data = image.image();
         const uint8_t * dataEnd = data + image.width() * image.height();
@@ -2279,10 +2622,11 @@ namespace fheroes2
         }
     }
 
-    void ReplaceColorIdByTransformId( Image & image, uint8_t colorId, uint8_t transformId )
+    void ReplaceColorIdByTransformId( Image & image, const uint8_t colorId, const uint8_t transformId )
     {
-        if ( transformId > 15 )
+        if ( transformId > 15 || image.singleLayer() ) {
             return;
+        }
 
         const int32_t width = image.width();
         const int32_t height = image.height();
@@ -2309,8 +2653,9 @@ namespace fheroes2
     void Resize( const Image & in, const int32_t inX, const int32_t inY, const int32_t widthRoiIn, const int32_t heightRoiIn, Image & out, const int32_t outX,
                  const int32_t outY, const int32_t widthRoiOut, const int32_t heightRoiOut, const bool isSubpixelAccuracy )
     {
-        if ( !Validate( in, inX, inY, widthRoiIn, heightRoiIn ) || !Validate( out, outX, outY, widthRoiOut, heightRoiOut ) )
+        if ( !Validate( in, inX, inY, widthRoiIn, heightRoiIn ) || !Validate( out, outX, outY, widthRoiOut, heightRoiOut ) ) {
             return;
+        }
 
         if ( widthRoiIn == widthRoiOut && heightRoiIn == heightRoiOut ) {
             Copy( in, inX, inY, out, outX, outY, widthRoiIn, heightRoiIn );
@@ -2328,17 +2673,15 @@ namespace fheroes2
 
         if ( isSubpixelAccuracy ) {
             std::vector<double> positionX( widthRoiOut );
-            std::vector<double> positionY( heightRoiOut );
-            for ( int32_t x = 0; x < widthRoiOut; ++x )
+            for ( int32_t x = 0; x < widthRoiOut; ++x ) {
                 positionX[x] = static_cast<double>( x * widthRoiIn ) / widthRoiOut;
-            for ( int32_t y = 0; y < heightRoiOut; ++y )
-                positionY[y] = static_cast<double>( y * heightRoiIn ) / heightRoiOut;
+            }
 
             const uint8_t * gamePalette = getGamePalette();
 
             if ( in.singleLayer() && out.singleLayer() ) {
                 for ( int32_t y = 0; y < heightRoiOut; ++y, imageOutY += widthOut ) {
-                    const double posY = positionY[y];
+                    const double posY = static_cast<double>( y * heightRoiIn ) / heightRoiOut;
                     const int32_t startY = static_cast<int32_t>( posY );
                     const double coeffY = posY - startY;
 
@@ -2380,7 +2723,7 @@ namespace fheroes2
                 uint8_t * transformOutY = out.transform() + offsetOutY;
 
                 for ( int32_t y = 0; y < heightRoiOut; ++y, imageOutY += widthOut, transformOutY += widthOut ) {
-                    const double posY = positionY[y];
+                    const double posY = static_cast<double>( y * heightRoiIn ) / heightRoiOut;
                     const int32_t startY = static_cast<int32_t>( posY );
                     const double coeffY = posY - startY;
 
@@ -2431,22 +2774,22 @@ namespace fheroes2
             const uint8_t * imageOutYEnd = imageOutY + widthOut * heightRoiOut;
             int32_t idY = 0;
 
-            // Precalculation of X position
+            // Pre-calculation of X position
             std::vector<int32_t> positionX( widthRoiOut );
-            for ( int32_t x = 0; x < widthRoiOut; ++x )
+            for ( int32_t x = 0; x < widthRoiOut; ++x ) {
                 positionX[x] = ( x * widthRoiIn ) / widthRoiOut;
+            }
 
             if ( in.singleLayer() && out.singleLayer() ) {
                 for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, ++idY ) {
                     uint8_t * imageOutX = imageOutY;
-                    const uint8_t * imageOutXEnd = imageOutX + widthRoiOut;
 
                     const int32_t offset = ( ( idY * heightRoiIn ) / heightRoiOut ) * widthIn;
                     const uint8_t * imageInX = imageInY + offset;
-                    const int32_t * idX = positionX.data();
 
-                    for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++idX ) {
-                        *imageOutX = *( imageInX + ( *idX ) );
+                    for ( const int32_t posX : positionX ) {
+                        *imageOutX = *( imageInX + posX );
+                        ++imageOutX;
                     }
                 }
             }
@@ -2457,23 +2800,23 @@ namespace fheroes2
                 for ( ; imageOutY != imageOutYEnd; imageOutY += widthOut, transformOutY += widthOut, ++idY ) {
                     uint8_t * imageOutX = imageOutY;
                     uint8_t * transformOutX = transformOutY;
-                    const uint8_t * imageOutXEnd = imageOutX + widthRoiOut;
 
                     const int32_t offset = ( ( idY * heightRoiIn ) / heightRoiOut ) * widthIn;
                     const uint8_t * imageInX = imageInY + offset;
                     const uint8_t * transformInX = transformInY + offset;
-                    const int32_t * idX = positionX.data();
 
-                    for ( ; imageOutX != imageOutXEnd; ++imageOutX, ++transformOutX, ++idX ) {
-                        *imageOutX = *( imageInX + ( *idX ) );
-                        *transformOutX = *( transformInX + ( *idX ) );
+                    for ( const int32_t posX : positionX ) {
+                        *imageOutX = *( imageInX + posX );
+                        *transformOutX = *( transformInX + posX );
+                        ++imageOutX;
+                        ++transformOutX;
                     }
                 }
             }
         }
     }
 
-    void SetPixel( Image & image, int32_t x, int32_t y, uint8_t value )
+    void SetPixel( Image & image, const int32_t x, const int32_t y, const uint8_t value )
     {
         if ( image.empty() || x >= image.width() || y >= image.height() || x < 0 || y < 0 ) {
             return;
@@ -2481,10 +2824,12 @@ namespace fheroes2
 
         const int32_t offset = y * image.width() + x;
         *( image.image() + offset ) = value;
-        *( image.transform() + offset ) = 0;
+        if ( !image.singleLayer() ) {
+            *( image.transform() + offset ) = 0;
+        }
     }
 
-    void SetPixel( Image & image, const std::vector<Point> & points, uint8_t value )
+    void SetPixel( Image & image, const std::vector<Point> & points, const uint8_t value )
     {
         if ( image.empty() ) {
             return;
@@ -2492,6 +2837,7 @@ namespace fheroes2
 
         const int32_t width = image.width();
         const int32_t height = image.height();
+        const bool isDoubleLayer = !image.singleLayer();
 
         for ( const Point & point : points ) {
             if ( point.x >= width || point.y >= height || point.x < 0 || point.y < 0 ) {
@@ -2500,13 +2846,15 @@ namespace fheroes2
 
             const int32_t offset = point.y * width + point.x;
             *( image.image() + offset ) = value;
-            *( image.transform() + offset ) = 0;
+            if ( isDoubleLayer ) {
+                *( image.transform() + offset ) = 0;
+            }
         }
     }
 
-    void SetTransformPixel( Image & image, int32_t x, int32_t y, uint8_t value )
+    void SetTransformPixel( Image & image, const int32_t x, const int32_t y, const uint8_t value )
     {
-        if ( image.empty() || x >= image.width() || y >= image.height() || x < 0 || y < 0 ) {
+        if ( image.empty() || image.singleLayer() || x >= image.width() || y >= image.height() || x < 0 || y < 0 ) {
             return;
         }
 
@@ -2515,13 +2863,17 @@ namespace fheroes2
         *( image.transform() + offset ) = value;
     }
 
-    Image Stretch( const Image & in, int32_t inX, int32_t inY, int32_t widthIn, int32_t heightIn, int32_t widthOut, int32_t heightOut )
+    Image Stretch( const Image & in, int32_t inX, int32_t inY, int32_t widthIn, int32_t heightIn, const int32_t widthOut, const int32_t heightOut )
     {
         if ( !Validate( in, inX, inY, widthIn, heightIn ) || widthOut <= 0 || heightOut <= 0 ) {
-            return Image();
+            return {};
         }
 
-        Image out( widthOut, heightOut );
+        Image out;
+        if ( in.singleLayer() ) {
+            out._disableTransformLayer();
+        }
+        out.resize( widthOut, heightOut );
 
         const int32_t minWidth = widthIn < widthOut ? widthIn : widthOut;
         const int32_t minHeight = heightIn < heightOut ? heightIn : heightOut;
@@ -2591,27 +2943,77 @@ namespace fheroes2
         const uint8_t * imageInYEnd = imageInY + width * height;
         uint8_t * imageOutX = out.image();
 
-        const uint8_t * transformInY = in.transform();
-        uint8_t * transformOutX = out.transform();
+        if ( in.singleLayer() ) {
+            if ( out.singleLayer() ) {
+                for ( ; imageInY != imageInYEnd; imageInY += width, ++imageOutX ) {
+                    const uint8_t * imageInX = imageInY;
+                    const uint8_t * imageInXEnd = imageInX + width;
+                    uint8_t * imageOutY = imageOutX;
 
-        for ( ; imageInY != imageInYEnd; imageInY += width, transformInY += width, ++imageOutX, ++transformOutX ) {
-            const uint8_t * imageInX = imageInY;
-            const uint8_t * imageInXEnd = imageInX + width;
-            uint8_t * imageOutY = imageOutX;
+                    for ( ; imageInX != imageInXEnd; ++imageInX, imageOutY += height ) {
+                        *imageOutY = *imageInX;
+                    }
+                }
+            }
+            else {
+                uint8_t * transformOutX = out.transform();
 
-            const uint8_t * transformInX = transformInY;
-            uint8_t * transformOutY = transformOutX;
-            for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, imageOutY += height, transformOutY += height ) {
-                *imageOutY = *imageInX;
-                *transformOutY = *transformInX;
+                for ( ; imageInY != imageInYEnd; imageInY += width, ++imageOutX, ++transformOutX ) {
+                    const uint8_t * imageInX = imageInY;
+                    const uint8_t * imageInXEnd = imageInX + width;
+                    uint8_t * imageOutY = imageOutX;
+
+                    uint8_t * transformOutY = transformOutX;
+                    for ( ; imageInX != imageInXEnd; ++imageInX, imageOutY += height, transformOutY += height ) {
+                        *imageOutY = *imageInX;
+                        *transformOutY = 0;
+                    }
+                }
+            }
+        }
+        else {
+            const uint8_t * transformInY = in.transform();
+
+            if ( out.singleLayer() ) {
+                for ( ; imageInY != imageInYEnd; imageInY += width, transformInY += width, ++imageOutX ) {
+                    const uint8_t * imageInX = imageInY;
+                    const uint8_t * imageInXEnd = imageInX + width;
+                    uint8_t * imageOutY = imageOutX;
+
+                    const uint8_t * transformInX = transformInY;
+                    for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, imageOutY += height ) {
+                        // Copy image data only for non-transparent pixels.
+                        if ( *transformInX == 0 ) {
+                            *imageOutY = *imageInX;
+                        }
+                    }
+                }
+            }
+            else {
+                uint8_t * transformOutX = out.transform();
+
+                for ( ; imageInY != imageInYEnd; imageInY += width, transformInY += width, ++imageOutX, ++transformOutX ) {
+                    const uint8_t * imageInX = imageInY;
+                    const uint8_t * imageInXEnd = imageInX + width;
+                    uint8_t * imageOutY = imageOutX;
+
+                    const uint8_t * transformInX = transformInY;
+                    uint8_t * transformOutY = transformOutX;
+                    for ( ; imageInX != imageInXEnd; ++imageInX, ++transformInX, imageOutY += height, transformOutY += height ) {
+                        *imageOutY = *imageInX;
+                        *transformOutY = *transformInX;
+                    }
+                }
             }
         }
     }
 
     void updateShadow( Image & image, const Point & shadowOffset, const uint8_t transformId )
     {
-        if ( image.empty() || ( std::abs( shadowOffset.x ) >= image.width() ) || ( std::abs( shadowOffset.y ) >= image.height() ) || shadowOffset == Point() )
+        if ( image.empty() || image.singleLayer() || ( std::abs( shadowOffset.x ) >= image.width() ) || ( std::abs( shadowOffset.y ) >= image.height() )
+             || shadowOffset == Point() ) {
             return;
+        }
 
         const int32_t width = image.width() - std::abs( shadowOffset.x );
         const int32_t height = image.height() - std::abs( shadowOffset.y );

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -499,8 +499,8 @@ namespace fheroes2
     {
         if ( !empty() ) {
             const size_t totalSize = static_cast<size_t>( _width ) * _height;
-            std::fill( image(), image() + totalSize, value );
-            std::fill( transform(), transform() + totalSize, static_cast<uint8_t>( 0 ) );
+            memset( image(), value, totalSize );
+            memset( transform(), static_cast<uint8_t>( 0 ), totalSize );
         }
     }
 
@@ -528,9 +528,9 @@ namespace fheroes2
     {
         if ( !empty() ) {
             const size_t totalSize = static_cast<size_t>( _width ) * _height;
-            std::fill( image(), image() + totalSize, static_cast<uint8_t>( 0 ) );
+            memset( image(), static_cast<uint8_t>( 0 ), totalSize );
             // Set the transform layer to skip all data.
-            std::fill( transform(), transform() + totalSize, static_cast<uint8_t>( 1 ) );
+            memset( transform(), static_cast<uint8_t>( 1 ), totalSize );
         }
     }
 
@@ -1294,7 +1294,7 @@ namespace fheroes2
 
             for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, imageOutY += widthOut, transformOutY += widthOut ) {
                 memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
-                std::fill( transformOutY, transformOutY + width, static_cast<uint8_t>( 0 ) );
+                memset( transformOutY, static_cast<uint8_t>( 0 ), width );
             }
         }
         else {
@@ -2092,14 +2092,14 @@ namespace fheroes2
 
         if ( image.singleLayer() ) {
             for ( ; imageY != imageYEnd; imageY += imageWidth ) {
-                std::fill( imageY, imageY + width, colorId );
+                memset( imageY, colorId, width );
             }
         }
         else {
             uint8_t * transformY = image.transform() + static_cast<ptrdiff_t>( y ) * imageWidth + x;
             for ( ; imageY != imageYEnd; imageY += imageWidth, transformY += imageWidth ) {
-                std::fill( imageY, imageY + width, colorId );
-                std::fill( transformY, transformY + width, static_cast<uint8_t>( 0 ) );
+                memset( imageY, colorId, width );
+                memset( transformY, static_cast<uint8_t>( 0 ), width );
             }
         }
     }
@@ -2117,8 +2117,8 @@ namespace fheroes2
         const uint8_t * imageYEnd = imageY + height * imageWidth;
 
         for ( ; imageY != imageYEnd; imageY += imageWidth, transformY += imageWidth ) {
-            std::fill( imageY, imageY + width, static_cast<uint8_t>( 0 ) );
-            std::fill( transformY, transformY + width, transformId );
+            memset( imageY, static_cast<uint8_t>( 0 ), width );
+            memset( transformY, transformId, width );
         }
     }
 
@@ -2267,7 +2267,7 @@ namespace fheroes2
                         }
 
                         // Set 'in' image transform data not to skip image data.
-                        std::fill( transformOutY, transformOutY + width, static_cast<uint8_t>( 0 ) );
+                        memset( transformOutY, static_cast<uint8_t>( 0 ), width );
 
                         transformOutY += widthOut;
                     }
@@ -2317,7 +2317,7 @@ namespace fheroes2
                         memcpy( imageOutY, imageInY, static_cast<size_t>( width ) );
 
                         // Set 'in' image transform data not to skip image data.
-                        std::fill( transformOutY, transformOutY + width, static_cast<uint8_t>( 0 ) );
+                        memset( transformOutY, static_cast<uint8_t>( 0 ), width );
                     }
                 }
             }
@@ -2370,7 +2370,7 @@ namespace fheroes2
                         }
 
                         // Set 'in' image transform data not to skip image data.
-                        std::fill( transformOutY, transformOutY + width, static_cast<uint8_t>( 0 ) );
+                        memset( transformOutY, static_cast<uint8_t>( 0 ), width );
                     }
                 }
             }

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -995,7 +995,7 @@ namespace fheroes2
                             inValue = *( transformTable + static_cast<ptrdiff_t>( *transformInX ) * 256 + *imageOutX );
                         }
 
-                        const uint8_t * inPAL = gamePalette + static_cast<ptrdiff_t> (inValue) * 3;
+                        const uint8_t * inPAL = gamePalette + static_cast<ptrdiff_t>( inValue ) * 3;
                         const uint8_t * outPAL = gamePalette + static_cast<ptrdiff_t>( *imageOutX ) * 3;
 
                         const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -365,10 +365,11 @@ namespace
                 int32_t minDistance = 3 * 255 * 255;
                 uint32_t bestPos = 0;
 
-                const uint8_t * correctorX = transformTable + 256 * 15;
+                // 6400 = 256 * 15. This is the offset of "No cycle" transform table.
+                const uint8_t * correctorX = transformTable + 6400;
 
                 for ( uint32_t i = 0; i < 256; ++i, ++correctorX ) {
-                    const uint8_t * palette = gamePalette + *correctorX * 3;
+                    const uint8_t * palette = gamePalette + static_cast<ptrdiff_t>( *correctorX ) * 3;
 
                     const int32_t offsetRed = static_cast<int32_t>( *palette ) - static_cast<int32_t>( r );
                     ++palette;
@@ -400,9 +401,9 @@ namespace
         const int32_t widthIn = in.width();
         const int32_t widthOut = out.width();
 
-        const uint8_t * imageInY = in.image() + inY * widthIn + inX;
-        uint8_t * imageOutY = out.image() + outY * widthOut + outX;
-        const uint8_t * imageInYEnd = imageInY + height * widthIn;
+        const uint8_t * imageInY = in.image() + static_cast<ptrdiff_t>( inY ) * widthIn + inX;
+        uint8_t * imageOutY = out.image() + static_cast<ptrdiff_t>( outY ) * widthOut + outX;
+        const uint8_t * imageInYEnd = imageInY + static_cast<ptrdiff_t>( height ) * widthIn;
 
         if ( in.singleLayer() ) {
             // All pixels in a single-layer image do not have any transform values so there is no need to check for them.
@@ -417,7 +418,7 @@ namespace
             }
         }
         else {
-            const uint8_t * transformInY = in.transform() + inY * widthIn + inX;
+            const uint8_t * transformInY = in.transform() + static_cast<ptrdiff_t>( inY ) * widthIn + inX;
 
             for ( ; imageInY != imageInYEnd; imageInY += widthIn, transformInY += widthIn, imageOutY += widthOut ) {
                 const uint8_t * imageInX = imageInY;
@@ -515,7 +516,7 @@ namespace fheroes2
             return;
         }
 
-        size_t size = static_cast<size_t>( width_ ) * height_;
+        const size_t size = static_cast<size_t>( width_ ) * height_;
 
         _data.reset( new uint8_t[size * 2] );
 
@@ -902,7 +903,7 @@ namespace fheroes2
 
             const int32_t offsetOutY = outY * widthOut + outX;
             uint8_t * imageOutY = out.image() + offsetOutY;
-            const uint8_t * imageOutYEnd = imageOutY + height * widthOut;
+            const uint8_t * imageOutYEnd = imageOutY + static_cast<ptrdiff_t>( height ) * widthOut;
 
             if ( in.singleLayer() ) {
                 for ( ; imageOutY != imageOutYEnd; imageInY += widthIn, imageOutY += widthOut ) {
@@ -911,8 +912,8 @@ namespace fheroes2
                     const uint8_t * imageOutXEnd = imageOutX + width;
 
                     for ( ; imageOutX != imageOutXEnd; --imageInX, ++imageOutX ) {
-                        const uint8_t * inPAL = gamePalette + ( *imageInX ) * 3;
-                        const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+                        const uint8_t * inPAL = gamePalette + static_cast<ptrdiff_t>( *imageInX ) * 3;
+                        const uint8_t * outPAL = gamePalette + static_cast<ptrdiff_t>( *imageOutX ) * 3;
 
                         const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
                         const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
@@ -937,11 +938,11 @@ namespace fheroes2
 
                         uint8_t inValue = *imageInX;
                         if ( *transformInX > 1 ) {
-                            inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                            inValue = *( transformTable + static_cast<ptrdiff_t>( *transformInX ) * 256 + *imageOutX );
                         }
 
-                        const uint8_t * inPAL = gamePalette + inValue * 3;
-                        const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+                        const uint8_t * inPAL = gamePalette + static_cast<ptrdiff_t>( inValue ) * 3;
+                        const uint8_t * outPAL = gamePalette + static_cast<ptrdiff_t>( *imageOutX ) * 3;
 
                         const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
                         const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
@@ -955,8 +956,8 @@ namespace fheroes2
             const int32_t offsetInY = inY * widthIn + inX;
             const uint8_t * imageInY = in.image() + offsetInY;
 
-            uint8_t * imageOutY = out.image() + outY * widthOut + outX;
-            const uint8_t * imageInYEnd = imageInY + height * widthIn;
+            uint8_t * imageOutY = out.image() + static_cast<ptrdiff_t>( outY ) * widthOut + outX;
+            const uint8_t * imageInYEnd = imageInY + static_cast<ptrdiff_t>( height ) * widthIn;
 
             if ( in.singleLayer() ) {
                 for ( ; imageInY != imageInYEnd; imageInY += widthIn, imageOutY += widthOut ) {
@@ -965,8 +966,8 @@ namespace fheroes2
                     const uint8_t * imageInXEnd = imageInX + width;
 
                     for ( ; imageInX != imageInXEnd; ++imageInX, ++imageOutX ) {
-                        const uint8_t * inPAL = gamePalette + ( *imageInX ) * 3;
-                        const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+                        const uint8_t * inPAL = gamePalette + static_cast<ptrdiff_t>( *imageInX ) * 3;
+                        const uint8_t * outPAL = gamePalette + static_cast<ptrdiff_t>( *imageOutX ) * 3;
 
                         const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
                         const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;
@@ -991,11 +992,11 @@ namespace fheroes2
 
                         uint8_t inValue = *imageInX;
                         if ( *transformInX > 1 ) {
-                            inValue = *( transformTable + ( *transformInX ) * 256 + *imageOutX );
+                            inValue = *( transformTable + static_cast<ptrdiff_t>( *transformInX ) * 256 + *imageOutX );
                         }
 
-                        const uint8_t * inPAL = gamePalette + inValue * 3;
-                        const uint8_t * outPAL = gamePalette + ( *imageOutX ) * 3;
+                        const uint8_t * inPAL = gamePalette + static_cast<ptrdiff_t> (inValue) * 3;
+                        const uint8_t * outPAL = gamePalette + static_cast<ptrdiff_t>( *imageOutX ) * 3;
 
                         const uint32_t red = static_cast<uint32_t>( *inPAL ) * alphaValue + static_cast<uint32_t>( *outPAL ) * behindValue;
                         const uint32_t green = static_cast<uint32_t>( *( inPAL + 1 ) ) * alphaValue + static_cast<uint32_t>( *( outPAL + 1 ) ) * behindValue;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -365,8 +365,8 @@ namespace
                 int32_t minDistance = 3 * 255 * 255;
                 uint32_t bestPos = 0;
 
-                // 6400 = 256 * 15. This is the offset of "No cycle" transform table.
-                const uint8_t * correctorX = transformTable + 6400;
+                // 3840 = 256 * 15. This is the offset of "No cycle" transform table.
+                const uint8_t * correctorX = transformTable + 3840;
 
                 for ( uint32_t i = 0; i < 256; ++i, ++correctorX ) {
                     const uint8_t * palette = gamePalette + static_cast<ptrdiff_t>( *correctorX ) * 3;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -365,8 +365,7 @@ namespace
                 int32_t minDistance = 3 * 255 * 255;
                 uint32_t bestPos = 0;
 
-                // 3840 = 256 * 15. This is the offset of "No cycle" transform table.
-                const uint8_t * correctorX = transformTable + 3840;
+                const uint8_t * correctorX = transformTable + 256 * 15;
 
                 for ( uint32_t i = 0; i < 256; ++i, ++correctorX ) {
                     const uint8_t * palette = gamePalette + static_cast<ptrdiff_t>( *correctorX ) * 3;

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -103,7 +103,7 @@ namespace fheroes2
         int32_t _height{ 0 };
         std::unique_ptr<uint8_t[]> _data; // holds 2 image layers
 
-        // Jnly for images which are not used for any other operations except displaying on screen.
+        // Only for images which are not used for any other operations except displaying on screen.
         bool _singleLayer{ false };
     };
 

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -34,8 +34,8 @@ namespace fheroes2
     class Image
     {
     public:
-        Image();
-        Image( int32_t width_, int32_t height_ );
+        Image() = default;
+        Image( const int32_t width_, const int32_t height_ );
         Image( const Image & image_ );
         Image( Image && image_ ) noexcept;
 
@@ -44,7 +44,7 @@ namespace fheroes2
         Image & operator=( const Image & image_ );
         Image & operator=( Image && image_ ) noexcept;
 
-        virtual void resize( int32_t width_, int32_t height_ );
+        virtual void resize( const int32_t width_, const int32_t height_ );
 
         // It's safe to cast to uint32_t as width and height are always >= 0
         int32_t width() const
@@ -58,6 +58,7 @@ namespace fheroes2
         }
 
         virtual uint8_t * image();
+
         virtual const uint8_t * image() const;
 
         uint8_t * transform()
@@ -78,7 +79,8 @@ namespace fheroes2
         void reset(); // makes image fully transparent (transform layer is set to 1)
         void clear(); // makes the image empty
 
-        void fill( uint8_t value ); // fill 'image' layer with given value, setting 'transform' layer set to 0
+        // Fill 'image' layer with given value, setting 'transform' layer to 0.
+        void fill( const uint8_t value );
 
         // This is an optional indicator for image processing functions.
         // The whole image still consists of 2 layers but transform layer might be ignored in computations.
@@ -97,20 +99,21 @@ namespace fheroes2
     private:
         void copy( const Image & image );
 
-        int32_t _width;
-        int32_t _height;
+        int32_t _width{ 0 };
+        int32_t _height{ 0 };
         std::unique_ptr<uint8_t[]> _data; // holds 2 image layers
 
-        bool _singleLayer; // only for images which are not used for any other operations except displaying on screen. Non-copyable member.
+        // Jnly for images which are not used for any other operations except displaying on screen.
+        bool _singleLayer{ false };
     };
 
     class Sprite : public Image
     {
     public:
-        Sprite();
-        Sprite( int32_t width_, int32_t height_, int32_t x_ = 0, int32_t y_ = 0 );
-        Sprite( const Image & image, int32_t x_ = 0, int32_t y_ = 0 );
-        Sprite( const Sprite & sprite );
+        Sprite() = default;
+        Sprite( const int32_t width_, const int32_t height_, const int32_t x_ = 0, const int32_t y_ = 0 );
+        Sprite( const Image & image, const int32_t x_ = 0, const int32_t y_ = 0 );
+        Sprite( const Sprite & sprite ) = default;
         Sprite( Sprite && sprite ) noexcept;
 
         ~Sprite() override = default;
@@ -128,11 +131,11 @@ namespace fheroes2
             return _y;
         }
 
-        virtual void setPosition( int32_t x_, int32_t y_ );
+        virtual void setPosition( const int32_t x_, const int32_t y_ );
 
     private:
-        int32_t _x;
-        int32_t _y;
+        int32_t _x{ 0 };
+        int32_t _y{ 0 };
     };
 
     // This class is used in situations when we draw a window within another window
@@ -140,12 +143,12 @@ namespace fheroes2
     {
     public:
         explicit ImageRestorer( Image & image );
-        ImageRestorer( Image & image, int32_t x_, int32_t y_, int32_t width, int32_t height );
+        ImageRestorer( Image & image, const int32_t x_, const int32_t y_, const int32_t width, const int32_t height );
         ~ImageRestorer(); // restore method will be call upon object's destruction
 
         ImageRestorer( const ImageRestorer & ) = delete;
 
-        void update( int32_t x_, int32_t y_, int32_t width, int32_t height );
+        void update( const int32_t x_, const int32_t y_, const int32_t width, const int32_t height );
 
         int32_t x() const
         {
@@ -173,20 +176,23 @@ namespace fheroes2
         }
 
         void restore();
-        void reset();
+        void reset()
+        {
+            _isRestored = true;
+        }
 
     private:
         Image & _image;
         Image _copy;
 
-        int32_t _x;
-        int32_t _y;
-        int32_t _width;
-        int32_t _height;
+        int32_t _x{ 0 };
+        int32_t _y{ 0 };
+        int32_t _width{ 0 };
+        int32_t _height{ 0 };
 
         void _updateRoi();
 
-        bool _isRestored;
+        bool _isRestored{ false };
     };
 
     // Apply shadow that gradually reduces strength using 'in' image shape. Shadow is applied to the 'out' image.
@@ -196,32 +202,32 @@ namespace fheroes2
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId );
 
     // Replace a particular pixel value by transparency value (transform layer value will be 1)
-    void AddTransparency( Image & image, uint8_t valueToReplace );
+    void AddTransparency( Image & image, const uint8_t valueToReplace );
 
     // make sure that output image's transform layer doesn't have skipping values (transform == 1)
-    void AlphaBlit( const Image & in, Image & out, uint8_t alphaValue, bool flip = false );
-    void AlphaBlit( const Image & in, Image & out, int32_t outX, int32_t outY, uint8_t alphaValue, bool flip = false );
-    void AlphaBlit( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, uint8_t alphaValue,
-                    bool flip = false );
+    void AlphaBlit( const Image & in, Image & out, const uint8_t alphaValue, const bool flip = false );
+    void AlphaBlit( const Image & in, Image & out, int32_t outX, int32_t outY, const uint8_t alphaValue, const bool flip = false );
+    void AlphaBlit( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const uint8_t alphaValue,
+                    const bool flip = false );
 
     // apply palette only for image layer, it doesn't affect transform part
     void ApplyPalette( Image & image, const std::vector<uint8_t> & palette );
     void ApplyPalette( const Image & in, Image & out, const std::vector<uint8_t> & palette );
-    void ApplyPalette( Image & image, uint8_t paletteId );
-    void ApplyPalette( const Image & in, Image & out, uint8_t paletteId );
+    void ApplyPalette( Image & image, const uint8_t paletteId );
+    void ApplyPalette( const Image & in, Image & out, const uint8_t paletteId );
     void ApplyPalette( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, uint8_t paletteId );
     void ApplyPalette( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height,
                        const std::vector<uint8_t> & palette );
 
-    void ApplyAlpha( const Image & in, Image & out, uint8_t alpha );
-    void ApplyAlpha( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, uint8_t alpha );
+    void ApplyAlpha( const Image & in, Image & out, const uint8_t alpha );
+    void ApplyAlpha( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const uint8_t alpha );
 
-    void ApplyTransform( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, uint8_t transformId );
+    void ApplyTransform( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, const uint8_t transformId );
 
     // draw one image onto another
-    void Blit( const Image & in, Image & out, bool flip = false );
-    void Blit( const Image & in, Image & out, int32_t outX, int32_t outY, bool flip = false );
-    void Blit( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, bool flip = false );
+    void Blit( const Image & in, Image & out, const bool flip = false );
+    void Blit( const Image & in, Image & out, int32_t outX, int32_t outY, const bool flip = false );
+    void Blit( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool flip = false );
 
     // inPos must contain non-negative values
     void Blit( const Image & in, const Point & inPos, Image & out, const Point & outPos, const Size & size, bool flip = false );
@@ -232,7 +238,7 @@ namespace fheroes2
     // Copies transform the layer from in to out. Both images must be of the same size.
     void CopyTransformLayer( const Image & in, Image & out );
 
-    Sprite CreateContour( const Image & image, uint8_t value );
+    Sprite CreateContour( const Image & image, const uint8_t value );
 
     // Make a transition to "in" image from left to right or vertically - from top to bottom using dithering (https://en.wikipedia.org/wiki/Dither).
     // The direction of transition can be reversed.
@@ -242,12 +248,12 @@ namespace fheroes2
     Sprite Crop( const Image & image, int32_t x, int32_t y, int32_t width, int32_t height );
 
     // skipFactor is responsible for non-solid line. You can interpret it as skip every N pixel
-    void DrawBorder( Image & image, uint8_t value, uint32_t skipFactor = 0 );
+    void DrawBorder( Image & image, const uint8_t value, const uint32_t skipFactor = 0 );
 
     // roi is an optional parameter when you need to draw in a small than image area
-    void DrawLine( Image & image, const Point & start, const Point & end, uint8_t value, const Rect & roi = Rect() );
+    void DrawLine( Image & image, const Point & start, const Point & end, const uint8_t value, const Rect & roi = Rect() );
 
-    void DrawRect( Image & image, const Rect & roi, uint8_t value );
+    void DrawRect( Image & image, const Rect & roi, const uint8_t value );
 
     void DivideImageBySquares( const Point & spriteOffset, const Image & original, const int32_t squareSize, std::vector<Point> & outputSquareId,
                                std::vector<std::pair<Point, Rect>> & outputImageInfo );
@@ -256,22 +262,23 @@ namespace fheroes2
     Image ExtractCommonPattern( const std::vector<const Image *> & input );
 
     // Please use GetColorId function if you want to use an RGB value
-    void Fill( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, uint8_t colorId );
+    void Fill( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, const uint8_t colorId );
 
-    void FillTransform( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, uint8_t transformId );
+    void FillTransform( Image & image, int32_t x, int32_t y, int32_t width, int32_t height, const uint8_t transformId );
 
     Image FilterOnePixelNoise( const Image & input );
 
     bool FitToRoi( const Image & in, Point & inPos, const Image & out, Point & outPos, Size & outputSize, const Rect & outputRoi );
 
-    Image Flip( const Image & in, bool horizontally, bool vertically );
-    void Flip( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, bool horizontally, bool vertically );
+    Image Flip( const Image & in, const bool horizontally, const bool vertically );
+    void Flip( const Image & in, int32_t inX, int32_t inY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height, const bool horizontally,
+               const bool vertically );
 
     // Return ROI with pixels which are not skipped and not used for shadow creation. 1 is to skip, 2 - 5 types of shadows
     Rect GetActiveROI( const Image & image, const uint8_t minTransformValue = 6 );
 
     // Returns a closest color ID from the original game's palette
-    uint8_t GetColorId( uint8_t red, uint8_t green, uint8_t blue );
+    uint8_t GetColorId( const uint8_t red, const uint8_t green, const uint8_t blue );
 
     std::vector<uint8_t> getTransformTable( const Image & in, const Image & out, int32_t x, int32_t y, int32_t width, int32_t height );
 
@@ -280,10 +287,10 @@ namespace fheroes2
     void MaskTransformLayer( const Image & mask, int32_t maskX, int32_t maskY, Image & out, int32_t outX, int32_t outY, int32_t width, int32_t height );
 
     // This function does NOT check transform layer. If you intent to replace few colors at the same image please use ApplyPalette to be more efficient.
-    void ReplaceColorId( Image & image, uint8_t oldColorId, uint8_t newColorId );
+    void ReplaceColorId( Image & image, const uint8_t oldColorId, const uint8_t newColorId );
 
     // Use this function only when you need to convert pixel value into transform layer
-    void ReplaceColorIdByTransformId( Image & image, uint8_t colorId, uint8_t transformId );
+    void ReplaceColorIdByTransformId( Image & image, const uint8_t colorId, const uint8_t transformId );
 
     // Please remember that subpixel accuracy resizing is extremely slow!
     void Resize( const Image & in, Image & out, const bool isSubpixelAccuracy = false );
@@ -292,14 +299,14 @@ namespace fheroes2
                  const int32_t outY, const int32_t widthRoiOut, const int32_t heightRoiOut, const bool isSubpixelAccuracy = false );
 
     // Please use value from the main palette only
-    void SetPixel( Image & image, int32_t x, int32_t y, uint8_t value );
+    void SetPixel( Image & image, const int32_t x, const int32_t y, const uint8_t value );
 
-    void SetPixel( Image & image, const std::vector<Point> & points, uint8_t value );
+    void SetPixel( Image & image, const std::vector<Point> & points, const uint8_t value );
 
     // Please set value not bigger than 13!
-    void SetTransformPixel( Image & image, int32_t x, int32_t y, uint8_t value );
+    void SetTransformPixel( Image & image, const int32_t x, const int32_t y, const uint8_t value );
 
-    Image Stretch( const Image & in, int32_t inX, int32_t inY, int32_t widthIn, int32_t heightIn, int32_t widthOut, int32_t heightOut );
+    Image Stretch( const Image & in, int32_t inX, int32_t inY, int32_t widthIn, int32_t heightIn, const int32_t widthOut, const int32_t heightOut );
 
     void Transpose( const Image & in, Image & out );
 


### PR DESCRIPTION
This PR contains changes made in https://github.com/ihhub/fheroes2/pull/7233
While working on https://github.com/ihhub/fheroes2/pull/7233 there were made some necessary for that PR changes in the code, but PR became very big. To reduce the size of that PR and to properly test and merge some changes this PR is made. It contains:
- improved image processing logic for single-layer images: currently (in master build) some functions analyze and change the 'transform' layer of single-layer images which is not correct (wastes resources and in some places may give unpredictable result);
- clean up `image.h` and `image.cpp` code to make Clang-Tidy a little happier.
