### PR TITLE
Fix archer evaluation regression

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -432,7 +432,7 @@ namespace AI
             const double unitStr = unit.GetStrength();
 
             _enemyArmyStrength += unitStr;
-            if ( unit.canShoot() ) {
+            if ( unit.isArchers() && !unit.isImmovable() ) {
                 _enemyRangedUnitsOnly += unitStr;
             }
 
@@ -476,7 +476,7 @@ namespace AI
                 continue;
             }
             _myArmyStrength += unitStr;
-            if ( unit.canShoot() ) {
+            if ( unit.isArchers() && !unit.isImmovable() ) {
                 _myShooterStr += unitStr;
             }
         }

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -320,8 +320,7 @@ namespace AI
 
         // Make sure this spell can be applied to the current unit (skip check for dispel estimation)
         if ( !forDispel
-             && ( ( target.isImmovable() && spellID != Spell::ANTIMAGIC ) || target.isUnderSpellEffect( spell )
-                  || !target.AllowApplySpell( spell, _commander ) ) ) {
+             && ( ( target.isImmovable() && spellID != Spell::ANTIMAGIC ) || target.isUnderSpellEffect( spell ) || !target.AllowApplySpell( spell, _commander ) ) ) {
             return 0.0;
         }
 

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -159,7 +159,7 @@ namespace AI
             double unitPercentageLost = std::min( static_cast<double>( damage ) / hitpoints, 1.0 );
 
             // Penalty for waking up disabled unit (if you kill only 30%, rest 70% is your penalty)
-            if ( unit->Modes( SP_BLIND | SP_PARALYZE | SP_STONE ) ) {
+            if ( unit->isImmovable() ) {
                 unitPercentageLost += unitPercentageLost - 1.0;
             }
             return unitPercentageLost * unit->GetStrength();
@@ -320,7 +320,7 @@ namespace AI
 
         // Make sure this spell can be applied to the current unit (skip check for dispel estimation)
         if ( !forDispel
-             && ( ( target.Modes( SP_BLIND | SP_PARALYZE | SP_STONE ) && spellID != Spell::ANTIMAGIC ) || target.isUnderSpellEffect( spell )
+             && ( ( target.isImmovable() && spellID != Spell::ANTIMAGIC ) || target.isUnderSpellEffect( spell )
                   || !target.AllowApplySpell( spell, _commander ) ) ) {
             return 0.0;
         }
@@ -443,7 +443,7 @@ namespace AI
         else if ( spellID == Spell::SHIELD || spellID == Spell::MASSSHIELD ) {
             ratio = _enemyRangedUnitsOnly / _enemyArmyStrength * 0.3;
 
-            if ( target.canShoot() ) {
+            if ( target.isArchers() ) {
                 ratio *= 1.25;
             }
         }

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -375,7 +375,7 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
                     defender->SetResponse();
                 }
 
-                if ( doubleAttack && attacker->isValid() && !attacker->Modes( SP_BLIND | IS_PARALYZE_MAGIC ) ) {
+                if ( doubleAttack && attacker->isValid() && !attacker->isImmovable() ) {
                     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "double attack" )
                     BattleProcess( *attacker, *defender, dst, dir );
                 }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -479,11 +479,10 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
                 break;
             }
 
-            const bool isImmovable = troop->Modes( SP_BLIND | IS_PARALYZE_MAGIC );
             const bool isSkipsMove = troop->Modes( TR_SKIP );
 
             // Good morale
-            if ( troop->isValid() && troop->Modes( TR_MOVED ) && troop->Modes( MORALE_GOOD ) && !isImmovable && !isSkipsMove ) {
+            if ( troop->isValid() && troop->Modes( TR_MOVED ) && troop->Modes( MORALE_GOOD ) && !troop->isImmovable() && !isSkipsMove ) {
                 actions.emplace_back( CommandType::MSG_BATTLE_MORALE, troop->GetUID(), true );
             }
         }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -278,7 +278,7 @@ bool Battle::Force::animateIdleUnits() const
         if ( unit->isValid() ) {
             if ( unit->isIdling() ) {
                 // Go to 'STATIC' animation state if idle animation is over or if unit is blinded or paralyzed.
-                if ( unit->isFinishAnimFrame() || unit->Modes( SP_BLIND | IS_PARALYZE_MAGIC ) ) {
+                if ( unit->isFinishAnimFrame() || unit->isImmovable() ) {
                     redrawNeeded = unit->SwitchAnimation( Monster_Info::STATIC ) || redrawNeeded;
                 }
                 else {
@@ -288,7 +288,7 @@ bool Battle::Force::animateIdleUnits() const
             }
             // checkIdleDelay() sets and checks unit's internal timer if we're ready to switch to next one.
             // Do not start idle animations for paralyzed or blinded units.
-            else if ( unit->GetAnimationState() == Monster_Info::STATIC && !unit->Modes( SP_BLIND | IS_PARALYZE_MAGIC ) && unit->checkIdleDelay() ) {
+            else if ( unit->GetAnimationState() == Monster_Info::STATIC && !unit->isImmovable() && unit->checkIdleDelay() ) {
                 redrawNeeded = unit->SwitchAnimation( Monster_Info::IDLE ) || redrawNeeded;
             }
         }
@@ -300,7 +300,7 @@ void Battle::Force::resetIdleAnimation() const
 {
     for ( Unit * unit : *this ) {
         // Check if unit is alive, not paralyzed or blinded and is in 'STATIC' animation state.
-        if ( unit->isValid() && unit->GetAnimationState() == Monster_Info::STATIC && !unit->Modes( SP_BLIND | IS_PARALYZE_MAGIC ) ) {
+        if ( unit->isValid() && unit->GetAnimationState() == Monster_Info::STATIC && !unit->isImmovable() ) {
             unit->checkIdleDelay();
         }
     }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -30,7 +30,6 @@
 #include "army_troop.h"
 #include "artifact.h"
 #include "artifact_info.h"
-#include "battle.h"
 #include "battle_arena.h"
 #include "battle_cell.h"
 #include "battle_troop.h"

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -758,9 +758,9 @@ uint32_t Battle::Unit::Resurrect( const uint32_t points, const bool allow_overfl
     return resurrect;
 }
 
-bool Battle::Unit::canShoot() const
+bool Battle::Unit::isImmovable() const
 {
-    return isArchers() && !Modes( SP_BLIND | IS_PARALYZE_MAGIC ) && !isHandFighting();
+    return Modes( SP_BLIND | IS_PARALYZE_MAGIC );
 }
 
 uint32_t Battle::Unit::ApplyDamage( Unit & enemy, const uint32_t dmg, uint32_t & killed, uint32_t * ptrResurrected )
@@ -1199,7 +1199,7 @@ int32_t Battle::Unit::GetScoreQuality( const Unit & defender ) const
         }
     }
     // Finally ignore disabled units (if belong to the enemy)
-    else if ( attacker.Modes( SP_BLIND ) || attacker.Modes( IS_PARALYZE_MAGIC ) ) {
+    else if ( attacker.isImmovable() ) {
         attackerThreat = 0;
     }
 

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -179,7 +179,7 @@ namespace Battle
             return shots;
         }
 
-        bool canShoot() const;
+        bool isImmovable() const;
 
         uint32_t ApplyDamage( Unit & enemy, const uint32_t dmg, uint32_t & killed, uint32_t * ptrResurrected );
 


### PR DESCRIPTION
Fixes #7857 . Handfighting check caused AI to flip between defence and offence modes constantly. Also wrapped a common unit modes check as a function.