### PR TITLE
Combat victory window creature position

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -539,21 +539,6 @@ void Troops::MergeSameMonsterTroops()
     }
 }
 
-Troops Troops::GetReversed() const
-{
-    Troops result;
-    result.reserve( size() );
-
-    for ( auto iter = rbegin(); iter != rend(); ++iter ) {
-
-        Troop * newTroop = new Troop( **iter );
-        result.push_back( newTroop );
-    }
-
-    return result;
-}
-
-
 bool Troops::MergeSameMonsterOnce()
 {
     for ( size_t slot = 0; slot < size(); ++slot ) {

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -539,6 +539,21 @@ void Troops::MergeSameMonsterTroops()
     }
 }
 
+Troops Troops::GetReversed() const
+{
+    Troops result;
+    result.reserve( size() );
+
+    for ( auto iter = rbegin(); iter != rend(); ++iter ) {
+
+        Troop * newTroop = new Troop( **iter );
+        result.push_back( newTroop );
+    }
+
+    return result;
+}
+
+
 bool Troops::MergeSameMonsterOnce()
 {
     for ( size_t slot = 0; slot < size(); ++slot ) {

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1502,12 +1502,12 @@ bool Army::isMeleeDominantArmy() const
     return meleeInfantry > other;
 }
 
-void Army::drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, uint32_t width )
+void Army::drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, int32_t width )
 {
     fheroes2::drawMiniMonsters( troops, cx, cy, width, 0, 0, false, true, false, 0, fheroes2::Display::instance() );
 }
 
-void Army::drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_t posY, uint32_t lineWidth, bool isCompact, const bool isDetailedView,
+void Army::drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_t posY, int32_t lineWidth, bool isCompact, const bool isDetailedView,
                                      const bool isGarrisonView /* = false */, const uint32_t thievesGuildsCount /* = 0 */ )
 {
     const uint32_t count = troops.GetOccupiedSlotCount();

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -122,8 +122,6 @@ public:
     // Combines all stacks consisting of identical monsters
     void MergeSameMonsterTroops();
 
-    Troops GetReversed() const;
-
 protected:
     void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver );
 

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -173,8 +173,8 @@ public:
 
     static NeutralMonsterJoiningCondition GetJoinSolution( const Heroes &, const Maps::Tiles &, const Troop & );
 
-    static void drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, uint32_t width );
-    static void drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_t posY, uint32_t lineWidth, bool isCompact, const bool isDetailedView,
+    static void drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, int32_t width );
+    static void drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_t posY, int32_t lineWidth, bool isCompact, const bool isDetailedView,
                                           const bool isGarrisonView = false, const uint32_t thievesGuildsCount = 0 );
 
     explicit Army( HeroBase * cmdr = nullptr );

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -122,6 +122,8 @@ public:
     // Combines all stacks consisting of identical monsters
     void MergeSameMonsterTroops();
 
+    Troops GetReversed() const;
+
 protected:
     void JoinStrongest( Troops & giverArmy, const bool keepAtLeastOneSlotForGiver );
 

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -59,7 +59,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         }
 
         int marginLeft = 18;
-        chunk =  ( width - marginLeft ) / ( count + ( slotsToSkip * 2 ) ) ;
+        chunk = ( width - marginLeft ) / ( count + ( slotsToSkip * 2 ) );
 
         slots = troops.Size() + slotsToSkip;
 
@@ -81,7 +81,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
             troop = troops.GetTroop( slot );
         }
         else {
-            troop = troops.GetTroop( ( troops.Size() - 1 ) - slot + slotOffset ); 
+            troop = troops.GetTroop( ( troops.Size() - 1 ) - slot + slotOffset );
         }
 
         if ( troop == nullptr || !troop->isValid() ) {

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -45,8 +45,8 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
     }
 
     int slotsToSkip = 1;
-    if ( count < 5 ) {
-        slotsToSkip = 1;
+    if ( count <= 2 ) {
+        slotsToSkip = 2;
     }
     else if ( count >= 7 ) {
         slotsToSkip = 0;
@@ -65,7 +65,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
     const int slotOffset = slotsToSkip;
 
     for ( size_t slot = 0; slot < slots; ++slot ) {
-
+        //Skip the monster handling when a slot is empty
         if ( slotsToSkip > 0 ) {
             slotsToSkip--;
             cx -= chunk;
@@ -113,7 +113,13 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         else {
             if ( slotsToSkip == 0 ) {
                 const int offsetY = 28 - monster.height();
-                const int OffsetX = -15; //(monster.width() / 2) -12;
+                int OffsetX = -14;    
+
+                //Center the monster if there is only one
+                if ( count == 1 && slot == 1 ) {
+                    OffsetX = -10;
+                }
+
                 int x = ( cx - ( monster.width() / 2 ) ) + OffsetX;
                 int y = cy + offsetY + monster.y(); 
                 fheroes2::Blit( monster, output, x, y);

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -45,13 +45,15 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
     }
 
     const int chunk = width / count;
+    Troops reversedTroops = troops.GetReversed();
 
     if ( !isCompact ) {
-        cx += chunk / 2;
+        cx -= chunk / 2;
+        cx += width;
     }
 
-    for ( size_t slot = 0; slot <= troops.Size(); ++slot ) {
-        const Troop * troop = troops.GetTroop( slot );
+    for ( size_t slot = 0; slot < reversedTroops.Size(); ++slot ) {
+        const Troop * troop = reversedTroops.GetTroop( slot );
         if ( troop == nullptr || !troop->isValid() ) {
             continue;
         }
@@ -90,10 +92,12 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         }
         else {
             const int offsetY = 28 - monster.height();
-            fheroes2::Blit( monster, output, cx - monster.width() / 2 + monster.x() + 2, cy + offsetY + monster.y() );
-            text.draw( cx - text.width() / 2, cy + 29, output );
+            int x = ( cx - ( monster.width() / 2 ) ) + monster.x() -12; //( monster.width() / 2 ) - 25;
+            int y = cy + offsetY + monster.y(); 
+            fheroes2::Blit( monster, output, x, y);
+            text.draw( cx - text.width() / 2  -12, cy + 29, output );
         }
-        cx += chunk;
+        cx -= chunk;
         --count;
     }
 }

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -44,11 +44,10 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         count = troops.GetOccupiedSlotCount();
     }
 
-    int chunk = static_cast<int32_t>( width / count );
+    int32_t chunk = width / static_cast<int32_t>( count );
     size_t slots = troops.Size();
-    int slotsToSkip = 1;
-
-    int slotOffset = 1;
+    int32_t slotsToSkip = 1;
+    int32_t slotOffset = 1;
 
     if ( !isCompact ) {
         if ( count <= 2 ) {
@@ -58,10 +57,10 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
             slotsToSkip = 0;
         }
 
-        int marginLeft = 18;
-        chunk = static_cast<int32_t>( ( width - marginLeft ) / ( count + ( slotsToSkip * 2 ) ) );
+        int32_t marginLeft = 18;
+        chunk = ( width - marginLeft ) / ( static_cast<int32_t>( count ) + ( slotsToSkip * 2 ) );
 
-        slots = troops.Size() + slotsToSkip;
+        slots += static_cast<size_t>( slotsToSkip );
 
         cx -= chunk / 2;
         cx += width;
@@ -121,16 +120,16 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
             text.draw( cx + chunk - text.width() - offset, cy + 23, output );
         }
         else if ( slotsToSkip == 0 ) {
-            const int offsetY = 28 - monster.height();
-            int offsetX = -14;
+            const int32_t offsetY = 28 - monster.height();
+            int32_t offsetX = -14;
 
             // Center the monster if there is only one
             if ( count == 1 && slot == 1 ) {
                 offsetX = -10;
             }
 
-            int x = ( cx - ( monster.width() / 2 ) ) + offsetX;
-            int y = cy + offsetY + monster.y();
+            int32_t x = ( cx - ( monster.width() / 2 ) ) + offsetX;
+            int32_t y = cy + offsetY + monster.y();
             fheroes2::Blit( monster, output, x, y );
             text.draw( ( cx - text.width() / 2 ) + offsetX, cy + 29, output );
         }

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -59,7 +59,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         }
 
         int marginLeft = 18;
-        chunk = ( width - marginLeft ) / ( count + ( slotsToSkip * 2 ) );
+        chunk = static_cast<int32_t>( ( width - marginLeft ) / ( count + ( slotsToSkip * 2 ) ) );
 
         slots = troops.Size() + slotsToSkip;
 

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -44,16 +44,36 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         count = troops.GetOccupiedSlotCount();
     }
 
-    const int chunk = width / count;
+    int slotsToSkip = 1;
+    if ( count < 5 ) {
+        slotsToSkip = 1;
+    }
+    else if ( count >= 7 ) {
+        slotsToSkip = 0;
+    }
+
+    int marginLeft = 18;
+    const int chunk = ( width - marginLeft ) / (count + ( slotsToSkip * 2 ) );
     Troops reversedTroops = troops.GetReversed();
+    const size_t slots = reversedTroops.Size() + slotsToSkip;
 
     if ( !isCompact ) {
         cx -= chunk / 2;
         cx += width;
     }
 
-    for ( size_t slot = 0; slot < reversedTroops.Size(); ++slot ) {
-        const Troop * troop = reversedTroops.GetTroop( slot );
+    const int slotOffset = slotsToSkip;
+
+    for ( size_t slot = 0; slot < slots; ++slot ) {
+
+        if ( slotsToSkip > 0 ) {
+            slotsToSkip--;
+            cx -= chunk;
+            continue;
+        }
+ 
+        const Troop * troop = reversedTroops.GetTroop( slot - slotOffset );
+
         if ( troop == nullptr || !troop->isValid() ) {
             continue;
         }
@@ -91,11 +111,14 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
             text.draw( cx + chunk - text.width() - offset, cy + 23, output );
         }
         else {
-            const int offsetY = 28 - monster.height();
-            int x = ( cx - ( monster.width() / 2 ) ) + monster.x() -12; //( monster.width() / 2 ) - 25;
-            int y = cy + offsetY + monster.y(); 
-            fheroes2::Blit( monster, output, x, y);
-            text.draw( cx - text.width() / 2  -12, cy + 29, output );
+            if ( slotsToSkip == 0 ) {
+                const int offsetY = 28 - monster.height();
+                const int OffsetX = -15; //(monster.width() / 2) -12;
+                int x = ( cx - ( monster.width() / 2 ) ) + OffsetX;
+                int y = cy + offsetY + monster.y(); 
+                fheroes2::Blit( monster, output, x, y);
+                text.draw( ( cx - text.width() / 2 ) +  OffsetX , cy + 29, output );
+            }
         }
         cx -= chunk;
         --count;

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -33,7 +33,7 @@
 #include "image.h"
 #include "ui_text.h"
 
-void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_t cy, const uint32_t width, uint32_t first, uint32_t count, const bool isCompact,
+void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_t cy, const int32_t width, uint32_t first, uint32_t count, const bool isCompact,
                                  const bool isDetailedView, const bool isGarrisonView, const uint32_t thievesGuildsCount, Image & output )
 {
     if ( !troops.isValid() ) {
@@ -47,7 +47,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
     int chunk = static_cast<int32_t>( width / count );
     size_t slots = troops.Size();
     int slotsToSkip = 1;
-    Troops reversedTroops;
+
     int slotOffset = 1;
 
     if ( !isCompact ) {
@@ -59,26 +59,12 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         }
 
         int marginLeft = 18;
-        chunk = static_cast<int32_t>( ( width - marginLeft ) / ( count + ( slotsToSkip * 2 ) ) );
+        chunk =  ( width - marginLeft ) / ( count + ( slotsToSkip * 2 ) ) ;
 
-        if ( troops.Size() > 0 ) {
-            for ( size_t i = troops.Size() - 1;; ) {
-                const Troop * monster = troops.GetTroop( i );
-                reversedTroops.PushBack( *monster, monster->GetCount() );
-
-                if ( i > 0 ) {
-                    --i;
-                }
-                else {
-                    break;
-                }
-            }
-        }
-
-        slots = reversedTroops.Size() + slotsToSkip;
+        slots = troops.Size() + slotsToSkip;
 
         cx -= chunk / 2;
-        cx += static_cast<int32_t>( width );
+        cx += width;
         slotOffset = slotsToSkip;
     }
 
@@ -90,9 +76,12 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
             continue;
         }
 
-        const Troop * troop = troops.GetTroop( slot );
-        if ( !isCompact ) {
-            troop = reversedTroops.GetTroop( slot - slotOffset );
+        const Troop * troop = nullptr;
+        if ( isCompact ) {
+            troop = troops.GetTroop( slot );
+        }
+        else {
+            troop = troops.GetTroop( ( troops.Size() - 1 ) - slot + slotOffset ); 
         }
 
         if ( troop == nullptr || !troop->isValid() ) {
@@ -131,21 +120,19 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
             fheroes2::Blit( monster, output, cx + offset, cy + offsetY + monster.y() );
             text.draw( cx + chunk - text.width() - offset, cy + 23, output );
         }
-        else {
-            if ( slotsToSkip == 0 ) {
-                const int offsetY = 28 - monster.height();
-                int OffsetX = -14;
+        else if ( slotsToSkip == 0 ) {
+            const int offsetY = 28 - monster.height();
+            int offsetX = -14;
 
-                // Center the monster if there is only one
-                if ( count == 1 && slot == 1 ) {
-                    OffsetX = -10;
-                }
-
-                int x = ( cx - ( monster.width() / 2 ) ) + OffsetX;
-                int y = cy + offsetY + monster.y();
-                fheroes2::Blit( monster, output, x, y );
-                text.draw( ( cx - text.width() / 2 ) + OffsetX, cy + 29, output );
+            // Center the monster if there is only one
+            if ( count == 1 && slot == 1 ) {
+                offsetX = -10;
             }
+
+            int x = ( cx - ( monster.width() / 2 ) ) + offsetX;
+            int y = cy + offsetY + monster.y();
+            fheroes2::Blit( monster, output, x, y );
+            text.draw( ( cx - text.width() / 2 ) + offsetX, cy + 29, output );
         }
         if ( isCompact ) {
             cx += chunk;

--- a/src/fheroes2/army/army_ui_helper.h
+++ b/src/fheroes2/army/army_ui_helper.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2023                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/army/army_ui_helper.h
+++ b/src/fheroes2/army/army_ui_helper.h
@@ -28,6 +28,6 @@ namespace fheroes2
 {
     class Image;
 
-    void drawMiniMonsters( const Troops & troops, int32_t cx, const int32_t cy, const uint32_t width, uint32_t first, uint32_t count, const bool isCompact,
+    void drawMiniMonsters( const Troops & troops, int32_t cx, const int32_t cy, const int32_t width, uint32_t first, uint32_t count, const bool isCompact,
                            const bool isDetailedView, const bool isGarrisonView, const uint32_t thievesGuildsCount, Image & output );
 }

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -496,68 +496,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     LocalEvent & le = LocalEvent::Get();
     const Settings & conf = Settings::Get();
 
-    //Army monsters2;
-
-    //monsters2.GetTroop( 0 )->Set( Monster::BOAR, 1 );
-    //monsters2.GetTroop( 1 )->Set( Monster::BOAR, 50 );
-    //monsters2.GetTroop( 2 )->Set( Monster::BOAR, 1 );
-    //monsters2.GetTroop( 3 )->Set( Monster::BOAR, 1 );
-    //monsters2.GetTroop( 4 )->Set( Monster::BOAR, 1 );
-
-
-    Troops killedcustom = Troops(); 
-    Troop troop = Troop(Monster::AIR_ELEMENT, 10);
-    Troop troopBoar = Troop( Monster::BOAR, 10 );
-    Troop troopCav = Troop( Monster::CAVALRY, 10 );
-
-    killedcustom.PushBack( troopBoar, 6 );
-    killedcustom.PushBack( troop, 6 );
-    killedcustom.PushBack( troop, 6 );
-    killedcustom.PushBack( troop, 6 );
-    killedcustom.PushBack( troopCav, 6 );
-    killedcustom.PushBack( troopCav, 6 );
-    killedcustom.PushBack( troopCav, 6 );
-    killedcustom.PushBack( troop, 6 );
-    killedcustom.PushBack( troop, 6 );
-    killedcustom.PushBack( troop, 6 );
-    killedcustom.PushBack( troop, 6 );
-    killedcustom.PushBack( troop, 6 );
-    killedcustom.PushBack( troopBoar, 6 );
-    //killedcustom.PushBack( troop, 6 );
-    //killedcustom.PushBack( troop, 6 );
-    //killedcustom.PushBack( troopCav, 6 );
-    //killedcustom.PushBack( troop, 6 );
-    //killedcustom.PushBack( troop, 6 );
-    //killedcustom.PushBack( troop, 6 );
-    //killedcustom.PushBack( troopBoar, 6 );
-    //killedcustom.PushBack( troopBoar, 6 );
-    //killedcustom.PushBack( troopBoar, 6 );
-    //killedcustom.PushBack( troopBoar, 6 );
-    killedcustom.GetTroop( 0 )->SetCount( 2 );
-    killedcustom.GetTroop( 1 )->SetCount( 2 );
-    killedcustom.GetTroop( 2 )->SetCount(3 );
-    killedcustom.GetTroop( 3 )->SetCount( 34 );
-    killedcustom.GetTroop( 4 )->SetCount( 3 );
-    killedcustom.GetTroop( 5 )->SetCount( 2 );
-    killedcustom.GetTroop( 6 )->SetCount( 3 );
-    killedcustom.GetTroop( 7 )->SetCount( 34 );
-    killedcustom.GetTroop( 8 )->SetCount( 3 );
-    killedcustom.GetTroop( 6 )->SetCount( 2 );
-    killedcustom.GetTroop( 7 )->SetCount( 3 );
-    killedcustom.GetTroop( 8 )->SetCount( 34 );
-    killedcustom.GetTroop( 9 )->SetCount( 3 );
-    //killedcustom.GetTroop( 10 )->SetCount( 3 );
-    //killedcustom.GetTroop( 11 )->SetCount( 2 );
-    //killedcustom.GetTroop( 12 )->SetCount( 3 );
-    //killedcustom.GetTroop( 13 )->SetCount( 34 );
-    //killedcustom.GetTroop( 14 )->SetCount( 3 );
-    //killedcustom.GetTroop( 15 )->SetCount( 3 );
-    //killedcustom.GetTroop( 16 )->SetCount( 2 );
-    //killedcustom.GetTroop( 17 )->SetCount( 3 );
-    //killedcustom.GetTroop( 18 )->SetCount( 34 );
-    //killedcustom.GetTroop( 19 )->SetCount( 3 );
-
-    const Troops killed1 = killedcustom; //_army1->GetKilledTroops();
+    const Troops killed1 = _army1->GetKilledTroops();
     const Troops killed2 = _army2->GetKilledTroops();
 
     // Set the cursor image. After this dialog the Game Area or the Battlefield will be shown, so it does not require a cursor restorer.

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -496,7 +496,68 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     LocalEvent & le = LocalEvent::Get();
     const Settings & conf = Settings::Get();
 
-    const Troops killed1 = _army1->GetKilledTroops();
+    //Army monsters2;
+
+    //monsters2.GetTroop( 0 )->Set( Monster::BOAR, 1 );
+    //monsters2.GetTroop( 1 )->Set( Monster::BOAR, 50 );
+    //monsters2.GetTroop( 2 )->Set( Monster::BOAR, 1 );
+    //monsters2.GetTroop( 3 )->Set( Monster::BOAR, 1 );
+    //monsters2.GetTroop( 4 )->Set( Monster::BOAR, 1 );
+
+
+    Troops killedcustom = Troops(); 
+    Troop troop = Troop(Monster::AIR_ELEMENT, 10);
+    Troop troopBoar = Troop( Monster::BOAR, 10 );
+    Troop troopCav = Troop( Monster::CAVALRY, 10 );
+
+    killedcustom.PushBack( troopBoar, 6 );
+    killedcustom.PushBack( troop, 6 );
+    killedcustom.PushBack( troop, 6 );
+    killedcustom.PushBack( troop, 6 );
+    killedcustom.PushBack( troopCav, 6 );
+    killedcustom.PushBack( troopCav, 6 );
+    killedcustom.PushBack( troopCav, 6 );
+    killedcustom.PushBack( troop, 6 );
+    killedcustom.PushBack( troop, 6 );
+    killedcustom.PushBack( troop, 6 );
+    killedcustom.PushBack( troop, 6 );
+    killedcustom.PushBack( troop, 6 );
+    killedcustom.PushBack( troopBoar, 6 );
+    //killedcustom.PushBack( troop, 6 );
+    //killedcustom.PushBack( troop, 6 );
+    //killedcustom.PushBack( troopCav, 6 );
+    //killedcustom.PushBack( troop, 6 );
+    //killedcustom.PushBack( troop, 6 );
+    //killedcustom.PushBack( troop, 6 );
+    //killedcustom.PushBack( troopBoar, 6 );
+    //killedcustom.PushBack( troopBoar, 6 );
+    //killedcustom.PushBack( troopBoar, 6 );
+    //killedcustom.PushBack( troopBoar, 6 );
+    killedcustom.GetTroop( 0 )->SetCount( 2 );
+    killedcustom.GetTroop( 1 )->SetCount( 2 );
+    killedcustom.GetTroop( 2 )->SetCount(3 );
+    killedcustom.GetTroop( 3 )->SetCount( 34 );
+    killedcustom.GetTroop( 4 )->SetCount( 3 );
+    killedcustom.GetTroop( 5 )->SetCount( 2 );
+    killedcustom.GetTroop( 6 )->SetCount( 3 );
+    killedcustom.GetTroop( 7 )->SetCount( 34 );
+    killedcustom.GetTroop( 8 )->SetCount( 3 );
+    killedcustom.GetTroop( 6 )->SetCount( 2 );
+    killedcustom.GetTroop( 7 )->SetCount( 3 );
+    killedcustom.GetTroop( 8 )->SetCount( 34 );
+    killedcustom.GetTroop( 9 )->SetCount( 3 );
+    //killedcustom.GetTroop( 10 )->SetCount( 3 );
+    //killedcustom.GetTroop( 11 )->SetCount( 2 );
+    //killedcustom.GetTroop( 12 )->SetCount( 3 );
+    //killedcustom.GetTroop( 13 )->SetCount( 34 );
+    //killedcustom.GetTroop( 14 )->SetCount( 3 );
+    //killedcustom.GetTroop( 15 )->SetCount( 3 );
+    //killedcustom.GetTroop( 16 )->SetCount( 2 );
+    //killedcustom.GetTroop( 17 )->SetCount( 3 );
+    //killedcustom.GetTroop( 18 )->SetCount( 34 );
+    //killedcustom.GetTroop( 19 )->SetCount( 3 );
+
+    const Troops killed1 = killedcustom; //_army1->GetKilledTroops();
     const Troops killed2 = _army2->GetKilledTroops();
 
     // Set the cursor image. After this dialog the Game Area or the Battlefield will be shown, so it does not require a cursor restorer.


### PR DESCRIPTION
Fix #1611
Margins fixed and displaying starts from the right of the window so overlapping is more appealing. 
To test with different army sizes you can setup a hardcoded army in battle_dialogs.cpp, l. 500:
```
    Troops killedcustom = Troops(); 
    Troop troop = Troop(Monster::AIR_ELEMENT, 10);
    Troop troopBoar = Troop( Monster::BOAR, 10 );

    killedcustom.PushBack( troop, troop.GetCount() );
    killedcustom.PushBack( troopBoar, 5 );

    const Troops killed1 = killedcustom; //_army1->GetKilledTroops();
```
    
I'm new to c++ and memory management on this level, so if you could be extra alert on that while reviewing, then that would be great.