### PR TITLE
Change heroes animation speed (before and after casting a spell) on the battlefield, fix lack of the first (and sometimes only) animation frame.

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3312,17 +3312,22 @@ void Battle::Interface::AnimateUnitWithDelay( Unit & unit, const bool skipLastFr
     }
 }
 
-void Battle::Interface::AnimateOpponents( OpponentSprite * target )
+void Battle::Interface::AnimateOpponents( OpponentSprite * hero )
 {
-    if ( target == nullptr || target->isFinishFrame() ) // nothing to animate
+    if ( hero == nullptr ) {
         return;
+    }
+
+    // Render the first animation frame. We do it here not to skip small animations with duration for 1 frame.
+    // For such (one frame) animations we are already ad the end of animation and `isFinishFrame()` always will return true.
+    Redraw();
 
     LocalEvent & le = LocalEvent::Get();
 
     // We need to wait this delay before rendering the first frame of hero animation.
     Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
 
-    // 'BATTLE_OPPONENTS_DELAY' is more than 2 times the value of 'BATTLE_IDLE_DELAY', so we need to handle the idle animation separately in this loop.
+    // 'BATTLE_OPPONENTS_DELAY' is different than 'BATTLE_IDLE_DELAY', so we handle the idle animation separately in this loop.
     while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_OPPONENTS_DELAY, Game::BATTLE_IDLE_DELAY } ) ) ) {
         // Animate the idling units.
         if ( IdleTroopsAnimation() ) {
@@ -3330,15 +3335,15 @@ void Battle::Interface::AnimateOpponents( OpponentSprite * target )
         }
 
         if ( Game::validateAnimationDelay( Game::BATTLE_OPPONENTS_DELAY ) ) {
-            // Render before switching to the next frame.
-            Redraw();
-
-            if ( target->isFinishFrame() ) {
+            if ( hero->isFinishFrame() ) {
                 // We have reached the end of animation.
                 break;
             }
 
-            target->IncreaseAnimFrame();
+            hero->IncreaseAnimFrame();
+
+            // Render the next frame and then wait a delay before checking if it is the last frame in the animation.
+            Redraw();
         }
     }
 }

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -376,7 +376,7 @@ namespace Battle
         // Use this if a function may be called from other functions with different render delay types.
         void WaitForAllActionDelays();
 
-        void AnimateOpponents( OpponentSprite * target );
+        void AnimateOpponents( OpponentSprite * hero );
         void AnimateUnitWithDelay( Unit & unit, const bool skipLastFrameRender = false );
         void RedrawTroopDefaultDelay( Unit & unit );
         void RedrawTroopWithFrameAnimation( Unit & unit, const int icn, const int m82, const CreatureSpellAnimation animation );

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -200,7 +200,7 @@ void Game::UpdateGameSpeed()
     delays[BATTLE_CATAPULT_CLOUD_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
     delays[BATTLE_BRIDGE_DELAY].setDelay( static_cast<uint64_t>( 90 * adjustedBattleSpeed ) );
     delays[BATTLE_IDLE_DELAY].setDelay( static_cast<uint64_t>( 150 * adjustedIdleAnimationSpeed ) );
-    delays[BATTLE_OPPONENTS_DELAY].setDelay( static_cast<uint64_t>( 350 * adjustedBattleSpeed ) );
+    delays[BATTLE_OPPONENTS_DELAY].setDelay( static_cast<uint64_t>( 60 * adjustedIdleAnimationSpeed ) );
     delays[BATTLE_FLAGS_DELAY].setDelay( static_cast<uint64_t>( 250 * adjustedIdleAnimationSpeed ) );
 }
 

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -117,7 +117,7 @@ void Game::AnimateDelaysInitialize()
     delays[BATTLE_CATAPULT_CLOUD_DELAY].setDelay( 40 );
     delays[BATTLE_BRIDGE_DELAY].setDelay( 90 );
     delays[BATTLE_IDLE_DELAY].setDelay( 150 );
-    delays[BATTLE_OPPONENTS_DELAY].setDelay( 350 );
+    delays[BATTLE_OPPONENTS_DELAY].setDelay( 75 );
     delays[BATTLE_FLAGS_DELAY].setDelay( 250 );
     delays[BATTLE_POPUP_DELAY].setDelay( 800 );
     delays[BATTLE_COLOR_CYCLE_DELAY].setDelay( 220 );
@@ -200,7 +200,7 @@ void Game::UpdateGameSpeed()
     delays[BATTLE_CATAPULT_CLOUD_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
     delays[BATTLE_BRIDGE_DELAY].setDelay( static_cast<uint64_t>( 90 * adjustedBattleSpeed ) );
     delays[BATTLE_IDLE_DELAY].setDelay( static_cast<uint64_t>( 150 * adjustedIdleAnimationSpeed ) );
-    delays[BATTLE_OPPONENTS_DELAY].setDelay( static_cast<uint64_t>( 60 * adjustedIdleAnimationSpeed ) );
+    delays[BATTLE_OPPONENTS_DELAY].setDelay( static_cast<uint64_t>( 75 * adjustedIdleAnimationSpeed ) );
     delays[BATTLE_FLAGS_DELAY].setDelay( static_cast<uint64_t>( 250 * adjustedIdleAnimationSpeed ) );
 }
 


### PR DESCRIPTION
fix #1057

This PR changes `BATTLE_OPPONENTS_DELAY` to be much less dependent on the battle speed setting and have lower delay values to be closer to the original game.
This PR changes only the animation speed of heroes before and after casting a spell.

https://github.com/ihhub/fheroes2/assets/113276641/83597066-7c70-41ea-a7cc-097eb5148307

