### PR TITLE
Change Army Order to Turn Order

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -206,9 +206,9 @@ namespace
         const fheroes2::Sprite & speedIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, speedIcnIndex );
         fheroes2::drawOption( areas[0], speedIcon, _( "Speed" ), str, fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
-        const bool isShowArmyOrderEnabled = conf.BattleShowArmyOrder();
-        const fheroes2::Sprite & armyOrderIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowArmyOrderEnabled ? 4 : 3 );
-        fheroes2::drawOption( areas[1], armyOrderIcon, _( "Army Order" ), isShowArmyOrderEnabled ? _( "On" ) : _( "Off" ),
+        const bool isShowTurnOrderEnabled = conf.BattleShowTurnOrder();
+        const fheroes2::Sprite & turnOrderIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowTurnOrderEnabled ? 4 : 3 );
+        fheroes2::drawOption( areas[1], turnOrderIcon, _( "Turn Order" ), isShowTurnOrderEnabled ? _( "On" ) : _( "Off" ),
                               fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
 
         const bool isBattleAudoSpellCastEnabled = conf.BattleAutoSpellcast();
@@ -311,7 +311,7 @@ namespace
                 redrawScreen = true;
             }
             else if ( le.MouseClickLeft( optionAreas[1] ) ) {
-                conf.setBattleShowArmyOrder( !conf.BattleShowArmyOrder() );
+                conf.setBattleShowTurnOrder( !conf.BattleShowTurnOrder() );
                 redrawScreen = true;
             }
             else if ( le.MouseClickLeft( optionAreas[2] ) ) {
@@ -345,7 +345,7 @@ namespace
                 fheroes2::showStandardTextMessage( _( "Speed" ), _( "Set the speed of combat actions and animations." ), 0 );
             }
             else if ( le.MousePressRight( optionAreas[1] ) ) {
-                fheroes2::showStandardTextMessage( _( "Army Order" ), _( "Toggle to display army order during the battle." ), 0 );
+                fheroes2::showStandardTextMessage( _( "Turn Order" ), _( "Toggle to display the turn order during the battle." ), 0 );
             }
             else if ( le.MousePressRight( optionAreas[2] ) ) {
                 fheroes2::showStandardTextMessage(

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1295,7 +1295,7 @@ Battle::Interface::~Interface()
 
 void Battle::Interface::SetOrderOfUnits( const std::shared_ptr<const Units> & units )
 {
-    armies_order.Set( GetArea(), units, arena.GetArmy2Color() );
+    _turnOrder.Set( GetArea(), units, arena.GetArmy2Color() );
 }
 
 fheroes2::Point Battle::Interface::GetMouseCursor() const
@@ -1399,7 +1399,7 @@ void Battle::Interface::RedrawPartialFinish()
 void Battle::Interface::redrawPreRender()
 {
     if ( Settings::Get().BattleShowTurnOrder() ) {
-        armies_order.Redraw( _currentUnit, _contourColor, _mainSurface );
+        _turnOrder.Redraw( _currentUnit, _contourColor, _mainSurface );
     }
 
 #ifdef WITH_DEBUG
@@ -2802,7 +2802,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
     // Add offsets to inner objects
     const fheroes2::Rect mainTowerRect = main_tower + _interfacePosition.getPosition();
-    const fheroes2::Rect turnOrderRect = armies_order + _interfacePosition.getPosition();
+    const fheroes2::Rect turnOrderRect = _turnOrder + _interfacePosition.getPosition();
     if ( Arena::GetTower( TowerType::TWR_CENTER ) && le.MouseCursor( mainTowerRect ) ) {
         cursor.SetThemes( Cursor::WAR_INFO );
         msg = _( "View Ballista info" );
@@ -2821,7 +2821,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
     }
     else if ( conf.BattleShowTurnOrder() && le.MouseCursor( turnOrderRect ) ) {
         cursor.SetThemes( Cursor::POINTER );
-        armies_order.QueueEventProcessing( msg, _interfacePosition.getPosition() );
+        _turnOrder.QueueEventProcessing( msg, _interfacePosition.getPosition() );
     }
     else if ( le.MouseCursor( btn_auto.area() ) ) {
         cursor.SetThemes( Cursor::WAR_POINTER );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2819,7 +2819,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             Dialog::Message( _( "Ballista" ), ballistaMessage, Font::BIG, le.MousePressRight() ? 0 : Dialog::OK );
         }
     }
-    else if ( conf.BattleShowArmyOrder() && le.MouseCursor( turnOrderRect ) ) {
+    else if ( conf.BattleShowTurnOrder() && le.MouseCursor( turnOrderRect ) ) {
         cursor.SetThemes( Cursor::POINTER );
         armies_order.QueueEventProcessing( msg, _interfacePosition.getPosition() );
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1004,7 +1004,7 @@ void Battle::TurnOrder::QueueEventProcessing( std::string & msg, const fheroes2:
 }
 
 void Battle::TurnOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, const bool revert, const bool isCurrentUnit, const uint8_t currentUnitColor,
-                                      fheroes2::Image & output ) const
+                                    fheroes2::Image & output ) const
 {
     // Render background.
     const fheroes2::Sprite & backgroundOriginal = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -92,7 +92,7 @@ namespace
 {
     const int32_t cellYOffset = -9;
 
-    const int32_t armyOrderMonsterIconSize = 43; // in both directions.
+    const int32_t turnOrderMonsterIconSize = 43; // in both directions.
 
     // The parameters of castle buildings destruction by a catapult:
     // Smoke cloud frame number, after which the building should be drawn as destroyed.
@@ -1008,7 +1008,7 @@ void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::
 {
     // Render background.
     const fheroes2::Sprite & backgroundOriginal = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
-    fheroes2::Copy( backgroundOriginal, 37, 268, output, pos.x + 1, pos.y + 1, armyOrderMonsterIconSize - 2, armyOrderMonsterIconSize - 2 );
+    fheroes2::Copy( backgroundOriginal, 37, 268, output, pos.x + 1, pos.y + 1, turnOrderMonsterIconSize - 2, turnOrderMonsterIconSize - 2 );
 
     // Draw a monster's sprite.
     const fheroes2::Sprite & mons32 = fheroes2::AGG::GetICN( ICN::MONS32, unit.GetSpriteIndex() );
@@ -1028,7 +1028,7 @@ void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::
     number.Blit( pos.x + 2, pos.y + 2, output );
 
     if ( isCurrentUnit ) {
-        fheroes2::DrawRect( output, { pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize }, currentUnitColor );
+        fheroes2::DrawRect( output, { pos.x, pos.y, turnOrderMonsterIconSize, turnOrderMonsterIconSize }, currentUnitColor );
     }
     else {
         uint8_t color = 0;
@@ -1063,12 +1063,12 @@ void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::
             break;
         }
 
-        fheroes2::DrawRect( output, { pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize }, color );
+        fheroes2::DrawRect( output, { pos.x, pos.y, turnOrderMonsterIconSize, turnOrderMonsterIconSize }, color );
 
         if ( unit.Modes( Battle::TR_MOVED ) ) {
-            fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize,
+            fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, turnOrderMonsterIconSize, turnOrderMonsterIconSize,
                                     PAL::GetPalette( PAL::PaletteType::GRAY ) );
-            fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize, 3 );
+            fheroes2::ApplyPalette( output, pos.x, pos.y, output, pos.x, pos.y, turnOrderMonsterIconSize, turnOrderMonsterIconSize, 3 );
         }
     }
 }
@@ -1087,20 +1087,20 @@ void Battle::ArmiesOrder::Redraw( const Unit * current, const uint8_t currentUni
         return unit->isValid();
     } ) );
 
-    const int32_t maximumUnitsToDraw = _area.width / armyOrderMonsterIconSize;
+    const int32_t maximumUnitsToDraw = _area.width / turnOrderMonsterIconSize;
 
     int32_t offsetX = _area.x;
 
     if ( validUnitCount > maximumUnitsToDraw ) {
-        offsetX += ( _area.width - armyOrderMonsterIconSize * maximumUnitsToDraw ) / 2;
+        offsetX += ( _area.width - turnOrderMonsterIconSize * maximumUnitsToDraw ) / 2;
     }
     else {
-        offsetX += ( _area.width - armyOrderMonsterIconSize * validUnitCount ) / 2;
+        offsetX += ( _area.width - turnOrderMonsterIconSize * validUnitCount ) / 2;
     }
 
     fheroes2::Rect::x = offsetX;
     fheroes2::Rect::y = _area.y;
-    fheroes2::Rect::height = armyOrderMonsterIconSize;
+    fheroes2::Rect::height = turnOrderMonsterIconSize;
 
     _rects.clear();
 
@@ -1122,10 +1122,10 @@ void Battle::ArmiesOrder::Redraw( const Unit * current, const uint8_t currentUni
             continue;
         }
 
-        _rects.emplace_back( unit, fheroes2::Rect( offsetX, _area.y, armyOrderMonsterIconSize, armyOrderMonsterIconSize ) );
+        _rects.emplace_back( unit, fheroes2::Rect( offsetX, _area.y, turnOrderMonsterIconSize, turnOrderMonsterIconSize ) );
         RedrawUnit( _rects.back().second, *unit, unit->GetColor() == _army2Color, current == unit, currentUnitColor, output );
-        offsetX += armyOrderMonsterIconSize;
-        fheroes2::Rect::width += armyOrderMonsterIconSize;
+        offsetX += turnOrderMonsterIconSize;
+        fheroes2::Rect::width += turnOrderMonsterIconSize;
 
         ++unitsDrawn;
         ++unitsProcessed;
@@ -1398,7 +1398,7 @@ void Battle::Interface::RedrawPartialFinish()
 
 void Battle::Interface::redrawPreRender()
 {
-    if ( Settings::Get().BattleShowArmyOrder() ) {
+    if ( Settings::Get().BattleShowTurnOrder() ) {
         armies_order.Redraw( _currentUnit, _contourColor, _mainSurface );
     }
 
@@ -2819,7 +2819,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             Dialog::Message( _( "Ballista" ), ballistaMessage, Font::BIG, le.MousePressRight() ? 0 : Dialog::OK );
         }
     }
-    else if ( conf.BattleShowArmyOrder() && le.MouseCursor( armiesOrderRect ) ) {
+    else if ( conf.BattleShowTurnOrder() && le.MouseCursor( armiesOrderRect ) ) {
         cursor.SetThemes( Cursor::POINTER );
         armies_order.QueueEventProcessing( msg, _interfacePosition.getPosition() );
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -964,13 +964,13 @@ void Battle::Status::clear()
     bar2.Clear();
 }
 
-Battle::ArmiesOrder::ArmiesOrder()
+Battle::TurnOrder::TurnOrder()
     : _army2Color( 0 )
 {
     // Do nothing.
 }
 
-void Battle::ArmiesOrder::Set( const fheroes2::Rect & rt, const std::shared_ptr<const Units> & units, const int army2Color )
+void Battle::TurnOrder::Set( const fheroes2::Rect & rt, const std::shared_ptr<const Units> & units, const int army2Color )
 {
     _area = rt;
     _orders = units;
@@ -981,7 +981,7 @@ void Battle::ArmiesOrder::Set( const fheroes2::Rect & rt, const std::shared_ptr<
     }
 }
 
-void Battle::ArmiesOrder::QueueEventProcessing( std::string & msg, const fheroes2::Point & offset ) const
+void Battle::TurnOrder::QueueEventProcessing( std::string & msg, const fheroes2::Point & offset ) const
 {
     LocalEvent & le = LocalEvent::Get();
 
@@ -1003,7 +1003,7 @@ void Battle::ArmiesOrder::QueueEventProcessing( std::string & msg, const fheroes
     }
 }
 
-void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, const bool revert, const bool isCurrentUnit, const uint8_t currentUnitColor,
+void Battle::TurnOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, const bool revert, const bool isCurrentUnit, const uint8_t currentUnitColor,
                                       fheroes2::Image & output ) const
 {
     // Render background.
@@ -1073,7 +1073,7 @@ void Battle::ArmiesOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::
     }
 }
 
-void Battle::ArmiesOrder::Redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output )
+void Battle::TurnOrder::Redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output )
 {
     if ( _orders.expired() ) {
         // Nothing to show.
@@ -2802,7 +2802,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
     // Add offsets to inner objects
     const fheroes2::Rect mainTowerRect = main_tower + _interfacePosition.getPosition();
-    const fheroes2::Rect armiesOrderRect = armies_order + _interfacePosition.getPosition();
+    const fheroes2::Rect turnOrderRect = armies_order + _interfacePosition.getPosition();
     if ( Arena::GetTower( TowerType::TWR_CENTER ) && le.MouseCursor( mainTowerRect ) ) {
         cursor.SetThemes( Cursor::WAR_INFO );
         msg = _( "View Ballista info" );
@@ -2819,7 +2819,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             Dialog::Message( _( "Ballista" ), ballistaMessage, Font::BIG, le.MousePressRight() ? 0 : Dialog::OK );
         }
     }
-    else if ( conf.BattleShowTurnOrder() && le.MouseCursor( armiesOrderRect ) ) {
+    else if ( conf.BattleShowArmyOrder() && le.MouseCursor( turnOrderRect ) ) {
         cursor.SetThemes( Cursor::POINTER );
         armies_order.QueueEventProcessing( msg, _interfacePosition.getPosition() );
     }

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -458,7 +458,7 @@ namespace Battle
         std::unique_ptr<StatusListBox> listlog;
 
         PopupDamageInfo popup;
-        TurnOrder armies_order;
+        TurnOrder _turnOrder;
 
         CursorRestorer _cursorRestorer;
         std::unique_ptr<fheroes2::StandardWindow> _background;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -204,13 +204,13 @@ namespace Battle
         StatusListBox * listlog;
     };
 
-    class ArmiesOrder : public fheroes2::Rect
+    class TurnOrder : public fheroes2::Rect
     {
     public:
-        ArmiesOrder();
-        ArmiesOrder( const ArmiesOrder & ) = delete;
+        TurnOrder();
+        TurnOrder( const TurnOrder & ) = delete;
 
-        ArmiesOrder & operator=( const ArmiesOrder & ) = delete;
+        TurnOrder & operator=( const TurnOrder & ) = delete;
 
         void Set( const fheroes2::Rect & rt, const std::shared_ptr<const Units> & units, const int army2Color );
         void Redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output );
@@ -458,7 +458,7 @@ namespace Battle
         std::unique_ptr<StatusListBox> listlog;
 
         PopupDamageInfo popup;
-        ArmiesOrder armies_order;
+        TurnOrder armies_order;
 
         CursorRestorer _cursorRestorer;
         std::unique_ptr<fheroes2::StandardWindow> _background;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -70,7 +70,7 @@ namespace
         GLOBAL_EVIL_INTERFACE = 0x00080000,
         GLOBAL_HIDE_INTERFACE = 0x00100000,
         GLOBAL_BATTLE_SHOW_DAMAGE = 0x00200000,
-        GLOBAL_BATTLE_SHOW_ARMY_ORDER = 0x00400000,
+        GLOBAL_BATTLE_SHOW_TURN_ORDER = 0x00400000,
         GLOBAL_BATTLE_SHOW_GRID = 0x00800000,
         GLOBAL_BATTLE_SHOW_MOUSE_SHADOW = 0x01000000,
         GLOBAL_BATTLE_SHOW_MOVE_SHADOW = 0x02000000,
@@ -219,8 +219,8 @@ bool Settings::Read( const std::string & filePath )
         setBattleAutoSpellcast( config.StrParams( "auto spell casting" ) == "on" );
     }
 
-    if ( config.Exists( "battle army order" ) ) {
-        setBattleShowArmyOrder( config.StrParams( "battle army order" ) == "on" );
+    if ( config.Exists( "battle turn order" ) ) {
+        setBattleShowTurnOrder( config.StrParams( "battle turn order" ) == "on" );
     }
 
     if ( config.Exists( "use evil interface" ) ) {
@@ -409,8 +409,8 @@ std::string Settings::String() const
     os << std::endl << "# auto combat spell casting: on/off" << std::endl;
     os << "auto spell casting = " << ( _optGlobal.Modes( GLOBAL_BATTLE_AUTO_SPELLCAST ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# show army order during battle: on/off" << std::endl;
-    os << "battle army order = " << ( _optGlobal.Modes( GLOBAL_BATTLE_SHOW_ARMY_ORDER ) ? "on" : "off" ) << std::endl;
+    os << std::endl << "# show turn order during battle: on/off" << std::endl;
+    os << "battle turn order = " << ( _optGlobal.Modes( GLOBAL_BATTLE_SHOW_TURN_ORDER ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# use evil interface style: on/off" << std::endl;
     os << "use evil interface = " << ( _optGlobal.Modes( GLOBAL_EVIL_INTERFACE ) ? "on" : "off" ) << std::endl;
@@ -647,13 +647,13 @@ void Settings::setBattleAutoSpellcast( bool enable )
     }
 }
 
-void Settings::setBattleShowArmyOrder( const bool enable )
+void Settings::setBattleShowTurnOrder( const bool enable )
 {
     if ( enable ) {
-        _optGlobal.SetModes( GLOBAL_BATTLE_SHOW_ARMY_ORDER );
+        _optGlobal.SetModes( GLOBAL_BATTLE_SHOW_TURN_ORDER );
     }
     else {
-        _optGlobal.ResetModes( GLOBAL_BATTLE_SHOW_ARMY_ORDER );
+        _optGlobal.ResetModes( GLOBAL_BATTLE_SHOW_TURN_ORDER );
     }
 }
 
@@ -882,9 +882,9 @@ bool Settings::BattleAutoSpellcast() const
     return _optGlobal.Modes( GLOBAL_BATTLE_AUTO_SPELLCAST );
 }
 
-bool Settings::BattleShowArmyOrder() const
+bool Settings::BattleShowTurnOrder() const
 {
-    return _optGlobal.Modes( GLOBAL_BATTLE_SHOW_ARMY_ORDER );
+    return _optGlobal.Modes( GLOBAL_BATTLE_SHOW_TURN_ORDER );
 }
 
 void Settings::setDebug( int debug )

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -177,7 +177,7 @@ public:
     bool BattleShowMoveShadow() const;
     bool BattleAutoResolve() const;
     bool BattleAutoSpellcast() const;
-    bool BattleShowArmyOrder() const;
+    bool BattleShowTurnOrder() const;
     bool isPriceOfLoyaltySupported() const;
     bool isMonochromeCursorEnabled() const;
     bool isTextSupportModeEnabled() const;
@@ -236,7 +236,7 @@ public:
     void SetBattleSpeed( int );
     void setBattleAutoResolve( bool enable );
     void setBattleAutoSpellcast( bool enable );
-    void setBattleShowArmyOrder( const bool enable );
+    void setBattleShowTurnOrder( const bool enable );
     void setFullScreen( const bool enable );
     void setMonochromeCursor( const bool enable );
     void setTextSupportMode( const bool enable );


### PR DESCRIPTION
This has been bothering me for long enough now.

Army Order sounds like and means something more similar to this
![image](https://github.com/ihhub/fheroes2/assets/12501091/53fdd2a1-e20e-4c5f-83f1-e0c445da96ce)

If Turn Order isn't accepted, then alternatives are "Battle Queue" or "Turn Queue".

I've changed the relevant identifiers I could find that were using some variant of "army order".

