### PR TITLE
Bump the timeout for SonarCloud Analyzer workflow to 60 minutes

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,7 +11,7 @@ jobs:
     name: SonarCloud Analyzer
     if: ${{ github.repository == 'ihhub/fheroes2' && ( github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) ) }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 60
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Our codebase is gradually growing (and Microsoft may be gradually getting carried away with saving money), and, when changing any popular header file that is included in many project files, or during the recurrent upgrade of GitHub Ubuntu runner images (with some newer compiler) the time for a full SonarCloud analysis is dangerously close to 30 minutes.