### PR TITLE
Fix Abandoned Mine right sprite update

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1712,8 +1712,8 @@ void Maps::Tiles::RestoreAbandonedMine( Tiles & tile, const int resource )
     auto restoreMineObjectType = [&tile]( int directionVector ) {
         if ( Maps::isValidDirection( tile._index, directionVector ) ) {
             Tiles & mineTile = world.GetTiles( Maps::GetDirectionIndex( tile._index, directionVector ) );
-            if ( ( mineTile._uid == tile._uid || mineTile.FindAddonLevel1( tile._uid ) || mineTile.FindAddonLevel2( tile._uid ) )
-                 && ( mineTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) ) {
+            if ( ( mineTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE )
+                 && ( mineTile._uid == tile._uid || mineTile.FindAddonLevel1( tile._uid ) || mineTile.FindAddonLevel2( tile._uid ) ) ) {
                 mineTile.SetObject( MP2::OBJ_NON_ACTION_MINES );
             }
         }
@@ -1728,11 +1728,12 @@ void Maps::Tiles::RestoreAbandonedMine( Tiles & tile, const int resource )
 
     if ( Maps::isValidDirection( tile._index, Direction::RIGHT ) ) {
         Tiles & rightTile = world.GetTiles( Maps::GetDirectionIndex( tile._index, Direction::RIGHT ) );
-        TilesAddon * addon = rightTile.FindAddonLevel1( tile._uid );
 
         if ( rightTile._uid == tile._uid ) {
             restoreRightSprite( rightTile._objectIcnType, rightTile._imageIndex );
         }
+
+        TilesAddon * addon = rightTile.FindAddonLevel1( tile._uid );
 
         if ( addon ) {
             restoreRightSprite( addon->_objectIcnType, addon->_imageIndex );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1709,52 +1709,41 @@ void Maps::Tiles::RestoreAbandonedMine( Tiles & tile, const int resource )
         }
     };
 
+    auto restoreMineObjectType = [&tile]( int directionVector ) {
+        if ( Maps::isValidDirection( tile._index, directionVector ) ) {
+            Tiles & mineTile = world.GetTiles( Maps::GetDirectionIndex( tile._index, directionVector ) );
+            if ( ( mineTile._uid == tile._uid || mineTile.FindAddonLevel1( tile._uid ) || mineTile.FindAddonLevel2( tile._uid ) )
+                 && ( mineTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) ) {
+                mineTile.SetObject( MP2::OBJ_NON_ACTION_MINES );
+            }
+        }
+    };
+
     restoreLeftSprite( tile._objectIcnType, tile._imageIndex );
     for ( TilesAddon & addon : tile.addons_level1 ) {
-        restoreLeftSprite( addon._objectIcnType, addon._imageIndex );
+        if ( addon._uid == tile._uid ) {
+            restoreLeftSprite( addon._objectIcnType, addon._imageIndex );
+        }
     }
 
     if ( Maps::isValidDirection( tile._index, Direction::RIGHT ) ) {
         Tiles & rightTile = world.GetTiles( Maps::GetDirectionIndex( tile._index, Direction::RIGHT ) );
         TilesAddon * addon = rightTile.FindAddonLevel1( tile._uid );
 
-        restoreRightSprite( rightTile._objectIcnType, rightTile._imageIndex );
+        if ( rightTile._uid == tile._uid ) {
+            restoreRightSprite( rightTile._objectIcnType, rightTile._imageIndex );
+        }
+
         if ( addon ) {
             restoreRightSprite( addon->_objectIcnType, addon->_imageIndex );
         }
-
-        if ( rightTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) {
-            rightTile.SetObject( MP2::OBJ_NON_ACTION_MINES );
-        }
     }
 
-    if ( Maps::isValidDirection( tile._index, Direction::LEFT ) ) {
-        Tiles & leftTile = world.GetTiles( Maps::GetDirectionIndex( tile._index, Direction::LEFT ) );
-        if ( leftTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) {
-            leftTile.SetObject( MP2::OBJ_NON_ACTION_MINES );
-        }
-    }
-
-    if ( Maps::isValidDirection( tile._index, Direction::TOP ) ) {
-        Tiles & upperTile = world.GetTiles( Maps::GetDirectionIndex( tile._index, Direction::TOP ) );
-        if ( upperTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) {
-            upperTile.SetObject( MP2::OBJ_NON_ACTION_MINES );
-        }
-
-        if ( Maps::isValidDirection( upperTile._index, Direction::LEFT ) ) {
-            Tiles & upperLeftTile = world.GetTiles( Maps::GetDirectionIndex( upperTile._index, Direction::LEFT ) );
-            if ( upperLeftTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) {
-                upperLeftTile.SetObject( MP2::OBJ_NON_ACTION_MINES );
-            }
-        }
-
-        if ( Maps::isValidDirection( upperTile._index, Direction::RIGHT ) ) {
-            Tiles & upperRightTile = world.GetTiles( Maps::GetDirectionIndex( upperTile._index, Direction::RIGHT ) );
-            if ( upperRightTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) {
-                upperRightTile.SetObject( MP2::OBJ_NON_ACTION_MINES );
-            }
-        }
-    }
+    restoreMineObjectType( Direction::LEFT );
+    restoreMineObjectType( Direction::RIGHT );
+    restoreMineObjectType( Direction::TOP );
+    restoreMineObjectType( Direction::TOP_LEFT );
+    restoreMineObjectType( Direction::TOP_RIGHT );
 }
 
 void Maps::Tiles::ClearFog( const int colors )

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1718,13 +1718,13 @@ void Maps::Tiles::RestoreAbandonedMine( Tiles & tile, const int resource )
         Tiles & rightTile = world.GetTiles( Maps::GetDirectionIndex( tile._index, Direction::RIGHT ) );
         TilesAddon * addon = rightTile.FindAddonLevel1( tile._uid );
 
+        restoreRightSprite( rightTile._objectIcnType, rightTile._imageIndex );
         if ( addon ) {
             restoreRightSprite( addon->_objectIcnType, addon->_imageIndex );
         }
 
         if ( rightTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE ) {
             rightTile.SetObject( MP2::OBJ_NON_ACTION_MINES );
-            restoreRightSprite( rightTile._objectIcnType, rightTile._imageIndex );
         }
     }
 


### PR DESCRIPTION
This PR fixes this issue: https://github.com/ihhub/fheroes2/issues/5716#issuecomment-1601480162
It makes engine to update the Abandoned Mine right sprite even if its tile object type is not `MP2::OBJ_NON_ACTION_ABANDONED_MINE`.

Master build:
![bug](https://github.com/ihhub/fheroes2/assets/113276641/e4bdd373-4444-4a8b-8b90-40a518b9e0ec)

The save file with the issue: [ghostmine_capture_sprit_bug.zip](https://github.com/ihhub/fheroes2/files/11823903/ghostmine_capture_sprit_bug.zip)

This PR: 
![after_fix](https://github.com/ihhub/fheroes2/assets/113276641/84e6db01-9081-4708-bd9d-18594a338cd1)