### PR TITLE
Reduce old Text class usage within the code

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -41,7 +41,6 @@
 #include "localevent.h"
 #include "monster.h"
 #include "race.h"
-#include "text.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_monster.h"
@@ -249,7 +248,7 @@ void ArmyBar::RedrawItem( ArmyTroop & troop, const fheroes2::Rect & pos, bool se
         return;
     }
 
-    Text text( std::to_string( troop.GetCount() ), ( use_mini_sprite ? Font::SMALL : Font::BIG ) );
+    const fheroes2::Text text( std::to_string( troop.GetCount() ),  use_mini_sprite ? fheroes2::FontType::smallWhite() : fheroes2::FontType::normalWhite() );
 
     if ( use_mini_sprite ) {
         const fheroes2::Sprite & mons32 = fheroes2::AGG::GetICN( ICN::MONS32, troop.GetSpriteIndex() );
@@ -268,12 +267,12 @@ void ArmyBar::RedrawItem( ArmyTroop & troop, const fheroes2::Rect & pos, bool se
         fheroes2::Blit( mons32, srcrt.x, srcrt.y, dstsf, pos.x + ( pos.width - mons32.width() ) / 2, pos.y + pos.height - mons32.height() - 1, srcrt.width,
                         srcrt.height );
 
-        text.Blit( pos.x + pos.width - text.w() - 3, pos.y + pos.height - text.h(), dstsf );
+        text.draw( pos.x + pos.width - text.width() - 3, pos.y + pos.height - text.height() + 2, dstsf );
     }
     else {
         fheroes2::renderMonsterFrame( troop, dstsf, pos.getPosition() );
 
-        text.Blit( pos.x + pos.width - text.w() - 3, pos.y + pos.height - text.h() - 1, dstsf );
+        text.draw( pos.x + pos.width - text.width() - 3, pos.y + pos.height - text.height() + 1, dstsf );
     }
 
     if ( selected ) {

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -248,7 +248,7 @@ void ArmyBar::RedrawItem( ArmyTroop & troop, const fheroes2::Rect & pos, bool se
         return;
     }
 
-    const fheroes2::Text text( std::to_string( troop.GetCount() ),  use_mini_sprite ? fheroes2::FontType::smallWhite() : fheroes2::FontType::normalWhite() );
+    const fheroes2::Text text( std::to_string( troop.GetCount() ), use_mini_sprite ? fheroes2::FontType::smallWhite() : fheroes2::FontType::normalWhite() );
 
     if ( use_mini_sprite ) {
         const fheroes2::Sprite & mons32 = fheroes2::AGG::GetICN( ICN::MONS32, troop.GetSpriteIndex() );

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -44,6 +44,7 @@
 #include "tools.h"
 #include "translations.h"
 #include "ui_monster.h"
+#include "ui_text.h"
 #include "world.h"
 
 namespace

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -963,12 +963,14 @@ void Battle::Status::Redraw( fheroes2::Image & output ) const
     fheroes2::Copy( back1, 0, 0, output, x, y, back1.width(), back1.height() );
     fheroes2::Copy( back2, 0, 0, output, x, y + back1.height(), back2.width(), back2.height() );
 
+    fheroes2::Display & display = fheroes2::Display::instance();
+
     if ( !_upperText.empty() ) {
-        _upperText.draw( x + ( back1.width() - _upperText.width() ) / 2, y + 4, fheroes2::Display::instance() );
+        _upperText.draw( x + ( back1.width() - _upperText.width() ) / 2, y + 4, display );
     }
 
     if ( !_lowerText.empty() ) {
-        _lowerText.draw( x + ( back2.width() - _lowerText.width() ) / 2, y + back1.height(), fheroes2::Display::instance() );
+        _lowerText.draw( x + ( back2.width() - _lowerText.width() ) / 2, y + back1.height(), display );
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -106,6 +106,15 @@ namespace
 
     const int32_t offsetForTextBar{ 32 };
 
+    const int32_t maxElementsInBattleLog{ 6 };
+
+    // This value must be equal to the height of Normal font.
+    const int32_t battleLogElementHeight{ 17 };
+
+    const int32_t battleLogLastElementOffset{ 4 };
+
+    const int32_t battleLogElementWidth{ fheroes2::Display::DEFAULT_WIDTH - 32 - 16 };
+
     struct LightningPoint
     {
         explicit LightningPoint( const fheroes2::Point & p = fheroes2::Point(), const int32_t thick = 1 )
@@ -370,16 +379,14 @@ namespace Battle
         {
             assert( px >= 0 && py >= 0 );
 
-            const int32_t mx = 6;
-            const int32_t sw = fheroes2::Display::DEFAULT_WIDTH;
-            const int32_t sh = mx * 20;
-            border.SetPosition( px, py - sh - 2, sw - 32, sh - 30 );
+            const int32_t totalElementHeight = maxElementsInBattleLog * battleLogElementHeight - battleLogLastElementOffset;
+            border.SetPosition( px, py - totalElementHeight - 32, fheroes2::Display::DEFAULT_WIDTH - 32, totalElementHeight );
             const fheroes2::Rect & area = border.GetArea();
-            const int32_t ax = area.x + area.width - 20;
 
             SetTopLeft( area.getPosition() );
-            SetAreaMaxItems( mx );
+            SetAreaMaxItems( maxElementsInBattleLog );
 
+            const int32_t ax = area.x + area.width - 20;
             SetScrollButtonUp( ICN::DROPLISL, 6, 7, fheroes2::Point( ax + 8, area.y - 10 ) );
             SetScrollButtonDn( ICN::DROPLISL, 8, 9, fheroes2::Point( ax + 8, area.y + area.height - 11 ) );
 
@@ -394,7 +401,7 @@ namespace Battle
 
             setScrollBarImage( scrollbarSlider );
             _scrollbar.hide();
-            SetAreaItems( { area.x, area.y, area.width - 10, area.height } );
+            SetAreaItems( { area.x, area.y, area.width - 16, area.height + battleLogLastElementOffset } );
             SetListContent( messages );
         }
 
@@ -424,8 +431,10 @@ namespace Battle
 
         void RedrawItem( const std::string & str, int32_t px, int32_t py, bool /* unused */ ) override
         {
-            const Text text( str, Font::BIG );
-            text.Blit( px, py );
+            fheroes2::Text text( str, fheroes2::FontType::normalWhite() );
+            text.fitToOneRow( battleLogElementWidth );
+
+            text.draw( px, py, fheroes2::Display::instance() );
         }
 
         void RedrawBackground( const fheroes2::Point & /* unused*/ ) override

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -76,7 +76,6 @@
 #include "screen.h"
 #include "settings.h"
 #include "spell_book.h"
-#include "text.h"
 #include "timing.h"
 #include "tools.h"
 #include "translations.h"
@@ -967,6 +966,7 @@ void Battle::Status::Redraw( fheroes2::Image & output ) const
     if ( !_upperText.empty() ) {
         _upperText.draw( x + ( back1.width() - _upperText.width() ) / 2, y + 4, fheroes2::Display::instance() );
     }
+
     if ( !_lowerText.empty() ) {
         _lowerText.draw( x + ( back2.width() - _lowerText.width() ) / 2, y + back1.height(), fheroes2::Display::instance() );
     }
@@ -1038,8 +1038,8 @@ void Battle::TurnOrder::RedrawUnit( const fheroes2::Rect & pos, const Battle::Un
                         revert );
     }
 
-    const Text number( fheroes2::abbreviateNumber( static_cast<int32_t>( unit.GetCount() ) ), Font::SMALL );
-    number.Blit( pos.x + 2, pos.y + 2, output );
+    const fheroes2::Text number( fheroes2::abbreviateNumber( static_cast<int32_t>( unit.GetCount() ) ), fheroes2::FontType::smallWhite() );
+    number.draw( pos.x + 2, pos.y + 4, output );
 
     if ( isCurrentUnit ) {
         fheroes2::DrawRect( output, { pos.x, pos.y, turnOrderMonsterIconSize, turnOrderMonsterIconSize }, currentUnitColor );
@@ -1423,8 +1423,8 @@ void Battle::Interface::redrawPreRender()
         assert( board != nullptr );
 
         for ( const Cell & cell : *board ) {
-            const Text text( std::to_string( cell.GetIndex() ), Font::SMALL );
-            text.Blit( cell.GetPos().x + 20, cell.GetPos().y + 22, _mainSurface );
+            const fheroes2::Text text( std::to_string( cell.GetIndex() ), fheroes2::FontType::smallWhite() );
+            text.draw( cell.GetPos().x + 20, cell.GetPos().y + 24, _mainSurface );
         }
     }
 #endif
@@ -1932,8 +1932,8 @@ void Battle::Interface::RedrawTroopCount( const Unit & unit )
 
     fheroes2::Copy( bar, 0, 0, _mainSurface, sx, sy, bar.width(), bar.height() );
 
-    const Text text( fheroes2::abbreviateNumber( static_cast<int32_t>( unit.GetCount() ) ), Font::SMALL );
-    text.Blit( sx + ( bar.width() - text.w() ) / 2, sy, _mainSurface );
+    const fheroes2::Text text( fheroes2::abbreviateNumber( static_cast<int32_t>( unit.GetCount() ) ), fheroes2::FontType::smallWhite() );
+    text.draw( sx + ( bar.width() - text.width() ) / 2, sy + 2, _mainSurface );
 }
 
 void Battle::Interface::RedrawCover()
@@ -6557,7 +6557,7 @@ void Battle::PopupDamageInfo::Redraw() const
     StringReplace( str, "%{min}", std::to_string( _minDamage ) );
     StringReplace( str, "%{max}", std::to_string( _maxDamage ) );
 
-    Text damageText( str, Font::SMALL );
+    const fheroes2::Text damageText( str, fheroes2::FontType::smallWhite() );
 
     const uint32_t minNumKilled = _defender->HowManyWillBeKilled( _minDamage );
     const uint32_t maxNumKilled = _defender->HowManyWillBeKilled( _maxDamage );
@@ -6569,7 +6569,7 @@ void Battle::PopupDamageInfo::Redraw() const
     StringReplace( str, "%{min}", std::to_string( minNumKilled ) );
     StringReplace( str, "%{max}", std::to_string( maxNumKilled ) );
 
-    Text killedText( str, Font::SMALL );
+    const fheroes2::Text killedText( str, fheroes2::FontType::smallWhite() );
 
     const fheroes2::Rect & cellRect = _cell->GetPos();
 
@@ -6577,8 +6577,8 @@ void Battle::PopupDamageInfo::Redraw() const
     const int borderWidth = BorderWidth();
     const int x = _battleUIRect.x + cellRect.x + cellRect.width;
     const int y = _battleUIRect.y + cellRect.y;
-    const int w = std::max( damageText.w(), killedText.w() ) + 2 * borderWidth;
-    const int h = damageText.h() + killedText.h() + 2 * borderWidth;
+    const int w = std::max( damageText.width(), killedText.width() ) + 2 * borderWidth;
+    const int h = damageText.height() + killedText.height() + 2 * borderWidth;
 
     // If the damage info popup doesn't fit the battlefield draw surface, then try to place it on the left side of the cell
     const bool isLeftSidePopup = ( cellRect.x + cellRect.width + w ) > _battleUIRect.width;
@@ -6587,6 +6587,8 @@ void Battle::PopupDamageInfo::Redraw() const
     Dialog::FrameBorder::RenderOther( fheroes2::AGG::GetICN( ICN::CELLWIN, 1 ), borderRect );
 
     const int leftTextBorder = borderRect.x + borderWidth;
-    damageText.Blit( leftTextBorder, borderRect.y + borderWidth );
-    killedText.Blit( leftTextBorder, borderRect.y + borderRect.height / 2 );
+
+    fheroes2::Display & display = fheroes2::Display::instance();
+    damageText.draw( leftTextBorder, borderRect.y + borderWidth + 2, display );
+    killedText.draw( leftTextBorder, borderRect.y + borderRect.height / 2 + 2, display );
 }

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -39,8 +39,8 @@
 #include "image.h"
 #include "math_base.h"
 #include "spell.h"
-#include "text.h"
 #include "ui_button.h"
+#include "ui_text.h"
 
 class Castle;
 class HeroBase;
@@ -190,17 +190,17 @@ namespace Battle
 
         const std::string & GetMessage() const
         {
-            return message;
+            return _lastMessage;
         }
 
         void clear();
 
     private:
-        Text bar1;
-        Text bar2;
+        fheroes2::Text _upperText;
+        fheroes2::Text _lowerText;
         const fheroes2::Sprite & back1;
         const fheroes2::Sprite & back2;
-        std::string message;
+        std::string _lastMessage;
         StatusListBox * listlog;
     };
 

--- a/src/fheroes2/dialog/dialog_buyboat.cpp
+++ b/src/fheroes2/dialog/dialog_buyboat.cpp
@@ -33,9 +33,9 @@
 #include "resource.h"
 #include "screen.h"
 #include "settings.h"
-#include "text.h"
 #include "translations.h"
 #include "ui_button.h"
+#include "ui_text.h"
 
 int Dialog::BuyBoat( bool enable )
 {
@@ -49,23 +49,23 @@ int Dialog::BuyBoat( bool enable )
     Resource::BoxSprite rbs( PaymentConditions::BuyBoat(), BOXAREA_WIDTH );
 
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOATWIND, 0 );
-    Text text( _( "Build a new ship:" ), Font::BIG );
+    fheroes2::Text text{ _( "Build a new ship:" ), fheroes2::FontType::normalWhite() };
     const int spacer = 10;
 
-    Dialog::FrameBox box( text.h() + spacer + sprite.height() + spacer + text.h() + spacer + rbs.GetArea().height - 20, true );
+    Dialog::FrameBox box( text.height() + spacer + sprite.height() + spacer + text.height() + spacer + rbs.GetArea().height - 20, true );
 
     const fheroes2::Rect & box_rt = box.GetArea();
-    fheroes2::Point dst_pt( box_rt.x + ( box_rt.width - text.w() ) / 2, box_rt.y );
-    text.Blit( dst_pt.x, dst_pt.y );
+    fheroes2::Point dst_pt( box_rt.x + ( box_rt.width - text.width() ) / 2, box_rt.y );
+    text.draw( dst_pt.x, dst_pt.y + 2, display );
 
     dst_pt.x = box_rt.x + ( box_rt.width - sprite.width() ) / 2;
-    dst_pt.y = box_rt.y + text.h() + spacer;
+    dst_pt.y = box_rt.y + text.height() + spacer;
     fheroes2::Blit( sprite, display, dst_pt.x, dst_pt.y );
 
-    text.Set( _( "Resource cost:" ), Font::BIG );
-    dst_pt.x = box_rt.x + ( box_rt.width - text.w() ) / 2;
+    text.set( _( "Resource cost:" ), fheroes2::FontType::normalWhite() );
+    dst_pt.x = box_rt.x + ( box_rt.width - text.width() ) / 2;
     dst_pt.y = dst_pt.y + sprite.height() + spacer;
-    text.Blit( dst_pt.x, dst_pt.y );
+    text.draw( dst_pt.x, dst_pt.y + 2, display );
 
     rbs.SetPos( box_rt.x, dst_pt.y + spacer );
     rbs.Redraw();

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -58,7 +58,6 @@
 #include "screen.h"
 #include "settings.h"
 #include "smk_decoder.h"
-#include "text.h"
 #include "translations.h"
 #include "ui_button.h"
 #include "ui_dialog.h"
@@ -250,8 +249,8 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
     // Fade-out screen before playing video.
     fheroes2::fadeOutDisplay();
 
-    const Text loadingScreen( _( "Loading video. Please wait..." ), Font::BIG );
-    loadingScreen.Blit( display.width() / 2 - loadingScreen.w() / 2, display.height() / 2 - loadingScreen.h() / 2 );
+    const fheroes2::Text loadingScreen( _( "Loading video. Please wait..." ), fheroes2::FontType::normalWhite() );
+    loadingScreen.draw( display.width() / 2 - loadingScreen.width() / 2, display.height() / 2 - loadingScreen.height() / 2 + 2, display );
     display.render();
 
     Video::ShowVideo( "INTRO.SMK", Video::VideoAction::PLAY_TILL_VIDEO_END );

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -21,6 +21,7 @@
 #include "skill_bar.h"
 
 #include <cassert>
+#include <utility>
 
 #include "agg_image.h"
 #include "dialog.h"

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -29,7 +29,6 @@
 #include "icn.h"
 #include "screen.h"
 #include "skill.h"
-#include "text.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_dialog.h"
@@ -87,29 +86,34 @@ void PrimarySkillsBar::RedrawItem( int & skill, const fheroes2::Rect & pos, fher
     if ( useSmallSize ) {
         const fheroes2::Sprite & backSprite = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
         const int ww = 32;
-        Text text( "", Font::SMALL );
         const fheroes2::Point dstpt( pos.x + ( pos.width - ww ) / 2, pos.y + ( pos.height - ww ) / 2 );
+
+        std::string skillText;
 
         switch ( skill ) {
         case Skill::Primary::ATTACK:
             fheroes2::Blit( backSprite, 217, 52, dstsf, dstpt.x, dstpt.y, ww, ww );
-            if ( _hero )
-                text.Set( std::to_string( _hero->GetAttack() ) );
+            if ( _hero ) {
+                skillText = std::to_string( _hero->GetAttack() );
+            }
             break;
         case Skill::Primary::DEFENSE:
             fheroes2::Blit( backSprite, 217, 85, dstsf, dstpt.x, dstpt.y, ww, ww );
-            if ( _hero )
-                text.Set( std::to_string( _hero->GetDefense() ) );
+            if ( _hero ) {
+                skillText = std::to_string( _hero->GetDefense() );
+            }
             break;
         case Skill::Primary::POWER:
             fheroes2::Blit( backSprite, 217, 118, dstsf, dstpt.x, dstpt.y, ww, ww );
-            if ( _hero )
-                text.Set( std::to_string( _hero->GetPower() ) );
+            if ( _hero ) {
+                skillText = std::to_string( _hero->GetPower() );
+            }
             break;
         case Skill::Primary::KNOWLEDGE:
             fheroes2::Blit( backSprite, 217, 151, dstsf, dstpt.x, dstpt.y, ww, ww );
-            if ( _hero )
-                text.Set( std::to_string( _hero->GetKnowledge() ) );
+            if ( _hero ) {
+                skillText = std::to_string( _hero->GetKnowledge() );
+            }
             break;
         default:
             // Your primary skill is different. Make sure that the logic is correct!
@@ -117,37 +121,44 @@ void PrimarySkillsBar::RedrawItem( int & skill, const fheroes2::Rect & pos, fher
             break;
         }
 
-        if ( _hero )
-            text.Blit( pos.x + ( pos.width + toff.x - text.w() ) / 2, pos.y + pos.height + toff.y, dstsf );
+        if ( _hero != nullptr && !skillText.empty() ) {
+            // Render text only if there is something to render.
+            const fheroes2::Text text{ std::move( skillText ), fheroes2::FontType::smallWhite() };
+            text.draw( pos.x + ( pos.width + toff.x - text.width() ) / 2, pos.y + pos.height + toff.y + 2, dstsf );
+        }
     }
     else {
         const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::PRIMSKIL, skill - 1 );
         fheroes2::Blit( sprite, dstsf, pos.x + ( pos.width - sprite.width() ) / 2, pos.y + ( pos.height - sprite.height() ) / 2 );
 
-        Text text( Skill::Primary::String( skill ), Font::SMALL );
-        text.Blit( pos.x + ( pos.width - text.w() ) / 2, pos.y + 4, dstsf );
+        fheroes2::Text text{ Skill::Primary::String( skill ), fheroes2::FontType::smallWhite() };
+        text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + 6, dstsf );
 
-        if ( _hero ) {
-            switch ( skill ) {
-            case Skill::Primary::ATTACK:
-                text.Set( std::to_string( _hero->GetAttack() ), Font::BIG );
-                break;
-            case Skill::Primary::DEFENSE:
-                text.Set( std::to_string( _hero->GetDefense() ), Font::BIG );
-                break;
-            case Skill::Primary::POWER:
-                text.Set( std::to_string( _hero->GetPower() ), Font::BIG );
-                break;
-            case Skill::Primary::KNOWLEDGE:
-                text.Set( std::to_string( _hero->GetKnowledge() ), Font::BIG );
-                break;
-            default:
-                // Your primary skill is different. Make sure that the logic is correct!
-                break;
-            }
-
-            text.Blit( pos.x + ( pos.width - text.w() ) / 2, pos.y + pos.height - text.h() - 2, dstsf );
+        if ( _hero == nullptr ) {
+            // Nothing more to render.
+            return;
         }
+
+        switch ( skill ) {
+        case Skill::Primary::ATTACK:
+            text.set( std::to_string( _hero->GetAttack() ), fheroes2::FontType::normalWhite() );
+            break;
+        case Skill::Primary::DEFENSE:
+            text.set( std::to_string( _hero->GetDefense() ), fheroes2::FontType::normalWhite() );
+            break;
+        case Skill::Primary::POWER:
+            text.set( std::to_string( _hero->GetPower() ), fheroes2::FontType::normalWhite() );
+            break;
+        case Skill::Primary::KNOWLEDGE:
+            text.set( std::to_string( _hero->GetKnowledge() ), fheroes2::FontType::normalWhite() );
+            break;
+        default:
+            // Your primary skill is different. Make sure that the logic is correct!
+            assert( 0 );
+            return;
+        }
+
+        text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + pos.height - text.height(), dstsf );
     }
 }
 
@@ -215,22 +226,25 @@ void SecondarySkillsBar::RedrawBackground( const fheroes2::Rect & pos, fheroes2:
 
 void SecondarySkillsBar::RedrawItem( Skill::Secondary & skill, const fheroes2::Rect & pos, fheroes2::Image & dstsf )
 {
-    if ( skill.isValid() ) {
-        const fheroes2::Sprite & sprite
-            = use_mini_sprite ? fheroes2::AGG::GetICN( ICN::MINISS, skill.GetIndexSprite2() ) : fheroes2::AGG::GetICN( ICN::SECSKILL, skill.GetIndexSprite1() );
-        fheroes2::Blit( sprite, dstsf, pos.x + ( pos.width - sprite.width() ) / 2, pos.y + ( pos.height - sprite.height() ) / 2 );
+    if ( !skill.isValid() ) {
+        // If the skill is invalid nothing we need to do.
+        return;
+    }
 
-        if ( use_mini_sprite ) {
-            Text text( std::to_string( skill.Level() ), Font::SMALL );
-            text.Blit( pos.x + ( pos.width - text.w() ) - 3, pos.y + pos.height - 12, dstsf );
-        }
-        else {
-            Text text( Skill::Secondary::String( skill.Skill() ), Font::SMALL );
-            text.Blit( pos.x + ( pos.width - text.w() ) / 2, pos.y + 3, dstsf );
+    const fheroes2::Sprite & sprite
+        = use_mini_sprite ? fheroes2::AGG::GetICN( ICN::MINISS, skill.GetIndexSprite2() ) : fheroes2::AGG::GetICN( ICN::SECSKILL, skill.GetIndexSprite1() );
+    fheroes2::Blit( sprite, dstsf, pos.x + ( pos.width - sprite.width() ) / 2, pos.y + ( pos.height - sprite.height() ) / 2 );
 
-            text.Set( Skill::Level::StringWithBonus( _hero, skill ) );
-            text.Blit( pos.x + ( pos.width - text.w() ) / 2, pos.y + 51, dstsf );
-        }
+    if ( use_mini_sprite ) {
+        const fheroes2::Text text{ std::to_string( skill.Level() ), fheroes2::FontType::smallWhite() };
+        text.draw( pos.x + ( pos.width - text.width() ) - 3, pos.y + pos.height - 10, dstsf );
+    }
+    else {
+        fheroes2::Text text{ Skill::Secondary::String( skill.Skill() ), fheroes2::FontType::smallWhite() };
+        text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + 5, dstsf );
+
+        text.set( Skill::Level::StringWithBonus( _hero, skill ), fheroes2::FontType::smallWhite() );
+        text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + 53, dstsf );
     }
 }
 

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -38,8 +38,8 @@
 #include "rand.h"
 #include "screen.h"
 #include "serialize.h"
-#include "text.h"
 #include "translations.h"
+#include "ui_text.h"
 
 Funds::Funds()
     : wood( 0 )
@@ -636,11 +636,13 @@ void Resource::BoxSprite::SetPos( int32_t px, int32_t py )
 
 void RedrawResourceSprite( const fheroes2::Image & sf, const fheroes2::Point & pos, int32_t count, int32_t width, int32_t offset, int32_t value )
 {
-    const fheroes2::Point dst_pt( pos.x + width / 2 + count * width, pos.y + offset );
-    fheroes2::Blit( sf, fheroes2::Display::instance(), dst_pt.x - sf.width() / 2, dst_pt.y - sf.height() );
+    fheroes2::Display & display = fheroes2::Display::instance();
 
-    const Text text( std::to_string( value ), Font::SMALL );
-    text.Blit( dst_pt.x - text.w() / 2, dst_pt.y + 2 );
+    const fheroes2::Point dst_pt( pos.x + width / 2 + count * width, pos.y + offset );
+    fheroes2::Blit( sf, display, dst_pt.x - sf.width() / 2, dst_pt.y - sf.height() );
+
+    const fheroes2::Text text{ std::to_string( value ), fheroes2::FontType::smallWhite() };
+    text.draw( dst_pt.x - text.width() / 2, dst_pt.y + 4, display );
 }
 
 void Resource::BoxSprite::Redraw() const


### PR DESCRIPTION
We need to use only one class to avoid ambiguity in using text related classes. Places where the text rendering was changes:
- army / monster bar
- battle log, unit number in the battle and battle order, damage info dialog
- shipyard message about boat purchase
- primary and secondary skills bars
- resource rendering for building requirements
- `Loading video. Please wait...` text when starting The Succession Wars campaign

Also this pull request does:
- fixes long sentences in battle log (fix #6357):
![image](https://github.com/ihhub/fheroes2/assets/19829520/67a88191-ef43-41ea-8b6e-fb8e5f281a9f)

- open battle log has the same offset between lines like every else in the game: 17 pixels instead of 15 pixels. In this case the log is by 8 pixels higher. The text offset in the log is 16 pixels from all sides.

To test pull request compare the corresponding dialogs with texts on master branch and from here. The text should be on the same position as before, except the battle log (see the explanation above).