### PR TITLE
Add support for the future new heroes

### DIFF
--- a/src/fheroes2/agg/icn.cpp
+++ b/src/fheroes2/agg/icn.cpp
@@ -721,6 +721,8 @@ uint32_t ICN::AnimationFrame( int icn, uint32_t start, uint32_t ticket, bool qua
 int ICN::PORTxxxx( int heroId )
 {
     switch ( heroId ) {
+    case Heroes::UNKNOWN:
+        return ICN::UNKNOWN;
     case Heroes::LORDKILBURN:
         return ICN::PORT0000;
     case Heroes::SIRGALLANTH:
@@ -841,7 +843,6 @@ int ICN::PORTxxxx( int heroId )
         return ICN::PORT0058;
     case Heroes::BRAX:
         return ICN::PORT0059;
-
     case Heroes::SOLMYR:
         return ICN::PORT0060;
     case Heroes::DAINWIN:
@@ -864,11 +865,11 @@ int ICN::PORTxxxx( int heroId )
         return ICN::PORT0069;
     case Heroes::JARKONAS:
         return ICN::PORT0070;
-
     case Heroes::DEBUG_HERO:
         return ICN::PORT0059;
-
     default:
+        // Did you add a new hero? Add the logic above!
+        assert( 0 );
         break;
     }
 

--- a/src/fheroes2/agg/icn.cpp
+++ b/src/fheroes2/agg/icn.cpp
@@ -22,6 +22,9 @@
  ***************************************************************************/
 
 #include "icn.h"
+
+#include <cassert>
+
 #include "color.h"
 #include "heroes.h"
 #include "race.h"

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -551,9 +551,9 @@ Monster Dialog::selectMonster( const int monsterId, const bool includeRandomMons
 
 int Dialog::selectHeroes( const int heroId /* = Heroes::UNKNOWN */ )
 {
-    std::vector<int> heroes( static_cast<int>( Settings::Get().isCurrentMapPriceOfLoyalty() ? Heroes::DEBUG_HERO : Heroes::SOLMYR ), Heroes::UNKNOWN );
+    std::vector<int> heroes( static_cast<int>( Settings::Get().isCurrentMapPriceOfLoyalty() ? Heroes::JARKONAS : Heroes::BRAX ), Heroes::UNKNOWN );
 
-    std::iota( heroes.begin(), heroes.end(), 0 );
+    std::iota( heroes.begin(), heroes.end(), Heroes::UNKNOWN + 1 );
 
     SelectEnumHeroes listbox( { 240, fheroes2::Display::instance().height() - 200 } );
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2178,7 +2178,7 @@ Heroes * AllHeroes::GetHeroForHire( const int race, const int heroIDToIgnore ) c
 
 void AllHeroes::Scout( int colors ) const
 {
-    for ( Heroes * hero : *this ) {
+    for ( const Heroes * hero : *this ) {
         assert( hero != nullptr );
         if ( colors & hero->GetColor() ) {
             hero->Scout( hero->GetIndex() );
@@ -2336,7 +2336,7 @@ StreamBase & operator<<( StreamBase & msg, const AllHeroes & heroes )
 {
     msg << static_cast<uint32_t>( heroes.size() );
 
-    for ( const auto & hero : heroes ) {
+    for ( Heroes * const & hero : heroes ) {
         msg << *hero;
     }
 
@@ -2364,7 +2364,7 @@ StreamBase & operator>>( StreamBase & msg, AllHeroes & heroes )
         msg >> *heroes[0];
     }
     else {
-        for ( auto & hero : heroes ) {
+        for ( Heroes *& hero : heroes ) {
             hero = new Heroes();
             msg >> *hero;
         }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2263,8 +2263,7 @@ StreamBase & operator>>( StreamBase & msg, Heroes & hero )
             hero._id = Heroes::UNKNOWN;
             hero.portrait = Heroes::UNKNOWN;
         }
-        else
-        {
+        else {
             ++hero._id;
             ++hero.portrait;
         }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1967,8 +1967,7 @@ Heroes::HeroSeedsForLevelUp Heroes::GetSeedsForLevelUp() const
 
 double Heroes::getAIMinimumJoiningArmyStrength() const
 {
-    // Ideally we need to assert here that the hero is under AI control.
-    // But in cases when we regain a temporary control from the AI then the hero becomes non-AI.
+    assert( isControlAI() );
 
     double strengthThreshold = 0.05;
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2326,9 +2326,21 @@ StreamBase & operator>>( StreamBase & msg, AllHeroes & heroes )
     heroes.clear();
     heroes.resize( size, nullptr );
 
-    for ( AllHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it ) {
-        *it = new Heroes();
-        msg >> **it;
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
+        for ( size_t i = 1; i < heroes.size(); ++i ) {
+            heroes[i] = new Heroes();
+            msg >> *heroes[i];
+        }
+
+        heroes[0] = new Heroes();
+        msg >> *heroes[0];
+    }
+    else {
+        for ( AllHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it ) {
+            *it = new Heroes();
+            msg >> **it;
+        }
     }
 
     return msg;

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2237,7 +2237,7 @@ StreamBase & operator>>( StreamBase & msg, VecHeroes & heroes )
             heroes.emplace_back( hero );
         }
         else {
-            if ( Heroes::isValidId( hid ) ) {
+            if ( !Heroes::isValidId( hid ) ) {
                 continue;
             }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2212,17 +2212,17 @@ StreamBase & operator>>( StreamBase & msg, VecHeroes & heroes )
 
     heroes.resize( size, nullptr );
 
-    for ( AllHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it ) {
+    for ( Heroes * hero : heroes ) {
         uint32_t hid;
         msg >> hid;
 
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
         if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
             // UNKNOWN was 72 before FORMAT_VERSION_1010_RELEASE.
-            *it = ( hid != 72 ? world.GetHeroes( hid + 1 ) : nullptr );
+            hero = ( hid != 72 ? world.GetHeroes( hid + 1 ) : nullptr );
         }
         else {
-            *it = ( Heroes::isValidId( hid ) ? world.GetHeroes( hid ) : nullptr );
+            hero = ( Heroes::isValidId( hid ) ? world.GetHeroes( hid ) : nullptr );
         }
     }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2212,17 +2212,17 @@ StreamBase & operator>>( StreamBase & msg, VecHeroes & heroes )
 
     heroes.resize( size, nullptr );
 
-    for ( Heroes * hero : heroes ) {
+    for ( AllHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it ) {
         uint32_t hid;
         msg >> hid;
 
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
         if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
             // UNKNOWN was 72 before FORMAT_VERSION_1010_RELEASE.
-            hero = ( hid != 72 ? world.GetHeroes( hid + 1 ) : nullptr );
+            *it = ( hid != 72 ? world.GetHeroes( hid + 1 ) : nullptr );
         }
         else {
-            hero = ( Heroes::isValidId( hid ) ? world.GetHeroes( hid ) : nullptr );
+            *it = ( Heroes::isValidId( hid ) ? world.GetHeroes( hid ) : nullptr );
         }
     }
 
@@ -2336,9 +2336,9 @@ StreamBase & operator>>( StreamBase & msg, AllHeroes & heroes )
         msg >> *heroes[0];
     }
     else {
-        for ( Heroes * hero : heroes ) {
-            hero = new Heroes();
-            msg >> *hero;
+        for ( AllHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it ) {
+            *it = new Heroes();
+            msg >> **it;
         }
     }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2258,8 +2258,16 @@ StreamBase & operator>>( StreamBase & msg, Heroes & hero )
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
-        ++hero._id;
-        ++hero.portrait;
+        // Before FORMAT_VERSION_1010_RELEASE Heroes::UNKNOWN was 72.
+        if ( hero._id == 72 ) {
+            hero._id = Heroes::UNKNOWN;
+            hero.portrait = Heroes::UNKNOWN;
+        }
+        else
+        {
+            ++hero._id;
+            ++hero.portrait;
+        }
     }
 
     using ObjectTypeUnderHeroType = std::underlying_type_t<decltype( hero._objectTypeUnderHero )>;

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2336,9 +2336,9 @@ StreamBase & operator>>( StreamBase & msg, AllHeroes & heroes )
         msg >> *heroes[0];
     }
     else {
-        for ( AllHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it ) {
-            *it = new Heroes();
-            msg >> **it;
+        for ( Heroes * hero : heroes ) {
+            hero = new Heroes();
+            msg >> *hero;
         }
     }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1825,7 +1825,7 @@ const fheroes2::Sprite & Heroes::GetPortrait( int id, int type )
         }
         case PORT_SMALL:
             if ( id == Heroes::DEBUG_HERO ) {
-                return fheroes2::AGG::GetICN( ICN::MINIPORT, BRAX );
+                return fheroes2::AGG::GetICN( ICN::MINIPORT, BRAX - 1 );
             }
 
             // Since hero IDs start from 1 we have to deduct 1 from the ID.

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2198,8 +2198,8 @@ StreamBase & operator<<( StreamBase & msg, const VecHeroes & heroes )
 {
     msg << static_cast<uint32_t>( heroes.size() );
 
-    for ( AllHeroes::const_iterator it = heroes.begin(); it != heroes.end(); ++it ) {
-        msg << ( *it ? ( *it )->GetID() : Heroes::UNKNOWN );
+    for ( const Heroes * hero : heroes ) {
+        msg << ( ( hero != nullptr ) ? hero->GetID() : Heroes::UNKNOWN );
     }
 
     return msg;

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2217,7 +2217,7 @@ StreamBase & operator>>( StreamBase & msg, VecHeroes & heroes )
     heroes.clear();
 
     for ( uint32_t i = 0; i < size; ++i ) {
-        uint32_t hid;
+        int32_t hid;
         msg >> hid;
 
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2212,17 +2212,17 @@ StreamBase & operator>>( StreamBase & msg, VecHeroes & heroes )
 
     heroes.resize( size, nullptr );
 
-    for ( AllHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it ) {
+    for ( auto & hero : heroes ) {
         uint32_t hid;
         msg >> hid;
 
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
         if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
             // UNKNOWN was 72 before FORMAT_VERSION_1010_RELEASE.
-            *it = ( hid != 72 ? world.GetHeroes( hid + 1 ) : nullptr );
+            hero = ( hid != 72 ? world.GetHeroes( hid + 1 ) : nullptr );
         }
         else {
-            *it = ( Heroes::isValidId( hid ) ? world.GetHeroes( hid ) : nullptr );
+            hero = ( Heroes::isValidId( hid ) ? world.GetHeroes( hid ) : nullptr );
         }
     }
 
@@ -2336,9 +2336,9 @@ StreamBase & operator>>( StreamBase & msg, AllHeroes & heroes )
         msg >> *heroes[0];
     }
     else {
-        for ( AllHeroes::iterator it = heroes.begin(); it != heroes.end(); ++it ) {
-            *it = new Heroes();
-            msg >> **it;
+        for ( auto & hero : heroes ) {
+            hero = new Heroes();
+            msg >> *hero;
         }
     }
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1827,7 +1827,7 @@ const fheroes2::Sprite & Heroes::GetPortrait( int id, int type )
             if ( id == Heroes::DEBUG_HERO ) {
                 return fheroes2::AGG::GetICN( ICN::MINIPORT, BRAX );
             }
-            
+
             // Since hero IDs start from 1 we have to deduct 1 from the ID.
             return fheroes2::AGG::GetICN( ICN::MINIPORT, id - 1 );
         default:
@@ -2017,10 +2017,6 @@ Heroes * VecHeroes::Get( int hid ) const
 
 Heroes * VecHeroes::Get( const fheroes2::Point & center ) const
 {
-    for ( Heroes * hero : * this ) {
-        assert( hero != nullptr );
-    }
-
     const_iterator it = begin();
     for ( ; it != end(); ++it )
         if ( ( *it )->isPosition( center ) )

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -714,7 +714,7 @@ struct AllHeroes : public VecHeroes
     void Init();
     void clear();
 
-    void Scout( int ) const;
+    void Scout( int colors ) const;
 
     void ResetModes( const uint32_t modes ) const
     {
@@ -736,9 +736,8 @@ struct AllHeroes : public VecHeroes
         std::for_each( begin(), end(), []( Heroes * hero ) { hero->ActionNewMonth(); } );
     }
 
-    Heroes * GetHero( const Castle & castle ) const;
     Heroes * GetHeroForHire( const int race, const int heroIDToIgnore ) const;
-    Heroes * FromJail( int32_t ) const;
+    Heroes * FromJail( int32_t index ) const;
 };
 
 StreamBase & operator<<( StreamBase &, const VecHeroes & );

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -65,22 +65,17 @@ namespace fheroes2
     class Sprite;
 }
 
-struct HeroSeedsForLevelUp
-{
-    uint32_t seedPrimarySkill = 0;
-    uint32_t seedSecondarySkill1 = 0;
-    uint32_t seedSecondarySkill2 = 0;
-    uint32_t seedSecondarySkillRandomChoose = 0;
-};
-
 class Heroes final : public HeroBase, public ColorBase
 {
 public:
     friend class Battle::Only;
 
-    enum
+    enum : int32_t
     {
-        // knight
+        // Unknown / undefined hero.
+        UNKNOWN,
+
+        // Knight heroes from The Succession Wars.
         LORDKILBURN,
         SIRGALLANTH,
         ECTOR,
@@ -90,7 +85,8 @@ public:
         RUBY,
         MAXIMUS,
         DIMITRY,
-        // barbarian
+
+        // Barbarian heroes from The Succession Wars.
         THUNDAX,
         FINEOUS,
         JOJOSH,
@@ -100,7 +96,8 @@ public:
         ERGON,
         TSABU,
         ATLAS,
-        // sorceress
+
+        // Sorceress heroes from The Succession Wars.
         ASTRA,
         NATASHA,
         TROYAN,
@@ -110,7 +107,8 @@ public:
         ARIEL,
         CARLAWN,
         LUNA,
-        // warlock
+
+        // Warlock heroes from The Succession Wars.
         ARIE,
         ALAMAR,
         VESPER,
@@ -120,7 +118,8 @@ public:
         AGAR,
         FALAGAR,
         WRATHMONT,
-        // wizard
+
+        // Wizard heroes from The Succession Wars.
         MYRA,
         FLINT,
         DAWN,
@@ -130,7 +129,8 @@ public:
         SARAKIN,
         KALINDRA,
         MANDIGAL,
-        // necromancer
+
+        // Necromancer heroes from The Succession Wars.
         ZOM,
         DARLANA,
         ZAM,
@@ -140,14 +140,16 @@ public:
         ROXANA,
         SANDRO,
         CELIA,
-        // From The Succession Wars campaign.
+
+        // The Succession Wars campaign heroes.
         ROLAND,
         CORLAGON,
         ELIZA,
         ARCHIBALD,
         HALTON,
         BRAX,
-        // From The Price of Loyalty expansion.
+
+        // The Price of Loyalty expansion heroes.
         SOLMYR,
         DAINWIN,
         MOG,
@@ -159,9 +161,14 @@ public:
         DRAKONIA,
         MARTINE,
         JARKONAS,
-        // debugger
+
+        // Debug hero. Should not be used anywhere outside the development!
         DEBUG_HERO,
-        UNKNOWN
+
+        // Resurrection expansion heroes.
+
+        // IMPORTANT! Put all new heroes just above this line.
+        HEROES_COUNT
     };
 
     enum : uint32_t
@@ -273,9 +280,6 @@ public:
 
     Heroes & operator=( const Heroes & ) = delete;
 
-    static const fheroes2::Sprite & GetPortrait( int heroid, int type );
-    static const char * GetName( int heroid );
-
     bool isValid() const override;
     // Returns true if the hero is active on the adventure map (i.e. has a valid ID, is not imprisoned, and is hired by
     // some kingdom), otherwise returns false
@@ -304,7 +308,7 @@ public:
 
     int GetID() const
     {
-        return hid;
+        return _id;
     }
 
     double getMeetingValue( const Heroes & otherHero ) const;
@@ -393,7 +397,7 @@ public:
         return secondary_skills;
     }
 
-    bool PickupArtifact( const Artifact & );
+    bool PickupArtifact( const Artifact & art );
 
     bool HasUltimateArtifact() const
     {
@@ -563,9 +567,6 @@ public:
         return ( portrait >= SOLMYR && portrait <= JARKONAS );
     }
 
-    static int GetLevelFromExperience( uint32_t );
-    static uint32_t GetExperienceFromLevel( int );
-
     fheroes2::Point MovementDirection() const;
 
     int GetAttackedMonsterTileIndex() const
@@ -609,16 +610,39 @@ public:
 
     bool isInDeepOcean() const;
 
+    static int GetLevelFromExperience( uint32_t exp );
+    static uint32_t GetExperienceFromLevel( int lvl );
+
+    static const fheroes2::Sprite & GetPortrait( int heroid, int type );
+    static const char * GetName( int heroid );
+
+    static bool isValidId( const int32_t id )
+    {
+        return id > UNKNOWN && id < HEROES_COUNT;
+    }
+
 private:
     friend StreamBase & operator<<( StreamBase &, const Heroes & );
     friend StreamBase & operator>>( StreamBase &, Heroes & );
+
+    enum
+    {
+        SKILL_VALUE = 100
+    };
+
+    struct HeroSeedsForLevelUp
+    {
+        uint32_t seedPrimarySkill{ 0 };
+        uint32_t seedSecondarySkill1{ 0 };
+        uint32_t seedSecondarySkill2{ 0 };
+        uint32_t seedSecondarySkillRandomChoose{ 0 };
+    };
 
     HeroSeedsForLevelUp GetSeedsForLevelUp() const;
     void LevelUp( bool skipsecondary, bool autoselect = false );
     void LevelUpSecondarySkill( const HeroSeedsForLevelUp & seeds, int primary, bool autoselect = false );
     void AngleStep( int );
     bool MoveStep( const bool jumpToNextTile );
-    static uint32_t GetStartingXp();
     bool isInVisibleMapArea() const;
 
     // This function is useful only in a situation when AI hero moves out of the fog
@@ -631,10 +655,7 @@ private:
     // Daily replenishment of spell points
     void ReplenishSpellPoints();
 
-    enum
-    {
-        SKILL_VALUE = 100
-    };
+    static uint32_t GetStartingXp();
 
     std::string name;
     uint32_t experience;
@@ -644,7 +665,7 @@ private:
     Army army;
 
     // Hero ID
-    int hid;
+    int _id;
     // Corresponds to the ID of the hero whose portrait is applied. Usually equal to the
     // ID of this hero, unless a custom portrait is applied.
     int portrait;
@@ -673,11 +694,6 @@ private:
 
     // This value should NOT be saved in save file as it's dynamically set during AI turn.
     Role _aiRole;
-
-    enum
-    {
-        HERO_MOVE_STEP = 4 // in pixels
-    };
 };
 
 struct VecHeroes : public std::vector<Heroes *>
@@ -688,7 +704,7 @@ struct VecHeroes : public std::vector<Heroes *>
 
 struct AllHeroes : public VecHeroes
 {
-    AllHeroes();
+    AllHeroes() = default;
     AllHeroes( const AllHeroes & ) = delete;
 
     ~AllHeroes();

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -50,6 +50,8 @@
 
 namespace
 {
+    const int32_t heroMoveStep{ 4 };// in pixels
+
     void playHeroWalkingSound( const int groundType )
     {
         const int heroMovementSpeed = Settings::Get().HeroesMoveSpeed();
@@ -465,17 +467,17 @@ fheroes2::Point Heroes::getCurrentPixelOffset() const
     fheroes2::Point realOffset{ _offset };
 
     if ( direction & DIRECTION_LEFT_COL ) {
-        realOffset.x -= HERO_MOVE_STEP * frame;
+        realOffset.x -= heroMoveStep * frame;
     }
     else if ( direction & DIRECTION_RIGHT_COL ) {
-        realOffset.x += HERO_MOVE_STEP * frame;
+        realOffset.x += heroMoveStep * frame;
     }
 
     if ( direction & DIRECTION_TOP_ROW ) {
-        realOffset.y -= HERO_MOVE_STEP * frame;
+        realOffset.y -= heroMoveStep * frame;
     }
     else if ( direction & DIRECTION_BOTTOM_ROW ) {
-        realOffset.y += HERO_MOVE_STEP * frame;
+        realOffset.y += heroMoveStep * frame;
     }
 
     return realOffset;

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -50,7 +50,7 @@
 
 namespace
 {
-    const int32_t heroMoveStep{ 4 };// in pixels
+    const int32_t heroMoveStep{ 4 }; // in pixels
 
     void playHeroWalkingSound( const int groundType )
     {

--- a/src/fheroes2/heroes/heroes_recruits.cpp
+++ b/src/fheroes2/heroes/heroes_recruits.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,10 +21,13 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "heroes_recruits.h"
+
 #include <cassert>
 
+#include "game_io.h"
 #include "heroes.h"
-#include "heroes_recruits.h"
+#include "save_format_version.h"
 #include "serialize.h"
 #include "world.h"
 
@@ -124,5 +127,12 @@ StreamBase & operator<<( StreamBase & msg, const Recruit & recruit )
 
 StreamBase & operator>>( StreamBase & msg, Recruit & recruit )
 {
-    return msg >> recruit._id >> recruit._surrenderDay;
+    msg >> recruit._id >> recruit._surrenderDay;
+
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
+        ++recruit._id;
+    }
+
+    return msg;
 }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -553,7 +553,6 @@ const Recruits & Kingdom::GetRecruits()
                 continue;
             }
 
-            // TODO: fix this.
             Heroes * hero = world.GetHeroes( obtainedAward._subType );
 
             if ( hero && hero->isAvailableForHire() ) {

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -186,7 +186,7 @@ void Kingdom::LossPostActions()
     if ( isPlay() ) {
         Players::SetPlayerInGame( color, false );
 
-        // Heroes::Dismiss() calls Kingdom::RemoveHeroes(), which eventually calls heroes.erase()
+        // Heroes::Dismiss() calls Kingdom::RemoveHero(), which eventually calls heroes.erase()
         while ( !heroes.empty() ) {
             Heroes * hero = heroes.back();
 
@@ -307,23 +307,27 @@ void Kingdom::ActionNewMonth()
     visit_object.remove_if( Visit::isMonthLife );
 }
 
-void Kingdom::AddHeroes( Heroes * hero )
+void Kingdom::AddHero( Heroes * hero )
 {
-    if ( hero ) {
-        if ( heroes.end() == std::find( heroes.begin(), heroes.end(), hero ) )
-            heroes.push_back( hero );
-
-        const Player * player = Settings::Get().GetPlayers().GetCurrent();
-        if ( player && player->isColor( GetColor() ) && player->isControlHuman() )
-            Interface::AdventureMap::Get().GetIconsPanel().ResetIcons( ICON_HEROES );
-
-        AI::Get().HeroesAdd( *hero );
+    if ( hero == nullptr ) {
+        // Why are you adding an empty hero?
+        assert( 0 );
+        return;
     }
+
+    if ( heroes.end() == std::find( heroes.begin(), heroes.end(), hero ) )
+        heroes.push_back( hero );
+
+    const Player * player = Settings::Get().GetPlayers().GetCurrent();
+    if ( player && player->isColor( GetColor() ) && player->isControlHuman() )
+        Interface::AdventureMap::Get().GetIconsPanel().ResetIcons( ICON_HEROES );
+
+    AI::Get().HeroesAdd( *hero );
 }
 
-void Kingdom::RemoveHeroes( const Heroes * hero )
+void Kingdom::RemoveHero( const Heroes * hero )
 {
-    if ( hero ) {
+    if ( hero != nullptr ) {
         if ( !heroes.empty() ) {
             auto it = std::find( heroes.begin(), heroes.end(), hero );
             assert( it != heroes.end() );
@@ -341,6 +345,10 @@ void Kingdom::RemoveHeroes( const Heroes * hero )
         assert( hero != nullptr );
 
         AI::Get().HeroesRemove( *hero );
+    }
+    else {
+        // Why are trying to delete a non existing hero?
+        assert( 0 );
     }
 
     if ( isLoss() )
@@ -890,10 +898,13 @@ int Kingdoms::FindWins( int cond ) const
 
 void Kingdoms::AddHeroes( const AllHeroes & heroes )
 {
-    for ( AllHeroes::const_iterator it = heroes.begin(); it != heroes.end(); ++it )
-        // skip gray color
-        if ( ( *it )->GetColor() )
-            GetKingdom( ( *it )->GetColor() ).AddHeroes( *it );
+    for ( Heroes * hero : heroes ) {
+        assert( hero != nullptr );
+
+        if ( hero->GetColor() ) {
+            GetKingdom( hero->GetColor() ).AddHero( hero );
+        }
+    }
 }
 
 void Kingdoms::AddCastles( const AllCastles & castles )

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -1008,7 +1008,7 @@ StreamBase & operator>>( StreamBase & msg, Kingdom & kingdom )
 {
     msg >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits >> kingdom.visit_object
         >> kingdom.puzzle_maps >> kingdom.visited_tents_colors >> kingdom._lastBattleWinHeroID;
-    
+
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
         ++kingdom._lastBattleWinHeroID;

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -1006,8 +1006,8 @@ StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )
 
 StreamBase & operator>>( StreamBase & msg, Kingdom & kingdom )
 {
-    msg >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits
-           >> kingdom.visit_object >> kingdom.puzzle_maps >> kingdom.visited_tents_colors >> kingdom._lastBattleWinHeroID;
+    msg >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits >> kingdom.visit_object
+        >> kingdom.puzzle_maps >> kingdom.visited_tents_colors >> kingdom._lastBattleWinHeroID;
     
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -42,6 +42,7 @@
 #include "difficulty.h"
 #include "game.h"
 #include "game_interface.h"
+#include "game_io.h"
 #include "game_static.h"
 #include "interface_icons.h"
 #include "logging.h"
@@ -55,6 +56,7 @@
 #include "profit.h"
 #include "race.h"
 #include "route.h"
+#include "save_format_version.h"
 #include "serialize.h"
 #include "settings.h"
 #include "skill.h"
@@ -551,6 +553,7 @@ const Recruits & Kingdom::GetRecruits()
                 continue;
             }
 
+            // TODO: fix this.
             Heroes * hero = world.GetHeroes( obtainedAward._subType );
 
             if ( hero && hero->isAvailableForHire() ) {
@@ -1003,9 +1006,15 @@ StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )
 
 StreamBase & operator>>( StreamBase & msg, Kingdom & kingdom )
 {
-    return msg >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits
-           >> kingdom.visit_object >> kingdom.puzzle_maps >> kingdom.visited_tents_colors >> kingdom._lastBattleWinHeroID >> kingdom._topCastleInKingdomView
-           >> kingdom._topHeroInKingdomView;
+    msg >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits
+           >> kingdom.visit_object >> kingdom.puzzle_maps >> kingdom.visited_tents_colors >> kingdom._lastBattleWinHeroID;
+    
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
+        ++kingdom._lastBattleWinHeroID;
+    }
+
+    return msg >> kingdom._topCastleInKingdomView >> kingdom._topHeroInKingdomView;
 }
 
 StreamBase & operator<<( StreamBase & msg, const Kingdoms & obj )

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -901,7 +901,7 @@ void Kingdoms::AddHeroes( const AllHeroes & heroes )
     for ( Heroes * hero : heroes ) {
         assert( hero != nullptr );
 
-        if ( hero->GetColor() ) {
+        if ( hero->GetColor() != Color::NONE ) {
             GetKingdom( hero->GetColor() ).AddHero( hero );
         }
     }

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -162,8 +162,8 @@ public:
         return castles;
     }
 
-    void AddHeroes( Heroes * );
-    void RemoveHeroes( const Heroes * );
+    void AddHero( Heroes * hero );
+    void RemoveHero( const Heroes * hero );
     void ApplyPlayWithStartingHero();
 
     void AddCastle( const Castle * );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -553,7 +553,7 @@ void Maps::Tiles::setTerrain( const uint16_t terrainImageIndex, const bool horiz
 
 Heroes * Maps::Tiles::getHero() const
 {
-    return MP2::OBJ_HEROES == _mainObjectType && _occupantHeroId ? world.GetHeroes( _occupantHeroId - 1 ) : nullptr;
+    return MP2::OBJ_HEROES == _mainObjectType && _occupantHeroId ? world.GetHeroes( _occupantHeroId ) : nullptr;
 }
 
 void Maps::Tiles::setHero( Heroes * hero )
@@ -565,7 +565,7 @@ void Maps::Tiles::setHero( Heroes * hero )
         hero->setObjectTypeUnderHero( _mainObjectType );
 
         assert( hero->GetID() >= std::numeric_limits<HeroIDType>::min() && hero->GetID() < std::numeric_limits<HeroIDType>::max() );
-        _occupantHeroId = static_cast<HeroIDType>( hero->GetID() + 1 );
+        _occupantHeroId = static_cast<HeroIDType>( hero->GetID() );
 
         SetObject( MP2::OBJ_HEROES );
     }
@@ -580,7 +580,7 @@ void Maps::Tiles::setHero( Heroes * hero )
             setAsEmpty();
         }
 
-        _occupantHeroId = 0;
+        _occupantHeroId = Heroes::UNKNOWN;
     }
 }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -553,7 +553,7 @@ void Maps::Tiles::setTerrain( const uint16_t terrainImageIndex, const bool horiz
 
 Heroes * Maps::Tiles::getHero() const
 {
-    return MP2::OBJ_HEROES == _mainObjectType && _occupantHeroId ? world.GetHeroes( _occupantHeroId ) : nullptr;
+    return MP2::OBJ_HEROES == _mainObjectType && Heroes::isValidId( _occupantHeroId ) ? world.GetHeroes( _occupantHeroId ) : nullptr;
 }
 
 void Maps::Tiles::setHero( Heroes * hero )

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -38,7 +38,6 @@
 #include "mp2.h"
 #include "world_regions.h"
 
-class Heroes;
 class StreamBase;
 
 namespace Maps

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -33,6 +33,7 @@
 #include "color.h"
 #include "direction.h"
 #include "ground.h"
+#include "heroes.h"
 #include "math_base.h"
 #include "mp2.h"
 #include "world_regions.h"
@@ -388,9 +389,7 @@ namespace Maps
 
         bool _isTileMarkedAsRoad{ false };
 
-        // This member holds Hero ID that is incremented by 1.
-        // TODO: once hero IDs are going to be updated change the logic for this member as well.
-        uint8_t _occupantHeroId{ 0 };
+        uint8_t _occupantHeroId{ Heroes::UNKNOWN };
 
         // The following members are only used in the game.
 

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -28,6 +28,7 @@ enum SaveFileFormat : uint16_t
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
+    FORMAT_VERSION_1010_RELEASE = 10015,
     FORMAT_VERSION_1009_RELEASE = 10014,
     FORMAT_VERSION_PRE2_1009_RELEASE = 10013,
     FORMAT_VERSION_PRE1_1009_RELEASE = 10012,
@@ -36,5 +37,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_1005_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1009_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1010_RELEASE
 };

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1428,23 +1428,24 @@ StreamBase & operator>>( StreamBase & msg, MapObjects & objs )
 
 StreamBase & operator<<( StreamBase & msg, const World & w )
 {
-    // TODO: before 0.9.4 Size was uint16_t type
-    const uint16_t width = static_cast<uint16_t>( w.width );
-    const uint16_t height = static_cast<uint16_t>( w.height );
-
-    return msg << width << height << w.vec_tiles << w.vec_heroes << w.vec_castles << w.vec_kingdoms << w._rumors << w.vec_eventsday << w.map_captureobj
+    return msg << w.width << w.height << w.vec_tiles << w.vec_heroes << w.vec_castles << w.vec_kingdoms << w._rumors << w.vec_eventsday << w.map_captureobj
                << w.ultimate_artifact << w.day << w.week << w.month << w.heroes_cond_wins << w.heroes_cond_loss << w.map_objects << w._seed;
 }
 
 StreamBase & operator>>( StreamBase & msg, World & w )
 {
-    // TODO: before 0.9.4 Size was uint16_t type
-    uint16_t width = 0;
-    uint16_t height = 0;
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
+        uint16_t width = 0;
+        uint16_t height = 0;
 
-    msg >> width >> height;
-    w.width = width;
-    w.height = height;
+        msg >> width >> height;
+        w.width = width;
+        w.height = height;
+    }
+    else {
+        msg >> w.width >> w.height;
+    }
 
     msg >> w.vec_tiles >> w.vec_heroes >> w.vec_castles >> w.vec_kingdoms >> w._rumors >> w.vec_eventsday >> w.map_captureobj >> w.ultimate_artifact >> w.day >> w.week
         >> w.month >> w.heroes_cond_wins >> w.heroes_cond_loss;

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -445,7 +445,7 @@ Heroes * World::FromJailHeroes( int32_t index )
 
 Heroes * World::GetHero( const Castle & castle ) const
 {
-    return vec_heroes.GetHero( castle );
+    return vec_heroes.Get( castle.GetCenter() );
 }
 
 int World::GetDay() const

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1448,7 +1448,7 @@ StreamBase & operator>>( StreamBase & msg, World & w )
 
     msg >> w.vec_tiles >> w.vec_heroes >> w.vec_castles >> w.vec_kingdoms >> w._rumors >> w.vec_eventsday >> w.map_captureobj >> w.ultimate_artifact >> w.day >> w.week
         >> w.month >> w.heroes_cond_wins >> w.heroes_cond_loss;
-    
+
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
         ++w.heroes_cond_wins;

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -41,6 +41,7 @@
 #include "color.h"
 #include "direction.h"
 #include "game.h"
+#include "game_io.h"
 #include "game_over.h"
 #include "gamedefs.h"
 #include "heroes.h"
@@ -55,6 +56,7 @@
 #include "rand.h"
 #include "resource.h"
 #include "route.h"
+#include "save_format_version.h"
 #include "serialize.h"
 #include "settings.h"
 #include "tools.h"
@@ -1445,7 +1447,15 @@ StreamBase & operator>>( StreamBase & msg, World & w )
     w.height = height;
 
     msg >> w.vec_tiles >> w.vec_heroes >> w.vec_castles >> w.vec_kingdoms >> w._rumors >> w.vec_eventsday >> w.map_captureobj >> w.ultimate_artifact >> w.day >> w.week
-        >> w.month >> w.heroes_cond_wins >> w.heroes_cond_loss >> w.map_objects >> w._seed;
+        >> w.month >> w.heroes_cond_wins >> w.heroes_cond_loss;
+    
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
+        ++w.heroes_cond_wins;
+        ++w.heroes_cond_loss;
+    }
+
+    msg >> w.map_objects >> w._seed;
 
     w.PostLoad( false );
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -517,6 +517,7 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
 
                     // Byte 17 determines whether the hero has a custom portrait, and byte 18 contains the custom portrait ID. If the hero has a custom portrait, then we
                     // should directly use the hero corresponding to this portrait, if possible.
+                    // MP2 format stores hero IDs start from 0, while fheroes2 engine starts from 1.
                     if ( pblock[17] && pblock[18] + 1 <= Heroes::JARKONAS ) {
                         hero = vec_heroes.Get( pblock[18] + 1 );
                     }
@@ -553,6 +554,7 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
 
                         // Byte 17 determines whether the hero has a custom portrait, and byte 18 contains the custom portrait ID. If the hero has a custom portrait, then
                         // we should directly use the hero corresponding to this portrait, if possible.
+                        // MP2 format stores hero IDs start from 0, while fheroes2 engine starts from 1.
                         if ( pblock[17] && pblock[18] + 1 <= Heroes::JARKONAS ) {
                             hero = vec_heroes.Get( pblock[18] + 1 );
                         }

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -517,8 +517,8 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
 
                     // Byte 17 determines whether the hero has a custom portrait, and byte 18 contains the custom portrait ID. If the hero has a custom portrait, then we
                     // should directly use the hero corresponding to this portrait, if possible.
-                    if ( pblock[17] && pblock[18] <= Heroes::JARKONAS ) {
-                        hero = vec_heroes.Get( pblock[18] );
+                    if ( pblock[17] && pblock[18] + 1 <= Heroes::JARKONAS ) {
+                        hero = vec_heroes.Get( pblock[18] + 1 );
                     }
 
                     if ( !hero || !hero->isAvailableForHire() ) {
@@ -553,8 +553,8 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
 
                         // Byte 17 determines whether the hero has a custom portrait, and byte 18 contains the custom portrait ID. If the hero has a custom portrait, then
                         // we should directly use the hero corresponding to this portrait, if possible.
-                        if ( pblock[17] && pblock[18] <= Heroes::JARKONAS ) {
-                            hero = vec_heroes.Get( pblock[18] );
+                        if ( pblock[17] && pblock[18] + 1 <= Heroes::JARKONAS ) {
+                            hero = vec_heroes.Get( pblock[18] + 1 );
                         }
 
                         if ( !hero || !hero->isAvailableForHire() ) {
@@ -653,7 +653,7 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
         return false;
     }
 
-    DEBUG_LOG( DBG_GAME, DBG_INFO, "end load" )
+    DEBUG_LOG( DBG_GAME, DBG_INFO, "Loading of MP2 map is completed." )
     return true;
 }
 
@@ -679,14 +679,28 @@ bool World::ProcessNewMap( const std::string & filename, const bool checkPoLObje
 
     // update wins, loss conditions
     if ( GameOver::WINS_HERO & conf.ConditionWins() ) {
-        const Heroes * hero = GetHeroes( conf.WinsMapsPositionObject() );
-        heroes_cond_wins = hero ? hero->GetID() : Heroes::UNKNOWN;
-    }
-    if ( GameOver::LOSS_HERO & conf.ConditionLoss() ) {
-        Heroes * hero = GetHeroes( conf.LossMapsPositionObject() );
-        heroes_cond_loss = hero ? hero->GetID() : Heroes::UNKNOWN;
+        const fheroes2::Point & pos = conf.WinsMapsPositionObject();
 
-        if ( hero ) {
+        const Heroes * hero = GetHeroes( pos );
+        if ( hero == nullptr ) {
+            heroes_cond_wins = Heroes::UNKNOWN;
+            ERROR_LOG( "A winning condition hero at location ['" << pos.x << ", " << pos.y << "'] is not found." )
+        }
+        else {
+            heroes_cond_wins = hero->GetID();
+        }
+    }
+
+    if ( GameOver::LOSS_HERO & conf.ConditionLoss() ) {
+        const fheroes2::Point & pos = conf.LossMapsPositionObject();
+
+        Heroes * hero = GetHeroes( pos );
+        if ( hero == nullptr ) {
+            heroes_cond_loss = Heroes::UNKNOWN;
+            ERROR_LOG( "A loosing condition hero at location ['" << pos.x << ", " << pos.y << "'] is not found." )
+        }
+        else {
+            heroes_cond_loss = hero->GetID();
             hero->SetModes( Heroes::NOTDISMISS | Heroes::CUSTOM );
         }
     }


### PR DESCRIPTION
relates to #6845

- make Heroes::UNKNOWN entry first. Having this entry as non-zero was preventing to add new heroes in the future
- add much more checks in the code and rewrite certain functions to be human readable
- rearrange some code to have some sort of structure (it is still a huge mess)

This pull request needs very extensive testing to make sure that it doesn't break things:
- verify that all heroes from old saves are the same as loading the same files by master branch build.
- verify that all heroes from new saves are the same as before making a save.
- verify that heroes transferred between scenarios in campaigns are correct.
- verify that basic functionality with heroes for new and old saves is correct. This includes but not limited to checking heroes in castles, hiring and dismissing them.
- verify that winning and loosing conditions related to heroes are correct for new and old saves.
- verify that custom heroes set in maps are correct while starting a hero game for these maps.
- verify that the heroes order for Battle Only and the Editor is not broken.