### PR TITLE
Fix a few recently introduced code smells, fix GitHub Actions build with ASAN & TSAN

### DIFF
--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   clang:
     name: Clang Analyzer
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   tidy:
     name: Clang-Tidy
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     defaults:
       run:

--- a/.github/workflows/code_style_check.yml
+++ b/.github/workflows/code_style_check.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   style:
     name: Code style check
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
       run:

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   iwyu:
     name: IWYU
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -29,7 +29,7 @@ jobs:
           release_name: Ubuntu x86-64 (Linux) build with SDL1 (latest commit)
           release_tag: fheroes2-linux-sdl1_dev
         - name: Linux x86-64 SDL1 Debug
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           dependencies: libsdl1.2-dev libsdl-mixer1.2-dev gettext
           env:
             FHEROES2_STRICT_COMPILATION: ON
@@ -71,7 +71,7 @@ jobs:
           release_name: Ubuntu x86-64 (Linux) build with SDL2 (latest commit)
           release_tag: fheroes2-linux-sdl2_dev
         - name: Linux x86-64 SDL2 Debug
-          os: ubuntu-20.04
+          os: ubuntu-22.04
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
           env:
             FHEROES2_STRICT_COMPILATION: ON

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -29,7 +29,7 @@ jobs:
           release_name: Ubuntu x86-64 (Linux) build with SDL1 (latest commit)
           release_tag: fheroes2-linux-sdl1_dev
         - name: Linux x86-64 SDL1 Debug
-          os: ubuntu-22.04
+          os: ubuntu-latest
           dependencies: libsdl1.2-dev libsdl-mixer1.2-dev gettext
           env:
             FHEROES2_STRICT_COMPILATION: ON
@@ -71,7 +71,7 @@ jobs:
           release_name: Ubuntu x86-64 (Linux) build with SDL2 (latest commit)
           release_tag: fheroes2-linux-sdl2_dev
         - name: Linux x86-64 SDL2 Debug
-          os: ubuntu-22.04
+          os: ubuntu-latest
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
           env:
             FHEROES2_STRICT_COMPILATION: ON
@@ -103,7 +103,7 @@ jobs:
           release_name: Ubuntu ARM64 (Linux) build with SDL1 (latest commit)
           release_tag: fheroes2-linux-arm-sdl1_dev
         - name: Linux ARM64 SDL1 Debug
-          os: ubuntu-22.04
+          os: ubuntu-latest
           dependencies: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libsdl1.2-dev:arm64 libsdl-mixer1.2-dev:arm64 gettext
           env:
             FHEROES2_STRICT_COMPILATION: ON
@@ -151,7 +151,7 @@ jobs:
           release_name: Ubuntu ARM64 (Linux) build with SDL2 (latest commit)
           release_tag: fheroes2-linux-arm-sdl2_dev
         - name: Linux ARM64 SDL2 Debug
-          os: ubuntu-22.04
+          os: ubuntu-latest
           dependencies: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libsdl2-dev:arm64 libsdl2-mixer-dev:arm64 libsdl2-image-dev:arm64 libpng-dev:arm64 gettext
           env:
             FHEROES2_STRICT_COMPILATION: ON
@@ -183,7 +183,7 @@ jobs:
           release_name: macOS x86-64 build with SDL1 (latest commit)
           release_tag: fheroes2-osx-sdl1_dev
         - name: macOS SDL1 App Bundle
-          os: macos-11
+          os: macos-latest
           dependencies: sdl sdl_mixer dylibbundler
           env:
             FHEROES2_STRICT_COMPILATION: ON
@@ -224,7 +224,7 @@ jobs:
           release_name: macOS x86-64 build with SDL2 (latest commit)
           release_tag: fheroes2-osx-sdl2_dev
         - name: macOS SDL2 App Bundle
-          os: macos-11
+          os: macos-latest
           dependencies: sdl2 sdl2_mixer dylibbundler
           env:
             FHEROES2_STRICT_COMPILATION: ON

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -31,7 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Queue;
-import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
@@ -134,7 +134,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             new Thread( () -> {
                 Exception caughtException = null;
 
-                final Function<String, Boolean> checkExtension = ( String name ) ->
+                final Predicate<String> checkExtension = ( String name ) ->
                 {
                     final String lowercaseName = name.toLowerCase( Locale.ROOT );
 
@@ -158,7 +158,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                         }
 
                         final String zEntryFileName = new File( zEntry.getName() ).getName();
-                        if ( !checkExtension.apply( zEntryFileName ) ) {
+                        if ( !checkExtension.test( zEntryFileName ) ) {
                             continue;
                         }
 


### PR DESCRIPTION
Fixes issues like this one:

https://github.com/ihhub/fheroes2/actions/runs/5809318729/job/15748134142

Apparently, `libasan` and `libtsan` are broken or not installed on the current revision of Ubuntu 20.04 image from GitHub.