### PR TITLE
Apply AI growth bonus only on first AI player turn

### DIFF
--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -890,6 +890,7 @@ void Castle::ActionNewWeekAIBonuses()
 {
     if ( world.GetWeekType().GetType() == WeekName::PLAGUE ) {
         // No growth bonus can be applied.
+        return;
     }
 
     if ( !isControlAI() ) {

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -222,7 +222,10 @@ public:
     void ChangeColor( int );
 
     void ActionNewDay();
+
     void ActionNewWeek();
+    void ActionNewWeekAIBonuses();
+
     void ActionNewMonth() const;
 
     void ActionPreBattle();
@@ -435,6 +438,11 @@ public:
     void NewWeek()
     {
         std::for_each( _castles.begin(), _castles.end(), []( Castle * castle ) { castle->ActionNewWeek(); } );
+    }
+
+    void NewWeekAI()
+    {
+        std::for_each( _castles.begin(), _castles.end(), []( Castle * castle ) { castle->ActionNewWeekAIBonuses(); } );
     }
 
     void NewMonth()

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -80,14 +80,14 @@ double Difficulty::GetGoldIncomeBonus( int difficulty )
     return 1.0;
 }
 
-double Difficulty::GetUnitGrowthBonusForAI( int difficulty )
+double Difficulty::GetUnitGrowthBonusForAI( const int difficulty )
 {
     // In the original game AI has a cheeky monster growth bonus depending on difficulty:
-    // Easy - 1.0 (no bonus)
-    // Normal - 1.0 (no bonus)
-    // Hard - 1.20 (or 20% extra)
-    // Expert - 1.32 (or 32% extra)
-    // Impossible - 1.44 (or 44% extra)
+    // Easy - 0.0 (no bonus)
+    // Normal - 0.0 (no bonus)
+    // Hard - 0.20 (or 20% extra)
+    // Expert - 0.32 (or 32% extra)
+    // Impossible - 0.44 (or 44% extra)
     // This bonus was introduced to compensate weak AI in the game.
     //
     // However, with introduction of proper AI in this engine AI has become much stronger and some maps are impossible to beat.
@@ -99,19 +99,19 @@ double Difficulty::GetUnitGrowthBonusForAI( int difficulty )
     switch ( difficulty ) {
     case Difficulty::EASY:
     case Difficulty::NORMAL:
-        return 1.0;
+        return 0;
     case Difficulty::HARD:
-        return 1.14;
+        return 0.14;
     case Difficulty::EXPERT:
-        return 1.254;
+        return 0.254;
     case Difficulty::IMPOSSIBLE:
-        return 1.368;
+        return 0.368;
     default:
         // Did you add a new difficulty level? Add the logic above!
         assert( 0 );
         break;
     }
-    return 1.0;
+    return 0;
 }
 
 int Difficulty::GetHeroMovementBonus( int difficulty )

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -40,7 +40,10 @@ namespace Difficulty
 
     int GetScoutingBonus( int difficulty );
     double GetGoldIncomeBonus( int difficulty );
-    double GetUnitGrowthBonusForAI( int difficulty );
+
+    // Returns an extra growth bonus modifier for AI based on difficulty level.
+    double GetUnitGrowthBonusForAI( const int difficulty );
+
     int GetHeroMovementBonus( int difficulty );
     double GetAIRetreatRatio( int difficulty );
 }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -708,6 +708,12 @@ fheroes2::GameMode Interface::AdventureMap::StartGame()
             Kingdom & kingdom = world.GetKingdom( playerColor );
 
             if ( skipTurns && !player->isColor( conf.CurrentColor() ) ) {
+                if ( kingdom.isPlay() && kingdom.GetControl() == CONTROL_AI ) {
+                    // Only the first AI player can trigger AI bonuses.
+                    // Since this player is the one the bonuses have been applied.
+                    isFirstAIPlayer = false;
+                }
+
                 continue;
             }
 
@@ -767,7 +773,7 @@ fheroes2::GameMode Interface::AdventureMap::StartGame()
                     // TODO: remove this temporary assertion
                     assert( res == fheroes2::GameMode::END_TURN );
 
-                    if ( isFirstAIPlayer && !loadedFromSave ) {
+                    if ( isFirstAIPlayer ) {
                         isFirstAIPlayer = false;
                         // All bonuses for AI must be applied on the first AI player turn, not the first player in general.
                         // This prevents human players to abuse AI bonuses.

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -698,6 +698,8 @@ fheroes2::GameMode Interface::AdventureMap::StartGame()
 
         res = fheroes2::GameMode::END_TURN;
 
+        bool isFirstAIPlayer = true;
+
         for ( const Player * player : sortedPlayers ) {
             assert( player != nullptr );
 
@@ -764,6 +766,13 @@ fheroes2::GameMode Interface::AdventureMap::StartGame()
                 case CONTROL_AI:
                     // TODO: remove this temporary assertion
                     assert( res == fheroes2::GameMode::END_TURN );
+
+                    if ( isFirstAIPlayer && !loadedFromSave ) {
+                        isFirstAIPlayer = false;
+                        // All bonuses for AI must be applied on the first AI player turn, not the first player in general.
+                        // This prevents human players to abuse AI bonuses.
+                        world.NewDayAI();
+                    }
 
                     Cursor::Get().SetThemes( Cursor::WAIT );
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -260,9 +260,15 @@ void Kingdom::ActionNewDayResourceUpdate( const std::function<void( const EventD
         }
     }
 
+    const bool isAIPlayer = ( GetControl() == CONTROL_AI );
+
     // Resources from events
     const EventsDate events = world.GetEventsDate( GetColor() );
     for ( const EventDate & event : events ) {
+        if ( isAIPlayer && !event.isApplicableForAIPlayers ) {
+            continue;
+        }
+
         const Funds fundsUpdate = Resource::CalculateEventResourceUpdate( GetFunds(), event.resource );
         AddFundsResource( fundsUpdate );
         if ( displayEventDialog )

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -544,6 +544,13 @@ void World::NewDay()
     vec_eventsday.remove_if( [this]( const EventDate & v ) { return v.isDeprecated( day - 1 ); } );
 }
 
+void World::NewDayAI()
+{
+    if ( BeginWeek() ) {
+        vec_castles.NewWeekAI();
+    }
+}
+
 void World::NewWeek()
 {
     // update objects

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -303,6 +303,7 @@ public:
     std::string DateString() const;
 
     void NewDay();
+    void NewDayAI();
     void NewWeek();
     void NewMonth();
 


### PR DESCRIPTION
This pull request fixes multiple issues:
- apply weekly monster growth bonuses only when the first AI player starts its turn (close #6939). This eliminates a possibility to abuse this bonus by human players when they capture a castle on the first day of week.
- global events which were marked as not applicable for AI players were still used for them. For example, AI players should not have events deducting their resources in Great War II map as human players do.