### PR TITLE
Add "tent visited" info to barrier quick info dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -333,9 +333,10 @@ namespace
     std::string showBarrierInfo( const Maps::Tiles & tile, const Kingdom & kingdom )
     {
         std::string str = _( "%{color} Barrier" );
-        StringReplace( str, "%{color}", fheroes2::getBarrierColorName( getColorFromTile( tile ) ) );
-        const int32_t tentColor = getColorFromTile( tile );
-        if ( kingdom.IsVisitTravelersTent( tentColor ) ) {
+        const int32_t barrierColor = getColorFromTile( tile );
+        StringReplace( str, "%{color}", fheroes2::getBarrierColorName( barrierColor ) );
+
+        if ( kingdom.IsVisitTravelersTent( barrierColor ) ) {
             str.append( "\n\n" );
             str.append( _( "(tent visited)" ) );
         }

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -330,10 +330,15 @@ namespace
         return str;
     }
 
-    std::string showBarrierInfo( const Maps::Tiles & tile )
+    std::string showBarrierInfo( const Maps::Tiles & tile, const Kingdom & kingdom )
     {
         std::string str = _( "%{color} Barrier" );
         StringReplace( str, "%{color}", fheroes2::getBarrierColorName( getColorFromTile( tile ) ) );
+        const int32_t tentColor = getColorFromTile( tile );
+        if ( kingdom.IsVisitTravelersTent( tentColor ) ) {
+            str.append( "\n\n" );
+            str.append( _( "(tent visited)" ) );
+        }
 
         return str;
     }
@@ -538,7 +543,7 @@ namespace
             return showWitchHutInfo( tile, kingdom.isVisited( tile ) );
 
         case MP2::OBJ_BARRIER:
-            return showBarrierInfo( tile );
+            return showBarrierInfo( tile, kingdom );
 
         case MP2::OBJ_TRAVELLER_TENT:
             return showTentInfo( tile, kingdom );


### PR DESCRIPTION
This will tell you when right-clicking a barrier if the corresponding tent has been visited or not.

This is helpful for those XL maps when you don't remember what colors of tents you have visted and don't want to play Where's Waldo trying to find them.

![image](https://github.com/ihhub/fheroes2/assets/12501091/87074813-c888-44f8-bd9c-3ac945a9d0d9)
