### PR TITLE
Fix the misplaced check for the need of transform layer while loading ICN images

### DIFF
--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -344,6 +344,8 @@ namespace fheroes2
 
         while ( true ) {
             if ( 0 == *data ) { // 0x00 - end of row
+                noTransformLayer = noTransformLayer && ( static_cast<int32_t>( posX ) >= width );
+
                 imageData += width;
                 imageTransform += width;
                 posX = 0;

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -352,8 +352,6 @@ namespace fheroes2
                 ++data;
             }
             else if ( 0x80 > *data ) { // 0x01-0x7F - repeat a pixel N times
-                noTransformLayer = noTransformLayer && ( static_cast<int32_t>( posX ) >= width );
-
                 const uint8_t pixelCount = *data;
                 ++data;
 


### PR DESCRIPTION
A quick fix for #7449

This PR puts the check for need of transform layer into the right place.
In previous PR it was placed to the part where non-transparent images were loaded. So the transform layer was considered as needed for all images.
There is no noticeable bug in #7449, but it does not work as intended without this fix.