### PR TITLE
Move scrollbar background and button rendering code to 'ui_window'

### DIFF
--- a/src/fheroes2/dialog/dialog_hotkeys.cpp
+++ b/src/fheroes2/dialog/dialog_hotkeys.cpp
@@ -246,50 +246,20 @@ namespace fheroes2
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
         // Prepare OKAY button and render its shadow.
+        fheroes2::Button buttonOk;
         const int buttonOkIcn = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
-        const fheroes2::Sprite & buttonOkSprite = fheroes2::AGG::GetICN( buttonOkIcn, 0 );
-        fheroes2::Button buttonOk( roi.x + ( roi.width - buttonOkSprite.width() ) / 2, roi.y + roi.height - 32, buttonOkIcn, 0, 1 );
-        fheroes2::addGradientShadow( buttonOkSprite, display, buttonOk.area().getPosition(), { -5, 5 } );
-        buttonOk.draw();
+        background.renderButton( buttonOk, buttonOkIcn, 0, 1, { 0, 7 }, StandardWindow::Padding::BOTTOM_CENTER );
 
         HotKeyList listbox( roi.getPosition() );
         listbox.initListBackgroundRestorer( listRoi );
         listbox.SetAreaItems( { listRoi.x, listRoi.y + 3, listRoi.width - 3, listRoi.height - 4 } );
 
-        // Render the scrollbar.
-        const fheroes2::Sprite & scrollBar = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
         int32_t scrollbarOffsetX = roi.x + roi.width - 35;
+        background.renderScrollbarBackground( { scrollbarOffsetX, listRoi.y, listRoi.width, listRoi.height }, isEvilInterface );
 
-        // Top part of scrollbar background.
         const int32_t topPartHeight = 19;
-        const int32_t scrollBarWidth = 16;
-        fheroes2::Copy( scrollBar, 536, 176, display, scrollbarOffsetX, listRoi.y, scrollBarWidth, topPartHeight );
-
-        // Middle part of scrollbar background.
-        int32_t offsetY = topPartHeight;
-        const int32_t middlePartHeight = 88;
-        const int32_t middlePartCount = ( listRoi.height - 2 * topPartHeight + middlePartHeight - 1 ) / middlePartHeight;
-
-        for ( int32_t i = 0; i < middlePartCount; ++i ) {
-            fheroes2::Copy( scrollBar, 536, 196, display, scrollbarOffsetX, listRoi.y + offsetY, scrollBarWidth,
-                            std::min( middlePartHeight, listRoi.height - offsetY - topPartHeight ) );
-            offsetY += middlePartHeight;
-        }
-
-        // Bottom part of scrollbar background.
-        fheroes2::Copy( scrollBar, 536, 285, display, scrollbarOffsetX, listRoi.y + listRoi.height - topPartHeight, scrollBarWidth, topPartHeight );
-
         const int listIcnId = isEvilInterface ? ICN::SCROLLE : ICN::SCROLL;
-
         ++scrollbarOffsetX;
-
-        // Make scrollbar shadow.
-        for ( uint8_t i = 0; i < 4; ++i ) {
-            const uint8_t transformId = i + 2;
-            const int32_t sizeCorrection = i + 1;
-            fheroes2::ApplyTransform( display, scrollbarOffsetX - transformId, listRoi.y + sizeCorrection, 1, listRoi.height - sizeCorrection, transformId );
-            fheroes2::ApplyTransform( display, scrollbarOffsetX - transformId, listRoi.y + listRoi.height + i, scrollBarWidth, 1, transformId );
-        }
 
         listbox.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, listRoi.y + 1 } );
         listbox.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, listRoi.y + listRoi.height - 15 } );

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -71,8 +71,7 @@ public:
         fheroes2::Display & display = fheroes2::Display::instance();
         background = std::make_unique<fheroes2::StandardWindow>( dialogSize.width, dialogSize.height, true, display );
 
-        const fheroes2::Rect area = background->activeArea();
-
+        const fheroes2::Rect area( background->activeArea() );
         const fheroes2::Rect listRoi( area.x + 10, area.y + 30, area.width - 40, area.height - 70 );
 
         background->applyTextBackgroundShading( listRoi );
@@ -82,66 +81,20 @@ public:
         SetAreaItems( { listRoi.x + 5, listRoi.y + 5, listRoi.width - 10, listRoi.height - 10 } );
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
+        const int32_t scrollbarOffsetX = area.x + area.width - 25;
 
-        const fheroes2::Sprite & scrollBar = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
+        background->renderScrollbarBackground( { scrollbarOffsetX, listRoi.y, listRoi.width, listRoi.height }, isEvilInterface );
 
-        int32_t scrollbarOffsetX = area.x + area.width - 25;
-
-        // Top part of scrollbar background.
         const int32_t topPartHeight = 19;
-        const int32_t scrollBarWidth = 16;
-        fheroes2::Copy( scrollBar, 536, 176, display, scrollbarOffsetX, listRoi.y, scrollBarWidth, topPartHeight );
-
-        // Middle part of scrollbar background.
-        int32_t offsetY = topPartHeight;
-        const int32_t middlePartHeight = 88;
-        const int32_t middlePartCount = ( listRoi.height - 2 * topPartHeight + middlePartHeight - 1 ) / middlePartHeight;
-
-        for ( int32_t i = 0; i < middlePartCount; ++i ) {
-            fheroes2::Copy( scrollBar, 536, 196, display, scrollbarOffsetX, listRoi.y + offsetY, scrollBarWidth,
-                            std::min( middlePartHeight, listRoi.height - offsetY - topPartHeight ) );
-            offsetY += middlePartHeight;
-        }
-
-        // Bottom part of scrollbar background.
-        fheroes2::Copy( scrollBar, 536, 285, display, scrollbarOffsetX, listRoi.y + listRoi.height - topPartHeight, scrollBarWidth, topPartHeight );
-
         const int listIcnId = isEvilInterface ? ICN::SCROLLE : ICN::SCROLL;
 
-        ++scrollbarOffsetX;
-
-        SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, listRoi.y + 1 } );
-        SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, listRoi.y + listRoi.height - 15 } );
-
-        setScrollBarArea( { scrollbarOffsetX + 2, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-
+        SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX + 1, listRoi.y + 1 } );
+        SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX + 1, listRoi.y + listRoi.height - 15 } );
+        setScrollBarArea( { scrollbarOffsetX + 3, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
         setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
 
-        // Make scrollbar shadow.
-        for ( uint8_t i = 0; i < 4; ++i ) {
-            const uint8_t transformId = i + 2;
-            const int32_t sizeCorrection = i + 1;
-            fheroes2::ApplyTransform( display, scrollbarOffsetX - transformId, listRoi.y + sizeCorrection, 1, listRoi.height - sizeCorrection, transformId );
-            fheroes2::ApplyTransform( display, scrollbarOffsetX - transformId, listRoi.y + listRoi.height + i, scrollBarWidth, 1, transformId );
-        }
-
-        // Dialog buttons.
-        const int32_t buttonFromBorderOffsetX = 20;
-        const int32_t buttonY = listRoi.y + listRoi.height + 7;
-
-        const int buttonOkIcn = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
-        buttonOk.setICNInfo( buttonOkIcn, 0, 1 );
-        buttonOk.setPosition( area.x + buttonFromBorderOffsetX, buttonY );
-        const fheroes2::Sprite & buttonOkSprite = fheroes2::AGG::GetICN( buttonOkIcn, 0 );
-        fheroes2::addGradientShadow( buttonOkSprite, display, buttonOk.area().getPosition(), { -5, 5 } );
-        buttonOk.draw();
-
-        const int buttonCancelIcn = isEvilInterface ? ICN::BUTTON_SMALL_CANCEL_EVIL : ICN::BUTTON_SMALL_CANCEL_GOOD;
-        buttonCancel.setICNInfo( buttonCancelIcn, 0, 1 );
-        const fheroes2::Sprite & buttonCancelSprite = fheroes2::AGG::GetICN( buttonCancelIcn, 0 );
-        buttonCancel.setPosition( area.x + area.width - buttonCancelSprite.width() - buttonFromBorderOffsetX, buttonY );
-        fheroes2::addGradientShadow( buttonCancelSprite, display, buttonCancel.area().getPosition(), { -5, 5 } );
-        buttonCancel.draw();
+        // Render dialog buttons.
+        background->renderOkayCancelButtons( buttonOk, buttonCancel, isEvilInterface );
     }
 
     void RedrawBackground( const fheroes2::Point & /* unused */ ) override

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -27,6 +27,7 @@
 #include "gamedefs.h"
 #include "icn.h"
 #include "settings.h"
+#include "ui_button.h"
 
 namespace
 {

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -21,6 +21,7 @@
 #include "ui_window.h"
 
 #include <algorithm>
+#include <cassert>
 
 #include "agg_image.h"
 #include "gamedefs.h"
@@ -76,8 +77,8 @@ namespace fheroes2
         // Offset from window edges to background copy area and also the size of corners to render.
         const int32_t cornerSize = _hasBackground ? backgroundOffset : borderSize;
 
-        const int32_t horizontalSpriteWidth = horizontalSprite.width() - BORDERWIDTH;
-        const int32_t horizontalSpriteHeight = horizontalSprite.height() - BORDERWIDTH;
+        const int32_t horizontalSpriteWidth = horizontalSprite.width() - borderSize;
+        const int32_t horizontalSpriteHeight = horizontalSprite.height() - borderSize;
         const int32_t verticalSpriteHeight = verticalSprite.height();
         const int32_t verticalSpriteWidth = verticalSprite.width();
 
@@ -93,64 +94,64 @@ namespace fheroes2
 
         // Render additional part of border corners. This part will not be repeated to fill the border length.
         const int32_t extraCornerSize = borderEdgeOffset - cornerSize;
+        const Point cornerOffset( _windowArea.x + cornerSize, _windowArea.y + cornerSize );
+        const int32_t rightBorderEdgeOffset = verticalSpriteWidth - borderEdgeOffset;
+        const int32_t bottomBorderEdgeOffset = verticalSpriteHeight - borderEdgeOffset;
 
-        Blit( verticalSprite, cornerSize, 0, _output, _windowArea.x + cornerSize, _windowArea.y, extraCornerSize, cornerSize );
-        Blit( verticalSprite, 0, cornerSize, _output, _windowArea.x, _windowArea.y + cornerSize, cornerSize, extraCornerSize );
+        Blit( verticalSprite, cornerSize, 0, _output, cornerOffset.x, _windowArea.y, extraCornerSize, cornerSize );
+        Blit( verticalSprite, 0, cornerSize, _output, _windowArea.x, cornerOffset.y, cornerSize, extraCornerSize );
 
-        Blit( verticalSprite, verticalSpriteWidth - borderEdgeOffset, 0, _output, rightCornerOffsetX - extraCornerSize, _windowArea.y, extraCornerSize, cornerSize );
-        Blit( verticalSprite, rightCornerSpriteOffsetX, cornerSize, _output, rightCornerOffsetX, _windowArea.y + cornerSize, cornerSize, extraCornerSize );
+        Blit( verticalSprite, rightBorderEdgeOffset, 0, _output, rightCornerOffsetX - extraCornerSize, _windowArea.y, extraCornerSize, cornerSize );
+        Blit( verticalSprite, rightCornerSpriteOffsetX, cornerSize, _output, rightCornerOffsetX, cornerOffset.y, cornerSize, extraCornerSize );
 
-        Blit( verticalSprite, cornerSize, bottomCornerSpriteOffsetY, _output, _windowArea.x + cornerSize, bottomCornerOffsetY, extraCornerSize, cornerSize );
-        Blit( verticalSprite, 0, verticalSpriteHeight - borderEdgeOffset, _output, _windowArea.x, bottomCornerOffsetY - extraCornerSize, cornerSize, extraCornerSize );
+        Blit( verticalSprite, cornerSize, bottomCornerSpriteOffsetY, _output, cornerOffset.x, bottomCornerOffsetY, extraCornerSize, cornerSize );
+        Blit( verticalSprite, 0, bottomBorderEdgeOffset, _output, _windowArea.x, bottomCornerOffsetY - extraCornerSize, cornerSize, extraCornerSize );
 
-        Blit( verticalSprite, verticalSpriteWidth - borderEdgeOffset, bottomCornerSpriteOffsetY, _output, rightCornerOffsetX - extraCornerSize, bottomCornerOffsetY,
-              extraCornerSize, cornerSize );
-        Blit( verticalSprite, rightCornerSpriteOffsetX, verticalSpriteHeight - borderEdgeOffset, _output, rightCornerOffsetX, bottomCornerOffsetY - extraCornerSize,
-              cornerSize, extraCornerSize );
+        Blit( verticalSprite, rightBorderEdgeOffset, bottomCornerSpriteOffsetY, _output, rightCornerOffsetX - extraCornerSize, bottomCornerOffsetY, extraCornerSize,
+              cornerSize );
+        Blit( verticalSprite, rightCornerSpriteOffsetX, bottomBorderEdgeOffset, _output, rightCornerOffsetX, bottomCornerOffsetY - extraCornerSize, cornerSize,
+              extraCornerSize );
 
         if ( _hasBackground ) {
             // Render the background image.
             _renderBackground( isEvilInterface );
 
             // Make a transition from borders to the background in the corners.
-            CreateDitheringTransition( verticalSprite, cornerSize, cornerSize, _output, _windowArea.x + cornerSize, _windowArea.y + cornerSize, extraCornerSize,
+            CreateDitheringTransition( verticalSprite, cornerSize, cornerSize, _output, cornerOffset.x, cornerOffset.y, extraCornerSize, transitionSize, false, true );
+            CreateDitheringTransition( verticalSprite, cornerSize, cornerSize, _output, cornerOffset.x, cornerOffset.y, transitionSize, extraCornerSize, true, true );
+
+            CreateDitheringTransition( verticalSprite, rightBorderEdgeOffset, cornerSize, _output, rightCornerOffsetX - extraCornerSize, cornerOffset.y, extraCornerSize,
                                        transitionSize, false, true );
-            CreateDitheringTransition( verticalSprite, cornerSize, cornerSize, _output, _windowArea.x + cornerSize, _windowArea.y + cornerSize, transitionSize,
+            CreateDitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, cornerSize, _output, rightCornerOffsetX - transitionSize,
+                                       cornerOffset.y, transitionSize, extraCornerSize, true, false );
+
+            CreateDitheringTransition( verticalSprite, cornerSize, bottomCornerSpriteOffsetY - transitionSize, _output, cornerOffset.x,
+                                       bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
+            CreateDitheringTransition( verticalSprite, cornerSize, bottomBorderEdgeOffset, _output, cornerOffset.x, bottomCornerOffsetY - extraCornerSize, transitionSize,
                                        extraCornerSize, true, true );
 
-            CreateDitheringTransition( verticalSprite, verticalSpriteWidth - borderEdgeOffset, cornerSize, _output, rightCornerOffsetX - extraCornerSize,
-                                       _windowArea.y + cornerSize, extraCornerSize, transitionSize, false, true );
-            CreateDitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, cornerSize, _output, rightCornerOffsetX - transitionSize,
-                                       _windowArea.y + cornerSize, transitionSize, extraCornerSize, true, false );
-
-            CreateDitheringTransition( verticalSprite, cornerSize, bottomCornerSpriteOffsetY - transitionSize, _output, _windowArea.x + cornerSize,
+            CreateDitheringTransition( verticalSprite, rightBorderEdgeOffset, bottomCornerSpriteOffsetY - transitionSize, _output, rightCornerOffsetX - extraCornerSize,
                                        bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
-            CreateDitheringTransition( verticalSprite, cornerSize, verticalSpriteHeight - borderEdgeOffset, _output, _windowArea.x + cornerSize,
-                                       bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, true );
-
-            CreateDitheringTransition( verticalSprite, verticalSpriteWidth - borderEdgeOffset, bottomCornerSpriteOffsetY - transitionSize, _output,
-                                       rightCornerOffsetX - extraCornerSize, bottomCornerOffsetY - transitionSize, extraCornerSize, transitionSize, false, false );
-            CreateDitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, verticalSpriteHeight - borderEdgeOffset, _output,
-                                       rightCornerOffsetX - transitionSize, bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, false );
+            CreateDitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, bottomBorderEdgeOffset, _output, rightCornerOffsetX - transitionSize,
+                                       bottomCornerOffsetY - extraCornerSize, transitionSize, extraCornerSize, true, false );
         }
 
         // Render vertical borders.
-        const int32_t verticalSpriteCopyHeight = std::min( _windowArea.height, verticalSpriteHeight ) - borderEdgeOffset * 2;
+        const int32_t doubleBorderEdgeOffset = borderEdgeOffset * 2;
+        const int32_t verticalSpriteCopyHeight = std::min( _windowArea.height, verticalSpriteHeight ) - doubleBorderEdgeOffset;
         const int32_t verticalSpriteCopies
-            = ( _windowArea.height - borderEdgeOffset * 2 - 1 - transitionSize ) / ( verticalSpriteHeight - borderEdgeOffset * 2 - transitionSize );
-        const int32_t rightBorderOffsetX = _windowArea.x + _windowArea.width - cornerSize;
-        const int32_t rightBorderSpriteOffsetX = verticalSpriteWidth - cornerSize;
+            = ( _windowArea.height - doubleBorderEdgeOffset - 1 - transitionSize ) / ( bottomBorderEdgeOffset - borderEdgeOffset - transitionSize );
+        const int32_t topBorderEdgeOffset = _windowArea.y + borderEdgeOffset;
 
-        Blit( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, _windowArea.y + borderEdgeOffset, cornerSize, verticalSpriteCopyHeight );
-        Blit( verticalSprite, rightBorderSpriteOffsetX, borderEdgeOffset, _output, rightBorderOffsetX, _windowArea.y + borderEdgeOffset, cornerSize,
-              verticalSpriteCopyHeight );
+        Blit( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, topBorderEdgeOffset, cornerSize, verticalSpriteCopyHeight );
+        Blit( verticalSprite, rightCornerSpriteOffsetX, borderEdgeOffset, _output, rightCornerOffsetX, topBorderEdgeOffset, cornerSize, verticalSpriteCopyHeight );
 
         // Render a transition to the background.
         if ( _hasBackground ) {
-            CreateDitheringTransition( verticalSprite, cornerSize, borderEdgeOffset, _output, _windowArea.x + cornerSize, _windowArea.y + borderEdgeOffset,
-                                       transitionSize, verticalSpriteCopyHeight, true, true );
-            CreateDitheringTransition( verticalSprite, rightBorderSpriteOffsetX - transitionSize, borderEdgeOffset, _output, rightBorderOffsetX - transitionSize,
-                                       _windowArea.y + borderEdgeOffset, transitionSize, verticalSpriteCopyHeight, true, false );
+            CreateDitheringTransition( verticalSprite, cornerSize, borderEdgeOffset, _output, cornerOffset.x, topBorderEdgeOffset, transitionSize,
+                                       verticalSpriteCopyHeight, true, true );
+            CreateDitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, borderEdgeOffset, _output, rightCornerOffsetX - transitionSize,
+                                       topBorderEdgeOffset, transitionSize, verticalSpriteCopyHeight, true, false );
         }
 
         // If we need more copies to fill vertical borders we make a transition and copy the central part of the border.
@@ -158,24 +159,22 @@ namespace fheroes2
             int32_t toOffsetY = borderEdgeOffset + verticalSpriteCopyHeight;
             const int32_t outputY = _windowArea.y + toOffsetY - transitionSize;
             CreateDitheringTransition( verticalSprite, 0, borderEdgeOffset, _output, _windowArea.x, outputY, cornerSize, transitionSize, false, false );
-            CreateDitheringTransition( verticalSprite, rightBorderSpriteOffsetX, borderEdgeOffset, _output, rightBorderOffsetX, outputY, cornerSize, transitionSize,
+            CreateDitheringTransition( verticalSprite, rightCornerSpriteOffsetX, borderEdgeOffset, _output, rightCornerOffsetX, outputY, cornerSize, transitionSize,
                                        false, false );
 
             const int32_t stepY = verticalSpriteCopyHeight - transitionSize;
             const int32_t fromOffsetY = borderEdgeOffset + transitionSize;
+            const int32_t copyHeight = std::min( verticalSpriteCopyHeight, _windowArea.height - borderEdgeOffset - toOffsetY );
+            const int32_t toY = _windowArea.y + toOffsetY;
 
             for ( int32_t i = 0; i < verticalSpriteCopies; ++i ) {
-                const int32_t copyHeight = std::min( verticalSpriteCopyHeight, _windowArea.height - borderEdgeOffset - toOffsetY );
-                const int32_t toY = _windowArea.y + toOffsetY;
-
                 Blit( verticalSprite, 0, fromOffsetY, _output, _windowArea.x, toY, cornerSize, copyHeight );
-                Blit( verticalSprite, rightBorderSpriteOffsetX, fromOffsetY, _output, rightBorderOffsetX, toY, cornerSize, copyHeight );
+                Blit( verticalSprite, rightCornerSpriteOffsetX, fromOffsetY, _output, rightCornerOffsetX, toY, cornerSize, copyHeight );
 
                 // Render a transition to the background.
                 if ( _hasBackground ) {
-                    CreateDitheringTransition( verticalSprite, cornerSize, fromOffsetY, _output, _windowArea.x + cornerSize, toY, transitionSize, copyHeight, true,
-                                               true );
-                    CreateDitheringTransition( verticalSprite, rightBorderSpriteOffsetX - transitionSize, fromOffsetY, _output, rightBorderOffsetX - transitionSize, toY,
+                    CreateDitheringTransition( verticalSprite, cornerSize, fromOffsetY, _output, cornerOffset.x, toY, transitionSize, copyHeight, true, true );
+                    CreateDitheringTransition( verticalSprite, rightCornerSpriteOffsetX - transitionSize, fromOffsetY, _output, rightCornerOffsetX - transitionSize, toY,
                                                transitionSize, copyHeight, true, false );
                 }
 
@@ -184,31 +183,31 @@ namespace fheroes2
         }
 
         // Make a transition to the bottom corners.
-        const int32_t verticalSpriteBottomCornerEdgeY = verticalSpriteHeight - borderEdgeOffset - transitionSize;
+        const int32_t verticalSpriteBottomCornerEdgeY = bottomBorderEdgeOffset - transitionSize;
         const int32_t optputBottomCornerEdgeY = _windowArea.y + _windowArea.height - borderEdgeOffset - transitionSize;
         CreateDitheringTransition( verticalSprite, 0, verticalSpriteBottomCornerEdgeY, _output, _windowArea.x, optputBottomCornerEdgeY, cornerSize, transitionSize, false,
                                    false );
-        CreateDitheringTransition( verticalSprite, rightBorderSpriteOffsetX, verticalSpriteBottomCornerEdgeY, _output, rightBorderOffsetX, optputBottomCornerEdgeY,
+        CreateDitheringTransition( verticalSprite, rightCornerSpriteOffsetX, verticalSpriteBottomCornerEdgeY, _output, rightCornerOffsetX, optputBottomCornerEdgeY,
                                    cornerSize, transitionSize, false, false );
 
         // Render horizontal borders. We have to remember that 'verticalSprite' has 16 (equals to BORDERWIDTH) pixels of shadow at the left and bottom sides.
-        const int32_t horizontalSpriteCopyWidth = std::min( _windowArea.width, horizontalSpriteWidth ) - borderEdgeOffset * 2;
+        const int32_t horizontalSpriteCopyWidth = std::min( _windowArea.width, horizontalSpriteWidth ) - doubleBorderEdgeOffset;
         const int32_t horizontalSpriteCopies
-            = ( _windowArea.width - borderEdgeOffset * 2 - 1 - transitionSize ) / ( horizontalSpriteWidth - borderEdgeOffset * 2 - transitionSize );
-        const int32_t bottomBorderOffsetY = _windowArea.y + _windowArea.height - cornerSize;
+            = ( _windowArea.width - doubleBorderEdgeOffset - 1 - transitionSize ) / ( horizontalSpriteWidth - doubleBorderEdgeOffset - transitionSize );
         const int32_t bottomBorderSpriteOffsetY = horizontalSpriteHeight - cornerSize;
-        const int32_t horizontalSpriteCopyStartX = borderEdgeOffset + BORDERWIDTH;
+        const int32_t horizontalSpriteCopyStartX = borderEdgeOffset + borderSize;
+        const int32_t leftBorderEdgeOffset = _windowArea.x + borderEdgeOffset;
 
-        Blit( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, _windowArea.x + borderEdgeOffset, _windowArea.y, horizontalSpriteCopyWidth, cornerSize );
-        Blit( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, _windowArea.x + borderEdgeOffset, bottomBorderOffsetY,
-              horizontalSpriteCopyWidth, cornerSize );
+        Blit( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, leftBorderEdgeOffset, _windowArea.y, horizontalSpriteCopyWidth, cornerSize );
+        Blit( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, leftBorderEdgeOffset, bottomCornerOffsetY, horizontalSpriteCopyWidth,
+              cornerSize );
 
         // Render a transition to the background.
         if ( _hasBackground ) {
-            CreateDitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, cornerSize, _output, _windowArea.x + borderEdgeOffset, _windowArea.y + cornerSize,
-                                       horizontalSpriteCopyWidth, transitionSize, false, true );
-            CreateDitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY - transitionSize, _output,
-                                       _windowArea.x + borderEdgeOffset, bottomBorderOffsetY - transitionSize, horizontalSpriteCopyWidth, transitionSize, false, false );
+            CreateDitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, cornerSize, _output, leftBorderEdgeOffset, cornerOffset.y, horizontalSpriteCopyWidth,
+                                       transitionSize, false, true );
+            CreateDitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY - transitionSize, _output, leftBorderEdgeOffset,
+                                       bottomCornerOffsetY - transitionSize, horizontalSpriteCopyWidth, transitionSize, false, false );
         }
 
         // If we need more copies to fill horizontal borders we make a transition and copy the central part of the border.
@@ -216,25 +215,23 @@ namespace fheroes2
             int32_t toOffsetX = borderEdgeOffset + horizontalSpriteCopyWidth;
             const int32_t outputX = _windowArea.x + toOffsetX - transitionSize;
             CreateDitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, 0, _output, outputX, _windowArea.y, transitionSize, cornerSize, true, false );
-            CreateDitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, outputX, bottomBorderOffsetY, transitionSize,
+            CreateDitheringTransition( horizontalSprite, horizontalSpriteCopyStartX, bottomBorderSpriteOffsetY, _output, outputX, bottomCornerOffsetY, transitionSize,
                                        cornerSize, true, false );
 
             const int32_t stepX = horizontalSpriteCopyWidth - transitionSize;
             const int32_t fromOffsetX = horizontalSpriteCopyStartX + transitionSize;
+            const int32_t copyWidth = std::min( horizontalSpriteCopyWidth, _windowArea.width - borderEdgeOffset - toOffsetX );
+            const int32_t toX = _windowArea.x + toOffsetX;
 
             for ( int32_t i = 0; i < horizontalSpriteCopies; ++i ) {
-                const int32_t copyWidth = std::min( horizontalSpriteCopyWidth, _windowArea.width - borderEdgeOffset - toOffsetX );
-                const int32_t toX = _windowArea.x + toOffsetX;
-
                 Blit( horizontalSprite, fromOffsetX, 0, _output, toX, _windowArea.y, copyWidth, cornerSize );
-                Blit( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY, _output, toX, bottomBorderOffsetY, copyWidth, cornerSize );
+                Blit( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY, _output, toX, bottomCornerOffsetY, copyWidth, cornerSize );
 
                 // Render a transition to the background.
                 if ( _hasBackground ) {
-                    CreateDitheringTransition( horizontalSprite, fromOffsetX, cornerSize, _output, toX, _windowArea.y + cornerSize, copyWidth, transitionSize, false,
-                                               true );
+                    CreateDitheringTransition( horizontalSprite, fromOffsetX, cornerSize, _output, toX, cornerOffset.y, copyWidth, transitionSize, false, true );
                     CreateDitheringTransition( horizontalSprite, fromOffsetX, bottomBorderSpriteOffsetY - transitionSize, _output, toX,
-                                               bottomBorderOffsetY - transitionSize, copyWidth, transitionSize, false, false );
+                                               bottomCornerOffsetY - transitionSize, copyWidth, transitionSize, false, false );
                 }
 
                 toOffsetX += stepX;
@@ -246,26 +243,32 @@ namespace fheroes2
         const int32_t optputRightCornerEdgeX = _windowArea.x + _windowArea.width - borderEdgeOffset - transitionSize;
         CreateDitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, 0, _output, optputRightCornerEdgeX, _windowArea.y, transitionSize, cornerSize,
                                    true, false );
-        CreateDitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, bottomBorderSpriteOffsetY, _output, optputRightCornerEdgeX, bottomBorderOffsetY,
+        CreateDitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, bottomBorderSpriteOffsetY, _output, optputRightCornerEdgeX, bottomCornerOffsetY,
                                    transitionSize, cornerSize, true, false );
 
         // Render shadow at the left side of the window.
-        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + borderSize, borderSize, 1, 5 );
-        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + borderSize + 1, 1, _windowArea.height - 2, 5 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + borderSize + 1, borderSize - 1, 1, 4 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + borderSize + 2, 1, _windowArea.height - 4, 4 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + borderSize + 2, borderSize - 2, 1, 3 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + borderSize + 3, 1, _windowArea.height - 6, 3 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 3, _windowArea.y + borderSize + 3, borderSize - 3, _windowArea.height - borderSize - 3, 2 );
+        int32_t offsetY = _windowArea.y + borderSize;
+        ApplyTransform( _output, _totalArea.x, offsetY, borderSize, 1, 5 );
+        ++offsetY;
+        ApplyTransform( _output, _totalArea.x, offsetY, 1, _windowArea.height - 2, 5 );
+        ApplyTransform( _output, _totalArea.x + 1, offsetY, borderSize - 1, 1, 4 );
+        ++offsetY;
+        ApplyTransform( _output, _totalArea.x + 1, offsetY, 1, _windowArea.height - 4, 4 );
+        ApplyTransform( _output, _totalArea.x + 2, offsetY, borderSize - 2, 1, 3 );
+        ++offsetY;
+        ApplyTransform( _output, _totalArea.x + 2, offsetY, 1, _windowArea.height - 6, 3 );
+        ApplyTransform( _output, _totalArea.x + 3, offsetY, borderSize - 3, _windowArea.height - borderSize - 3, 2 );
 
         // Render shadow at the bottom side of the window.
-        ApplyTransform( _output, _windowArea.x - borderSize + 3, _windowArea.y + _windowArea.height, _windowArea.width - 6, borderSize - 3, 2 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 2, _windowArea.y + _windowArea.height + borderSize - 3, _windowArea.width - 4, 1, 3 );
-        ApplyTransform( _output, _windowArea.x + _windowArea.width - borderSize - 3, _windowArea.y + _windowArea.height, 1, borderSize - 3, 3 );
-        ApplyTransform( _output, _windowArea.x - borderSize + 1, _windowArea.y + _windowArea.height + borderSize - 2, _windowArea.width - 2, 1, 4 );
-        ApplyTransform( _output, _windowArea.x + _windowArea.width - borderSize - 2, _windowArea.y + _windowArea.height, 1, borderSize - 2, 4 );
-        ApplyTransform( _output, _windowArea.x - borderSize, _windowArea.y + _windowArea.height + borderSize - 1, _windowArea.width, 1, 5 );
-        ApplyTransform( _output, _windowArea.x + _windowArea.width - borderSize - 1, _windowArea.y + _windowArea.height, 1, borderSize - 1, 5 );
+        offsetY = _windowArea.y + _windowArea.height;
+        const int32_t shadowBottomEdge = _windowArea.y + _totalArea.height;
+        ApplyTransform( _output, _totalArea.x + 3, offsetY, _windowArea.width - 6, borderSize - 3, 2 );
+        ApplyTransform( _output, _totalArea.x + 2, shadowBottomEdge - 3, _windowArea.width - 4, 1, 3 );
+        ApplyTransform( _output, _totalArea.x + _windowArea.width - 3, offsetY, 1, borderSize - 3, 3 );
+        ApplyTransform( _output, _totalArea.x + 1, shadowBottomEdge - 2, _windowArea.width - 2, 1, 4 );
+        ApplyTransform( _output, _totalArea.x + _windowArea.width - 2, offsetY, 1, borderSize - 2, 4 );
+        ApplyTransform( _output, _totalArea.x, shadowBottomEdge - 1, _windowArea.width, 1, 5 );
+        ApplyTransform( _output, _totalArea.x + _windowArea.width - 1, offsetY, 1, borderSize - 1, 5 );
     }
 
     void StandardWindow::applyTextBackgroundShading( const Rect & roi )
@@ -298,6 +301,133 @@ namespace fheroes2
         applyRectTransform( _output, 6, 1, 3 );
         applyRectTransform( _output, 7, 1, 4 );
         applyRectTransform( _output, 8, 1, 5 );
+    }
+
+    void StandardWindow::renderScrollbarBackground( const Rect & roi, const bool isEvilInterface )
+    {
+        const fheroes2::Sprite & scrollBar = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
+
+        const int32_t topPartHeight = 19;
+        const int32_t scrollBarWidth = 16;
+        const int32_t middlePartHeight = 88;
+        const int32_t icnOffsetX = 536;
+        const int32_t middleAndBottomPartsHeight = roi.height - topPartHeight;
+
+        // Top part of scrollbar background.
+        fheroes2::Copy( scrollBar, icnOffsetX, 176, _output, roi.x, roi.y, scrollBarWidth, topPartHeight );
+
+        // Middle part of scrollbar background.
+        const int32_t middlePartCount = ( roi.height - 2 * topPartHeight + middlePartHeight - 1 ) / middlePartHeight;
+        int32_t offsetY = topPartHeight;
+
+        for ( int32_t i = 0; i < middlePartCount; ++i ) {
+            fheroes2::Copy( scrollBar, icnOffsetX, 196, _output, roi.x, roi.y + offsetY, scrollBarWidth,
+                            std::min( middlePartHeight, middleAndBottomPartsHeight - offsetY ) );
+            offsetY += middlePartHeight;
+        }
+
+        // Bottom part of scrollbar background.
+        fheroes2::Copy( scrollBar, icnOffsetX, 285, _output, roi.x, roi.y + middleAndBottomPartsHeight, scrollBarWidth, topPartHeight );
+
+        // Make scrollbar shadow.
+        for ( uint8_t i = 0; i < 4; ++i ) {
+            const uint8_t transformId = i + 1;
+            fheroes2::ApplyTransform( _output, roi.x - transformId, roi.y + transformId, 1, roi.height - transformId, transformId );
+            fheroes2::ApplyTransform( _output, roi.x - transformId, roi.y + roi.height + i, scrollBarWidth, 1, transformId );
+        }
+    }
+
+    void StandardWindow::renderButtonSprite( ButtonSprite & button, const std::string & buttonText, const int32_t buttonWidth, const Point & offset,
+                                             const bool isEvilInterface, const Padding padding )
+    {
+        fheroes2::Sprite released;
+        fheroes2::Sprite pressed;
+
+        makeButtonSprites( released, pressed, buttonText, buttonWidth, isEvilInterface, false );
+
+        const Point pos = _getRenderPos( offset, { released.width(), released.height() }, padding );
+
+        button.setSprite( released, pressed );
+        button.setPosition( pos.x, pos.y );
+        fheroes2::addGradientShadow( released, _output, button.area().getPosition(), { -5, 5 } );
+        button.draw();
+    }
+
+    void StandardWindow::renderButton( Button & button, const int icnId, const uint32_t releasedIndex, const uint32_t pressedIndex, const Point & offset,
+                                       const Padding padding )
+    {
+        const fheroes2::Sprite & buttonSprite = fheroes2::AGG::GetICN( icnId, 0 );
+
+        const Point pos = _getRenderPos( offset, { buttonSprite.width(), buttonSprite.height() }, padding );
+
+        button.setICNInfo( icnId, releasedIndex, pressedIndex );
+        button.setPosition( pos.x, pos.y );
+        fheroes2::addGradientShadow( buttonSprite, _output, button.area().getPosition(), { -5, 5 } );
+        button.draw();
+    }
+
+    void StandardWindow::renderOkayCancelButtons( Button & buttonOk, Button & buttonCancel, const bool isEvilInterface )
+    {
+        const Point buttonOffset( 20, 7 );
+
+        const int buttonOkIcn = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
+        renderButton( buttonOk, buttonOkIcn, 0, 1, buttonOffset, Padding::BOTTOM_LEFT );
+
+        const int buttonCancelIcn = isEvilInterface ? ICN::BUTTON_SMALL_CANCEL_EVIL : ICN::BUTTON_SMALL_CANCEL_GOOD;
+        renderButton( buttonCancel, buttonCancelIcn, 0, 1, buttonOffset, Padding::BOTTOM_RIGHT );
+    }
+
+    Point StandardWindow::_getRenderPos( const Point & offset, const Size & itemSize, const Padding padding ) const
+    {
+        Point pos( _activeArea.x, _activeArea.y );
+
+        // Apply horizontal padding.
+        switch ( padding ) {
+        case Padding::TOP_LEFT:
+        case Padding::CENTER_LEFT:
+        case Padding::BOTTOM_LEFT:
+            pos.x += offset.x;
+            break;
+        case Padding::TOP_CENTER:
+        case Padding::CENTER_CENTER:
+        case Padding::BOTTOM_CENTER:
+            pos.x += ( _activeArea.width - itemSize.width ) / 2 + offset.x;
+            break;
+        case Padding::TOP_RIGHT:
+        case Padding::CENTER_RIGHT:
+        case Padding::BOTTOM_RIGHT:
+            pos.x += _activeArea.width - itemSize.width - offset.x;
+            break;
+        default:
+            // Have you added a new padding? Add a logic for it.
+            assert( 0 );
+            break;
+        }
+
+        // Apply vertical padding.
+        switch ( padding ) {
+        case Padding::TOP_LEFT:
+        case Padding::TOP_CENTER:
+        case Padding::TOP_RIGHT:
+            pos.y += offset.y;
+            break;
+        case Padding::CENTER_LEFT:
+        case Padding::CENTER_CENTER:
+        case Padding::CENTER_RIGHT:
+            pos.y += ( _activeArea.height - itemSize.height ) / 2 + offset.y;
+            break;
+        case Padding::BOTTOM_LEFT:
+        case Padding::BOTTOM_CENTER:
+        case Padding::BOTTOM_RIGHT:
+            pos.y += _activeArea.height - itemSize.height - offset.y;
+            break;
+        default:
+            // Have you added a new padding? Add a logic for it.
+            assert( 0 );
+            break;
+        }
+
+        return pos;
     }
 
     void StandardWindow::_renderBackground( const bool isEvilInterface )

--- a/src/fheroes2/gui/ui_window.h
+++ b/src/fheroes2/gui/ui_window.h
@@ -25,6 +25,7 @@
 #include "image.h"
 #include "math_base.h"
 #include "screen.h"
+#include "ui_button.h"
 
 namespace fheroes2
 {
@@ -32,8 +33,32 @@ namespace fheroes2
     class StandardWindow
     {
     public:
+        enum class Padding : uint8_t
+        {
+            TOP_LEFT,
+            TOP_CENTER,
+            TOP_RIGHT,
+            CENTER_LEFT,
+            CENTER_CENTER,
+            CENTER_RIGHT,
+            BOTTOM_LEFT,
+            BOTTOM_CENTER,
+            BOTTOM_RIGHT
+        };
+
+        StandardWindow() = delete;
+        StandardWindow( const StandardWindow & ) = delete;
+        StandardWindow & operator=( const StandardWindow & ) = delete;
         StandardWindow( const int32_t width, const int32_t height, const bool renderBackground, Image & output = Display::instance() );
         StandardWindow( const int32_t x, const int32_t y, const int32_t width, const int32_t height, const bool renderBackground, Image & output = Display::instance() );
+        ~StandardWindow()
+        {
+            Display & display = Display::instance();
+            if ( &_output == &display ) {
+                // The screen area of the closed window should be updated during the next '.render()' call.
+                display.updateNextRenderRoi( _totalArea );
+            }
+        }
 
         // Returns the window background ROI.
         const Rect & activeArea() const
@@ -55,6 +80,13 @@ namespace fheroes2
 
         void render();
 
+        void renderScrollbarBackground( const Rect & roi, const bool isEvilInterface );
+
+        void renderButtonSprite( ButtonSprite & button, const std::string & buttonText, const int32_t buttonWidth, const Point & offset, const bool isEvilInterface,
+                                 const Padding padding );
+        void renderButton( Button & button, const int icnId, const uint32_t releasedIndex, const uint32_t pressedIndex, const Point & offset, const Padding padding );
+        void renderOkayCancelButtons( Button & buttonOk, Button & buttonCancel, const bool isEvilInterface );
+
         void applyTextBackgroundShading( const Rect & roi );
 
     private:
@@ -65,6 +97,7 @@ namespace fheroes2
         ImageRestorer _restorer;
         const bool _hasBackground{ true };
 
+        Point _getRenderPos( const Point & offset, const Size & itemSize, const Padding padding ) const;
         void _renderBackground( const bool isEvilInterface );
     };
 }

--- a/src/fheroes2/gui/ui_window.h
+++ b/src/fheroes2/gui/ui_window.h
@@ -21,6 +21,7 @@
 #pragma once
 
 #include <cstdint>
+#include <string>
 
 #include "image.h"
 #include "math_base.h"

--- a/src/fheroes2/gui/ui_window.h
+++ b/src/fheroes2/gui/ui_window.h
@@ -25,11 +25,13 @@
 #include "image.h"
 #include "math_base.h"
 #include "screen.h"
-#include "ui_button.h"
 
 namespace fheroes2
 {
-    // Standard window with shadow
+    class Button;
+    class ButtonSprite;
+
+    // Standard window with shadow.
     class StandardWindow
     {
     public:


### PR DESCRIPTION
This PR optimizes `ui_window.cpp` code a bit and moves the scrollbar background generation and rendering code and button rendering code to `ui_window`. It slightly reduces the code duplication in dialogs with lists.
This PR also forces to update the dialog area on the screen on the next redraw call after the dialog is closed.

This PR affects all "Select ..." dialogs, including save/load and hotkeys dialogs: shadow and dialog rendering, dialog items (scrollbar, buttons) rendering and positioning.