### PR TITLE
Fix the AI first strike logic

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -151,6 +151,7 @@ namespace AI
                 targetCell = moveIndex;
             }
         }
+
         return targetCell;
     }
 
@@ -917,6 +918,8 @@ namespace AI
     {
         BattleTargetPair target;
 
+        const Castle * castle = Arena::GetCastle();
+        const bool isMoatBuilt = castle && castle->isBuild( BUILD_MOAT );
         // Current unit can be under the influence of the Hypnotize spell
         const Units enemies( arena.getEnemyForce( _myColor ).getUnits(), &currentUnit );
 
@@ -965,7 +968,7 @@ namespace AI
                         DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Arena::GetPath() returned an empty path to cell " << move.first << " for " << currentUnit.GetName() << "!" )
                     }
                     // Unit rushes through the moat, step into the moat to get more freedom of action on the next turn
-                    else if ( Board::isMoatIndex( path.back(), currentUnit ) ) {
+                    else if ( isMoatBuilt && Board::isMoatIndex( path.back(), currentUnit ) ) {
                         target.cell = path.back();
 
                         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Going after target " << enemy->GetName() << " stopping in the moat at " << target.cell )

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -470,11 +470,6 @@ uint32_t Battle::Unit::GetSpeed( const bool skipStandingCheck, const bool skipMo
     return speed;
 }
 
-uint32_t Battle::Unit::GetMoveRange() const
-{
-    return isFlying() ? ARENASIZE : GetSpeed( false, false );
-}
-
 uint32_t Battle::Unit::EstimateRetaliatoryDamage( const uint32_t damageTaken ) const
 {
     // The entire unit is destroyed, no retaliation

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -162,7 +162,6 @@ namespace Battle
         int GetControl() const override;
         int GetCurrentControl() const;
 
-        uint32_t GetMoveRange() const;
         uint32_t GetSpeed( const bool skipStandingCheck, const bool skipMovedCheck ) const;
 
         uint32_t GetDamage( const Unit & ) const;


### PR DESCRIPTION
Related to #7824

<details>
<summary>Crusaders vs Water Elementals</summary>

`master` branch:

https://github.com/ihhub/fheroes2/assets/32623900/f6506051-9f83-48db-97e4-e39add4475df

This PR:

https://github.com/ihhub/fheroes2/assets/32623900/23afaffb-816a-4463-bcac-e5ac5cd6c2ef
</details>

<details>
<summary>Attacking wide units in reverse direction</summary>

`master` branch:

https://github.com/ihhub/fheroes2/assets/32623900/924978ae-31e3-476b-ac62-e582e1d81009

This PR:

https://github.com/ihhub/fheroes2/assets/32623900/5fc0769e-5423-45f0-8e9e-eab2c3718dbd
</details>
