### PR TITLE
Fix AI logic for visiting Shrines and Arena

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -289,8 +289,8 @@ namespace
                 case Spell::EARTHQUAKE:
                 case Spell::HAUNT:
                 case Spell::IDENTIFYHERO:
-                case Spell::SETEGUARDIAN:
                 case Spell::SETAGUARDIAN:
+                case Spell::SETEGUARDIAN:
                 case Spell::SETFGUARDIAN:
                 case Spell::SETWGUARDIAN:
                 case Spell::TELEPORT:

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -309,7 +309,7 @@ namespace
                 return false;
             }
 
-            if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) && !isSpellUsedByAI( spell.GetID() ) ) {
+            if ( hero.isVisited( tile, Visit::GLOBAL ) && !isSpellUsedByAI( spell.GetID() ) ) {
                 return false;
             }
             return true;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -315,8 +315,11 @@ namespace
             return true;
         }
 
-        // On-time visit free Primary Skill or Experience object.
+        // Arena allows to visit only one time for the whole map.
         case MP2::OBJ_ARENA:
+            return !hero.isObjectTypeVisited( objectType );
+
+        // On-time visit free Primary Skill or Experience object.
         case MP2::OBJ_FORT:
         case MP2::OBJ_GAZEBO:
         case MP2::OBJ_MERCENARY_CAMP:

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -283,11 +283,27 @@ namespace
                 return false;
             }
 
-            if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL )
-                 && ( spell == Spell::VIEWARTIFACTS || spell == Spell::VIEWHEROES || spell == Spell::VIEWMINES || spell == Spell::VIEWRESOURCES
-                      || spell == Spell::VIEWTOWNS || spell == Spell::IDENTIFYHERO || spell == Spell::VISIONS ) ) {
-                // AI never uses View spells except "View All".
-                return false;
+            if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
+                // TODO: All these spells are not used by AI at the moment.
+                switch ( spell.GetID() ) {
+                case Spell::EARTHQUAKE:
+                case Spell::HAUNT:
+                case Spell::IDENTIFYHERO:
+                case Spell::SETEGUARDIAN:
+                case Spell::SETAGUARDIAN:
+                case Spell::SETFGUARDIAN:
+                case Spell::SETWGUARDIAN:
+                case Spell::TELEPORT:
+                case Spell::VIEWARTIFACTS:
+                case Spell::VIEWHEROES:
+                case Spell::VIEWMINES:
+                case Spell::VIEWRESOURCES:
+                case Spell::VIEWTOWNS:
+                case Spell::VISIONS:
+                    return false;
+                default:
+                    break;
+                }
             }
             return true;
         }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -168,6 +168,32 @@ namespace
         return monster.GetStrength() > armyStrengthThreshold;
     }
 
+    bool isSpellUsedByAI( const int spellId )
+    {
+        // TODO: All these spells are not used by AI at the moment.
+        switch ( spellId ) {
+        case Spell::EARTHQUAKE:
+        case Spell::HAUNT:
+        case Spell::IDENTIFYHERO:
+        case Spell::SETAGUARDIAN:
+        case Spell::SETEGUARDIAN:
+        case Spell::SETFGUARDIAN:
+        case Spell::SETWGUARDIAN:
+        case Spell::TELEPORT:
+        case Spell::VIEWARTIFACTS:
+        case Spell::VIEWHEROES:
+        case Spell::VIEWMINES:
+        case Spell::VIEWRESOURCES:
+        case Spell::VIEWTOWNS:
+        case Spell::VISIONS:
+            return false;
+        default:
+            break;
+        }
+
+        return true;
+    }
+
     bool HeroesValidObject( const Heroes & hero, const double heroArmyStrength, const int32_t index, const AIWorldPathfinder & pathfinder, AI::Normal & ai,
                             const double armyStrengthThreshold )
     {
@@ -283,27 +309,8 @@ namespace
                 return false;
             }
 
-            if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
-                // TODO: All these spells are not used by AI at the moment.
-                switch ( spell.GetID() ) {
-                case Spell::EARTHQUAKE:
-                case Spell::HAUNT:
-                case Spell::IDENTIFYHERO:
-                case Spell::SETAGUARDIAN:
-                case Spell::SETEGUARDIAN:
-                case Spell::SETFGUARDIAN:
-                case Spell::SETWGUARDIAN:
-                case Spell::TELEPORT:
-                case Spell::VIEWARTIFACTS:
-                case Spell::VIEWHEROES:
-                case Spell::VIEWMINES:
-                case Spell::VIEWRESOURCES:
-                case Spell::VIEWTOWNS:
-                case Spell::VISIONS:
-                    return false;
-                default:
-                    break;
-                }
+            if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) && !isSpellUsedByAI( spell.GetID() ) ) {
+                return false;
             }
             return true;
         }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -994,16 +994,18 @@ bool Heroes::isVisited( const Maps::Tiles & tile, Visit::type_t type ) const
     const int32_t index = tile.GetIndex();
     const MP2::MapObjectType objectType = tile.GetObject( false );
 
-    if ( Visit::GLOBAL == type )
+    if ( Visit::GLOBAL == type ) {
         return GetKingdom().isVisited( index, objectType );
+    }
 
     return visit_object.end() != std::find( visit_object.begin(), visit_object.end(), IndexObject( index, objectType ) );
 }
 
 bool Heroes::isObjectTypeVisited( const MP2::MapObjectType objectType, Visit::type_t type ) const
 {
-    if ( Visit::GLOBAL == type )
+    if ( Visit::GLOBAL == type ) {
         return GetKingdom().isVisited( objectType );
+    }
 
     return std::any_of( visit_object.begin(), visit_object.end(), [objectType]( const IndexObject & v ) { return v.isObject( objectType ); } );
 }
@@ -1017,7 +1019,7 @@ void Heroes::SetVisited( int32_t index, Visit::type_t type )
         GetKingdom().SetVisited( index, objectType );
     }
     else if ( !isVisited( tile ) && MP2::OBJ_NONE != objectType ) {
-        visit_object.push_front( IndexObject( index, objectType ) );
+        visit_object.emplace_front( index, objectType );
     }
 }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1065,7 +1065,7 @@ void Heroes::SetVisitedWideTile( int32_t index, const MP2::MapObjectType objectT
 void Heroes::markHeroMeeting( int heroID )
 {
     if ( heroID < UNKNOWN && !hasMetWithHero( heroID ) )
-        visit_object.push_front( IndexObject( heroID, MP2::OBJ_HEROES ) );
+        visit_object.emplace_front( heroID, MP2::OBJ_HEROES );
 }
 
 void Heroes::unmarkHeroMeeting()

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -454,7 +454,7 @@ uint32_t Kingdom::CountVisitedObjects( const MP2::MapObjectType objectType ) con
 void Kingdom::SetVisited( int32_t index, const MP2::MapObjectType objectType )
 {
     if ( !isVisited( index, objectType ) && objectType != MP2::OBJ_NONE )
-        visit_object.push_front( IndexObject( index, objectType ) );
+        visit_object.emplace_front( index, objectType );
 }
 
 bool Kingdom::isValidKingdomObject( const Maps::Tiles & tile, const MP2::MapObjectType objectType ) const


### PR DESCRIPTION
This pull request fixes multiple issues with AI behavior on the Adventure Map:
1) before the changes AI heroes "knew" if any Shrine contains "useless" spell after visiting a single Shrine on the map. Now AI heroes should visit a Shrine in order to "know" the spell there.
2) Arena was still considered as a valuable object to visit even after visiting one. Arena can be visited only once per map even if there are multiple Arenas on the map.
3) expand the list of spells the AI currently does not know how to use:
- Earthquake
- Haunt
- Identify Hero
- Set Air Elemental
- Set Earth Elemental
- Set Fire Elemental
- Set Water Elemental
- Teleport (don't mix with Dimension Door)
- View Artifacts
- View Heroes
- View Mines
- View Resources
- View Towns
- Visions

So in this case there is no need to visit a Shrine if it contains one of these spells.

I am attaching save files to verify the changes:
- **arena_visit.sav**: a hero should visit any Arena only once per game (case 2)
- **shrine_spells.sav**: heroes should visit Shrines at least once in order to know the spell and also to avoid visiting them again if shrines contain useless spells (cases 1 and 3)
[adventure_map.zip](https://github.com/ihhub/fheroes2/files/11928726/adventure_map.zip)

