### PR TITLE
Limit dimension door usage on easier difficulties

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -2135,6 +2135,7 @@ namespace AI
         hero.Scout( targetIndex );
         hero.Move2Dest( targetIndex );
         hero.SpellCasted( dimensionDoor );
+        hero.setDimensionDoorUsage( hero.getDimensionDoorUses() + 1 );
         hero.GetPath().Reset();
 
         if ( AIIsShowAnimationForHero( hero, AIGetAllianceColors() ) ) {

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -720,6 +720,7 @@ namespace AI
 
         for ( Heroes * hero : heroes ) {
             hero->ResetModes( Heroes::SLEEPER );
+            hero->setDimensionDoorUsage( 0 );
 
             const double strength = hero->GetArmy().GetStrength();
             _combinedHeroStrength += strength;

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -21,9 +21,10 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "difficulty.h"
+
 #include <cassert>
 
-#include "difficulty.h"
 #include "translations.h"
 
 std::string Difficulty::String( int difficulty )
@@ -140,4 +141,19 @@ double Difficulty::GetAIRetreatRatio( int difficulty )
         break;
     }
     return 100.0 / 6.0;
+}
+
+uint32_t Difficulty::GetDimensionDoorLimit( int difficulty )
+{
+    switch ( difficulty ) {
+    case Difficulty::EASY:
+        return 1;
+    case Difficulty::NORMAL:
+        return 2;
+    case Difficulty::HARD:
+        return 3;
+    default:
+        break;
+    }
+    return UINT32_MAX;
 }

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -46,6 +46,8 @@ namespace Difficulty
 
     int GetHeroMovementBonus( int difficulty );
     double GetAIRetreatRatio( int difficulty );
+
+    uint32_t GetDimensionDoorLimit( int difficulty );
 }
 
 #endif

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -576,6 +576,16 @@ public:
         return _aiRole;
     }
 
+    void setDimensionDoorUsage( const uint32_t newUsage )
+    {
+        _dimensionDoorsUsed = newUsage;
+    }
+
+    uint32_t getDimensionDoorUses() const
+    {
+        return _dimensionDoorsUsed;
+    }
+
     uint8_t getAlphaValue() const
     {
         return static_cast<uint8_t>( _alphaValue );
@@ -643,6 +653,9 @@ private:
 
     std::list<IndexObject> visit_object;
     uint32_t _lastGroundRegion = 0;
+
+    // Tracking how many spells this hero used this turn
+    uint32_t _dimensionDoorsUsed = 0;
 
     mutable int _alphaValue;
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -30,6 +30,9 @@
 #include <type_traits>
 #include <utility>
 
+#include <difficulty.h>
+#include <game.h>
+
 #include "army.h"
 #include "artifact.h"
 #include "castle.h"
@@ -1197,7 +1200,8 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
     }
 
     const uint32_t movementCost = std::max( 1U, dimensionDoor.movePoints() );
-    const uint32_t maxCasts = std::min( currentSpellPoints / std::max( 1U, dimensionDoor.spellPoints( &hero ) ), hero.GetMovePoints() / movementCost );
+    const uint32_t spellcastsPossible = std::min( currentSpellPoints / std::max( 1U, dimensionDoor.spellPoints( &hero ) ), hero.GetMovePoints() / movementCost );
+    const uint32_t maxCasts = std::min( spellcastsPossible, Difficulty::GetDimensionDoorLimit( Game::getDifficulty() ) );
 
     // Have to explicitly call GetObject( false ) since hero might be standing on it
     if ( tile.GetObject( false ) == MP2::OBJ_CASTLE ) {

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -1176,7 +1176,9 @@ std::vector<IndexObject> AIWorldPathfinder::getObjectsOnTheWay( const int target
 
 std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & hero, int targetIndex ) const
 {
-    if ( hero.GetIndex() == targetIndex ) {
+    uint32_t difficultyLimit = Difficulty::GetDimensionDoorLimit( Game::getDifficulty() );
+    const uint32_t spellsUsedThisTurn = hero.getDimensionDoorUses();
+    if ( hero.GetIndex() == targetIndex || spellsUsedThisTurn >= difficultyLimit ) {
         return {};
     }
 
@@ -1199,9 +1201,10 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
         currentSpellPoints -= static_cast<uint32_t>( hero.GetMaxSpellPoints() * _spellPointsReserveRatio );
     }
 
+    difficultyLimit -= spellsUsedThisTurn;
     const uint32_t movementCost = std::max( 1U, dimensionDoor.movePoints() );
     const uint32_t spellcastsPossible = std::min( currentSpellPoints / std::max( 1U, dimensionDoor.spellPoints( &hero ) ), hero.GetMovePoints() / movementCost );
-    const uint32_t maxCasts = std::min( spellcastsPossible, Difficulty::GetDimensionDoorLimit( Game::getDifficulty() ) );
+    const uint32_t maxCasts = std::min( spellcastsPossible, difficultyLimit );
 
     // Have to explicitly call GetObject( false ) since hero might be standing on it
     if ( tile.GetObject( false ) == MP2::OBJ_CASTLE ) {


### PR DESCRIPTION
Could tag it with "AI downgrade" instead. It's time to make "easy" difficulty actually easier.

Still debating if it's worth putting `_dimensionDoorsUsed` in the savegame.