### PR TITLE
Fix recruit dialog MIN/MAX button when switching creature upgrades

### DIFF
--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -505,6 +505,15 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
             fheroes2::Copy( background, 0, 0, display, dialogOffset.x, dialogOffset.y, windowSize.width, windowSize.height );
 
             max = CalculateMax( monster, kingdom, available );
+
+            if ( max == 0 ) {
+                buttonMin.disable();
+                buttonMax.disable();
+            }
+            else if ( !buttonMax.isEnabled() && !buttonMin.isEnabled() ) {
+                buttonMin.enable();
+            }
+
             result = max;
             paymentMonster = monster.GetCost();
             paymentCosts = paymentMonster * result;


### PR DESCRIPTION
Fix #7936 

This PR fixes MIN/MAX button render when switching creature upgrades in recruit window.

https://github.com/ihhub/fheroes2/assets/113276641/063dd50c-877d-4aee-bdbd-9f9b1eb170f6

