### PR TITLE
Fix troops sprites overlap in quick info

### DIFF
--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -40,7 +40,8 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         return;
     }
 
-    if ( 0 == count ) {
+    if ( count == 0 ) {
+        // If this function was called with 'count == 0' than the count is determined by the number of troop slots.
         count = troops.GetOccupiedSlotCount();
     }
 
@@ -60,6 +61,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
     const size_t slots = troops.Size();
     for ( size_t slot = 0; slot < slots; ++slot ) {
         if ( count == 0 ) {
+            // We have rendered the given count of troops. There is nothing more to do.
             break;
         }
 

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -40,16 +40,21 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
         return;
     }
 
+    bool isRightToLeftRender = false;
+
     if ( count == 0 ) {
         // If this function was called with 'count == 0' than the count is determined by the number of troop slots.
         count = troops.GetOccupiedSlotCount();
+
+        if ( first == 0 ) {
+            // This is the case when we render all the troops and do it from left to right.
+            // It is done to make troop sprites overlapping more appealing when troops are close to each other.
+            // This case may occur if many troops were killed during the battle (lots of summoned elementals and/or mirror image troops).
+            isRightToLeftRender = true;
+        }
     }
 
     const double chunk = width / static_cast<double>( count );
-
-    // If troops are close to each other (it may occur if many troops were killed during the battle)
-    // we render them from right to left to make troop sprites overlapping more appealing.
-    const bool isRightToLeftRender = chunk < 25;
 
     if ( !isCompact ) {
         cx += static_cast<int32_t>( chunk / 2 );
@@ -65,7 +70,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
             break;
         }
 
-        const Troop * troop = troops.GetTroop( slot );
+        const Troop * troop = troops.GetTroop( isRightToLeftRender ? ( slots - slot - 1 ) : slot );
 
         if ( troop == nullptr || !troop->isValid() ) {
             continue;

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -579,7 +579,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     text.draw( pos_rt.x + ( pos_rt.width - text.width() ) / 2, pos_rt.y + 287, display );
 
     if ( killed1.isValid() ) {
-        Army::drawSingleDetailedMonsterLine( killed1, pos_rt.x + 25, pos_rt.y + 308, 270 );
+        Army::drawSingleDetailedMonsterLine( killed1, pos_rt.x + 40, pos_rt.y + 308, 240 );
     }
     else {
         text.set( _( "None" ), fheroes2::FontType::smallWhite() );
@@ -591,7 +591,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     text.draw( pos_rt.x + ( pos_rt.width - text.width() ) / 2, pos_rt.y + 347, display );
 
     if ( killed2.isValid() ) {
-        Army::drawSingleDetailedMonsterLine( killed2, pos_rt.x + 25, pos_rt.y + 368, 270 );
+        Army::drawSingleDetailedMonsterLine( killed2, pos_rt.x + 40, pos_rt.y + 368, 240 );
     }
     else {
         text.set( _( "None" ), fheroes2::FontType::smallWhite() );


### PR DESCRIPTION
Fix #7927 

![1](https://github.com/ihhub/fheroes2/assets/113276641/076fe339-a513-4b4b-9833-922b835ed53c)
![2](https://github.com/ihhub/fheroes2/assets/113276641/d31c5697-da4b-4b3a-992b-dc937d4aea24)
![3](https://github.com/ihhub/fheroes2/assets/113276641/87319e49-375b-44c1-aaa0-e3207808e33a)
![4](https://github.com/ihhub/fheroes2/assets/113276641/10b34adb-e446-4865-b01b-e5fd5ad1cbcc)
![5](https://github.com/ihhub/fheroes2/assets/113276641/5a6d56b5-dc66-4978-af27-e2bef0c34d3f)
