### PR TITLE
Update Windows & Android dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -90,14 +90,14 @@ dependencies {
     implementation 'com.google.android.material:material:1.9.0'
 }
 
-task copyH2D(type: Copy) {
+tasks.register('copyH2D', Copy) {
     from('../../files/data') {
         include '*.h2d'
     }
     into 'src/main/assets/files/data'
 }
 
-task copyTranslations(type: Copy) {
+tasks.register('copyTranslations', Copy) {
     from('../../files/lang') {
         include '*.mo'
     }

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,13 +3,13 @@ apply plugin: 'com.android.application'
 android {
     namespace 'org.fheroes2'
 
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         applicationId 'org.fheroes2'
 
         minSdkVersion 22
-        targetSdkVersion 33
+        targetSdkVersion 34
 
         // These paths are set relative to the android project directory
         versionCode((new File('../version_code.txt')).getText('UTF-8').trim().toInteger())

--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.application'
 android {
     namespace 'org.fheroes2'
 
-    compileSdkVersion 34
+    compileSdk 34
 
     defaultConfig {
         applicationId 'org.fheroes2'

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.0'
+        classpath 'com.android.tools.build:gradle:8.1.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/isotools/build.gradle
+++ b/android/isotools/build.gradle
@@ -3,10 +3,10 @@ apply plugin: 'com.android.library'
 android {
     namespace 'com.github.stephenc.javaisotools'
 
-    compileSdkVersion 33
+    compileSdkVersion 34
 
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 33
+        targetSdkVersion 34
     }
 }

--- a/android/isotools/build.gradle
+++ b/android/isotools/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'com.android.library'
 android {
     namespace 'com.github.stephenc.javaisotools'
 
-    compileSdkVersion 34
+    compileSdk 34
 
     defaultConfig {
         minSdkVersion 19

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=090B501B3874B0285934F6DF75A8AE202F428ECAA31D7161304864BEF25B2118
+set PKG_FILE_SHA256=9F1EC030BFA63DC7E2353EC9BD4E1210707F6DBF7A8E57928E84B182543D325E
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=9F1EC030BFA63DC7E2353EC9BD4E1210707F6DBF7A8E57928E84B182543D325E
+set PKG_FILE_SHA256=E5B1166AF1A2E133E0D5A59FC3B1681F079EE752D849D555703C1C265FB03D24
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -23,7 +23,7 @@
 set -e -o pipefail
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="9f1ec030bfa63dc7e2353ec9bd4e1210707f6dbf7a8e57928e84b182543d325e"
+PKG_FILE_SHA256="e5b1166af1a2e133e0d5a59fc3b1681f079ee752d849d555703c1c265fb03d24"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -23,7 +23,7 @@
 set -e -o pipefail
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="090b501b3874b0285934f6df75a8ae202f428ecaa31d7161304864bef25b2118"
+PKG_FILE_SHA256="9f1ec030bfa63dc7e2353ec9bd4e1210707f6dbf7a8e57928e84b182543d325e"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=4C651CC7026DAA1B45C5787C2A22591618E85DCDC1AEB7B207A11E8967181222
+set PKG_FILE_SHA256=14F2C29E0A4AF4B5BA686F426DBA2488C3F8D359AF40AE89132B4EE3628A7F08
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
See https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/37 and https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/38 for details. Also this PR bumps target Android SDK version to 34 (Android 14) and updates the Android Gradle Plugin to the latest available version.