### PR TITLE
Update hashes for Android & Windows dependency packages

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.1.1'
+        classpath 'com.android.tools.build:gradle:8.1.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=E5B1166AF1A2E133E0D5A59FC3B1681F079EE752D849D555703C1C265FB03D24
+set PKG_FILE_SHA256=EE7B465DDCE33B34FB1D389D36203441CBC28A56CAAF24F3F0BA6AD60D1A3A22
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -23,7 +23,7 @@
 set -e -o pipefail
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="e5b1166af1a2e133e0d5a59fc3b1681f079ee752d849d555703c1c265fb03d24"
+PKG_FILE_SHA256="ee7b465ddce33b34fb1d389d36203441cbc28a56caaf24f3f0ba6ad60d1a3a22"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=14F2C29E0A4AF4B5BA686F426DBA2488C3F8D359AF40AE89132B4EE3628A7F08
+set PKG_FILE_SHA256=8D434511D0DD206CAECD781652C88F2F67B4CAB3DF371DB21F856F88D3E047B8
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
See https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/39 for details. Also this PR bumps AGP version to 8.1.2.