### PR TITLE
Fix regressions after #7662: cursor position setting in text input field and display restoration after closing the virtual keyboard

### DIFF
--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -483,16 +483,20 @@ namespace
             else if ( isEditing ) {
                 if ( le.MouseClickLeft( buttonVirtualKB->area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( textInputRoi ) ) ) {
                     fheroes2::openVirtualKeyboard( filename );
+
                     charInsertPos = filename.size();
                     listbox.Unselect();
                     isListboxSelected = false;
                     needRedraw = true;
+
+                    // Set the whole screen to redraw next time to properly restore image under the Virtual Keyboard dialog.
+                    display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
                 }
                 else if ( le.MouseClickLeft( textInputRoi ) ) {
                     const fheroes2::Text text( filename, fheroes2::FontType::normalWhite() );
-                    charInsertPos
-                        = fheroes2::getTextInputCursorPosition( insertCharToString( filename, charInsertPos, '_' ), fheroes2::FontType::normalWhite(), charInsertPos,
-                                                                le.GetMouseCursor().x, textInputRoi.x + ( textInputRoi.width - text.width() ) / 2 );
+                    const int32_t textStartOffsetX = isTextLimit ? 8 : ( textInputRoi.width - text.width() ) / 2;
+                    charInsertPos = fheroes2::getTextInputCursorPosition( filename, fheroes2::FontType::normalWhite(), charInsertPos, le.GetMouseCursor().x,
+                                                                          textInputRoi.x + textStartOffsetX );
                     if ( filename.empty() ) {
                         buttonOk.disable();
                     }


### PR DESCRIPTION
Fix regressions after #7662:
- fix cursor position setting in text input field in Save dialog:
    - clicking to the right of a file name and trying to type a letter caused the game crash;
    - if the filename was truncated with '...', clicking on it resulted in an unpredictable cursor position;
- fix display redraw after closing the Virtual Keyboard: the part outside of the Save dialog was updated with a delay.