### PR TITLE
AI heroes shouldn't know what exactly a Treasure or Sea Chest contains

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1066,12 +1066,10 @@ namespace AI
         case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_TREASURE_CHEST: {
             const Artifact art = getArtifactFromTile( tile );
-            if ( art.isValid() ) {
+            if ( art.isValid() && isFindArtifactVictoryConditionForHuman( art ) ) {
                 // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this object untouched for the human player.
-                if ( isFindArtifactVictoryConditionForHuman( art ) ) {
-                    assert( 0 );
-                    return -dangerousTaskPenalty;
-                }
+                assert( 0 );
+                return -dangerousTaskPenalty;
             }
 
             // This is an average gold amount you can get from a treasure chest or sea chest.
@@ -1733,12 +1731,10 @@ namespace AI
         case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_TREASURE_CHEST: {
             const Artifact art = getArtifactFromTile( tile );
-            if ( art.isValid() ) {
+            if ( art.isValid() && isFindArtifactVictoryConditionForHuman( art ) ) {
                 // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this object untouched for the human player.
-                if ( isFindArtifactVictoryConditionForHuman( art ) ) {
-                    assert( 0 );
-                    return -dangerousTaskPenalty;
-                }
+                assert( 0 );
+                return -dangerousTaskPenalty;
             }
 
             return twoTiles;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1065,9 +1065,8 @@ namespace AI
         }
         case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_TREASURE_CHEST: {
-            if ( getArtifactFromTile( tile ).isValid() ) {
-                const Artifact art = getArtifactFromTile( tile );
-
+            const Artifact art = getArtifactFromTile( tile );
+            if ( art.isValid() ) {
                 // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this object untouched for the human player.
                 if ( isFindArtifactVictoryConditionForHuman( art ) ) {
                     assert( 0 );
@@ -1733,9 +1732,8 @@ namespace AI
         }
         case MP2::OBJ_SEA_CHEST:
         case MP2::OBJ_TREASURE_CHEST: {
-            if ( getArtifactFromTile( tile ).isValid() ) {
-                const Artifact art = getArtifactFromTile( tile );
-
+            const Artifact art = getArtifactFromTile( tile );
+            if ( art.isValid() ) {
                 // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this object untouched for the human player.
                 if ( isFindArtifactVictoryConditionForHuman( art ) ) {
                     assert( 0 );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -793,6 +793,7 @@ namespace
         case MP2::OBJ_GENIE_LAMP:
         case MP2::OBJ_RESOURCE:
         case MP2::OBJ_SEA_CHEST:
+        case MP2::OBJ_TREASURE_CHEST:
             return 0.95;
         case MP2::OBJ_BUOY:
         case MP2::OBJ_TEMPLE:
@@ -1049,7 +1050,8 @@ namespace AI
             // Since mines constantly bring resources, they are valuable objects
             return resourceAmount * getResourcePriorityModifier( resourceType, true );
         }
-        case MP2::OBJ_ARTIFACT: {
+        case MP2::OBJ_ARTIFACT:
+        case MP2::OBJ_SHIPWRECK_SURVIVOR: {
             const Artifact art = getArtifactFromTile( tile );
             assert( art.isValid() );
 
@@ -1062,23 +1064,19 @@ namespace AI
             return 1000.0 * art.getArtifactValue();
         }
         case MP2::OBJ_SEA_CHEST:
-        case MP2::OBJ_SHIPWRECK_SURVIVOR:
         case MP2::OBJ_TREASURE_CHEST: {
             if ( getArtifactFromTile( tile ).isValid() ) {
                 const Artifact art = getArtifactFromTile( tile );
 
-                // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this artifact untouched for the human player
+                // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this object untouched for the human player.
                 if ( isFindArtifactVictoryConditionForHuman( art ) ) {
                     assert( 0 );
                     return -dangerousTaskPenalty;
                 }
-
-                return 1000.0 * art.getArtifactValue();
             }
 
-            const Funds funds = getFundsFromTile( tile );
-            assert( funds.gold > 0 || funds.GetValidItemsCount() == 0 );
-
+            // This is an average gold amount you can get from a treasure chest or sea chest.
+            const Funds funds{ Resource::GOLD, 1500 };
             return funds.gold * getResourcePriorityModifier( Resource::GOLD, false );
         }
         case MP2::OBJ_DAEMON_CAVE: {
@@ -1730,8 +1728,21 @@ namespace AI
         case MP2::OBJ_CAMPFIRE:
         case MP2::OBJ_FLOTSAM:
         case MP2::OBJ_GENIE_LAMP:
-        case MP2::OBJ_RESOURCE:
-        case MP2::OBJ_SEA_CHEST: {
+        case MP2::OBJ_RESOURCE: {
+            return twoTiles;
+        }
+        case MP2::OBJ_SEA_CHEST:
+        case MP2::OBJ_TREASURE_CHEST: {
+            if ( getArtifactFromTile( tile ).isValid() ) {
+                const Artifact art = getArtifactFromTile( tile );
+
+                // WINS_ARTIFACT victory condition does not apply to AI-controlled players, we should leave this object untouched for the human player.
+                if ( isFindArtifactVictoryConditionForHuman( art ) ) {
+                    assert( 0 );
+                    return -dangerousTaskPenalty;
+                }
+            }
+
             return twoTiles;
         }
         case MP2::OBJ_ARENA:


### PR DESCRIPTION
AI heroes "knew" what is inside Treasure and Sea chests and it was visible when they ignore some chests while moving to more distant ones. This is wrong and breaks user experience of "fair" AI.

You can check this save file on master branch and this branch: 
[Chests.zip](https://github.com/ihhub/fheroes2/files/12327199/Chests.zip)


What is done in this pull request:
- make Treasure and Sea chests to have the "same" averaged value, removing the knowledge what it inside (except the fact that there is an important for the human player artifact)
- Treasure Chest should have the same distance modifier as Sea Chest
- artifact check was missing for the chests for Courier heroes
- an assertion was triggered for Sea Chests when an AI hero picks it up on the way