### PR TITLE
Android Toolset: handle potential errors when trying to launch an external activity to download the HoMM2 demo

### DIFF
--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -24,6 +24,7 @@ import java.io.File;
 import java.io.InputStream;
 import java.util.Objects;
 
+import android.app.AlertDialog;
 import android.content.ContentResolver;
 import android.content.Intent;
 import android.net.Uri;
@@ -167,7 +168,19 @@ public final class ToolsetActivity extends AppCompatActivity
     @SuppressWarnings( "java:S1172" ) // SonarQube warning "Remove unused method parameter"
     public void downloadHoMM2DemoButtonClicked( final View view )
     {
-        startActivity( new Intent( Intent.ACTION_VIEW, Uri.parse( getString( R.string.activity_toolset_homm2_demo_url ) ) ) );
+        try {
+            startActivity( new Intent( Intent.ACTION_VIEW, Uri.parse( getString( R.string.activity_toolset_homm2_demo_url ) ) ) );
+        }
+        catch ( final Exception ex ) {
+            Log.e( "fheroes2", "Failed to download HoMM2 demo archive.", ex );
+
+            ( new AlertDialog.Builder( this ) )
+                .setTitle( R.string.activity_toolset_download_homm2_demo_error_title )
+                .setMessage( R.string.activity_toolset_download_homm2_demo_error_message )
+                .setPositiveButton( R.string.activity_toolset_download_homm2_demo_error_positive_btn_text, ( dialog, which ) -> {} )
+                .create()
+                .show();
+        }
     }
 
     @SuppressWarnings( "java:S1172" ) // SonarQube warning "Remove unused method parameter"

--- a/android/app/src/main/res/values-ru/strings.xml
+++ b/android/app/src/main/res/values-ru/strings.xml
@@ -12,6 +12,9 @@
     <string name="activity_toolset_last_task_status_lbl_text_completed_successfully">Операция успешно завершена.</string>
     <string name="activity_toolset_last_task_status_lbl_text_no_assets_found">Операция успешно завершена, но никаких ресурсов HoMM2 найдено не было.</string>
     <string name="activity_toolset_last_task_status_lbl_text_failed">Во время операции произошла ошибка: %s</string>
+    <string name="activity_toolset_download_homm2_demo_error_title">Ошибка скачивания</string>
+    <string name="activity_toolset_download_homm2_demo_error_message">При попытке скачать демо-версию HoMM2 произошла ошибка. Возможной причиной является отсутствие приложения, которое может загружать файлы из Интернета. Пожалуйста, попробуйте установить такое приложение и повторите попытку.</string>
+    <string name="activity_toolset_download_homm2_demo_error_positive_btn_text">OK</string>
     <string name="activity_save_file_manager_label">fh2 менеджер файлов сохранений</string>
     <string name="activity_save_file_manager_filter_standard_btn_text">Стандарт</string>
     <string name="activity_save_file_manager_filter_campaign_btn_text">Кампания</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -13,7 +13,7 @@
     <string name="activity_toolset_last_task_status_lbl_text_no_assets_found">Operation completed successfully, but no HoMM2 assets were found.</string>
     <string name="activity_toolset_last_task_status_lbl_text_failed">An error occurred during the operation: %s</string>
     <string name="activity_toolset_download_homm2_demo_error_title">Download error</string>
-    <string name="activity_toolset_download_homm2_demo_error_message">An error occurred while downloading the HoMM2 demo. A possible reason is the lack of an installed application that can download files from the Internet. Please try to install such an application and try again.</string>
+    <string name="activity_toolset_download_homm2_demo_error_message">An error occurred while trying to download the HoMM2 demo. A possible reason is the lack of an installed application that can download files from the Internet. Please try to install such an application and try again.</string>
     <string name="activity_toolset_download_homm2_demo_error_positive_btn_text">OK</string>
     <string name="activity_toolset_homm2_demo_url" translatable="false">https://archive.org/download/HeroesofMightandMagicIITheSuccessionWars_1020/h2demo.zip</string>
     <string name="activity_save_file_manager_label">fh2 Save File Manager</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -12,6 +12,9 @@
     <string name="activity_toolset_last_task_status_lbl_text_completed_successfully">Operation completed successfully.</string>
     <string name="activity_toolset_last_task_status_lbl_text_no_assets_found">Operation completed successfully, but no HoMM2 assets were found.</string>
     <string name="activity_toolset_last_task_status_lbl_text_failed">An error occurred during the operation: %s</string>
+    <string name="activity_toolset_download_homm2_demo_error_title">Download error</string>
+    <string name="activity_toolset_download_homm2_demo_error_message">An error occurred while downloading the HoMM2 demo. A possible reason is the lack of an installed application that can download files from the Internet. Please try to install such an application and try again.</string>
+    <string name="activity_toolset_download_homm2_demo_error_positive_btn_text">OK</string>
     <string name="activity_toolset_homm2_demo_url" translatable="false">https://archive.org/download/HeroesofMightandMagicIITheSuccessionWars_1020/h2demo.zip</string>
     <string name="activity_save_file_manager_label">fh2 Save File Manager</string>
     <string name="activity_save_file_manager_filter_standard_btn_text">Standard</string>


### PR DESCRIPTION
fix #7415

![Screenshot_20230716_014330](https://github.com/ihhub/fheroes2/assets/32623900/07f6f308-ca42-45cf-8251-3e921b77ca29)
