### PR TITLE
Display missing resource dialog not less than 5 seconds

### DIFF
--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -128,8 +128,20 @@ namespace
         display.render();
 
         LocalEvent & le = LocalEvent::Get();
-        while ( le.HandleEvents() && !le.KeyPress() && !le.MouseClickLeft() ) {
-            // Do nothing.
+
+        // Display the message for 5 seconds so that the user sees it enough and not immediately closes without reading properly.
+        fheroes2::Time timer;
+
+        bool closeWindow = false;
+
+        while ( le.HandleEvents() ) {
+            if ( closeWindow && timer.getS() >= 5 ) {
+                break;
+            }
+
+            if ( le.KeyPress() || le.MouseClickLeft() ) {
+                closeWindow = true;
+            }
         }
     }
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -130,7 +130,7 @@ namespace
         LocalEvent & le = LocalEvent::Get();
 
         // Display the message for 5 seconds so that the user sees it enough and not immediately closes without reading properly.
-        fheroes2::Time timer;
+        const fheroes2::Time timer;
 
         bool closeWindow = false;
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -60,6 +60,7 @@
 #include "screen.h"
 #include "settings.h"
 #include "system.h"
+#include "timing.h"
 #include "ui_tool.h"
 #include "zzlib.h"
 


### PR DESCRIPTION
In this case users won't claim that the application crashes for no reason.