### PR TITLE
Add Dismiss hotkey to hero screen and fix last hotkey not showing up in the hotkey dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -588,7 +588,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
             }
         }
 
-        if ( buttonDismiss.isEnabled() && ( le.MouseClickLeft( buttonDismiss.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::ARMY_DISMISS_TROOP ) )
+        if ( buttonDismiss.isEnabled() && ( le.MouseClickLeft( buttonDismiss.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::ARMY_DISMISS ) )
              && Dialog::YES
                     == Dialog::Message( troop.GetPluralName( troop.GetCount() ), _( "Are you sure you want to dismiss this army?" ), Font::BIG,
                                         Dialog::YES | Dialog::NO ) ) {

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -327,8 +327,9 @@ namespace
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::ARMY_JOIN_STACKS )] = { HotKeyCategory::ARMY, gettext_noop( "hotkey|join stacks" ), fheroes2::Key::KEY_ALT };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::ARMY_UPGRADE_TROOP )]
             = { HotKeyCategory::ARMY, gettext_noop( "hotkey|upgrade troop" ), fheroes2::Key::KEY_U };
-        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::ARMY_DISMISS_TROOP )]
-            = { HotKeyCategory::ARMY, gettext_noop( "hotkey|dismiss troop" ), fheroes2::Key::KEY_D };
+        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::ARMY_DISMISS )]
+            = { HotKeyCategory::ARMY, gettext_noop( "hotkey|dismiss hero or troop" ), fheroes2::Key::KEY_D };
+        
     }
 
     std::string getHotKeyFileContent()

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -329,7 +329,6 @@ namespace
             = { HotKeyCategory::ARMY, gettext_noop( "hotkey|upgrade troop" ), fheroes2::Key::KEY_U };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::ARMY_DISMISS )]
             = { HotKeyCategory::ARMY, gettext_noop( "hotkey|dismiss hero or troop" ), fheroes2::Key::KEY_D };
-        
     }
 
     std::string getHotKeyFileContent()

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -402,7 +402,7 @@ const char * Game::getHotKeyEventNameByEventId( const HotKeyEvent eventID )
 std::vector<Game::HotKeyEvent> Game::getAllHotKeyEvents()
 {
     std::vector<Game::HotKeyEvent> events;
-    events.reserve( hotKeyEventInfo.size() - 2 );
+    events.reserve( hotKeyEventInfo.size() - 1 );
 
     for ( size_t i = 1; i < hotKeyEventInfo.size(); ++i ) {
         events.emplace_back( static_cast<Game::HotKeyEvent>( i ) );

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -404,7 +404,7 @@ std::vector<Game::HotKeyEvent> Game::getAllHotKeyEvents()
     std::vector<Game::HotKeyEvent> events;
     events.reserve( hotKeyEventInfo.size() - 2 );
 
-    for ( size_t i = 1; i < hotKeyEventInfo.size() - 1; ++i ) {
+    for ( size_t i = 1; i < hotKeyEventInfo.size(); ++i ) {
         events.emplace_back( static_cast<Game::HotKeyEvent>( i ) );
     }
 

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -159,7 +159,7 @@ namespace Game
         ARMY_SPLIT_STACK_BY_ONE,
         ARMY_JOIN_STACKS,
         ARMY_UPGRADE_TROOP,
-        ARMY_DISMISS_TROOP,
+        ARMY_DISMISS,
 
         // WARNING! Put all new event only above this line. No adding in between.
         NO_EVENT,

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -316,8 +316,11 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
         // button click
         le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
-        if ( buttonDismiss.isEnabled() )
-            le.MousePressLeft( buttonDismiss.area() ) ? buttonDismiss.drawOnPress() : buttonDismiss.drawOnRelease();
+        if ( buttonDismiss.isEnabled() && ( le.MousePressLeft( buttonDismiss.area() ) || HotKeyPressEvent( Game::HotKeyEvent::ARMY_DISMISS_TROOP ) ) )
+            buttonDismiss.drawOnPress();
+        else {
+            buttonDismiss.drawOnRelease();
+        }
         if ( buttonPrevHero.isEnabled() )
             le.MousePressLeft( buttonPrevHero.area() ) ? buttonPrevHero.drawOnPress() : buttonPrevHero.drawOnRelease();
         if ( buttonNextHero.isEnabled() )
@@ -336,7 +339,8 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         }
 
         // dismiss
-        if ( buttonDismiss.isEnabled() && buttonDismiss.isVisible() && le.MouseClickLeft( buttonDismiss.area() )
+        if ( buttonDismiss.isEnabled() && buttonDismiss.isVisible()
+             && ( le.MouseClickLeft( buttonDismiss.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::ARMY_DISMISS_TROOP ) )
              && Dialog::YES == Dialog::Message( GetName(), _( "Are you sure you want to dismiss this Hero?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
             // Fade-out hero dialog.
             fheroes2::fadeOutDisplay( fadeRoi, !isDefaultScreenSize );

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -314,12 +314,15 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
             redrawLuck = true;
         }
 
-        // button click
+        // button click or hotkey press
         le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
-        if ( buttonDismiss.isEnabled() && ( le.MousePressLeft( buttonDismiss.area() ) || HotKeyPressEvent( Game::HotKeyEvent::ARMY_DISMISS_TROOP ) ) )
-            buttonDismiss.drawOnPress();
-        else {
-            buttonDismiss.drawOnRelease();
+        if ( buttonDismiss.isEnabled() ) {
+            if ( le.MousePressLeft( buttonDismiss.area() ) || HotKeyPressEvent( Game::HotKeyEvent::ARMY_DISMISS ) ) {
+                buttonDismiss.drawOnPress();
+            }
+            else {
+                buttonDismiss.drawOnRelease();
+            }
         }
         if ( buttonPrevHero.isEnabled() )
             le.MousePressLeft( buttonPrevHero.area() ) ? buttonPrevHero.drawOnPress() : buttonPrevHero.drawOnRelease();
@@ -340,7 +343,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
         // dismiss
         if ( buttonDismiss.isEnabled() && buttonDismiss.isVisible()
-             && ( le.MouseClickLeft( buttonDismiss.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::ARMY_DISMISS_TROOP ) )
+             && ( le.MouseClickLeft( buttonDismiss.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::ARMY_DISMISS ) )
              && Dialog::YES == Dialog::Message( GetName(), _( "Are you sure you want to dismiss this Hero?" ), Font::BIG, Dialog::YES | Dialog::NO ) ) {
             // Fade-out hero dialog.
             fheroes2::fadeOutDisplay( fadeRoi, !isDefaultScreenSize );


### PR DESCRIPTION
This makes it possible to press the Dismiss hotkey in the hero screen, by default "D".

Additionally it was discovered that the last hotkey didn't show up in the hotkey dialog due to both the call to `reserve()` and the for loop in `Game::getAllHotKeyEvents()`.