### PR TITLE
Do not play more than 2 simultaneous creature walk sounds. Battlefield

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -917,6 +917,20 @@ void Mixer::setVolume( const int channelId, const int volumePercentage )
     }
 }
 
+void Mixer::fadeOutChannel( const int channelId, const int timeMs )
+{
+    const std::scoped_lock<std::recursive_mutex> lock( audioMutex );
+
+    if ( isInitialized ) {
+#if SDL_VERSION_ATLEAST( 2, 0, 0 )
+        Mix_FadeOutChannel( channelId, timeMs );
+#else
+        // SDL1 does not have sound fade functions so we stop the sound in this channel.
+        Mix_HaltChannel( channelId );
+#endif
+    }
+}
+
 void Mixer::Pause( const int channelId /* = -1 */ )
 {
     const std::scoped_lock<std::recursive_mutex> lock( audioMutex );

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -57,6 +57,9 @@ namespace Mixer
 
     void setVolume( const int channelId, const int volumePercentage );
 
+    // Stop playing sound in a channel after fading it out for a specified time in milliseconds.
+    void fadeOutChannel( const int channelId, const int timeMs );
+
     void Pause( const int channelId = -1 );
     void Resume( const int channelId = -1 );
     void Stop( const int channelId = -1 );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3954,6 +3954,8 @@ void Battle::Interface::RedrawActionMove( Unit & unit, const Indexes & path )
 
     // We allow to play maximum 2 simultaneous walk sounds. '-1' means that the channel is not set.
     std::array<int, 2> walkSounds{ -1, -1 };
+    // Set sound fade out time: 325 ms for battle speed 1 - 100 ms for battle speed 10.
+    const int soundFateTimeMs = 1300 / ( Settings::Get().BattleSpeed() + 3 );
 
     while ( dst != pathEnd ) {
         // Check if a wide unit changes its horizontal direction.
@@ -4002,8 +4004,8 @@ void Battle::Interface::RedrawActionMove( Unit & unit, const Indexes & path )
         if ( ( walkSounds[0] != -1 ) && Mixer ::isPlaying( walkSounds[0] ) ) {
             // The walk sound is playing in the first channel.
             if ( walkSounds[1] != -1 && Mixer ::isPlaying( walkSounds[1] ) ) {
-                // The walk sound is also playing in the second channel. Stop it.
-                Mixer::Stop( walkSounds[1] );
+                // The walk sound is also playing in the second channel. Fade it out and stop.
+                Mixer::fadeOutChannel( walkSounds[1], soundFateTimeMs );
             }
 
             // Start a new walk sound in the second channel.
@@ -4060,8 +4062,8 @@ void Battle::Interface::RedrawActionMove( Unit & unit, const Indexes & path )
     }
 
     if ( Mixer::isPlaying( walkSounds[0] ) && Mixer::isPlaying( walkSounds[1] ) ) {
-        // Both sound channels are playing walk sound. Stop sound in the second channel.
-        Mixer::Stop( walkSounds[1] );
+        // Both sound channels are playing walk sound. Stop sound in the second channel with fade.
+        Mixer::fadeOutChannel( walkSounds[1], soundFateTimeMs );
     }
 
     // Slowed flying creature has to land.


### PR DESCRIPTION
Currently in master build on high battle speeds when creature is moving the walk sound is played for move to every next cell. It results in many simultaneous move sounds playback.

This PR makes limit to play maximum 2 simultaneous creature walk sounds. The sound in one channel will play fully until it ends. The simultaneous playing sound will be interrupted on every cell with the new walk sound. This is made to hear all creature steps to the next cell.

Also the SDL2 ability to fade out sound is used in this PR to avoid clicks when stopping the sound playback.