### PR TITLE
Correct spell value estimation for AI heroes

### DIFF
--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -221,11 +221,11 @@ double Spell::getStrategicValue( double armyStrength, uint32_t currentSpellPoint
         switch ( id ) {
         case Spell::DIMENSIONDOOR:
             return 500 * amountModifier;
-        case Spell::VIEWALL:
-            return 500;
         case Spell::TOWNGATE:
         case Spell::TOWNPORTAL:
             return 250 * amountModifier;
+        case Spell::VIEWALL:
+            return 500;
         default:
             break;
         }

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -217,27 +217,38 @@ double Spell::getStrategicValue( double armyStrength, uint32_t currentSpellPoint
     const double amountModifier = ( casts == 1 ) ? 1 : casts - ( 0.05 * casts * casts );
 
     if ( isAdventure() ) {
-        // AI uses Dimension door and View All only spells right now
-        if ( id == Spell::DIMENSIONDOOR ) {
-            return 500.0 * amountModifier;
+        // TODO: update this logic if you add support for more Adventure Map spells.
+        switch ( id ) {
+        case Spell::DIMENSIONDOOR:
+            return 500 * amountModifier;
+        case Spell::VIEWALL:
+            return 500;
+        case Spell::TOWNGATE:
+        case Spell::TOWNPORTAL:
+            return 250 * amountModifier;
+        default:
+            break;
         }
-        if ( id == Spell::VIEWALL ) {
-            return 500.0;
-        }
-        return 0.0;
+
+        return 0;
     }
 
     if ( isDamage() ) {
         // Benchmark for Lightning for 20 power * 20 knowledge (maximum uses) is 2500.0
         return amountModifier * Damage() * spellPower;
     }
+
     // These high impact spells can turn tide of battle
     if ( isResurrect() || isMassActions() || id == Spell::BLIND || id == Spell::PARALYZE ) {
         return armyStrength * 0.1 * amountModifier;
     }
+
     if ( isSummon() ) {
-        return Monster( id ).GetMonsterStrength() * ExtraValue() * spellPower * amountModifier;
+        // Summoning spells can be effective only per single turn as a summoned stack of monster could be killed within the same turn.
+        // Also if the opponent targets the army's monsters and kill all of them the battle would be lost for this hero.
+        return Monster( id ).GetMonsterStrength() * ExtraValue() * spellPower;
     }
+
     return armyStrength * 0.04 * amountModifier;
 }
 


### PR DESCRIPTION
This pull request fixes 2 cases:
1) Town Portal and Town Gate were not considered as valued spells for visiting castles or shrines.
2) Summoning spells were overestimated causing AI heroes to attack too powerful neutral monsters.

close #7194

Moreover, this is a save file when an AI hero attacks Druids having an idea in mind that Summoning spells are too powerful (hit F8 in debug mode for this):
[AI_army_overestimation.zip](https://github.com/ihhub/fheroes2/files/11928748/AI_army_overestimation.zip)
