### PR TITLE
Fix the correct default monster count in the Editor by default

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -608,6 +608,9 @@ namespace Interface
                 const fheroes2::ActionCreator action( _historyManager );
 
                 Maps::setMonsterOnTile( tile, _editorPanel.getMonsterId(), 0 );
+                // Since setMonsterOnTile() function interprets 0 as a random number of monsters it is important to set the correct value.
+                Maps::setMonsterCountOnTile( tile, 0 );
+
                 _redraw |= mapUpdateFlags;
             }
         }


### PR DESCRIPTION
0 means default. This is important as we need to save this value into the map format and later read and set during map loading.