### PR TITLE
Don't handle an event on the map twice

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -54,7 +54,6 @@
 #include "luck.h"
 #include "m82.h"
 #include "maps.h"
-#include "maps_objects.h"
 #include "maps_tiles.h"
 #include "monster.h"
 #include "morale.h"

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1720,15 +1720,6 @@ void Heroes::ActionNewPosition( const bool allowMonsterAttack )
         }
     }
 
-    if ( isActive() && GetMapsObject() == MP2::OBJ_EVENT ) {
-        const MapEvent * event = world.GetMapEvent( GetCenter() );
-
-        if ( event && event->isAllow( GetColor() ) ) {
-            Action( GetIndex() );
-            SetMove( false );
-        }
-    }
-
     if ( isControlAI() )
         AI::Get().HeroesActionNewPosition( *this );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3564,8 +3564,8 @@ void Heroes::Action( int tileIndex )
         SetModes( ACTION );
     }
 
-    // Most likely there will be some action, immediately center the map on the hero to avoid subsequent minor screen movements
-    if ( Modes( ACTION ) ) {
+    // Most likely there will be some action or event, immediately center the map on the hero to avoid subsequent minor screen movements
+    if ( Modes( ACTION ) || objectType == MP2::OBJ_EVENT ) {
         Interface::AdventureMap & I = Interface::AdventureMap::Get();
 
         I.getGameArea().SetCenter( GetCenter() );


### PR DESCRIPTION
The same event will later be handled in the `Heroes::MoveStep()` anyway.

BTW there is a difference in handling of events with "Cancel event after first visit" checkbox not set. In OG this event fires every time when a hero steps on it, even if this event has already happened in this kingdom:

https://github.com/ihhub/fheroes2/assets/32623900/4484e35a-d5b7-4c00-b65e-47950eb72e27

in fheroes2 this is not the case - such an event fires just once for each kingdom (video from this PR):

https://github.com/ihhub/fheroes2/assets/32623900/7f34d6c3-db0a-4226-81b9-249c20094d3b

I suppose that this difference is for a reason, so I'm not going to do anything about it in this PR.