### PR TITLE
Fix the logic of MonsterAbilityType::ALWAYS_RETALIATE in regard to paralyzed units

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -796,7 +796,7 @@ namespace AI
                 assert( enemy != nullptr );
 
                 const int archerMeleeDmg = currentUnit.GetDamage( *enemy );
-                const int damageDiff = archerMeleeDmg - enemy->CalculateRetaliationDamage( archerMeleeDmg );
+                const int damageDiff = archerMeleeDmg - enemy->EstimateRetaliatoryDamage( archerMeleeDmg );
 
                 if ( bestOutcome < damageDiff ) {
                     bestOutcome = damageDiff;

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -475,27 +475,42 @@ uint32_t Battle::Unit::GetMoveRange() const
     return isFlying() ? ARENASIZE : GetSpeed( false, false );
 }
 
-uint32_t Battle::Unit::CalculateRetaliationDamage( uint32_t damageTaken ) const
+uint32_t Battle::Unit::EstimateRetaliatoryDamage( const uint32_t damageTaken ) const
 {
-    // Check if there will be retaliation in the first place
-    if ( damageTaken > hp || Modes( CAP_MIRRORIMAGE ) || !AllowResponse() ) {
+    // The entire unit is destroyed, no retaliation
+    if ( damageTaken >= hp ) {
         return 0;
     }
 
-    const uint32_t unitsLeft = ( hp - damageTaken ) / Monster::GetHitPoints();
-
-    uint32_t damagePerUnit = 0;
-    if ( Modes( SP_CURSE ) ) {
-        damagePerUnit = Monster::GetDamageMin();
-    }
-    else if ( Modes( SP_BLESS ) ) {
-        damagePerUnit = Monster::GetDamageMax();
-    }
-    else {
-        damagePerUnit = ( Monster::GetDamageMin() + Monster::GetDamageMax() ) / 2;
+    // Mirror images are destroyed anyway and hypnotized units never respond to an attack
+    if ( Modes( TR_RESPONDED | CAP_MIRRORIMAGE | SP_HYPNOTIZE ) ) {
+        return 0;
     }
 
-    return unitsLeft * damagePerUnit;
+    // Units with this ability retaliate even when under the influence of paralyzing spells
+    if ( Modes( IS_PARALYZE_MAGIC ) && !isAbilityPresent( fheroes2::MonsterAbilityType::ALWAYS_RETALIATE ) ) {
+        return 0;
+    }
+
+    const uint32_t unitsLeft = GetCountFromHitPoints( *this, hp - damageTaken );
+    assert( unitsLeft > 0 );
+
+    const uint32_t damagePerUnit = [this]() {
+        if ( Modes( SP_CURSE ) ) {
+            return Monster::GetDamageMin();
+        }
+
+        if ( Modes( SP_BLESS ) ) {
+            return Monster::GetDamageMax();
+        }
+
+        return ( Monster::GetDamageMin() + Monster::GetDamageMax() ) / 2;
+    }();
+
+    const uint32_t retaliatoryDamage = unitsLeft * damagePerUnit;
+
+    // The retaliatory damage of a blinded unit is halved
+    return ( Modes( SP_BLIND ) ? retaliatoryDamage / 2 : retaliatoryDamage );
 }
 
 uint32_t Battle::Unit::CalculateMinDamage( const Unit & enemy ) const
@@ -627,7 +642,11 @@ uint32_t Battle::Unit::ApplyDamage( const uint32_t dmg )
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, dmg << " to " << String() << " and killed: " << killed )
 
     if ( Modes( IS_PARALYZE_MAGIC ) ) {
-        SetModes( TR_RESPONDED );
+        // Units with this ability retaliate even when under the influence of paralyzing spells
+        if ( !isAbilityPresent( fheroes2::MonsterAbilityType::ALWAYS_RETALIATE ) ) {
+            SetModes( TR_RESPONDED );
+        }
+
         SetModes( TR_MOVED );
 
         removeAffection( IS_PARALYZE_MAGIC );
@@ -1010,16 +1029,12 @@ bool Battle::Unit::AllowResponse() const
         return false;
     }
 
-    // Blindness can be cast by an attacking unit. In this case, there should be no response to the attack.
+    // Blindness can be cast by an attacking unit. There should never be any retaliation in this case.
     if ( Modes( SP_BLIND ) && !_blindRetaliation ) {
         return false;
     }
 
-    // Units with this ability retaliate even when under the influence of paralyzing spells
-    if ( isAbilityPresent( fheroes2::MonsterAbilityType::ALWAYS_RETALIATE ) ) {
-        return true;
-    }
-
+    // Paralyzing magic can be cast by an attacking unit. There should never be any retaliation in this case.
     if ( Modes( IS_PARALYZE_MAGIC ) ) {
         return false;
     }
@@ -1029,6 +1044,10 @@ bool Battle::Unit::AllowResponse() const
 
 void Battle::Unit::SetResponse()
 {
+    if ( isAbilityPresent( fheroes2::MonsterAbilityType::ALWAYS_RETALIATE ) ) {
+        return;
+    }
+
     SetModes( TR_RESPONDED );
 }
 

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -181,14 +181,21 @@ namespace Battle
         }
 
         uint32_t ApplyDamage( Unit & enemy, const uint32_t dmg, uint32_t & killed, uint32_t * ptrResurrected );
-        uint32_t CalculateRetaliationDamage( uint32_t damageTaken ) const;
+
         uint32_t CalculateMinDamage( const Unit & ) const;
         uint32_t CalculateMaxDamage( const Unit & ) const;
         uint32_t CalculateDamageUnit( const Unit & enemy, double dmg ) const;
+
+        // Returns a very rough estimate of the retaliatory damage after this unit receives the damage of the specified value.
+        // The returned value is not suitable for accurate calculations, but only for approximate comparison with other units
+        // in similar circumstances.
+        uint32_t EstimateRetaliatoryDamage( const uint32_t damageTaken ) const;
+
         bool ApplySpell( const Spell &, const HeroBase * hero, TargetInfo & );
         bool AllowApplySpell( const Spell &, const HeroBase * hero, std::string * msg = nullptr, bool forceApplyToAlly = false ) const;
         bool isUnderSpellEffect( const Spell & spell ) const;
         std::vector<Spell> getCurrentSpellEffects() const;
+
         void PostAttackAction();
 
         // Sets whether a unit performs a retaliatory attack while being blinded (i.e. with reduced efficiency)

--- a/src/fheroes2/monster/monster.cpp
+++ b/src/fheroes2/monster/monster.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "monster.h"
+
 #include <algorithm>
 #include <vector>
 
@@ -28,7 +30,6 @@
 #include "color.h"
 #include "icn.h"
 #include "luck.h"
-#include "monster.h"
 #include "morale.h"
 #include "race.h"
 #include "rand.h"
@@ -828,13 +829,15 @@ payment_t Monster::GetUpgradeCost() const
     return ( upgr.GetCost() - GetCost() ) * 2;
 }
 
-uint32_t Monster::GetCountFromHitPoints( const Monster & mons, uint32_t hp )
+uint32_t Monster::GetCountFromHitPoints( const Monster & mons, const uint32_t hp )
 {
-    if ( hp ) {
-        const uint32_t hp1 = mons.GetHitPoints();
-        const uint32_t count = hp / hp1;
-        return ( count * hp1 ) < hp ? count + 1 : count;
+    if ( hp == 0 ) {
+        return 0;
     }
 
-    return 0;
+    const uint32_t singleMonsterHP = mons.GetHitPoints();
+    const uint32_t quotient = hp / singleMonsterHP;
+    const uint32_t remainder = hp % singleMonsterHP;
+
+    return ( remainder > 0 ? quotient + 1 : quotient );
 }

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -297,7 +297,7 @@ public:
 
     static Monster Rand( const LevelType type );
 
-    static uint32_t GetCountFromHitPoints( const Monster &, uint32_t );
+    static uint32_t GetCountFromHitPoints( const Monster & mons, const uint32_t hp );
 
     static uint32_t GetMissileICN( uint32_t monsterID );
 


### PR DESCRIPTION
fix #7784

Units with this ability should not retaliate to an attack if they were paralyzed by this particular attack.