### PR TITLE
Fix the fade effect on the "View World" screen

### DIFF
--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -580,7 +580,7 @@ void ViewWorld::ViewWorldWindow( const int32_t color, const ViewWorldMode mode, 
     const bool isHideInterface = conf.isHideInterfaceEnabled();
     const ZoomLevel zoomLevel = conf.ViewWorldZoomLevel();
 
-    fheroes2::Rect fadeRoi( { 0, 0 }, display.screenSize() );
+    fheroes2::Rect fadeRoi( 0, 0, display.width(), display.height() );
 
     if ( !isHideInterface ) {
         // If interface is on there is no need to fade the whole screen, just only map area.


### PR DESCRIPTION
fix #7328

`Display::screenSize()` is the "physical" dimensions of the screen, and we need to operate in "logical" dimensions.