### PR TITLE
Use "Redmean" color distance calculation for GetPALColorId()

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -371,7 +371,7 @@ namespace
                 for ( uint32_t i = 0; i < 256; ++i, ++correctorX ) {
                     const uint8_t * palette = gamePalette + static_cast<ptrdiff_t>( *correctorX ) * 3;
 
-                    const int32_t sumRed = ( static_cast<int32_t>( *palette ) + r );
+                    const int32_t sumRed = static_cast<int32_t>( *palette ) + r;
                     const int32_t offsetRed = static_cast<int32_t>( *palette ) - r;
                     ++palette;
                     const int32_t offsetGreen = static_cast<int32_t>( *palette ) - g;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -362,7 +362,7 @@ namespace
                 r = ( id % 64 );
                 g = ( id >> 6 ) % 64;
                 b = ( id >> 12 );
-                int32_t minDistance = 3 * 255 * 255;
+                int32_t minDistance = INT32_MAX;
                 uint32_t bestPos = 0;
 
                 const uint8_t * correctorX = transformTable + 256 * 15;
@@ -370,13 +370,15 @@ namespace
                 for ( uint32_t i = 0; i < 256; ++i, ++correctorX ) {
                     const uint8_t * palette = gamePalette + static_cast<ptrdiff_t>( *correctorX ) * 3;
 
+                    // Use "Redmean" color distance calculation (https://www.compuphase.com/cmetric.htm).
+                    const int32_t meanRed = ( static_cast<int32_t>( *palette ) + static_cast<int32_t>( r ) ) / 2;
                     const int32_t offsetRed = static_cast<int32_t>( *palette ) - static_cast<int32_t>( r );
                     ++palette;
                     const int32_t offsetGreen = static_cast<int32_t>( *palette ) - static_cast<int32_t>( g );
                     ++palette;
                     const int32_t offsetBlue = static_cast<int32_t>( *palette ) - static_cast<int32_t>( b );
                     ++palette;
-                    const int32_t distance = offsetRed * offsetRed + offsetGreen * offsetGreen + offsetBlue * offsetBlue;
+                    const int32_t distance = ( 512 + meanRed ) * offsetRed * offsetRed + 1024 * offsetGreen * offsetGreen + ( 767 - meanRed ) * offsetBlue * offsetBlue;
                     if ( minDistance > distance ) {
                         minDistance = distance;
                         bestPos = *correctorX;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -352,33 +352,35 @@ namespace
             isInitialized = true;
             const uint32_t size = 64 * 64 * 64;
 
-            uint32_t r = 0;
-            uint32_t g = 0;
-            uint32_t b = 0;
+            int32_t r = 0;
+            int32_t g = 0;
+            int32_t b = 0;
 
             const uint8_t * gamePalette = fheroes2::getGamePalette();
 
             for ( uint32_t id = 0; id < size; ++id ) {
-                r = ( id % 64 );
-                g = ( id >> 6 ) % 64;
-                b = ( id >> 12 );
+                r = static_cast<int32_t>( id % 64 );
+                g = static_cast<int32_t>( id >> 6 ) % 64;
+                b = static_cast<int32_t>( id >> 12 );
                 int32_t minDistance = INT32_MAX;
                 uint32_t bestPos = 0;
 
+                // Use the "No cycle" palette.
                 const uint8_t * correctorX = transformTable + 256 * 15;
 
                 for ( uint32_t i = 0; i < 256; ++i, ++correctorX ) {
                     const uint8_t * palette = gamePalette + static_cast<ptrdiff_t>( *correctorX ) * 3;
 
-                    // Use "Redmean" color distance calculation (https://www.compuphase.com/cmetric.htm).
-                    const int32_t meanRed = ( static_cast<int32_t>( *palette ) + static_cast<int32_t>( r ) ) / 2;
-                    const int32_t offsetRed = static_cast<int32_t>( *palette ) - static_cast<int32_t>( r );
+                    const int32_t sumRed = ( static_cast<int32_t>( *palette ) + r );
+                    const int32_t offsetRed = static_cast<int32_t>( *palette ) - r;
                     ++palette;
-                    const int32_t offsetGreen = static_cast<int32_t>( *palette ) - static_cast<int32_t>( g );
+                    const int32_t offsetGreen = static_cast<int32_t>( *palette ) - g;
                     ++palette;
-                    const int32_t offsetBlue = static_cast<int32_t>( *palette ) - static_cast<int32_t>( b );
+                    const int32_t offsetBlue = static_cast<int32_t>( *palette ) - b;
                     ++palette;
-                    const int32_t distance = ( 512 + meanRed ) * offsetRed * offsetRed + 1024 * offsetGreen * offsetGreen + ( 767 - meanRed ) * offsetBlue * offsetBlue;
+                    // Based on "Redmean" color distance calculation (https://www.compuphase.com/cmetric.htm).
+                    const int32_t distance = ( 2 * 2 * 256 + sumRed ) * offsetRed * offsetRed + 4 * 2 * 256 * offsetGreen * offsetGreen
+                                             + ( 2 * ( 2 * 256 + 255 ) - sumRed ) * offsetBlue * offsetBlue;
                     if ( minDistance > distance ) {
                         minDistance = distance;
                         bestPos = *correctorX;


### PR DESCRIPTION
Relates to https://github.com/ihhub/fheroes2/issues/7574

This PR modifies the color distance calculation formula to better fit human perception (https://en.wikipedia.org/wiki/Color_difference).

One disadvantage of this PR is that it takes about 40% more time to calculate `rgbToId` array data (120 ms vs 85 ms) during game load.

For the comparison:
Ideal color transitions (click to view in non-scaled size):
![testBest](https://github.com/ihhub/fheroes2/assets/113276641/114acd3a-c2c8-439a-948d-6b0d86567d07)
![test2Best](https://github.com/ihhub/fheroes2/assets/113276641/23359a68-926a-4762-a1b3-750ffcde921f)

Master build:
![testOrig](https://github.com/ihhub/fheroes2/assets/113276641/fb09cf3c-0ba9-40f8-81e6-0995460cadd0)
![test2Orig](https://github.com/ihhub/fheroes2/assets/113276641/d05e920d-ae04-4949-b969-7f38cf2beb46)

This PR:
![testRedmean](https://github.com/ihhub/fheroes2/assets/113276641/39534ca5-ac66-461d-ad3f-1812d94b3e66)
![test2Redmean](https://github.com/ihhub/fheroes2/assets/113276641/f29e4a7f-7638-4ae2-95fe-ab6c0d86c6eb)

The change is noticeable for the dark colors: (there are less noticeable flashes wile fading the credits page)

Master build:
![fheroes2 master 2023-08-23 14-33-36-140](https://github.com/ihhub/fheroes2/assets/113276641/e30a1a18-a691-4a95-97a7-27bd0c99e659)

This PR:
![fheroes2 PR 2023-08-23 14-31-45-500](https://github.com/ihhub/fheroes2/assets/113276641/76fd49ae-f7d9-45fe-90a2-550c50dfd4c8)

<details><summary>Another comparison (castle screen)</summary>

Master build:
![fheroes2 master 2023-08-23 14-09-19-740](https://github.com/ihhub/fheroes2/assets/113276641/b209d4eb-40a1-4e63-88cf-71fce40d93d4)

This PR:
![fheroes2 PR 2023-08-23 14-10-36-540](https://github.com/ihhub/fheroes2/assets/113276641/0028d234-68e8-4045-9031-899b030197d2)

</details>