### PR TITLE
Allow early exit from puzzle map during reveal animation

### DIFF
--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -125,6 +125,7 @@ namespace
             if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() ) {
                 return true;
             }
+
             if ( Game::validateAnimationDelay( Game::PUZZLE_FADE_DELAY ) ) {
                 fheroes2::Blit( sf, display, dstx, dsty );
 
@@ -152,6 +153,7 @@ namespace
                 assert( alpha >= 0 );
             }
         }
+
         return false;
     }
 
@@ -185,7 +187,7 @@ namespace
 
         LocalEvent & le = LocalEvent::Get();
 
-        while ( le.HandleEvents() && !earlyExit ) {
+        while ( !earlyExit && le.HandleEvents() ) {
             le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
             if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() )
                 break;

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -103,11 +103,12 @@ namespace
         }
     }
 
-    void revealPuzzle( const Puzzle & pzl, const fheroes2::Image & sf, int32_t dstx, int32_t dsty, const std::function<fheroes2::Rect()> * drawControlPanel = nullptr )
+    bool revealPuzzle( const Puzzle & pzl, const fheroes2::Image & sf, int32_t dstx, int32_t dsty, fheroes2::Button & buttonExit,
+                       const std::function<fheroes2::Rect()> * drawControlPanel = nullptr )
     {
         // In developer mode, the entire puzzle should already be revealed
         if ( IS_DEVEL() ) {
-            return;
+            return false;
         }
 
         fheroes2::Display & display = fheroes2::Display::instance();
@@ -119,6 +120,11 @@ namespace
         int alpha = 250;
 
         while ( alpha >= 0 && le.HandleEvents( Game::isDelayNeeded( delayTypes ) ) ) {
+            le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
+            // If exit button was pressed before reveal animation is finished, return true to indicate early exit.
+            if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() ) {
+                return true;
+            }
             if ( Game::validateAnimationDelay( Game::PUZZLE_FADE_DELAY ) ) {
                 fheroes2::Blit( sf, display, dstx, dsty );
 
@@ -146,6 +152,7 @@ namespace
                 assert( alpha >= 0 );
             }
         }
+        return false;
     }
 
     void ShowStandardDialog( const Puzzle & pzl, const fheroes2::Image & sf )
@@ -174,11 +181,11 @@ namespace
 
         fheroes2::fadeInDisplay( back.rect(), false );
 
-        revealPuzzle( pzl, sf, BORDERWIDTH, BORDERWIDTH );
+        const bool earlyExit = revealPuzzle( pzl, sf, BORDERWIDTH, BORDERWIDTH, buttonExit );
 
         LocalEvent & le = LocalEvent::Get();
 
-        while ( le.HandleEvents() ) {
+        while ( le.HandleEvents() && !earlyExit ) {
             le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
             if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() )
                 break;
@@ -245,11 +252,11 @@ namespace
         display.updateNextRenderRoi( border.totalArea() );
         fheroes2::fadeInDisplay( border.activeArea(), true );
 
-        revealPuzzle( pzl, sf, blitArea.x, blitArea.y, isHideInterface ? &drawControlPanel : nullptr );
+        const bool earlyExit = revealPuzzle( pzl, sf, blitArea.x, blitArea.y, buttonExit, isHideInterface ? &drawControlPanel : nullptr );
 
         LocalEvent & le = LocalEvent::Get();
 
-        while ( le.HandleEvents() ) {
+        while ( le.HandleEvents() && !earlyExit ) {
             le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
             if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() )
                 break;


### PR DESCRIPTION
Solves https://github.com/ihhub/fheroes2/issues/7448 by allowing exiting puzzle map during reveal animation.