### PR TITLE
Restoring original Summon Boat spell

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1499,6 +1499,7 @@ namespace
         AI::Get().HeroesClearTask( hero );
 
         world.GetTiles( dst_index ).resetBoatOwnerColor();
+        world.GetTiles( dst_index ).resetBoatOwnerHeroID();
 
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() )
     }
@@ -1517,7 +1518,7 @@ namespace
 
         hero.ResetMovePoints();
         hero.Move2Dest( dst_index );
-        from.setBoat( Maps::GetDirection( fromIndex, dst_index ), hero.GetColor() );
+        from.setBoat( Maps::GetDirection( fromIndex, dst_index ), hero.GetColor(), hero.GetID() );
         hero.SetShipMaster( false );
         hero.GetPath().Reset();
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2539,15 +2539,15 @@ bool Castle::BuyBoat() const
 
     if ( MP2::OBJ_NONE == left.GetObject() && left.isWater() ) {
         kingdom.OddFundsResource( PaymentConditions::BuyBoat() );
-        left.setBoat( Direction::RIGHT, kingdom.GetColor() );
+        left.setBoat( Direction::RIGHT, kingdom.GetColor(), -1 );
     }
     else if ( MP2::OBJ_NONE == right.GetObject() && right.isWater() ) {
         kingdom.OddFundsResource( PaymentConditions::BuyBoat() );
-        right.setBoat( Direction::RIGHT, kingdom.GetColor() );
+        right.setBoat( Direction::RIGHT, kingdom.GetColor(), -1 );
     }
     else if ( MP2::OBJ_NONE == middle.GetObject() && middle.isWater() ) {
         kingdom.OddFundsResource( PaymentConditions::BuyBoat() );
-        middle.setBoat( Direction::RIGHT, kingdom.GetColor() );
+        middle.setBoat( Direction::RIGHT, kingdom.GetColor(), -1 );
     }
 
     return true;

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -616,6 +616,7 @@ namespace
 
         // Boat is no longer empty so we reset color to default
         world.GetTiles( dst_index ).resetBoatOwnerColor();
+        world.GetTiles( dst_index ).resetBoatOwnerHeroID();     
 
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
     }
@@ -631,7 +632,7 @@ namespace
 
         hero.ResetMovePoints();
         hero.Move2Dest( dst_index );
-        from.setBoat( Maps::GetDirection( fromIndex, dst_index ), hero.GetColor() );
+        from.setBoat( Maps::GetDirection( fromIndex, dst_index ), hero.GetColor(), hero.GetID() );
         hero.SetShipMaster( false );
         AudioManager::PlaySound( M82::KILLFADE );
         hero.GetPath().Hide();

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -304,6 +304,7 @@ namespace
         assert( boatSource != -1 );
 
         const int heroColor = hero.GetColor();
+        const int boatHeroID = hero.GetID();
 
         Maps::Tiles & tileSource = world.GetTiles( boatSource );
 
@@ -311,8 +312,9 @@ namespace
         gameArea.runSingleObjectAnimation( std::make_shared<Interface::ObjectFadingOutInfo>( tileSource.GetObjectUID(), boatSource, MP2::OBJ_BOAT ) );
 
         Maps::Tiles & tileDest = world.GetTiles( boatDestination );
-        tileDest.setBoat( Direction::RIGHT, heroColor );
+        tileDest.setBoat( Direction::RIGHT, heroColor, boatHeroID );
         tileSource.resetBoatOwnerColor();
+        tileSource.resetBoatOwnerHeroID();
 
         gameArea.runSingleObjectAnimation( std::make_shared<Interface::ObjectFadingInInfo>( tileDest.GetObjectUID(), boatDestination, MP2::OBJ_BOAT ) );
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -507,6 +507,7 @@ void Maps::Tiles::Init( int32_t index, const MP2::mp2tile_t & mp2 )
     _terrainImageIndex = mp2.terrainImageIndex;
     _terrainFlags = mp2.terrainFlags;
     _boatOwnerColor = Color::NONE;
+    _boatOwnerHeroID = -1;
 
     SetIndex( index );
     SetObject( static_cast<MP2::MapObjectType>( mp2.mapObjectType ) );
@@ -592,7 +593,7 @@ void Maps::Tiles::SetObject( const MP2::MapObjectType objectType )
     world.resetPathfinder();
 }
 
-void Maps::Tiles::setBoat( const int direction, const int color )
+void Maps::Tiles::setBoat( const int direction, const int color, const int boatHeroID )
 {
     if ( _objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && _imageIndex != 255 ) {
         AddonsPushLevel1( TilesAddon( OBJECT_LAYER, _uid, _objectIcnType, _imageIndex, false, false ) );
@@ -639,7 +640,13 @@ void Maps::Tiles::setBoat( const int direction, const int color )
 
     assert( color >= std::numeric_limits<BoatOwnerColorType>::min() && color <= std::numeric_limits<BoatOwnerColorType>::max() );
 
+    using BoatOwnerHeroIDType = decltype( _boatOwnerHeroID );
+    static_assert( std::is_same_v<BoatOwnerHeroIDType, int8_t>, "Type of _boatOwnerHeroID has been changed, check the logic below" );
+
+    assert( color >= std::numeric_limits<BoatOwnerHeroIDType>::min() && color <= std::numeric_limits<BoatOwnerHeroIDType>::max() );
+
     _boatOwnerColor = static_cast<BoatOwnerColorType>( color );
+    _boatOwnerHeroID = static_cast<BoatOwnerHeroIDType>( boatHeroID );
 }
 
 int Maps::Tiles::getBoatDirection() const

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -219,13 +219,23 @@ namespace Maps
         {
             _boatOwnerColor = Color::NONE;
         }
+        
+        void resetBoatOwnerHeroID()
+        {
+            _boatOwnerHeroID = -1;
+        }       
 
         int getBoatOwnerColor() const
         {
             return _boatOwnerColor;
         }
+        
+        int getBoatOwnerHeroID() const
+        {
+            return _boatOwnerHeroID;
+        }       
 
-        void setBoat( const int direction, const int color );
+        void setBoat( const int direction, const int color, const int boatHeroID );
         int getBoatDirection() const;
 
         void resetObjectSprite()
@@ -427,8 +437,11 @@ namespace Maps
 
         bool tileIsRoad = false;
 
-        // Heroes can only summon neutral empty boats or empty boats belonging to their kingdom.
+        // Heroes can only summon empty boats belonging to their kingdom
+        // first of all, a search is made for a boat belonging to this particular hero
         uint8_t _boatOwnerColor = Color::NONE;
+        
+        int8_t _boatOwnerHeroID = -1; 
 
         // This field does not persist in savegame.
         uint32_t _region = REGION_NODE_BLOCKED;

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -364,12 +364,27 @@ namespace fheroes2
     {
         const int32_t center = hero.GetIndex();
         const int heroColor = hero.GetColor();
+        const int heroid = hero.GetID();        
+
+        for ( const int32_t boatSource : Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false ) ) {
+            assert( Maps::isValidAbsIndex( boatSource ) );
+
+            const int boatHeroID = world.GetTiles( boatSource ).getBoatOwnerHeroID();
+            if ( boatHeroID != heroid ) {
+                continue;
+            }
+
+            const uint32_t distance = Maps::GetStraightLineDistance( boatSource, center );
+            if ( distance > 1 ) {
+                return boatSource;
+            }
+        }
 
         for ( const int32_t boatSource : Maps::GetObjectPositions( center, MP2::OBJ_BOAT, false ) ) {
             assert( Maps::isValidAbsIndex( boatSource ) );
 
             const int boatColor = world.GetTiles( boatSource ).getBoatOwnerColor();
-            if ( boatColor != Color::NONE && boatColor != heroColor ) {
+            if ( boatColor != heroColor ) {
                 continue;
             }
 


### PR DESCRIPTION
In OG, summoning a boat by a hero is done as follows:
first, the boat belonging to the given hero is searched (each boat
belonging to a certain player, but frequently also belonging to certain hero),
If such boat is not found, then a free boat belonging to this player is searched for.
A free boat on the map that does not belong to anyone cannot be summoned.
Summoning a boat in fheroes2 works in a completely different way. BTW, this
may break a number of maps.
It should be noted that summoning a boat in OG is also quite convenient - usually it is most profitable to summon the boat that this particular hero used.
(not another boat, which another hero might need soon).
This PR restores the original algorithm. The only thing which I did not realized is adaptation for Save / Load (I ask for help).
