### PR TITLE
Move Spanish Language to Official Localizations in Supported Languages List 

### DIFF
--- a/src/fheroes2/gui/ui_language.h
+++ b/src/fheroes2/gui/ui_language.h
@@ -34,7 +34,7 @@ namespace fheroes2
         Russian, // Buka and XXI Vek versions
         Italian, // Rare version?
         Czech, // Local release occurred in 2002 by CD Projekt
-        Spanish, // Published by Proein. Only Succesion Wars
+        Spanish, // Published by Proein. Only Succession Wars
 
         // All languages listed below are original to fheroes2.
         Belarusian,


### PR DESCRIPTION
The Spanish supported language is moved together with the other supported languages for tidyness and clarity's sake.

The Spanish assets have the exact same FONT file as the English original so there is no need for it to have a specific CRC32 checksum connected to it (this would even break things as it would appear to be the English resources to the engine).

Together with @Joarico we decided to accept this and have Spanish buttons be replaced by the engine-produced buttons.