### PR TITLE
Add an extra check for AI Gold income bonus

### DIFF
--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -713,7 +713,7 @@ Funds Kingdom::GetIncome( int type /* INCOME_ALL */ ) const
         }
     }
 
-    if ( isControlAI() ) {
+    if ( isControlAI() && totalIncome.gold > 0 ) {
         totalIncome.gold = static_cast<int32_t>( totalIncome.gold * Difficulty::GetGoldIncomeBonus( Game::getDifficulty() ) );
     }
 


### PR DESCRIPTION
The bonus which AI has should be applied only on a positive gold income.