### PR TITLE
Pass "hero delay" to immediately start hero movement sequence

### DIFF
--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -97,7 +97,9 @@ void Interface::AdventureMap::ShowPathOrStartMoveHero( Heroes * hero, const int3
 
         hero->SetMove( true );
 
-        // We reset this delay to start hero moving immediately and set all the variables needed to handle game events correctly.
+        // We pass this delay to start hero moving immediately and set all the variables needed to handle game events correctly
+        // and to stop handling mouse click events until hero stops. Otherwise there could be a rare case
+        // when double click is faster than this delay and the second click will also be handled which should not happen.
         Game::passAnimationDelay( Game::DelayType::CURRENT_HERO_DELAY );
     }
 }


### PR DESCRIPTION
This PR fixes the issue found by @drevoborod:
>One more core dump, but hard to reproduce: occured when I tapped a hero with a finger on touchscreen of a laptop (yes, laptop with touchscreen, so both mouse coursor and touch interface were enabled).
`fheroes2: ../fheroes2/game/game_startgame.cpp:1356: virtual void Interface::AdventureMap::mouseCursorAreaClickLeft(int32_t): Assertion 'focusedHero == nullptr || !focusedHero->Modes( Heroes::ENABLEMOVE )' failed.`

This assertion could fail if hero's move was initialized in `ShowPathOrStartMoveHero()` but the `CURRENT_HERO_DELAY` has not pass ( it is up to 18 ms) and so `isMovingHero = true;` was skipped and after that if there was another left click the mouse click event handler started because `!isMovingHero` and the assertion fails.

In this PR `CURRENT_HERO_DELAY` is passed immediately after the hero's movement is set.