### PR TITLE
Fix missing redraw in Battle Only dialog after cancelling hero selection

### DIFF
--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -210,8 +210,9 @@ bool Battle::Only::ChangeSettings()
                 if ( hero1 )
                     hero1->GetSecondarySkills().FillMax( Skill::Secondary() );
                 UpdateHero1( cur_pt );
-                redraw = true;
             }
+
+            redraw = true;
         }
         else if ( allow2 && le.MouseClickLeft( rtPortrait2 ) ) {
             int hid = Dialog::SelectHeroes( hero2 ? hero2->GetID() : Heroes::UNKNOWN );
@@ -226,8 +227,9 @@ bool Battle::Only::ChangeSettings()
                 if ( player2.isControlLocal() && nullptr == cinfo2 ) {
                     cinfo2.reset( new ControlInfo( { cur_pt.x + 500, cur_pt.y + 425 }, player2.GetControl() ) );
                 }
-                redraw = true;
             }
+
+            redraw = true;
         }
 
         if ( hero1 && allow1 ) {


### PR DESCRIPTION
relates to #4352