### PR TITLE
Fix castle dialog rendering bugs

### DIFF
--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -82,7 +82,7 @@ struct buildstats_t
     cost_t cost;
 };
 
-buildstats_t _builds[] = {
+const buildstats_t _builds[] = {
     // id                             gold wood mercury ore sulfur crystal gems
     { BUILD_THIEVESGUILD, Race::ALL, { 750, 5, 0, 0, 0, 0, 0 } },
     { BUILD_TAVERN, Race::ALL, { 500, 5, 0, 0, 0, 0, 0 } },
@@ -405,13 +405,14 @@ void BuildingInfo::Redraw() const
         fheroes2::Sprite grayedOut = fheroes2::Crop( buildingFrame, offset.x, offset.y, 125, 12 );
         fheroes2::ApplyPalette( grayedOut, PAL::GetPalette( PAL::PaletteType::GRAY ) );
         fheroes2::ApplyPalette( grayedOut, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
-        fheroes2::Blit( grayedOut, display, area.x + offset.x, area.y + offset.y );
+        fheroes2::Copy( grayedOut, 0, 0, display, area.x + offset.x, area.y + offset.y, 125, 12 );
     }
 
     // build image
     if ( BUILD_NOTHING == building ) {
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-        fheroes2::Blit( fheroes2::AGG::GetICN( isEvilInterface ? ICN::CASLXTRA_EVIL : ICN::CASLXTRA, 0 ), display, area.x, area.y );
+        const fheroes2::Sprite & buildBackground = fheroes2::AGG::GetICN( isEvilInterface ? ICN::CASLXTRA_EVIL : ICN::CASLXTRA, 0 );
+        fheroes2::Blit( buildBackground, 0, 0, display, area.x, area.y, buildBackground.width(), buildBackground.height() );
         return;
     }
 
@@ -438,11 +439,13 @@ void BuildingInfo::Redraw() const
             const fheroes2::Sprite & spriteDeny = fheroes2::AGG::GetICN( ICN::TOWNWIND, 12 );
             fheroes2::Blit( spriteDeny, display, area.x + buildingFrame.width() - 5 + 1 - spriteDeny.width(), area.y + 58 - 2 - spriteDeny.height() );
         }
-    }
 
-    // status bar
-    if ( bcond != BUILD_DISABLE && bcond != ALREADY_BUILT ) {
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CASLXTRA, bcond == ALLOW_BUILD ? 1 : 2 ), display, area.x, area.y + 58 );
+        const fheroes2::Sprite & textBackground = fheroes2::AGG::GetICN( ICN::CASLXTRA, 2 );
+        fheroes2::Copy( textBackground, 0, 0, display, area.x, area.y + 58, textBackground.width(), textBackground.height() );
+    }
+    else {
+        const fheroes2::Sprite & textBackground = fheroes2::AGG::GetICN( ICN::CASLXTRA, 1 );
+        fheroes2::Copy( textBackground, 0, 0, display, area.x, area.y + 58, textBackground.width(), textBackground.height() );
     }
 
     const fheroes2::Text buildingName( Castle::GetStringBuilding( building, castle.GetRace() ), fheroes2::FontType::smallWhite() );
@@ -460,7 +463,7 @@ bool BuildingInfo::QueueEventProcessing( fheroes2::ButtonBase & exitButton ) con
 
     if ( le.MouseClickLeft( area ) ) {
         if ( bcond == LACK_RESOURCES || bcond == ALLOW_BUILD ) {
-            fheroes2::ButtonRestorer exitRestorer( exitButton );
+            const fheroes2::ButtonRestorer exitRestorer( exitButton );
             return DialogBuyBuilding( true );
         }
     }
@@ -488,7 +491,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
         }
     }
 
-    fheroes2::Text descriptionText( std::move( extendedDescription ), fheroes2::FontType::normalWhite() );
+    const fheroes2::Text descriptionText( std::move( extendedDescription ), fheroes2::FontType::normalWhite() );
 
     // prepare requirement build string
     std::string requirement;
@@ -508,8 +511,8 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
 
     const bool requirementsPresent = !requirement.empty();
 
-    fheroes2::Text requirementTitle( _( "Requires:" ), fheroes2::FontType::normalWhite() );
-    fheroes2::Text requirementText( std::move( requirement ), fheroes2::FontType::normalWhite() );
+    const fheroes2::Text requirementTitle( _( "Requires:" ), fheroes2::FontType::normalWhite() );
+    const fheroes2::Text requirementText( std::move( requirement ), fheroes2::FontType::normalWhite() );
 
     const int elementOffset = 10;
 
@@ -525,20 +528,20 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
     const int32_t totalDialogHeight
         = elementOffset + buildingFrame.height() + elementOffset + descriptionText.height( BOXAREA_WIDTH ) + elementOffset + requirementHeight + rbs.GetArea().height;
 
-    Dialog::FrameBox dialogFrame( totalDialogHeight, buttons );
+    const Dialog::FrameBox dialogFrame( totalDialogHeight, buttons );
     const fheroes2::Rect & dialogRoi = dialogFrame.GetArea();
 
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int buttonOkayIcnID = isEvilInterface ? ICN::UNIFORM_EVIL_OKAY_BUTTON : ICN::UNIFORM_GOOD_OKAY_BUTTON;
 
     fheroes2::Point pos{ dialogRoi.x, dialogRoi.y + dialogRoi.height - fheroes2::AGG::GetICN( buttonOkayIcnID, 0 ).height() };
-    fheroes2::Button button1( pos.x, pos.y, buttonOkayIcnID, 0, 1 );
+    fheroes2::Button buttonOkay( pos.x, pos.y, buttonOkayIcnID, 0, 1 );
 
     const int buttonCancelIcnID = isEvilInterface ? ICN::UNIFORM_EVIL_CANCEL_BUTTON : ICN::UNIFORM_GOOD_CANCEL_BUTTON;
 
     pos.x = dialogRoi.x + dialogRoi.width - fheroes2::AGG::GetICN( buttonCancelIcnID, 0 ).width();
     pos.y = dialogRoi.y + dialogRoi.height - fheroes2::AGG::GetICN( buttonCancelIcnID, 0 ).height();
-    fheroes2::Button button2( pos.x, pos.y, buttonCancelIcnID, 0, 1 );
+    fheroes2::Button buttonCancel( pos.x, pos.y, buttonCancelIcnID, 0, 1 );
 
     pos.x = dialogRoi.x + ( dialogRoi.width - buildingFrame.width() ) / 2;
     pos.y = dialogRoi.y + elementOffset;
@@ -551,7 +554,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
     pos.y += 1;
     fheroes2::Blit( buildingImage, display, pos.x, pos.y );
 
-    fheroes2::Text buildingName( GetName(), fheroes2::FontType::smallWhite() );
+    const fheroes2::Text buildingName( GetName(), fheroes2::FontType::smallWhite() );
     pos.x = dialogRoi.x + ( dialogRoi.width - buildingName.width() ) / 2;
     pos.y += 58;
     buildingName.draw( pos.x, pos.y + 2, display );
@@ -576,28 +579,41 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
     rbs.Redraw();
 
     if ( buttons ) {
-        if ( ALLOW_BUILD != castle.CheckBuyBuilding( building ) )
-            button1.disable();
+        if ( ALLOW_BUILD != castle.CheckBuyBuilding( building ) ) {
+            buttonOkay.disable();
+        }
 
-        button1.draw();
-        button2.draw();
+        buttonOkay.draw();
+        buttonCancel.draw();
     }
+
+    const bool buttonOkayEnabled = buttonOkay.isEnabled();
 
     display.render();
 
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents() ) {
-        if ( !buttons && !le.MousePressRight() )
+        if ( !buttons && !le.MousePressRight() ) {
             break;
+        }
 
-        le.MousePressLeft( button1.area() ) ? button1.drawOnPress() : button1.drawOnRelease();
-        le.MousePressLeft( button2.area() ) ? button2.drawOnPress() : button2.drawOnRelease();
+        le.MousePressLeft( buttonOkay.area() ) ? buttonOkay.drawOnPress() : buttonOkay.drawOnRelease();
+        le.MousePressLeft( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
 
-        if ( button1.isEnabled() && ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) || le.MouseClickLeft( button1.area() ) ) )
+        if ( buttonOkayEnabled && ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) || le.MouseClickLeft( buttonOkay.area() ) ) ) {
             return true;
+        }
 
-        if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( button2.area() ) )
+        if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( buttonCancel.area() ) ) {
             break;
+        }
+
+        if ( le.MousePressRight( buttonOkay.area() ) ) {
+            fheroes2::showStandardTextMessage( _( "Okay" ), GetConditionDescription(), Dialog::ZERO );
+        }
+        else if ( le.MousePressRight( buttonCancel.area() ) ) {
+            fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
+        }
     }
 
     return false;
@@ -746,7 +762,7 @@ bool DwellingsBar::ActionBarLeftMouseSingleClick( DwellingItem & dwl )
     else if ( !castle.isBuild( BUILD_CASTLE ) )
         fheroes2::showStandardTextMessage( "", GetBuildConditionDescription( NEED_CASTLE ), Dialog::OK );
     else {
-        BuildingInfo dwelling( castle, static_cast<building_t>( dwl.type ) );
+        const BuildingInfo dwelling( castle, static_cast<building_t>( dwl.type ) );
 
         if ( dwelling.DialogBuyBuilding( true ) ) {
             AudioManager::PlaySound( M82::BUILDTWN );

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -39,12 +39,38 @@
 #include "settings.h"
 #include "ui_castle.h"
 
-void CastleRedrawCurrentBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CastleDialog::CacheBuildings & orders,
-                                  const CastleDialog::FadeBuilding & alphaBuilding, const uint32_t animationIndex );
-fheroes2::Rect CastleGetMaxArea( const Castle &, const fheroes2::Point & );
-
 namespace
 {
+    int getTownIcnId( const int race )
+    {
+        switch ( race ) {
+        case Race::KNGT:
+            return ICN::TOWNBKG0;
+        case Race::BARB:
+            return ICN::TOWNBKG1;
+        case Race::SORC:
+            return ICN::TOWNBKG2;
+        case Race::WRLK:
+            return ICN::TOWNBKG3;
+        case Race::WZRD:
+            return ICN::TOWNBKG4;
+        case Race::NECR:
+            return ICN::TOWNBKG5;
+        default:
+            // Have you added a new race? Add the logic for it!
+            assert( 0 );
+            break;
+        }
+        return ICN::UNKNOWN;
+    }
+
+    fheroes2::Rect CastleGetMaxArea( const Castle & castle, const fheroes2::Point & top )
+    {
+        const fheroes2::Sprite & townbkg = fheroes2::AGG::GetICN( getTownIcnId( castle.GetRace() ), 0 );
+
+        return { top.x, top.y, townbkg.width(), townbkg.height() };
+    }
+
     bool isBuildingConnectionNeeded( const Castle & castle, const uint32_t buildId, const bool constructionInProgress )
     {
         const int race = castle.GetRace();
@@ -59,14 +85,13 @@ namespace
                 assert( mageGuildLevel > 0 );
                 return buildId == ( BUILD_MAGEGUILD1 << ( mageGuildLevel - 1 ) );
             }
-            else if ( buildId == BUILD_THIEVESGUILD ) {
+
+            if ( buildId == BUILD_THIEVESGUILD ) {
                 return true;
             }
         }
-        else if ( race == Race::NECR ) {
-            if ( buildId == BUILD_CAPTAIN ) {
-                return true;
-            }
+        else if ( race == Race::NECR && buildId == BUILD_CAPTAIN ) {
+            return true;
         }
 
         return false;
@@ -81,39 +106,36 @@ namespace
 
         if ( race == Race::BARB ) {
             if ( buildId & BUILD_MAGEGUILD || buildId == BUILD_SPEC ) {
-                if ( buildId & BUILD_MAGEGUILD ) {
-                    if ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_SPEC ) ) )
-                        return;
+                if ( buildId & BUILD_MAGEGUILD && ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_SPEC ) ) ) ) {
+                    return;
                 }
-                else if ( buildId == BUILD_SPEC ) {
-                    if ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_MAGEGUILD1 ) ) )
-                        return;
+
+                if ( buildId == BUILD_SPEC && ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_MAGEGUILD1 ) ) ) ) {
+                    return;
                 }
 
                 fheroes2::drawCastleDialogBuilding( ICN::TWNBEXT2, 0, castle, position, roi, alpha );
             }
 
             if ( buildId == DWELLING_MONSTER3 || buildId == BUILD_THIEVESGUILD ) {
-                if ( buildId == DWELLING_MONSTER3 ) {
-                    if ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_THIEVESGUILD ) ) )
-                        return;
+                if ( buildId == DWELLING_MONSTER3 && ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_THIEVESGUILD ) ) ) ) {
+                    return;
                 }
-                else if ( buildId == BUILD_THIEVESGUILD ) {
-                    if ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( DWELLING_MONSTER3 ) ) )
-                        return;
+
+                if ( buildId == BUILD_THIEVESGUILD && ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( DWELLING_MONSTER3 ) ) ) ) {
+                    return;
                 }
 
                 fheroes2::drawCastleDialogBuilding( ICN::TWNBEXT3, 0, castle, position, roi, alpha );
             }
         }
         else if ( race == Race::NECR ) {
-            if ( buildId == BUILD_CAPTAIN ) {
-                if ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_CASTLE ) ) )
-                    return;
+            if ( buildId == BUILD_CAPTAIN && ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_CASTLE ) ) ) ) {
+                return;
             }
-            else if ( buildId == BUILD_CASTLE ) {
-                if ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_CAPTAIN ) ) )
-                    return;
+
+            if ( buildId == BUILD_CASTLE && ( ( !constructionInProgress && !castle.isBuild( buildId ) ) || ( !castle.isBuild( BUILD_CAPTAIN ) ) ) ) {
+                return;
             }
 
             fheroes2::drawCastleDialogBuilding( ICN::NECROMANCER_CASTLE_CAPTAIN_QUARTERS_BRIDGE, 0, castle, position, roi, alpha );
@@ -158,50 +180,14 @@ void CastleDialog::FadeBuilding::StopFadeBuilding()
     }
 }
 
-void CastleDialog::RedrawAllBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CacheBuildings & orders,
-                                      const CastleDialog::FadeBuilding & alphaBuilding, const uint32_t animationIndex )
-{
-    CastleRedrawCurrentBuilding( castle, dst_pt, orders, alphaBuilding, animationIndex );
-    fheroes2::drawCastleName( castle, fheroes2::Display::instance(), dst_pt );
-}
-
 void CastleRedrawCurrentBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CastleDialog::CacheBuildings & orders,
                                   const CastleDialog::FadeBuilding & fadeBuilding, const uint32_t animationIndex )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    int townIcnId = -1;
-
-    switch ( castle.GetRace() ) {
-    case Race::KNGT:
-        townIcnId = ICN::TOWNBKG0;
-        break;
-    case Race::BARB:
-        townIcnId = ICN::TOWNBKG1;
-        break;
-    case Race::SORC:
-        townIcnId = ICN::TOWNBKG2;
-        break;
-    case Race::WRLK:
-        townIcnId = ICN::TOWNBKG3;
-        break;
-    case Race::WZRD:
-        townIcnId = ICN::TOWNBKG4;
-        break;
-    case Race::NECR:
-        townIcnId = ICN::TOWNBKG5;
-        break;
-    default:
-        break;
-    }
-
-    const fheroes2::Rect max = CastleGetMaxArea( castle, dst_pt );
-
-    if ( townIcnId != -1 ) {
-        // We shouldn't Blit this image. This is a background image so a normal Copy is enough.
-        const fheroes2::Sprite & townbkg = fheroes2::AGG::GetICN( townIcnId, 0 );
-        fheroes2::Copy( townbkg, 0, 0, display, dst_pt.x, dst_pt.y, townbkg.width(), townbkg.height() );
-    }
+    const fheroes2::Sprite & townbkg = fheroes2::AGG::GetICN( getTownIcnId( castle.GetRace() ), 0 );
+    const fheroes2::Rect max( dst_pt.x, dst_pt.y, townbkg.width(), townbkg.height() );
+    fheroes2::Copy( townbkg, 0, 0, display, dst_pt.x, dst_pt.y, max.width, max.height );
 
     if ( Race::BARB == castle.GetRace() ) {
         const fheroes2::Sprite & sprite0 = fheroes2::AGG::GetICN( ICN::TWNBEXT1, 1 + animationIndex % 5 );
@@ -244,52 +230,56 @@ void CastleRedrawCurrentBuilding( const Castle & castle, const fheroes2::Point &
 
     // redraw all builds
     if ( BUILD_NOTHING == fadeBuilding.GetBuild() ) {
-        for ( auto it = orders.cbegin(); it != orders.cend(); ++it ) {
-            const uint32_t currentBuildId = it->id;
-            if ( castle.isBuild( currentBuildId ) ) {
-                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuildId, animationIndex );
-                CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuildId, animationIndex );
-                if ( isBuildingConnectionNeeded( castle, currentBuildId, false ) ) {
-                    redrawBuildingConnection( castle, dst_pt, currentBuildId );
+        for ( const CastleDialog::builds_t & currentBuild : orders ) {
+            if ( castle.isBuild( currentBuild.id ) ) {
+                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuild.id, animationIndex );
+                CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex );
+                if ( isBuildingConnectionNeeded( castle, currentBuild.id, false ) ) {
+                    redrawBuildingConnection( castle, dst_pt, currentBuild.id );
                 }
             }
         }
     }
     // redraw build with alpha
     else if ( orders.cend() != std::find( orders.cbegin(), orders.cend(), fadeBuilding.GetBuild() ) ) {
-        for ( auto it = orders.cbegin(); it != orders.cend(); ++it ) {
-            const uint32_t currentBuildId = it->id;
-
-            if ( castle.isBuild( currentBuildId ) ) {
-                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuildId, animationIndex );
-                if ( currentBuildId == BUILD_SHIPYARD && fadeBuilding.GetBuild() == BUILD_SHIPYARD ) {
-                    CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuildId, animationIndex, fadeBuilding.GetAlpha() );
+        for ( const CastleDialog::builds_t & currentBuild : orders ) {
+            if ( castle.isBuild( currentBuild.id ) ) {
+                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuild.id, animationIndex );
+                if ( currentBuild.id == BUILD_SHIPYARD && fadeBuilding.GetBuild() == BUILD_SHIPYARD ) {
+                    CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
                 }
                 else {
-                    CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuildId, animationIndex );
+                    CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex );
                 }
-                if ( isBuildingConnectionNeeded( castle, currentBuildId, false ) ) {
+                if ( isBuildingConnectionNeeded( castle, currentBuild.id, false ) ) {
                     redrawBuildingConnection( castle, dst_pt, fadeBuilding.GetBuild(), fadeBuilding.GetAlpha() );
-                    redrawBuildingConnection( castle, dst_pt, currentBuildId );
+                    redrawBuildingConnection( castle, dst_pt, currentBuild.id );
                 }
             }
-            else if ( currentBuildId == fadeBuilding.GetBuild() ) {
-                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuildId, animationIndex, fadeBuilding.GetAlpha() );
-                CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuildId, animationIndex, fadeBuilding.GetAlpha() );
-                if ( isBuildingConnectionNeeded( castle, currentBuildId, true ) ) {
-                    redrawBuildingConnection( castle, dst_pt, currentBuildId, fadeBuilding.GetAlpha() );
+            else if ( currentBuild.id == fadeBuilding.GetBuild() ) {
+                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
+                CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
+                if ( isBuildingConnectionNeeded( castle, currentBuild.id, true ) ) {
+                    redrawBuildingConnection( castle, dst_pt, currentBuild.id, fadeBuilding.GetAlpha() );
                 }
             }
         }
     }
 }
 
+void CastleDialog::RedrawAllBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CacheBuildings & orders,
+                                      const CastleDialog::FadeBuilding & alphaBuilding, const uint32_t animationIndex )
+{
+    CastleRedrawCurrentBuilding( castle, dst_pt, orders, alphaBuilding, animationIndex );
+    fheroes2::drawCastleName( castle, fheroes2::Display::instance(), dst_pt );
+}
+
 void CastleDialog::CastleRedrawBuilding( const Castle & castle, const fheroes2::Point & dst_pt, uint32_t build, uint32_t frame, uint8_t alpha )
 {
-    if ( build == BUILD_TENT ) // we don't need to draw a tent as it's on the background image
+    if ( build == BUILD_TENT ) {
+        // We don't need to draw a tent because it's on the background image.
         return;
-
-    const fheroes2::Rect max = CastleGetMaxArea( castle, dst_pt );
+    }
 
     // correct build
     switch ( build ) {
@@ -306,75 +296,85 @@ void CastleDialog::CastleRedrawBuilding( const Castle & castle, const fheroes2::
     }
 
     const int race = castle.GetRace();
-    const int icn = Castle::GetICNBuilding( build, race );
     uint32_t index = 0;
 
     // correct index (mage guild)
     switch ( build ) {
     case BUILD_MAGEGUILD1:
-        if ( castle.GetLevelMageGuild() > 1 )
+        if ( castle.GetLevelMageGuild() > 1 ) {
             return;
-        index = 0;
+        }
         break;
     case BUILD_MAGEGUILD2:
-        if ( castle.GetLevelMageGuild() > 2 )
+        if ( castle.GetLevelMageGuild() > 2 ) {
             return;
-        index = Race::NECR == race ? 6 : 1;
+        }
+        index = ( Race::NECR == race ) ? 6 : 1;
         break;
     case BUILD_MAGEGUILD3:
-        if ( castle.GetLevelMageGuild() > 3 )
+        if ( castle.GetLevelMageGuild() > 3 ) {
             return;
-        index = Race::NECR == race ? 12 : 2;
+        }
+        index = ( Race::NECR == race ) ? 12 : 2;
         break;
     case BUILD_MAGEGUILD4:
-        if ( castle.GetLevelMageGuild() > 4 )
+        if ( castle.GetLevelMageGuild() > 4 ) {
             return;
-        index = Race::NECR == race ? 18 : 3;
+        }
+        index = ( Race::NECR == race ) ? 18 : 3;
         break;
     case BUILD_MAGEGUILD5:
-        index = Race::NECR == race ? 24 : 4;
+        index = ( Race::NECR == race ) ? 24 : 4;
         break;
     default:
         break;
     }
 
-    if ( icn != ICN::UNKNOWN ) {
-        // simple first sprite
-        fheroes2::drawCastleDialogBuilding( icn, index, castle, dst_pt, max, alpha );
+    const int icn = Castle::GetICNBuilding( build, race );
+    if ( icn == ICN::UNKNOWN ) {
+        // Have you added a new building? Add the logic for it!
+        assert( 0 );
+        return;
+    }
 
-        // Special case: Knight castle's flags are overlapped by Right Turret so we need to draw flags after drawing the Turret.
-        const bool knightCastleCase = ( race == Race::KNGT && castle.isBuild( BUILD_RIGHTTURRET ) && castle.isBuild( BUILD_CASTLE ) );
-        if ( knightCastleCase && build == BUILD_CASTLE ) {
-            // Do not draw flags.
-            return;
-        }
+    const fheroes2::Rect max = CastleGetMaxArea( castle, dst_pt );
 
-        // second anime sprite
-        if ( const uint32_t index2 = ICN::AnimationFrame( icn, index, frame ) ) {
-            fheroes2::drawCastleDialogBuilding( icn, index2, castle, dst_pt, max, alpha );
-        }
+    // Building main sprite.
+    fheroes2::drawCastleDialogBuilding( icn, index, castle, dst_pt, max, alpha );
 
-        if ( knightCastleCase && build == BUILD_RIGHTTURRET ) {
-            // Draw Castle's flags after the Turret.
-            const int castleIcn = Castle::GetICNBuilding( BUILD_CASTLE, race );
-            const uint32_t flagAnimFrame = ICN::AnimationFrame( castleIcn, index, frame );
-            if ( flagAnimFrame > 0 ) {
-                fheroes2::drawCastleDialogBuilding( castleIcn, flagAnimFrame, castle, dst_pt, max, alpha );
-            }
+    // Special case: Knight castle's flags are overlapped by Right Turret so we need to draw flags after drawing the Turret.
+    const bool knightCastleCase = ( race == Race::KNGT && castle.isBuild( BUILD_RIGHTTURRET ) && castle.isBuild( BUILD_CASTLE ) );
+    if ( knightCastleCase && build == BUILD_CASTLE ) {
+        // Do not draw flags.
+        return;
+    }
+
+    // Building animation sprite.
+    if ( const uint32_t index2 = ICN::AnimationFrame( icn, index, frame ) ) {
+        fheroes2::drawCastleDialogBuilding( icn, index2, castle, dst_pt, max, alpha );
+    }
+
+    if ( knightCastleCase && build == BUILD_RIGHTTURRET ) {
+        // Draw Castle's flags after the Turret.
+        const int castleIcn = Castle::GetICNBuilding( BUILD_CASTLE, race );
+        const uint32_t flagAnimFrame = ICN::AnimationFrame( castleIcn, index, frame );
+        if ( flagAnimFrame > 0 ) {
+            fheroes2::drawCastleDialogBuilding( castleIcn, flagAnimFrame, castle, dst_pt, max, alpha );
         }
     }
 }
 
 void CastleDialog::CastleRedrawBuildingExtended( const Castle & castle, const fheroes2::Point & dst_pt, uint32_t build, uint32_t frame, uint8_t alpha )
 {
-    if ( build == BUILD_TENT ) // we don't need to draw a tent as it's on the background image
+    if ( build == BUILD_TENT ) {
+        // We don't need to draw a tent because it's on the background image.
         return;
+    }
 
     const fheroes2::Rect max = CastleGetMaxArea( castle, dst_pt );
-    int icn = Castle::GetICNBuilding( build, castle.GetRace() );
+    const int icn = Castle::GetICNBuilding( build, castle.GetRace() );
 
-    // shipyard
-    if ( BUILD_SHIPYARD == build ) {
+    if ( build == BUILD_SHIPYARD ) {
         // boat
         if ( castle.PresentBoat() ) {
             const int icn2 = Castle::GetICNBoat( castle.GetRace() );
@@ -391,7 +391,7 @@ void CastleDialog::CastleRedrawBuildingExtended( const Castle & castle, const fh
             }
         }
     }
-    else if ( Race::SORC == castle.GetRace() && BUILD_WEL2 == build ) { // sorc and anime wel2 or statue
+    else if ( build == BUILD_WEL2 && Race::SORC == castle.GetRace() ) { // sorc and anime wel2 or statue
         const int icn2 = castle.isBuild( BUILD_STATUE ) ? ICN::TWNSEXT1 : icn;
 
         fheroes2::drawCastleDialogBuilding( icn2, 0, castle, dst_pt, max, alpha );
@@ -400,55 +400,19 @@ void CastleDialog::CastleRedrawBuildingExtended( const Castle & castle, const fh
             fheroes2::drawCastleDialogBuilding( icn2, index2, castle, dst_pt, max, alpha );
         }
     }
-    else if ( castle.GetRace() == Race::KNGT && BUILD_WEL2 == build && !castle.isBuild( BUILD_CASTLE ) ) {
+    else if ( build == BUILD_WEL2 && castle.GetRace() == Race::KNGT && !castle.isBuild( BUILD_CASTLE ) ) {
         const fheroes2::Sprite & rightFarm = fheroes2::AGG::GetICN( ICN::KNIGHT_CASTLE_RIGHT_FARM, 0 );
         const fheroes2::Sprite & leftFarm = fheroes2::AGG::GetICN( ICN::KNIGHT_CASTLE_LEFT_FARM, 0 );
         fheroes2::drawCastleDialogBuilding( ICN::KNIGHT_CASTLE_LEFT_FARM, 0, castle, { dst_pt.x + rightFarm.x() - leftFarm.width(), dst_pt.y + rightFarm.y() }, max,
                                             alpha );
     }
-    else if ( castle.GetRace() == Race::BARB && BUILD_CAPTAIN == build && !castle.isBuild( BUILD_CASTLE ) ) {
+    else if ( build == BUILD_CAPTAIN && castle.GetRace() == Race::BARB && !castle.isBuild( BUILD_CASTLE ) ) {
         const fheroes2::Sprite & rightCaptainQuarters = fheroes2::AGG::GetICN( ICN::TWNBCAPT, 0 );
         const fheroes2::Sprite & leftCaptainQuarters = fheroes2::AGG::GetICN( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0 );
         fheroes2::drawCastleDialogBuilding( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0, castle,
                                             { dst_pt.x + rightCaptainQuarters.x() - leftCaptainQuarters.width(), dst_pt.y + rightCaptainQuarters.y() }, max, alpha );
     }
-    else if ( castle.GetRace() == Race::SORC && BUILD_CAPTAIN == build && !castle.isBuild( BUILD_CASTLE ) ) {
+    else if ( build == BUILD_CAPTAIN && castle.GetRace() == Race::SORC && !castle.isBuild( BUILD_CASTLE ) ) {
         fheroes2::drawCastleDialogBuilding( ICN::SORCERESS_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0, castle, dst_pt, max, alpha );
     }
-}
-
-fheroes2::Rect CastleGetMaxArea( const Castle & castle, const fheroes2::Point & top )
-{
-    fheroes2::Rect res( top.x, top.y, 0, 0 );
-
-    int townIcnId = -1;
-
-    switch ( castle.GetRace() ) {
-    case Race::KNGT:
-        townIcnId = ICN::TOWNBKG0;
-        break;
-    case Race::BARB:
-        townIcnId = ICN::TOWNBKG1;
-        break;
-    case Race::SORC:
-        townIcnId = ICN::TOWNBKG2;
-        break;
-    case Race::WRLK:
-        townIcnId = ICN::TOWNBKG3;
-        break;
-    case Race::WZRD:
-        townIcnId = ICN::TOWNBKG4;
-        break;
-    case Race::NECR:
-        townIcnId = ICN::TOWNBKG5;
-        break;
-    default:
-        return res;
-    }
-
-    const fheroes2::Sprite & townbkg = fheroes2::AGG::GetICN( townIcnId, 0 );
-    res.width = townbkg.width();
-    res.height = townbkg.height();
-
-    return res;
 }

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -135,23 +135,22 @@ namespace
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 0 ), display, pt.x, pt.y + 256 );
 
         if ( castle.isBuild( BUILD_CAPTAIN ) ) {
-            fheroes2::Blit( castle.GetCaptain().GetPortrait( PORT_BIG ), display, pt.x + 5, pt.y + 262 );
+            const fheroes2::Sprite & captainImage = castle.GetCaptain().GetPortrait( PORT_BIG );
+            fheroes2::Copy( captainImage, 0, 0, display, pt.x + 5, pt.y + 262, captainImage.width(), captainImage.height() );
         }
         else {
-            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( castle.GetColor() ) ), display, pt.x + 5, pt.y + 262 );
+            const fheroes2::Sprite & crestImage = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( castle.GetColor() ) );
+            fheroes2::Copy( crestImage, 0, 0, display, pt.x + 5, pt.y + 262, crestImage.width(), crestImage.height() );
         }
 
         if ( hero ) {
             hero->PortraitRedraw( pt.x + 5, pt.y + 361, PORT_BIG, display );
         }
         else {
-            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 3 ), display, pt.x + 5, pt.y + 361 );
-        }
-
-        if ( hero == nullptr ) {
+            const fheroes2::Sprite & heroImage = fheroes2::AGG::GetICN( ICN::STRIP, 3 );
             const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( ICN::STRIP, 11 );
-
-            fheroes2::Blit( backgroundImage, display, pt.x + 112, pt.y + 361 );
+            fheroes2::Copy( heroImage, 0, 0, display, pt.x + 5, pt.y + 361, heroImage.width(), heroImage.height() );
+            fheroes2::Copy( backgroundImage, 0, 0, display, pt.x + 112, pt.y + 361, backgroundImage.width(), backgroundImage.height() );
         }
     }
 
@@ -188,10 +187,12 @@ namespace
         Game::SetUpdateSoundsOnFocusUpdate( false );
         Game::OpenHeroesDialog( hero, false, false );
 
-        if ( topArmyBar.isValid() && topArmyBar.isSelected() )
+        if ( topArmyBar.isValid() && topArmyBar.isSelected() ) {
             topArmyBar.ResetSelected();
-        if ( bottomArmyBar.isValid() && bottomArmyBar.isSelected() )
+        }
+        if ( bottomArmyBar.isValid() && bottomArmyBar.isSelected() ) {
             bottomArmyBar.ResetSelected();
+        }
     }
 
     void generateHeroImage( fheroes2::Image & image, Heroes * hero )
@@ -205,7 +206,7 @@ namespace
 
         fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 0 ), 0, 100, image, 0, 0, 552, 107 );
         const fheroes2::Sprite & port = hero->GetPortrait( PORT_BIG );
-        fheroes2::Blit( port, image, 5, 5 );
+        fheroes2::Copy( port, 0, 0, image, 5, 5, port.width(), port.height() );
 
         ArmyBar armyBar( &hero->GetArmy(), false, false );
         armyBar.setTableSize( { 5, 1 } );
@@ -223,27 +224,27 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    fheroes2::Rect fadeRoi;
-    fheroes2::Rect dialodWithShadowRoi;
+    fheroes2::Rect dialogRoi;
+    fheroes2::Rect dialogWithShadowRoi;
     std::unique_ptr<fheroes2::StandardWindow> background;
     std::unique_ptr<fheroes2::ImageRestorer> restorer;
 
     if ( renderBackgroundDialog ) {
         background = std::make_unique<fheroes2::StandardWindow>( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, false );
-        fadeRoi = background->activeArea();
-        dialodWithShadowRoi = background->totalArea();
+        dialogRoi = background->activeArea();
+        dialogWithShadowRoi = background->totalArea();
     }
     else {
-        fadeRoi = { ( display.width() - fheroes2::Display::DEFAULT_WIDTH ) / 2, ( display.height() - fheroes2::Display::DEFAULT_HEIGHT ) / 2,
-                    fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT };
-        dialodWithShadowRoi = { fadeRoi.x - 2 * BORDERWIDTH, fadeRoi.y - BORDERWIDTH, fadeRoi.width + 3 * BORDERWIDTH, fadeRoi.height + 3 * BORDERWIDTH };
-        restorer = std::make_unique<fheroes2::ImageRestorer>( display, fadeRoi.x, fadeRoi.y, fadeRoi.width, fadeRoi.height );
+        dialogRoi = { ( display.width() - fheroes2::Display::DEFAULT_WIDTH ) / 2, ( display.height() - fheroes2::Display::DEFAULT_HEIGHT ) / 2,
+                      fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT };
+        dialogWithShadowRoi = { dialogRoi.x - 2 * BORDERWIDTH, dialogRoi.y - BORDERWIDTH, dialogRoi.width + 3 * BORDERWIDTH, dialogRoi.height + 3 * BORDERWIDTH };
+        restorer = std::make_unique<fheroes2::ImageRestorer>( display, dialogRoi.x, dialogRoi.y, dialogRoi.width, dialogRoi.height );
     }
 
     // Fade-out game screen only for 640x480 resolution and if 'renderBackgroundDialog' is false (we are replacing image in already opened dialog).
     const bool isDefaultScreenSize = display.isDefaultSize();
     if ( fade && ( isDefaultScreenSize || !renderBackgroundDialog ) ) {
-        fheroes2::fadeOutDisplay( fadeRoi, !isDefaultScreenSize );
+        fheroes2::fadeOutDisplay( dialogRoi, !isDefaultScreenSize );
     }
 
     AudioManager::PlayMusicAsync( MUS::FromRace( race ), Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
@@ -255,99 +256,104 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
     fheroes2::Image surfaceHero;
 
-    if ( openConstructionWindow && isBuild( BUILD_CASTLE ) ) {
-        uint32_t build = BUILD_NOTHING;
-        const ConstructionDialogResult townResult = openConstructionDialog( build );
-
-        if ( townResult == ConstructionDialogResult::NextConstructionWindow ) {
+    auto constructionDialogHandler = [this, &display, &dialogRoi, &fadeBuilding, &hero, &surfaceHero, &alphaHero]() {
+        switch ( uint32_t build = BUILD_NOTHING; openConstructionDialog( build ) ) {
+        case ConstructionDialogResult::NextConstructionWindow:
             return CastleDialogReturnValue::NextCostructionWindow;
-        }
-        if ( townResult == ConstructionDialogResult::PrevConstructionWindow ) {
+        case ConstructionDialogResult::PrevConstructionWindow:
             return CastleDialogReturnValue::PreviousCostructionWindow;
-        }
-
-        if ( build != BUILD_NOTHING ) {
-            AudioManager::PlaySound( M82::BUILDTWN );
-            fadeBuilding.StartFadeBuilding( build );
-        }
-
-        if ( townResult == ConstructionDialogResult::RecruitHero ) {
+        case ConstructionDialogResult::RecruitHero:
             hero = world.GetHero( *this );
-
             generateHeroImage( surfaceHero, hero );
-
             AudioManager::PlaySound( M82::BUILDTWN );
             alphaHero = 0;
+            break;
+        default:
+            if ( build != BUILD_NOTHING ) {
+                AudioManager::PlaySound( M82::BUILDTWN );
+                fadeBuilding.StartFadeBuilding( build );
+            }
+            break;
+        }
+
+        // Set next render ROI to dialog ROI. It is needed to properly update the castle dialog after the construction dialog is closed.
+        display.updateNextRenderRoi( dialogRoi );
+
+        return CastleDialogReturnValue::DoNothing;
+    };
+
+    if ( openConstructionWindow && isBuild( BUILD_CASTLE ) ) {
+        const CastleDialogReturnValue constructionResult = constructionDialogHandler();
+        if ( constructionResult != CastleDialogReturnValue::DoNothing ) {
+            return constructionResult;
         }
     }
 
-    const fheroes2::Point cur_pt( fadeRoi.x, fadeRoi.y );
     const std::string currentDate = getDateString();
 
-    // button prev castle
-    const int32_t statusBarOffsetY = 480 - 19;
+    // Previous castle button.
+    fheroes2::Point statusBarPosition( dialogRoi.x, dialogRoi.y + 480 - 19 );
 
-    fheroes2::Button buttonPrevCastle( cur_pt.x, cur_pt.y + statusBarOffsetY, ICN::SMALLBAR, 1, 2 );
+    fheroes2::Button buttonPrevCastle( statusBarPosition.x, statusBarPosition.y, ICN::SMALLBAR, 1, 2 );
     fheroes2::TimedEventValidator timedButtonPrevCastle( [&buttonPrevCastle]() { return buttonPrevCastle.isPressed(); } );
     buttonPrevCastle.subscribe( &timedButtonPrevCastle );
 
-    // bottom small bar
+    statusBarPosition.x += buttonPrevCastle.area().width;
+
+    // Status bar at the bottom of dialog.
     const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::SMALLBAR, 0 );
-    fheroes2::Blit( bar, display, cur_pt.x + buttonPrevCastle.area().width, cur_pt.y + statusBarOffsetY );
+    fheroes2::Copy( bar, 0, 0, display, statusBarPosition.x, statusBarPosition.y, bar.width(), bar.height() );
 
     StatusBar statusBar;
     // Status bar must be smaller due to extra art on both sides.
-    statusBar.setRoi( { cur_pt.x + buttonPrevCastle.area().width + 16, cur_pt.y + statusBarOffsetY + 2, bar.width() - 16 * 2, 0 } );
+    statusBar.setRoi( { statusBarPosition.x + 16, statusBarPosition.y + 3, bar.width() - 16 * 2, 0 } );
 
-    // button next castle
-    fheroes2::Button buttonNextCastle( cur_pt.x + buttonPrevCastle.area().width + bar.width(), cur_pt.y + statusBarOffsetY, ICN::SMALLBAR, 3, 4 );
+    // Next castle button.
+    fheroes2::Button buttonNextCastle( statusBarPosition.x + bar.width(), statusBarPosition.y, ICN::SMALLBAR, 3, 4 );
     fheroes2::TimedEventValidator timedButtonNextCastle( [&buttonNextCastle]() { return buttonNextCastle.isPressed(); } );
     buttonNextCastle.subscribe( &timedButtonNextCastle );
 
-    // color crest
+    // Position of the captain/crest and hero portrait to the left of army bars.
     const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( GetColor() ) );
-    const fheroes2::Rect rectSign1( cur_pt.x + 5, cur_pt.y + 262, crest.width(), crest.height() );
+    const fheroes2::Rect rectSign1( dialogRoi.x + 5, dialogRoi.y + 262, crest.width(), crest.height() );
+    const fheroes2::Rect rectSign2( dialogRoi.x + 5, dialogRoi.y + 361, 100, 92 );
 
-    RedrawIcons( *this, hero, cur_pt );
+    // For the case when new hero is recruited we need to render bottom army bar
+    // without hero and his army to properly perform hero fade-in.
+    RedrawIcons( *this, ( alphaHero == 0 ) ? nullptr : hero, dialogRoi.getPosition() );
 
-    // castle troops selector
-    // castle army bar
+    auto setArmyBarParameters = []( ArmyBar & armyBar, const fheroes2::Point & offset ) {
+        armyBar.setTableSize( { 5, 1 } );
+        armyBar.setRenderingOffset( offset );
+        armyBar.setInBetweenItemsOffset( { 6, 0 } );
+    };
+
+    // Castle army (top) bar.
     ArmyBar topArmyBar( &army, false, false );
-    topArmyBar.setTableSize( { 5, 1 } );
-    topArmyBar.setRenderingOffset( { cur_pt.x + 112, cur_pt.y + 262 } );
-    topArmyBar.setInBetweenItemsOffset( { 6, 0 } );
+    setArmyBarParameters( topArmyBar, { dialogRoi.x + 112, dialogRoi.y + 262 } );
     topArmyBar.Redraw( display );
 
-    // portrait heroes or captain or sign
-    const fheroes2::Rect rectSign2( cur_pt.x + 5, cur_pt.y + 361, 100, 92 );
+    // Hero army (bottom) bar.
+    ArmyBar bottomArmyBar( hero ? &hero->GetArmy() : nullptr, false, false );
+    setArmyBarParameters( bottomArmyBar, { dialogRoi.x + 112, dialogRoi.y + 361 } );
 
-    // castle_heroes troops background
-    ArmyBar bottomArmyBar( nullptr, false, false );
-    bottomArmyBar.setTableSize( { 5, 1 } );
-    bottomArmyBar.setRenderingOffset( { cur_pt.x + 112, cur_pt.y + 361 } );
-    bottomArmyBar.setInBetweenItemsOffset( { 6, 0 } );
-
-    if ( hero ) {
-        bottomArmyBar.SetArmy( &hero->GetArmy() );
-
-        if ( alphaHero != 0 ) {
-            // Draw bottom bar only if no hero fading animation is going.
-            bottomArmyBar.Redraw( display );
-        }
+    if ( hero && alphaHero != 0 ) {
+        // Draw bottom bar only if no hero fading animation is going.
+        bottomArmyBar.Redraw( display );
     }
 
-    // button exit
-    fheroes2::Button buttonExit( cur_pt.x + 553, cur_pt.y + 428, ICN::BUTTON_EXIT_TOWN, 0, 1 );
+    // Exit button.
+    fheroes2::Button buttonExit( dialogRoi.x + 553, dialogRoi.y + 428, ICN::BUTTON_EXIT_TOWN, 0, 1 );
 
-    // resource
-    const fheroes2::Rect & rectResource = fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, cur_pt );
+    // Kingdom resources.
+    const fheroes2::Rect & rectResource = fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, dialogRoi.getPosition() );
     const fheroes2::Rect resActiveArea( rectResource.x, rectResource.y, rectResource.width, buttonExit.area().y - rectResource.y - 3 );
 
-    // fill cache buildings
-    CastleDialog::CacheBuildings cacheBuildings( *this, cur_pt );
+    // Cache a vector of castle buildings in the order they are rendered.
+    const CastleDialog::CacheBuildings cacheBuildings( *this, dialogRoi.getPosition() );
 
-    // draw building
-    CastleDialog::RedrawAllBuilding( *this, cur_pt, cacheBuildings, fadeBuilding, castleAnimationIndex );
+    // Render castle buildings.
+    CastleDialog::RedrawAllBuilding( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
 
     if ( GetKingdom().GetCastles().size() < 2 ) {
         buttonPrevCastle.disable();
@@ -362,29 +368,28 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     if ( fade ) {
         if ( renderBackgroundDialog && !isDefaultScreenSize ) {
             // We need to expand the ROI for the next render to properly render window borders and shadow.
-            display.updateNextRenderRoi( dialodWithShadowRoi );
+            display.updateNextRenderRoi( dialogWithShadowRoi );
         }
 
         // Use half fade if game resolution is not 640x480.
-        fheroes2::fadeInDisplay( fadeRoi, !isDefaultScreenSize );
+        fheroes2::fadeInDisplay( dialogRoi, !isDefaultScreenSize );
     }
     else {
-        display.render();
+        display.render( dialogWithShadowRoi );
     }
 
     CastleDialogReturnValue result = CastleDialogReturnValue::DoNothing;
-    bool need_redraw = false;
+    bool needRedraw = false;
     bool needFadeIn = false;
-
-    // dialog menu loop
-    Game::passAnimationDelay( Game::CASTLE_AROUND_DELAY );
 
     // This variable must be declared out of the loop for performance reasons.
     std::string statusMessage;
 
+    Game::passAnimationDelay( Game::CASTLE_AROUND_DELAY );
+
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents() && result == CastleDialogReturnValue::DoNothing ) {
-        // During hero purchase or building construction disable any interaction
+        // During hero purchase or building construction skip any interaction with the dialog.
         if ( alphaHero >= 255 && fadeBuilding.IsFadeDone() ) {
             if ( buttonPrevCastle.isEnabled() ) {
                 le.MousePressLeft( buttonPrevCastle.area() ) ? buttonPrevCastle.drawOnPress() : buttonPrevCastle.drawOnRelease();
@@ -400,7 +405,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                 result = CastleDialogReturnValue::Close;
 
                 // Fade-out castle dialog.
-                fheroes2::fadeOutDisplay( fadeRoi, !isDefaultScreenSize );
+                fheroes2::fadeOutDisplay( dialogRoi, !isDefaultScreenSize );
                 break;
             }
             if ( buttonPrevCastle.isEnabled()
@@ -415,7 +420,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             }
 
             if ( le.MouseClickLeft( resActiveArea ) ) {
-                fheroes2::ButtonRestorer exitRestorer( buttonExit );
+                const fheroes2::ButtonRestorer exitRestorer( buttonExit );
 
                 fheroes2::showKingdomIncome( GetKingdom(), Dialog::OK );
             }
@@ -431,16 +436,22 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             else if ( le.MousePressRight( buttonPrevCastle.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Show previous town" ), _( "Click to show previous town." ), Dialog::ZERO );
             }
+            else if ( isBuild( BUILD_CAPTAIN ) && le.MousePressRight( rectSign1 ) ) {
+                Dialog::QuickInfo( GetCaptain() );
+            }
+            else if ( hero && le.MousePressRight( rectSign2 ) ) {
+                Dialog::QuickInfo( *hero );
+            }
 
-            // selector troops event
+            // Army bar events processing.
             if ( ( bottomArmyBar.isValid()
                    && ( ( le.MouseCursor( topArmyBar.GetArea() ) && topArmyBar.QueueEventProcessing( bottomArmyBar, &statusMessage ) )
                         || ( le.MouseCursor( bottomArmyBar.GetArea() ) && bottomArmyBar.QueueEventProcessing( topArmyBar, &statusMessage ) ) ) )
                  || ( !bottomArmyBar.isValid() && le.MouseCursor( topArmyBar.GetArea() ) && topArmyBar.QueueEventProcessing( &statusMessage ) ) ) {
-                need_redraw = true;
+                needRedraw = true;
             }
 
-            // Actions with hero armies.
+            // Actions with hero army.
             if ( hero ) {
                 bool isArmyActionPerformed = false;
 
@@ -463,7 +474,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                     isArmyActionPerformed = true;
                 }
 
-                // Redraw and reset if any action modifying armies has been made.
+                // Reset selection and schedule dialog redraw if any action modifying armies has been made.
                 if ( isArmyActionPerformed ) {
                     if ( topArmyBar.isSelected() ) {
                         topArmyBar.ResetSelected();
@@ -472,7 +483,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                         bottomArmyBar.ResetSelected();
                     }
 
-                    need_redraw = true;
+                    needRedraw = true;
                 }
             }
 
@@ -481,14 +492,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                 openHeroDialog( topArmyBar, bottomArmyBar, *hero );
 
                 needFadeIn = true;
-                need_redraw = true;
-            }
-
-            if ( isBuild( BUILD_CAPTAIN ) && le.MousePressRight( rectSign1 ) ) {
-                Dialog::QuickInfo( GetCaptain() );
-            }
-            else if ( hero && le.MousePressRight( rectSign2 ) ) {
-                Dialog::QuickInfo( *hero );
+                needRedraw = true;
             }
 
             // Get pressed hotkey.
@@ -521,29 +525,31 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                 const bool isMagicGuild = ( BUILD_MAGEGUILD & it->id ) != 0;
 
                 if ( le.MouseClickLeft( it->coord ) || hotKeyBuilding == it->id || ( isMagicGuild && hotKeyBuilding == BUILD_MAGEGUILD ) ) {
-                    if ( topArmyBar.isSelected() )
+                    if ( topArmyBar.isSelected() ) {
                         topArmyBar.ResetSelected();
-                    if ( bottomArmyBar.isValid() && bottomArmyBar.isSelected() )
+                    }
+                    if ( bottomArmyBar.isValid() && bottomArmyBar.isSelected() ) {
                         bottomArmyBar.ResetSelected();
+                    }
 
                     if ( isMagicGuild ) {
-                        fheroes2::ButtonRestorer exitRestorer( buttonExit );
+                        const fheroes2::ButtonRestorer exitRestorer( buttonExit );
 
                         if ( purchaseSpellBookIfNecessary( *this, hero ) ) {
                             // Guest hero purchased the spellbook, redraw the resource panel
-                            need_redraw = true;
+                            needRedraw = true;
                         }
 
                         OpenMageGuild( hero );
                     }
                     else if ( isMonsterDwelling ) {
-                        fheroes2::ButtonRestorer exitRestorer( buttonExit );
+                        const fheroes2::ButtonRestorer exitRestorer( buttonExit );
 
                         const int32_t recruitMonsterWindowOffsetY = -65;
                         const Troop monsterToRecruit
                             = Dialog::RecruitMonster( Monster( race, monsterDwelling ), getMonstersInDwelling( it->id ), true, recruitMonsterWindowOffsetY );
                         if ( Castle::RecruitMonster( monsterToRecruit ) ) {
-                            need_redraw = true;
+                            needRedraw = true;
                         }
                     }
                     else {
@@ -553,7 +559,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                             break;
 
                         case BUILD_TAVERN: {
-                            fheroes2::ButtonRestorer exitRestorer( buttonExit );
+                            const fheroes2::ButtonRestorer exitRestorer( buttonExit );
                             OpenTavern();
                             break;
                         }
@@ -564,13 +570,13 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                         case BUILD_MOAT:
                         case BUILD_SPEC:
                         case BUILD_SHRINE: {
-                            fheroes2::ButtonRestorer exitRestorer( buttonExit );
+                            const fheroes2::ButtonRestorer exitRestorer( buttonExit );
                             fheroes2::showStandardTextMessage( GetStringBuilding( it->id ), GetDescriptionBuilding( it->id ), Dialog::OK );
                             break;
                         }
 
                         case BUILD_SHIPYARD: {
-                            fheroes2::ButtonRestorer exitRestorer( buttonExit );
+                            const fheroes2::ButtonRestorer exitRestorer( buttonExit );
                             if ( Dialog::OK == Dialog::BuyBoat( AllowBuyBoat() ) ) {
                                 BuyBoat();
                                 fadeBuilding.StartFadeBuilding( BUILD_SHIPYARD );
@@ -579,19 +585,19 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                         }
 
                         case BUILD_MARKETPLACE: {
-                            fheroes2::ButtonRestorer exitRestorer( buttonExit );
+                            const fheroes2::ButtonRestorer exitRestorer( buttonExit );
                             Dialog::Marketplace( GetKingdom(), false );
-                            need_redraw = true;
+                            needRedraw = true;
                             break;
                         }
 
                         case BUILD_WELL:
                             OpenWell();
-                            need_redraw = true;
+                            needRedraw = true;
                             break;
 
                         case BUILD_TENT: {
-                            fheroes2::ButtonRestorer exitRestorer( buttonExit );
+                            const fheroes2::ButtonRestorer exitRestorer( buttonExit );
                             if ( !Modes( ALLOWCASTLE ) ) {
                                 fheroes2::showStandardTextMessage( _( "Town" ), _( "This town may not be upgraded to a castle." ), Dialog::OK );
                             }
@@ -603,33 +609,11 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                         }
 
                         case BUILD_CASTLE: {
-                            uint32_t build = BUILD_NOTHING;
-                            const ConstructionDialogResult townResult = openConstructionDialog( build );
-
-                            if ( townResult == ConstructionDialogResult::NextConstructionWindow ) {
-                                result = CastleDialogReturnValue::NextCostructionWindow;
-                                break;
-                            }
-                            if ( townResult == ConstructionDialogResult::PrevConstructionWindow ) {
-                                result = CastleDialogReturnValue::PreviousCostructionWindow;
-                                break;
-                            }
-
-                            if ( build != BUILD_NOTHING ) {
-                                AudioManager::PlaySound( M82::BUILDTWN );
-                                fadeBuilding.StartFadeBuilding( build );
-                            }
-
-                            hero = world.GetHero( *this );
-
-                            if ( townResult == ConstructionDialogResult::RecruitHero ) {
-                                AudioManager::PlaySound( M82::BUILDTWN );
-
-                                bottomArmyBar.SetArmy( &hero->GetArmy() );
-                                generateHeroImage( surfaceHero, hero );
-
-                                alphaHero = 0;
-                                need_redraw = true;
+                            const bool noHeroInCastle = ( hero == nullptr );
+                            result = constructionDialogHandler();
+                            if ( noHeroInCastle && hero != nullptr ) {
+                                // A hero has been recruited.
+                                needRedraw = true;
                             }
                             break;
                         }
@@ -650,27 +634,26 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             break;
         }
 
-        if ( alphaHero < 255 ) {
-            if ( Game::validateAnimationDelay( Game::CASTLE_BUYHERO_DELAY ) ) {
-                alphaHero += 10;
-                if ( alphaHero >= 255 ) {
-                    alphaHero = 255;
-                }
+        if ( alphaHero < 255 && Game::validateAnimationDelay( Game::CASTLE_BUYHERO_DELAY ) ) {
+            alphaHero += 10;
+            if ( alphaHero >= 255 ) {
+                alphaHero = 255;
+            }
 
-                fheroes2::AlphaBlit( surfaceHero, display, cur_pt.x, cur_pt.y + 356, static_cast<uint8_t>( alphaHero ) );
+            fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
 
-                if ( !need_redraw ) {
-                    display.render();
-                }
+            if ( !needRedraw ) {
+                display.render( dialogRoi );
             }
         }
 
-        if ( need_redraw ) {
+        if ( needRedraw ) {
+            // Redraw the bottom part of the castle dialog (army bars, resources, exit button).
             topArmyBar.Redraw( display );
-            if ( bottomArmyBar.isValid() && alphaHero >= 255 )
+            if ( bottomArmyBar.isValid() && alphaHero >= 255 ) {
                 bottomArmyBar.Redraw( display );
-            fheroes2::drawCastleName( *this, display, cur_pt );
-            fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, cur_pt );
+            }
+            fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, dialogRoi.getPosition() );
 
             if ( buttonExit.isPressed() ) {
                 buttonExit.draw();
@@ -679,10 +662,10 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             if ( needFadeIn ) {
                 needFadeIn = false;
 
-                fheroes2::fadeInDisplay( fadeRoi, !isDefaultScreenSize );
+                fheroes2::fadeInDisplay( dialogRoi, !isDefaultScreenSize );
             }
             else {
-                display.render();
+                display.render( dialogRoi );
             }
         }
 
@@ -720,35 +703,44 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             statusMessage.clear();
         }
 
-        need_redraw = fadeBuilding.UpdateFadeBuilding();
+        needRedraw = fadeBuilding.UpdateFadeBuilding();
         if ( fadeBuilding.IsFadeDone() ) {
             const uint32_t build = fadeBuilding.GetBuild();
 
             if ( build != BUILD_NOTHING ) {
                 BuyBuilding( build );
                 if ( BUILD_CAPTAIN == build ) {
-                    RedrawIcons( *this, hero, cur_pt );
+                    RedrawIcons( *this, hero, dialogRoi.getPosition() );
+                    fheroes2::drawCastleName( *this, fheroes2::Display::instance(), dialogRoi.getPosition() );
                 }
 
-                fheroes2::drawCastleName( *this, display, cur_pt );
-                fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, cur_pt );
+                fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, dialogRoi.getPosition() );
 
-                display.render();
+                display.render( dialogRoi );
             }
 
             fadeBuilding.StopFadeBuilding();
         }
-        // animation sprite
-        if ( Game::validateAnimationDelay( Game::CASTLE_AROUND_DELAY ) ) {
-            CastleDialog::RedrawAllBuilding( *this, cur_pt, cacheBuildings, fadeBuilding, castleAnimationIndex );
-            display.render();
-
-            ++castleAnimationIndex;
+        else if ( fadeBuilding.GetBuild() == BUILD_CAPTAIN ) {
+            // Fade-in the captain image while fading-in his quarters.
+            const fheroes2::Sprite & crestImage = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( GetColor() ) );
+            fheroes2::Copy( crestImage, 0, 0, display, dialogRoi.x + 5, dialogRoi.y + 262, crestImage.width(), crestImage.height() );
+            const fheroes2::Sprite & captainImage = GetCaptain().GetPortrait( PORT_BIG );
+            fheroes2::AlphaBlit( captainImage, display, dialogRoi.x + 5, dialogRoi.y + 262, fadeBuilding.GetAlpha() );
         }
-        else if ( need_redraw ) {
-            CastleDialog::RedrawAllBuilding( *this, cur_pt, cacheBuildings, fadeBuilding, castleAnimationIndex );
-            display.render();
-            need_redraw = false;
+
+        // Castle dialog animation.
+        if ( Game::validateAnimationDelay( Game::CASTLE_AROUND_DELAY ) || needRedraw ) {
+            CastleDialog::RedrawAllBuilding( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
+
+            display.render( dialogRoi );
+
+            if ( needRedraw ) {
+                needRedraw = false;
+            }
+            else {
+                ++castleAnimationIndex;
+            }
         }
     }
 

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -63,22 +63,24 @@
 
 int Castle::DialogBuyHero( const Heroes * hero ) const
 {
-    if ( !hero )
+    if ( !hero ) {
         return Dialog::CANCEL;
+    }
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const int spacer = 10;
+    const int32_t spacer = 10;
     const fheroes2::Sprite & portrait_frame = fheroes2::AGG::GetICN( ICN::SURRENDR, 4 );
 
-    fheroes2::Text recruitHeroText( _( "Recruit Hero" ), fheroes2::FontType::normalYellow() );
+    const fheroes2::Text recruitHeroText( _( "Recruit Hero" ), fheroes2::FontType::normalYellow() );
 
     uint32_t count = hero->GetCountArtifacts();
-    if ( hero->hasArtifact( Artifact::MAGIC_BOOK ) )
+    if ( hero->hasArtifact( Artifact::MAGIC_BOOK ) ) {
         --count;
+    }
 
     std::string str = _( "%{name} is a level %{value} %{race} " );
 
@@ -94,14 +96,14 @@ int Castle::DialogBuyHero( const Heroes * hero ) const
     StringReplace( str, "%{race}", Race::String( hero->GetRace() ) );
     StringReplace( str, "%{count}", count );
 
-    fheroes2::Text heroDescriptionText( std::move( str ), fheroes2::FontType::normalWhite() );
+    const fheroes2::Text heroDescriptionText( std::move( str ), fheroes2::FontType::normalWhite() );
 
     Resource::BoxSprite rbs( PaymentConditions::RecruitHero(), BOXAREA_WIDTH );
 
     const int32_t dialogHeight = recruitHeroText.height( BOXAREA_WIDTH ) + spacer + portrait_frame.height() + spacer + heroDescriptionText.height( BOXAREA_WIDTH )
                                  + spacer + rbs.GetArea().height;
 
-    Dialog::FrameBox box( dialogHeight, true );
+    const Dialog::FrameBox box( dialogHeight, true );
     const fheroes2::Rect & dialogRoi = box.GetArea();
 
     recruitHeroText.draw( dialogRoi.x, dialogRoi.y + 2, BOXAREA_WIDTH, display );
@@ -115,48 +117,58 @@ int Castle::DialogBuyHero( const Heroes * hero ) const
     pos.y = pos.y + 6;
     hero->PortraitRedraw( pos.x, pos.y, PORT_BIG, display );
 
-    pos.x = dialogRoi.x;
-    pos.y = pos.y + portrait_frame.height() + spacer;
-    heroDescriptionText.draw( pos.x, pos.y + 2, BOXAREA_WIDTH, display );
+    pos.y += portrait_frame.height() + spacer;
+    heroDescriptionText.draw( dialogRoi.x, pos.y + 2, BOXAREA_WIDTH, display );
 
-    rbs.SetPos( pos.x, pos.y + heroDescriptionText.height( BOXAREA_WIDTH ) + spacer );
+    rbs.SetPos( dialogRoi.x, pos.y + heroDescriptionText.height( BOXAREA_WIDTH ) + spacer );
     rbs.Redraw();
 
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int okayButtonIcnID = isEvilInterface ? ICN::UNIFORM_EVIL_OKAY_BUTTON : ICN::UNIFORM_GOOD_OKAY_BUTTON;
 
-    pos.x = dialogRoi.x;
     pos.y = dialogRoi.y + dialogRoi.height - fheroes2::AGG::GetICN( okayButtonIcnID, 0 ).height();
-    fheroes2::Button button1( pos.x, pos.y, okayButtonIcnID, 0, 1 );
+    fheroes2::Button buttonOkay( dialogRoi.x, pos.y, okayButtonIcnID, 0, 1 );
 
     if ( !AllowBuyHero() ) {
-        button1.disable();
+        buttonOkay.disable();
     }
 
     const int cancelButtonIcnID = isEvilInterface ? ICN::UNIFORM_EVIL_CANCEL_BUTTON : ICN::UNIFORM_GOOD_CANCEL_BUTTON;
 
     pos.x = dialogRoi.x + dialogRoi.width - fheroes2::AGG::GetICN( cancelButtonIcnID, 0 ).width();
     pos.y = dialogRoi.y + dialogRoi.height - fheroes2::AGG::GetICN( cancelButtonIcnID, 0 ).height();
-    fheroes2::Button button2( pos.x, pos.y, cancelButtonIcnID, 0, 1 );
+    fheroes2::Button buttonCancel( pos.x, pos.y, cancelButtonIcnID, 0, 1 );
 
-    button1.draw();
-    button2.draw();
+    buttonOkay.draw();
+    buttonCancel.draw();
 
     display.render();
 
     LocalEvent & le = LocalEvent::Get();
     while ( le.HandleEvents() ) {
-        le.MousePressLeft( button1.area() ) ? button1.drawOnPress() : button1.drawOnRelease();
-        le.MousePressLeft( button2.area() ) ? button2.drawOnPress() : button2.drawOnRelease();
+        le.MousePressLeft( buttonOkay.area() ) ? buttonOkay.drawOnPress() : buttonOkay.drawOnRelease();
+        le.MousePressLeft( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
 
-        if ( button1.isEnabled() && ( le.MouseClickLeft( button1.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) ) )
+        if ( buttonOkay.isEnabled() && ( le.MouseClickLeft( buttonOkay.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) ) ) {
             return Dialog::OK;
+        }
 
-        if ( le.MouseClickLeft( button2.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) )
+        if ( le.MouseClickLeft( buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
             break;
+        }
 
         if ( le.MousePressRight( heroPortraitArea ) ) {
             Dialog::QuickInfo( *hero );
+        }
+        else if ( le.MousePressRight( buttonOkay.area() ) ) {
+            std::string recruitHero = _( "Recruit %{name} the %{race}" );
+            StringReplace( recruitHero, "%{name}", hero->GetName() );
+            StringReplace( recruitHero, "%{race}", Race::String( hero->GetRace() ) );
+            recruitHero += '.';
+            fheroes2::showStandardTextMessage( _( "Okay" ), std::move( recruitHero ), Dialog::ZERO );
+        }
+        else if ( le.MousePressRight( buttonCancel.area() ) ) {
+            fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
         }
     }
 
@@ -165,7 +177,7 @@ int Castle::DialogBuyHero( const Heroes * hero ) const
 
 int Castle::DialogBuyCastle( bool buttons ) const
 {
-    BuildingInfo info( *this, BUILD_CASTLE );
+    const BuildingInfo info( *this, BUILD_CASTLE );
     return info.DialogBuyBuilding( buttons ) ? Dialog::OK : Dialog::CANCEL;
 }
 
@@ -203,7 +215,7 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
         dst_pt.y += cur_pt.y;
 
         const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
-        fheroes2::Blit( backgroundImage, rect.x, rect.y, display, dst_pt.x, dst_pt.y, rect.width, rect.height );
+        fheroes2::Copy( backgroundImage, rect.x, rect.y, display, dst_pt.x, dst_pt.y, rect.width, rect.height );
     }
 
     // draw castle sprite
@@ -215,28 +227,32 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
     const fheroes2::Text castleName( GetName(), fheroes2::FontType::smallWhite() );
     castleName.draw( cur_pt.x + 538 - castleName.width() / 2, cur_pt.y + 3, display );
 
+    dst_pt.y = cur_pt.y + 2;
+
     BuildingInfo dwelling1( *this, DWELLING_MONSTER1 );
-    dwelling1.SetPos( cur_pt.x + 5, cur_pt.y + 2 );
+    dwelling1.SetPos( cur_pt.x + 5, dst_pt.y );
     dwelling1.Redraw();
 
     BuildingInfo dwelling2( *this, DWELLING_MONSTER2 );
-    dwelling2.SetPos( cur_pt.x + 149, cur_pt.y + 2 );
+    dwelling2.SetPos( cur_pt.x + 149, dst_pt.y );
     dwelling2.Redraw();
 
     BuildingInfo dwelling3( *this, DWELLING_MONSTER3 );
-    dwelling3.SetPos( cur_pt.x + 293, cur_pt.y + 2 );
+    dwelling3.SetPos( cur_pt.x + 293, dst_pt.y );
     dwelling3.Redraw();
 
+    dst_pt.y = cur_pt.y + 77;
+
     BuildingInfo dwelling4( *this, DWELLING_MONSTER4 );
-    dwelling4.SetPos( cur_pt.x + 5, cur_pt.y + 77 );
+    dwelling4.SetPos( cur_pt.x + 5, dst_pt.y );
     dwelling4.Redraw();
 
     BuildingInfo dwelling5( *this, DWELLING_MONSTER5 );
-    dwelling5.SetPos( cur_pt.x + 149, cur_pt.y + 77 );
+    dwelling5.SetPos( cur_pt.x + 149, dst_pt.y );
     dwelling5.Redraw();
 
     BuildingInfo dwelling6( *this, DWELLING_MONSTER6 );
-    dwelling6.SetPos( cur_pt.x + 293, cur_pt.y + 77 );
+    dwelling6.SetPos( cur_pt.x + 293, dst_pt.y );
     dwelling6.Redraw();
 
     // mage guild
@@ -258,64 +274,73 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
         level = BUILD_MAGEGUILD5;
         break;
     }
+
+    dst_pt.y = cur_pt.y + 157;
+
     BuildingInfo buildingMageGuild( *this, level );
-    buildingMageGuild.SetPos( cur_pt.x + 5, cur_pt.y + 157 );
+    buildingMageGuild.SetPos( cur_pt.x + 5, dst_pt.y );
     buildingMageGuild.Redraw();
 
     // tavern
     const bool isSkipTavernInteraction = ( Race::NECR == race ) && !Settings::Get().isCurrentMapPriceOfLoyalty();
     BuildingInfo buildingTavern( *this, BUILD_TAVERN );
-    buildingTavern.SetPos( cur_pt.x + 149, cur_pt.y + 157 );
+    buildingTavern.SetPos( cur_pt.x + 149, dst_pt.y );
     buildingTavern.Redraw();
 
     // thieves guild
     BuildingInfo buildingThievesGuild( *this, BUILD_THIEVESGUILD );
-    buildingThievesGuild.SetPos( cur_pt.x + 293, cur_pt.y + 157 );
+    buildingThievesGuild.SetPos( cur_pt.x + 293, dst_pt.y );
     buildingThievesGuild.Redraw();
+
+    dst_pt.y = cur_pt.y + 232;
 
     // shipyard
     BuildingInfo buildingShipyard( *this, BUILD_SHIPYARD );
-    buildingShipyard.SetPos( cur_pt.x + 5, cur_pt.y + 232 );
+    buildingShipyard.SetPos( cur_pt.x + 5, dst_pt.y );
     buildingShipyard.Redraw();
 
     // statue
     BuildingInfo buildingStatue( *this, BUILD_STATUE );
-    buildingStatue.SetPos( cur_pt.x + 149, cur_pt.y + 232 );
+    buildingStatue.SetPos( cur_pt.x + 149, dst_pt.y );
     buildingStatue.Redraw();
 
     // marketplace
     BuildingInfo buildingMarketplace( *this, BUILD_MARKETPLACE );
-    buildingMarketplace.SetPos( cur_pt.x + 293, cur_pt.y + 232 );
+    buildingMarketplace.SetPos( cur_pt.x + 293, dst_pt.y );
     buildingMarketplace.Redraw();
+
+    dst_pt.y = cur_pt.y + 307;
 
     // well
     BuildingInfo buildingWell( *this, BUILD_WELL );
-    buildingWell.SetPos( cur_pt.x + 5, cur_pt.y + 307 );
+    buildingWell.SetPos( cur_pt.x + 5, dst_pt.y );
     buildingWell.Redraw();
 
     // wel2
     BuildingInfo buildingWel2( *this, BUILD_WEL2 );
-    buildingWel2.SetPos( cur_pt.x + 149, cur_pt.y + 307 );
+    buildingWel2.SetPos( cur_pt.x + 149, dst_pt.y );
     buildingWel2.Redraw();
 
     // spec
     BuildingInfo buildingSpec( *this, BUILD_SPEC );
-    buildingSpec.SetPos( cur_pt.x + 293, cur_pt.y + 307 );
+    buildingSpec.SetPos( cur_pt.x + 293, dst_pt.y );
     buildingSpec.Redraw();
+
+    dst_pt.y = cur_pt.y + 387;
 
     // left turret
     BuildingInfo buildingLTurret( *this, BUILD_LEFTTURRET );
-    buildingLTurret.SetPos( cur_pt.x + 5, cur_pt.y + 387 );
+    buildingLTurret.SetPos( cur_pt.x + 5, dst_pt.y );
     buildingLTurret.Redraw();
 
     // right turret
     BuildingInfo buildingRTurret( *this, BUILD_RIGHTTURRET );
-    buildingRTurret.SetPos( cur_pt.x + 149, cur_pt.y + 387 );
+    buildingRTurret.SetPos( cur_pt.x + 149, dst_pt.y );
     buildingRTurret.Redraw();
 
     // moat
     BuildingInfo buildingMoat( *this, BUILD_MOAT );
-    buildingMoat.SetPos( cur_pt.x + 293, cur_pt.y + 387 );
+    buildingMoat.SetPos( cur_pt.x + 293, dst_pt.y );
     buildingMoat.Redraw();
 
     // captain
@@ -333,6 +358,8 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
     const std::string descriptionGroupedArmyFormat( _( "'Grouped' combat formation bunches your army together in the center of your side of the battlefield." ) );
     const fheroes2::Point pointSpreadArmyFormat( rectSpreadArmyFormat.x - 1, rectSpreadArmyFormat.y - 1 );
     const fheroes2::Point pointGroupedArmyFormat( rectGroupedArmyFormat.x - 1, rectGroupedArmyFormat.y - 1 );
+    const fheroes2::Rect armyFormatRenderRect( pointSpreadArmyFormat, { rectGroupedArmyFormat.x + rectGroupedArmyFormat.width - pointSpreadArmyFormat.x + 1,
+                                                                        rectGroupedArmyFormat.y + rectGroupedArmyFormat.height - pointSpreadArmyFormat.y + 1 } );
 
     fheroes2::MovableSprite cursorFormat( fheroes2::AGG::GetICN( ICN::HSICONS, 11 ) );
 
@@ -369,13 +396,16 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
         text.set( std::to_string( captain.GetKnowledge() ), fheroes2::FontType::smallWhite() );
         text.draw( dst_pt.x + skillValueOffsetX, dst_pt.y, display );
 
-        fheroes2::Blit( spriteSpreadArmyFormat, display, rectSpreadArmyFormat.x, rectSpreadArmyFormat.y );
-        fheroes2::Blit( spriteGroupedArmyFormat, display, rectGroupedArmyFormat.x, rectGroupedArmyFormat.y );
+        fheroes2::Copy( spriteSpreadArmyFormat, 0, 0, display, rectSpreadArmyFormat.x, rectSpreadArmyFormat.y, rectSpreadArmyFormat.width, rectSpreadArmyFormat.height );
+        fheroes2::Copy( spriteGroupedArmyFormat, 0, 0, display, rectGroupedArmyFormat.x, rectGroupedArmyFormat.y, rectGroupedArmyFormat.width,
+                        rectGroupedArmyFormat.height );
 
-        if ( army.isSpreadFormation() )
+        if ( army.isSpreadFormation() ) {
             cursorFormat.setPosition( pointSpreadArmyFormat.x, pointSpreadArmyFormat.y );
-        else
+        }
+        else {
             cursorFormat.setPosition( pointGroupedArmyFormat.x, pointGroupedArmyFormat.y );
+        }
     }
 
     Kingdom & kingdom = GetKingdom();
@@ -393,14 +423,14 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
     dst_pt.y = cur_pt.y + 260;
     const fheroes2::Rect rectHero1( dst_pt.x, dst_pt.y, 102, 93 );
 
-    fheroes2::Image noHeroPortrait( rectHero1.width, rectHero1.height );
-    noHeroPortrait.fill( 0 );
-
     if ( hero1 ) {
         hero1->PortraitRedraw( dst_pt.x, dst_pt.y, PORT_BIG, display );
     }
     else {
-        fheroes2::Blit( noHeroPortrait, display, rectHero1.x, rectHero1.y );
+        fheroes2::Image noHeroPortrait( rectHero1.width, rectHero1.height );
+        noHeroPortrait._disableTransformLayer();
+        noHeroPortrait.fill( 0 );
+        fheroes2::Copy( noHeroPortrait, 0, 0, display, rectHero1.x, rectHero1.y, rectHero1.width, rectHero1.height );
     }
 
     // indicator
@@ -417,7 +447,10 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
         hero2->PortraitRedraw( dst_pt.x, dst_pt.y, PORT_BIG, display );
     }
     else {
-        fheroes2::Blit( noHeroPortrait, display, rectHero2.x, rectHero2.y );
+        fheroes2::Image noHeroPortrait( rectHero2.width, rectHero2.height );
+        noHeroPortrait._disableTransformLayer();
+        noHeroPortrait.fill( 0 );
+        fheroes2::Copy( noHeroPortrait, 0, 0, display, rectHero2.x, rectHero2.y, rectHero2.width, rectHero2.height );
     }
 
     // indicator
@@ -426,29 +459,33 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
         fheroes2::Blit( spriteDeny, display, dst_pt.x + 102 - 4 + 1 - spriteDeny.width(), dst_pt.y + 93 - 2 - spriteDeny.height() );
     }
 
-    const int32_t statusBarOffsetY = 480 - 19;
-
-    fheroes2::Button buttonPrevCastle( cur_pt.x, cur_pt.y + statusBarOffsetY, ICN::SMALLBAR, 1, 2 );
+    dst_pt.y = cur_pt.y + 480 - 19;
+    fheroes2::Button buttonPrevCastle( cur_pt.x, dst_pt.y, ICN::SMALLBAR, 1, 2 );
     fheroes2::TimedEventValidator timedButtonPrevCastle( [&buttonPrevCastle]() { return buttonPrevCastle.isPressed(); } );
     buttonPrevCastle.subscribe( &timedButtonPrevCastle );
+    const fheroes2::Rect buttonPrevCastleArea( buttonPrevCastle.area() );
 
     // bottom small bar
     const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::SMALLBAR, 0 );
-    fheroes2::Blit( bar, display, cur_pt.x + buttonPrevCastle.area().width, cur_pt.y + statusBarOffsetY );
+    const int32_t statusBarWidth = bar.width();
+    dst_pt.x = cur_pt.x + buttonPrevCastleArea.width;
+    fheroes2::Copy( bar, 0, 0, display, dst_pt.x, dst_pt.y, statusBarWidth, bar.height() );
 
     StatusBar statusBar;
     // Status bar must be smaller due to extra art on both sides.
-    statusBar.setRoi( { cur_pt.x + buttonPrevCastle.area().width + 16, cur_pt.y + statusBarOffsetY + 2, bar.width() - 16 * 2, 0 } );
+    statusBar.setRoi( { dst_pt.x + 16, dst_pt.y + 3, statusBarWidth - 16 * 2, 0 } );
 
     // button next castle
-    fheroes2::Button buttonNextCastle( cur_pt.x + buttonPrevCastle.area().width + bar.width(), cur_pt.y + statusBarOffsetY, ICN::SMALLBAR, 3, 4 );
+    fheroes2::Button buttonNextCastle( dst_pt.x + statusBarWidth, dst_pt.y, ICN::SMALLBAR, 3, 4 );
     fheroes2::TimedEventValidator timedButtonNextCastle( [&buttonNextCastle]() { return buttonNextCastle.isPressed(); } );
     buttonNextCastle.subscribe( &timedButtonNextCastle );
+    const fheroes2::Rect buttonNextCastleArea( buttonNextCastle.area() );
 
     // button exit
     dst_pt.x = cur_pt.x + 553;
     dst_pt.y = cur_pt.y + 428;
     fheroes2::Button buttonExit( dst_pt.x, dst_pt.y, ICN::BUTTON_EXIT_TOWN, 0, 1 );
+    const fheroes2::Rect buttonExitArea( buttonExit.area() );
 
     if ( GetKingdom().GetCastles().size() < 2 ) {
         buttonPrevCastle.disable();
@@ -461,47 +498,54 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
 
     // redraw resource panel
     const fheroes2::Rect & rectResource = fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, cur_pt );
-    const fheroes2::Rect resActiveArea( rectResource.x, rectResource.y, rectResource.width, buttonExit.area().y - rectResource.y - 3 );
+    const fheroes2::Rect resActiveArea( rectResource.x, rectResource.y, rectResource.width, buttonExitArea.y - rectResource.y - 3 );
 
-    display.render();
+    auto recruitHeroDialog = [this, &buttonExit]( Heroes * hero ) {
+        const fheroes2::ButtonRestorer exitRestorer( buttonExit );
+        if ( Dialog::OK == DialogBuyHero( hero ) ) {
+            RecruitHero( hero );
+            return true;
+        }
+        return false;
+    };
+
+    display.render( restorer.rect() );
 
     LocalEvent & le = LocalEvent::Get();
 
     while ( le.HandleEvents() ) {
-        le.MousePressLeft( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
+        le.MousePressLeft( buttonExitArea ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
+
+        if ( le.MouseClickLeft( buttonExitArea ) || Game::HotKeyCloseWindow() ) {
+            break;
+        }
 
         if ( buttonPrevCastle.isEnabled() ) {
-            le.MousePressLeft( buttonPrevCastle.area() ) ? buttonPrevCastle.drawOnPress() : buttonPrevCastle.drawOnRelease();
+            le.MousePressLeft( buttonPrevCastleArea ) ? buttonPrevCastle.drawOnPress() : buttonPrevCastle.drawOnRelease();
+
+            if ( le.MouseClickLeft( buttonPrevCastleArea ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_LEFT ) || timedButtonPrevCastle.isDelayPassed() ) {
+                return ConstructionDialogResult::PrevConstructionWindow;
+            }
         }
         if ( buttonNextCastle.isEnabled() ) {
-            le.MousePressLeft( buttonNextCastle.area() ) ? buttonNextCastle.drawOnPress() : buttonNextCastle.drawOnRelease();
-        }
+            le.MousePressLeft( buttonNextCastleArea ) ? buttonNextCastle.drawOnPress() : buttonNextCastle.drawOnRelease();
 
-        if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() )
-            break;
-
-        if ( buttonPrevCastle.isEnabled()
-             && ( le.MouseClickLeft( buttonPrevCastle.area() ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_LEFT ) || timedButtonPrevCastle.isDelayPassed() ) ) {
-            return ConstructionDialogResult::PrevConstructionWindow;
-        }
-        if ( buttonNextCastle.isEnabled()
-             && ( le.MouseClickLeft( buttonNextCastle.area() ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_RIGHT ) || timedButtonNextCastle.isDelayPassed() ) ) {
-            return ConstructionDialogResult::NextConstructionWindow;
+            if ( le.MouseClickLeft( buttonNextCastleArea ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_RIGHT ) || timedButtonNextCastle.isDelayPassed() ) {
+                return ConstructionDialogResult::NextConstructionWindow;
+            }
         }
 
         if ( le.MouseClickLeft( resActiveArea ) ) {
-            fheroes2::ButtonRestorer exitRestorer( buttonExit );
+            const fheroes2::ButtonRestorer exitRestorer( buttonExit );
             fheroes2::showKingdomIncome( world.GetKingdom( GetColor() ), Dialog::OK );
         }
         else if ( le.MousePressRight( resActiveArea ) ) {
             fheroes2::showKingdomIncome( world.GetKingdom( GetColor() ), 0 );
         }
-        else if ( le.MousePressRight( buttonExit.area() ) ) {
+        else if ( le.MousePressRight( buttonExitArea ) ) {
             fheroes2::showStandardTextMessage( _( "Exit" ), _( "Exit this menu." ), Dialog::ZERO );
         }
-
-        // click left
-        if ( le.MouseCursor( dwelling1.GetArea() ) && dwelling1.QueueEventProcessing( buttonExit ) ) {
+        else if ( le.MouseCursor( dwelling1.GetArea() ) && dwelling1.QueueEventProcessing( buttonExit ) ) {
             dwellingTobuild = dwelling1.getBuilding();
             return ConstructionDialogResult::Build;
         }
@@ -577,43 +621,36 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
             dwellingTobuild = BUILD_CAPTAIN;
             return ConstructionDialogResult::Build;
         }
-        else if ( hero1 && le.MouseClickLeft( rectHero1 ) ) {
-            fheroes2::ButtonRestorer exitRestorer( buttonExit );
-            if ( Dialog::OK == DialogBuyHero( hero1 ) ) {
-                RecruitHero( hero1 );
-
-                return ConstructionDialogResult::RecruitHero;
-            }
+        if ( hero1 && le.MouseClickLeft( rectHero1 ) && recruitHeroDialog( hero1 ) ) {
+            return ConstructionDialogResult::RecruitHero;
         }
-        else if ( hero2 && le.MouseClickLeft( rectHero2 ) ) {
-            fheroes2::ButtonRestorer exitRestorer( buttonExit );
-            if ( Dialog::OK == DialogBuyHero( hero2 ) ) {
-                RecruitHero( hero2 );
-
-                return ConstructionDialogResult::RecruitHero;
-            }
-        }
-        else if ( isBuild( BUILD_CAPTAIN ) ) {
-            if ( le.MouseClickLeft( rectSpreadArmyFormat ) && !army.isSpreadFormation() ) {
-                cursorFormat.setPosition( pointSpreadArmyFormat.x, pointSpreadArmyFormat.y );
-                display.render();
-                army.SetSpreadFormation( true );
-            }
-            else if ( le.MouseClickLeft( rectGroupedArmyFormat ) && army.isSpreadFormation() ) {
-                cursorFormat.setPosition( pointGroupedArmyFormat.x, pointGroupedArmyFormat.y );
-                display.render();
-                army.SetSpreadFormation( false );
-            }
+        if ( hero2 && le.MouseClickLeft( rectHero2 ) && recruitHeroDialog( hero2 ) ) {
+            return ConstructionDialogResult::RecruitHero;
         }
 
         const bool isCaptainBuilt = isBuild( BUILD_CAPTAIN );
 
+        if ( isCaptainBuilt ) {
+            if ( le.MouseClickLeft( rectSpreadArmyFormat ) && !army.isSpreadFormation() ) {
+                cursorFormat.setPosition( pointSpreadArmyFormat.x, pointSpreadArmyFormat.y );
+                display.render( armyFormatRenderRect );
+                army.SetSpreadFormation( true );
+            }
+            else if ( le.MouseClickLeft( rectGroupedArmyFormat ) && army.isSpreadFormation() ) {
+                cursorFormat.setPosition( pointGroupedArmyFormat.x, pointGroupedArmyFormat.y );
+                display.render( armyFormatRenderRect );
+                army.SetSpreadFormation( false );
+            }
+            else if ( le.MousePressRight( rectSpreadArmyFormat ) ) {
+                fheroes2::showStandardTextMessage( _( "Spread Formation" ), descriptionSpreadArmyFormat, Dialog::ZERO );
+            }
+            else if ( le.MousePressRight( rectGroupedArmyFormat ) ) {
+                fheroes2::showStandardTextMessage( _( "Grouped Formation" ), descriptionGroupedArmyFormat, Dialog::ZERO );
+            }
+        }
+
         // Right click
-        if ( isCaptainBuilt && le.MousePressRight( rectSpreadArmyFormat ) )
-            fheroes2::showStandardTextMessage( _( "Spread Formation" ), descriptionSpreadArmyFormat, Dialog::ZERO );
-        else if ( isCaptainBuilt && le.MousePressRight( rectGroupedArmyFormat ) )
-            fheroes2::showStandardTextMessage( _( "Grouped Formation" ), descriptionGroupedArmyFormat, Dialog::ZERO );
-        else if ( hero1 && le.MousePressRight( rectHero1 ) ) {
+        if ( hero1 && le.MousePressRight( rectHero1 ) ) {
             LocalEvent::GetClean();
             hero1->OpenDialog( true, true, false, false, false );
 
@@ -627,10 +664,10 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
             // Use half fade if game resolution is not 640x480.
             fheroes2::fadeInDisplay( restorer.rect(), !display.isDefaultSize() );
         }
-        else if ( le.MousePressRight( buttonNextCastle.area() ) ) {
+        else if ( le.MousePressRight( buttonNextCastleArea ) ) {
             fheroes2::showStandardTextMessage( _( "Show next town" ), _( "Click to show next town." ), Dialog::ZERO );
         }
-        else if ( le.MousePressRight( buttonPrevCastle.area() ) ) {
+        else if ( le.MousePressRight( buttonPrevCastleArea ) ) {
             fheroes2::showStandardTextMessage( _( "Show previous town" ), _( "Click to show previous town." ), Dialog::ZERO );
         }
 
@@ -693,18 +730,18 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
                 statusBar.ShowMessage( str );
             }
         }
-        else if ( le.MouseCursor( rectSpreadArmyFormat ) && isCaptainBuilt )
+        else if ( isCaptainBuilt && le.MouseCursor( rectSpreadArmyFormat ) )
             statusBar.ShowMessage( _( "Set garrison combat formation to 'Spread'" ) );
-        else if ( le.MouseCursor( rectGroupedArmyFormat ) && isCaptainBuilt )
+        else if ( isCaptainBuilt && le.MouseCursor( rectGroupedArmyFormat ) )
             statusBar.ShowMessage( _( "Set garrison combat formation to 'Grouped'" ) );
-        else if ( le.MouseCursor( buttonExit.area() ) )
+        else if ( le.MouseCursor( buttonExitArea ) )
             statusBar.ShowMessage( _( "Exit Castle Options" ) );
         else if ( le.MouseCursor( resActiveArea ) )
             statusBar.ShowMessage( _( "Show Income" ) );
-        else if ( buttonPrevCastle.isEnabled() && le.MouseCursor( buttonPrevCastle.area() ) ) {
+        else if ( buttonPrevCastle.isEnabled() && le.MouseCursor( buttonPrevCastleArea ) ) {
             statusBar.ShowMessage( _( "Show previous town" ) );
         }
-        else if ( buttonNextCastle.isEnabled() && le.MouseCursor( buttonNextCastle.area() ) ) {
+        else if ( buttonNextCastle.isEnabled() && le.MouseCursor( buttonNextCastleArea ) ) {
             statusBar.ShowMessage( _( "Show next town" ) );
         }
         else {

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -459,22 +459,27 @@ namespace fheroes2
         return Dialog::ZERO;
     }
 
-    ButtonRestorer::ButtonRestorer( ButtonBase & button, Image & area )
+    ButtonRestorer::ButtonRestorer( ButtonBase & button )
         : _button( button )
-        , _area( area )
-        , _isDisabled( button.isDisabled() )
+        , _isEnabled( button.isEnabled() )
     {
-        if ( !_isDisabled ) {
+        if ( _isEnabled ) {
+            Display & display = Display::instance();
+
             _button.disable();
-            _button.draw( _area );
+            _button.draw( display );
+            display.render( _button.area() );
         }
     }
 
     ButtonRestorer::~ButtonRestorer()
     {
-        if ( !_isDisabled ) {
+        if ( _isEnabled ) {
+            Display & display = Display::instance();
+
             _button.enable();
-            _button.draw( _area );
+            _button.draw( display );
+            display.render( _button.area() );
         }
     }
 

--- a/src/fheroes2/gui/ui_button.h
+++ b/src/fheroes2/gui/ui_button.h
@@ -196,11 +196,12 @@ namespace fheroes2
         std::vector<int> _value;
     };
 
-    // this class is used for a situations when we need to disabled a button for certain action and restore it within the scope of code
+    // This class is used for a situations when we need to disable a button for certain action
+    // and restore it within the scope of code. The changed button is immediately rendered on display.
     class ButtonRestorer
     {
     public:
-        explicit ButtonRestorer( ButtonBase & button, Image & area = Display::instance() );
+        explicit ButtonRestorer( ButtonBase & button );
         ButtonRestorer( const ButtonRestorer & ) = delete;
 
         ~ButtonRestorer();
@@ -209,8 +210,7 @@ namespace fheroes2
 
     private:
         ButtonBase & _button;
-        Image & _area;
-        bool _isDisabled;
+        bool _isEnabled;
     };
 
     class OptionButtonGroup : public ActionObject


### PR DESCRIPTION
This PR fixes #7913, fixes #6971 and also fixes incorrect hero recruitment animation when a hero is recruited after the castle was changed in the construction dialog:
Master build:

https://github.com/ihhub/fheroes2/assets/113276641/b38ec73e-7f80-4cff-ae23-981b3f37ca36

This PR:

https://github.com/ihhub/fheroes2/assets/113276641/8cc797c9-7683-4e32-ac3d-d7fef423d91a

Some minor code lean-up is also made in this PR along with adding the right mouse button press tips for OKAY and CANCEL buttons in Recruit Hero dialog and Build dialog.

![pic](https://github.com/ihhub/fheroes2/assets/113276641/3fb5e29e-0926-489c-943b-482b115aea8c)
