### PR TITLE
Eliminate redundant headers that were detected as required by IWYU with older compilers

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+// TODO: this header is redundant here, but detected as required by IWYU with older compilers
+// IWYU pragma: no_include <type_traits>
 #include <algorithm>
 #include <cassert>
 #include <climits>
@@ -31,7 +33,6 @@
 #include <set>
 #include <string>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 #include <vector>
 

--- a/src/fheroes2/battle/battle_grave.cpp
+++ b/src/fheroes2/battle/battle_grave.cpp
@@ -21,9 +21,10 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+// TODO: this header is redundant here, but detected as required by IWYU with older compilers
+// IWYU pragma: no_include <type_traits>
 #include <algorithm>
 #include <cassert>
-#include <type_traits>
 #include <utility>
 
 #include "battle_board.h"

--- a/src/fheroes2/battle/battle_grave.cpp
+++ b/src/fheroes2/battle/battle_grave.cpp
@@ -21,6 +21,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "battle_grave.h"
+
 // TODO: this header is redundant here, but detected as required by IWYU with older compilers
 // IWYU pragma: no_include <type_traits>
 #include <algorithm>
@@ -28,7 +30,6 @@
 #include <utility>
 
 #include "battle_board.h"
-#include "battle_grave.h"
 #include "battle_troop.h"
 
 Battle::Indexes Battle::Graveyard::GetOccupiedCells() const

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -23,6 +23,8 @@
 
 #include "battle_interface.h"
 
+// TODO: this header is redundant here, but detected as required by IWYU with older compilers
+// IWYU pragma: no_include <type_traits>
 #include <algorithm>
 #include <array>
 #include <cassert>
@@ -35,7 +37,6 @@
 #include <iterator>
 #include <ostream>
 #include <set>
-#include <type_traits>
 
 #include "agg_image.h"
 #include "audio.h"

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -20,13 +20,14 @@
 
 #include "battle_pathfinding.h"
 
+// TODO: this header is redundant here, but detected as required by IWYU with older compilers
+// IWYU pragma: no_include <type_traits>
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <set>
 #include <tuple>
-#include <type_traits>
 #include <vector>
 
 #include "battle_arena.h"


### PR DESCRIPTION
With the newer version of the GitHub Ubuntu Runner Image, which is currently [rolling out](https://github.com/actions/runner-images?tab=readme-ov-file#available-images), the `<type_traits>` header is not detected as required in a few places anymore.