### PR TITLE
Use the "continue movement" button to interact with an object a hero is standing on

### DIFF
--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -110,7 +110,7 @@ namespace Interface
         void updateFocus();
 
         void EventSwitchHeroSleeping();
-        fheroes2::GameMode EventDefaultAction( const fheroes2::GameMode gameMode );
+        fheroes2::GameMode EventDefaultAction();
         void EventOpenFocus() const;
         fheroes2::GameMode EventSaveGame() const;
         void EventPuzzleMaps() const;
@@ -118,7 +118,7 @@ namespace Interface
         void EventSystemDialog() const;
         void EventNextHero();
         void EventNextTown();
-        void EventContinueMovement() const;
+        fheroes2::GameMode EventContinueMovement();
         void EventKingdomInfo() const;
         void EventCastSpell();
         void EventSwitchShowRadar() const;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1035,7 +1035,7 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isload )
             else if ( HotKeyPressEvent( Game::HotKeyEvent::WORLD_TOGGLE_ICONS ) )
                 EventSwitchShowIcons();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::WORLD_CONTINUE_HERO_MOVEMENT ) )
-                EventContinueMovement();
+                res = EventContinueMovement();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::WORLD_DIG_ARTIFACT ) )
                 res = EventDigArtifact();
             else if ( HotKeyPressEvent( Game::HotKeyEvent::WORLD_SLEEP_HERO ) )
@@ -1068,7 +1068,7 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isload )
                 _gameArea.SetScroll( SCROLL_BOTTOM );
             // default action
             else if ( HotKeyPressEvent( Game::HotKeyEvent::WORLD_DEFAULT_ACTION ) )
-                res = EventDefaultAction( res );
+                res = EventDefaultAction();
             // open focus
             else if ( HotKeyPressEvent( Game::HotKeyEvent::WORLD_OPEN_FOCUS ) )
                 EventOpenFocus();

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -161,13 +161,20 @@ void Interface::AdventureMap::EventNextHero()
     RedrawFocus();
 }
 
-void Interface::AdventureMap::EventContinueMovement() const
+fheroes2::GameMode Interface::AdventureMap::EventContinueMovement()
 {
     Heroes * hero = GetFocusHeroes();
 
-    if ( hero && hero->GetPath().isValidForMovement() && hero->MayStillMove( false, true ) ) {
-        hero->SetMove( true );
+    if ( hero ) {
+        if ( hero->GetPath().isValidForMovement() && hero->MayStillMove( false, true ) ) {
+            hero->SetMove( true );
+        }
+        else if ( MP2::isActionObject( hero->getObjectTypeUnderHero(), hero->isShipMaster() ) ) {
+            return EventDefaultAction();
+        }
     }
+
+    return fheroes2::GameMode::CANCEL;
 }
 
 void Interface::AdventureMap::EventKingdomInfo() const
@@ -445,12 +452,11 @@ fheroes2::GameMode Interface::AdventureMap::EventDigArtifact()
     return fheroes2::GameMode::CANCEL;
 }
 
-fheroes2::GameMode Interface::AdventureMap::EventDefaultAction( const fheroes2::GameMode gameMode )
+fheroes2::GameMode Interface::AdventureMap::EventDefaultAction()
 {
     Heroes * hero = GetFocusHeroes();
 
     if ( hero ) {
-        // 1. action object
         if ( MP2::isActionObject( hero->getObjectTypeUnderHero(), hero->isShipMaster() ) ) {
             hero->Action( hero->GetIndex() );
 
@@ -459,20 +465,20 @@ fheroes2::GameMode Interface::AdventureMap::EventDefaultAction( const fheroes2::
             ResetFocus( GameFocus::HEROES, true );
             RedrawFocus();
 
-            // If a hero completed an action we must verify the condition for the scenario.
+            // If the hero has performed an action, we have to check the completion condition
+            // of the scenario
             if ( hero->isAction() ) {
                 hero->ResetAction();
-                // check if the game is over after the hero's action
+
                 return GameOver::Result::Get().checkGameOver();
             }
         }
     }
     else if ( GetFocusCastle() ) {
-        // 2. town dialog
         Game::OpenCastleDialog( *GetFocusCastle() );
     }
 
-    return gameMode;
+    return fheroes2::GameMode::CANCEL;
 }
 
 void Interface::AdventureMap::EventOpenFocus() const


### PR DESCRIPTION
close #7765

I know it looks somewhat controversial, but this mechanism allows the hero to interact with the object on which he stands when playing on touch-screen devices, without additional user interface changes and various cryptic finger gestures that no one will know about.