### PR TITLE
Fix missing hero and town name in dialogs

### DIFF
--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -56,6 +56,7 @@
 #include "ui_button.h"
 #include "ui_castle.h"
 #include "ui_kingdom.h"
+#include "ui_text.h"
 #include "ui_tool.h"
 #include "world.h"
 
@@ -212,8 +213,8 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
     DrawImageCastle( dst_pt );
 
     // castle name
-    Text text( GetName(), Font::SMALL );
-    text.Blit( cur_pt.x + 538 - text.w() / 2, cur_pt.y + 1 );
+    const fheroes2::Text castleName( GetName(), fheroes2::FontType::smallWhite() );
+    castleName.draw( cur_pt.x + 538 - castleName.width() / 2, cur_pt.y + 3, display );
 
     BuildingInfo dwelling1( *this, DWELLING_MONSTER1 );
     dwelling1.SetPos( cur_pt.x + 5, cur_pt.y + 2 );
@@ -337,7 +338,7 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
     fheroes2::MovableSprite cursorFormat( fheroes2::AGG::GetICN( ICN::HSICONS, 11 ) );
 
     if ( isBuild( BUILD_CAPTAIN ) ) {
-        text.Set( Skill::Primary::String( Skill::Primary::ATTACK ) + std::string( " " ), Font::SMALL );
+        Text text( Skill::Primary::String( Skill::Primary::ATTACK ) + std::string( " " ), Font::SMALL );
         dst_pt.x = cur_pt.x + 535;
         dst_pt.y = cur_pt.y + 168;
         text.Blit( dst_pt );

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -52,6 +52,7 @@
 #include "tools.h"
 #include "translations.h"
 #include "ui_button.h"
+#include "ui_text.h"
 #include "ui_tool.h"
 #include "ui_window.h"
 
@@ -102,8 +103,9 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     StringReplace( message, "%{name}", name );
     StringReplace( message, "%{race}", Race::String( _race ) );
     StringReplace( message, "%{level}", GetLevel() );
-    const Text text( message, Font::BIG );
-    text.Blit( cur_pt.x + 320 - text.w() / 2, cur_pt.y + 1 );
+
+    const fheroes2::Text title( message, fheroes2::FontType::normalWhite() );
+    title.draw( cur_pt.x + 320 - title.width() / 2, cur_pt.y + 3, display );
 
     PrimarySkillsBar primskill_bar( this, false );
     primskill_bar.setTableSize( { 4, 1 } );

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -48,6 +48,7 @@
 #include "skill.h"
 #include "skill_bar.h"
 #include "statusbar.h"
+#include "text.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_button.h"

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -48,7 +48,6 @@
 #include "skill.h"
 #include "skill_bar.h"
 #include "statusbar.h"
-#include "text.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_button.h"


### PR DESCRIPTION
If the selected game language is not the same as the save game then in the Hero View dialog we cannot see any name. This is because old Text doesn't support invalid characters. The new class does with ? symbols.

Before:
![image](https://github.com/ihhub/fheroes2/assets/19829520/e37e835b-9dd8-44c4-8633-ec386c0a752a)

After:
![image](https://github.com/ihhub/fheroes2/assets/19829520/95fda6f9-0773-44bb-8cbe-fceef160ddbe)

Also castle name is not being displayed:
![image](https://github.com/ihhub/fheroes2/assets/19829520/4cd0899b-532e-45c9-8629-459a7dca790b)

After:
![image](https://github.com/ihhub/fheroes2/assets/19829520/b3c48b65-650b-4eed-99de-7d3a767482a2)

Recruit message in the status bar will be fixed in a separate pull request.

Of course it doesn't solve the problem with invalid characters but at least it is better to show something than an empty text.