### PR TITLE
Add the ability to confirm actions in battle for touch devices

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -802,6 +802,7 @@ LocalEvent & LocalEvent::GetClean()
     le.ResetModes( MOUSE_RELEASED );
     le.ResetModes( MOUSE_CLICKED );
     le.ResetModes( MOUSE_WHEEL );
+    le.ResetModes( MOUSE_TOUCH );
     le.ResetModes( KEY_HOLD );
 
     return le;
@@ -828,12 +829,17 @@ bool LocalEvent::HandleEvents( const bool sleepAfterEventProcessing, const bool 
 
     SDL_Event event;
 
-    // We shouldn't reset the MOUSE_PRESSED and KEY_HOLD here because these are "lasting" states
+    // We shouldn't reset the MOUSE_PRESSED and KEY_HOLD here because these are "ongoing" states
     ResetModes( KEY_PRESSED );
     ResetModes( MOUSE_MOTION );
     ResetModes( MOUSE_RELEASED );
     ResetModes( MOUSE_CLICKED );
     ResetModes( MOUSE_WHEEL );
+
+    // MOUSE_PRESSED is an "ongoing" state, so we shouldn't reset the MOUSE_TOUCH while that state is active
+    if ( !( modes & MOUSE_PRESSED ) ) {
+        ResetModes( MOUSE_TOUCH );
+    }
 
     while ( SDL_PollEvent( &event ) ) {
         switch ( event.type ) {
@@ -1034,6 +1040,7 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
         mouse_cu.y = static_cast<int32_t>( _emulatedPointerPosY );
 
         SetModes( MOUSE_MOTION );
+        SetModes( MOUSE_TOUCH );
 
         if ( _globalMouseMotionEventHook ) {
             _mouseCursorRenderArea = _globalMouseMotionEventHook( mouse_cu.x, mouse_cu.y );
@@ -1063,6 +1070,7 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
             mouse_pr = mouse_cu;
 
             SetModes( MOUSE_PRESSED );
+            SetModes( MOUSE_TOUCH );
 
             // When the second finger touches the screen, the two-finger gesture processing begins. This
             // gesture simulates the operation of the right mouse button and ends when both fingers are
@@ -1075,6 +1083,7 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
             ResetModes( MOUSE_PRESSED );
             SetModes( MOUSE_RELEASED );
             SetModes( MOUSE_CLICKED );
+            SetModes( MOUSE_TOUCH );
         }
 
         mouse_button = SDL_BUTTON_RIGHT;
@@ -1380,7 +1389,7 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
     _emulatedPointerPosX = mouse_cu.x;
     _emulatedPointerPosY = mouse_cu.y;
 
-    if ( modes & MOUSE_PRESSED )
+    if ( modes & MOUSE_PRESSED ) {
         switch ( button.button ) {
         case SDL_BUTTON_LEFT:
             mouse_pl = mouse_cu;
@@ -1397,7 +1406,9 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
         default:
             break;
         }
-    else // mouse button released
+    }
+    // Mouse button has been released
+    else {
         switch ( button.button ) {
         case SDL_BUTTON_LEFT:
             mouse_rl = mouse_cu;
@@ -1414,6 +1425,7 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
         default:
             break;
         }
+    }
 }
 
 bool LocalEvent::MouseClickLeft()

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -256,6 +256,15 @@ public:
         return rt & mouse_cu;
     }
 
+    // Returns true if the current mouse event is triggered by the touchpad and not the mouse (in other words,
+    // this event is emulated using the touchpad). It is assumed that there is only one mouse in the system,
+    // and touchpad events have priority in this sense - that is, as long as the touchpad emulates pressing any
+    // mouse button, it is assumed that all mouse events are triggered by the touchpad.
+    bool MouseEventFromTouchpad() const
+    {
+        return modes & MOUSE_TOUCH;
+    }
+
     bool KeyPress() const
     {
         return modes & KEY_PRESSED;
@@ -321,15 +330,24 @@ private:
 
     void ProcessControllerAxisMotion();
 
-    enum flag_t
+    enum : uint32_t
     {
-        KEY_PRESSED = 0x0001, // key on the keyboard has been pressed
-        MOUSE_MOTION = 0x0002, // mouse cursor has been moved
-        MOUSE_PRESSED = 0x0004, // mouse button is currently pressed
-        MOUSE_RELEASED = 0x0008, // mouse button has just been released
-        MOUSE_CLICKED = 0x0010, // mouse button has been clicked
-        MOUSE_WHEEL = 0x0020, // mouse wheel has been rotated
-        KEY_HOLD = 0x0040 // key on the keyboard is currently being held down
+        // Key on the keyboard has been pressed
+        KEY_PRESSED = 0x0001,
+        // Mouse cursor has been moved
+        MOUSE_MOTION = 0x0002,
+        // Mouse button is currently pressed
+        MOUSE_PRESSED = 0x0004,
+        // Mouse button has just been released
+        MOUSE_RELEASED = 0x0008,
+        // Mouse button has been clicked
+        MOUSE_CLICKED = 0x0010,
+        // Mouse wheel has been rotated
+        MOUSE_WHEEL = 0x0020,
+        // Current mouse event has been triggered by the touchpad
+        MOUSE_TOUCH = 0x0040,
+        // Key on the keyboard is currently being held down
+        KEY_HOLD = 0x0080,
     };
 
     enum
@@ -338,17 +356,17 @@ private:
         CONTROLLER_R_DEADZONE = 25000
     };
 
-    void SetModes( flag_t f )
+    void SetModes( const uint32_t f )
     {
         modes |= f;
     }
 
-    void ResetModes( flag_t f )
+    void ResetModes( const uint32_t f )
     {
         modes &= ~f;
     }
 
-    int modes;
+    uint32_t modes;
     fheroes2::Key key_value;
     int mouse_button;
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2747,7 +2747,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
     LocalEvent & le = LocalEvent::Get();
     const Settings & conf = Settings::Get();
 
-    BoardActionIntentUpdater boardActionIntentUpdater( *this, le.MouseEventFromTouchpad() );
+    BoardActionIntentUpdater boardActionIntentUpdater( _boardActionIntent, le.MouseEventFromTouchpad() );
 
     if ( le.KeyPress() ) {
         // Skip the turn
@@ -2989,7 +2989,7 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
     Cursor & cursor = Cursor::Get();
     LocalEvent & le = LocalEvent::Get();
 
-    BoardActionIntentUpdater boardActionIntentUpdater( *this, le.MouseEventFromTouchpad() );
+    BoardActionIntentUpdater boardActionIntentUpdater( _boardActionIntent, le.MouseEventFromTouchpad() );
 
     // Cancel the spellcast
     if ( le.MousePressRight() || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2995,9 +2995,10 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
     Cursor & cursor = Cursor::Get();
     LocalEvent & le = LocalEvent::Get();
 
-    // reset cast
+    // Cancel the spellcast
     if ( le.MousePressRight() || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
         humanturn_spell = Spell::NONE;
+
         _teleportSpellSrcIdx = -1;
     }
     else if ( le.MouseCursor( _interfacePosition ) && humanturn_spell.isValid() ) {
@@ -3012,36 +3013,50 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
             popup.Reset();
         }
 
-        if ( le.MouseClickLeft() && Cursor::WAR_NONE != cursor.Themes() ) {
+        const BoardActionIntent intent{ themes, index_pos };
+        // If the mouse event has been triggered by the touchpad, it should be considered confirmed only if this event orders to
+        // perform the same action that is already suggested on the screen using the mouse cursor and (optionally) cell highlighting.
+        const bool isConfirmed = ( !le.MouseEventFromTouchpad() || _boardActionIntent == intent );
+
+        if ( le.MouseClickLeft() && Cursor::WAR_NONE != cursor.Themes() && isConfirmed ) {
             if ( !Board::isValidIndex( index_pos ) ) {
-                DEBUG_LOG( DBG_BATTLE, DBG_WARN,
-                           "dst: "
-                               << "out of range" )
+                DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Spell destination is out of range: " << index_pos )
                 return;
             }
 
             DEBUG_LOG( DBG_BATTLE, DBG_TRACE, humanturn_spell.GetName() << ", dst: " << index_pos )
 
             if ( Cursor::SP_TELEPORT == cursor.Themes() ) {
-                if ( 0 > _teleportSpellSrcIdx )
+                if ( _teleportSpellSrcIdx < 0 ) {
                     _teleportSpellSrcIdx = index_pos;
+                }
                 else {
                     actions.emplace_back( CommandType::MSG_BATTLE_CAST, Spell::TELEPORT, _teleportSpellSrcIdx, index_pos );
+
                     humanturn_spell = Spell::NONE;
                     humanturn_exit = true;
+
                     _teleportSpellSrcIdx = -1;
                 }
             }
             else if ( Cursor::SP_MIRRORIMAGE == cursor.Themes() ) {
                 actions.emplace_back( CommandType::MSG_BATTLE_CAST, Spell::MIRRORIMAGE, index_pos );
+
                 humanturn_spell = Spell::NONE;
                 humanturn_exit = true;
             }
             else {
                 actions.emplace_back( CommandType::MSG_BATTLE_CAST, humanturn_spell.GetID(), index_pos );
+
                 humanturn_spell = Spell::NONE;
                 humanturn_exit = true;
             }
+        }
+
+        // Do not remember intermediate touch gestures (such as simulated mouse button pressing) as intents. When using the touchpad,
+        // only a complete simulated click is considered an intent.
+        if ( !le.MouseEventFromTouchpad() || le.MouseClickLeft() ) {
+            _boardActionIntent = intent;
         }
     }
     else {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -52,7 +52,6 @@
 #include "bin_info.h"
 #include "castle.h"
 #include "color.h"
-#include "cursor.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "gamedefs.h"

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2946,7 +2946,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
             const BoardActionIntent intent{ themes, index_pos };
             // If the mouse event has been triggered by the touchpad, it should be considered confirmed only if this event orders to
-            // perform the same action that is already suggested on the screen using the mouse cursor and (optionally) cell highlighting.
+            // perform the same action that is already indicated on the battle board with the mouse cursor.
             const bool isConfirmed = ( !le.MouseEventFromTouchpad() || _boardActionIntent == intent );
 
             if ( le.MouseClickLeft() ) {
@@ -3015,7 +3015,7 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
 
         const BoardActionIntent intent{ themes, index_pos };
         // If the mouse event has been triggered by the touchpad, it should be considered confirmed only if this event orders to
-        // perform the same action that is already suggested on the screen using the mouse cursor and (optionally) cell highlighting.
+        // perform the same action that is already indicated on the battle board with the mouse cursor.
         const bool isConfirmed = ( !le.MouseEventFromTouchpad() || _boardActionIntent == intent );
 
         if ( le.MouseClickLeft() && Cursor::WAR_NONE != cursor.Themes() && isConfirmed ) {

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -509,9 +509,8 @@ namespace Battle
 
             ~BoardActionIntentUpdater()
             {
-                // Do not remember intermediate touch gestures (such as simulated mouse button pressing) as intents. When using the touchpad,
-                // only a complete simulated click is considered an intent.
-                if ( _isFromTouchpad && !_isClick ) {
+                // Do not remember intermediate touch gestures as intents
+                if ( _isFromTouchpad ) {
                     return;
                 }
 
@@ -519,11 +518,6 @@ namespace Battle
             }
 
             BoardActionIntentUpdater & operator=( const BoardActionIntentUpdater & ) = delete;
-
-            void setClick()
-            {
-                _isClick = true;
-            }
 
             void setIntent( const BoardActionIntent & intent )
             {
@@ -540,7 +534,6 @@ namespace Battle
         private:
             Interface & _interface;
             const bool _isFromTouchpad;
-            bool _isClick{ false };
             std::optional<BoardActionIntent> _intent;
         };
     };

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -398,8 +398,8 @@ namespace Battle
         void EventShowOptions();
         void ButtonAutoAction( const Unit & unit, Actions & actions );
         void ButtonSettingsAction();
-        void ButtonSkipAction( Actions & acrions );
-        void MouseLeftClickBoardAction( const int themes, const Cell & cell, Actions & actions );
+        void ButtonSkipAction( Actions & actions );
+        void MouseLeftClickBoardAction( const int themes, const Cell & cell, const bool isConfirmed, Actions & actions );
         void MousePressRightBoardAction( const Cell & cell ) const;
 
         int GetBattleCursor( std::string & statusMsg ) const;
@@ -483,6 +483,20 @@ namespace Battle
         // this may be needed in the future (for example, in expansion) to display some sprites over
         // troops for some time (e.g. long duration spell effects or other permanent effects).
         std::vector<UnitSpellEffectInfo> _unitSpellEffectInfos;
+
+        struct BoardActionIntent
+        {
+            int cursorTheme = Cursor::NONE;
+            int32_t cellIndex = -1;
+
+            bool operator==( const BoardActionIntent & other ) const
+            {
+                return cursorTheme == other.cursorTheme && cellIndex == other.cellIndex;
+            }
+        };
+
+        // Intents are used to confirm actions in combat performed using touch gestures
+        BoardActionIntent _boardActionIntent;
     };
 }
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -33,6 +33,7 @@
 
 #include "battle_animation.h"
 #include "battle_board.h"
+#include "cursor.h"
 #include "dialog.h"
 #include "icn.h"
 #include "image.h"

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -500,8 +500,8 @@ namespace Battle
         class BoardActionIntentUpdater
         {
         public:
-            BoardActionIntentUpdater( Interface & interface, const bool isFromTouchpad )
-                : _interface( interface )
+            BoardActionIntentUpdater( BoardActionIntent & storedIntent, const bool isFromTouchpad )
+                : _storedIntent( storedIntent )
                 , _isFromTouchpad( isFromTouchpad )
             {}
 
@@ -514,7 +514,7 @@ namespace Battle
                     return;
                 }
 
-                _interface._boardActionIntent = _intent.value_or( BoardActionIntent{} );
+                _storedIntent = _intent.value_or( BoardActionIntent{} );
             }
 
             BoardActionIntentUpdater & operator=( const BoardActionIntentUpdater & ) = delete;
@@ -528,11 +528,11 @@ namespace Battle
             {
                 // If the mouse event has been triggered by the touchpad, it should be considered confirmed only if this event orders to
                 // perform the same action that is already indicated on the battle board with the mouse cursor.
-                return ( !_isFromTouchpad || _interface._boardActionIntent == _intent );
+                return ( !_isFromTouchpad || _storedIntent == _intent );
             }
 
         private:
-            Interface & _interface;
+            BoardActionIntent & _storedIntent;
             const bool _isFromTouchpad;
             std::optional<BoardActionIntent> _intent;
         };


### PR DESCRIPTION
Related to #7765

The ability to confirm actions is supported for moves, melee attacks, shots, and spell casts.

It would be good to check its work on desktop devices (with mouse), on touch-only devices AND on touch devices with the mouse (it should behave adequately and not require unnecessary clicks when performing operations with the mouse, as well as in the case when pointing at the cell is performed with the mouse, but triggering the action is performed with the touch). Also it would be good to check its work on PSV and Switch. 