### PR TITLE
Rework the Save/Load game dialog to allow variable dialog size and support Evil interface

### DIFF
--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -204,13 +204,13 @@ namespace Battle
         StatusListBox * listlog;
     };
 
-    class TurnOrder : public fheroes2::Rect
+    class ArmiesOrder : public fheroes2::Rect
     {
     public:
-        TurnOrder();
-        TurnOrder( const TurnOrder & ) = delete;
+        ArmiesOrder();
+        ArmiesOrder( const ArmiesOrder & ) = delete;
 
-        TurnOrder & operator=( const TurnOrder & ) = delete;
+        ArmiesOrder & operator=( const ArmiesOrder & ) = delete;
 
         void Set( const fheroes2::Rect & rt, const std::shared_ptr<const Units> & units, const int army2Color );
         void Redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output );
@@ -458,7 +458,7 @@ namespace Battle
         std::unique_ptr<StatusListBox> listlog;
 
         PopupDamageInfo popup;
-        TurnOrder armies_order;
+        ArmiesOrder armies_order;
 
         CursorRestorer _cursorRestorer;
         std::unique_ptr<fheroes2::StandardWindow> _background;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -204,13 +204,13 @@ namespace Battle
         StatusListBox * listlog;
     };
 
-    class ArmiesOrder : public fheroes2::Rect
+    class TurnOrder : public fheroes2::Rect
     {
     public:
-        ArmiesOrder();
-        ArmiesOrder( const ArmiesOrder & ) = delete;
+        TurnOrder();
+        TurnOrder( const TurnOrder & ) = delete;
 
-        ArmiesOrder & operator=( const ArmiesOrder & ) = delete;
+        TurnOrder & operator=( const TurnOrder & ) = delete;
 
         void Set( const fheroes2::Rect & rt, const std::shared_ptr<const Units> & units, const int army2Color );
         void Redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output );
@@ -458,7 +458,7 @@ namespace Battle
         std::unique_ptr<StatusListBox> listlog;
 
         PopupDamageInfo popup;
-        ArmiesOrder armies_order;
+        TurnOrder armies_order;
 
         CursorRestorer _cursorRestorer;
         std::unique_ptr<fheroes2::StandardWindow> _background;

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -310,7 +310,7 @@ namespace
 
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        // Dialog height is also caped with the current screen height.
+        // Dialog height is also capped with the current screen height.
         fheroes2::StandardWindow background( 455, std::min( display.height() - 100, maxDialogHeight ), true, display );
 
         const fheroes2::Rect area = background.activeArea();
@@ -596,8 +596,8 @@ namespace
                     charInsertPos = filename.size();
                 }
                 else if ( isEditing ) {
-                    // Empty last selected save file name so that we can replace the input field's name if we select the same save file again
-                    // but when loading (isEditing == false), this doesn't matter since we cannot write to the input field
+                    // Empty last selected save file name so that we can replace the input field's name if we select the same save file again.
+                    // But when loading (i.e. isEditing == false), this doesn't matter since we cannot write to the input field
                     lastSelectedSaveFileName = "";
                 }
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -62,6 +62,9 @@
 
 namespace
 {
+    // This constant sets the maximum displayed file name width. This value affects the dialog horizontal size.
+    const int32_t maxFileNameWidth = 260;
+
     std::string ResizeToShortName( const std::string & str )
     {
         std::string res = System::GetBasename( str );
@@ -132,14 +135,12 @@ namespace
 
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        const int32_t maxTextWidth = field.width - 4;
-
         fheroes2::Text currentFilename( filename, isEditing ? fheroes2::FontType::normalWhite() : fheroes2::FontType::normalYellow() );
         const int32_t initialTextWidth = currentFilename.width();
-        currentFilename.fitToOneRow( maxTextWidth );
-        currentFilename.draw( field.x + 2 + ( maxTextWidth - currentFilename.width() ) / 2, field.y + 4, display );
+        currentFilename.fitToOneRow( maxFileNameWidth );
+        currentFilename.draw( field.x + 4 + ( maxFileNameWidth - currentFilename.width() ) / 2, field.y + 4, display );
 
-        return ( initialTextWidth + 12 ) > maxTextWidth;
+        return ( initialTextWidth + 10 ) > maxFileNameWidth;
     }
 
     class FileInfoListBox : public Interface::ListBox<Maps::FileInfo>
@@ -240,13 +241,10 @@ namespace
         dsty += 2;
 
         fheroes2::Text text{ std::move( savname ), font };
-        const int32_t textMaxWidth = _listBackground->width() - 119;
-        text.fitToOneRow( textMaxWidth );
-        text.draw( dstx + ( textMaxWidth - text.width() ) / 2, dsty, display );
+        text.fitToOneRow( maxFileNameWidth );
+        text.draw( dstx + 4 + ( maxFileNameWidth - text.width() ) / 2, dsty, display );
 
-        dstx += textMaxWidth;
-
-        redrawDateTime( display, info.timestamp, dstx, dsty, font );
+        redrawDateTime( display, info.timestamp, dstx + maxFileNameWidth + 9, dsty, font );
     }
 
     void FileInfoListBox::RedrawBackground( const fheroes2::Point & /* unused */ )
@@ -302,20 +300,20 @@ namespace
         MapsFileInfoList lists = getSortedMapsFileInfoList();
 
         const int32_t listHeightDeduction = 112;
-        const int32_t listAreaOffserY = 3;
+        const int32_t listAreaOffsetY = 3;
         const int32_t listAreaHeightDeduction = 4;
         // If we have not much save files we reduce the maximum dialog height but not less than for 4 elements.
-        const int32_t maxDialogHeight = fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) * std::max( static_cast<int32_t>( lists.size() ), 4 ) + listAreaOffserY
+        const int32_t maxDialogHeight = fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) * std::max( static_cast<int32_t>( lists.size() ), 4 ) + listAreaOffsetY
                                         + listAreaHeightDeduction + listHeightDeduction;
 
         fheroes2::Display & display = fheroes2::Display::instance();
 
         // Dialog height is also capped with the current screen height.
-        fheroes2::StandardWindow background( 455, std::min( display.height() - 100, maxDialogHeight ), true, display );
+        fheroes2::StandardWindow background( maxFileNameWidth + 204, std::min( display.height() - 100, maxDialogHeight ), true, display );
 
         const fheroes2::Rect area = background.activeArea();
         const fheroes2::Rect listRoi( area.x + 24, area.y + 37, area.width - 75, area.height - listHeightDeduction );
-        const fheroes2::Rect textInputRoi( listRoi.x, listRoi.y + listRoi.height + 12, listRoi.width - 119, 21 );
+        const fheroes2::Rect textInputRoi( listRoi.x, listRoi.y + listRoi.height + 12, maxFileNameWidth + 8, 21 );
         const int32_t dateTimeoffsetX = textInputRoi.x + textInputRoi.width;
         const int32_t dateTimeWidth = listRoi.width - textInputRoi.width;
 
@@ -362,7 +360,7 @@ namespace
         // Initialize list background restorer to use it in list method 'listbox.RedrawBackground()'.
         listbox.initListBackgroundRestorer( listRoi );
 
-        listbox.SetAreaItems( { listRoi.x, listRoi.y + 3, listRoi.width - listAreaOffserY, listRoi.height - listAreaHeightDeduction } );
+        listbox.SetAreaItems( { listRoi.x, listRoi.y + 3, listRoi.width - listAreaOffsetY, listRoi.height - listAreaHeightDeduction } );
 
         // Render the scrollbar.
         const fheroes2::Sprite & scrollBar = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -201,7 +201,7 @@ namespace
             dsty += 2;
 
             fheroes2::Text text{ std::move( savname ), font };
-            const int32_t textMaxWidth = _listBackground->width() - 120;
+            const int32_t textMaxWidth = _listBackground->width() - 119;
             text.fitToOneRow( textMaxWidth );
             text.draw( dstx + ( textMaxWidth - text.width() ) / 2, dsty, display );
 
@@ -297,7 +297,7 @@ namespace
 
         // We divide the save-files list: file name and file date/time.
         background.applyTextBackgroundShading( { listRoi.x, listRoi.y, textInputRoi.width, listRoi.height } );
-        background.applyTextBackgroundShading( { listRoi.x + textInputRoi.width - 2, listRoi.y, listRoi.width - textInputRoi.width + 2, listRoi.height } );
+        background.applyTextBackgroundShading( { listRoi.x + textInputRoi.width, listRoi.y, listRoi.width - textInputRoi.width, listRoi.height } );
         background.applyTextBackgroundShading( textInputRoi );
 
         fheroes2::ImageRestorer textInputBackground( fheroes2::Display::instance(), textInputRoi.x, textInputRoi.y, textInputRoi.width, textInputRoi.height );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -459,8 +459,7 @@ namespace
         }
         else if ( listbox.isSelected() ) {
             // Render the game date from file info.
-            redrawShortGameDate( display, listbox.GetCurrent(), dateTimeoffsetX, textInputRoi.y + 4, dateTimeWidth,
-                                 fheroes2::FontType::normalYellow() );
+            redrawShortGameDate( display, listbox.GetCurrent(), dateTimeoffsetX, textInputRoi.y + 4, dateTimeWidth, fheroes2::FontType::normalYellow() );
         }
 
         display.render( background.totalArea() );
@@ -609,8 +608,7 @@ namespace
                 }
                 else {
                     redrawTextInputField( filename, textInputRoi, false );
-                    redrawShortGameDate( display, listbox.GetCurrent(), dateTimeoffsetX, textInputRoi.y + 4, dateTimeWidth,
-                                         fheroes2::FontType::normalYellow() );
+                    redrawShortGameDate( display, listbox.GetCurrent(), dateTimeoffsetX, textInputRoi.y + 4, dateTimeWidth, fheroes2::FontType::normalYellow() );
                 }
             }
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -302,8 +302,8 @@ namespace
         const int32_t listHeightDeduction = 112;
         const int32_t listAreaOffsetY = 3;
         const int32_t listAreaHeightDeduction = 4;
-        // If we have not much save files we reduce the maximum dialog height but not less than for 4 elements.
-        const int32_t maxDialogHeight = fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) * std::max( static_cast<int32_t>( lists.size() ), 4 ) + listAreaOffsetY
+        // If we have not much save files we reduce the maximum dialog height but not less than for 11 elements.
+        const int32_t maxDialogHeight = fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) * std::max( static_cast<int32_t>( lists.size() ), 11 ) + listAreaOffsetY
                                         + listAreaHeightDeduction + listHeightDeduction;
 
         fheroes2::Display & display = fheroes2::Display::instance();

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -400,13 +400,13 @@ namespace
             MapsFileInfoList::iterator it = lists.begin();
             for ( ; it != lists.end(); ++it ) {
                 if ( ( *it ).file == lastfile ) {
-                    fileTimestamp = ( *it ).timestamp;
                     break;
                 }
             }
 
             if ( it != lists.end() ) {
                 listbox.SetCurrent( std::distance( lists.begin(), it ) );
+                fileTimestamp = ( *it ).timestamp;
             }
             else {
                 if ( !isEditing ) {
@@ -442,7 +442,7 @@ namespace
 
             Game::passAnimationDelay( Game::DelayType::CURSOR_BLINK_DELAY );
         }
-        else {
+        else if ( listbox.isSelected() ) {
             // Render date and time of selected file.
             redrawDateTime( display, fileTimestamp, textInputRoi.x + textInputRoi.width, textInputRoi.y + 4, fheroes2::FontType::normalYellow() );
         }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -286,9 +286,12 @@ namespace
         const int32_t listHeightDeduction = 112;
         const int32_t listAreaOffsetY = 3;
         const int32_t listAreaHeightDeduction = 4;
-        // If we have not much save files we reduce the maximum dialog height but not less than for 11 elements.
-        const int32_t maxDialogHeight = fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) * std::max( static_cast<int32_t>( lists.size() ), 11 ) + listAreaOffsetY
-                                        + listAreaHeightDeduction + listHeightDeduction;
+
+        // If we don't have many save files, we reduce the maximum dialog height,
+        // but not less than enough for 11 elements.
+        // We also limit the maximum list height to 22 lines.
+        const int32_t maxDialogHeight = fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) * std::clamp( static_cast<int32_t>( lists.size() ), 11, 22 )
+                                        + listAreaOffsetY + listAreaHeightDeduction + listHeightDeduction;
 
         fheroes2::Display & display = fheroes2::Display::instance();
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -115,7 +115,7 @@ namespace
             // To avoid this we have to replace all '\' symbols by '/' symbols.
             std::string fullPath = info.file;
 
-            // TODO: Make '\' symbol in small font to properly show file path in OS familliar style.
+            // TODO: Make '\' symbol in small font to properly show file path in OS familiar style.
             StringReplace( fullPath, "\\", "/" );
 
             const fheroes2::Text header( ResizeToShortName( info.file ), fheroes2::FontType::normalYellow() );
@@ -295,7 +295,7 @@ namespace
         const fheroes2::Rect listRoi( area.x + 24, area.y + 37, area.width - 75, area.height - listHeightDeduction );
         const fheroes2::Rect textInputRoi( listRoi.x, listRoi.y + listRoi.height + 12, listRoi.width - 119, 21 );
 
-        // We divide the savefiles list: file name and file date/time.
+        // We divide the save-files list: file name and file date/time.
         background.applyTextBackgroundShading( { listRoi.x, listRoi.y, textInputRoi.width, listRoi.height } );
         background.applyTextBackgroundShading( { listRoi.x + textInputRoi.width - 2, listRoi.y, listRoi.width - textInputRoi.width + 2, listRoi.height } );
         background.applyTextBackgroundShading( textInputRoi );
@@ -304,7 +304,7 @@ namespace
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
-        // Prepare OKAY and CANCEL buttont and render their shadows.
+        // Prepare OKAY and CANCEL buttons and render their shadows.
         const int buttonOkIcn = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
         const int32_t buttonOffsetY = area.y + area.height - 32;
         fheroes2::Button buttonOk( area.x + 18, buttonOffsetY, buttonOkIcn, 0, 1 );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -74,11 +74,11 @@ namespace
 
     bool redrawTextInputField( const std::string & filename, const fheroes2::Rect & field, const bool whiteFont )
     {
-        fheroes2::Display & display = fheroes2::Display::instance();
-
         if ( filename.empty() ) {
             return false;
         }
+
+        fheroes2::Display & display = fheroes2::Display::instance();
 
         const int32_t maxTextWidth = field.width - 4;
 
@@ -171,6 +171,12 @@ namespace
 
     void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, int32_t dstx, int32_t dsty, bool current )
     {
+        std::string savname( System::GetBasename( info.file ) );
+
+        if ( savname.empty() ) {
+            return;
+        }
+
         const size_t arraySize = 5;
 
         char shortMonth[arraySize];
@@ -185,46 +191,43 @@ namespace
         std::strftime( shortDate, arraySize, "%d", &tmi );
         std::strftime( shortHours, arraySize, "%H", &tmi );
         std::strftime( shortMinutes, arraySize, "%M", &tmi );
-        std::string savname( System::GetBasename( info.file ) );
 
-        if ( !savname.empty() ) {
-            const std::string saveExtension = Game::GetSaveFileExtension();
-            const size_t dotPos = savname.size() - saveExtension.size();
+        const std::string saveExtension = Game::GetSaveFileExtension();
+        const size_t dotPos = savname.size() - saveExtension.size();
 
-            if ( StringLower( savname.substr( dotPos ) ) == saveExtension ) {
-                savname.erase( dotPos );
-            }
-
-            const fheroes2::FontType font = current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
-            fheroes2::Display & display = fheroes2::Display::instance();
-
-            dsty += 2;
-
-            fheroes2::Text text{ std::move( savname ), font };
-            const int32_t textMaxWidth = _listBackground->width() - 119;
-            text.fitToOneRow( textMaxWidth );
-            text.draw( dstx + ( textMaxWidth - text.width() ) / 2, dsty, display );
-
-            dstx += textMaxWidth;
-
-            text.set( shortMonth, font );
-            text.draw( dstx + 4, dsty, display );
-
-            text.set( shortDate, font );
-            text.draw( dstx + 56 - text.width() / 2, dsty, display );
-
-            text.set( ",", font );
-            text.draw( dstx + 66, dsty, display );
-
-            text.set( shortHours, font );
-            text.draw( dstx + 82 - text.width() / 2, dsty, display );
-
-            text.set( ":", font );
-            text.draw( dstx + 92, dsty, display );
-
-            text.set( shortMinutes, font );
-            text.draw( dstx + 105 - text.width() / 2, dsty, display );
+        if ( StringLower( savname.substr( dotPos ) ) == saveExtension ) {
+            savname.erase( dotPos );
         }
+
+        const fheroes2::FontType font = current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
+        fheroes2::Display & display = fheroes2::Display::instance();
+
+        dsty += 2;
+
+        fheroes2::Text text{ std::move( savname ), font };
+        const int32_t textMaxWidth = _listBackground->width() - 119;
+        text.fitToOneRow( textMaxWidth );
+        text.draw( dstx + ( textMaxWidth - text.width() ) / 2, dsty, display );
+
+        dstx += textMaxWidth;
+
+        text.set( shortMonth, font );
+        text.draw( dstx + 4, dsty, display );
+
+        text.set( shortDate, font );
+        text.draw( dstx + 56 - text.width() / 2, dsty, display );
+
+        text.set( ",", font );
+        text.draw( dstx + 66, dsty, display );
+
+        text.set( shortHours, font );
+        text.draw( dstx + 82 - text.width() / 2, dsty, display );
+
+        text.set( ":", font );
+        text.draw( dstx + 92, dsty, display );
+
+        text.set( shortMinutes, font );
+        text.draw( dstx + 105 - text.width() / 2, dsty, display );
     }
 
     void FileInfoListBox::RedrawBackground( const fheroes2::Point & /* unused */ )
@@ -258,13 +261,13 @@ namespace
         list1.ReadDir( Game::GetSaveDir(), Game::GetSaveFileExtension(), false );
 
         MapsFileInfoList list2( list1.size() );
-        int32_t saveFileCount = 0;
+        size_t saveFileCount = 0;
         for ( const std::string & saveFile : list1 ) {
             if ( list2[saveFileCount].ReadSAV( saveFile ) ) {
                 ++saveFileCount;
             }
         }
-        if ( static_cast<size_t>( saveFileCount ) != list2.size() ) {
+        if ( saveFileCount != list2.size() ) {
             list2.resize( saveFileCount );
         }
         std::sort( list2.begin(), list2.end(), Maps::FileInfo::FileSorting );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -48,8 +48,8 @@
 #include "maps_fileinfo.h"
 #include "math_base.h"
 #include "screen.h"
+#include "settings.h"
 #include "system.h"
-#include "text.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_button.h"
@@ -58,6 +58,7 @@
 #include "ui_scrollbar.h"
 #include "ui_text.h"
 #include "ui_tool.h"
+#include "ui_window.h"
 #include "world.h"
 
 namespace
@@ -72,12 +73,9 @@ namespace
         return res;
     }
 
-    bool RedrawExtraInfo( const fheroes2::Rect & windowArea, const std::string & header, const std::string & filename, const fheroes2::Rect & field )
+    bool redrawExtraInfo( const std::string & filename, const fheroes2::Rect & field )
     {
         fheroes2::Display & display = fheroes2::Display::instance();
-
-        const fheroes2::Text title( header, fheroes2::FontType::normalYellow() );
-        title.draw( windowArea.x + ( windowArea.width - title.width() ) / 2, windowArea.y + 32, display );
 
         if ( filename.empty() ) {
             return false;
@@ -85,417 +83,473 @@ namespace
 
         fheroes2::Text currentFilename( filename, fheroes2::FontType::normalWhite() );
         currentFilename.fitToOneRow( field.width );
-        currentFilename.draw( field.x, field.y + 3, display );
+        currentFilename.draw( field.x + 2, field.y + 4, display );
 
         return currentFilename.width() + 10 > field.width;
     }
-}
 
-std::string SelectFileListSimple( const std::string &, const std::string &, const bool );
-
-class FileInfoListBox : public Interface::ListBox<Maps::FileInfo>
-{
-public:
-    using Interface::ListBox<Maps::FileInfo>::ActionListDoubleClick;
-    using Interface::ListBox<Maps::FileInfo>::ActionListSingleClick;
-    using Interface::ListBox<Maps::FileInfo>::ActionListPressRight;
-
-    explicit FileInfoListBox( const fheroes2::Point & pt )
-        : Interface::ListBox<Maps::FileInfo>( pt )
-        , _isDoubleClicked( false )
-    {}
-
-    void RedrawItem( const Maps::FileInfo & info, int32_t dstx, int32_t dsty, bool current ) override;
-    void RedrawBackground( const fheroes2::Point & ) override;
-
-    void ActionCurrentUp() override;
-    void ActionCurrentDn() override;
-    void ActionListDoubleClick( Maps::FileInfo & ) override;
-    void ActionListSingleClick( Maps::FileInfo & ) override;
-
-    void ActionListPressRight( Maps::FileInfo & info ) override
+    class FileInfoListBox : public Interface::ListBox<Maps::FileInfo>
     {
-        // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
-        // To avoid this we have to replace all '\' symbols by '/' symbols.
-        std::string fullPath = info.file;
-        StringReplace( fullPath, "\\", "/" );
+    public:
+        using Interface::ListBox<Maps::FileInfo>::ActionListDoubleClick;
+        using Interface::ListBox<Maps::FileInfo>::ActionListSingleClick;
+        using Interface::ListBox<Maps::FileInfo>::ActionListPressRight;
 
-        const fheroes2::Text header( ResizeToShortName( info.file ), fheroes2::FontType::normalYellow() );
+        explicit FileInfoListBox( const fheroes2::Point & pt )
+            : Interface::ListBox<Maps::FileInfo>( pt )
+        {}
 
-        fheroes2::MultiFontText body;
+        void RedrawItem( const Maps::FileInfo & info, int32_t dstx, int32_t dsty, bool current ) override;
+        void RedrawBackground( const fheroes2::Point & dst ) override;
 
-        body.add( { _( "Map: " ), fheroes2::FontType::normalYellow() } );
-        body.add( { info.name, fheroes2::FontType::normalWhite() } );
+        void ActionCurrentUp() override;
+        void ActionCurrentDn() override;
+        void ActionListDoubleClick( Maps::FileInfo & info ) override;
+        void ActionListSingleClick( Maps::FileInfo & info ) override;
 
-        if ( info.worldDay > 0 || info.worldWeek > 0 || info.worldMonth > 0 ) {
-            body.add( { _( "\n\nMonth: " ), fheroes2::FontType::normalYellow() } );
-            body.add( { std::to_string( info.worldMonth ), fheroes2::FontType::normalWhite() } );
-            body.add( { _( ", Week: " ), fheroes2::FontType::normalYellow() } );
-            body.add( { std::to_string( info.worldWeek ), fheroes2::FontType::normalWhite() } );
-            body.add( { _( ", Day: " ), fheroes2::FontType::normalYellow() } );
-            body.add( { std::to_string( info.worldDay ), fheroes2::FontType::normalWhite() } );
+        void ActionListPressRight( Maps::FileInfo & info ) override
+        {
+            // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
+            // To avoid this we have to replace all '\' symbols by '/' symbols.
+            std::string fullPath = info.file;
+
+            // TODO: Make '\' symbol in small font to properly show file path in OS familliar style.
+            StringReplace( fullPath, "\\", "/" );
+
+            const fheroes2::Text header( ResizeToShortName( info.file ), fheroes2::FontType::normalYellow() );
+
+            fheroes2::MultiFontText body;
+
+            body.add( { _( "Map: " ), fheroes2::FontType::normalYellow() } );
+            body.add( { info.name, fheroes2::FontType::normalWhite() } );
+
+            if ( info.worldDay > 0 || info.worldWeek > 0 || info.worldMonth > 0 ) {
+                body.add( { _( "\n\nMonth: " ), fheroes2::FontType::normalYellow() } );
+                body.add( { std::to_string( info.worldMonth ), fheroes2::FontType::normalWhite() } );
+                body.add( { _( ", Week: " ), fheroes2::FontType::normalYellow() } );
+                body.add( { std::to_string( info.worldWeek ), fheroes2::FontType::normalWhite() } );
+                body.add( { _( ", Day: " ), fheroes2::FontType::normalYellow() } );
+                body.add( { std::to_string( info.worldDay ), fheroes2::FontType::normalWhite() } );
+            }
+
+            body.add( { _( "\n\nLocation: " ), fheroes2::FontType::smallYellow() } );
+            body.add( { fullPath, fheroes2::FontType::smallWhite() } );
+
+            fheroes2::showMessage( header, body, Dialog::ZERO );
         }
 
-        body.add( { _( "\n\nLocation: " ), fheroes2::FontType::smallYellow() } );
-        body.add( { fullPath, fheroes2::FontType::smallWhite() } );
+        void updateScrollBarImage()
+        {
+            const int32_t scrollBarWidth = _scrollbar.width();
 
-        fheroes2::showMessage( header, body, Dialog::ZERO );
-    }
+            setScrollBarImage( fheroes2::generateScrollbarSlider( _scrollbar, false, _scrollbar.getArea().height, VisibleItemCount(), _size(),
+                                                                  { 0, 0, scrollBarWidth, 8 }, { 0, 7, scrollBarWidth, 8 } ) );
+            _scrollbar.moveToIndex( _topId );
+        }
 
-    bool isDoubleClicked() const
+        void initListBackgroundRestorer( fheroes2::Rect roi )
+        {
+            _listBackground = std::make_unique<fheroes2::ImageRestorer>( fheroes2::Display::instance(), roi.x, roi.y, roi.width, roi.height );
+        }
+
+        bool isDoubleClicked() const
+        {
+            return _isDoubleClicked;
+        }
+
+    private:
+        bool _isDoubleClicked{ false };
+        std::unique_ptr<fheroes2::ImageRestorer> _listBackground;
+    };
+
+    void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, int32_t dstx, int32_t dsty, bool current )
     {
-        return _isDoubleClicked;
+        const size_t arraySize = 10;
+        const size_t arrayWriteSize = arraySize - 1;
+
+        char shortDate[arraySize]{ 0 };
+        char shortHours[arraySize]{ 0 };
+        char shortMinutes[arraySize]{ 0 };
+
+        const tm tmi = System::GetTM( info.timestamp );
+
+        std::strftime( shortDate, arrayWriteSize, "%b %d,", &tmi );
+        std::strftime( shortHours, arrayWriteSize, "%H", &tmi );
+        std::strftime( shortMinutes, arrayWriteSize, ":%M", &tmi );
+        std::string savname( System::GetBasename( info.file ) );
+
+        if ( !savname.empty() ) {
+            const std::string saveExtension = Game::GetSaveFileExtension();
+            const size_t dotPos = savname.size() - saveExtension.size();
+
+            if ( StringLower( savname.substr( dotPos ) ) == saveExtension ) {
+                savname.erase( dotPos );
+            }
+
+            const fheroes2::FontType font = current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
+            fheroes2::Display & display = fheroes2::Display::instance();
+
+            dsty += 2;
+
+            fheroes2::Text text{ std::move( savname ), font };
+            text.fitToOneRow( _listBackground->width() - 120 );
+            text.draw( dstx + 5, dsty, display );
+
+            dstx += _listBackground->width();
+
+            text.set( shortDate, font );
+            text.draw( dstx - 45 - text.width(), dsty, display );
+
+            text.set( shortHours, font );
+            text.draw( dstx - 35 - text.width() / 2, dsty, display );
+
+            text.set( shortMinutes, font );
+            text.draw( dstx - 25, dsty, display );
+        }
     }
 
-private:
-    bool _isDoubleClicked;
-};
+    void FileInfoListBox::RedrawBackground( const fheroes2::Point & /* unused */ )
+    {
+        _listBackground->restore();
+    }
 
-#define ARRAY_COUNT( A ) sizeof( A ) / sizeof( A[0] )
+    void FileInfoListBox::ActionCurrentUp()
+    {
+        // Do nothing.
+    }
 
-void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, int32_t dstx, int32_t dsty, bool current )
-{
-    char shortDate[20];
-    char shortHours[20];
-    char shortMinutes[20];
+    void FileInfoListBox::ActionCurrentDn()
+    {
+        // Do nothing.
+    }
 
-    const tm tmi = System::GetTM( info.timestamp );
+    void FileInfoListBox::ActionListDoubleClick( Maps::FileInfo & /*unused*/ )
+    {
+        _isDoubleClicked = true;
+    }
 
-    std::fill( shortDate, std::end( shortDate ), static_cast<char>( 0 ) );
-    std::fill( shortHours, std::end( shortHours ), static_cast<char>( 0 ) );
-    std::fill( shortMinutes, std::end( shortMinutes ), static_cast<char>( 0 ) );
-    std::strftime( shortDate, ARRAY_COUNT( shortDate ) - 1, "%b %d,", &tmi );
-    std::strftime( shortHours, ARRAY_COUNT( shortHours ) - 1, "%H", &tmi );
-    std::strftime( shortMinutes, ARRAY_COUNT( shortMinutes ) - 1, ":%M", &tmi );
-    std::string savname( System::GetBasename( info.file ) );
+    void FileInfoListBox::ActionListSingleClick( Maps::FileInfo & /*unused*/ )
+    {
+        // Do nothing.
+    }
 
-    if ( !savname.empty() ) {
-        const std::string saveExtension = Game::GetSaveFileExtension();
-        const size_t dotPos = savname.size() - saveExtension.size();
+    MapsFileInfoList GetSortedMapsFileInfoList()
+    {
+        ListFiles list1;
+        list1.ReadDir( Game::GetSaveDir(), Game::GetSaveFileExtension(), false );
 
-        if ( StringLower( savname.substr( dotPos ) ) == saveExtension )
-            savname.erase( dotPos );
+        MapsFileInfoList list2( list1.size() );
+        int32_t saveFileCount = 0;
+        for ( const std::string & saveFile : list1 ) {
+            if ( list2[saveFileCount].ReadSAV( saveFile ) ) {
+                ++saveFileCount;
+            }
+        }
+        if ( static_cast<size_t>( saveFileCount ) != list2.size() ) {
+            list2.resize( saveFileCount );
+        }
+        std::sort( list2.begin(), list2.end(), Maps::FileInfo::FileSorting );
 
-        const fheroes2::FontType font = current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
+        return list2;
+    }
+
+    std::string SelectFileListSimple( const std::string & header, const std::string & lastfile, const bool isEditing )
+    {
+        // setup cursor
+        const CursorRestorer cursorRestorer( true, Cursor::POINTER );
+
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        dsty += 2;
+        fheroes2::StandardWindow background( 455, display.height() - 100, true, display );
 
-        fheroes2::Text text{ std::move( savname ), font };
-        text.fitToOneRow( 150 );
-        text.draw( dstx + 5, dsty, display );
+        const fheroes2::Rect area = background.activeArea();
+        const fheroes2::Rect listRoi( area.x + 24, area.y + 37, area.width - 75, area.height - 112 );
+        const fheroes2::Rect textInputRoi( area.x + 24, listRoi.y + listRoi.height + 12, 270, 20 );
+        background.applyTextBackgroundShading( listRoi );
+        background.applyTextBackgroundShading( textInputRoi );
 
-        text.set( shortDate, font );
-        text.draw( dstx + 225 - text.width(), dsty, display );
+        fheroes2::ImageRestorer textInputBackground( fheroes2::Display::instance(), textInputRoi.x, textInputRoi.y, textInputRoi.width, textInputRoi.height );
 
-        text.set( shortHours, font );
-        text.draw( dstx + 245 - text.width(), dsty, display );
+        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
-        text.set( shortMinutes, font );
-        text.draw( dstx + 245, dsty, display );
-    }
-}
+        const int buttonOkIcn = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
+        fheroes2::Button buttonOk( area.x + 18, area.y + area.height - 32, buttonOkIcn, 0, 1 );
+        fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonOkIcn, 0 ), display, buttonOk.area().getPosition(), { -5, 5 } );
 
-void FileInfoListBox::RedrawBackground( const fheroes2::Point & dst )
-{
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::REQBKG, 0 ), fheroes2::Display::instance(), dst.x, dst.y );
-}
+        const int buttonCancelIcn = isEvilInterface ? ICN::BUTTON_SMALL_CANCEL_EVIL : ICN::BUTTON_SMALL_CANCEL_GOOD;
+        const fheroes2::Sprite & buttonCancelSprite = fheroes2::AGG::GetICN( buttonCancelIcn, 0 );
+        fheroes2::Button buttonCancel( area.x + area.width - buttonCancelSprite.width() - 20, area.y + area.height - 32, buttonCancelIcn, 0, 1 );
+        fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonCancelIcn, 0 ), display, buttonCancel.area().getPosition(), { -5, 5 } );
 
-void FileInfoListBox::ActionCurrentUp()
-{
-    // Do nothing.
-}
+        std::unique_ptr<fheroes2::ButtonSprite> buttonVirtualKB;
 
-void FileInfoListBox::ActionCurrentDn()
-{
-    // Do nothing.
-}
+        MapsFileInfoList lists = GetSortedMapsFileInfoList();
+        FileInfoListBox listbox( area.getPosition() );
 
-void FileInfoListBox::ActionListDoubleClick( Maps::FileInfo & )
-{
-    _isDoubleClicked = true;
-}
+        listbox.initListBackgroundRestorer( listRoi );
 
-void FileInfoListBox::ActionListSingleClick( Maps::FileInfo & /*unused*/ )
-{
-    // Do nothing.
-}
+        listbox.SetAreaItems( { listRoi.x, listRoi.y + 5, listRoi.width - 10, listRoi.height - 5 } );
 
-MapsFileInfoList GetSortedMapsFileInfoList()
-{
-    ListFiles list1;
-    list1.ReadDir( Game::GetSaveDir(), Game::GetSaveFileExtension(), false );
+        const fheroes2::Sprite & scrollBar = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
 
-    MapsFileInfoList list2( list1.size() );
-    int32_t saveFileCount = 0;
-    for ( std::string & saveFile : list1 ) {
-        if ( list2[saveFileCount].ReadSAV( std::move( saveFile ) ) ) {
-            ++saveFileCount;
-        }
-    }
-    if ( static_cast<size_t>( saveFileCount ) != list2.size() ) {
-        list2.resize( saveFileCount );
-    }
-    std::sort( list2.begin(), list2.end(), Maps::FileInfo::FileSorting );
+        int32_t scrollbarOffsetX = area.x + area.width - 35;
 
-    return list2;
-}
+        // Top part of scrollbar background.
+        const int32_t topPartHeight = 19;
+        const int32_t scrollBarWidth = 16;
+        fheroes2::Copy( scrollBar, 536, 176, display, scrollbarOffsetX, listRoi.y, scrollBarWidth, topPartHeight );
 
-std::string Dialog::SelectFileSave()
-{
-    std::ostringstream os;
+        // Middle part of scrollbar background.
+        int32_t offsetY = topPartHeight;
+        const int32_t middlePartHeight = 88;
+        const int32_t middlePartCount = ( listRoi.height - 2 * topPartHeight + middlePartHeight - 1 ) / middlePartHeight;
 
-    os << System::concatPath( Game::GetSaveDir(), Game::GetSaveFileBaseName() ) << '_' << std::setw( 4 ) << std::setfill( '0' ) << world.CountDay()
-       << Game::GetSaveFileExtension();
-
-    return SelectFileListSimple( _( "File to Save:" ), os.str(), true );
-}
-
-std::string Dialog::SelectFileLoad()
-{
-    const std::string & lastfile = Game::GetLastSaveName();
-    return SelectFileListSimple( _( "File to Load:" ), ( !lastfile.empty() ? lastfile : "" ), false );
-}
-
-std::string SelectFileListSimple( const std::string & header, const std::string & lastfile, const bool isEditing )
-{
-    fheroes2::Display & display = fheroes2::Display::instance();
-    LocalEvent & le = LocalEvent::Get();
-
-    // setup cursor
-    const CursorRestorer cursorRestorer( true, Cursor::POINTER );
-
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::REQBKG, 0 );
-    const fheroes2::Sprite & spriteShadow = fheroes2::AGG::GetICN( ICN::REQBKG, 1 );
-
-    const fheroes2::Point dialogOffset( ( display.width() - sprite.width() ) / 2, ( display.height() - sprite.height() ) / 2 );
-    const fheroes2::Point shadowOffset( dialogOffset.x - BORDERWIDTH, dialogOffset.y );
-
-    const fheroes2::ImageRestorer restorer( display, shadowOffset.x, shadowOffset.y, sprite.width() + BORDERWIDTH, sprite.height() + BORDERWIDTH );
-    const fheroes2::Rect rt( dialogOffset.x, dialogOffset.y, sprite.width(), sprite.height() );
-
-    fheroes2::Blit( spriteShadow, display, rt.x - BORDERWIDTH, rt.y + BORDERWIDTH );
-
-    const fheroes2::Rect enter_field( rt.x + 42, rt.y + 286, 260, 16 );
-
-    fheroes2::Button buttonOk( rt.x + 34, rt.y + 315, ICN::BUTTON_SMALL_OKAY_GOOD, 0, 1 );
-    fheroes2::Button buttonCancel( rt.x + 244, rt.y + 315, ICN::BUTTON_SMALL_CANCEL_GOOD, 0, 1 );
-
-    fheroes2::ButtonSprite buttonVirtualKB;
-
-    MapsFileInfoList lists = GetSortedMapsFileInfoList();
-    FileInfoListBox listbox( rt.getPosition() );
-
-    listbox.RedrawBackground( rt.getPosition() );
-    listbox.SetScrollButtonUp( ICN::REQUESTS, 5, 6, { rt.x + 327, rt.y + 55 } );
-    listbox.SetScrollButtonDn( ICN::REQUESTS, 7, 8, { rt.x + 327, rt.y + 257 } );
-
-    const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( ICN::ESCROLL, 3 );
-    const fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, 180, 11, static_cast<int32_t>( lists.size() ),
-                                                                               { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
-
-    listbox.setScrollBarArea( { rt.x + 328, rt.y + 73, 12, 180 } );
-    listbox.setScrollBarImage( scrollbarSlider );
-    listbox.SetAreaMaxItems( 11 );
-    listbox.SetAreaItems( { rt.x + 40, rt.y + 55, 265, 215 } );
-    listbox.SetListContent( lists );
-
-    std::string filename;
-    size_t charInsertPos = 0;
-
-    if ( !lastfile.empty() ) {
-        filename = ResizeToShortName( lastfile );
-        charInsertPos = filename.size();
-
-        MapsFileInfoList::iterator it = lists.begin();
-        for ( ; it != lists.end(); ++it ) {
-            if ( ( *it ).file == lastfile ) {
-                break;
-            }
+        for ( int32_t i = 0; i < middlePartCount; ++i ) {
+            fheroes2::Copy( scrollBar, 536, 196, display, scrollbarOffsetX, listRoi.y + offsetY, scrollBarWidth,
+                            std::min( middlePartHeight, listRoi.height - offsetY - topPartHeight ) );
+            offsetY += middlePartHeight;
         }
 
-        if ( it != lists.end() ) {
-            listbox.SetCurrent( std::distance( lists.begin(), it ) );
-        }
-        else {
-            if ( !isEditing ) {
-                filename.clear();
-                charInsertPos = 0;
-            }
-            listbox.Unselect();
-        }
-    }
+        // Bottom part of scrollbar background.
+        fheroes2::Copy( scrollBar, 536, 285, display, scrollbarOffsetX, listRoi.y + listRoi.height - topPartHeight, scrollBarWidth, topPartHeight );
 
-    if ( !isEditing && lists.empty() ) {
-        buttonOk.disable();
-    }
+        const int listIcnId = isEvilInterface ? ICN::SCROLLE : ICN::SCROLL;
 
-    if ( filename.empty() && listbox.isSelected() ) {
-        filename = ResizeToShortName( listbox.GetCurrent().file );
-        charInsertPos = filename.size();
-    }
+        ++scrollbarOffsetX;
 
-    listbox.Redraw();
-    RedrawExtraInfo( rt, header, filename, enter_field );
+        listbox.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, listRoi.y + 1 } );
+        listbox.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, listRoi.y + listRoi.height - 15 } );
 
-    buttonOk.draw();
-    buttonCancel.draw();
+        listbox.setScrollBarArea( { scrollbarOffsetX + 2, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
 
-    if ( isEditing ) {
-        // Generate and render a button to open the Virtual Keyboard window.
-        fheroes2::Sprite released;
-        fheroes2::Sprite pressed;
+        listbox.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
 
-        makeButtonSprites( released, pressed, "...", 15, false, true );
-        buttonVirtualKB = makeButtonWithShadow( rt.x + 315, rt.y + 283, released, pressed, display, { -4, 4 } );
-
-        buttonVirtualKB.draw();
-
-        Game::passAnimationDelay( Game::DelayType::CURSOR_BLINK_DELAY );
-    }
-
-    display.render();
-
-    std::string result;
-    bool is_limit = false;
-    std::string lastSelectedSaveFileName;
-
-    const bool isInGameKeyboardRequired = System::isVirtualKeyboardSupported();
-
-    bool isCursorVisible = true;
-
-    while ( le.HandleEvents( !isEditing || Game::isDelayNeeded( { Game::DelayType::CURSOR_BLINK_DELAY } ) ) && result.empty() ) {
-        le.MousePressLeft( buttonOk.area() ) && buttonOk.isEnabled() ? buttonOk.drawOnPress() : buttonOk.drawOnRelease();
-        le.MousePressLeft( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
-        if ( isEditing ) {
-            le.MousePressLeft( buttonVirtualKB.area() ) ? buttonVirtualKB.drawOnPress() : buttonVirtualKB.drawOnRelease();
+        // Make scrollbar shadow.
+        for ( uint8_t i = 0; i < 4; ++i ) {
+            const uint8_t transformId = i + 2;
+            const int32_t sizeCorrection = i + 1;
+            fheroes2::ApplyTransform( display, scrollbarOffsetX - transformId, listRoi.y + sizeCorrection, 1, listRoi.height - sizeCorrection, transformId );
+            fheroes2::ApplyTransform( display, scrollbarOffsetX - transformId, listRoi.y + listRoi.height + i, scrollBarWidth, 1, transformId );
         }
 
-        const bool listboxEvent = listbox.QueueEventProcessing();
+        listbox.SetAreaMaxItems( ( listRoi.height - 10 ) / fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) );
+        listbox.SetListContent( lists );
+        listbox.updateScrollBarImage();
 
-        bool isListboxSelected = listbox.isSelected();
+        std::string filename;
+        size_t charInsertPos = 0;
 
-        bool needRedraw = false;
+        if ( !lastfile.empty() ) {
+            filename = ResizeToShortName( lastfile );
+            charInsertPos = filename.size();
 
-        if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY )
-             || listbox.isDoubleClicked() ) {
-            if ( !filename.empty() ) {
-                result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
-            }
-            else if ( isListboxSelected ) {
-                result = listbox.GetCurrent().file;
-            }
-        }
-        else if ( le.MouseClickLeft( buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-            break;
-        }
-        else if ( isEditing ) {
-            if ( le.MouseClickLeft( buttonVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( enter_field ) ) ) {
-                fheroes2::openVirtualKeyboard( filename );
-                charInsertPos = filename.size();
-                listbox.Unselect();
-                isListboxSelected = false;
-                needRedraw = true;
-            }
-            else if ( le.MouseClickLeft( enter_field ) ) {
-                charInsertPos = fheroes2::getTextInputCursorPosition( filename, fheroes2::FontType::normalWhite(), charInsertPos, le.GetMouseCursor().x, enter_field.x );
-                if ( filename.empty() ) {
-                    buttonOk.disable();
+            MapsFileInfoList::iterator it = lists.begin();
+            for ( ; it != lists.end(); ++it ) {
+                if ( ( *it ).file == lastfile ) {
+                    break;
                 }
-
-                needRedraw = true;
             }
-            else if ( !listboxEvent && le.KeyPress() && ( !is_limit || fheroes2::Key::KEY_BACKSPACE == le.KeyValue() || fheroes2::Key::KEY_DELETE == le.KeyValue() ) ) {
-                charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
-                if ( filename.empty() ) {
-                    buttonOk.disable();
-                }
-                else {
-                    buttonOk.enable();
-                }
 
-                needRedraw = true;
-                listbox.Unselect();
-                isListboxSelected = false;
-            }
-        }
-
-        if ( le.MousePressRight( buttonCancel.area() ) ) {
-            Dialog::Message( _( "Cancel" ), _( "Exit this menu without doing anything." ), Font::BIG );
-        }
-        else if ( le.MousePressRight( buttonOk.area() ) ) {
-            if ( isEditing ) {
-                Dialog::Message( _( "Okay" ), _( "Click to save the current game." ), Font::BIG );
+            if ( it != lists.end() ) {
+                listbox.SetCurrent( std::distance( lists.begin(), it ) );
             }
             else {
-                Dialog::Message( _( "Okay" ), _( "Click to load a previously saved game." ), Font::BIG );
-            }
-        }
-        else if ( isEditing && le.MousePressRight( buttonVirtualKB.area() ) ) {
-            Dialog::Message( _( "Open Virtual Keyboard" ), _( "Click to open the Virtual Keyboard dialog." ), Font::BIG );
-        }
-
-        if ( !isEditing && le.KeyPress( fheroes2::Key::KEY_DELETE ) && isListboxSelected ) {
-            std::string msg( _( "Are you sure you want to delete file:" ) );
-            msg.append( "\n \n" );
-            msg.append( System::GetBasename( listbox.GetCurrent().file ) );
-            if ( Dialog::YES == Dialog::Message( _( "Warning!" ), msg, Font::BIG, Dialog::YES | Dialog::NO ) ) {
-                System::Unlink( listbox.GetCurrent().file );
-                listbox.RemoveSelected();
-                if ( lists.empty() || filename.empty() ) {
-                    buttonOk.disable();
-                    isListboxSelected = false;
+                if ( !isEditing ) {
                     filename.clear();
+                    charInsertPos = 0;
                 }
-
-                const fheroes2::Image updatedScrollbarSlider
-                    = fheroes2::generateScrollbarSlider( originalSlider, false, 180, 11, static_cast<int32_t>( lists.size() ), { 0, 0, originalSlider.width(), 8 },
-                                                         { 0, 7, originalSlider.width(), 8 } );
-
-                listbox.setScrollBarImage( updatedScrollbarSlider );
-
-                listbox.SetListContent( lists );
+                listbox.Unselect();
             }
-
-            needRedraw = true;
         }
 
-        // Text input cursor blink.
-        if ( isEditing && Game::validateAnimationDelay( Game::DelayType::CURSOR_BLINK_DELAY ) ) {
-            isCursorVisible = !isCursorVisible;
-            needRedraw = true;
+        if ( !isEditing && lists.empty() ) {
+            buttonOk.disable();
         }
 
-        if ( !needRedraw && !listbox.IsNeedRedraw() ) {
-            continue;
+        if ( filename.empty() && listbox.isSelected() ) {
+            filename = ResizeToShortName( listbox.GetCurrent().file );
+            charInsertPos = filename.size();
         }
 
         listbox.Redraw();
+        redrawExtraInfo( filename, textInputRoi );
 
-        const std::string selectedFileName = isListboxSelected ? ResizeToShortName( listbox.GetCurrent().file ) : "";
-        if ( isListboxSelected && lastSelectedSaveFileName != selectedFileName ) {
-            lastSelectedSaveFileName = selectedFileName;
-            filename = selectedFileName;
-            charInsertPos = filename.size();
-        }
-        else if ( isEditing ) {
-            // Empty last selected save file name so that we can replace the input field's name if we select the same save file again
-            // but when loading (isEditing == false), this doesn't matter since we cannot write to the input field
-            lastSelectedSaveFileName = "";
-        }
-
-        is_limit = isEditing ? RedrawExtraInfo( rt, header, insertCharToString( filename, charInsertPos, isCursorVisible ? '_' : '\x7F' ), enter_field )
-                             : RedrawExtraInfo( rt, header, filename, enter_field );
+        const fheroes2::Text title( header, fheroes2::FontType::normalYellow() );
+        title.draw( area.x + ( area.width - title.width() ) / 2, area.y + 16, display );
 
         buttonOk.draw();
         buttonCancel.draw();
 
         if ( isEditing ) {
-            buttonVirtualKB.draw();
+            // Generate and render a button to open the Virtual Keyboard window.
+            fheroes2::Sprite released;
+            fheroes2::Sprite pressed;
+
+            makeButtonSprites( released, pressed, "...", 15, isEvilInterface, false );
+            buttonVirtualKB = std::make_unique<fheroes2::ButtonSprite>( textInputRoi.x + textInputRoi.width + 5, textInputRoi.y, released, pressed );
+
+            fheroes2::addGradientShadow( released, display, buttonVirtualKB->area().getPosition(), { -5, 5 } );
+            buttonVirtualKB->draw();
+
+            Game::passAnimationDelay( Game::DelayType::CURSOR_BLINK_DELAY );
         }
 
-        display.render();
+        display.render( background.totalArea() );
+
+        std::string result;
+        bool isTextLimit = false;
+        std::string lastSelectedSaveFileName;
+
+        const bool isInGameKeyboardRequired = System::isVirtualKeyboardSupported();
+
+        bool isCursorVisible = true;
+
+        LocalEvent & le = LocalEvent::Get();
+
+        while ( le.HandleEvents( !isEditing || Game::isDelayNeeded( { Game::DelayType::CURSOR_BLINK_DELAY } ) ) && result.empty() ) {
+            le.MousePressLeft( buttonOk.area() ) && buttonOk.isEnabled() ? buttonOk.drawOnPress() : buttonOk.drawOnRelease();
+            le.MousePressLeft( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
+            if ( isEditing ) {
+                le.MousePressLeft( buttonVirtualKB->area() ) ? buttonVirtualKB->drawOnPress() : buttonVirtualKB->drawOnRelease();
+            }
+
+            const bool listboxEvent = listbox.QueueEventProcessing();
+
+            bool isListboxSelected = listbox.isSelected();
+
+            bool needRedraw = false;
+
+            if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY )
+                 || listbox.isDoubleClicked() ) {
+                if ( !filename.empty() ) {
+                    result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
+                }
+                else if ( isListboxSelected ) {
+                    result = listbox.GetCurrent().file;
+                }
+            }
+            else if ( le.MouseClickLeft( buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
+                break;
+            }
+            else if ( isEditing ) {
+                if ( le.MouseClickLeft( buttonVirtualKB->area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( textInputRoi ) ) ) {
+                    fheroes2::openVirtualKeyboard( filename );
+                    charInsertPos = filename.size();
+                    listbox.Unselect();
+                    isListboxSelected = false;
+                    needRedraw = true;
+                }
+                else if ( le.MouseClickLeft( textInputRoi ) ) {
+                    charInsertPos
+                        = fheroes2::getTextInputCursorPosition( filename, fheroes2::FontType::normalWhite(), charInsertPos, le.GetMouseCursor().x, textInputRoi.x );
+                    if ( filename.empty() ) {
+                        buttonOk.disable();
+                    }
+
+                    needRedraw = true;
+                }
+                else if ( !listboxEvent && le.KeyPress()
+                          && ( !isTextLimit || fheroes2::Key::KEY_BACKSPACE == le.KeyValue() || fheroes2::Key::KEY_DELETE == le.KeyValue() ) ) {
+                    charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
+                    if ( filename.empty() ) {
+                        buttonOk.disable();
+                    }
+                    else {
+                        buttonOk.enable();
+                    }
+
+                    needRedraw = true;
+                    listbox.Unselect();
+                    isListboxSelected = false;
+                }
+            }
+
+            if ( le.MousePressRight( buttonCancel.area() ) ) {
+                fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
+            }
+            else if ( le.MousePressRight( buttonOk.area() ) ) {
+                if ( isEditing ) {
+                    fheroes2::showStandardTextMessage( _( "Okay" ), _( "Click to save the current game." ), Dialog::ZERO );
+                }
+                else {
+                    fheroes2::showStandardTextMessage( _( "Okay" ), _( "Click to load a previously saved game." ), Dialog::ZERO );
+                }
+            }
+            else if ( isEditing && le.MousePressRight( buttonVirtualKB->area() ) ) {
+                fheroes2::showStandardTextMessage( _( "Open Virtual Keyboard" ), _( "Click to open the Virtual Keyboard dialog." ), Dialog::ZERO );
+            }
+
+            if ( !isEditing && le.KeyPress( fheroes2::Key::KEY_DELETE ) && isListboxSelected ) {
+                std::string msg( _( "Are you sure you want to delete file:" ) );
+                msg.append( "\n \n" );
+                msg.append( System::GetBasename( listbox.GetCurrent().file ) );
+                if ( Dialog::YES == fheroes2::showStandardTextMessage( _( "Warning!" ), msg, Dialog::YES | Dialog::NO ) ) {
+                    System::Unlink( listbox.GetCurrent().file );
+                    listbox.RemoveSelected();
+                    if ( lists.empty() || filename.empty() ) {
+                        buttonOk.disable();
+                        isListboxSelected = false;
+                        filename.clear();
+                    }
+
+                    listbox.updateScrollBarImage();
+
+                    listbox.SetListContent( lists );
+                }
+
+                needRedraw = true;
+            }
+
+            // Text input cursor blink.
+            if ( isEditing && Game::validateAnimationDelay( Game::DelayType::CURSOR_BLINK_DELAY ) ) {
+                isCursorVisible = !isCursorVisible;
+                needRedraw = true;
+            }
+
+            if ( !needRedraw && !listbox.IsNeedRedraw() ) {
+                continue;
+            }
+
+            listbox.Redraw();
+
+            const std::string selectedFileName = isListboxSelected ? ResizeToShortName( listbox.GetCurrent().file ) : "";
+            if ( isListboxSelected && lastSelectedSaveFileName != selectedFileName ) {
+                lastSelectedSaveFileName = selectedFileName;
+                filename = selectedFileName;
+                charInsertPos = filename.size();
+            }
+            else if ( isEditing ) {
+                // Empty last selected save file name so that we can replace the input field's name if we select the same save file again
+                // but when loading (isEditing == false), this doesn't matter since we cannot write to the input field
+                lastSelectedSaveFileName = "";
+            }
+
+            textInputBackground.restore();
+            isTextLimit = isEditing ? redrawExtraInfo( insertCharToString( filename, charInsertPos, isCursorVisible ? '_' : '\x7F' ), textInputRoi )
+                                    : redrawExtraInfo( filename, textInputRoi );
+
+            display.render( background.activeArea() );
+        }
+
+        return result;
+    }
+}
+
+namespace Dialog
+{
+    std::string SelectFileSave()
+    {
+        std::ostringstream os;
+
+        os << System::concatPath( Game::GetSaveDir(), Game::GetSaveFileBaseName() ) << '_' << std::setw( 4 ) << std::setfill( '0' ) << world.CountDay()
+           << Game::GetSaveFileExtension();
+
+        return SelectFileListSimple( _( "File to Save:" ), os.str(), true );
     }
 
-    return result;
+    std::string SelectFileLoad()
+    {
+        const std::string & lastfile = Game::GetLastSaveName();
+        return SelectFileListSimple( _( "File to Load:" ), ( !lastfile.empty() ? lastfile : "" ), false );
+    }
 }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -426,7 +426,7 @@ namespace
             fheroes2::Sprite released;
             fheroes2::Sprite pressed;
 
-            const int32_t buttonWidth = 17;
+            const int32_t buttonWidth = buttonCancelSprite.width() / 2;
 
             makeButtonSprites( released, pressed, "...", buttonWidth, isEvilInterface, false );
             buttonVirtualKB = std::make_unique<fheroes2::ButtonSprite>( area.x + ( area.width - buttonWidth ) / 2, buttonOffsetY, released, pressed );

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -128,13 +128,13 @@ public:
         const int buttonOkIcn = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
         buttonOk.setICNInfo( buttonOkIcn, 0, 1 );
         buttonOk.setPosition( area.x + buttonFromBorderOffsetX, buttonY );
-        const fheroes2::Sprite buttonOkSprite = fheroes2::AGG::GetICN( buttonOkIcn, 0 );
+        const fheroes2::Sprite & buttonOkSprite = fheroes2::AGG::GetICN( buttonOkIcn, 0 );
         fheroes2::addGradientShadow( buttonOkSprite, display, buttonOk.area().getPosition(), { -5, 5 } );
         buttonOk.draw();
 
         const int buttonCancelIcn = isEvilInterface ? ICN::BUTTON_SMALL_CANCEL_EVIL : ICN::BUTTON_SMALL_CANCEL_GOOD;
         buttonCancel.setICNInfo( buttonCancelIcn, 0, 1 );
-        const fheroes2::Sprite buttonCancelSprite = fheroes2::AGG::GetICN( buttonCancelIcn, 0 );
+        const fheroes2::Sprite & buttonCancelSprite = fheroes2::AGG::GetICN( buttonCancelIcn, 0 );
         buttonCancel.setPosition( area.x + area.width - buttonCancelSprite.width() - buttonFromBorderOffsetX, buttonY );
         fheroes2::addGradientShadow( buttonCancelSprite, display, buttonCancel.area().getPosition(), { -5, 5 } );
         buttonCancel.draw();
@@ -270,7 +270,7 @@ public:
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
         const Monster mons( index );
-        const fheroes2::Sprite monsterSprite = fheroes2::AGG::GetICN( ICN::MONS32, mons.GetSpriteIndex() );
+        const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( ICN::MONS32, mons.GetSpriteIndex() );
 
         renderItem( monsterSprite, mons.GetName(), { dstx, dsty }, { 45, 43 }, current );
     }

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -297,8 +297,12 @@ namespace Interface
 
         void RemoveSelected()
         {
-            if ( content != nullptr && _currentId >= 0 && _currentId < _size() )
+            if ( content != nullptr && _currentId >= 0 && _currentId < _size() ) {
                 content->erase( content->begin() + _currentId );
+
+                // List item is removed, so we need redraw the list.
+                needRedraw = true;
+            }
         }
 
         bool isSelected() const
@@ -309,8 +313,12 @@ namespace Interface
         void Unselect()
         {
             Verify();
-            if ( IsValid() )
+            if ( IsValid() ) {
                 _currentId = -1;
+
+                // List item is unselected, so we need redraw the list with no selected elements.
+                needRedraw = true;
+            }
         }
 
         bool QueueEventProcessing() override

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -300,7 +300,7 @@ namespace Interface
             if ( content != nullptr && _currentId >= 0 && _currentId < _size() ) {
                 content->erase( content->begin() + _currentId );
 
-                // List item is removed, so we need redraw the list.
+                // List item is removed, so we need to redraw the list.
                 needRedraw = true;
             }
         }
@@ -316,7 +316,7 @@ namespace Interface
             if ( IsValid() ) {
                 _currentId = -1;
 
-                // List item is unselected, so we need redraw the list with no selected elements.
+                // List item is unselected, so we need to redraw the list with no selected elements.
                 needRedraw = true;
             }
         }

--- a/src/fheroes2/gui/ui_scrollbar.cpp
+++ b/src/fheroes2/gui/ui_scrollbar.cpp
@@ -81,18 +81,25 @@ namespace fheroes2
 
     bool Scrollbar::moveToIndex( const int indexId )
     {
-        if ( _maxIndex == _minIndex )
+        const int32_t roiWidth = _area.width - width();
+        const int32_t roiHeight = _area.height - height();
+
+        if ( _maxIndex == _minIndex ) {
+            // There are less elements than the list height. We set scrollbar slider to the center of scrollbar.
+            setPosition( _area.x + roiWidth / 2, _area.y + roiHeight / 2 );
+
             return false;
+        }
 
-        if ( indexId < _minIndex )
+        if ( indexId < _minIndex ) {
             _currentIndex = _minIndex;
-        else if ( indexId > _maxIndex )
+        }
+        else if ( indexId > _maxIndex ) {
             _currentIndex = _maxIndex;
-        else
+        }
+        else {
             _currentIndex = indexId;
-
-        const int roiWidth = _area.width - width();
-        const int roiHeight = _area.height - height();
+        }
 
         Point newPosition;
 


### PR DESCRIPTION
Close #7497, relates to #1892

This PR implements variable size for Save/Load dialog, using StandardWindow class.

- The horizontal size of window is extended not to cut the save file names if a name was given in fheroes2 (you can rename save file in OS and if the name is very long it will be cut with '...' at the end).
- The vertical size is set automatically according to the selected screen height and available save files: dialog is not higher than (screen height - 100) and not lower than 4 rows in the list.
- Fixed rendering of slider when item count in the list is equal or less than rows in dialog (when there is nowhere to scroll in the list).
- Added setting the `needRedraw` to `true` in cases when list was changed (list item removed, list item unselected).
- Applied most proposals of #1892;
- ~Added in-game date near the name of selected file to load.~

![изображение](https://github.com/ihhub/fheroes2/assets/113276641/452b226f-8a90-4f78-95fc-d20d66c2c7b1)

![изображение](https://github.com/ihhub/fheroes2/assets/113276641/02fb9cb7-483d-4670-adc8-7e2e81349976)

