### PR TITLE
Fix the object cache update when AI-controlled hero uses the Dimension Door spell

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2091,7 +2091,7 @@ namespace AI
             const size_t heroesBefore = heroes.size();
             _pathfinder.reEvaluateIfNeeded( *bestHero );
 
-            const int prevHeroPosition = bestHero->GetIndex();
+            int prevHeroPosition = bestHero->GetIndex();
 
             // check if we want to use Dimension Door spell or move regularly
             std::list<Route::Step> dimensionPath = _pathfinder.getDimensionDoorPath( *bestHero, bestTargetIndex );
@@ -2107,6 +2107,15 @@ namespace AI
                     moveDistance = _pathfinder.getDistance( bestTargetIndex );
 
                     dimensionPath.pop_front();
+
+                    // Hero can jump straight into the fog using the Dimension Door spell, which triggers the fog discovery mechanics for his new tile
+                    // and this results in inserting a new hero position into the action object cache. Perform the necessary updates.
+                    assert( !bestHero->isFreeman() && bestHero->GetIndex() != prevHeroPosition );
+
+                    updateMapActionObjectCache( prevHeroPosition );
+                    updateMapActionObjectCache( bestHero->GetIndex() );
+
+                    prevHeroPosition = bestHero->GetIndex();
                 }
 
                 if ( dimensionDoorDistance > 0 ) {

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2108,7 +2108,7 @@ namespace AI
 
                     dimensionPath.pop_front();
 
-                    // Hero can jump straight into the fog using the Dimension Door spell, which triggers the fog discovery mechanics for his new tile
+                    // Hero can jump straight into the fog using the Dimension Door spell, which triggers the mechanics of fog revealing for his new tile
                     // and this results in inserting a new hero position into the action object cache. Perform the necessary updates.
                     assert( !bestHero->isFreeman() && bestHero->GetIndex() != prevHeroPosition );
 


### PR DESCRIPTION
Fix the assertion failure in the `master` branch on this line:

https://github.com/ihhub/fheroes2/blob/96a1ef0d61cad88760bb48dd93cfc6086f4d31e5/src/fheroes2/ai/normal/ai_normal_hero.cpp#L1673

How to reproduce:

1. Load the attached save file using the debug build;
2. Press F8 to transfer the control to AI;
3. Wait until the blue Wizard Caerlyn begins to attack the Necromancer's castle Chandler.

[Crash.zip](https://github.com/ihhub/fheroes2/files/11931896/Crash.zip)
