### PR TITLE
Do not show second brackets when hero can learn secondary skill from witch hut

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -276,16 +276,20 @@ namespace
             const Heroes * hero = Interface::GetFocusHeroes();
 
             if ( hero ) {
-                str.append( "\n(" );
+                std::string heroStr;
 
                 if ( hero->HasSecondarySkill( skill.Skill() ) ) {
-                    str.append( _( "already knows this skill" ) );
+                    heroStr = ( _( "already knows this skill" ) );
                 }
                 else if ( hero->HasMaxSecondarySkill() ) {
-                    str.append( _( "already has max skills" ) );
+                    heroStr = ( _( "already has max skills" ) );
                 }
 
-                str += ')';
+                if ( !heroStr.empty() ) {
+                    str.append( "\n(" );
+                    str.append( heroStr );
+                    str += ')';
+                }
             }
         }
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -276,7 +276,7 @@ namespace
             const Heroes * hero = Interface::GetFocusHeroes();
 
             if ( hero ) {
-                std::string heroStr;
+                const char * heroStr = nullptr;
 
                 if ( hero->HasSecondarySkill( skill.Skill() ) ) {
                     heroStr = ( _( "already knows this skill" ) );
@@ -285,7 +285,7 @@ namespace
                     heroStr = ( _( "already has max skills" ) );
                 }
 
-                if ( !heroStr.empty() ) {
+                if ( heroStr != nullptr ) {
                     str.append( "\n(" );
                     str.append( heroStr );
                     str += ')';


### PR DESCRIPTION
Fix #7670

- hero does not know skill, has all skill slots occupied = 'already has max skills'
- hero does know skill, has all skill slots occupied = 'already knows this skill'
- hero does not know skill, can learn new skills = no second brackets
- hero does know skill, can learn new skills = 'already knows this skill'
![Screenshot 2023-08-31 10-10-56](https://github.com/ihhub/fheroes2/assets/26660595/71fa5088-6b1b-43e0-b37c-aa64a27ba762)
![Screenshot 2023-08-31 10-11-10](https://github.com/ihhub/fheroes2/assets/26660595/7d437f44-3387-4df3-b1ad-fc9f3b3d710f)
![Screenshot 2023-08-31 10-11-14](https://github.com/ihhub/fheroes2/assets/26660595/7d2ffbe3-f028-4f93-83a8-a16a0463ea5c)


![Screenshot 2023-08-31 10-11-23](https://github.com/ihhub/fheroes2/assets/26660595/13c9e27f-99c7-4021-8854-4291d7fdc0d2)
![Screenshot 2023-08-31 10-11-25](https://github.com/ihhub/fheroes2/assets/26660595/ce1ee2a5-3548-45c9-8d3b-d5926e08ffbb)
![Screenshot 2023-08-31 10-11-40](https://github.com/ihhub/fheroes2/assets/26660595/41f5602a-80cc-42e2-aee0-6e53f9a6ca25)