### PR TITLE
Make thieves guild adapt background to chosen interface

### DIFF
--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -310,7 +310,10 @@ void Dialog::ThievesGuild( bool oracle )
     Dialog::FrameBorder frameborder( { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } );
     const fheroes2::Point cur_pt( frameborder.GetArea().x, frameborder.GetArea().y );
 
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STONEBAK, 0 ), display, cur_pt.x, cur_pt.y );
+    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
+    const int backgroundIcnID = isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK;
+
+    fheroes2::Blit( fheroes2::AGG::GetICN( backgroundIcnID, 0 ), display, cur_pt.x, cur_pt.y );
 
     fheroes2::Point dst_pt( cur_pt.x, cur_pt.y );
 

--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -310,9 +310,9 @@ void Dialog::ThievesGuild( bool oracle )
     Dialog::FrameBorder frameborder( { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } );
     const fheroes2::Point cur_pt( frameborder.GetArea().x, frameborder.GetArea().y );
 
-    const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-    const int backgroundIcnID = isEvilInterface && !oracle ? ICN::STONEBAK_EVIL : ICN::STONEBAK;
+    const bool isEvilInterfaceTown = Settings::Get().isEvilInterfaceEnabled() && !oracle;
 
+    const int backgroundIcnID = isEvilInterfaceTown ? ICN::STONEBAK_EVIL : ICN::STONEBAK;
     fheroes2::Blit( fheroes2::AGG::GetICN( backgroundIcnID, 0 ), display, cur_pt.x, cur_pt.y );
 
     fheroes2::Point dst_pt( cur_pt.x, cur_pt.y );
@@ -490,7 +490,7 @@ void Dialog::ThievesGuild( bool oracle )
     dst_pt.x = cur_pt.x + startx + 1;
     dst_pt.y -= 2;
     GetBestHeroArmyInfo( v, colors );
-    const int frameIcnID = isEvilInterface && !oracle ? ICN::LOCATORE : ICN::LOCATORS;
+    const int frameIcnID = isEvilInterfaceTown ? ICN::LOCATORE : ICN::LOCATORS;
     DrawHeroIcons( v, dst_pt, stepx, frameIcnID );
 
     text.Set( _( "Best Hero Stats:" ) );

--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -311,7 +311,7 @@ void Dialog::ThievesGuild( bool oracle )
     const fheroes2::Point cur_pt( frameborder.GetArea().x, frameborder.GetArea().y );
 
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-    const int backgroundIcnID = isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK;
+    const int backgroundIcnID = isEvilInterface && !oracle ? ICN::STONEBAK_EVIL : ICN::STONEBAK;
 
     fheroes2::Blit( fheroes2::AGG::GetICN( backgroundIcnID, 0 ), display, cur_pt.x, cur_pt.y );
 

--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -490,7 +490,7 @@ void Dialog::ThievesGuild( bool oracle )
     dst_pt.x = cur_pt.x + startx + 1;
     dst_pt.y -= 2;
     GetBestHeroArmyInfo( v, colors );
-    const int frameIcnID = isEvilInterface && !oracle ? ICN::LOCATORE : ICN::LOCATORS; 
+    const int frameIcnID = isEvilInterface && !oracle ? ICN::LOCATORE : ICN::LOCATORS;
     DrawHeroIcons( v, dst_pt, stepx, frameIcnID );
 
     text.Set( _( "Best Hero Stats:" ) );

--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -231,7 +231,7 @@ void DrawFlags( const std::vector<ValueColors> & v, const fheroes2::Point & pos,
     }
 }
 
-void DrawHeroIcons( const std::vector<ValueColors> & v, const fheroes2::Point & pos, int step )
+void DrawHeroIcons( const std::vector<ValueColors> & v, const fheroes2::Point & pos, int step, const int frameIcnID )
 {
     if ( !v.empty() ) {
         fheroes2::Display & display = fheroes2::Display::instance();
@@ -240,7 +240,7 @@ void DrawHeroIcons( const std::vector<ValueColors> & v, const fheroes2::Point & 
             const Heroes * hero = world.GetHeroes( v[ii].first );
             if ( hero ) {
                 int32_t px = pos.x + ii * step;
-                const fheroes2::Sprite & window = fheroes2::AGG::GetICN( ICN::LOCATORS, 22 );
+                const fheroes2::Sprite & window = fheroes2::AGG::GetICN( frameIcnID, 22 );
                 fheroes2::Blit( window, display, px - window.width() / 2, pos.y - 4 );
 
                 const fheroes2::Sprite & icon = hero->GetPortrait( PORT_SMALL );
@@ -490,7 +490,8 @@ void Dialog::ThievesGuild( bool oracle )
     dst_pt.x = cur_pt.x + startx + 1;
     dst_pt.y -= 2;
     GetBestHeroArmyInfo( v, colors );
-    DrawHeroIcons( v, dst_pt, stepx );
+    const int frameIcnID = isEvilInterface && !oracle ? ICN::LOCATORE : ICN::LOCATORS; 
+    DrawHeroIcons( v, dst_pt, stepx, frameIcnID );
 
     text.Set( _( "Best Hero Stats:" ) );
     dst_pt.x = cur_pt.x + textx - text.w();

--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -310,7 +310,7 @@ void Dialog::ThievesGuild( bool oracle )
     Dialog::FrameBorder frameborder( { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } );
     const fheroes2::Point cur_pt( frameborder.GetArea().x, frameborder.GetArea().y );
 
-    const bool isEvilInterfaceTown = Settings::Get().isEvilInterfaceEnabled() && !oracle;
+    const bool isEvilInterfaceTown = !oracle && Settings::Get().isEvilInterfaceEnabled();
 
     const int backgroundIcnID = isEvilInterfaceTown ? ICN::STONEBAK_EVIL : ICN::STONEBAK;
     fheroes2::Blit( fheroes2::AGG::GetICN( backgroundIcnID, 0 ), display, cur_pt.x, cur_pt.y );


### PR DESCRIPTION
This makes the thieves guild show with evil stone background if that interface type is chosen.

When visiting the oracle the good interface will always show because the Oracle isn't playing on your team and should therefore not change their interface according to your alignment.

![image](https://github.com/ihhub/fheroes2/assets/12501091/d756b7ec-7d59-4712-be7b-bd23900172b8)
