### PR TITLE
Expand gamepad / controller support for other platforms

### DIFF
--- a/src/engine/core.cpp
+++ b/src/engine/core.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "core.h"
+
 #include <cassert>
 #include <cstdint>
 #include <stdexcept>
@@ -27,10 +29,9 @@
 #include <SDL_version.h>
 
 #include "audio.h"
-#include "core.h"
-#include "screen.h"
 #include "localevent.h"
 #include "logging.h"
+#include "screen.h"
 
 #if defined( TARGET_PS_VITA )
 #include <psp2/kernel/processmgr.h>

--- a/src/engine/core.cpp
+++ b/src/engine/core.cpp
@@ -28,6 +28,7 @@
 
 #include "audio.h"
 #include "core.h"
+#include "screen.h"
 #include "localevent.h"
 #include "logging.h"
 
@@ -116,11 +117,12 @@ namespace
         }
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )
-        if ( components.count( fheroes2::SystemInitializationComponent::GameController ) > 0 ) {
+        LocalEvent::Get().OpenTouchpad();
+
+        // A game controller can be initialized if it is set explicitly or when software cursor rendering mode is enabled.
+        if ( components.count( fheroes2::SystemInitializationComponent::GameController ) > 0 || fheroes2::cursor().isSoftwareEmulation() ) {
             LocalEvent::Get().OpenController();
         }
-
-        LocalEvent::Get().OpenTouchpad();
 #endif
 
 #if SDL_VERSION_ATLEAST( 2, 0, 0 )


### PR DESCRIPTION
close #4435

We were facing issues with controllers when software cursor mode was not set. In the past we were toggling between hardware and software cursor modes. However, now if software cursor mode is set we never set if off. In this case it is safe to enable controller support for such cases.

This pull request requires extensive testing on multiple platforms before being merged.