### PR TITLE
Fix marketplace assertion if one of the resources is not selected

### DIFF
--- a/src/fheroes2/dialog/dialog_marketplace.cpp
+++ b/src/fheroes2/dialog/dialog_marketplace.cpp
@@ -399,9 +399,10 @@ void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
                 resourceFrom = Resource::getResourceTypeFromIconIndex( ii );
                 max_sell = fundsFrom.Get( resourceFrom );
 
-                if ( GetTradeCosts( kingdom, resourceFrom, resourceTo, fromTradingPost ) ) {
-                    max_buy = Resource::GOLD == resourceTo ? max_sell * GetTradeCosts( kingdom, resourceFrom, resourceTo, fromTradingPost )
-                                                           : max_sell / GetTradeCosts( kingdom, resourceFrom, resourceTo, fromTradingPost );
+                const uint32_t tradeCost = GetTradeCosts( kingdom, resourceFrom, resourceTo, fromTradingPost );
+
+                if ( tradeCost ) {
+                    max_buy = Resource::GOLD == resourceTo ? max_sell * tradeCost : max_sell / tradeCost;
                 }
 
                 count_sell = 0;
@@ -433,9 +434,10 @@ void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
             if ( le.MouseClickLeft( rect_to ) ) {
                 resourceTo = Resource::getResourceTypeFromIconIndex( ii );
 
-                if ( GetTradeCosts( kingdom, resourceFrom, resourceTo, fromTradingPost ) ) {
-                    max_buy = Resource::GOLD == resourceTo ? max_sell * GetTradeCosts( kingdom, resourceFrom, resourceTo, fromTradingPost )
-                                                           : max_sell / GetTradeCosts( kingdom, resourceFrom, resourceTo, fromTradingPost );
+                const uint32_t tradeCost = GetTradeCosts( kingdom, resourceFrom, resourceTo, fromTradingPost );
+
+                if ( tradeCost ) {
+                    max_buy = Resource::GOLD == resourceTo ? max_sell * tradeCost : max_sell / tradeCost;
                 }
 
                 count_sell = 0;

--- a/src/fheroes2/kingdom/resource_trading.cpp
+++ b/src/fheroes2/kingdom/resource_trading.cpp
@@ -65,16 +65,17 @@ namespace fheroes2
             return 0;
         }
 
+        if ( resourceFrom == resourceTo || resourceFrom == Resource::UNKNOWN || resourceTo == Resource::UNKNOWN ) {
+            // The resource is not selected (Resource::UNKNOWN) or resources are the same.
+            // What are we trying to achieve?
+            return 0;
+        }
+
         if ( marketplaceCount > 9 ) {
             marketplaceCount = 9;
         }
 
         --marketplaceCount;
-
-        if ( resourceFrom == resourceTo ) {
-            // What are we trying to achieve?
-            return 0;
-        }
 
         switch ( resourceFrom ) {
         case Resource::GOLD: {


### PR DESCRIPTION
Fix #7547

If one (or both) of the resources is not selected (this will always happen at the beginning because we cannot select both resources at the same time) their type is `Resource::Unknown` - this means that resource is not selected.
This case is now handled and `getTradeCost()` returns 0 as we may get only nothing for nothing.