### PR TITLE
Change the formula for monster strength calculation

### DIFF
--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -179,7 +179,7 @@ double Monster::GetMonsterStrength( int attack, int defense ) const
     if ( defense == -1 )
         defense = GetDefense();
 
-    const double attackDefense = 1.0 + attack * 0.1 + defense * 0.05;
+    const double attackDefense = 1.0 + 0.1 * ( attack + defense );
     return attackDefense * fheroes2::getMonsterData( id ).battleStats.monsterBaseStrength;
 }
 


### PR DESCRIPTION
I would like to fix a game analytics in Monster::GetMonsterStrength.

Here in this line:
const double attackDefense = 1.0 + attack * 0.1 + defense * 0.05;

More correctly like this:
const double attackDefense = 1.0 + 0.1 * ( attack + defense );

Rationale:

1) In practice, damage in battle is determined by the difference between attack parameter (of the 1st monster)  and defense parameter (2nd monster), and not by some formula that would include parameters only one of the monsters. Therefore, in practice, as a result, one unit of defense parameter mutually
annihilates with one unit of the opponent's attack parameter. In this sense, the value attack and defense are equivalent.
Example:
Consider a battle (exchange of blows) of 2 hypothetical monsters. The 1st monster has attack parameter is 15 and defense parameter is 5.  2nd monster has attack is 5, and the defense is 15. In practice, these 2 monsters in the battle with each other are equal, and according to the formula above, for the 1st monster the function will return 2.75, and for the 2nd monster it will return 2.25.

2) Consider the "abstract" value of these 2 parameters (for example, when considering combat against a hypothetical monster with an attack equal 0 and a defense equal 0). 
It turns out that the effect of increasing attack parameter increases linearly (we consider the damage dealt by this monster):
If the monster has attack equal 5, then the ratio of total damage to base damage is 1.5.
If the monster has attack equal 10, then the ratio of total damage to base damage is 2.0.
If the monster has attack equal 15, then the ratio of total damage to base damage is 2.5.

The effect of the growth of the defense parameter grows non-linearly (we consider the damage dealt to this monster):
If the monster has defense equal of 5, then the ratio of total damage to base damage is 1.33.
If the monster has defense equal of 10, then the ratio of total damage to base damage is 2.0.
If the monster has defense equal of 15, then the ratio of total damage to base damage is 4.0.
(however, in the original game there is a limiter, so in practice ratio 4.0 will not be reached)

P.S. It was this logic that NWC game analysts adhered to. In both Heroes 2 and Heroes 3 they consider the value of attack and defense parameters as equal.
