### PR TITLE
Avoid engine execution with corrupted video files

### DIFF
--- a/VisualStudio/fheroes2/sources.props
+++ b/VisualStudio/fheroes2/sources.props
@@ -234,6 +234,7 @@
     <ClInclude Include="src\engine\core.h" />
     <ClInclude Include="src\engine\dir.h" />
     <ClInclude Include="src\engine\endian_h2.h" />
+    <ClInclude Include="src\engine\exception.h" />
     <ClInclude Include="src\engine\h2d_file.h" />
     <ClInclude Include="src\engine\image.h" />
     <ClInclude Include="src\engine\image_palette.h" />

--- a/src/engine/exception.h
+++ b/src/engine/exception.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2023                                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -20,35 +20,12 @@
 
 #pragma once
 
-#include <cstdint>
-#include <string>
+#include <stdexcept>
 
 namespace fheroes2
 {
-    class Image;
-    class Sprite;
-    enum class FontSize : uint8_t;
-    struct FontType;
-    enum class SupportedLanguage : int;
-
-    namespace AGG
+    class InvalidDataResources : public std::logic_error
     {
-        const Sprite & GetICN( int icnId, uint32_t index );
-        uint32_t GetICNCount( int icnId );
-
-        // shapeId could be 0, 1, 2 or 3 only
-        const Image & GetTIL( int tilId, uint32_t index, uint32_t shapeId );
-        const Sprite & GetLetter( uint32_t character, uint32_t fontType );
-
-        // Returns the last supported ASCII character in existing font.
-        uint32_t ASCIILastSupportedCharacter( const uint32_t fontType );
-
-        int32_t GetAbsoluteICNHeight( int icnId );
-
-        uint32_t getCharacterLimit( const FontSize fontSize );
-        const Sprite & getChar( const uint8_t character, const FontType & fontType );
-
-        // This function must be called only at the type of setting up a new language.
-        void updateLanguageDependentResources( const SupportedLanguage language, const bool loadOriginalAlphabet );
-    }
+        using std::logic_error::logic_error;
+    };
 }

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <functional>
 #include <memory>
 
 #include "exception.h"
@@ -45,14 +46,13 @@ namespace
         }
 
         // Verify that the file is valid. We use C-code on purpose since libsmacker library does the same.
-        std::FILE * file = std::fopen( filePath.c_str(), "rb" );
+        std::unique_ptr<std::FILE, std::function<int( std::FILE * )>> file( std::fopen( filePath.c_str(), "rb" ), std::fclose );
         if ( file == nullptr ) {
             return;
         }
 
-        std::fseek( file, 0, SEEK_END );
-        const size_t fileSize = std::ftell( file );
-        std::fclose( file );
+        std::fseek( file.get(), 0, SEEK_END );
+        const size_t fileSize = std::ftell( file.get() );
 
         // According to https://wiki.multimedia.cx/index.php/Smacker the minimum size of a file must be 56 bytes.
         if ( fileSize < 56 ) {

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "smk_decoder.h"
+
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
@@ -29,7 +31,6 @@
 #include "image.h"
 #include "serialize.h"
 #include "smacker.h"
-#include "smk_decoder.h"
 
 namespace
 {

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -21,9 +21,11 @@
 #include <algorithm>
 #include <cassert>
 #include <cstdint>
+#include <cstdio>
 #include <cstring>
 #include <memory>
 
+#include "exception.h"
 #include "image.h"
 #include "serialize.h"
 #include "smacker.h"
@@ -32,6 +34,30 @@
 namespace
 {
     const size_t audioHeaderSize = 44;
+
+    void verifyVideoFile( const std::string & filePath )
+    {
+        if ( filePath.empty() ) {
+            // Why are you trying to even play a file from an empty path?
+            assert( 0 );
+            return;
+        }
+
+        // Verify that the file is valid. We use C-code on purpose since libsmacker library does the same.
+        std::FILE * file = std::fopen( filePath.c_str(), "rb" );
+        if ( file == nullptr ) {
+            return;
+        }
+
+        std::fseek( file, 0, SEEK_END );
+        const size_t fileSize = std::ftell( file );
+        std::fclose( file );
+
+        // According to https://wiki.multimedia.cx/index.php/Smacker the minimum size of a file must be 56 bytes.
+        if ( fileSize < 56 ) {
+            throw fheroes2::InvalidDataResources( "Video file " + filePath + " is being corrupted. Make sure that you own an official version of the game." );
+        }
+    }
 }
 
 SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
@@ -43,6 +69,8 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     , _currentFrameId( 0 )
     , _videoFile( nullptr )
 {
+    verifyVideoFile( filePath );
+
     _videoFile = smk_open_file( filePath.c_str(), SMK_MODE_MEMORY );
     if ( _videoFile == nullptr )
         return;

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -38,6 +38,7 @@
 #include "agg.h"
 #include "agg_file.h"
 #include "battle_cell.h"
+#include "exception.h"
 #include "h2d.h"
 #include "icn.h"
 #include "image.h"

--- a/src/fheroes2/agg/agg_image.h
+++ b/src/fheroes2/agg/agg_image.h
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <cstdint>
-#include <string>
 
 namespace fheroes2
 {

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -54,6 +54,7 @@
 #include "cursor.h"
 #include "dir.h"
 #include "embedded_image.h"
+#include "exception.h"
 #include "game.h"
 #include "game_logo.h"
 #include "game_video.h"


### PR DESCRIPTION
close #5741

We shouldn't handle corrupted resources.