### PR TITLE
Add checks for object reachability when calculating their value for AI heroes

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -324,7 +324,7 @@ namespace AI
         double getGeneralObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getCourierObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
-        int getCourierMainTarget( const Heroes & hero, double lowestPossibleValue ) const;
+        int getCourierMainTarget( const Heroes & hero, const AIWorldPathfinder & pathfinder, double lowestPossibleValue ) const;
         double getResourcePriorityModifier( const int resource, const bool isMine ) const;
 
         void updatePriorityTargets( Heroes & hero, const int32_t tileIndex, const MP2::MapObjectType objectType );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -122,6 +122,18 @@ namespace
         return false;
     }
 
+    uint32_t getDistanceToObject( const Heroes & hero, const AIWorldPathfinder & pathfinder, const int32_t index )
+    {
+        uint32_t dist = pathfinder.getDistance( index );
+
+        const uint32_t dimensionDoorDist = AIWorldPathfinder::calculatePathPenalty( pathfinder.getDimensionDoorPath( hero, index ) );
+        if ( dimensionDoorDist > 0 && ( dist == 0 || dimensionDoorDist < dist / 2 ) ) {
+            return dimensionDoorDist;
+        }
+
+        return dist;
+    }
+
     bool AIShouldVisitCastle( const Heroes & hero, int castleIndex, const double heroArmyStrength )
     {
         const Castle * castle = world.getCastleEntrance( Maps::GetPoint( castleIndex ) );
@@ -347,7 +359,7 @@ namespace
                 return false;
             }
 
-            const uint32_t distance = pathfinder.getDistance( index );
+            const uint32_t distance = getDistanceToObject( hero, pathfinder, index );
             if ( distance == 0 ) {
                 return false;
             }
@@ -369,7 +381,7 @@ namespace
                 return false;
             }
 
-            const uint32_t distance = pathfinder.getDistance( index );
+            const uint32_t distance = getDistanceToObject( hero, pathfinder, index );
             if ( distance == 0 ) {
                 return false;
             }
@@ -490,7 +502,7 @@ namespace
                 return true;
             }
 
-            const uint32_t distance = pathfinder.getDistance( index );
+            const uint32_t distance = getDistanceToObject( hero, pathfinder, index );
             if ( distance == 0 ) {
                 return false;
             }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -347,11 +347,16 @@ namespace
                 return false;
             }
 
-            const double movementPenalty = 2.0 * pathfinder.getDistance( index );
+            const uint32_t distance = pathfinder.getDistance( index );
+            if ( distance == 0 ) {
+                return false;
+            }
+
+            const double movementPenalty = 2.0 * distance;
             return movementPenalty < GameStatic::getMovementPointBonus( objectType ) || hero.GetMorale() < Morale::BLOOD;
         }
 
-        case MP2::OBJ_MAGIC_WELL:
+        case MP2::OBJ_MAGIC_WELL: {
             if ( hero.isObjectTypeVisited( objectType ) ) {
                 return false;
             }
@@ -364,13 +369,19 @@ namespace
                 return false;
             }
 
-            if ( pathfinder.getDistance( index ) > hero.GetMovePoints() && hero.getDailyRestoredSpellPoints() + hero.GetSpellPoints() >= hero.GetMaxSpellPoints() ) {
+            const uint32_t distance = pathfinder.getDistance( index );
+            if ( distance == 0 ) {
+                return false;
+            }
+
+            if ( distance > hero.GetMovePoints() && hero.getDailyRestoredSpellPoints() + hero.GetSpellPoints() >= hero.GetMaxSpellPoints() ) {
                 // The Well is located at a distance which cannot be reached by the hero at the current turn.
                 // But if the hero will restore all spell points by the next day there is no reason to even to visit the Well.
                 return false;
             }
 
             return true;
+        }
 
         case MP2::OBJ_ARTESIAN_SPRING:
             return !hero.isVisited( tile, Visit::GLOBAL ) && hero.HaveSpellBook() && hero.GetSpellPoints() < 2 * hero.GetMaxSpellPoints();
@@ -479,8 +490,13 @@ namespace
                 return true;
             }
 
+            const uint32_t distance = pathfinder.getDistance( index );
+            if ( distance == 0 ) {
+                return false;
+            }
+
             const int daysActive = DAYOFWEEK - world.GetDay() + 1;
-            const double movementBonus = daysActive * GameStatic::getMovementPointBonus( objectType ) - 2.0 * pathfinder.getDistance( index );
+            const double movementBonus = daysActive * GameStatic::getMovementPointBonus( objectType ) - 2.0 * distance;
 
             return !hero.isObjectTypeVisited( objectType ) && movementBonus > 0;
         }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1605,7 +1605,7 @@ namespace AI
         return 0;
     }
 
-    int Normal::getCourierMainTarget( const Heroes & hero, double lowestPossibleValue ) const
+    int Normal::getCourierMainTarget( const Heroes & hero, const AIWorldPathfinder & pathfinder, double lowestPossibleValue ) const
     {
         assert( hero.getAIRole() == Heroes::Role::COURIER );
         int targetIndex = -1;
@@ -1625,7 +1625,7 @@ namespace AI
                 continue;
 
             const int currentHeroIndex = otherHero->GetIndex();
-            const uint32_t dist = _pathfinder.getDistance( currentHeroIndex );
+            const uint32_t dist = getDistanceToObject( hero, pathfinder, currentHeroIndex );
             if ( dist == 0 || hero.hasMetWithHero( otherHero->GetID() ) )
                 continue;
 
@@ -1655,7 +1655,7 @@ namespace AI
                 continue;
 
             const int currentCastleIndex = castle->GetIndex();
-            const uint32_t dist = _pathfinder.getDistance( currentCastleIndex );
+            const uint32_t dist = getDistanceToObject( hero, pathfinder, currentCastleIndex );
 
             if ( dist == 0 )
                 continue;
@@ -1821,7 +1821,7 @@ namespace AI
 
         // Set baseline target if it's a special role
         if ( hero.getAIRole() == Heroes::Role::COURIER ) {
-            const int courierTarget = getCourierMainTarget( hero, lowestPossibleValue );
+            const int courierTarget = getCourierMainTarget( hero, _pathfinder, lowestPossibleValue );
             if ( courierTarget != -1 ) {
                 // Anything with positive value can override the courier's main task (i.e. castle or mine capture on the way)
                 maxPriority = 0;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -124,10 +124,17 @@ namespace
 
     uint32_t getDistanceToObject( const Heroes & hero, const AIWorldPathfinder & pathfinder, const int32_t index )
     {
-        uint32_t dist = pathfinder.getDistance( index );
+        const uint32_t dist = pathfinder.getDistance( index );
 
-        const uint32_t dimensionDoorDist = AIWorldPathfinder::calculatePathPenalty( pathfinder.getDimensionDoorPath( hero, index ) );
-        if ( dimensionDoorDist > 0 && ( dist == 0 || dimensionDoorDist < dist / 2 ) ) {
+        const std::list<Route::Step> dimensionDoorSteps = pathfinder.getDimensionDoorPath( hero, index );
+        if ( dimensionDoorSteps.empty() ) {
+            return dist;
+        }
+
+        const uint32_t dimensionDoorDist = AIWorldPathfinder::calculatePathPenalty( dimensionDoorSteps );
+        assert( dimensionDoorDist > 0 );
+
+        if ( dist == 0 || dimensionDoorDist < dist / 2 ) {
             return dimensionDoorDist;
         }
 


### PR DESCRIPTION
This pull request fixed multiple issues with evaluation objects on the Adventure Map for AI heroes:
1) pathfinding for couriers was not taking into an account possible Dimension Door spell usage.
2) for some objects (Oasis, Watering Hole, Magic Well and Stables) we use distance from a hero in order to analyze whether it is worth to visit the object. However, previously we did not take into account a situation when a hero could have Dimension Door spell. This was making AI heroes to use Dimension Door to reach objects which are less valuable than others.