### PR TITLE
Implement basic terrain draw in Map Editor (currently without terrain connections)

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -279,7 +279,7 @@ namespace Interface
                 if ( Cursor::POINTER != cursor.Themes() ) {
                     cursor.SetThemes( Cursor::POINTER );
                 }
-                if ( !_gameArea.isDragScroll() ) {
+                if ( !_gameArea.isDragScroll() && !( _editorPanel.isAreaSelect() && _selectedTile != -1 ) ) {
                     _radar.QueueEventProcessing();
                 }
             }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -293,21 +293,6 @@ namespace Interface
             // cursor is over the game area
             else if ( le.MouseCursor( _gameArea.GetROI() ) && !_gameArea.NeedScroll() ) {
                 isCursorOverGamearea = true;
-
-                // Get tile index under the cursor.
-                const int32_t tileIndex = _gameArea.GetValidTileIdFromPoint( le.GetMouseCursor() );
-                if ( _tileUnderCursor != tileIndex ) {
-                    _tileUnderCursor = tileIndex;
-
-                    // Force redraw if cursor position was changed as area rectangle is also changed.
-                    if ( _editorPanel.isTerrainEdit() && ( !_editorPanel.isAreaSelect() || _selectedTile != -1 ) ) {
-                        _redraw |= REDRAW_GAMEAREA;
-                    }
-                }
-
-                if ( _selectedTile == -1 && _editorPanel.isAreaSelect() && le.MousePressLeft() ) {
-                    _selectedTile = tileIndex;
-                }
             }
             // cursor is over the buttons area
             else if ( le.MouseCursor( _editorPanel.getRect() ) ) {
@@ -334,6 +319,28 @@ namespace Interface
                 else if ( !le.MousePressLeft() ) {
                     _radar.QueueEventProcessing();
                 }
+            }
+
+            if ( isCursorOverGamearea ) {
+                // Get tile index under the cursor.
+                const int32_t tileIndex = _gameArea.GetValidTileIdFromPoint( le.GetMouseCursor() );
+                if ( _tileUnderCursor != tileIndex ) {
+                    _tileUnderCursor = tileIndex;
+
+                    // Force redraw if cursor position was changed as area rectangle is also changed.
+                    if ( _editorPanel.isTerrainEdit() && ( !_editorPanel.isAreaSelect() || _selectedTile != -1 ) ) {
+                        _redraw |= REDRAW_GAMEAREA;
+                    }
+                }
+
+                if ( _selectedTile == -1 && _editorPanel.isAreaSelect() && le.MousePressLeft() ) {
+                    _selectedTile = tileIndex;
+                    _redraw |= REDRAW_GAMEAREA;
+                }
+            }
+            else if ( _tileUnderCursor != -1 ) {
+                _tileUnderCursor = -1;
+                _redraw |= REDRAW_GAMEAREA;
             }
 
             // Fill the selected area in terrain edit mode.

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -279,7 +279,7 @@ namespace Interface
                 if ( Cursor::POINTER != cursor.Themes() ) {
                     cursor.SetThemes( Cursor::POINTER );
                 }
-                if ( !_gameArea.isDragScroll() && !( _editorPanel.isAreaSelect() && _selectedTile != -1 ) ) {
+                if ( !_gameArea.isDragScroll() && ( !_editorPanel.isAreaSelect() || _selectedTile == -1 ) ) {
                     _radar.QueueEventProcessing();
                 }
             }
@@ -293,13 +293,13 @@ namespace Interface
                     _tileUnderCursor = tileIndex;
 
                     // Force redraw if cursor position was changed as area rectangle is also changed.
-                    if ( _editorPanel.isTerrainEdit() && !( _editorPanel.isAreaSelect() && _selectedTile == -1 ) ) {
+                    if ( _editorPanel.isTerrainEdit() && ( !_editorPanel.isAreaSelect() || _selectedTile != -1 ) ) {
                         _redraw |= REDRAW_GAMEAREA;
                     }
+                }
 
-                    if ( _selectedTile == -1 && _editorPanel.isAreaSelect() && le.MousePressLeft() ) {
-                        _selectedTile = _tileUnderCursor;
-                    }
+                if ( _selectedTile == -1 && _editorPanel.isAreaSelect() && le.MousePressLeft() ) {
+                    _selectedTile = tileIndex;
                 }
             }
             // cursor is over the buttons area
@@ -506,7 +506,7 @@ namespace Interface
 
     void Editor::mouseCursorAreaClickLeft( const int32_t tileIndex )
     {
-        Maps::Tiles & tile = world.GetTiles( tileIndex );
+        const Maps::Tiles & tile = world.GetTiles( tileIndex );
 
         Heroes * otherHero = tile.GetHeroes();
         Castle * otherCastle = world.getCastle( tile.GetCenter() );
@@ -528,10 +528,13 @@ namespace Interface
                 const int32_t cursorSizeX = std::min( brushSize, worldWidth - tileIndex % worldWidth ) - 1;
                 const int32_t cursorSizeY = std::min( brushSize, world.h() - tileIndex / worldWidth ) - 1;
                 const int32_t endIndex = tileIndex + cursorSizeX + worldWidth * cursorSizeY;
+
                 Maps::setTerrainImageOnTiles( tileIndex, endIndex, groundId );
             }
             else if ( _editorPanel.isAreaSelect() ) {
+                // This is a case when area was not selected but a single tile was clicked.
                 Maps::setTerrainImageOnTiles( tileIndex, tileIndex, groundId );
+
                 _selectedTile = -1;
             }
             _redraw |= REDRAW_GAMEAREA | REDRAW_RADAR;

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -31,7 +31,6 @@
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "gamedefs.h"
-#include "ground.h"
 #include "heroes.h"
 #include "icn.h"
 #include "image.h"

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -20,6 +20,7 @@
 
 #include "editor_interface.h"
 
+#include <algorithm>
 #include <cassert>
 #include <vector>
 

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -31,6 +31,7 @@
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "gamedefs.h"
+#include "ground.h"
 #include "heroes.h"
 #include "icn.h"
 #include "image.h"
@@ -458,18 +459,22 @@ namespace Interface
     }
     void Editor::mouseCursorAreaClickLeft( const int32_t tileIndex )
     {
-        const Maps::Tiles & tile = world.GetTiles( tileIndex );
+        Maps::Tiles & tile = world.GetTiles( tileIndex );
 
         Heroes * otherHero = tile.GetHeroes();
+        Castle * otherCastle = world.getCastle( tile.GetCenter() );
+
         if ( otherHero ) {
             // TODO: Make hero edit dialog: like Battle only dialog, but only for one hero.
             Game::OpenHeroesDialog( *otherHero, true, true );
         }
-
-        Castle * otherCastle = world.getCastle( tile.GetCenter() );
-        if ( otherCastle ) {
+        else if ( otherCastle ) {
             // TODO: Make Castle edit dialog: like original build dialog.
             Game::OpenCastleDialog( *otherCastle );
+        }
+        else if ( _editorPanel.isTerrainEdit() ) {
+            tile.setTerrainImageIndex( Maps::Ground::getRandomTerrainImageIndex( _editorPanel.selectedGroundType() ) );
+            _redraw |= REDRAW_GAMEAREA | REDRAW_RADAR;
         }
     }
     void Editor::mouseCursorAreaPressRight( const int32_t tileIndex ) const

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -56,6 +56,17 @@
 
 class Castle;
 
+namespace
+{
+    int32_t brushAreaEndIndex( const int32_t brushSize, const int32_t startIndex )
+    {
+        const int32_t worldWidth = world.w();
+        const int32_t cursorSizeX = std::min( brushSize, worldWidth - startIndex % worldWidth ) - 1;
+        const int32_t cursorSizeY = std::min( brushSize, world.h() - startIndex / worldWidth ) - 1;
+        return startIndex + cursorSizeX + worldWidth * cursorSizeY;
+    }
+}
+
 namespace Interface
 {
     Interface::Editor::Editor()
@@ -107,11 +118,7 @@ namespace Interface
                     const int32_t brushSize = _editorPanel.getBrushSize();
 
                     if ( brushSize > 0 ) {
-                        const int32_t worldWidth = world.w();
-                        const int32_t cursorSizeX = std::min( brushSize, worldWidth - _tileUnderCursor % worldWidth ) - 1;
-                        const int32_t cursorSizeY = std::min( brushSize, world.h() - _tileUnderCursor / worldWidth ) - 1;
-                        const int32_t endIndex = _tileUnderCursor + cursorSizeX + worldWidth * cursorSizeY;
-                        _gameArea.renderTileCursor( display, _tileUnderCursor, endIndex );
+                        _gameArea.renderTileCursor( display, _tileUnderCursor, brushAreaEndIndex( brushSize, _tileUnderCursor ) );
                     }
                     else if ( _editorPanel.isAreaSelect() ) {
                         _gameArea.renderTileCursor( display, _selectedTile, _tileUnderCursor );
@@ -524,12 +531,7 @@ namespace Interface
             const int groundId = _editorPanel.selectedGroundType();
 
             if ( brushSize > 0 ) {
-                const int32_t worldWidth = world.w();
-                const int32_t cursorSizeX = std::min( brushSize, worldWidth - tileIndex % worldWidth ) - 1;
-                const int32_t cursorSizeY = std::min( brushSize, world.h() - tileIndex / worldWidth ) - 1;
-                const int32_t endIndex = tileIndex + cursorSizeX + worldWidth * cursorSizeY;
-
-                Maps::setTerrainImageOnTiles( tileIndex, endIndex, groundId );
+                Maps::setTerrainImageOnTiles( tileIndex, brushAreaEndIndex( brushSize, tileIndex ), groundId );
             }
             else if ( _editorPanel.isAreaSelect() ) {
                 // This is a case when area was not selected but a single tile was clicked.

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -46,12 +46,20 @@ namespace Interface
         static fheroes2::GameMode eventFileDialog();
         void eventViewWorld();
 
+        bool useMouseDragMovment() override
+        {
+            return _editorPanel.useMouseDragMovment();
+        }
+
         void mouseCursorAreaClickLeft( const int32_t tileIndex ) override;
+        void mouseCursorAreaPressLeft( const int32_t tileIndex ) override;
         void mouseCursorAreaPressRight( const int32_t tileIndex ) const override;
 
     private:
         Editor();
 
         EditorPanel _editorPanel;
+
+        int32_t _selectedTile{ -1 };
     };
 }

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -52,7 +52,6 @@ namespace Interface
         }
 
         void mouseCursorAreaClickLeft( const int32_t tileIndex ) override;
-        void mouseCursorAreaPressLeft( const int32_t tileIndex ) override;
         void mouseCursorAreaPressRight( const int32_t tileIndex ) const override;
 
     private:
@@ -61,5 +60,6 @@ namespace Interface
         EditorPanel _editorPanel;
 
         int32_t _selectedTile{ -1 };
+        int32_t _tileUnderCursor{ -1 };
     };
 }

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -46,9 +46,9 @@ namespace Interface
         static fheroes2::GameMode eventFileDialog();
         void eventViewWorld();
 
-        bool useMouseDragMovment() override
+        bool useMouseDragMovement() override
         {
-            return _editorPanel.useMouseDragMovment();
+            return _editorPanel.useMouseDragMovement();
         }
 
         void mouseCursorAreaClickLeft( const int32_t tileIndex ) override;

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -81,10 +81,11 @@ namespace Interface
         case BrushSize::LARGE:
             return 4;
         case BrushSize::AREA:
-            return -1;
+            return 0;
         default:
             // Have you added a new Brush size? Update the logic above!
             assert( 0 );
+            break;
         }
 
         return 0;

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -197,44 +197,42 @@ namespace Interface
         display.render( _rectInstrumentPanel );
     }
 
-    const char * EditorPanel::_getTerrainTypeName( const uint8_t brushId )
+    const int EditorPanel::_getGroundId( const uint8_t brushId )
     {
-        int groundId = Maps::Ground::UNKNOWN;
         switch ( brushId ) {
         case Brush::WATER:
-            groundId = Maps::Ground::WATER;
+            return Maps::Ground::WATER;
             break;
         case Brush::GRASS:
-            groundId = Maps::Ground::GRASS;
+            return Maps::Ground::GRASS;
             break;
         case Brush::SNOW:
-            groundId = Maps::Ground::SNOW;
+            return Maps::Ground::SNOW;
             break;
         case Brush::SWAMP:
-            groundId = Maps::Ground::SWAMP;
+            return Maps::Ground::SWAMP;
             break;
         case Brush::LAVA:
-            groundId = Maps::Ground::LAVA;
+            return Maps::Ground::LAVA;
             break;
         case Brush::DESERT:
-            groundId = Maps::Ground::DESERT;
+            return Maps::Ground::DESERT;
             break;
         case Brush::DIRT:
-            groundId = Maps::Ground::DIRT;
+            return Maps::Ground::DIRT;
             break;
         case Brush::WASTELAND:
-            groundId = Maps::Ground::WASTELAND;
+            return Maps::Ground::WASTELAND;
             break;
         case Brush::BEACH:
-            groundId = Maps::Ground::BEACH;
+            return Maps::Ground::BEACH;
             break;
         default:
-            // Have you added a new terrain type?
+            // Have you added a new terrain type? Add the logic above!
             assert( 0 );
             break;
         }
-
-        return Maps::Ground::String( groundId );
+        return Maps::Ground::UNKNOWN;
     }
 
     const char * EditorPanel::_getObjectTypeName( const uint8_t brushId )
@@ -269,7 +267,7 @@ namespace Interface
         case Brush::TREASURES:
             return _( "Treasures" );
         default:
-            // Have you added a new object type?
+            // Have you added a new object type? Add the logic above!
             assert( 0 );
             break;
         }

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -71,7 +71,7 @@ namespace Interface
         _brushSizeButtons[_selectedBrushSize].press();
     }
 
-    uint8_t EditorPanel::getBrushSize() const
+    int32_t EditorPanel::getBrushSize() const
     {
         switch ( _selectedBrushSize ) {
         case BrushSize::SMALL:
@@ -81,7 +81,7 @@ namespace Interface
         case BrushSize::LARGE:
             return 4;
         case BrushSize::AREA:
-            return 0;
+            return -1;
         default:
             // Have you added a new Brush size? Update the logic above!
             assert( 0 );

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -71,6 +71,25 @@ namespace Interface
         _brushSizeButtons[_selectedBrushSize].press();
     }
 
+    uint8_t EditorPanel::getBrushSize() const
+    {
+        switch ( _selectedBrushSize ) {
+        case BrushSize::SMALL:
+            return 1;
+        case BrushSize::MEDIUM:
+            return 2;
+        case BrushSize::LARGE:
+            return 4;
+        case BrushSize::AREA:
+            return 0;
+        default:
+            // Have you added a new Brush size? Update the logic above!
+            assert( 0 );
+        }
+
+        return 0;
+    }
+
     void EditorPanel::setPos( const int32_t displayX, int32_t displayY )
     {
         int32_t offsetX = displayX;
@@ -202,31 +221,22 @@ namespace Interface
         switch ( brushId ) {
         case Brush::WATER:
             return Maps::Ground::WATER;
-            break;
         case Brush::GRASS:
             return Maps::Ground::GRASS;
-            break;
         case Brush::SNOW:
             return Maps::Ground::SNOW;
-            break;
         case Brush::SWAMP:
             return Maps::Ground::SWAMP;
-            break;
         case Brush::LAVA:
             return Maps::Ground::LAVA;
-            break;
         case Brush::DESERT:
             return Maps::Ground::DESERT;
-            break;
         case Brush::DIRT:
             return Maps::Ground::DIRT;
-            break;
         case Brush::WASTELAND:
             return Maps::Ground::WASTELAND;
-            break;
         case Brush::BEACH:
             return Maps::Ground::BEACH;
-            break;
         default:
             // Have you added a new terrain type? Add the logic above!
             assert( 0 );

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -216,7 +216,7 @@ namespace Interface
         display.render( _rectInstrumentPanel );
     }
 
-    const int EditorPanel::_getGroundId( const uint8_t brushId )
+    int EditorPanel::_getGroundId( const uint8_t brushId )
     {
         switch ( brushId ) {
         case Brush::WATER:

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -81,7 +81,7 @@ namespace Interface
     private:
         Editor & _interface;
 
-        static const int _getGroundId( const uint8_t brushId );
+        static int _getGroundId( const uint8_t brushId );
         static const char * _getTerrainTypeName( const uint8_t brushId )
         {
             return Maps::Ground::String( _getGroundId( brushId ) );

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -56,12 +56,7 @@ namespace Interface
             return _selectedInstrument == Instrument::TERRAIN;
         }
 
-        bool isAreaSelect() const
-        {
-            return _selectedBrushSize == BrushSize::AREA;
-        }
-
-        bool useMouseDragMovment() const
+        bool useMouseDragMovement() const
         {
             return ( _selectedInstrument != Instrument::TERRAIN ) || ( _selectedBrushSize != BrushSize::AREA );
         }
@@ -82,10 +77,12 @@ namespace Interface
         Editor & _interface;
 
         static int _getGroundId( const uint8_t brushId );
+
         static const char * _getTerrainTypeName( const uint8_t brushId )
         {
             return Maps::Ground::String( _getGroundId( brushId ) );
         }
+
         static const char * _getObjectTypeName( const uint8_t brushId );
 
         enum Instrument : uint8_t

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -44,7 +44,7 @@ namespace Interface
             return _rectEditorPanel;
         }
 
-        uint8_t getBrushSize() const;
+        int32_t getBrushSize() const;
 
         int selectedGroundType() const
         {
@@ -54,6 +54,11 @@ namespace Interface
         bool isTerrainEdit() const
         {
             return _selectedInstrument == Instrument::TERRAIN;
+        }
+
+        bool useMouseDragMovment() const
+        {
+            return ( _selectedInstrument != Instrument::TERRAIN ) || ( _selectedBrushSize != BrushSize::AREA );
         }
 
         // Set Editor panel positions on screen.

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -44,6 +44,8 @@ namespace Interface
             return _rectEditorPanel;
         }
 
+        uint8_t getBrushSize() const;
+
         int selectedGroundType() const
         {
             return _getGroundId( _selectedTerrain );

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -24,6 +24,7 @@
 #include <cstdint>
 
 #include "game_mode.h"
+#include "ground.h"
 #include "math_base.h"
 #include "ui_button.h"
 
@@ -43,6 +44,16 @@ namespace Interface
             return _rectEditorPanel;
         }
 
+        int selectedGroundType() const
+        {
+            return _getGroundId( _selectedTerrain );
+        }
+
+        bool isTerrainEdit() const
+        {
+            return _selectedInstrument == Instrument::TERRAIN;
+        }
+
         // Set Editor panel positions on screen.
         void setPos( const int32_t displayX, int32_t displayY );
 
@@ -58,7 +69,11 @@ namespace Interface
     private:
         Editor & _interface;
 
-        static const char * _getTerrainTypeName( const uint8_t brushId );
+        static const int _getGroundId( const uint8_t brushId );
+        static const char * _getTerrainTypeName( const uint8_t brushId )
+        {
+            return Maps::Ground::String( _getGroundId( brushId ) );
+        }
         static const char * _getObjectTypeName( const uint8_t brushId );
 
         enum Instrument : uint8_t

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -56,6 +56,11 @@ namespace Interface
             return _selectedInstrument == Instrument::TERRAIN;
         }
 
+        bool isAreaSelect() const
+        {
+            return _selectedBrushSize == BrushSize::AREA;
+        }
+
         bool useMouseDragMovment() const
         {
             return ( _selectedInstrument != Instrument::TERRAIN ) || ( _selectedBrushSize != BrushSize::AREA );

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -139,10 +139,6 @@ namespace Interface
         fheroes2::GameMode StartGame();
 
         void mouseCursorAreaClickLeft( const int32_t tileIndex ) override;
-        void mouseCursorAreaPressLeft( const int32_t /* unused */ ) override
-        {
-            // Do nothing;
-        }
         void mouseCursorAreaPressRight( const int32_t tileIndex ) const override;
 
         static int GetCursorTileIndex( int32_t dstIndex );

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -139,6 +139,10 @@ namespace Interface
         fheroes2::GameMode StartGame();
 
         void mouseCursorAreaClickLeft( const int32_t tileIndex ) override;
+        void mouseCursorAreaPressLeft( const int32_t /* unused */ ) override
+        {
+            // Do nothing;
+        }
         void mouseCursorAreaPressRight( const int32_t tileIndex ) const override;
 
         static int GetCursorTileIndex( int32_t dstIndex );

--- a/src/fheroes2/gui/interface_base.h
+++ b/src/fheroes2/gui/interface_base.h
@@ -120,7 +120,13 @@ namespace Interface
 
         static fheroes2::GameMode EventExit();
 
+        virtual bool useMouseDragMovment()
+        {
+            return true;
+        }
+
         virtual void mouseCursorAreaClickLeft( const int32_t tileIndex ) = 0;
+        virtual void mouseCursorAreaPressLeft( const int32_t tileIndex ) = 0;
         virtual void mouseCursorAreaPressRight( const int32_t tileIndex ) const = 0;
 
         // Regenerates the game area and updates the panel positions depending on the UI settings

--- a/src/fheroes2/gui/interface_base.h
+++ b/src/fheroes2/gui/interface_base.h
@@ -126,7 +126,6 @@ namespace Interface
         }
 
         virtual void mouseCursorAreaClickLeft( const int32_t tileIndex ) = 0;
-        virtual void mouseCursorAreaPressLeft( const int32_t tileIndex ) = 0;
         virtual void mouseCursorAreaPressRight( const int32_t tileIndex ) const = 0;
 
         // Regenerates the game area and updates the panel positions depending on the UI settings

--- a/src/fheroes2/gui/interface_base.h
+++ b/src/fheroes2/gui/interface_base.h
@@ -120,7 +120,7 @@ namespace Interface
 
         static fheroes2::GameMode EventExit();
 
-        virtual bool useMouseDragMovment()
+        virtual bool useMouseDragMovement()
         {
             return true;
         }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -770,7 +770,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
     updateObjectAnimationInfo();
 }
 
-void Interface::GameArea::renderTileCursor( fheroes2::Image & dst, const int32_t startTile, const int32_t endTile ) const
+void Interface::GameArea::renderTileAreaSelect( fheroes2::Image & dst, const int32_t startTile, const int32_t endTile ) const
 {
     if ( startTile < 0 || endTile < 0 ) {
         return;
@@ -938,7 +938,7 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
         _mouseDraggingInitiated = true;
         _lastMouseDragPosition = mousePosition;
     }
-    else if ( isCursorOverGamearea && _interface.useMouseDragMovment()
+    else if ( isCursorOverGamearea && _interface.useMouseDragMovement()
               && ( std::abs( _lastMouseDragPosition.x - mousePosition.x ) > minimalRequiredDraggingMovement
                    || std::abs( _lastMouseDragPosition.y - mousePosition.y ) > minimalRequiredDraggingMovement ) ) {
         _mouseDraggingMovement = true;

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -781,10 +781,10 @@ void Interface::GameArea::renderTileCursor( fheroes2::Image & dst, const int32_t
 
     const int32_t startX = std::min( startTileOffset.x, endTileOffset.x );
     const int32_t startY = std::min( startTileOffset.y, endTileOffset.y );
-    const int32_t endX = std::max( startTileOffset.x, endTileOffset.x );
-    const int32_t endY = std::max( startTileOffset.y, endTileOffset.y );
+    const int32_t sizeX = TILEWIDTH + std::abs( startTileOffset.x - endTileOffset.x );
+    const int32_t sizeY = TILEWIDTH + std::abs( startTileOffset.y - endTileOffset.y );
 
-    const fheroes2::Rect imageRoi{ startX, startY, TILEWIDTH + endX - startX, TILEWIDTH + endY - startY };
+    const fheroes2::Rect imageRoi{ startX, startY, sizeX, sizeY };
     const fheroes2::Rect overlappedRoi = _windowROI ^ imageRoi;
 
     fheroes2::Fill( dst, overlappedRoi.x, overlappedRoi.y, overlappedRoi.width, std::min( 2, overlappedRoi.height ), 181 );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -985,9 +985,6 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
     if ( le.MouseClickLeft( tileROI ) ) {
         _interface.mouseCursorAreaClickLeft( index );
     }
-    else if ( le.MousePressLeft( tileROI ) ) {
-        _interface.mouseCursorAreaPressLeft( index );
-    }
     else if ( le.MousePressRight( tileROI ) ) {
         _interface.mouseCursorAreaPressRight( index );
     }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -770,6 +770,29 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
     updateObjectAnimationInfo();
 }
 
+void Interface::GameArea::renderTileCursor( fheroes2::Image & dst, const int32_t startTile, const int32_t endTile ) const
+{
+    if ( startTile < 0 || endTile < 0 ) {
+        return;
+    }
+
+    const fheroes2::Point startTileOffset = GetRelativeTilePosition( Maps::GetPoint( startTile ) );
+    const fheroes2::Point endTileOffset = GetRelativeTilePosition( Maps::GetPoint( endTile ) );
+
+    const int32_t startX = std::min( startTileOffset.x, endTileOffset.x );
+    const int32_t startY = std::min( startTileOffset.y, endTileOffset.y );
+    const int32_t endX = std::max( startTileOffset.x, endTileOffset.x );
+    const int32_t endY = std::max( startTileOffset.y, endTileOffset.y );
+
+    const fheroes2::Rect imageRoi{ startX, startY, TILEWIDTH + endX - startX, TILEWIDTH + endY - startY };
+    const fheroes2::Rect overlappedRoi = _windowROI ^ imageRoi;
+
+    fheroes2::Fill( dst, overlappedRoi.x, overlappedRoi.y, overlappedRoi.width, std::min( 2, overlappedRoi.height ), 181 );
+    fheroes2::Fill( dst, overlappedRoi.x, overlappedRoi.y + 2, std::min( 2, overlappedRoi.width ), overlappedRoi.height - 4, 181 );
+    fheroes2::Fill( dst, overlappedRoi.x, overlappedRoi.y + overlappedRoi.height - 2, overlappedRoi.width, 2, 181 );
+    fheroes2::Fill( dst, overlappedRoi.x + overlappedRoi.width - 2, overlappedRoi.y + 2, 2, overlappedRoi.height - 4, 181 );
+}
+
 void Interface::GameArea::updateMapFogDirections()
 {
     const int32_t friendColors = Players::FriendColors();

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -915,9 +915,9 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
         _mouseDraggingInitiated = true;
         _lastMouseDragPosition = mousePosition;
     }
-    else if ( ( std::abs( _lastMouseDragPosition.x - mousePosition.x ) > minimalRequiredDraggingMovement
-                || std::abs( _lastMouseDragPosition.y - mousePosition.y ) > minimalRequiredDraggingMovement )
-              && isCursorOverGamearea ) {
+    else if ( isCursorOverGamearea
+              && ( std::abs( _lastMouseDragPosition.x - mousePosition.x ) > minimalRequiredDraggingMovement
+                   || std::abs( _lastMouseDragPosition.y - mousePosition.y ) > minimalRequiredDraggingMovement ) ) {
         _mouseDraggingMovement = true;
     }
 
@@ -934,7 +934,7 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
         return;
     }
 
-    int32_t index = GetValidTileIdFromPoint( mousePosition );
+    const int32_t index = GetValidTileIdFromPoint( mousePosition );
 
     // change cursor if need
     if ( ( updateCursor || index != _prevIndexPos ) && isCursorOverGamearea ) {
@@ -944,12 +944,14 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
     }
 
     // out of range
-    if ( index < 0 )
+    if ( !isCursorOverGamearea || !Maps::isValidAbsIndex( index ) ) {
         return;
+    }
 
     const Settings & conf = Settings::Get();
-    if ( conf.isHideInterfaceEnabled() && conf.ShowControlPanel() && le.MouseCursor( Interface::AdventureMap::Get().getControlPanel().GetArea() ) )
+    if ( conf.isHideInterfaceEnabled() && conf.ShowControlPanel() && le.MouseCursor( Interface::AdventureMap::Get().getControlPanel().GetArea() ) ) {
         return;
+    }
 
     const fheroes2::Point tileOffset = _topLeftTileOffset + mousePosition - _windowROI.getPosition();
     const fheroes2::Point tilePos( ( tileOffset.x / TILEWIDTH ) * TILEWIDTH - _topLeftTileOffset.x + _windowROI.x,
@@ -957,10 +959,12 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
 
     const fheroes2::Rect tileROI( tilePos.x, tilePos.y, TILEWIDTH, TILEWIDTH );
 
-    if ( le.MouseClickLeft( tileROI ) )
+    if ( le.MouseClickLeft( tileROI ) ) {
         _interface.mouseCursorAreaClickLeft( index );
-    else if ( le.MousePressRight( tileROI ) && isCursorOverGamearea )
+    }
+    else if ( le.MousePressRight( tileROI ) && isCursorOverGamearea ) {
         _interface.mouseCursorAreaPressRight( index );
+    }
 }
 
 fheroes2::Point Interface::GameArea::_getStartTileId() const

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -938,7 +938,7 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
         _mouseDraggingInitiated = true;
         _lastMouseDragPosition = mousePosition;
     }
-    else if ( isCursorOverGamearea
+    else if ( isCursorOverGamearea && _interface.useMouseDragMovment()
               && ( std::abs( _lastMouseDragPosition.x - mousePosition.x ) > minimalRequiredDraggingMovement
                    || std::abs( _lastMouseDragPosition.y - mousePosition.y ) > minimalRequiredDraggingMovement ) ) {
         _mouseDraggingMovement = true;
@@ -985,7 +985,10 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
     if ( le.MouseClickLeft( tileROI ) ) {
         _interface.mouseCursorAreaClickLeft( index );
     }
-    else if ( le.MousePressRight( tileROI ) && isCursorOverGamearea ) {
+    else if ( le.MousePressLeft( tileROI ) ) {
+        _interface.mouseCursorAreaPressLeft( index );
+    }
+    else if ( le.MousePressRight( tileROI ) ) {
         _interface.mouseCursorAreaPressRight( index );
     }
 }

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -204,7 +204,7 @@ namespace Interface
         // Interface::Basic::Redraw() instead to avoid issues in the "no interface" mode
         void Redraw( fheroes2::Image & dst, int flag, bool isPuzzleDraw = false ) const;
 
-        void renderTileCursor( fheroes2::Image & dst, const int32_t startTile, const int32_t endTile ) const;
+        void renderTileAreaSelect( fheroes2::Image & dst, const int32_t startTile, const int32_t endTile ) const;
 
         void BlitOnTile( fheroes2::Image & dst, const fheroes2::Image & src, int32_t ox, int32_t oy, const fheroes2::Point & mp, bool flip, uint8_t alpha ) const;
 

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -204,6 +204,8 @@ namespace Interface
         // Interface::Basic::Redraw() instead to avoid issues in the "no interface" mode
         void Redraw( fheroes2::Image & dst, int flag, bool isPuzzleDraw = false ) const;
 
+        void renderTileCursor( fheroes2::Image & dst, const int32_t startTile, const int32_t endTile ) const;
+
         void BlitOnTile( fheroes2::Image & dst, const fheroes2::Image & src, int32_t ox, int32_t oy, const fheroes2::Point & mp, bool flip, uint8_t alpha ) const;
 
         void BlitOnTile( fheroes2::Image & dst, const fheroes2::Image & src, const fheroes2::Rect & srcRoi, int32_t ox, int32_t oy, const fheroes2::Point & mp, bool flip,

--- a/src/fheroes2/maps/ground.cpp
+++ b/src/fheroes2/maps/ground.cpp
@@ -140,21 +140,21 @@ uint16_t Maps::Ground::getRandomTerrainImageIndex( const int groundId )
     const uint16_t indexOffset = static_cast<uint16_t>( Rand::Get( 7 ) );
     switch ( groundId ) {
     case DESERT:
-        return indexOffset + 300u;
+        return indexOffset + 300U;
     case SNOW:
-        return indexOffset + 130u;
+        return indexOffset + 130U;
     case SWAMP:
-        return indexOffset + 184u;
+        return indexOffset + 184U;
     case WASTELAND:
-        return indexOffset + 399u;
+        return indexOffset + 399U;
     case BEACH:
-        return indexOffset + 415u;
+        return indexOffset + 415U;
     case LAVA:
-        return indexOffset + 246u;
+        return indexOffset + 246U;
     case DIRT:
-        return indexOffset + 337u;
+        return indexOffset + 337U;
     case GRASS:
-        return indexOffset + 68u;
+        return indexOffset + 68U;
     default:
         // Have you added a new ground? Add the logic above!
         assert( 0 );
@@ -166,21 +166,21 @@ uint16_t Maps::Ground::getRandomTerrainSpecialImageIndex( const int groundId )
 {
     switch ( groundId ) {
     case DESERT:
-        return static_cast<uint16_t>( Rand::Get( 12 ) ) + 308u;
+        return static_cast<uint16_t>( Rand::Get( 12 ) ) + 308U;
     case SNOW:
-        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 138u;
+        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 138U;
     case SWAMP:
-        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 192u;
+        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 192U;
     case WASTELAND:
-        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 407u;
+        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 407U;
     case BEACH:
-        return static_cast<uint16_t>( Rand::Get( 8 ) ) + 423u;
+        return static_cast<uint16_t>( Rand::Get( 8 ) ) + 423U;
     case LAVA:
-        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 254u;
+        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 254U;
     case DIRT:
-        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 345u;
+        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 345U;
     case GRASS:
-        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 76u;
+        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 76U;
     case WATER:
         // There are no extra water terrain tiles. We return normal tiles instead.
         return getRandomTerrainImageIndex( groundId );

--- a/src/fheroes2/maps/ground.cpp
+++ b/src/fheroes2/maps/ground.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -23,13 +23,16 @@
 
 #include "ground.h"
 
+#include <cassert>
+
 #include "maps_tiles.h"
+#include "rand.h"
 #include "skill.h"
 #include "translations.h"
 
-const char * Maps::Ground::String( int ground )
+const char * Maps::Ground::String( int groundId )
 {
-    switch ( ground ) {
+    switch ( groundId ) {
     case DESERT:
         return _( "Desert" );
     case SNOW:
@@ -126,4 +129,33 @@ uint32_t Maps::Ground::GetPenalty( const Maps::Tiles & tile, uint32_t level )
     }
 
     return result;
+}
+
+uint16_t Maps::Ground::getRandomTerrainImageIndex( const int groundId )
+{
+    const uint16_t indexOffset = static_cast<uint16_t>( Rand::Get( 7 ) );
+    switch ( groundId ) {
+    case DESERT:
+        return indexOffset + 300u;
+    case SNOW:
+        return indexOffset + 130u;
+    case SWAMP:
+        return indexOffset + 184u;
+    case WASTELAND:
+        return indexOffset + 399u;
+    case BEACH:
+        return indexOffset + 415u;
+    case LAVA:
+        return indexOffset + 246u;
+    case DIRT:
+        return indexOffset + 337u;
+    case GRASS:
+        return indexOffset + 68u;
+    case WATER:
+        return indexOffset + 16u;
+    default:
+
+        assert( 0 );
+        return 0;
+    }
 }

--- a/src/fheroes2/maps/ground.cpp
+++ b/src/fheroes2/maps/ground.cpp
@@ -133,6 +133,10 @@ uint32_t Maps::Ground::GetPenalty( const Maps::Tiles & tile, uint32_t level )
 
 uint16_t Maps::Ground::getRandomTerrainImageIndex( const int groundId )
 {
+    if ( groundId == WATER ) {
+        return static_cast<uint16_t>( Rand::Get( 3 ) ) + 16u;
+    }
+
     const uint16_t indexOffset = static_cast<uint16_t>( Rand::Get( 7 ) );
     switch ( groundId ) {
     case DESERT:
@@ -151,10 +155,37 @@ uint16_t Maps::Ground::getRandomTerrainImageIndex( const int groundId )
         return indexOffset + 337u;
     case GRASS:
         return indexOffset + 68u;
-    case WATER:
-        return indexOffset + 16u;
     default:
+        // Have you added a new ground? Add the logic above!
+        assert( 0 );
+        return 0;
+    }
+}
 
+uint16_t Maps::Ground::getRandomTerrainSpecialImageIndex( const int groundId )
+{
+    switch ( groundId ) {
+    case DESERT:
+        return static_cast<uint16_t>( Rand::Get( 12 ) ) + 308u;
+    case SNOW:
+        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 138u;
+    case SWAMP:
+        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 192u;
+    case WASTELAND:
+        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 407u;
+    case BEACH:
+        return static_cast<uint16_t>( Rand::Get( 8 ) ) + 423u;
+    case LAVA:
+        return static_cast<uint16_t>( Rand::Get( 7 ) ) + 254u;
+    case DIRT:
+        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 345u;
+    case GRASS:
+        return static_cast<uint16_t>( Rand::Get( 15 ) ) + 76u;
+    case WATER:
+        // There are no extra water terrain tiles. We return normal tiles instead.
+        return getRandomTerrainImageIndex( groundId );
+    default:
+        // Have you added a new ground? Add the logic above!
         assert( 0 );
         return 0;
     }

--- a/src/fheroes2/maps/ground.h
+++ b/src/fheroes2/maps/ground.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -50,8 +50,10 @@ namespace Maps
         const uint32_t defaultGroundPenalty = 100;
         const uint32_t slowestMovePenalty = 200;
 
-        const char * String( int );
+        const char * String( int groundId );
         uint32_t GetPenalty( const Maps::Tiles & tile, uint32_t pathfinding );
+
+        uint16_t getRandomTerrainImageIndex( const int groundId );
     }
 }
 

--- a/src/fheroes2/maps/ground.h
+++ b/src/fheroes2/maps/ground.h
@@ -53,7 +53,10 @@ namespace Maps
         const char * String( int groundId );
         uint32_t GetPenalty( const Maps::Tiles & tile, uint32_t pathfinding );
 
+        // Returns the terrain index (used in TIL file) for normal terrain layout.
         uint16_t getRandomTerrainImageIndex( const int groundId );
+        // Returns the terrain index (used in TIL file) for extra terrain layout (stone, flowers, crack, etc.).
+        uint16_t getRandomTerrainSpecialImageIndex( const int groundId );
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1001,6 +1001,7 @@ std::string Maps::Tiles::String() const
        << "layer type      : " << static_cast<int>( _layerType ) << " - " << getObjectLayerName( _layerType ) << std::endl
        << "region          : " << _region << std::endl
        << "ground          : " << Ground::String( GetGround() ) << " (isRoad: " << tileIsRoad << ")" << std::endl
+       << "ground img index: " << _terrainImageIndex << ", image flags: " << static_cast<int>( _terrainFlags ) << std::endl
        << "shadow          : " << ( isShadowSprite( _objectIcnType, _imageIndex ) ? "true" : "false" ) << std::endl
        << "passable from   : " << ( tilePassable ? Direction::String( tilePassable ) : "nowhere" );
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -333,7 +333,7 @@ namespace Maps
             return _terrainImageIndex;
         }
 
-        void setTerrainImage( const uint16_t terrainImageIndex, const bool horizontalFlip, const bool verticalFlip )
+        void setTerrain( const uint16_t terrainImageIndex, const bool horizontalFlip, const bool verticalFlip )
         {
             _terrainImageIndex = terrainImageIndex;
             _terrainFlags = ( verticalFlip ? 1 : 0 ) + ( horizontalFlip ? 2 : 0 );

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -336,7 +336,7 @@ namespace Maps
         void setTerrainImage( const uint16_t terrainImageIndex, const bool horizontalFlip, const bool verticalFlip )
         {
             _terrainImageIndex = terrainImageIndex;
-            _terrainFlags = static_cast<uint8_t>( verticalFlip ) + 2 * static_cast<uint8_t>( horizontalFlip );
+            _terrainFlags = ( verticalFlip ? 1 : 0 ) + ( horizontalFlip ? 2 : 0 );
         }
 
         Heroes * GetHeroes() const;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -333,9 +333,10 @@ namespace Maps
             return _terrainImageIndex;
         }
 
-        void setTerrainImageIndex( const uint16_t terrainImageIndex )
+        void setTerrainImage( const uint16_t terrainImageIndex, const bool horizontalFlip, const bool verticalFlip )
         {
             _terrainImageIndex = terrainImageIndex;
+            _terrainFlags = static_cast<uint8_t>( verticalFlip ) + 2 * static_cast<uint8_t>( horizontalFlip );
         }
 
         Heroes * GetHeroes() const;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -333,6 +333,11 @@ namespace Maps
             return _terrainImageIndex;
         }
 
+        void setTerrainImageIndex( const uint16_t terrainImageIndex )
+        {
+            _terrainImageIndex = terrainImageIndex;
+        }
+
         Heroes * GetHeroes() const;
         void SetHeroes( Heroes * hero );
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -256,7 +256,7 @@ namespace Maps
 
                 // In original editor these tiles are never flipped.
                 // TODO: Decide and make the logic if some tiles can be flipped horizontally and/or vertically.
-                tile.setTerrainImage( terainImageIndex, false, false );
+                tile.setTerrain( terainImageIndex, false, false );
             }
         }
     }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -40,6 +40,7 @@
 #include "logging.h"
 #include "maps.h"
 #include "maps_tiles.h"
+#include "math_base.h"
 #include "monster.h"
 #include "mp2.h"
 #include "payment.h"

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -36,6 +36,7 @@
 #include "castle.h"
 #include "color.h"
 #include "direction.h"
+#include "ground.h"
 #include "logging.h"
 #include "maps.h"
 #include "maps_tiles.h"
@@ -231,6 +232,33 @@ namespace
 
 namespace Maps
 {
+    void setTerrainImageOnTiles( const int32_t startTileId, const int32_t endTileId, const int groundId )
+    {
+        if ( startTileId < 0 || startTileId < 0 ) {
+            return;
+        }
+
+        const fheroes2::Point startTileOffset = Maps::GetPoint( startTileId );
+        const fheroes2::Point endTileOffset = Maps::GetPoint( endTileId );
+
+        const int32_t startX = std::min( startTileOffset.x, endTileOffset.x );
+        const int32_t startY = std::min( startTileOffset.y, endTileOffset.y );
+        const int32_t endX = std::max( startTileOffset.x, endTileOffset.x );
+        const int32_t endY = std::max( startTileOffset.y, endTileOffset.y );
+
+        for ( int32_t y = startY; y <= endY; ++y ) {
+            for ( int32_t x = startX; x <= endX; ++x ) {
+                Maps::Tiles & tile = world.GetTiles( x, y );
+                const uint16_t terainImageIndex
+                    = ( Rand::Get( 6 ) == 0 ) ? Maps::Ground::getRandomTerrainSpecialImageIndex( groundId ) : Maps::Ground::getRandomTerrainImageIndex( groundId );
+
+                // In original editor these tiles are never flipped.
+                // TODO: Decide and make the logic if some tiles can be flipped horizontally and/or vertically.
+                tile.setTerrainImage( terainImageIndex, false, false );
+            }
+        }
+    }
+
     int32_t getMineSpellIdFromTile( const Tiles & tile )
     {
         if ( tile.GetObject( false ) != MP2::OBJ_MINES ) {

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -234,7 +234,7 @@ namespace Maps
 {
     void setTerrainImageOnTiles( const int32_t startTileId, const int32_t endTileId, const int groundId )
     {
-        if ( startTileId < 0 || startTileId < 0 ) {
+        if ( startTileId < 0 || endTileId < 0 ) {
             return;
         }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -233,9 +233,10 @@ namespace
 
 namespace Maps
 {
-    void setTerrainImageOnTiles( const int32_t startTileId, const int32_t endTileId, const int groundId )
+    void setTerrainOnTiles( const int32_t startTileId, const int32_t endTileId, const int groundId )
     {
-        if ( startTileId < 0 || endTileId < 0 ) {
+        const int32_t maxTileId = world.w() * world.h() - 1;
+        if ( startTileId < 0 || endTileId < 0 || startTileId > maxTileId || endTileId > maxTileId ) {
             return;
         }
 

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -75,7 +75,7 @@ namespace Maps
         FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT = 4
     };
 
-    void setTerrainImageOnTiles( Tiles & tile, const int32_t spellId );
+    void setTerrainImageOnTiles( const int32_t startTileId, const int32_t endTileId, const int groundId );
 
     // Only for MP2::OBJ_MINES.
     int32_t getMineSpellIdFromTile( const Tiles & tile );

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -75,7 +75,7 @@ namespace Maps
         FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT = 4
     };
 
-    void setTerrainImageOnTiles( const int32_t startTileId, const int32_t endTileId, const int groundId );
+    void setTerrainOnTiles( const int32_t startTileId, const int32_t endTileId, const int groundId );
 
     // Only for MP2::OBJ_MINES.
     int32_t getMineSpellIdFromTile( const Tiles & tile );

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -75,6 +75,8 @@ namespace Maps
         FIGHT_50_GHOSTS_AND_GET_2000_GOLD_WITH_ARTIFACT = 4
     };
 
+    void setTerrainImageOnTiles( Tiles & tile, const int32_t spellId );
+
     // Only for MP2::OBJ_MINES.
     int32_t getMineSpellIdFromTile( const Tiles & tile );
     void setMineSpellOnTile( Tiles & tile, const int32_t spellId );


### PR DESCRIPTION
Relates to #6845

This PR adds Editor ability to place (draw) specified terrain on a map by 1x1, 2x2 or 4x4 brush or by selecting a rectangle area on map.
Terrain interconnections are not implemented in this PR and they will be done in one of the next Editor related PRs.
Currently you cannot hold mouse button and draw withe selected brush by moving the cursor as it is done in original Editor, jus one draw in the selected area by one mouse click. This function will be implemented after the implementation of terrain interconnection.

https://github.com/ihhub/fheroes2/assets/113276641/4cb8e4e7-d937-46d4-94fd-f41c8041ee53

