### PR TITLE
Fix description text in Wizard's Isle 3rd scenario.

### DIFF
--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -508,7 +508,7 @@ namespace
                 "Your mission is to vanquish the warring mages in the magical Shrouded Isles. The completion of this task will give you a fighting chance against your rivals." ),
             gettext_noop( "The location of the great library has been discovered! You must make your way to it, and reclaim the city of Chronos in which it lies." ),
             gettext_noop(
-                "Find the Orb of negation, which is said to be buried in this land. There are clues inscribed on stone obelisks which will help lead you to your price. Find the orb before the first day of the sixth month, or your rivals will surely have gotten to the fount before you." ),
+                "Find the Orb of negation, which is said to be buried in this land. There are clues inscribed on stone obelisks which will help lead you to your prize. Find the Orb before the first day of the sixth month, or your rivals will surely have gotten to the fount before you." ),
             gettext_noop( "You must take control of the castle of Magic, where the fount of wizardry lies. Do this and your victory will be supreme." ) };
         std::vector<Campaign::ScenarioData> scenarioDatas;
         scenarioDatas.reserve( 4 );


### PR DESCRIPTION
Prize and not Price. Orb with capital O. This PR also makes it the same as the OG.