### PR TITLE
Fix Army info button in level up dialog

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3152,15 +3152,8 @@ namespace fheroes2
 
                 const int releasedIndex = ( id == ICN::GOOD_ARMY_BUTTON ) ? 0 : 4;
 
-                const Sprite & originalReleased = GetICN( ICN::ADVBTNS, releasedIndex );
-                _icnVsSprite[id][0].resize( originalReleased.width(), originalReleased.height() );
-
-                Copy( originalReleased, 0, 0, _icnVsSprite[id][0], 0, 0, originalReleased.width(), originalReleased.height() );
-
-                const Sprite & originalPressed = GetICN( ICN::ADVBTNS, releasedIndex + 1 );
-                _icnVsSprite[id][1].resize( originalPressed.width(), originalPressed.height() );
-
-                Copy( originalPressed, 0, 0, _icnVsSprite[id][1], 0, 0, originalPressed.width(), originalPressed.height() );
+                Copy( GetICN( ICN::ADVBTNS, releasedIndex ), _icnVsSprite[id][0] );
+                Copy( GetICN( ICN::ADVBTNS, releasedIndex + 1 ), _icnVsSprite[id][1] );
 
                 // Make all black pixels transparent.
                 AddTransparency( _icnVsSprite[id][0], 36 );
@@ -3174,9 +3167,11 @@ namespace fheroes2
                 _icnVsSprite[id].resize( 2 );
 
                 LoadOriginalICN( ICN::ADVEBTNS );
+
                 const int releasedIndex = ( id == ICN::EVIL_ARMY_BUTTON ) ? 0 : 4;
-                _icnVsSprite[id][0] = GetICN( ICN::ADVEBTNS, releasedIndex );
-                _icnVsSprite[id][1] = GetICN( ICN::ADVEBTNS, releasedIndex + 1 );
+
+                Copy( GetICN( ICN::ADVEBTNS, releasedIndex ), _icnVsSprite[id][0] );
+                Copy( GetICN( ICN::ADVEBTNS, releasedIndex + 1 ), _icnVsSprite[id][1] );
 
                 // Make all black pixels transparent.
                 AddTransparency( _icnVsSprite[id][0], 36 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3151,7 +3151,6 @@ namespace fheroes2
                 LoadOriginalICN( ICN::ADVBTNS );
 
                 const int releasedIndex = ( id == ICN::GOOD_ARMY_BUTTON ) ? 0 : 4;
-
                 Copy( GetICN( ICN::ADVBTNS, releasedIndex ), _icnVsSprite[id][0] );
                 Copy( GetICN( ICN::ADVBTNS, releasedIndex + 1 ), _icnVsSprite[id][1] );
 
@@ -3169,7 +3168,6 @@ namespace fheroes2
                 LoadOriginalICN( ICN::ADVEBTNS );
 
                 const int releasedIndex = ( id == ICN::EVIL_ARMY_BUTTON ) ? 0 : 4;
-
                 Copy( GetICN( ICN::ADVEBTNS, releasedIndex ), _icnVsSprite[id][0] );
                 Copy( GetICN( ICN::ADVEBTNS, releasedIndex + 1 ), _icnVsSprite[id][1] );
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3149,9 +3149,20 @@ namespace fheroes2
                 _icnVsSprite[id].resize( 2 );
 
                 LoadOriginalICN( ICN::ADVBTNS );
+
                 const int releasedIndex = ( id == ICN::GOOD_ARMY_BUTTON ) ? 0 : 4;
-                _icnVsSprite[id][0] = GetICN( ICN::ADVBTNS, releasedIndex );
-                _icnVsSprite[id][1] = GetICN( ICN::ADVBTNS, releasedIndex + 1 );
+
+                const Sprite & originalReleased = GetICN( ICN::ADVBTNS, releasedIndex );
+                _icnVsSprite[id][0].resize( originalReleased.width(), originalReleased.height() );
+                _icnVsSprite[id][0].reset();
+
+                Copy( originalReleased, 0, 0, _icnVsSprite[id][0], 0, 0, originalReleased.width(), originalReleased.height() );
+
+                const Sprite & originalPressed = GetICN( ICN::ADVBTNS, releasedIndex + 1 );
+                _icnVsSprite[id][1].resize( originalPressed.width(), originalPressed.height() );
+                _icnVsSprite[id][1].reset();
+
+                Copy( originalPressed, 0, 0, _icnVsSprite[id][1], 0, 0, originalPressed.width(), originalPressed.height() );
 
                 // Make all black pixels transparent.
                 AddTransparency( _icnVsSprite[id][0], 36 );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3154,13 +3154,11 @@ namespace fheroes2
 
                 const Sprite & originalReleased = GetICN( ICN::ADVBTNS, releasedIndex );
                 _icnVsSprite[id][0].resize( originalReleased.width(), originalReleased.height() );
-                _icnVsSprite[id][0].reset();
 
                 Copy( originalReleased, 0, 0, _icnVsSprite[id][0], 0, 0, originalReleased.width(), originalReleased.height() );
 
                 const Sprite & originalPressed = GetICN( ICN::ADVBTNS, releasedIndex + 1 );
                 _icnVsSprite[id][1].resize( originalPressed.width(), originalPressed.height() );
-                _icnVsSprite[id][1].reset();
 
                 Copy( originalPressed, 0, 0, _icnVsSprite[id][1], 0, 0, originalPressed.width(), originalPressed.height() );
 


### PR DESCRIPTION
Credits to @Districh-ru for the solution.

We have to use the `Copy()` function to avoid the `_singleLayer` attribute to be set to true, because this happens when you just use the `=-operator` since the regular Army button is rightly set to be single layered after the PR #7449


Fix #7514 