### PR TITLE
Fix the weird logic of MP2::isWaterActionObject()

### DIFF
--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -501,10 +501,6 @@ int Interface::AdventureMap::GetCursorFocusShipmaster( const Heroes & hero, cons
         break;
     }
 
-    case MP2::OBJ_MONSTER:
-        // TODO: Can monsters be placed on water?
-        return isWater ? Cursor::DistanceThemes( Cursor::CURSOR_HERO_FIGHT, hero.getNumOfTravelDays( tile.GetIndex() ) ) : Cursor::POINTER;
-
     case MP2::OBJ_COAST:
         return Cursor::DistanceThemes( Cursor::CURSOR_HERO_ANCHOR, hero.getNumOfTravelDays( tile.GetIndex() ) );
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -501,6 +501,10 @@ int Interface::AdventureMap::GetCursorFocusShipmaster( const Heroes & hero, cons
         break;
     }
 
+    // Some map editors allow to place monsters on water tiles
+    case MP2::OBJ_MONSTER:
+        return isWater ? Cursor::DistanceThemes( Cursor::CURSOR_HERO_FIGHT, hero.getNumOfTravelDays( tile.GetIndex() ) ) : Cursor::POINTER;
+
     case MP2::OBJ_COAST:
         return Cursor::DistanceThemes( Cursor::CURSOR_HERO_ANCHOR, hero.getNumOfTravelDays( tile.GetIndex() ) );
 

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -590,6 +590,7 @@ bool MP2::isWaterActionObject( const MapObjectType objectType )
     case OBJ_COAST:
     case OBJ_DERELICT_SHIP:
     case OBJ_FLOTSAM:
+    case OBJ_HEROES:
     case OBJ_MAGELLANS_MAPS:
     case OBJ_MERMAID:
     case OBJ_MONSTER:

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -583,8 +583,8 @@ bool MP2::isActionObject( const MapObjectType objectType, const bool accessedFro
 bool MP2::isWaterActionObject( const MapObjectType objectType )
 {
     switch ( objectType ) {
+    // It's funny, but the OG editor can place artifacts on the water, thus, hero should be able to reach them by water
     case OBJ_ARTIFACT:
-    case OBJ_BARRIER:
     case OBJ_BOTTLE:
     case OBJ_BUOY:
     case OBJ_COAST:
@@ -593,23 +593,17 @@ bool MP2::isWaterActionObject( const MapObjectType objectType )
     case OBJ_HEROES:
     case OBJ_MAGELLANS_MAPS:
     case OBJ_MERMAID:
-    case OBJ_MONSTER:
-    case OBJ_RESOURCE:
     case OBJ_SEA_CHEST:
     case OBJ_SHIPWRECK:
     case OBJ_SHIPWRECK_SURVIVOR:
     case OBJ_SIRENS:
     case OBJ_WHIRLPOOL:
         return true;
-    case OBJ_BOAT:
-    case OBJ_CASTLE:
-        return false;
     default:
         break;
     }
 
-    // price loyalty: editor allow place other objects
-    return Settings::Get().isPriceOfLoyaltySupported() ? isActionObject( objectType ) : false;
+    return false;
 }
 
 bool MP2::isActionObject( const MapObjectType objectType )

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -591,6 +591,7 @@ bool MP2::isWaterActionObject( const MapObjectType objectType )
     case OBJ_COAST:
     case OBJ_DERELICT_SHIP:
     case OBJ_FLOTSAM:
+    // Heroes cannot be placed on water by the original editor, but they can board a boat
     case OBJ_HEROES:
     case OBJ_MAGELLANS_MAPS:
     case OBJ_MERMAID:

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -583,7 +583,8 @@ bool MP2::isActionObject( const MapObjectType objectType, const bool accessedFro
 bool MP2::isWaterActionObject( const MapObjectType objectType )
 {
     switch ( objectType ) {
-    // It's funny, but the OG editor can place artifacts on the water, thus, hero should be able to reach them by water
+    // These are the types of objects that can be placed on water tiles by the original editor and,
+    // therefore, should be accessible to the hero who is on board the boat (yes, artifacts too).
     case OBJ_ARTIFACT:
     case OBJ_BOTTLE:
     case OBJ_BUOY:
@@ -599,11 +600,18 @@ bool MP2::isWaterActionObject( const MapObjectType objectType )
     case OBJ_SIRENS:
     case OBJ_WHIRLPOOL:
         return true;
+
+    case OBJ_BOAT:
+    case OBJ_CASTLE:
+        return false;
+
     default:
         break;
     }
 
-    return false;
+    // Here we would have to return false, but some map editors allow to place arbitrary objects
+    // on water tiles, so we have to work with this.
+    return isActionObject( objectType );
 }
 
 bool MP2::isActionObject( const MapObjectType objectType )


### PR DESCRIPTION
fix #7648

Although I'm perfectly sure about the `OBJ_HEROES` case, I'm not so sure about removed cases (barriers, monsters, resources and even other object types in PoL). Are there really any known maps where similar objects are located on water or should be accessed directly from water?