### PR TITLE
Move the barrier color constants to the anonymous namespace and fix the patrol zone for imprisoned heroes

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -412,7 +412,7 @@ void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int
     //     Is AI hero on patrol?
     //
     // - uint8_t (1 byte)
-    //     AI hero patrol distance.
+    //     Patrol distance of an AI hero, if this hero is placed on the map, or the race of this hero, if this hero is in Jail.
     //
     // - unused 15 bytes
     //    Always zeros.
@@ -569,10 +569,11 @@ void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int
         SetModes( PATROL );
 
         _patrolCenter = GetCenter();
+        _patrolDistance = dataStream.get();
     }
-
-    // Patrol distance
-    _patrolDistance = dataStream.get();
+    else {
+        dataStream.skip( 1 );
+    }
 
     // TODO: remove this temporary assertion
     assert( _objectTypeUnderHero == MP2::OBJ_NONE );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -412,7 +412,7 @@ void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int
     //     Is AI hero on patrol?
     //
     // - uint8_t (1 byte)
-    //     Patrol distance of an AI hero, if this hero is placed on the map, or the race of this hero, if this hero is in Jail.
+    //     Patrol distance of this hero, if this is an AI hero placed on the map, or the race of this hero, if this hero is in Jail.
     //
     // - unused 15 bytes
     //    Always zeros.

--- a/src/fheroes2/kingdom/color.cpp
+++ b/src/fheroes2/kingdom/color.cpp
@@ -22,11 +22,28 @@
  ***************************************************************************/
 
 #include "color.h"
+
 #include "players.h"
 #include "serialize.h"
 #include "tools.h"
 #include "translations.h"
 #include "world.h"
+
+namespace
+{
+    enum class BarrierColor : int
+    {
+        NONE = 0,
+        AQUA = 1,
+        BLUE = 2,
+        BROWN = 3,
+        GOLD = 4,
+        GREEN = 5,
+        ORANGE = 6,
+        PURPLE = 7,
+        RED = 8
+    };
+}
 
 std::string Color::String( int color )
 {
@@ -139,22 +156,22 @@ uint8_t Color::IndexToColor( const int index )
 
 const char * fheroes2::getBarrierColorName( const int color )
 {
-    switch ( color ) {
-    case AQUA:
+    switch ( static_cast<BarrierColor>( color ) ) {
+    case BarrierColor::AQUA:
         return _( "barrier|Aqua" );
-    case BLUE:
+    case BarrierColor::BLUE:
         return _( "barrier|Blue" );
-    case BROWN:
+    case BarrierColor::BROWN:
         return _( "barrier|Brown" );
-    case GOLD:
+    case BarrierColor::GOLD:
         return _( "barrier|Gold" );
-    case GREEN:
+    case BarrierColor::GREEN:
         return _( "barrier|Green" );
-    case ORANGE:
+    case BarrierColor::ORANGE:
         return _( "barrier|Orange" );
-    case PURPLE:
+    case BarrierColor::PURPLE:
         return _( "barrier|Purple" );
-    case RED:
+    case BarrierColor::RED:
         return _( "barrier|Red" );
     default:
         break;
@@ -165,22 +182,22 @@ const char * fheroes2::getBarrierColorName( const int color )
 
 const char * fheroes2::getTentColorName( const int color )
 {
-    switch ( color ) {
-    case AQUA:
+    switch ( static_cast<BarrierColor>( color ) ) {
+    case BarrierColor::AQUA:
         return _( "tent|Aqua" );
-    case BLUE:
+    case BarrierColor::BLUE:
         return _( "tent|Blue" );
-    case BROWN:
+    case BarrierColor::BROWN:
         return _( "tent|Brown" );
-    case GOLD:
+    case BarrierColor::GOLD:
         return _( "tent|Gold" );
-    case GREEN:
+    case BarrierColor::GREEN:
         return _( "tent|Green" );
-    case ORANGE:
+    case BarrierColor::ORANGE:
         return _( "tent|Orange" );
-    case PURPLE:
+    case BarrierColor::PURPLE:
         return _( "tent|Purple" );
-    case RED:
+    case BarrierColor::RED:
         return _( "tent|Red" );
     default:
         break;

--- a/src/fheroes2/kingdom/color.h
+++ b/src/fheroes2/kingdom/color.h
@@ -31,18 +31,6 @@ class StreamBase;
 
 namespace fheroes2
 {
-    enum ObjectColor
-    {
-        NONE = 0,
-        AQUA = 1,
-        BLUE = 2,
-        BROWN = 3,
-        GOLD = 4,
-        GREEN = 5,
-        ORANGE = 6,
-        PURPLE = 7,
-        RED = 8
-    };
     const char * getBarrierColorName( const int color );
     const char * getTentColorName( const int color );
 }


### PR DESCRIPTION
Fixing the patrol zone is merely a cosmetic action, but it helps to avoid some confusion.