### PR TITLE
Cancel Hut of Magi reveal area animation when a player clicks any button

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3291,15 +3291,14 @@ namespace
                     Maps::ClearFog( eyeIndex, scoutRange, hero.GetColor() );
 
                     const fheroes2::Point eyePosition = Maps::GetPoint( eyeIndex );
-
-                    I.getGameArea().SetCenter( eyePosition );
-
                     const fheroes2::Rect eyeRoi( eyePosition.x - scoutRange, eyePosition.y - scoutRange, 2 * scoutRange + 1, 2 * scoutRange + 1 );
 
                     if ( skipAnimation ) {
                         clearRadarArea = fheroes2::getBoundaryRect( clearRadarArea, eyeRoi );
                         continue;
                     }
+
+                    I.getGameArea().SetCenter( eyePosition );
 
                     I.getRadar().SetRenderArea( eyeRoi );
                     I.redraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3281,13 +3281,12 @@ namespace
 
                 fheroes2::Display & display = fheroes2::Display::instance();
 
-                const size_t fullTimeViewCount = 3;
-                size_t viewCount = 0;
                 size_t maxDelay = 7;
 
-                for ( const int32_t eyeIndex : eyeMagiIndexes ) {
-                    const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES ) );
+                const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES ) );
+                bool skipAnimation = false;
 
+                for ( const int32_t eyeIndex : eyeMagiIndexes ) {
                     Maps::ClearFog( eyeIndex, scoutRange, hero.GetColor() );
 
                     const fheroes2::Point eyePosition = Maps::GetPoint( eyeIndex );
@@ -3299,12 +3298,21 @@ namespace
                     I.getRadar().SetRenderArea( eyeRoi );
                     I.redraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
 
+                    if ( skipAnimation ) {
+                        continue;
+                    }
+
                     display.render();
 
                     LocalEvent & le = LocalEvent::Get();
                     size_t delay = 0;
 
                     while ( delay < maxDelay && le.HandleEvents( Game::isDelayNeeded( { Game::MAPS_DELAY } ) ) ) {
+                        if ( le.KeyPress() || le.MouseClickLeft() || le.MouseClickMiddle() || le.MouseClickRight() ) {
+                            skipAnimation = true;
+                            break;
+                        }
+
                         if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
                             ++delay;
                             Game::updateAdventureMapAnimationIndex();
@@ -3312,11 +3320,6 @@ namespace
 
                             display.render();
                         }
-                    }
-
-                    ++viewCount;
-                    if ( viewCount > fullTimeViewCount && maxDelay > 0 ) {
-                        --maxDelay;
                     }
                 }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3281,10 +3281,11 @@ namespace
 
                 fheroes2::Display & display = fheroes2::Display::instance();
 
-                size_t maxDelay = 7;
+                const size_t maxDelay = 7;
 
                 const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES ) );
                 bool skipAnimation = false;
+                fheroes2::Rect clearRadarArea;
 
                 for ( const int32_t eyeIndex : eyeMagiIndexes ) {
                     Maps::ClearFog( eyeIndex, scoutRange, hero.GetColor() );
@@ -3295,12 +3296,13 @@ namespace
 
                     const fheroes2::Rect eyeRoi( eyePosition.x - scoutRange, eyePosition.y - scoutRange, 2 * scoutRange + 1, 2 * scoutRange + 1 );
 
-                    I.getRadar().SetRenderArea( eyeRoi );
-                    I.redraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
-
                     if ( skipAnimation ) {
+                        clearRadarArea = fheroes2::getBoundaryRect( clearRadarArea, eyeRoi );
                         continue;
                     }
+
+                    I.getRadar().SetRenderArea( eyeRoi );
+                    I.redraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR );
 
                     display.render();
 
@@ -3321,6 +3323,11 @@ namespace
                             display.render();
                         }
                     }
+                }
+
+                if ( skipAnimation ) {
+                    I.getRadar().SetRenderArea( clearRadarArea );
+                    I.setRedraw( Interface::REDRAW_RADAR );
                 }
 
                 I.getGameArea().SetCenter( hero.GetCenter() );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3285,7 +3285,7 @@ namespace
 
                 const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES ) );
                 bool skipAnimation = false;
-                fheroes2::Rect clearRadarArea;
+                fheroes2::Rect radarRenderArea;
 
                 for ( const int32_t eyeIndex : eyeMagiIndexes ) {
                     Maps::ClearFog( eyeIndex, scoutRange, hero.GetColor() );
@@ -3294,7 +3294,7 @@ namespace
                     const fheroes2::Rect eyeRoi( eyePosition.x - scoutRange, eyePosition.y - scoutRange, 2 * scoutRange + 1, 2 * scoutRange + 1 );
 
                     if ( skipAnimation ) {
-                        clearRadarArea = fheroes2::getBoundaryRect( clearRadarArea, eyeRoi );
+                        radarRenderArea = fheroes2::getBoundaryRect( radarRenderArea, eyeRoi );
                         continue;
                     }
 
@@ -3325,7 +3325,7 @@ namespace
                 }
 
                 if ( skipAnimation ) {
-                    I.getRadar().SetRenderArea( clearRadarArea );
+                    I.getRadar().SetRenderArea( radarRenderArea );
                     I.setRedraw( Interface::REDRAW_RADAR );
                 }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3281,6 +3281,10 @@ namespace
 
                 fheroes2::Display & display = fheroes2::Display::instance();
 
+                const size_t fullTimeViewCount = 3;
+                size_t viewCount = 0;
+                size_t maxDelay = 7;
+
                 for ( const int32_t eyeIndex : eyeMagiIndexes ) {
                     const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES ) );
 
@@ -3298,9 +3302,9 @@ namespace
                     display.render();
 
                     LocalEvent & le = LocalEvent::Get();
-                    int delay = 0;
+                    size_t delay = 0;
 
-                    while ( le.HandleEvents( Game::isDelayNeeded( { Game::MAPS_DELAY } ) ) && delay < 7 ) {
+                    while ( delay < maxDelay && le.HandleEvents( Game::isDelayNeeded( { Game::MAPS_DELAY } ) ) ) {
                         if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
                             ++delay;
                             Game::updateAdventureMapAnimationIndex();
@@ -3308,6 +3312,11 @@ namespace
 
                             display.render();
                         }
+                    }
+
+                    ++viewCount;
+                    if ( viewCount > fullTimeViewCount && maxDelay > 0 ) {
+                        --maxDelay;
                     }
                 }
 


### PR DESCRIPTION
If a map contains a lot of eyes of magi it would take ages to show all of them. This is a solution to avoid such.

Try this save file on this branch and on master:
[Hut_of_Magi.zip](https://github.com/ihhub/fheroes2/files/12441063/Hut_of_Magi.zip)
