### PR TITLE
Avoid redrawing the whole High Score screen while performing monsters animation to reduce CPU usage

### DIFF
--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -95,7 +95,6 @@ namespace
                 animationIndex.push_back( fheroes2::HighScoreDataContainer::getMonsterByDay( data.rating ).GetSpriteIndex() * 9 );
             }
         }
-
         else {
             const std::vector<fheroes2::HighscoreData> & highScoreData = highScoreDataContainer.getHighScoresStandard();
 


### PR DESCRIPTION
This PR reworks the High Score screen render: cache background with the static part of animation and update only this part of screen while rendering next monsters animation frame.