### PR TITLE
Build the Editor for release but allow only with a specific config flag

### DIFF
--- a/src/fheroes2/editor/editor.h
+++ b/src/fheroes2/editor/editor.h
@@ -20,7 +20,6 @@
 
 #pragma once
 
-#if defined( WITH_DEBUG )
 #include "game.h"
 #include "game_mode.h"
 
@@ -30,4 +29,3 @@ namespace Editor
     fheroes2::GameMode menuNewMap();
     fheroes2::GameMode menuLoadMap();
 }
-#endif

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -202,12 +202,9 @@ namespace Interface
                 if ( HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_QUIT ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
                     res = EventExit();
                 }
-                // TODO: remove this 'if defined' when Editor is ready for release.
-#if defined( WITH_DEBUG )
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::EDITOR_NEW_MAP_MENU ) ) {
                     res = eventNewMap();
                 }
-#endif
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::WORLD_SAVE_GAME ) ) {
                     fheroes2::showStandardTextMessage( _( "Warning!" ), "The Map Editor is still in development. Save function is not implemented yet.", Dialog::OK );
                 }
@@ -246,15 +243,12 @@ namespace Interface
                     fheroes2::showStandardTextMessage( _( "Warning!" ), "The Map Editor is still in development. Open focused object dialog is not implemented yet.",
                                                        Dialog::OK );
                 }
-// TODO: remove this macro check once the Editor is ready for public.
-#if defined( WITH_DEBUG )
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::EDITOR_UNDO_LAST_ACTION ) ) {
                     undoAction();
                 }
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::EDITOR_REDO_LAST_ACTION ) ) {
                     redoAction();
                 }
-#endif
             }
 
             if ( res != fheroes2::GameMode::CANCEL ) {
@@ -467,12 +461,7 @@ namespace Interface
             le.MousePressLeft( buttonQuit.area() ) ? buttonQuit.drawOnPress() : buttonQuit.drawOnRelease();
             le.MousePressLeft( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
 
-            // TODO: remove this 'if defined' when Editor is ready for release.
-#if defined( WITH_DEBUG )
             if ( le.MouseClickLeft( buttonNew.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::EDITOR_NEW_MAP_MENU ) ) {
-#else
-            if ( le.MouseClickLeft( buttonNew.area() ) ) {
-#endif
                 if ( eventNewMap() == fheroes2::GameMode::EDITOR_NEW_MAP ) {
                     result = fheroes2::GameMode::EDITOR_NEW_MAP;
                     break;

--- a/src/fheroes2/editor/editor_mainmenu.cpp
+++ b/src/fheroes2/editor/editor_mainmenu.cpp
@@ -18,8 +18,6 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#if defined( WITH_DEBUG )
-
 #include <array>
 #include <cstddef>
 #include <cstdint>
@@ -319,4 +317,3 @@ namespace Editor
         return fheroes2::GameMode::EDITOR_MAIN_MENU;
     }
 }
-#endif

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -181,7 +181,6 @@ namespace
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::MAIN_MENU_NEW_EXPANSION_CAMPAIGN )]
             = { HotKeyCategory::MAIN_MENU, gettext_noop( "hotkey|choose the expansion campaign" ), fheroes2::Key::KEY_E };
 
-#if defined( WITH_DEBUG )
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::EDITOR_MAIN_MENU )]
             = { HotKeyCategory::EDITOR, gettext_noop( "hotkey|map editor main menu" ), fheroes2::Key::KEY_E };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::EDITOR_NEW_MAP_MENU )]
@@ -196,7 +195,6 @@ namespace
             = { HotKeyCategory::EDITOR, gettext_noop( "hotkey|undo last action" ), fheroes2::Key::KEY_U };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::EDITOR_REDO_LAST_ACTION )]
             = { HotKeyCategory::EDITOR, gettext_noop( "hotkey|redo last action" ), fheroes2::Key::KEY_R };
-#endif
 
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::CAMPAIGN_ROLAND )]
             = { HotKeyCategory::CAMPAIGN, gettext_noop( "hotkey|roland campaign" ), fheroes2::Key::KEY_1 };

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -65,8 +65,6 @@ namespace Game
         MAIN_MENU_NEW_ORIGINAL_CAMPAIGN,
         MAIN_MENU_NEW_EXPANSION_CAMPAIGN,
 
-#if defined( WITH_DEBUG )
-        // Editor is still in development.
         EDITOR_MAIN_MENU,
         EDITOR_NEW_MAP_MENU,
         EDITOR_LOAD_MAP_MENU,
@@ -74,7 +72,6 @@ namespace Game
         EDITOR_RANDOM_MAP_MENU,
         EDITOR_UNDO_LAST_ACTION,
         EDITOR_REDO_LAST_ACTION,
-#endif
 
         CAMPAIGN_ROLAND,
         CAMPAIGN_ARCHIBALD,

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -180,7 +180,6 @@ void Game::mainGameLoop( bool isFirstGameRun )
                 result = Game::SelectCampaignScenario( fheroes2::GameMode::LOAD_CAMPAIGN, false );
             }
             break;
-#if defined( WITH_DEBUG )
         case fheroes2::GameMode::EDITOR_MAIN_MENU:
             result = Editor::menuMain();
             break;
@@ -190,7 +189,6 @@ void Game::mainGameLoop( bool isFirstGameRun )
         case fheroes2::GameMode::EDITOR_LOAD_MAP:
             result = Editor::menuLoadMap();
             break;
-#endif
 
         default:
             // If this assertion blows up then you are entering an infinite loop!
@@ -374,12 +372,9 @@ fheroes2::GameMode Game::MainMenu( bool isFirstGameRun )
 
             return fheroes2::GameMode::MAIN_MENU;
         }
-#if defined( WITH_DEBUG )
-        // Editor is still in development.
-        else if ( HotKeyPressEvent( HotKeyEvent::EDITOR_MAIN_MENU ) ) {
+        else if ( conf.isEditorEnabled() && HotKeyPressEvent( HotKeyEvent::EDITOR_MAIN_MENU ) ) {
             return fheroes2::GameMode::EDITOR_MAIN_MENU;
         }
-#endif
 
         // right info
         if ( le.MousePressRight( buttonQuit.area() ) )

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -323,7 +323,7 @@ bool Settings::Read( const std::string & filePath )
     }
 
     if ( config.Exists( "editor" ) && config.StrParams( "editor" ) == "beta" ) {
-        _optGlobal.ResetModes( GLOBAL_ENABLE_EDITOR );
+        _optGlobal.SetModes( GLOBAL_ENABLE_EDITOR );
     }
 
     return true;
@@ -472,6 +472,10 @@ std::string Settings::String() const
 
     os << std::endl << "# scaling type: nearest or linear (set by default)" << std::endl;
     os << "screen scaling type = " << ( _optGlobal.Modes( GLOBAL_SCREEN_SCALING_TYPE_NEAREST ) ? "nearest" : "linear" ) << std::endl;
+
+    if ( _optGlobal.Modes( GLOBAL_ENABLE_EDITOR ) ) {
+        os << "editor = beta" << std::endl;
+    }
 
     return os.str();
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -78,7 +78,9 @@ namespace
         GLOBAL_BATTLE_AUTO_RESOLVE = 0x04000000,
         GLOBAL_BATTLE_AUTO_SPELLCAST = 0x08000000,
         GLOBAL_AUTO_SAVE_AT_BEGINNING_OF_TURN = 0x10000000,
-        GLOBAL_SCREEN_SCALING_TYPE_NEAREST = 0x20000000
+        GLOBAL_SCREEN_SCALING_TYPE_NEAREST = 0x20000000,
+        // TODO: remove this setting once the Editor goes public.
+        GLOBAL_ENABLE_EDITOR = 0x40000000
     };
 }
 
@@ -318,6 +320,10 @@ bool Settings::Read( const std::string & filePath )
 
     if ( config.Exists( "screen scaling type" ) ) {
         setScreenScalingTypeNearest( config.StrParams( "screen scaling type" ) == "nearest" );
+    }
+
+    if ( config.Exists( "editor" ) && config.StrParams( "editor" ) == "beta" ) {
+        _optGlobal.ResetModes( GLOBAL_ENABLE_EDITOR );
     }
 
     return true;
@@ -833,6 +839,11 @@ bool Settings::isHideInterfaceEnabled() const
 bool Settings::isEvilInterfaceEnabled() const
 {
     return _optGlobal.Modes( GLOBAL_EVIL_INTERFACE );
+}
+
+bool Settings::isEditorEnabled() const
+{
+    return _optGlobal.Modes( GLOBAL_ENABLE_EDITOR );
 }
 
 bool Settings::ShowControlPanel() const

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -187,6 +187,7 @@ public:
     bool isBattleShowDamageInfoEnabled() const;
     bool isHideInterfaceEnabled() const;
     bool isEvilInterfaceEnabled() const;
+    bool isEditorEnabled() const;
 
     bool LoadedGameVersion() const
     {


### PR DESCRIPTION
Since we are going to release the Editor in the future we should start building it for release builds now to catch any issues in the code. This will also help us with testing as we don't need to provide debug builds anymore. A special config flag is required to prevent users playing with an unfinished product and complain about it.