### PR TITLE
Add small skill icons for Xanadu visit dialog

### DIFF
--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -635,7 +635,7 @@ namespace fheroes2
 
     void SmallPrimarySkillDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const fheroes2::Sprite & originalImage = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+        const Sprite & originalImage = AGG::GetICN( ICN::SWAPWIN, 0 );
 
         switch ( _skillType ) {
         case Skill::Primary::ATTACK:

--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -639,16 +639,16 @@ namespace fheroes2
 
         switch ( _skillType ) {
         case Skill::Primary::ATTACK:
-            fheroes2::Copy( originalImage, 216, 51, output, offset.x, offset.y, _iconSize.width, _iconSize.height );
+            Copy( originalImage, 216, 51, output, offset.x, offset.y, _iconSize.width, _iconSize.height );
             break;
         case Skill::Primary::DEFENSE:
-            fheroes2::Copy( originalImage, 216, 84, output, offset.x, offset.y, _iconSize.width, _iconSize.height );
+            Copy( originalImage, 216, 84, output, offset.x, offset.y, _iconSize.width, _iconSize.height );
             break;
         case Skill::Primary::POWER:
-            fheroes2::Copy( originalImage, 216, 117, output, offset.x, offset.y, _iconSize.width, _iconSize.height );
+            Copy( originalImage, 216, 117, output, offset.x, offset.y, _iconSize.width, _iconSize.height );
             break;
         case Skill::Primary::KNOWLEDGE:
-            fheroes2::Copy( originalImage, 216, 150, output, offset.x, offset.y, _iconSize.width, _iconSize.height );
+            Copy( originalImage, 216, 150, output, offset.x, offset.y, _iconSize.width, _iconSize.height );
             break;
         default:
             // Are you sure you are passing the correct Primary Skill type?
@@ -805,111 +805,5 @@ namespace fheroes2
         }
 
         return false;
-    }
-
-    void FrameDialogElement::addItem( const DialogElement * item )
-    {
-        if ( item == nullptr ) {
-            // What are you trying to do?
-            assert( item != nullptr );
-            return;
-        }
-
-        _items.push_back( item );
-
-        int32_t height = 0;
-        int32_t currentWidth = 0;
-        int32_t currentHeight = 0;
-
-        _offsets.clear();
-
-        for ( const DialogElement * currentItem : _items ) {
-            const Size & area = currentItem->area();
-
-            if ( currentWidth == 0 ) {
-                _offsets.emplace_back( 0, height );
-                currentWidth = area.width;
-                currentHeight = area.height;
-            }
-            else if ( currentWidth + area.width + elementOffsetX > _width ) {
-                const int32_t leftOffset = ( _width - currentWidth ) / 2;
-
-                for ( auto iter = _offsets.rbegin(); iter != _offsets.rend(); ++iter ) {
-                    if ( iter->y != height ) {
-                        break;
-                    }
-
-                    iter->x += leftOffset;
-                }
-
-                height += currentHeight;
-                height += textOffsetY;
-
-                _offsets.emplace_back( 0, height );
-
-                currentWidth = area.width;
-                currentHeight = area.height;
-            }
-            else {
-                currentWidth += elementOffsetX;
-
-                _offsets.emplace_back( currentWidth, height );
-
-                currentWidth += area.width;
-                currentHeight = std::max( currentHeight, area.height );
-            }
-        }
-
-        const int32_t leftOffset = ( _width - currentWidth ) / 2;
-
-        for ( auto iter = _offsets.rbegin(); iter != _offsets.rend(); ++iter ) {
-            if ( iter->y != height ) {
-                break;
-            }
-
-            iter->x += leftOffset;
-        }
-
-        height += currentHeight;
-
-        _area = { _width, height };
-    }
-
-    void FrameDialogElement::draw( Image & output, const Point & offset ) const
-    {
-        assert( _offsets.size() == _items.size() );
-
-        for ( size_t i = 0; i < _items.size(); ++i ) {
-            _items[i]->draw( output, offset + _offsets[i] );
-        }
-    }
-
-    void FrameDialogElement::processEvents( const Point & offset ) const
-    {
-        assert( _offsets.size() == _items.size() );
-
-        for ( size_t i = 0; i < _items.size(); ++i ) {
-            _items[i]->processEvents( offset + _offsets[i] );
-        }
-    }
-
-    void FrameDialogElement::showPopup( const int /* buttons */ ) const
-    {
-        assert( 0 );
-    }
-
-    bool FrameDialogElement::update( Image & output, const Point & offset ) const
-    {
-        bool update = false;
-
-        assert( _offsets.size() == _items.size() );
-
-        for ( size_t i = 0; i < _items.size(); ++i ) {
-            if ( _items[i]->update( output, offset + _offsets[i] ) ) {
-                update = true;
-            }
-        }
-
-        return update;
     }
 }

--- a/src/fheroes2/gui/ui_dialog.h
+++ b/src/fheroes2/gui/ui_dialog.h
@@ -336,33 +336,4 @@ namespace fheroes2
 
         mutable uint32_t _currentIndex;
     };
-
-    class FrameDialogElement : public DialogElement
-    {
-    public:
-        explicit FrameDialogElement( const int32_t width )
-            : _width( width )
-        {
-            // Do nothing.
-        }
-
-        ~FrameDialogElement() override = default;
-
-        void addItem( const DialogElement * item );
-
-        void draw( Image & output, const Point & offset ) const override;
-
-        void processEvents( const Point & offset ) const override;
-
-        // Never call this method as a custom image has nothing to popup.
-        void showPopup( const int buttons ) const override;
-
-        bool update( Image & output, const Point & offset ) const override;
-
-    private:
-        const int32_t _width{ 0 };
-
-        std::vector<const DialogElement *> _items;
-        std::vector<Point> _offsets;
-    };
 }

--- a/src/fheroes2/gui/ui_dialog.h
+++ b/src/fheroes2/gui/ui_dialog.h
@@ -103,9 +103,7 @@ namespace fheroes2
     class CustomImageDialogElement : public DialogElement
     {
     public:
-        explicit CustomImageDialogElement( const Image & image );
-
-        explicit CustomImageDialogElement( Image && image );
+        explicit CustomImageDialogElement( Image image );
 
         ~CustomImageDialogElement() override = default;
 
@@ -140,9 +138,7 @@ namespace fheroes2
     class ResourceDialogElement : public DialogElement
     {
     public:
-        ResourceDialogElement( const int32_t resourceType, const std::string & text );
-
-        ResourceDialogElement( const int32_t resourceType, std::string && text );
+        ResourceDialogElement( const int32_t resourceType, std::string text );
 
         ~ResourceDialogElement() override = default;
 
@@ -156,8 +152,6 @@ namespace fheroes2
         const int32_t _resourceType = 0;
         const uint32_t _icnIndex = 0;
         const std::string _text;
-
-        void init();
     };
 
     std::vector<ResourceDialogElement> getResourceDialogElements( const Funds & funds );
@@ -236,9 +230,7 @@ namespace fheroes2
     class PrimarySkillDialogElement : public DialogElement
     {
     public:
-        PrimarySkillDialogElement( const int32_t skillType, const std::string & text );
-
-        PrimarySkillDialogElement( const int32_t skillType, std::string && text );
+        PrimarySkillDialogElement( const int32_t skillType, std::string text );
 
         ~PrimarySkillDialogElement() override = default;
 
@@ -248,11 +240,22 @@ namespace fheroes2
 
         void showPopup( const int buttons ) const override;
 
-    private:
+    protected:
         const int32_t _skillType;
         const std::string _text;
+    };
 
-        void init();
+    class SmallPrimarySkillDialogElement : public PrimarySkillDialogElement
+    {
+    public:
+        SmallPrimarySkillDialogElement( const int32_t skillType, std::string text );
+
+        ~SmallPrimarySkillDialogElement() override = default;
+
+        void draw( Image & output, const Point & offset ) const override;
+
+    private:
+        const Size _iconSize{ 34, 34 };
     };
 
     class SecondarySkillDialogElement : public DialogElement
@@ -332,5 +335,34 @@ namespace fheroes2
         const uint64_t _delay;
 
         mutable uint32_t _currentIndex;
+    };
+
+    class FrameDialogElement : public DialogElement
+    {
+    public:
+        explicit FrameDialogElement( const int32_t width )
+            : _width( width )
+        {
+            // Do nothing.
+        }
+
+        ~FrameDialogElement() override = default;
+
+        void addItem( const DialogElement * item );
+
+        void draw( Image & output, const Point & offset ) const override;
+
+        void processEvents( const Point & offset ) const override;
+
+        // Never call this method as a custom image has nothing to popup.
+        void showPopup( const int buttons ) const override;
+
+        bool update( Image & output, const Point & offset ) const override;
+
+    private:
+        const int32_t _width{ 0 };
+
+        std::vector<const DialogElement *> _items;
+        std::vector<Point> _offsets;
     };
 }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2490,8 +2490,6 @@ namespace
     {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
-        
-
         const Maps::Tiles & tile = world.GetTiles( dst_index );
         const std::string title( MP2::StringObject( objectType ) );
 
@@ -2517,10 +2515,11 @@ namespace
                     secondFrame.addItem( &powerUI );
                     secondFrame.addItem( &knowledgeUI );
 
-                    fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ),
-                                           fheroes2::Text( _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ),
-                                                           fheroes2::FontType::normalWhite() ), Dialog::OK,
-                               { &firstFrame, &secondFrame } );
+                    fheroes2::
+                        showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ),
+                                     fheroes2::Text( _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ),
+                                                     fheroes2::FontType::normalWhite() ),
+                                     Dialog::OK, { &firstFrame, &secondFrame } );
                 }
 
                 hero.IncreasePrimarySkill( Skill::Primary::ATTACK );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2490,6 +2490,8 @@ namespace
     {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
+        
+
         const Maps::Tiles & tile = world.GetTiles( dst_index );
         const std::string title( MP2::StringObject( objectType ) );
 
@@ -2502,8 +2504,23 @@ namespace
                 {
                     const MusicalEffectPlayer musicalEffectPlayer( MUS::XANADU );
 
-                    Dialog::Message( title, _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ), Font::BIG,
-                                     Dialog::OK );
+                    const fheroes2::SmallPrimarySkillDialogElement attackUI( Skill::Primary::ATTACK, "+1" );
+                    const fheroes2::SmallPrimarySkillDialogElement defenseUI( Skill::Primary::DEFENSE, "+1" );
+                    const fheroes2::SmallPrimarySkillDialogElement powerUI( Skill::Primary::POWER, "+1" );
+                    const fheroes2::SmallPrimarySkillDialogElement knowledgeUI( Skill::Primary::KNOWLEDGE, "+1" );
+
+                    fheroes2::FrameDialogElement firstFrame( BOXAREA_WIDTH );
+                    fheroes2::FrameDialogElement secondFrame( BOXAREA_WIDTH );
+
+                    firstFrame.addItem( &attackUI );
+                    firstFrame.addItem( &defenseUI );
+                    secondFrame.addItem( &powerUI );
+                    secondFrame.addItem( &knowledgeUI );
+
+                    fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ),
+                                           fheroes2::Text( _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ),
+                                                           fheroes2::FontType::normalWhite() ), Dialog::OK,
+                               { &firstFrame, &secondFrame } );
                 }
 
                 hero.IncreasePrimarySkill( Skill::Primary::ATTACK );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2507,19 +2507,11 @@ namespace
                     const fheroes2::SmallPrimarySkillDialogElement powerUI( Skill::Primary::POWER, "+1" );
                     const fheroes2::SmallPrimarySkillDialogElement knowledgeUI( Skill::Primary::KNOWLEDGE, "+1" );
 
-                    fheroes2::FrameDialogElement firstFrame( BOXAREA_WIDTH );
-                    fheroes2::FrameDialogElement secondFrame( BOXAREA_WIDTH );
-
-                    firstFrame.addItem( &attackUI );
-                    firstFrame.addItem( &defenseUI );
-                    secondFrame.addItem( &powerUI );
-                    secondFrame.addItem( &knowledgeUI );
-
                     fheroes2::
                         showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ),
                                      fheroes2::Text( _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ),
                                                      fheroes2::FontType::normalWhite() ),
-                                     Dialog::OK, { &firstFrame, &secondFrame } );
+                                     Dialog::OK, { &attackUI, &defenseUI, &powerUI, &knowledgeUI } );
                 }
 
                 hero.IncreasePrimarySkill( Skill::Primary::ATTACK );


### PR DESCRIPTION
close #5242

The icons are right clickable.
![image](https://github.com/ihhub/fheroes2/assets/19829520/4f4a6b59-9100-415f-9b51-6a0a95d19ce9)

You can test the change using this save file:
[xanadu.zip](https://github.com/ihhub/fheroes2/files/12444369/xanadu.zip)
