### PR TITLE
Fix the random generator usage by the non-Arena code

### DIFF
--- a/src/engine/rand.cpp
+++ b/src/engine/rand.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/engine/rand.cpp
+++ b/src/engine/rand.cpp
@@ -21,10 +21,11 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "rand.h"
+
 #include <cstdlib>
 
 #include "logging.h"
-#include "rand.h"
 
 std::mt19937 & Rand::CurrentThreadRandomDevice()
 {
@@ -142,7 +143,7 @@ void Rand::DeterministicRandomGenerator::UpdateSeed( const uint32_t seed )
     _currentSeed = seed;
 }
 
-uint32_t Rand::DeterministicRandomGenerator::Get( const uint32_t from, const uint32_t to /*= 0*/ ) const
+uint32_t Rand::DeterministicRandomGenerator::Get( const uint32_t from, const uint32_t to /* = 0 */ )
 {
     ++_currentSeed;
     return Rand::GetWithSeed( from, to, _currentSeed );

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
-#include <iterator>
 #include <list>
 #include <random>
 #include <type_traits>
@@ -86,16 +85,6 @@ namespace Rand
 
         const uint32_t id = Rand::GetWithGen( 0, static_cast<uint32_t>( vec.size() - 1 ), gen );
         return vec[id];
-    }
-
-    template <typename T>
-    const T & Get( const std::list<T> & list )
-    {
-        assert( !list.empty() );
-
-        typename std::list<T>::const_iterator it = list.begin();
-        std::advance( it, Rand::Get( static_cast<uint32_t>( list.size() - 1 ) ) );
-        return *it;
     }
 
     using ValuePercent = std::pair<int32_t, uint32_t>;

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -118,9 +118,8 @@ namespace Rand
     {
     public:
         explicit DeterministicRandomGenerator( const uint32_t initialSeed );
-
-        // prevent accidental copies
         DeterministicRandomGenerator( const DeterministicRandomGenerator & ) = delete;
+
         DeterministicRandomGenerator & operator=( const DeterministicRandomGenerator & ) = delete;
 
         uint32_t GetSeed() const;
@@ -136,15 +135,8 @@ namespace Rand
             return Rand::GetWithGen( vec, seededGen );
         }
 
-        template <class T>
-        void Shuffle( std::vector<T> & vector ) const
-        {
-            ++_currentSeed;
-            Rand::ShuffleWithSeed( vector, _currentSeed );
-        }
-
     private:
-        mutable uint32_t _currentSeed; // this is mutable so clients that only call RNG method can receive a const instance
+        mutable uint32_t _currentSeed;
     };
 }
 

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
-#include <iterator>
 #include <list>
 #include <random>
 #include <type_traits>

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -125,10 +125,10 @@ namespace Rand
         uint32_t GetSeed() const;
         void UpdateSeed( const uint32_t seed );
 
-        uint32_t Get( const uint32_t from, const uint32_t to = 0 ) const;
+        uint32_t Get( const uint32_t from, const uint32_t to = 0 );
 
         template <typename T>
-        const T & Get( const std::vector<T> & vec ) const
+        const T & Get( const std::vector<T> & vec )
         {
             ++_currentSeed;
             std::mt19937 seededGen( _currentSeed );
@@ -136,7 +136,7 @@ namespace Rand
         }
 
     private:
-        mutable uint32_t _currentSeed;
+        uint32_t _currentSeed;
     };
 }
 

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
+#include <iterator>
 #include <list>
 #include <random>
 #include <type_traits>

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -28,7 +28,6 @@
 #include <cstdint>
 #include <cstdlib>
 #include <functional>
-#include <list>
 #include <random>
 #include <type_traits>
 #include <utility>

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -55,11 +55,6 @@ namespace Maps
     class Tiles;
 }
 
-namespace Rand
-{
-    class DeterministicRandomGenerator;
-}
-
 struct VecHeroes;
 struct VecCastles;
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -228,8 +228,6 @@ namespace AI
 
         static double commanderMaximumSpellDamageValue( const HeroBase & commander );
 
-        const Rand::DeterministicRandomGenerator * _randomGenerator = nullptr;
-
         // When this limit of turns without deaths is exceeded for an attacking AI-controlled hero,
         // the auto battle should be interrupted (one way or another)
         static const uint32_t MAX_TURNS_WITHOUT_DEATHS = 50;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -55,7 +55,6 @@
 #include "heroes_base.h"
 #include "logging.h"
 #include "monster_info.h"
-#include "rand.h"
 #include "settings.h"
 #include "speed.h"
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -321,7 +321,7 @@ namespace AI
                 const SpellSelection & bestSpell = selectBestSpell( arena, currentUnit, true );
 
                 if ( bestSpell.spellID != -1 ) {
-                    actions.emplace_back( Command::CAST, bestSpell.spellID, bestSpell.cell );
+                    actions.emplace_back( Command::SPELLCAST, bestSpell.spellID, bestSpell.cell );
                 }
             }
 
@@ -334,7 +334,7 @@ namespace AI
             const SpellSelection & bestSpell = selectBestSpell( arena, currentUnit, false );
 
             if ( bestSpell.spellID != -1 ) {
-                actions.emplace_back( Command::CAST, bestSpell.spellID, bestSpell.cell );
+                actions.emplace_back( Command::SPELLCAST, bestSpell.spellID, bestSpell.cell );
                 return actions;
             }
         }
@@ -1248,7 +1248,7 @@ namespace AI
         actions.insert( actions.end(), plannedActions.begin(), plannedActions.end() );
 
         // Do not end the turn if we only cast a spell
-        if ( plannedActions.size() != 1 || !plannedActions.front().isType( CommandType::MSG_BATTLE_CAST ) ) {
+        if ( plannedActions.size() != 1 || !plannedActions.front().isType( CommandType::SPELLCAST ) ) {
             actions.emplace_back( Command::END_TURN, currentUnit.GetUID() );
         }
     }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -801,7 +801,18 @@ namespace AI
             const auto evaluateEnemyTarget = [&currentUnit, &target, &bestOutcome]( const Unit * enemy ) {
                 assert( enemy != nullptr );
 
-                const int archerMeleeDmg = currentUnit.CalculateMinDamage( *enemy );
+                const int archerMeleeDmg = [&currentUnit, enemy]() {
+                    if ( currentUnit.Modes( SP_CURSE ) ) {
+                        return currentUnit.CalculateMinDamage( *enemy );
+                    }
+
+                    if ( currentUnit.Modes( SP_BLESS ) ) {
+                        return currentUnit.CalculateMaxDamage( *enemy );
+                    }
+
+                    return ( currentUnit.CalculateMinDamage( *enemy ) + currentUnit.CalculateMaxDamage( *enemy ) ) / 2;
+                }();
+
                 const int damageDiff = archerMeleeDmg - enemy->EstimateRetaliatoryDamage( archerMeleeDmg );
 
                 if ( bestOutcome < damageDiff ) {

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -293,7 +293,7 @@ namespace AI
             double possibleReinforcementStrength = possibleReinforcement.GetStrength();
 
             // A very rough estimation of strength. We measure the strength of possible army to hire with the strength of purchasing a turret.
-            const Battle::Tower tower( castle, Battle::TowerType::TWR_RIGHT, Rand::DeterministicRandomGenerator( 0 ), 0 );
+            const Battle::Tower tower( castle, Battle::TowerType::TWR_RIGHT, 0 );
             const Troop towerMonster( Monster::ARCHER, tower.GetCount() );
             const double towerStrength = towerMonster.GetStrength();
             if ( possibleReinforcementStrength > towerStrength ) {

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -37,7 +37,6 @@
 #include "monster.h"
 #include "payment.h"
 #include "race.h"
-#include "rand.h"
 #include "resource.h"
 #include "world.h"
 #include "world_regions.h"

--- a/src/fheroes2/ai/normal/ai_normal_spell.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_spell.cpp
@@ -217,14 +217,14 @@ namespace AI
                     }
 
                     const int32_t index = enemy->GetHeadIndex();
-                    areaOfEffectCheck( arena.GetTargetsForSpells( _commander, spell, index ), index, _myColor );
+                    areaOfEffectCheck( arena.GetTargetsForSpell( _commander, spell, index ), index, _myColor );
                 }
             }
             else {
                 const Board & board = *Arena::GetBoard();
                 for ( const Cell & cell : board ) {
                     const int32_t index = cell.GetIndex();
-                    areaOfEffectCheck( arena.GetTargetsForSpells( _commander, spell, index ), index, _myColor );
+                    areaOfEffectCheck( arena.GetTargetsForSpell( _commander, spell, index ), index, _myColor );
                 }
             }
         }

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -127,6 +127,19 @@ namespace Battle
         IS_PARALYZE_MAGIC = SP_PARALYZE | SP_STONE,
         IS_MIND_MAGIC = SP_BERSERKER | SP_HYPNOTIZE | SP_BLIND | SP_PARALYZE,
     };
+
+    enum class CastleDefenseElement : int
+    {
+        NONE = 0,
+        WALL1 = 1,
+        WALL2 = 2,
+        WALL3 = 3,
+        WALL4 = 4,
+        TOWER1 = 5,
+        TOWER2 = 6,
+        BRIDGE = 7,
+        CENTRAL_TOWER = 8
+    };
 }
 
 #endif

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1027,7 +1027,9 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
                     }
                 }
 
+#ifdef WITH_DEBUG
                 using TargetUnderlyingType = std::underlying_type_t<decltype( target )>;
+#endif
 
                 DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "target: " << static_cast<TargetUnderlyingType>( target ) << ", damage: " << damage << ", hit: " << hit )
             }

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -978,13 +978,6 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForSpell( const HeroBase * hero, co
     return targets;
 }
 
-Battle::TargetsInfo Battle::Arena::GetTargetsForSpell( const HeroBase * hero, const Spell & spell, const int32_t dst )
-{
-    // This method can be called by external code (e.g. AI code) to pre-evaluate the effect of a spell, so probabilistic mechanisms, in particular unit's magic
-    // resistance, cannot be used
-    return GetTargetsForSpell( hero, spell, dst, false, nullptr );
-}
-
 void Battle::Arena::ApplyActionTower( Command & cmd )
 {
     const uint32_t type = cmd.GetNextValue();

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1194,7 +1194,7 @@ void Battle::Arena::ApplyActionSpellEarthQuake( const Command & /*cmd*/ )
     const HeroBase * commander = GetCurrentCommander();
     assert( commander != nullptr );
 
-    std::vector<CastleDefenseElement> targets = GetCastleTargets();
+    std::vector<CastleDefenseElement> targets = GetEarthQuakeTargets();
 
     if ( _interface ) {
         _interface->RedrawActionSpellCastStatus( Spell( Spell::EARTHQUAKE ), -1, commander->GetName(), {} );

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -304,7 +304,7 @@ void Battle::Arena::ApplyAction( Command & cmd )
 
 void Battle::Arena::ApplyActionSpellCast( Command & cmd )
 {
-    const Spell spell( cmd.GetValue() );
+    const Spell spell( cmd.GetNextValue() );
 
     HeroBase * commander = GetCurrentForce().GetCommander();
 
@@ -350,10 +350,10 @@ void Battle::Arena::ApplyActionSpellCast( Command & cmd )
 
 void Battle::Arena::ApplyActionAttack( Command & cmd )
 {
-    const uint32_t attackerUID = cmd.GetValue();
-    const uint32_t defenderUID = cmd.GetValue();
-    const int32_t dst = cmd.GetValue();
-    const int32_t dir = cmd.GetValue();
+    const uint32_t attackerUID = cmd.GetNextValue();
+    const uint32_t defenderUID = cmd.GetNextValue();
+    const int32_t dst = cmd.GetNextValue();
+    const int32_t dir = cmd.GetNextValue();
 
     Unit * attacker = GetTroopUID( attackerUID );
     Unit * defender = GetTroopUID( defenderUID );
@@ -409,8 +409,8 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
 
 void Battle::Arena::ApplyActionMove( Command & cmd )
 {
-    const uint32_t uid = cmd.GetValue();
-    const int32_t dst = cmd.GetValue();
+    const uint32_t uid = cmd.GetNextValue();
+    const int32_t dst = cmd.GetNextValue();
 
     Unit * unit = GetTroopUID( uid );
     const Cell * cell = Board::GetCell( dst );
@@ -511,7 +511,7 @@ void Battle::Arena::ApplyActionMove( Command & cmd )
 
 void Battle::Arena::ApplyActionSkip( Command & cmd )
 {
-    const uint32_t uid = cmd.GetValue();
+    const uint32_t uid = cmd.GetNextValue();
 
     Unit * unit = GetTroopUID( uid );
 
@@ -539,7 +539,7 @@ void Battle::Arena::ApplyActionSkip( Command & cmd )
 
 void Battle::Arena::ApplyActionEnd( Command & cmd )
 {
-    const uint32_t uid = cmd.GetValue();
+    const uint32_t uid = cmd.GetNextValue();
 
     Unit * unit = GetTroopUID( uid );
 
@@ -562,8 +562,8 @@ void Battle::Arena::ApplyActionEnd( Command & cmd )
 
 void Battle::Arena::ApplyActionMorale( Command & cmd )
 {
-    const uint32_t uid = cmd.GetValue();
-    const int32_t morale = cmd.GetValue();
+    const uint32_t uid = cmd.GetNextValue();
+    const int32_t morale = cmd.GetNextValue();
 
     Unit * unit = GetTroopUID( uid );
 
@@ -977,8 +977,8 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForSpells( const HeroBase * hero, c
 
 void Battle::Arena::ApplyActionTower( Command & cmd )
 {
-    const uint32_t type = cmd.GetValue();
-    const uint32_t uid = cmd.GetValue();
+    const uint32_t type = cmd.GetNextValue();
+    const uint32_t uid = cmd.GetNextValue();
 
     Tower * tower = GetTower( static_cast<TowerType>( type ) );
     Unit * unit = GetTroopUID( uid );
@@ -1006,12 +1006,12 @@ void Battle::Arena::ApplyActionTower( Command & cmd )
 void Battle::Arena::ApplyActionCatapult( Command & cmd )
 {
     if ( _catapult ) {
-        uint32_t shots = cmd.GetValue();
+        uint32_t shots = cmd.GetNextValue();
 
         while ( shots-- ) {
-            const int target = cmd.GetValue();
-            const uint32_t damage = cmd.GetValue();
-            const bool hit = cmd.GetValue() != 0;
+            const int target = cmd.GetNextValue();
+            const uint32_t damage = cmd.GetNextValue();
+            const bool hit = cmd.GetNextValue() != 0;
 
             if ( target ) {
                 if ( _interface ) {
@@ -1037,7 +1037,7 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
 
 void Battle::Arena::ApplyActionAutoSwitch( Command & cmd )
 {
-    const int color = cmd.GetValue();
+    const int color = cmd.GetNextValue();
 
     if ( ( color != GetArmy1Color() && color != GetArmy2Color() ) || ( getForce( color ).GetControl() & CONTROL_AI ) ) {
         DEBUG_LOG( DBG_BATTLE, DBG_WARN,
@@ -1107,7 +1107,7 @@ void Battle::Arena::ApplyActionSpellDefaults( Command & cmd, const Spell & spell
     const HeroBase * commander = GetCurrentCommander();
     assert( commander != nullptr );
 
-    const int32_t dst = cmd.GetValue();
+    const int32_t dst = cmd.GetNextValue();
 
     bool playResistSound = false;
     TargetsInfo targets = GetTargetsForSpells( commander, spell, dst, &playResistSound );
@@ -1140,8 +1140,8 @@ void Battle::Arena::ApplyActionSpellDefaults( Command & cmd, const Spell & spell
 
 void Battle::Arena::ApplyActionSpellTeleport( Command & cmd )
 {
-    const int32_t src = cmd.GetValue();
-    const int32_t dst = cmd.GetValue();
+    const int32_t src = cmd.GetNextValue();
+    const int32_t dst = cmd.GetNextValue();
 
     Unit * unit = GetTroopBoard( src );
     const Cell * cell = Board::GetCell( dst );
@@ -1215,7 +1215,7 @@ void Battle::Arena::ApplyActionSpellEarthQuake( const Command & /*cmd*/ )
 
 void Battle::Arena::ApplyActionSpellMirrorImage( Command & cmd )
 {
-    const int32_t who = cmd.GetValue();
+    const int32_t who = cmd.GetNextValue();
     Unit * unit = GetTroopBoard( who );
 
     if ( unit && unit->isValid() ) {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1009,11 +1009,11 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
         uint32_t shots = cmd.GetNextValue();
 
         while ( shots-- ) {
-            const int target = cmd.GetNextValue();
+            const CatapultTarget target = static_cast<CatapultTarget>( cmd.GetNextValue() );
             const uint32_t damage = cmd.GetNextValue();
             const bool hit = cmd.GetNextValue() != 0;
 
-            if ( target ) {
+            if ( target != CatapultTarget::CAT_NONE ) {
                 if ( _interface ) {
                     _interface->RedrawActionCatapultPart1( target, hit );
                 }
@@ -1026,7 +1026,9 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
                     }
                 }
 
-                DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "target: " << target << ", damage: " << damage << ", hit: " << hit )
+                using TargetUnderlyingType = std::underlying_type_t<decltype( target )>;
+
+                DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "target: " << static_cast<TargetUnderlyingType>( target ) << ", damage: " << damage << ", hit: " << hit )
             }
         }
     }
@@ -1180,7 +1182,7 @@ void Battle::Arena::ApplyActionSpellEarthQuake( const Command & /*cmd*/ )
     const HeroBase * commander = GetCurrentCommander();
     assert( commander != nullptr );
 
-    std::vector<int> targets = GetCastleTargets();
+    std::vector<CatapultTarget> targets = GetCastleTargets();
 
     if ( _interface ) {
         _interface->RedrawActionSpellCastStatus( Spell( Spell::EARTHQUAKE ), -1, commander->GetName(), {} );

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -30,6 +30,7 @@
 #include <ostream>
 #include <set>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -257,43 +257,43 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
 void Battle::Arena::ApplyAction( Command & cmd )
 {
     switch ( cmd.GetType() ) {
-    case CommandType::MSG_BATTLE_CAST:
+    case CommandType::SPELLCAST:
         ApplyActionSpellCast( cmd );
         break;
-    case CommandType::MSG_BATTLE_ATTACK:
+    case CommandType::ATTACK:
         ApplyActionAttack( cmd );
         break;
-    case CommandType::MSG_BATTLE_MOVE:
+    case CommandType::MOVE:
         ApplyActionMove( cmd );
         break;
-    case CommandType::MSG_BATTLE_SKIP:
+    case CommandType::SKIP:
         ApplyActionSkip( cmd );
         break;
-    case CommandType::MSG_BATTLE_END_TURN:
+    case CommandType::END_TURN:
         ApplyActionEnd( cmd );
         break;
-    case CommandType::MSG_BATTLE_MORALE:
+    case CommandType::MORALE:
         ApplyActionMorale( cmd );
         break;
 
-    case CommandType::MSG_BATTLE_TOWER:
+    case CommandType::TOWER:
         ApplyActionTower( cmd );
         break;
-    case CommandType::MSG_BATTLE_CATAPULT:
+    case CommandType::CATAPULT:
         ApplyActionCatapult( cmd );
         break;
 
-    case CommandType::MSG_BATTLE_RETREAT:
+    case CommandType::RETREAT:
         ApplyActionRetreat( cmd );
         break;
-    case CommandType::MSG_BATTLE_SURRENDER:
+    case CommandType::SURRENDER:
         ApplyActionSurrender( cmd );
         break;
 
-    case CommandType::MSG_BATTLE_AUTO_SWITCH:
+    case CommandType::AUTO_SWITCH:
         ApplyActionAutoSwitch( cmd );
         break;
-    case CommandType::MSG_BATTLE_AUTO_FINISH:
+    case CommandType::AUTO_FINISH:
         ApplyActionAutoFinish( cmd );
         break;
 
@@ -1009,11 +1009,11 @@ void Battle::Arena::ApplyActionCatapult( Command & cmd )
         uint32_t shots = cmd.GetNextValue();
 
         while ( shots-- ) {
-            const CatapultTarget target = static_cast<CatapultTarget>( cmd.GetNextValue() );
+            const CastleDefenseElement target = static_cast<CastleDefenseElement>( cmd.GetNextValue() );
             const uint32_t damage = cmd.GetNextValue();
             const bool hit = cmd.GetNextValue() != 0;
 
-            if ( target != CatapultTarget::CAT_NONE ) {
+            if ( target != CastleDefenseElement::NONE ) {
                 if ( _interface ) {
                     _interface->RedrawActionCatapultPart1( target, hit );
                 }
@@ -1182,7 +1182,7 @@ void Battle::Arena::ApplyActionSpellEarthQuake( const Command & /*cmd*/ )
     const HeroBase * commander = GetCurrentCommander();
     assert( commander != nullptr );
 
-    std::vector<CatapultTarget> targets = GetCastleTargets();
+    std::vector<CastleDefenseElement> targets = GetCastleTargets();
 
     if ( _interface ) {
         _interface->RedrawActionSpellCastStatus( Spell( Spell::EARTHQUAKE ), -1, commander->GetName(), {} );

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -172,7 +172,7 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
     }
 
     // Update the attacker's luck right before the attack
-    attacker.SetRandomLuck();
+    attacker.SetRandomLuck( _randomGenerator );
 
     // Do damage first
     TargetsInfo attackTargets = GetTargetsForDamage( attacker, defender, dst, dir );
@@ -189,7 +189,7 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t dst
     }
 
     // Then apply the attacker's built-in spell
-    const Spell spell = attacker.GetSpellMagic();
+    const Spell spell = attacker.GetSpellMagic( _randomGenerator );
 
     if ( spell.isValid() ) {
         // Only single target spells and special built-in only spells are allowed
@@ -674,7 +674,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
 
     // first target
     res.defender = &defender;
-    res.damage = attacker.GetDamage( defender );
+    res.damage = attacker.GetDamage( defender, _randomGenerator );
 
     // Genie special attack
     if ( attacker.GetID() == Monster::GENIE && _randomGenerator.Get( 1, 10 ) == 2 && defender.GetHitPoints() / 2 > res.damage ) {
@@ -704,7 +704,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
 
         if ( enemy && consideredTargets.insert( enemy ).second ) {
             res.defender = enemy;
-            res.damage = attacker.GetDamage( *enemy );
+            res.damage = attacker.GetDamage( *enemy, _randomGenerator );
 
             targets.push_back( res );
         }
@@ -718,7 +718,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
 
             if ( enemy && enemy->GetColor() != attacker.GetCurrentColor() && consideredTargets.insert( enemy ).second ) {
                 res.defender = enemy;
-                res.damage = attacker.GetDamage( *enemy );
+                res.damage = attacker.GetDamage( *enemy, _randomGenerator );
 
                 targets.push_back( res );
             }
@@ -733,7 +733,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
 
             if ( enemy && consideredTargets.insert( enemy ).second ) {
                 res.defender = enemy;
-                res.damage = attacker.GetDamage( *enemy );
+                res.damage = attacker.GetDamage( *enemy, _randomGenerator );
 
                 targets.push_back( res );
             }
@@ -988,7 +988,7 @@ void Battle::Arena::ApplyActionTower( Command & cmd )
 
         TargetInfo target;
         target.defender = unit;
-        target.damage = tower->GetDamage( *unit );
+        target.damage = tower->GetDamage( *unit, _randomGenerator );
 
         if ( _interface )
             _interface->RedrawActionTowerPart1( *tower, *unit );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -442,7 +442,7 @@ void Battle::Arena::TurnTroop( Unit * troop, const Units & orderHistory )
         }
 
         const uint32_t newSeed = std::accumulate( actions.cbegin(), actions.cend(), _randomGenerator.GetSeed(),
-                                                  []( const uint32_t seed, const Command & cmd ) { return cmd.updateRandomSeed( seed ); } );
+                                                  []( const uint32_t seed, const Command & cmd ) { return cmd.updateSeed( seed ); } );
         _randomGenerator.UpdateSeed( newSeed );
 
         while ( !actions.empty() ) {

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -658,21 +658,22 @@ void Battle::Arena::CatapultAction()
     if ( _catapult ) {
         uint32_t shots = _catapult->GetShots();
 
-        std::map<CatapultTarget, uint32_t> stateOfCatapultTargets = { { CatapultTarget::CAT_WALL1, GetCastleTargetValue( CatapultTarget::CAT_WALL1 ) },
-                                                                      { CatapultTarget::CAT_WALL2, GetCastleTargetValue( CatapultTarget::CAT_WALL2 ) },
-                                                                      { CatapultTarget::CAT_WALL3, GetCastleTargetValue( CatapultTarget::CAT_WALL3 ) },
-                                                                      { CatapultTarget::CAT_WALL4, GetCastleTargetValue( CatapultTarget::CAT_WALL4 ) },
-                                                                      { CatapultTarget::CAT_TOWER1, GetCastleTargetValue( CatapultTarget::CAT_TOWER1 ) },
-                                                                      { CatapultTarget::CAT_TOWER2, GetCastleTargetValue( CatapultTarget::CAT_TOWER2 ) },
-                                                                      { CatapultTarget::CAT_BRIDGE, GetCastleTargetValue( CatapultTarget::CAT_BRIDGE ) },
-                                                                      { CatapultTarget::CAT_CENTRAL_TOWER, GetCastleTargetValue( CatapultTarget::CAT_CENTRAL_TOWER ) } };
+        std::map<CastleDefenseElement, uint32_t> stateOfCatapultTargets
+            = { { CastleDefenseElement::WALL1, GetCastleTargetValue( CastleDefenseElement::WALL1 ) },
+                { CastleDefenseElement::WALL2, GetCastleTargetValue( CastleDefenseElement::WALL2 ) },
+                { CastleDefenseElement::WALL3, GetCastleTargetValue( CastleDefenseElement::WALL3 ) },
+                { CastleDefenseElement::WALL4, GetCastleTargetValue( CastleDefenseElement::WALL4 ) },
+                { CastleDefenseElement::TOWER1, GetCastleTargetValue( CastleDefenseElement::TOWER1 ) },
+                { CastleDefenseElement::TOWER2, GetCastleTargetValue( CastleDefenseElement::TOWER2 ) },
+                { CastleDefenseElement::BRIDGE, GetCastleTargetValue( CastleDefenseElement::BRIDGE ) },
+                { CastleDefenseElement::CENTRAL_TOWER, GetCastleTargetValue( CastleDefenseElement::CENTRAL_TOWER ) } };
 
         Command cmd( Command::CATAPULT );
 
         cmd << shots;
 
         while ( shots-- ) {
-            const CatapultTarget target = Catapult::GetTarget( stateOfCatapultTargets, _randomGenerator );
+            const CastleDefenseElement target = Catapult::GetTarget( stateOfCatapultTargets, _randomGenerator );
             const uint32_t damage = std::min( _catapult->GetDamage( _randomGenerator ), stateOfCatapultTargets[target] );
             const bool hit = _catapult->IsNextShotHit( _randomGenerator );
 
@@ -986,39 +987,39 @@ Battle::Indexes Battle::Arena::GraveyardOccupiedCells() const
     return graveyard.GetOccupiedCells();
 }
 
-void Battle::Arena::SetCastleTargetValue( const CatapultTarget target, const uint32_t value )
+void Battle::Arena::SetCastleTargetValue( const CastleDefenseElement target, const uint32_t value )
 {
     switch ( target ) {
-    case CatapultTarget::CAT_WALL1:
+    case CastleDefenseElement::WALL1:
         board[CASTLE_FIRST_TOP_WALL_POS].SetObject( value );
         break;
-    case CatapultTarget::CAT_WALL2:
+    case CastleDefenseElement::WALL2:
         board[CASTLE_SECOND_TOP_WALL_POS].SetObject( value );
         break;
-    case CatapultTarget::CAT_WALL3:
+    case CastleDefenseElement::WALL3:
         board[CASTLE_THIRD_TOP_WALL_POS].SetObject( value );
         break;
-    case CatapultTarget::CAT_WALL4:
+    case CastleDefenseElement::WALL4:
         board[CASTLE_FOURTH_TOP_WALL_POS].SetObject( value );
         break;
 
-    case CatapultTarget::CAT_TOWER1:
+    case CastleDefenseElement::TOWER1:
         if ( _towers[0] && _towers[0]->isValid() ) {
             _towers[0]->SetDestroy();
         }
         break;
-    case CatapultTarget::CAT_TOWER2:
+    case CastleDefenseElement::TOWER2:
         if ( _towers[2] && _towers[2]->isValid() ) {
             _towers[2]->SetDestroy();
         }
         break;
-    case CatapultTarget::CAT_CENTRAL_TOWER:
+    case CastleDefenseElement::CENTRAL_TOWER:
         if ( _towers[1] && _towers[1]->isValid() ) {
             _towers[1]->SetDestroy();
         }
         break;
 
-    case CatapultTarget::CAT_BRIDGE:
+    case CastleDefenseElement::BRIDGE:
         if ( _bridge->isValid() ) {
             _bridge->SetDestroyed();
         }
@@ -1029,26 +1030,26 @@ void Battle::Arena::SetCastleTargetValue( const CatapultTarget target, const uin
     }
 }
 
-uint32_t Battle::Arena::GetCastleTargetValue( const CatapultTarget target ) const
+uint32_t Battle::Arena::GetCastleTargetValue( const CastleDefenseElement target ) const
 {
     switch ( target ) {
-    case CatapultTarget::CAT_WALL1:
+    case CastleDefenseElement::WALL1:
         return board[CASTLE_FIRST_TOP_WALL_POS].GetObject();
-    case CatapultTarget::CAT_WALL2:
+    case CastleDefenseElement::WALL2:
         return board[CASTLE_SECOND_TOP_WALL_POS].GetObject();
-    case CatapultTarget::CAT_WALL3:
+    case CastleDefenseElement::WALL3:
         return board[CASTLE_THIRD_TOP_WALL_POS].GetObject();
-    case CatapultTarget::CAT_WALL4:
+    case CastleDefenseElement::WALL4:
         return board[CASTLE_FOURTH_TOP_WALL_POS].GetObject();
 
-    case CatapultTarget::CAT_TOWER1:
+    case CastleDefenseElement::TOWER1:
         return _towers[0] && _towers[0]->isValid() ? 1 : 0;
-    case CatapultTarget::CAT_TOWER2:
+    case CastleDefenseElement::TOWER2:
         return _towers[2] && _towers[2]->isValid() ? 1 : 0;
-    case CatapultTarget::CAT_CENTRAL_TOWER:
+    case CastleDefenseElement::CENTRAL_TOWER:
         return _towers[1] && _towers[1]->isValid() ? 1 : 0;
 
-    case CatapultTarget::CAT_BRIDGE:
+    case CastleDefenseElement::BRIDGE:
         return _bridge->isValid() ? 1 : 0;
 
     default:
@@ -1057,29 +1058,29 @@ uint32_t Battle::Arena::GetCastleTargetValue( const CatapultTarget target ) cons
     return 0;
 }
 
-std::vector<Battle::CatapultTarget> Battle::Arena::GetCastleTargets() const
+std::vector<Battle::CastleDefenseElement> Battle::Arena::GetCastleTargets() const
 {
-    std::vector<CatapultTarget> targets;
+    std::vector<CastleDefenseElement> targets;
     targets.reserve( 8 );
 
     if ( board[CASTLE_FIRST_TOP_WALL_POS].GetObject() > 0 ) {
-        targets.push_back( CatapultTarget::CAT_WALL1 );
+        targets.push_back( CastleDefenseElement::WALL1 );
     }
     if ( board[CASTLE_SECOND_TOP_WALL_POS].GetObject() > 0 ) {
-        targets.push_back( CatapultTarget::CAT_WALL2 );
+        targets.push_back( CastleDefenseElement::WALL2 );
     }
     if ( board[CASTLE_THIRD_TOP_WALL_POS].GetObject() > 0 ) {
-        targets.push_back( CatapultTarget::CAT_WALL3 );
+        targets.push_back( CastleDefenseElement::WALL3 );
     }
     if ( board[CASTLE_FOURTH_TOP_WALL_POS].GetObject() > 0 ) {
-        targets.push_back( CatapultTarget::CAT_WALL4 );
+        targets.push_back( CastleDefenseElement::WALL4 );
     }
 
     if ( _towers[0] && _towers[0]->isValid() ) {
-        targets.push_back( CatapultTarget::CAT_TOWER1 );
+        targets.push_back( CastleDefenseElement::TOWER1 );
     }
     if ( _towers[2] && _towers[2]->isValid() ) {
-        targets.push_back( CatapultTarget::CAT_TOWER2 );
+        targets.push_back( CastleDefenseElement::TOWER2 );
     }
 
     return targets;

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1059,7 +1059,7 @@ uint32_t Battle::Arena::GetCastleTargetValue( const CastleDefenseElement target 
     return 0;
 }
 
-std::vector<Battle::CastleDefenseElement> Battle::Arena::GetCastleTargets() const
+std::vector<Battle::CastleDefenseElement> Battle::Arena::GetEarthQuakeTargets() const
 {
     std::vector<CastleDefenseElement> targets;
     targets.reserve( 8 );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1246,8 +1246,3 @@ bool Battle::Arena::CanToggleAutoBattle() const
 {
     return !( GetCurrentForce().GetControl() & CONTROL_AI );
 }
-
-const Rand::DeterministicRandomGenerator & Battle::Arena::GetRandomGenerator() const
-{
-    return _randomGenerator;
-}

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -673,7 +673,7 @@ void Battle::Arena::CatapultAction()
         cmd << shots;
 
         while ( shots-- ) {
-            const int target = _catapult->GetTarget( stateOfCastleDefences, _randomGenerator );
+            const int target = Catapult::GetTarget( stateOfCastleDefences, _randomGenerator );
             const uint32_t damage = std::min( _catapult->GetDamage( _randomGenerator ), stateOfCastleDefences[target] );
             const bool hit = _catapult->IsNextShotHit( _randomGenerator );
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <cstddef>
 #include <iterator>
+#include <map>
 #include <numeric>
 #include <ostream>
 #include <random>

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -241,7 +241,7 @@ namespace Battle
         TargetsInfo TargetsForChainLightning( const HeroBase * hero, const int32_t attackedTroopIndex, const bool applyRandomMagicResistance );
         std::vector<Unit *> FindChainLightningTargetIndexes( const HeroBase * hero, Unit * firstUnit, const bool applyRandomMagicResistance );
 
-        std::vector<CastleDefenseElement> GetCastleTargets() const;
+        std::vector<CastleDefenseElement> GetEarthQuakeTargets() const;
 
         void ApplyActionRetreat( const Command & );
         void ApplyActionSurrender( const Command & );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -33,7 +33,6 @@
 
 #include "battle.h"
 #include "battle_board.h"
-#include "battle_catapult.h"
 #include "battle_command.h"
 #include "battle_grave.h"
 #include "battle_pathfinding.h"

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -173,7 +173,7 @@ namespace Battle
 
         void ApplyAction( Command & );
 
-        TargetsInfo GetTargetsForSpells( const HeroBase * hero, const Spell & spell, int32_t dest, bool * playResistSound = nullptr );
+        TargetsInfo GetTargetsForSpell( const HeroBase * hero, const Spell & spell, const int32_t dst );
 
         bool isSpellcastDisabled() const;
         bool isDisableCastSpell( const Spell &, std::string * msg = nullptr );
@@ -186,12 +186,6 @@ namespace Battle
         bool CanSurrenderOpponent( int color ) const;
         bool CanRetreatOpponent( int color ) const;
 
-        void ApplyActionSpellSummonElemental( const Command &, const Spell & );
-        void ApplyActionSpellMirrorImage( Command & );
-        void ApplyActionSpellTeleport( Command & );
-        void ApplyActionSpellEarthQuake( const Command & );
-        void ApplyActionSpellDefaults( Command &, const Spell & );
-
         bool IsShootingPenalty( const Unit &, const Unit & ) const;
 
         int GetICNCovr() const
@@ -202,8 +196,6 @@ namespace Battle
         uint32_t GetCastleTargetValue( const CastleDefenseElement target ) const;
 
         int32_t GetFreePositionNearHero( const int heroColor ) const;
-
-        const Rand::DeterministicRandomGenerator & GetRandomGenerator() const;
 
         static Board * GetBoard();
         static Tower * GetTower( const TowerType type );
@@ -238,13 +230,15 @@ namespace Battle
         void CatapultAction();
 
         TargetsInfo GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir ) const;
+        TargetsInfo GetTargetsForSpell( const HeroBase * hero, const Spell & spell, const int32_t dst, bool applyRandomMagicResistance, bool * playResistSound );
 
         static void TargetsApplyDamage( Unit & attacker, TargetsInfo & targets, uint32_t & resurrected );
         static void TargetsApplySpell( const HeroBase * hero, const Spell & spell, TargetsInfo & targets );
 
+        TargetsInfo TargetsForChainLightning( const HeroBase * hero, const int32_t attackedTroopIndex, const bool applyRandomMagicResistance );
+        std::vector<Unit *> FindChainLightningTargetIndexes( const HeroBase * hero, Unit * firstUnit, const bool applyRandomMagicResistance );
+
         std::vector<CastleDefenseElement> GetCastleTargets() const;
-        TargetsInfo TargetsForChainLightning( const HeroBase * hero, int32_t attackedTroopIndex );
-        std::vector<Unit *> FindChainLightningTargetIndexes( const HeroBase * hero, Unit * firstUnit );
 
         void ApplyActionRetreat( const Command & );
         void ApplyActionSurrender( const Command & );
@@ -258,6 +252,12 @@ namespace Battle
         void ApplyActionCatapult( Command & );
         void ApplyActionAutoSwitch( Command & cmd );
         void ApplyActionAutoFinish( const Command & cmd );
+
+        void ApplyActionSpellSummonElemental( const Command &, const Spell & );
+        void ApplyActionSpellMirrorImage( Command & );
+        void ApplyActionSpellTeleport( Command & );
+        void ApplyActionSpellEarthQuake( const Command & );
+        void ApplyActionSpellDefaults( Command &, const Spell & );
 
         // Performs an actual attack of one unit (defender) by another unit (attacker), applying the attacker's
         // built-in magic, if necessary. If the specified index of the target cell of the attack (dst) is negative,

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -200,7 +200,7 @@ namespace Battle
             return icn_covr;
         }
 
-        uint32_t GetCastleTargetValue( const CatapultTarget target ) const;
+        uint32_t GetCastleTargetValue( const CastleDefenseElement target ) const;
 
         int32_t GetFreePositionNearHero( const int heroColor ) const;
 
@@ -235,7 +235,7 @@ namespace Battle
         void TurnTroop( Unit * troop, const Units & orderHistory );
         void TowerAction( const Tower & );
 
-        void SetCastleTargetValue( const CatapultTarget target, const uint32_t value );
+        void SetCastleTargetValue( const CastleDefenseElement target, const uint32_t value );
         void CatapultAction();
 
         TargetsInfo GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir ) const;
@@ -243,7 +243,7 @@ namespace Battle
         static void TargetsApplyDamage( Unit & attacker, TargetsInfo & targets, uint32_t & resurrected );
         static void TargetsApplySpell( const HeroBase * hero, const Spell & spell, TargetsInfo & targets );
 
-        std::vector<CatapultTarget> GetCastleTargets() const;
+        std::vector<CastleDefenseElement> GetCastleTargets() const;
         TargetsInfo TargetsForChainLightning( const HeroBase * hero, int32_t attackedTroopIndex );
         std::vector<Unit *> FindChainLightningTargetIndexes( const HeroBase * hero, Unit * firstUnit );
 

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -309,13 +309,13 @@ namespace Battle
         // A set of colors of players for whom the auto-battle mode is enabled
         int _autoBattleColors;
 
-        Rand::DeterministicRandomGenerator & _randomGenerator;
-
         // This random number generator should only be used in code that is equally used by both AI and the human
         // player - that is, in code related to the processing of battle commands. It cannot be safely used in other
         // places (for example, in code that performs situation assessment or AI decision-making) because in this
         // case the battles performed by AI will not be reproducible by a human player when performing exactly the
         // same actions.
+        Rand::DeterministicRandomGenerator & _randomGenerator;
+
         TroopsUidGenerator _uidGenerator;
 
         enum

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -173,6 +173,9 @@ namespace Battle
 
         void ApplyAction( Command & );
 
+        // Returns a list of targets that will be affected by the given spell applied to a cell with a given index
+        // (potentially by the given hero). This method can be used by external code to evaluate the applicability
+        // of a spell, and does not use probabilistic mechanisms to determine units resisting the given spell.
         TargetsInfo GetTargetsForSpell( const HeroBase * hero, const Spell & spell, const int32_t dst );
 
         bool isSpellcastDisabled() const;
@@ -308,6 +311,11 @@ namespace Battle
 
         Rand::DeterministicRandomGenerator & _randomGenerator;
 
+        // This random number generator should only be used in code that is equally used by both AI and the human
+        // player - that is, in code related to the processing of battle commands. It cannot be safely used in other
+        // places (for example, in code that performs situation assessment or AI decision-making) because in this
+        // case the battles performed by AI will not be reproducible by a human player when performing exactly the
+        // same actions.
         TroopsUidGenerator _uidGenerator;
 
         enum

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -173,9 +173,9 @@ namespace Battle
 
         void ApplyAction( Command & );
 
-        // Returns a list of targets that will be affected by the given spell applied to a cell with a given index
-        // (potentially by the given hero). This method can be used by external code to evaluate the applicability
-        // of a spell, and does not use probabilistic mechanisms to determine units resisting the given spell.
+        // Returns a list of targets that will be affected by the given spell casted by the given hero and applied
+        // to a cell with a given index. This method can be used by external code to evaluate the applicability of
+        // a spell, and does not use probabilistic mechanisms to determine units resisting the given spell.
         TargetsInfo GetTargetsForSpell( const HeroBase * hero, const Spell & spell, const int32_t dst )
         {
             return GetTargetsForSpell( hero, spell, dst, false, nullptr );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -33,6 +33,7 @@
 
 #include "battle.h"
 #include "battle_board.h"
+#include "battle_catapult.h"
 #include "battle_command.h"
 #include "battle_grave.h"
 #include "battle_pathfinding.h"
@@ -199,7 +200,7 @@ namespace Battle
             return icn_covr;
         }
 
-        uint32_t GetCastleTargetValue( int ) const;
+        uint32_t GetCastleTargetValue( const CatapultTarget target ) const;
 
         int32_t GetFreePositionNearHero( const int heroColor ) const;
 
@@ -234,7 +235,7 @@ namespace Battle
         void TurnTroop( Unit * troop, const Units & orderHistory );
         void TowerAction( const Tower & );
 
-        void SetCastleTargetValue( int, uint32_t );
+        void SetCastleTargetValue( const CatapultTarget target, const uint32_t value );
         void CatapultAction();
 
         TargetsInfo GetTargetsForDamage( const Unit & attacker, Unit & defender, const int32_t dst, const int dir ) const;
@@ -242,7 +243,7 @@ namespace Battle
         static void TargetsApplyDamage( Unit & attacker, TargetsInfo & targets, uint32_t & resurrected );
         static void TargetsApplySpell( const HeroBase * hero, const Spell & spell, TargetsInfo & targets );
 
-        std::vector<int> GetCastleTargets() const;
+        std::vector<CatapultTarget> GetCastleTargets() const;
         TargetsInfo TargetsForChainLightning( const HeroBase * hero, int32_t attackedTroopIndex );
         std::vector<Unit *> FindChainLightningTargetIndexes( const HeroBase * hero, Unit * firstUnit );
 

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -176,7 +176,10 @@ namespace Battle
         // Returns a list of targets that will be affected by the given spell applied to a cell with a given index
         // (potentially by the given hero). This method can be used by external code to evaluate the applicability
         // of a spell, and does not use probabilistic mechanisms to determine units resisting the given spell.
-        TargetsInfo GetTargetsForSpell( const HeroBase * hero, const Spell & spell, const int32_t dst );
+        TargetsInfo GetTargetsForSpell( const HeroBase * hero, const Spell & spell, const int32_t dst )
+        {
+            return GetTargetsForSpell( hero, spell, dst, false, nullptr );
+        }
 
         bool isSpellcastDisabled() const;
         bool isDisableCastSpell( const Spell &, std::string * msg = nullptr );

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -104,7 +104,7 @@ Battle::Unit * Battle::Units::FindMode( uint32_t mod ) const
     return it == end() ? nullptr : *it;
 }
 
-Battle::Force::Force( Army & parent, bool opposite, const Rand::DeterministicRandomGenerator & randomGenerator, TroopsUidGenerator & generator )
+Battle::Force::Force( Army & parent, bool opposite, TroopsUidGenerator & generator )
     : army( parent )
 {
     uids.reserve( army.Size() );
@@ -132,7 +132,7 @@ Battle::Force::Force( Army & parent, bool opposite, const Rand::DeterministicRan
 
         assert( pos.GetHead() != nullptr && ( !troop->isWide() || pos.GetTail() != nullptr ) );
 
-        push_back( new Unit( *troop, pos, opposite, randomGenerator, generator.GetUnique() ) );
+        push_back( new Unit( *troop, pos, opposite, generator.GetUnique() ) );
         back()->SetArmy( army );
 
         uids.push_back( back()->GetUID() );

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -33,11 +33,6 @@
 
 class HeroBase;
 
-namespace Rand
-{
-    class DeterministicRandomGenerator;
-}
-
 namespace Battle
 {
     class Unit;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -72,7 +72,7 @@ namespace Battle
     class Force : public Units, public BitModes
     {
     public:
-        Force( Army & parent, bool opposite, const Rand::DeterministicRandomGenerator & randomGenerator, TroopsUidGenerator & generator );
+        Force( Army & parent, bool opposite, TroopsUidGenerator & generator );
         Force( const Force & ) = delete;
 
         ~Force() override;

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -108,7 +108,7 @@ Battle::CastleDefenseElement Battle::Catapult::GetTarget( const std::map<CastleD
         const auto iter = stateOfCatapultTargets.find( target );
         assert( iter != stateOfCatapultTargets.end() );
 
-        return iter->second > 0;
+        return ( iter->second > 0 );
     };
 
     std::vector<CastleDefenseElement> targets;

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -63,7 +63,7 @@ Battle::Catapult::Catapult( const HeroBase & hero )
     catShots += hero.GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::EXTRA_CATAPULT_SHOTS );
 }
 
-uint32_t Battle::Catapult::GetDamage( const Rand::DeterministicRandomGenerator & randomGenerator ) const
+uint32_t Battle::Catapult::GetDamage( Rand::DeterministicRandomGenerator & randomGenerator ) const
 {
     if ( doubleDamageChance == 100 || doubleDamageChance >= randomGenerator.Get( 1, 100 ) ) {
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "Catapult dealt double damage! (" << doubleDamageChance << "% chance)" )
@@ -99,7 +99,7 @@ fheroes2::Point Battle::Catapult::GetTargetPosition( int target, bool hit )
     return fheroes2::Point();
 }
 
-int Battle::Catapult::GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, const Rand::DeterministicRandomGenerator & randomGenerator )
+int Battle::Catapult::GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, Rand::DeterministicRandomGenerator & randomGenerator )
 {
     std::vector<uint32_t> targets;
     targets.reserve( 4 );
@@ -151,7 +151,7 @@ int Battle::Catapult::GetTarget( const std::vector<uint32_t> & stateOfCastleDefe
     return 0;
 }
 
-bool Battle::Catapult::IsNextShotHit( const Rand::DeterministicRandomGenerator & randomGenerator ) const
+bool Battle::Catapult::IsNextShotHit( Rand::DeterministicRandomGenerator & randomGenerator ) const
 {
     // Miss chance is 25%
     return !( canMiss && randomGenerator.Get( 1, 20 ) < 6 );

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -23,8 +23,10 @@
 
 #include "battle_catapult.h"
 
-#include <algorithm>
+#include <cassert>
 #include <ostream>
+#include <utility>
+#include <vector>
 
 #include "artifact.h"
 #include "artifact_info.h"

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -73,24 +73,24 @@ uint32_t Battle::Catapult::GetDamage( Rand::DeterministicRandomGenerator & rando
     return 1;
 }
 
-fheroes2::Point Battle::Catapult::GetTargetPosition( const CatapultTarget target, const bool hit )
+fheroes2::Point Battle::Catapult::GetTargetPosition( const CastleDefenseElement target, const bool hit )
 {
     switch ( target ) {
-    case CatapultTarget::CAT_WALL1:
+    case CastleDefenseElement::WALL1:
         return hit ? fheroes2::Point( 475, 45 ) : fheroes2::Point( 495, 105 );
-    case CatapultTarget::CAT_WALL2:
+    case CastleDefenseElement::WALL2:
         return hit ? fheroes2::Point( 420, 115 ) : fheroes2::Point( 460, 175 );
-    case CatapultTarget::CAT_WALL3:
+    case CastleDefenseElement::WALL3:
         return hit ? fheroes2::Point( 415, 280 ) : fheroes2::Point( 455, 280 );
-    case CatapultTarget::CAT_WALL4:
+    case CastleDefenseElement::WALL4:
         return hit ? fheroes2::Point( 490, 390 ) : fheroes2::Point( 530, 390 );
-    case CatapultTarget::CAT_TOWER1:
+    case CastleDefenseElement::TOWER1:
         return hit ? fheroes2::Point( 430, 40 ) : fheroes2::Point( 490, 120 );
-    case CatapultTarget::CAT_TOWER2:
+    case CastleDefenseElement::TOWER2:
         return hit ? fheroes2::Point( 430, 300 ) : fheroes2::Point( 490, 340 );
-    case CatapultTarget::CAT_BRIDGE:
+    case CastleDefenseElement::BRIDGE:
         return hit ? fheroes2::Point( 400, 195 ) : fheroes2::Point( 450, 235 );
-    case CatapultTarget::CAT_CENTRAL_TOWER:
+    case CastleDefenseElement::CENTRAL_TOWER:
         return hit ? fheroes2::Point( 580, 160 ) : fheroes2::Point( 610, 320 );
     default:
         break;
@@ -99,54 +99,54 @@ fheroes2::Point Battle::Catapult::GetTargetPosition( const CatapultTarget target
     return fheroes2::Point();
 }
 
-Battle::CatapultTarget Battle::Catapult::GetTarget( const std::map<CatapultTarget, uint32_t> & stateOfCatapultTargets,
-                                                    Rand::DeterministicRandomGenerator & randomGenerator )
+Battle::CastleDefenseElement Battle::Catapult::GetTarget( const std::map<CastleDefenseElement, uint32_t> & stateOfCatapultTargets,
+                                                          Rand::DeterministicRandomGenerator & randomGenerator )
 {
-    const auto checkTargetState = [&stateOfCatapultTargets]( const CatapultTarget target ) {
+    const auto checkTargetState = [&stateOfCatapultTargets]( const CastleDefenseElement target ) {
         const auto iter = stateOfCatapultTargets.find( target );
         assert( iter != stateOfCatapultTargets.end() );
 
         return iter->second > 0;
     };
 
-    std::vector<CatapultTarget> targets;
+    std::vector<CastleDefenseElement> targets;
     targets.reserve( 4 );
 
     // Walls
-    if ( checkTargetState( CatapultTarget::CAT_WALL1 ) ) {
-        targets.push_back( CatapultTarget::CAT_WALL1 );
+    if ( checkTargetState( CastleDefenseElement::WALL1 ) ) {
+        targets.push_back( CastleDefenseElement::WALL1 );
     }
-    if ( checkTargetState( CatapultTarget::CAT_WALL2 ) ) {
-        targets.push_back( CatapultTarget::CAT_WALL2 );
+    if ( checkTargetState( CastleDefenseElement::WALL2 ) ) {
+        targets.push_back( CastleDefenseElement::WALL2 );
     }
-    if ( checkTargetState( CatapultTarget::CAT_WALL3 ) ) {
-        targets.push_back( CatapultTarget::CAT_WALL3 );
+    if ( checkTargetState( CastleDefenseElement::WALL3 ) ) {
+        targets.push_back( CastleDefenseElement::WALL3 );
     }
-    if ( checkTargetState( CatapultTarget::CAT_WALL4 ) ) {
-        targets.push_back( CatapultTarget::CAT_WALL4 );
+    if ( checkTargetState( CastleDefenseElement::WALL4 ) ) {
+        targets.push_back( CastleDefenseElement::WALL4 );
     }
 
     // Right/left towers
     if ( targets.empty() ) {
-        if ( checkTargetState( CatapultTarget::CAT_TOWER1 ) ) {
-            targets.push_back( CatapultTarget::CAT_TOWER1 );
+        if ( checkTargetState( CastleDefenseElement::TOWER1 ) ) {
+            targets.push_back( CastleDefenseElement::TOWER1 );
         }
-        if ( checkTargetState( CatapultTarget::CAT_TOWER2 ) ) {
-            targets.push_back( CatapultTarget::CAT_TOWER2 );
+        if ( checkTargetState( CastleDefenseElement::TOWER2 ) ) {
+            targets.push_back( CastleDefenseElement::TOWER2 );
         }
     }
 
     // Bridge
     if ( targets.empty() ) {
-        if ( checkTargetState( CatapultTarget::CAT_BRIDGE ) ) {
-            targets.push_back( CatapultTarget::CAT_BRIDGE );
+        if ( checkTargetState( CastleDefenseElement::BRIDGE ) ) {
+            targets.push_back( CastleDefenseElement::BRIDGE );
         }
     }
 
     // Central tower
     if ( targets.empty() ) {
-        if ( checkTargetState( CatapultTarget::CAT_CENTRAL_TOWER ) ) {
-            targets.push_back( CatapultTarget::CAT_CENTRAL_TOWER );
+        if ( checkTargetState( CastleDefenseElement::CENTRAL_TOWER ) ) {
+            targets.push_back( CastleDefenseElement::CENTRAL_TOWER );
         }
     }
 
@@ -156,7 +156,7 @@ Battle::CatapultTarget Battle::Catapult::GetTarget( const std::map<CatapultTarge
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "no target was found" )
 
-    return CatapultTarget::CAT_NONE;
+    return CastleDefenseElement::NONE;
 }
 
 bool Battle::Catapult::IsNextShotHit( Rand::DeterministicRandomGenerator & randomGenerator ) const

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -99,7 +99,7 @@ fheroes2::Point Battle::Catapult::GetTargetPosition( int target, bool hit )
     return fheroes2::Point();
 }
 
-int Battle::Catapult::GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, const Rand::DeterministicRandomGenerator & randomGenerator ) const
+int Battle::Catapult::GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, const Rand::DeterministicRandomGenerator & randomGenerator )
 {
     std::vector<uint32_t> targets;
     targets.reserve( 4 );

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -105,33 +105,41 @@ int Battle::Catapult::GetTarget( const std::vector<uint32_t> & stateOfCastleDefe
     targets.reserve( 4 );
 
     // check walls
-    if ( 0 != stateOfCastleDefences[CAT_WALL1] )
+    if ( 0 != stateOfCastleDefences[CAT_WALL1] ) {
         targets.push_back( CAT_WALL1 );
-    if ( 0 != stateOfCastleDefences[CAT_WALL2] )
+    }
+    if ( 0 != stateOfCastleDefences[CAT_WALL2] ) {
         targets.push_back( CAT_WALL2 );
-    if ( 0 != stateOfCastleDefences[CAT_WALL3] )
+    }
+    if ( 0 != stateOfCastleDefences[CAT_WALL3] ) {
         targets.push_back( CAT_WALL3 );
-    if ( 0 != stateOfCastleDefences[CAT_WALL4] )
+    }
+    if ( 0 != stateOfCastleDefences[CAT_WALL4] ) {
         targets.push_back( CAT_WALL4 );
+    }
 
     // check right/left towers
     if ( targets.empty() ) {
-        if ( stateOfCastleDefences[CAT_TOWER1] )
+        if ( stateOfCastleDefences[CAT_TOWER1] ) {
             targets.push_back( CAT_TOWER1 );
-        if ( stateOfCastleDefences[CAT_TOWER2] )
+        }
+        if ( stateOfCastleDefences[CAT_TOWER2] ) {
             targets.push_back( CAT_TOWER2 );
+        }
     }
 
     // check bridge
     if ( targets.empty() ) {
-        if ( stateOfCastleDefences[CAT_BRIDGE] )
+        if ( stateOfCastleDefences[CAT_BRIDGE] ) {
             targets.push_back( CAT_BRIDGE );
+        }
     }
 
     // check general tower
     if ( targets.empty() ) {
-        if ( stateOfCastleDefences[CAT_CENTRAL_TOWER] )
+        if ( stateOfCastleDefences[CAT_CENTRAL_TOWER] ) {
             targets.push_back( CAT_CENTRAL_TOWER );
+        }
     }
 
     if ( !targets.empty() ) {

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -52,7 +52,7 @@ namespace Battle
     class Catapult
     {
     public:
-        explicit Catapult( const HeroBase & hero, const Rand::DeterministicRandomGenerator & randomGenerator );
+        explicit Catapult( const HeroBase & hero );
         Catapult( const Catapult & ) = delete;
 
         Catapult & operator=( const Catapult & ) = delete;
@@ -64,15 +64,14 @@ namespace Battle
             return catShots;
         }
 
-        int GetTarget( const std::vector<uint32_t> & ) const;
-        uint32_t GetDamage() const;
-        bool IsNextShotHit() const;
+        int GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, const Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        uint32_t GetDamage( const Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        bool IsNextShotHit( const Rand::DeterministicRandomGenerator & randomGenerator ) const;
 
     private:
         uint32_t catShots;
         uint32_t doubleDamageChance;
         bool canMiss;
-        const Rand::DeterministicRandomGenerator & _randomGenerator;
     };
 }
 

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -64,10 +64,10 @@ namespace Battle
             return catShots;
         }
 
-        static int GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, const Rand::DeterministicRandomGenerator & randomGenerator );
+        static int GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, Rand::DeterministicRandomGenerator & randomGenerator );
 
-        uint32_t GetDamage( const Rand::DeterministicRandomGenerator & randomGenerator ) const;
-        bool IsNextShotHit( const Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        uint32_t GetDamage( Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        bool IsNextShotHit( Rand::DeterministicRandomGenerator & randomGenerator ) const;
 
     private:
         uint32_t catShots;

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <map>
 
+#include "battle.h"
 #include "math_base.h"
 
 class HeroBase;
@@ -38,19 +39,6 @@ namespace Rand
 
 namespace Battle
 {
-    enum class CatapultTarget : int
-    {
-        CAT_NONE = 0,
-        CAT_WALL1 = 1,
-        CAT_WALL2 = 2,
-        CAT_WALL3 = 3,
-        CAT_WALL4 = 4,
-        CAT_TOWER1 = 5,
-        CAT_TOWER2 = 6,
-        CAT_BRIDGE = 7,
-        CAT_CENTRAL_TOWER = 8
-    };
-
     class Catapult
     {
     public:
@@ -59,8 +47,9 @@ namespace Battle
 
         Catapult & operator=( const Catapult & ) = delete;
 
-        static CatapultTarget GetTarget( const std::map<CatapultTarget, uint32_t> & stateOfCatapultTargets, Rand::DeterministicRandomGenerator & randomGenerator );
-        static fheroes2::Point GetTargetPosition( const CatapultTarget target, const bool hit );
+        static CastleDefenseElement GetTarget( const std::map<CastleDefenseElement, uint32_t> & stateOfCatapultTargets,
+                                               Rand::DeterministicRandomGenerator & randomGenerator );
+        static fheroes2::Point GetTargetPosition( const CastleDefenseElement target, const bool hit );
 
         uint32_t GetShots() const
         {

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -64,7 +64,8 @@ namespace Battle
             return catShots;
         }
 
-        int GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, const Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        static int GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, const Rand::DeterministicRandomGenerator & randomGenerator );
+
         uint32_t GetDamage( const Rand::DeterministicRandomGenerator & randomGenerator ) const;
         bool IsNextShotHit( const Rand::DeterministicRandomGenerator & randomGenerator ) const;
 

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -25,11 +25,12 @@
 #define H2BATTLE_CATAPULT_H
 
 #include <cstdint>
-#include <vector>
+#include <map>
 
 #include "math_base.h"
 
 class HeroBase;
+
 namespace Rand
 {
     class DeterministicRandomGenerator;
@@ -37,8 +38,9 @@ namespace Rand
 
 namespace Battle
 {
-    enum
+    enum class CatapultTarget : int
     {
+        CAT_NONE = 0,
         CAT_WALL1 = 1,
         CAT_WALL2 = 2,
         CAT_WALL3 = 3,
@@ -57,14 +59,13 @@ namespace Battle
 
         Catapult & operator=( const Catapult & ) = delete;
 
-        static fheroes2::Point GetTargetPosition( int target, bool hit );
+        static CatapultTarget GetTarget( const std::map<CatapultTarget, uint32_t> & stateOfCatapultTargets, Rand::DeterministicRandomGenerator & randomGenerator );
+        static fheroes2::Point GetTargetPosition( const CatapultTarget target, const bool hit );
 
         uint32_t GetShots() const
         {
             return catShots;
         }
-
-        static int GetTarget( const std::vector<uint32_t> & stateOfCastleDefences, Rand::DeterministicRandomGenerator & randomGenerator );
 
         uint32_t GetDamage( Rand::DeterministicRandomGenerator & randomGenerator ) const;
         bool IsNextShotHit( Rand::DeterministicRandomGenerator & randomGenerator ) const;

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -36,23 +36,6 @@ int Battle::Command::GetNextValue()
     return val;
 }
 
-Battle::Command & Battle::Command::operator<<( const int val )
-{
-    push_back( val );
-
-    return *this;
-}
-
-Battle::Command & Battle::Command::operator>>( int & val )
-{
-    if ( !empty() ) {
-        val = back();
-        pop_back();
-    }
-
-    return *this;
-}
-
 uint32_t Battle::Command::updateSeed( const uint32_t seed ) const
 {
     uint32_t newSeed = seed;
@@ -93,4 +76,21 @@ uint32_t Battle::Command::updateSeed( const uint32_t seed ) const
     }
 
     return newSeed;
+}
+
+Battle::Command & Battle::Command::operator<<( const int val )
+{
+    push_back( val );
+
+    return *this;
+}
+
+Battle::Command & Battle::Command::operator>>( int & val )
+{
+    if ( !empty() ) {
+        val = back();
+        pop_back();
+    }
+
+    return *this;
 }

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -36,18 +36,16 @@ int Battle::Command::GetNextValue()
     return val;
 }
 
-uint32_t Battle::Command::updateSeed( const uint32_t seed ) const
+uint32_t Battle::Command::updateSeed( uint32_t seed ) const
 {
-    uint32_t newSeed = seed;
-
     switch ( _type ) {
     case CommandType::ATTACK:
         assert( size() == 4 );
 
-        fheroes2::hashCombine( newSeed, _type );
+        fheroes2::hashCombine( seed, _type );
         // Use only attacker & defender UIDs, because cell index and direction may differ depending on whether the AI or the human player gives the command
-        fheroes2::hashCombine( newSeed, at( 2 ) );
-        fheroes2::hashCombine( newSeed, at( 3 ) );
+        fheroes2::hashCombine( seed, at( 2 ) );
+        fheroes2::hashCombine( seed, at( 3 ) );
         break;
 
     case CommandType::MOVE:
@@ -58,8 +56,8 @@ uint32_t Battle::Command::updateSeed( const uint32_t seed ) const
     case CommandType::RETREAT:
     case CommandType::SURRENDER:
     case CommandType::SKIP:
-        fheroes2::hashCombine( newSeed, _type );
-        std::for_each( begin(), end(), [&newSeed]( const int param ) { fheroes2::hashCombine( newSeed, param ); } );
+        fheroes2::hashCombine( seed, _type );
+        std::for_each( begin(), end(), [&seed]( const int param ) { fheroes2::hashCombine( seed, param ); } );
         break;
 
     // Ignore the end turn command, because the AI and the human player give them differently
@@ -75,7 +73,7 @@ uint32_t Battle::Command::updateSeed( const uint32_t seed ) const
         break;
     }
 
-    return newSeed;
+    return seed;
 }
 
 Battle::Command & Battle::Command::operator<<( const int val )

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -36,6 +36,7 @@ uint32_t Battle::Command::updateRandomSeed( const uint32_t seed ) const
         assert( size() == 4 );
 
         fheroes2::hashCombine( newSeed, _type );
+        // Use only attacker & defender UIDs, because cell index and direction may differ depending on whether the AI or the human player gives the command
         fheroes2::hashCombine( newSeed, at( 2 ) );
         fheroes2::hashCombine( newSeed, at( 3 ) );
         break;
@@ -52,7 +53,10 @@ uint32_t Battle::Command::updateRandomSeed( const uint32_t seed ) const
         std::for_each( begin(), end(), [&newSeed]( const int param ) { fheroes2::hashCombine( newSeed, param ); } );
         break;
 
+    // Ignore the end turn command, because the AI and the human player give them differently
+    // TODO: eventually get rid of this command
     case CommandType::MSG_BATTLE_END_TURN:
+    // These commands should never affect the seed generation
     case CommandType::MSG_BATTLE_AUTO_SWITCH:
     case CommandType::MSG_BATTLE_AUTO_FINISH:
         break;

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -27,6 +27,32 @@
 
 #include "tools.h"
 
+int Battle::Command::GetNextValue()
+{
+    int val = 0;
+
+    *this >> val;
+
+    return val;
+}
+
+Battle::Command & Battle::Command::operator<<( const int val )
+{
+    push_back( val );
+
+    return *this;
+}
+
+Battle::Command & Battle::Command::operator>>( int & val )
+{
+    if ( !empty() ) {
+        val = back();
+        pop_back();
+    }
+
+    return *this;
+}
+
 uint32_t Battle::Command::updateRandomSeed( const uint32_t seed ) const
 {
     uint32_t newSeed = seed;

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -58,7 +58,7 @@ uint32_t Battle::Command::updateSeed( const uint32_t seed ) const
     uint32_t newSeed = seed;
 
     switch ( _type ) {
-    case CommandType::MSG_BATTLE_ATTACK:
+    case CommandType::ATTACK:
         assert( size() == 4 );
 
         fheroes2::hashCombine( newSeed, _type );
@@ -67,24 +67,24 @@ uint32_t Battle::Command::updateSeed( const uint32_t seed ) const
         fheroes2::hashCombine( newSeed, at( 3 ) );
         break;
 
-    case CommandType::MSG_BATTLE_MOVE:
-    case CommandType::MSG_BATTLE_CAST:
-    case CommandType::MSG_BATTLE_MORALE:
-    case CommandType::MSG_BATTLE_CATAPULT:
-    case CommandType::MSG_BATTLE_TOWER:
-    case CommandType::MSG_BATTLE_RETREAT:
-    case CommandType::MSG_BATTLE_SURRENDER:
-    case CommandType::MSG_BATTLE_SKIP:
+    case CommandType::MOVE:
+    case CommandType::SPELLCAST:
+    case CommandType::MORALE:
+    case CommandType::CATAPULT:
+    case CommandType::TOWER:
+    case CommandType::RETREAT:
+    case CommandType::SURRENDER:
+    case CommandType::SKIP:
         fheroes2::hashCombine( newSeed, _type );
         std::for_each( begin(), end(), [&newSeed]( const int param ) { fheroes2::hashCombine( newSeed, param ); } );
         break;
 
     // Ignore the end turn command, because the AI and the human player give them differently
     // TODO: eventually get rid of this command
-    case CommandType::MSG_BATTLE_END_TURN:
+    case CommandType::END_TURN:
     // These commands should never affect the seed generation
-    case CommandType::MSG_BATTLE_AUTO_SWITCH:
-    case CommandType::MSG_BATTLE_AUTO_FINISH:
+    case CommandType::AUTO_SWITCH:
+    case CommandType::AUTO_FINISH:
         break;
 
     default:

--- a/src/fheroes2/battle/battle_command.cpp
+++ b/src/fheroes2/battle/battle_command.cpp
@@ -53,7 +53,7 @@ Battle::Command & Battle::Command::operator>>( int & val )
     return *this;
 }
 
-uint32_t Battle::Command::updateRandomSeed( const uint32_t seed ) const
+uint32_t Battle::Command::updateSeed( const uint32_t seed ) const
 {
     uint32_t newSeed = seed;
 

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2023                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <tuple>
 #include <type_traits>
 #include <vector>
 

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -138,36 +138,15 @@ namespace Battle
             return _type;
         }
 
-        int GetValue()
-        {
-            int val = 0;
-
-            *this >> val;
-
-            return val;
-        }
+        int GetNextValue();
 
         bool isType( const CommandType cmd ) const
         {
             return _type == cmd;
         }
 
-        Command & operator<<( const int val )
-        {
-            push_back( val );
-
-            return *this;
-        }
-
-        Command & operator>>( int & val )
-        {
-            if ( !empty() ) {
-                val = back();
-                pop_back();
-            }
-
-            return *this;
-        }
+        Command & operator<<( const int val );
+        Command & operator>>( int & val );
 
         uint32_t updateRandomSeed( const uint32_t seed ) const;
 

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -125,7 +125,7 @@ namespace Battle
                 int dummy = 0;
 
                 // Put the elements of the parameter pack in reverse order using the right-to-left associativity of the assignment operator
-                ( ( *this << params, dummy ) = ... );
+                (void)( ( *this << params, dummy ) = ... );
             }
         }
 

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -149,7 +149,7 @@ namespace Battle
         Command & operator<<( const int val );
         Command & operator>>( int & val );
 
-        uint32_t updateRandomSeed( const uint32_t seed ) const;
+        uint32_t updateSeed( const uint32_t seed ) const;
 
     private:
         CommandType _type;

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -38,49 +38,49 @@ namespace Battle
 {
     enum class CommandType : int32_t
     {
-        MSG_BATTLE_MOVE,
-        MSG_BATTLE_ATTACK,
-        MSG_BATTLE_CAST,
-        MSG_BATTLE_MORALE,
-        MSG_BATTLE_CATAPULT,
-        MSG_BATTLE_TOWER,
-        MSG_BATTLE_RETREAT,
-        MSG_BATTLE_SURRENDER,
-        MSG_BATTLE_SKIP,
-        MSG_BATTLE_END_TURN,
-        MSG_BATTLE_AUTO_SWITCH,
-        MSG_BATTLE_AUTO_FINISH
+        MOVE,
+        ATTACK,
+        SPELLCAST,
+        MORALE,
+        CATAPULT,
+        TOWER,
+        RETREAT,
+        SURRENDER,
+        SKIP,
+        END_TURN,
+        AUTO_SWITCH,
+        AUTO_FINISH
     };
 
     class Command final : public std::vector<int>
     {
     public:
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_MOVE> MOVE{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_ATTACK> ATTACK{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_CAST> CAST{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_MORALE> MORALE{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_CATAPULT> CATAPULT{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_TOWER> TOWER{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_RETREAT> RETREAT{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_SURRENDER> SURRENDER{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_SKIP> SKIP{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_END_TURN> END_TURN{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_AUTO_SWITCH> AUTO_SWITCH{};
-        static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_AUTO_FINISH> AUTO_FINISH{};
+        static constexpr std::integral_constant<CommandType, CommandType::MOVE> MOVE{};
+        static constexpr std::integral_constant<CommandType, CommandType::ATTACK> ATTACK{};
+        static constexpr std::integral_constant<CommandType, CommandType::SPELLCAST> SPELLCAST{};
+        static constexpr std::integral_constant<CommandType, CommandType::MORALE> MORALE{};
+        static constexpr std::integral_constant<CommandType, CommandType::CATAPULT> CATAPULT{};
+        static constexpr std::integral_constant<CommandType, CommandType::TOWER> TOWER{};
+        static constexpr std::integral_constant<CommandType, CommandType::RETREAT> RETREAT{};
+        static constexpr std::integral_constant<CommandType, CommandType::SURRENDER> SURRENDER{};
+        static constexpr std::integral_constant<CommandType, CommandType::SKIP> SKIP{};
+        static constexpr std::integral_constant<CommandType, CommandType::END_TURN> END_TURN{};
+        static constexpr std::integral_constant<CommandType, CommandType::AUTO_SWITCH> AUTO_SWITCH{};
+        static constexpr std::integral_constant<CommandType, CommandType::AUTO_FINISH> AUTO_FINISH{};
 
         template <CommandType cmd, typename... Types>
         Command( std::integral_constant<CommandType, cmd> /* tag */, const Types... params )
             : _type( cmd )
         {
-            if constexpr ( cmd == CommandType::MSG_BATTLE_MOVE ) {
+            if constexpr ( cmd == CommandType::MOVE ) {
                 // UID, cell index
                 static_assert( sizeof...( params ) == 2 );
             }
-            else if constexpr ( cmd == CommandType::MSG_BATTLE_ATTACK ) {
+            else if constexpr ( cmd == CommandType::ATTACK ) {
                 // Attacker UID, defender UID, cell index, direction
                 static_assert( sizeof...( params ) == 4 );
             }
-            else if constexpr ( cmd == CommandType::MSG_BATTLE_CAST ) {
+            else if constexpr ( cmd == CommandType::SPELLCAST ) {
                 static_assert( sizeof...( params ) > 0 );
 
                 const int spellId = std::get<0>( std::make_tuple( params... ) );
@@ -98,23 +98,23 @@ namespace Battle
                     assert( sizeof...( params ) == 2 );
                 }
             }
-            else if constexpr ( cmd == CommandType::MSG_BATTLE_MORALE ) {
+            else if constexpr ( cmd == CommandType::MORALE ) {
                 // UID, morale
                 static_assert( sizeof...( params ) == 2 );
             }
-            else if constexpr ( cmd == CommandType::MSG_BATTLE_TOWER ) {
+            else if constexpr ( cmd == CommandType::TOWER ) {
                 // Tower type, UID
                 static_assert( sizeof...( params ) == 2 );
             }
-            else if constexpr ( cmd == CommandType::MSG_BATTLE_SKIP ) {
+            else if constexpr ( cmd == CommandType::SKIP ) {
                 // UID
                 static_assert( sizeof...( params ) == 1 );
             }
-            else if constexpr ( cmd == CommandType::MSG_BATTLE_END_TURN ) {
+            else if constexpr ( cmd == CommandType::END_TURN ) {
                 // UID
                 static_assert( sizeof...( params ) == 1 );
             }
-            else if constexpr ( cmd == CommandType::MSG_BATTLE_AUTO_SWITCH ) {
+            else if constexpr ( cmd == CommandType::AUTO_SWITCH ) {
                 // Color
                 static_assert( sizeof...( params ) == 1 );
             }

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -69,7 +69,7 @@ namespace Battle
         static constexpr std::integral_constant<CommandType, CommandType::AUTO_FINISH> AUTO_FINISH{};
 
         template <CommandType cmd, typename... Types>
-        Command( std::integral_constant<CommandType, cmd> /* tag */, const Types... params )
+        explicit Command( std::integral_constant<CommandType, cmd> /* tag */, const Types... params )
             : _type( cmd )
         {
             if constexpr ( cmd == CommandType::MOVE ) {

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -147,7 +147,8 @@ namespace Battle
             return _type == cmd;
         }
 
-        uint32_t updateSeed( const uint32_t seed ) const;
+        // Updates the specified seed using the contents of this command. Returns the updated seed (or the original seed if this command is not suitable for seed update).
+        uint32_t updateSeed( uint32_t seed ) const;
 
         Command & operator<<( const int val );
 

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -147,12 +147,13 @@ namespace Battle
             return _type == cmd;
         }
 
-        Command & operator<<( const int val );
-        Command & operator>>( int & val );
-
         uint32_t updateSeed( const uint32_t seed ) const;
 
+        Command & operator<<( const int val );
+
     private:
+        Command & operator>>( int & val );
+
         CommandType _type;
     };
 }

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -125,7 +125,7 @@ namespace Battle
             if constexpr ( sizeof...( params ) > 0 ) {
                 reserve( sizeof...( params ) );
 
-                // Put the elements of the parameter pack in reverse order using the right-to-left associativity of the assignment operator
+                // Put the elements of the parameter pack in reverse order using the right-to-left sequencing of the assignment operator
                 int dummy = 0;
                 (void)( ( *this << params, dummy ) = ... );
             }

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -123,9 +123,10 @@ namespace Battle
             }
 
             if constexpr ( sizeof...( params ) > 0 ) {
-                int dummy = 0;
+                reserve( sizeof...( params ) );
 
                 // Put the elements of the parameter pack in reverse order using the right-to-left associativity of the assignment operator
+                int dummy = 0;
                 (void)( ( *this << params, dummy ) = ... );
             }
         }

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -68,7 +68,7 @@ namespace Battle
         static constexpr std::integral_constant<CommandType, CommandType::MSG_BATTLE_AUTO_FINISH> AUTO_FINISH{};
 
         template <CommandType cmd, typename... Types>
-        Command( std::integral_constant<CommandType, cmd>, const Types... params )
+        Command( std::integral_constant<CommandType, cmd> /* tag */, const Types... params )
             : _type( cmd )
         {
             if constexpr ( cmd == CommandType::MSG_BATTLE_MOVE ) {

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -131,10 +131,6 @@ namespace Battle
             }
         }
 
-        explicit Command( const CommandType cmd )
-            : _type( cmd )
-        {}
-
         CommandType GetType() const
         {
             return _type;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3040,7 +3040,7 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
                     _teleportSpellSrcIdx = index_pos;
                 }
                 else {
-                    actions.emplace_back( Command::CAST, Spell::TELEPORT, _teleportSpellSrcIdx, index_pos );
+                    actions.emplace_back( Command::SPELLCAST, Spell::TELEPORT, _teleportSpellSrcIdx, index_pos );
 
                     humanturn_spell = Spell::NONE;
                     humanturn_exit = true;
@@ -3049,13 +3049,13 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
                 }
             }
             else if ( Cursor::SP_MIRRORIMAGE == cursor.Themes() ) {
-                actions.emplace_back( Command::CAST, Spell::MIRRORIMAGE, index_pos );
+                actions.emplace_back( Command::SPELLCAST, Spell::MIRRORIMAGE, index_pos );
 
                 humanturn_spell = Spell::NONE;
                 humanturn_exit = true;
             }
             else {
-                actions.emplace_back( Command::CAST, humanturn_spell.GetID(), index_pos );
+                actions.emplace_back( Command::SPELLCAST, humanturn_spell.GetID(), index_pos );
 
                 humanturn_spell = Spell::NONE;
                 humanturn_exit = true;
@@ -4865,7 +4865,7 @@ void Battle::Interface::RedrawActionTowerPart2( const Tower & tower, const Targe
     assert( _movingUnit == nullptr );
 }
 
-void Battle::Interface::RedrawActionCatapultPart1( const CatapultTarget catapultTarget, const bool isHit )
+void Battle::Interface::RedrawActionCatapultPart1( const CastleDefenseElement catapultTarget, const bool isHit )
 {
     // Reset the delay before rendering the first frame of catapult animation.
     Game::AnimateResetDelay( Game::DelayType::BATTLE_CATAPULT_DELAY );
@@ -4897,24 +4897,24 @@ void Battle::Interface::RedrawActionCatapultPart1( const CatapultTarget catapult
     // set the projectile arc height for each castle target and a formula for an unknown target
     int32_t boulderArcHeight;
     switch ( catapultTarget ) {
-    case CatapultTarget::CAT_WALL1:
+    case CastleDefenseElement::WALL1:
         boulderArcHeight = 220;
         break;
-    case CatapultTarget::CAT_WALL2:
-    case CatapultTarget::CAT_BRIDGE:
+    case CastleDefenseElement::WALL2:
+    case CastleDefenseElement::BRIDGE:
         boulderArcHeight = 216;
         break;
-    case CatapultTarget::CAT_WALL3:
+    case CastleDefenseElement::WALL3:
         boulderArcHeight = 204;
         break;
-    case CatapultTarget::CAT_WALL4:
+    case CastleDefenseElement::WALL4:
         boulderArcHeight = 208;
         break;
-    case CatapultTarget::CAT_TOWER1:
-    case CatapultTarget::CAT_TOWER2:
+    case CastleDefenseElement::TOWER1:
+    case CastleDefenseElement::TOWER2:
         boulderArcHeight = 206;
         break;
-    case CatapultTarget::CAT_CENTRAL_TOWER:
+    case CastleDefenseElement::CENTRAL_TOWER:
         boulderArcHeight = 290;
         break;
     default:
@@ -4958,7 +4958,7 @@ void Battle::Interface::RedrawActionCatapultPart1( const CatapultTarget catapult
     uint32_t frame = 0;
     // If the building is hit, end the animation on the 5th frame to change the building state (when the smoke cloud is largest).
     uint32_t maxFrame = isHit ? castleBuildingDestroyFrame : fheroes2::AGG::GetICNCount( icn );
-    const bool isBridgeDestroyed = isHit && ( catapultTarget == CatapultTarget::CAT_BRIDGE );
+    const bool isBridgeDestroyed = isHit && ( catapultTarget == CastleDefenseElement::BRIDGE );
     // If the bridge is destroyed - prepare parameters for the second smoke cloud.
     if ( isBridgeDestroyed ) {
         pt1 = pt2 + bridgeDestroySmokeOffset;
@@ -4991,7 +4991,7 @@ void Battle::Interface::RedrawActionCatapultPart1( const CatapultTarget catapult
     }
 }
 
-void Battle::Interface::RedrawActionCatapultPart2( const CatapultTarget catapultTarget )
+void Battle::Interface::RedrawActionCatapultPart2( const CastleDefenseElement catapultTarget )
 {
     // Finish the smoke cloud animation after the building's state has changed after the hit and it is drawn as demolished.
 
@@ -5003,7 +5003,7 @@ void Battle::Interface::RedrawActionCatapultPart2( const CatapultTarget catapult
     uint32_t frame = castleBuildingDestroyFrame;
     const uint32_t maxFrame = fheroes2::AGG::GetICNCount( icnId );
     uint32_t maxAnimationFrame = maxFrame;
-    const bool isBridgeDestroyed = ( catapultTarget == CatapultTarget::CAT_BRIDGE );
+    const bool isBridgeDestroyed = ( catapultTarget == CastleDefenseElement::BRIDGE );
     // If the bridge is destroyed - prepare parameters for the second smoke cloud.
     if ( isBridgeDestroyed ) {
         pt2 = pt1 + bridgeDestroySmokeOffset;
@@ -5848,7 +5848,7 @@ void Battle::Interface::RedrawActionArmageddonSpell()
     }
 }
 
-void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<CatapultTarget> & targets )
+void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<CastleDefenseElement> & targets )
 {
     Cursor & cursor = Cursor::Get();
     LocalEvent & le = LocalEvent::Get();
@@ -5915,7 +5915,7 @@ void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<CatapultT
         if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
             RedrawPartialStart();
 
-            for ( const CatapultTarget target : targets ) {
+            for ( const CastleDefenseElement target : targets ) {
                 fheroes2::Point pt2 = Catapult::GetTargetPosition( target, true );
 
                 pt2.x += area.x;
@@ -6394,7 +6394,7 @@ void Battle::Interface::ProcessingHeroDialogResult( const int result, Actions & 
 
                             if ( hero->CanCastSpell( spell, &error ) ) {
                                 if ( spell.isApplyWithoutFocusObject() ) {
-                                    actions.emplace_back( Command::CAST, spell.GetID(), -1 );
+                                    actions.emplace_back( Command::SPELLCAST, spell.GetID(), -1 );
 
                                     humanturn_redraw = true;
                                     humanturn_exit = true;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2677,7 +2677,7 @@ int Battle::Interface::GetBattleSpellCursor( std::string & statusMsg ) const
 void Battle::Interface::getPendingActions( Actions & actions )
 {
     if ( _interruptAutoBattleForColor ) {
-        actions.emplace_back( CommandType::MSG_BATTLE_AUTO_SWITCH, _interruptAutoBattleForColor );
+        actions.emplace_back( Command::AUTO_SWITCH, _interruptAutoBattleForColor );
 
         _interruptAutoBattleForColor = 0;
     }
@@ -2768,7 +2768,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
     if ( le.KeyPress() ) {
         // Skip the turn
         if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_SKIP ) ) {
-            actions.emplace_back( CommandType::MSG_BATTLE_SKIP, unit.GetUID() );
+            actions.emplace_back( Command::SKIP, unit.GetUID() );
             humanturn_exit = true;
         }
         // Battle options
@@ -2803,14 +2803,14 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
                 // The attacker wins the battle instantly
                 arena.GetResult().army1 = RESULT_WINS;
                 humanturn_exit = true;
-                actions.emplace_back( CommandType::MSG_BATTLE_END_TURN, unit.GetUID() );
+                actions.emplace_back( Command::END_TURN, unit.GetUID() );
                 break;
 
             case fheroes2::Key::KEY_L:
                 // The attacker loses the battle instantly
                 arena.GetResult().army1 = RESULT_LOSS;
                 humanturn_exit = true;
-                actions.emplace_back( CommandType::MSG_BATTLE_END_TURN, unit.GetUID() );
+                actions.emplace_back( Command::END_TURN, unit.GetUID() );
                 break;
 
             default:
@@ -3040,7 +3040,7 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
                     _teleportSpellSrcIdx = index_pos;
                 }
                 else {
-                    actions.emplace_back( CommandType::MSG_BATTLE_CAST, Spell::TELEPORT, _teleportSpellSrcIdx, index_pos );
+                    actions.emplace_back( Command::CAST, Spell::TELEPORT, _teleportSpellSrcIdx, index_pos );
 
                     humanturn_spell = Spell::NONE;
                     humanturn_exit = true;
@@ -3049,13 +3049,13 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
                 }
             }
             else if ( Cursor::SP_MIRRORIMAGE == cursor.Themes() ) {
-                actions.emplace_back( CommandType::MSG_BATTLE_CAST, Spell::MIRRORIMAGE, index_pos );
+                actions.emplace_back( Command::CAST, Spell::MIRRORIMAGE, index_pos );
 
                 humanturn_spell = Spell::NONE;
                 humanturn_exit = true;
             }
             else {
-                actions.emplace_back( CommandType::MSG_BATTLE_CAST, humanturn_spell.GetID(), index_pos );
+                actions.emplace_back( Command::CAST, humanturn_spell.GetID(), index_pos );
 
                 humanturn_spell = Spell::NONE;
                 humanturn_exit = true;
@@ -3138,7 +3138,7 @@ void Battle::Interface::EventAutoSwitch( const Unit & unit, Actions & actions )
         return;
     }
 
-    actions.emplace_back( CommandType::MSG_BATTLE_AUTO_SWITCH, unit.GetCurrentOrArmyColor() );
+    actions.emplace_back( Command::AUTO_SWITCH, unit.GetCurrentOrArmyColor() );
 
     humanturn_redraw = true;
     humanturn_exit = true;
@@ -3153,7 +3153,7 @@ void Battle::Interface::EventAutoFinish( Actions & actions )
         return;
     }
 
-    actions.emplace_back( CommandType::MSG_BATTLE_AUTO_FINISH );
+    actions.emplace_back( Command::AUTO_FINISH );
 
     humanturn_redraw = true;
     humanturn_exit = true;
@@ -3196,7 +3196,7 @@ void Battle::Interface::ButtonSkipAction( Actions & actions )
     le.MousePressLeft( btn_skip.area() ) ? btn_skip.drawOnPress() : btn_skip.drawOnRelease();
 
     if ( le.MouseClickLeft( btn_skip.area() ) && _currentUnit ) {
-        actions.emplace_back( CommandType::MSG_BATTLE_SKIP, _currentUnit->GetUID() );
+        actions.emplace_back( Command::SKIP, _currentUnit->GetUID() );
         humanturn_exit = true;
     }
 }
@@ -3242,8 +3242,8 @@ void Battle::Interface::MouseLeftClickBoardAction( const int themes, const Cell 
                 break;
             }
 
-            actions.emplace_back( CommandType::MSG_BATTLE_MOVE, _currentUnit->GetUID(), fixupDestinationCell( *_currentUnit, index ) );
-            actions.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
+            actions.emplace_back( Command::MOVE, _currentUnit->GetUID(), fixupDestinationCell( *_currentUnit, index ) );
+            actions.emplace_back( Command::END_TURN, _currentUnit->GetUID() );
 
             humanturn_exit = true;
             break;
@@ -3264,10 +3264,10 @@ void Battle::Interface::MouseLeftClickBoardAction( const int themes, const Cell 
                 const int32_t move = fixupDestinationCell( *_currentUnit, Board::GetIndexDirection( index, dir ) );
 
                 if ( _currentUnit->GetHeadIndex() != move ) {
-                    actions.emplace_back( CommandType::MSG_BATTLE_MOVE, _currentUnit->GetUID(), move );
+                    actions.emplace_back( Command::MOVE, _currentUnit->GetUID(), move );
                 }
-                actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, _currentUnit->GetUID(), unitOnCell->GetUID(), index, Board::GetReflectDirection( dir ) );
-                actions.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
+                actions.emplace_back( Command::ATTACK, _currentUnit->GetUID(), unitOnCell->GetUID(), index, Board::GetReflectDirection( dir ) );
+                actions.emplace_back( Command::END_TURN, _currentUnit->GetUID() );
 
                 humanturn_exit = true;
             }
@@ -3281,8 +3281,8 @@ void Battle::Interface::MouseLeftClickBoardAction( const int themes, const Cell 
             }
 
             if ( unitOnCell ) {
-                actions.emplace_back( CommandType::MSG_BATTLE_ATTACK, _currentUnit->GetUID(), unitOnCell->GetUID(), index, 0 );
-                actions.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
+                actions.emplace_back( Command::ATTACK, _currentUnit->GetUID(), unitOnCell->GetUID(), index, 0 );
+                actions.emplace_back( Command::END_TURN, _currentUnit->GetUID() );
 
                 humanturn_exit = true;
             }
@@ -6394,7 +6394,7 @@ void Battle::Interface::ProcessingHeroDialogResult( const int result, Actions & 
 
                             if ( hero->CanCastSpell( spell, &error ) ) {
                                 if ( spell.isApplyWithoutFocusObject() ) {
-                                    actions.emplace_back( CommandType::MSG_BATTLE_CAST, spell.GetID(), -1 );
+                                    actions.emplace_back( Command::CAST, spell.GetID(), -1 );
 
                                     humanturn_redraw = true;
                                     humanturn_exit = true;
@@ -6420,8 +6420,8 @@ void Battle::Interface::ProcessingHeroDialogResult( const int result, Actions & 
     case 2: {
         if ( arena.CanRetreatOpponent( _currentUnit->GetCurrentOrArmyColor() ) ) {
             if ( Dialog::YES == fheroes2::showStandardTextMessage( "", _( "Are you sure you want to retreat?" ), Dialog::YES | Dialog::NO ) ) {
-                actions.emplace_back( CommandType::MSG_BATTLE_RETREAT );
-                actions.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
+                actions.emplace_back( Command::RETREAT );
+                actions.emplace_back( Command::END_TURN, _currentUnit->GetUID() );
                 humanturn_exit = true;
             }
         }
@@ -6441,8 +6441,8 @@ void Battle::Interface::ProcessingHeroDialogResult( const int result, Actions & 
                 Kingdom & kingdom = world.GetKingdom( arena.GetCurrentColor() );
 
                 if ( DialogBattleSurrender( *enemy, cost, kingdom ) ) {
-                    actions.emplace_back( CommandType::MSG_BATTLE_SURRENDER );
-                    actions.emplace_back( CommandType::MSG_BATTLE_END_TURN, _currentUnit->GetUID() );
+                    actions.emplace_back( Command::SURRENDER );
+                    actions.emplace_back( Command::END_TURN, _currentUnit->GetUID() );
                     humanturn_exit = true;
                 }
             }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4865,7 +4865,7 @@ void Battle::Interface::RedrawActionTowerPart2( const Tower & tower, const Targe
     assert( _movingUnit == nullptr );
 }
 
-void Battle::Interface::RedrawActionCatapultPart1( const int catapultTargetId, const bool isHit )
+void Battle::Interface::RedrawActionCatapultPart1( const CatapultTarget catapultTarget, const bool isHit )
 {
     // Reset the delay before rendering the first frame of catapult animation.
     Game::AnimateResetDelay( Game::DelayType::BATTLE_CATAPULT_DELAY );
@@ -4891,30 +4891,30 @@ void Battle::Interface::RedrawActionCatapultPart1( const int catapultTargetId, c
 
     // boulder animation
     fheroes2::Point pt1( 30, 290 );
-    fheroes2::Point pt2 = Catapult::GetTargetPosition( catapultTargetId, isHit );
+    fheroes2::Point pt2 = Catapult::GetTargetPosition( catapultTarget, isHit );
     const int32_t boulderArcStep = ( pt2.x - pt1.x ) / 30;
 
     // set the projectile arc height for each castle target and a formula for an unknown target
     int32_t boulderArcHeight;
-    switch ( catapultTargetId ) {
-    case Battle::CAT_WALL1:
+    switch ( catapultTarget ) {
+    case CatapultTarget::CAT_WALL1:
         boulderArcHeight = 220;
         break;
-    case Battle::CAT_WALL2:
-    case Battle::CAT_BRIDGE:
+    case CatapultTarget::CAT_WALL2:
+    case CatapultTarget::CAT_BRIDGE:
         boulderArcHeight = 216;
         break;
-    case Battle::CAT_WALL3:
+    case CatapultTarget::CAT_WALL3:
         boulderArcHeight = 204;
         break;
-    case Battle::CAT_WALL4:
+    case CatapultTarget::CAT_WALL4:
         boulderArcHeight = 208;
         break;
-    case Battle::CAT_TOWER1:
-    case Battle::CAT_TOWER2:
+    case CatapultTarget::CAT_TOWER1:
+    case CatapultTarget::CAT_TOWER2:
         boulderArcHeight = 206;
         break;
-    case Battle::CAT_CENTRAL_TOWER:
+    case CatapultTarget::CAT_CENTRAL_TOWER:
         boulderArcHeight = 290;
         break;
     default:
@@ -4958,7 +4958,7 @@ void Battle::Interface::RedrawActionCatapultPart1( const int catapultTargetId, c
     uint32_t frame = 0;
     // If the building is hit, end the animation on the 5th frame to change the building state (when the smoke cloud is largest).
     uint32_t maxFrame = isHit ? castleBuildingDestroyFrame : fheroes2::AGG::GetICNCount( icn );
-    const bool isBridgeDestroyed = isHit && ( catapultTargetId == Battle::CAT_BRIDGE );
+    const bool isBridgeDestroyed = isHit && ( catapultTarget == CatapultTarget::CAT_BRIDGE );
     // If the bridge is destroyed - prepare parameters for the second smoke cloud.
     if ( isBridgeDestroyed ) {
         pt1 = pt2 + bridgeDestroySmokeOffset;
@@ -4991,11 +4991,11 @@ void Battle::Interface::RedrawActionCatapultPart1( const int catapultTargetId, c
     }
 }
 
-void Battle::Interface::RedrawActionCatapultPart2( const int catapultTargetId )
+void Battle::Interface::RedrawActionCatapultPart2( const CatapultTarget catapultTarget )
 {
     // Finish the smoke cloud animation after the building's state has changed after the hit and it is drawn as demolished.
 
-    const fheroes2::Point pt1 = Catapult::GetTargetPosition( catapultTargetId, true ) + GetArea().getPosition();
+    const fheroes2::Point pt1 = Catapult::GetTargetPosition( catapultTarget, true ) + GetArea().getPosition();
     fheroes2::Point pt2;
 
     // Continue the smoke cloud animation from the 6th frame.
@@ -5003,7 +5003,7 @@ void Battle::Interface::RedrawActionCatapultPart2( const int catapultTargetId )
     uint32_t frame = castleBuildingDestroyFrame;
     const uint32_t maxFrame = fheroes2::AGG::GetICNCount( icnId );
     uint32_t maxAnimationFrame = maxFrame;
-    const bool isBridgeDestroyed = ( catapultTargetId == Battle::CAT_BRIDGE );
+    const bool isBridgeDestroyed = ( catapultTarget == CatapultTarget::CAT_BRIDGE );
     // If the bridge is destroyed - prepare parameters for the second smoke cloud.
     if ( isBridgeDestroyed ) {
         pt2 = pt1 + bridgeDestroySmokeOffset;
@@ -5848,7 +5848,7 @@ void Battle::Interface::RedrawActionArmageddonSpell()
     }
 }
 
-void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<int> & targets )
+void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<CatapultTarget> & targets )
 {
     Cursor & cursor = Cursor::Get();
     LocalEvent & le = LocalEvent::Get();
@@ -5915,8 +5915,8 @@ void Battle::Interface::RedrawActionEarthQuakeSpell( const std::vector<int> & ta
         if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
             RedrawPartialStart();
 
-            for ( std::vector<int>::const_iterator it = targets.begin(); it != targets.end(); ++it ) {
-                fheroes2::Point pt2 = Catapult::GetTargetPosition( *it, true );
+            for ( const CatapultTarget target : targets ) {
+                fheroes2::Point pt2 = Catapult::GetTargetPosition( target, true );
 
                 pt2.x += area.x;
                 pt2.y += area.y;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -315,10 +315,10 @@ namespace Battle
         void RedrawActionLuck( const Unit & unit );
         void RedrawActionTowerPart1( const Tower & tower, const Unit & defender );
         void RedrawActionTowerPart2( const Tower & tower, const TargetInfo & target );
-        void RedrawActionCatapultPart1( const CatapultTarget catapultTarget, const bool isHit );
-        void RedrawActionCatapultPart2( const CatapultTarget catapultTarget );
+        void RedrawActionCatapultPart1( const CastleDefenseElement catapultTarget, const bool isHit );
+        void RedrawActionCatapultPart2( const CastleDefenseElement catapultTarget );
         void RedrawActionTeleportSpell( Unit & target, const int32_t dst );
-        void RedrawActionEarthQuakeSpell( const std::vector<CatapultTarget> & targets );
+        void RedrawActionEarthQuakeSpell( const std::vector<CastleDefenseElement> & targets );
         void RedrawActionSummonElementalSpell( Unit & target );
         void RedrawActionMirrorImageSpell( const Unit & target, const Position & pos );
         void RedrawActionSkipStatus( const Unit & unit );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -33,6 +33,7 @@
 
 #include "battle_animation.h"
 #include "battle_board.h"
+#include "battle_catapult.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "icn.h"
@@ -314,10 +315,10 @@ namespace Battle
         void RedrawActionLuck( const Unit & unit );
         void RedrawActionTowerPart1( const Tower & tower, const Unit & defender );
         void RedrawActionTowerPart2( const Tower & tower, const TargetInfo & target );
-        void RedrawActionCatapultPart1( const int catapultTargetId, const bool isHit );
-        void RedrawActionCatapultPart2( const int catapultTargetId );
+        void RedrawActionCatapultPart1( const CatapultTarget catapultTarget, const bool isHit );
+        void RedrawActionCatapultPart2( const CatapultTarget catapultTarget );
         void RedrawActionTeleportSpell( Unit & target, const int32_t dst );
-        void RedrawActionEarthQuakeSpell( const std::vector<int> & targets );
+        void RedrawActionEarthQuakeSpell( const std::vector<CatapultTarget> & targets );
         void RedrawActionSummonElementalSpell( Unit & target );
         void RedrawActionMirrorImageSpell( const Unit & target, const Position & pos );
         void RedrawActionSkipStatus( const Unit & unit );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -31,9 +31,9 @@
 #include <utility>
 #include <vector>
 
+#include "battle.h"
 #include "battle_animation.h"
 #include "battle_board.h"
-#include "battle_catapult.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "icn.h"
@@ -63,9 +63,6 @@ namespace Battle
     class Tower;
     class Unit;
     class Units;
-
-    struct TargetInfo;
-    struct TargetsInfo;
 
     void DialogBattleSettings();
     bool DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdom & kingdom );

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -175,35 +175,35 @@ namespace
         const Skill::Secondary eagleeye( Skill::Secondary::EAGLEEYE, hero.GetLevelSkill( Skill::Secondary::EAGLEEYE ) );
 
         // filter spells
-        for ( SpellStorage::const_iterator it = spells.begin(); it != spells.end(); ++it ) {
-            const Spell & sp = *it;
-            if ( !hero.HaveSpell( sp ) ) {
-                switch ( eagleeye.Level() ) {
-                case Skill::Level::BASIC:
-                    // 20%
-                    if ( 3 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
-                        new_spells.push_back( sp );
-                    break;
-                case Skill::Level::ADVANCED:
-                    // 30%
-                    if ( 4 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
-                        new_spells.push_back( sp );
-                    break;
-                case Skill::Level::EXPERT:
-                    // 40%
-                    if ( 5 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
-                        new_spells.push_back( sp );
-                    break;
-                default:
-                    break;
-                }
+        for ( const Spell & sp : spells ) {
+            if ( hero.HaveSpell( sp ) ) {
+                continue;
+            }
+
+            switch ( eagleeye.Level() ) {
+            case Skill::Level::BASIC:
+                // 20%
+                if ( 3 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
+                    new_spells.push_back( sp );
+                break;
+            case Skill::Level::ADVANCED:
+                // 30%
+                if ( 4 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
+                    new_spells.push_back( sp );
+                break;
+            case Skill::Level::EXPERT:
+                // 40%
+                if ( 5 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
+                    new_spells.push_back( sp );
+                break;
+            default:
+                break;
             }
         }
 
         // add new spell
-        for ( SpellStorage::const_iterator it = new_spells.begin(); it != new_spells.end(); ++it ) {
-            const Spell & sp = *it;
-            if ( local ) {
+        if ( local ) {
+            for ( const Spell & sp : new_spells ) {
                 std::string msg = _( "Through eagle-eyed observation, %{name} is able to learn the magic spell %{spell}." );
                 StringReplace( msg, "%{name}", hero.GetName() );
                 StringReplace( msg, "%{spell}", sp.GetName() );

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -57,12 +57,6 @@
 #include "ui_text.h"
 #include "world.h"
 
-namespace Battle
-{
-    void EagleEyeSkillAction( HeroBase &, const SpellStorage &, bool, const Rand::DeterministicRandomGenerator & randomGenerator );
-    void NecromancySkillAction( HeroBase & hero, const uint32_t enemyTroopsKilled, const bool isControlHuman );
-}
-
 namespace
 {
     std::vector<Artifact> planArtifactTransfer( const BagArtifacts & winnerBag, const BagArtifacts & loserBag )
@@ -168,6 +162,78 @@ namespace
             return Battle::RESULT_WINS;
 
         return 0;
+    }
+
+    void eagleEyeSkillAction( HeroBase & hero, const SpellStorage & spells, bool local, const Rand::DeterministicRandomGenerator & randomGenerator )
+    {
+        if ( spells.empty() || !hero.HaveSpellBook() )
+            return;
+
+        SpellStorage new_spells;
+        new_spells.reserve( 10 );
+
+        const Skill::Secondary eagleeye( Skill::Secondary::EAGLEEYE, hero.GetLevelSkill( Skill::Secondary::EAGLEEYE ) );
+
+        // filter spells
+        for ( SpellStorage::const_iterator it = spells.begin(); it != spells.end(); ++it ) {
+            const Spell & sp = *it;
+            if ( !hero.HaveSpell( sp ) ) {
+                switch ( eagleeye.Level() ) {
+                case Skill::Level::BASIC:
+                    // 20%
+                    if ( 3 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
+                        new_spells.push_back( sp );
+                    break;
+                case Skill::Level::ADVANCED:
+                    // 30%
+                    if ( 4 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
+                        new_spells.push_back( sp );
+                    break;
+                case Skill::Level::EXPERT:
+                    // 40%
+                    if ( 5 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
+                        new_spells.push_back( sp );
+                    break;
+                default:
+                    break;
+                }
+            }
+        }
+
+        // add new spell
+        for ( SpellStorage::const_iterator it = new_spells.begin(); it != new_spells.end(); ++it ) {
+            const Spell & sp = *it;
+            if ( local ) {
+                std::string msg = _( "Through eagle-eyed observation, %{name} is able to learn the magic spell %{spell}." );
+                StringReplace( msg, "%{name}", hero.GetName() );
+                StringReplace( msg, "%{spell}", sp.GetName() );
+                Game::PlayPickupSound();
+
+                const fheroes2::SpellDialogElement spellUI( sp, &hero );
+                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK, { &spellUI } );
+            }
+        }
+
+        hero.AppendSpellsToBook( new_spells, true );
+    }
+
+    void necromancySkillAction( HeroBase & hero, const uint32_t enemyTroopsKilled, const bool isControlHuman )
+    {
+        Army & army = hero.GetArmy();
+
+        if ( 0 == enemyTroopsKilled || ( army.isFullHouse() && !army.HasMonster( Monster::SKELETON ) ) )
+            return;
+
+        const uint32_t necromancyPercent = GetNecromancyPercent( hero );
+
+        uint32_t raiseCount = std::max( enemyTroopsKilled * necromancyPercent / 100, 1U );
+        army.JoinTroop( Monster::SKELETON, raiseCount, false );
+
+        if ( isControlHuman ) {
+            Battle::Arena::DialogBattleNecromancy( raiseCount );
+        }
+
+        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "raise: " << raiseCount << " skeletons" )
     }
 }
 
@@ -335,11 +401,11 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
 
         // eagle eye capability
         if ( winnerHero && loserHero && winnerHero->GetLevelSkill( Skill::Secondary::EAGLEEYE ) && loserHero->isHeroes() )
-            EagleEyeSkillAction( *winnerHero, arena.GetUsageSpells(), winnerHero->isControlHuman(), randomGenerator );
+            eagleEyeSkillAction( *winnerHero, arena.GetUsageSpells(), winnerHero->isControlHuman(), randomGenerator );
 
         // necromancy capability
         if ( winnerHero && winnerHero->GetLevelSkill( Skill::Secondary::NECROMANCY ) )
-            NecromancySkillAction( *winnerHero, result.killed, winnerHero->isControlHuman() );
+            necromancySkillAction( *winnerHero, result.killed, winnerHero->isControlHuman() );
 
         if ( winnerHero ) {
             const Heroes * kingdomHero = dynamic_cast<const Heroes *>( winnerHero );
@@ -368,77 +434,6 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
     DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army1: " << ( result.army1 & RESULT_WINS ? "wins" : "loss" ) << ", army2: " << ( result.army2 & RESULT_WINS ? "wins" : "loss" ) )
 
     return result;
-}
-
-void Battle::EagleEyeSkillAction( HeroBase & hero, const SpellStorage & spells, bool local, const Rand::DeterministicRandomGenerator & randomGenerator )
-{
-    if ( spells.empty() || !hero.HaveSpellBook() )
-        return;
-
-    SpellStorage new_spells;
-    new_spells.reserve( 10 );
-
-    const Skill::Secondary eagleeye( Skill::Secondary::EAGLEEYE, hero.GetLevelSkill( Skill::Secondary::EAGLEEYE ) );
-
-    // filter spells
-    for ( SpellStorage::const_iterator it = spells.begin(); it != spells.end(); ++it ) {
-        const Spell & sp = *it;
-        if ( !hero.HaveSpell( sp ) ) {
-            switch ( eagleeye.Level() ) {
-            case Skill::Level::BASIC:
-                // 20%
-                if ( 3 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
-                    new_spells.push_back( sp );
-                break;
-            case Skill::Level::ADVANCED:
-                // 30%
-                if ( 4 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
-                    new_spells.push_back( sp );
-                break;
-            case Skill::Level::EXPERT:
-                // 40%
-                if ( 5 > sp.Level() && eagleeye.GetValues() >= randomGenerator.Get( 1, 100 ) )
-                    new_spells.push_back( sp );
-                break;
-            default:
-                break;
-            }
-        }
-    }
-
-    // add new spell
-    for ( SpellStorage::const_iterator it = new_spells.begin(); it != new_spells.end(); ++it ) {
-        const Spell & sp = *it;
-        if ( local ) {
-            std::string msg = _( "Through eagle-eyed observation, %{name} is able to learn the magic spell %{spell}." );
-            StringReplace( msg, "%{name}", hero.GetName() );
-            StringReplace( msg, "%{spell}", sp.GetName() );
-            Game::PlayPickupSound();
-
-            const fheroes2::SpellDialogElement spellUI( sp, &hero );
-            fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK, { &spellUI } );
-        }
-    }
-
-    hero.AppendSpellsToBook( new_spells, true );
-}
-
-void Battle::NecromancySkillAction( HeroBase & hero, const uint32_t enemyTroopsKilled, const bool isControlHuman )
-{
-    Army & army = hero.GetArmy();
-
-    if ( 0 == enemyTroopsKilled || ( army.isFullHouse() && !army.HasMonster( Monster::SKELETON ) ) )
-        return;
-
-    const uint32_t necromancyPercent = GetNecromancyPercent( hero );
-
-    uint32_t raiseCount = std::max( enemyTroopsKilled * necromancyPercent / 100, 1U );
-    army.JoinTroop( Monster::SKELETON, raiseCount, false );
-
-    if ( isControlHuman )
-        Arena::DialogBattleNecromancy( raiseCount );
-
-    DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "raise: " << raiseCount << " skeletons" )
 }
 
 uint32_t Battle::Result::AttackerResult() const

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -164,7 +164,7 @@ namespace
         return 0;
     }
 
-    void eagleEyeSkillAction( HeroBase & hero, const SpellStorage & spells, bool local, const Rand::DeterministicRandomGenerator & randomGenerator )
+    void eagleEyeSkillAction( HeroBase & hero, const SpellStorage & spells, bool local, Rand::DeterministicRandomGenerator & randomGenerator )
     {
         if ( spells.empty() || !hero.HaveSpellBook() )
             return;

--- a/src/fheroes2/battle/battle_tower.cpp
+++ b/src/fheroes2/battle/battle_tower.cpp
@@ -34,7 +34,6 @@
 #include "battle_cell.h"
 #include "castle.h"
 #include "monster.h"
-#include "rand.h"
 #include "tools.h"
 #include "translations.h"
 

--- a/src/fheroes2/battle/battle_tower.cpp
+++ b/src/fheroes2/battle/battle_tower.cpp
@@ -38,8 +38,8 @@
 #include "tools.h"
 #include "translations.h"
 
-Battle::Tower::Tower( const Castle & castle, const TowerType type, const Rand::DeterministicRandomGenerator & randomGenerator, const uint32_t uid )
-    : Unit( Troop( Monster::ARCHER, castle.CountBuildings() ), {}, false, randomGenerator, uid )
+Battle::Tower::Tower( const Castle & castle, const TowerType type, const uint32_t uid )
+    : Unit( Troop( Monster::ARCHER, castle.CountBuildings() ), {}, false, uid )
     , _towerType( type )
     , _attackBonus( castle.GetLevelMageGuild() )
     , _isValid( true )
@@ -160,7 +160,7 @@ std::string Battle::Tower::GetInfo( const Castle & castle )
         const TowerType towerType = *it;
 
         if ( isTowerValid( towerType ) ) {
-            const Tower tower( castle, towerType, Rand::DeterministicRandomGenerator( 0 ), 0 );
+            const Tower tower( castle, towerType, 0 );
 
             msg.append( _( "The %{name} fires with the strength of %{count} Archers" ) );
             StringReplace( msg, "%{name}", tower.GetName() );

--- a/src/fheroes2/battle/battle_tower.h
+++ b/src/fheroes2/battle/battle_tower.h
@@ -30,11 +30,6 @@
 #include "battle_troop.h"
 #include "math_base.h"
 
-namespace Rand
-{
-    class DeterministicRandomGenerator;
-}
-
 class Castle;
 
 namespace Battle

--- a/src/fheroes2/battle/battle_tower.h
+++ b/src/fheroes2/battle/battle_tower.h
@@ -49,7 +49,7 @@ namespace Battle
     class Tower : public Unit
     {
     public:
-        Tower( const Castle & castle, const TowerType type, const Rand::DeterministicRandomGenerator & randomGenerator, const uint32_t uid );
+        Tower( const Castle & castle, const TowerType type, const uint32_t uid );
         Tower( const Tower & ) = delete;
 
         Tower & operator=( const Tower & ) = delete;

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -118,7 +118,7 @@ uint32_t Battle::ModesAffected::FindZeroDuration() const
     return it == end() ? 0 : ( *it ).first;
 }
 
-Battle::Unit::Unit( const Troop & t, const Position & pos, const bool ref, const Rand::DeterministicRandomGenerator & randomGenerator, const uint32_t uid )
+Battle::Unit::Unit( const Troop & t, const Position & pos, const bool ref, const uint32_t uid )
     : ArmyTroop( nullptr, t )
     , animation( id )
     , _uid( uid )
@@ -132,7 +132,6 @@ Battle::Unit::Unit( const Troop & t, const Position & pos, const bool ref, const
     , idleTimer( animation.getIdleDelay() )
     , _blindRetaliation( false )
     , customAlphaMask( 255 )
-    , _randomGenerator( randomGenerator )
 {
     SetPosition( pos );
 }
@@ -292,28 +291,28 @@ int32_t Battle::Unit::GetTailIndex() const
     return position.GetTail() ? position.GetTail()->GetIndex() : -1;
 }
 
-void Battle::Unit::SetRandomMorale()
+void Battle::Unit::SetRandomMorale( const Rand::DeterministicRandomGenerator & randomGenerator )
 {
     const int morale = GetMorale();
 
-    if ( morale > 0 && static_cast<int32_t>( _randomGenerator.Get( 1, 24 ) ) <= morale ) {
+    if ( morale > 0 && static_cast<int32_t>( randomGenerator.Get( 1, 24 ) ) <= morale ) {
         SetModes( MORALE_GOOD );
     }
-    else if ( morale < 0 && static_cast<int32_t>( _randomGenerator.Get( 1, 12 ) ) <= -morale ) {
+    else if ( morale < 0 && static_cast<int32_t>( randomGenerator.Get( 1, 12 ) ) <= -morale ) {
         if ( isControlHuman() ) {
             SetModes( MORALE_BAD );
         }
         // AI is given a cheeky 25% chance to avoid it - because they build armies from random troops
-        else if ( _randomGenerator.Get( 1, 4 ) != 1 ) {
+        else if ( randomGenerator.Get( 1, 4 ) != 1 ) {
             SetModes( MORALE_BAD );
         }
     }
 }
 
-void Battle::Unit::SetRandomLuck()
+void Battle::Unit::SetRandomLuck( const Rand::DeterministicRandomGenerator & randomGenerator )
 {
     const int32_t luck = GetLuck();
-    const int32_t chance = static_cast<int32_t>( _randomGenerator.Get( 1, 24 ) );
+    const int32_t chance = static_cast<int32_t>( randomGenerator.Get( 1, 24 ) );
 
     if ( luck > 0 && chance <= luck ) {
         SetModes( LUCK_GOOD );
@@ -596,7 +595,7 @@ uint32_t Battle::Unit::CalculateDamageUnit( const Unit & enemy, double dmg ) con
     return static_cast<uint32_t>( dmg ) < 1 ? 1 : static_cast<uint32_t>( dmg );
 }
 
-uint32_t Battle::Unit::GetDamage( const Unit & enemy ) const
+uint32_t Battle::Unit::GetDamage( const Unit & enemy, const Rand::DeterministicRandomGenerator & randomGenerator ) const
 {
     uint32_t res = 0;
 
@@ -605,7 +604,7 @@ uint32_t Battle::Unit::GetDamage( const Unit & enemy ) const
     else if ( Modes( SP_CURSE ) )
         res = CalculateMinDamage( enemy );
     else
-        res = _randomGenerator.Get( CalculateMinDamage( enemy ), CalculateMaxDamage( enemy ) );
+        res = randomGenerator.Get( CalculateMinDamage( enemy ), CalculateMaxDamage( enemy ) );
 
     if ( Modes( LUCK_GOOD ) )
         res = res * 2;
@@ -1607,7 +1606,7 @@ uint32_t Battle::Unit::GetMagicResist( const Spell & spell, const uint32_t attac
     return fheroes2::getSpellResistance( id, spell.GetID() );
 }
 
-int Battle::Unit::GetSpellMagic() const
+int Battle::Unit::GetSpellMagic( const Rand::DeterministicRandomGenerator & randomGenerator ) const
 {
     const std::vector<fheroes2::MonsterAbility> & abilities = fheroes2::getMonsterData( GetID() ).battleStats.abilities;
     const auto foundAbility = std::find( abilities.begin(), abilities.end(), fheroes2::MonsterAbility( fheroes2::MonsterAbilityType::SPELL_CASTER ) );
@@ -1616,7 +1615,7 @@ int Battle::Unit::GetSpellMagic() const
         return Spell::NONE;
     }
 
-    if ( _randomGenerator.Get( 1, 100 ) > foundAbility->percentage ) {
+    if ( randomGenerator.Get( 1, 100 ) > foundAbility->percentage ) {
         // No luck to cast the spell.
         return Spell::NONE;
     }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -291,7 +291,7 @@ int32_t Battle::Unit::GetTailIndex() const
     return position.GetTail() ? position.GetTail()->GetIndex() : -1;
 }
 
-void Battle::Unit::SetRandomMorale( const Rand::DeterministicRandomGenerator & randomGenerator )
+void Battle::Unit::SetRandomMorale( Rand::DeterministicRandomGenerator & randomGenerator )
 {
     const int morale = GetMorale();
 
@@ -309,7 +309,7 @@ void Battle::Unit::SetRandomMorale( const Rand::DeterministicRandomGenerator & r
     }
 }
 
-void Battle::Unit::SetRandomLuck( const Rand::DeterministicRandomGenerator & randomGenerator )
+void Battle::Unit::SetRandomLuck( Rand::DeterministicRandomGenerator & randomGenerator )
 {
     const int32_t luck = GetLuck();
     const int32_t chance = static_cast<int32_t>( randomGenerator.Get( 1, 24 ) );
@@ -595,7 +595,7 @@ uint32_t Battle::Unit::CalculateDamageUnit( const Unit & enemy, double dmg ) con
     return static_cast<uint32_t>( dmg ) < 1 ? 1 : static_cast<uint32_t>( dmg );
 }
 
-uint32_t Battle::Unit::GetDamage( const Unit & enemy, const Rand::DeterministicRandomGenerator & randomGenerator ) const
+uint32_t Battle::Unit::GetDamage( const Unit & enemy, Rand::DeterministicRandomGenerator & randomGenerator ) const
 {
     uint32_t res = 0;
 
@@ -1606,7 +1606,7 @@ uint32_t Battle::Unit::GetMagicResist( const Spell & spell, const uint32_t attac
     return fheroes2::getSpellResistance( id, spell.GetID() );
 }
 
-int Battle::Unit::GetSpellMagic( const Rand::DeterministicRandomGenerator & randomGenerator ) const
+int Battle::Unit::GetSpellMagic( Rand::DeterministicRandomGenerator & randomGenerator ) const
 {
     const std::vector<fheroes2::MonsterAbility> & abilities = fheroes2::getMonsterData( GetID() ).battleStats.abilities;
     const auto foundAbility = std::find( abilities.begin(), abilities.end(), fheroes2::MonsterAbility( fheroes2::MonsterAbilityType::SPELL_CASTER ) );

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -99,8 +99,8 @@ namespace Battle
             mirror = ptr;
         }
 
-        void SetRandomMorale( const Rand::DeterministicRandomGenerator & randomGenerator );
-        void SetRandomLuck( const Rand::DeterministicRandomGenerator & randomGenerator );
+        void SetRandomMorale( Rand::DeterministicRandomGenerator & randomGenerator );
+        void SetRandomLuck( Rand::DeterministicRandomGenerator & randomGenerator );
         void NewTurn();
 
         bool isFlying() const;
@@ -164,7 +164,7 @@ namespace Battle
 
         uint32_t GetSpeed( const bool skipStandingCheck, const bool skipMovedCheck ) const;
 
-        uint32_t GetDamage( const Unit & enemy, const Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        uint32_t GetDamage( const Unit & enemy, Rand::DeterministicRandomGenerator & randomGenerator ) const;
 
         int32_t GetScoreQuality( const Unit & ) const;
 
@@ -258,7 +258,7 @@ namespace Battle
         void PostKilledAction();
 
         uint32_t GetMagicResist( const Spell & spell, const uint32_t attackingArmySpellPower, const HeroBase * attackingHero ) const;
-        int GetSpellMagic( const Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        int GetSpellMagic( Rand::DeterministicRandomGenerator & randomGenerator ) const;
 
         const HeroBase * GetCommander() const;
         const HeroBase * GetCurrentOrArmyCommander() const; // commander of the army with the current unit color (if valid), commander of the unit's army otherwise

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -74,7 +74,7 @@ namespace Battle
     class Unit : public ArmyTroop, public BitModes, public Control
     {
     public:
-        Unit( const Troop & t, const Position & pos, const bool ref, const Rand::DeterministicRandomGenerator & randomGenerator, const uint32_t uid );
+        Unit( const Troop & t, const Position & pos, const bool ref, const uint32_t uid );
         Unit( const Unit & ) = delete;
 
         Unit & operator=( const Unit & ) = delete;
@@ -99,8 +99,8 @@ namespace Battle
             mirror = ptr;
         }
 
-        void SetRandomMorale();
-        void SetRandomLuck();
+        void SetRandomMorale( const Rand::DeterministicRandomGenerator & randomGenerator );
+        void SetRandomLuck( const Rand::DeterministicRandomGenerator & randomGenerator );
         void NewTurn();
 
         bool isFlying() const;
@@ -164,7 +164,7 @@ namespace Battle
 
         uint32_t GetSpeed( const bool skipStandingCheck, const bool skipMovedCheck ) const;
 
-        uint32_t GetDamage( const Unit & ) const;
+        uint32_t GetDamage( const Unit & enemy, const Rand::DeterministicRandomGenerator & randomGenerator ) const;
 
         int32_t GetScoreQuality( const Unit & ) const;
 
@@ -258,7 +258,7 @@ namespace Battle
         void PostKilledAction();
 
         uint32_t GetMagicResist( const Spell & spell, const uint32_t attackingArmySpellPower, const HeroBase * attackingHero ) const;
-        int GetSpellMagic() const;
+        int GetSpellMagic( const Rand::DeterministicRandomGenerator & randomGenerator ) const;
 
         const HeroBase * GetCommander() const;
         const HeroBase * GetCurrentOrArmyCommander() const; // commander of the army with the current unit color (if valid), commander of the unit's army otherwise
@@ -322,8 +322,6 @@ namespace Battle
         bool _blindRetaliation;
 
         uint8_t customAlphaMask;
-
-        const Rand::DeterministicRandomGenerator & _randomGenerator;
     };
 }
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2491,7 +2491,7 @@ double Castle::GetGarrisonStrength( const Heroes * attackingHero ) const
 
     // Add castle bonuses if there are any troops defending the castle
     if ( isCastle() && totalStrength > 0.1 ) {
-        const Battle::Tower tower( *this, Battle::TowerType::TWR_CENTER, Rand::DeterministicRandomGenerator( 0 ), 0 );
+        const Battle::Tower tower( *this, Battle::TowerType::TWR_CENTER, 0 );
         const double towerStr = tower.GetStrengthWithBonus( tower.GetAttackBonus(), 0 );
 
         totalStrength += towerStr;


### PR DESCRIPTION
fix #7964

This PR prohibits the use of the `Battle::Arena`'s random generator by external code (mostly by AI decision-making code), which was the main reason for the non-reproducibility by a human of results of battles performed by AI.

It also redesignes the `Battle::Commands` in order to be able to perform additional checks at compile time and introduces a few minor improvements.