### PR TITLE
Fix several issues with loading ICN resources

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2637,7 +2637,7 @@ namespace fheroes2
                 }
                 return true;
             case ICN::TROLL2MSL:
-                LoadOriginalICN( ICN::TROLLMSL );
+                LoadModifiedICN( ICN::TROLLMSL );
                 if ( _icnVsSprite[ICN::TROLLMSL].size() == 1 ) {
                     _icnVsSprite[id].resize( 1 );
 
@@ -3391,7 +3391,7 @@ namespace fheroes2
             case ICN::GOOD_MARKET_BUTTON: {
                 _icnVsSprite[id].resize( 2 );
 
-                LoadOriginalICN( ICN::ADVBTNS );
+                LoadModifiedICN( ICN::ADVBTNS );
 
                 const int releasedIndex = ( id == ICN::GOOD_ARMY_BUTTON ) ? 0 : 4;
                 Copy( GetICN( ICN::ADVBTNS, releasedIndex ), _icnVsSprite[id][0] );
@@ -3408,7 +3408,7 @@ namespace fheroes2
             case ICN::EVIL_MARKET_BUTTON: {
                 _icnVsSprite[id].resize( 2 );
 
-                LoadOriginalICN( ICN::ADVEBTNS );
+                LoadModifiedICN( ICN::ADVEBTNS );
 
                 const int releasedIndex = ( id == ICN::EVIL_ARMY_BUTTON ) ? 0 : 4;
                 Copy( GetICN( ICN::ADVEBTNS, releasedIndex ), _icnVsSprite[id][0] );
@@ -3510,7 +3510,7 @@ namespace fheroes2
                 return true;
             }
             case ICN::MONO_CURSOR_ADVMBW: {
-                LoadOriginalICN( ICN::ADVMCO );
+                LoadModifiedICN( ICN::ADVMCO );
 
                 _icnVsSprite[id].resize( _icnVsSprite[ICN::ADVMCO].size() );
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
@@ -3525,7 +3525,7 @@ namespace fheroes2
                 return true;
             }
             case ICN::MONO_CURSOR_SPELBW: {
-                LoadOriginalICN( ICN::SPELCO );
+                LoadModifiedICN( ICN::SPELCO );
 
                 _icnVsSprite[id].resize( _icnVsSprite[ICN::SPELCO].size() );
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
@@ -3540,7 +3540,7 @@ namespace fheroes2
                 return true;
             }
             case ICN::MONO_CURSOR_CMSSBW: {
-                LoadOriginalICN( ICN::CMSECO );
+                LoadModifiedICN( ICN::CMSECO );
 
                 _icnVsSprite[id].resize( _icnVsSprite[ICN::CMSECO].size() );
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
@@ -3964,7 +3964,7 @@ namespace fheroes2
             case ICN::MINI_MONSTER_IMAGE:
             case ICN::MINI_MONSTER_SHADOW: {
                 // It doesn't matter which image is being called. We are generating both of them at the same time.
-                LoadOriginalICN( ICN::MINIMON );
+                LoadModifiedICN( ICN::MINIMON );
 
                 // Minotaur King original Adventure map sprite has blue armlets. We make them gold to correspond the ICN::MINOTAU2.
                 if ( _icnVsSprite[ICN::MINIMON].size() > 303 ) {

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -546,6 +546,8 @@ namespace fheroes2
 {
     namespace AGG
     {
+        void loadICN( const int id );
+
         void LoadOriginalICN( const int id )
         {
             const std::vector<uint8_t> & body = ::AGG::getDataFromAggFile( ICN::GetString( id ) );
@@ -2637,7 +2639,7 @@ namespace fheroes2
                 }
                 return true;
             case ICN::TROLL2MSL:
-                LoadModifiedICN( ICN::TROLLMSL );
+                loadICN( ICN::TROLLMSL );
                 if ( _icnVsSprite[ICN::TROLLMSL].size() == 1 ) {
                     _icnVsSprite[id].resize( 1 );
 
@@ -3391,7 +3393,7 @@ namespace fheroes2
             case ICN::GOOD_MARKET_BUTTON: {
                 _icnVsSprite[id].resize( 2 );
 
-                LoadModifiedICN( ICN::ADVBTNS );
+                loadICN( ICN::ADVBTNS );
 
                 const int releasedIndex = ( id == ICN::GOOD_ARMY_BUTTON ) ? 0 : 4;
                 Copy( GetICN( ICN::ADVBTNS, releasedIndex ), _icnVsSprite[id][0] );
@@ -3408,7 +3410,7 @@ namespace fheroes2
             case ICN::EVIL_MARKET_BUTTON: {
                 _icnVsSprite[id].resize( 2 );
 
-                LoadModifiedICN( ICN::ADVEBTNS );
+                loadICN( ICN::ADVEBTNS );
 
                 const int releasedIndex = ( id == ICN::EVIL_ARMY_BUTTON ) ? 0 : 4;
                 Copy( GetICN( ICN::ADVEBTNS, releasedIndex ), _icnVsSprite[id][0] );
@@ -3510,7 +3512,7 @@ namespace fheroes2
                 return true;
             }
             case ICN::MONO_CURSOR_ADVMBW: {
-                LoadModifiedICN( ICN::ADVMCO );
+                loadICN( ICN::ADVMCO );
 
                 _icnVsSprite[id].resize( _icnVsSprite[ICN::ADVMCO].size() );
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
@@ -3525,7 +3527,7 @@ namespace fheroes2
                 return true;
             }
             case ICN::MONO_CURSOR_SPELBW: {
-                LoadModifiedICN( ICN::SPELCO );
+                loadICN( ICN::SPELCO );
 
                 _icnVsSprite[id].resize( _icnVsSprite[ICN::SPELCO].size() );
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
@@ -3540,7 +3542,7 @@ namespace fheroes2
                 return true;
             }
             case ICN::MONO_CURSOR_CMSSBW: {
-                LoadModifiedICN( ICN::CMSECO );
+                loadICN( ICN::CMSECO );
 
                 _icnVsSprite[id].resize( _icnVsSprite[ICN::CMSECO].size() );
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
@@ -3964,7 +3966,7 @@ namespace fheroes2
             case ICN::MINI_MONSTER_IMAGE:
             case ICN::MINI_MONSTER_SHADOW: {
                 // It doesn't matter which image is being called. We are generating both of them at the same time.
-                LoadModifiedICN( ICN::MINIMON );
+                loadICN( ICN::MINIMON );
 
                 // Minotaur King original Adventure map sprite has blue armlets. We make them gold to correspond the ICN::MINOTAU2.
                 if ( _icnVsSprite[ICN::MINIMON].size() > 303 ) {
@@ -4069,7 +4071,7 @@ namespace fheroes2
             case ICN::EMPTY_EVIL_BUTTON: {
                 const bool isGoodInterface = ( id == ICN::EMPTY_GOOD_BUTTON );
                 const int32_t originalId = isGoodInterface ? ICN::SYSTEM : ICN::SYSTEME;
-                LoadOriginalICN( originalId );
+                loadICN( originalId );
 
                 if ( _icnVsSprite[originalId].size() < 13 ) {
                     return true;
@@ -4112,7 +4114,7 @@ namespace fheroes2
             }
             case ICN::EMPTY_POL_BUTTON: {
                 const int originalID = ICN::X_CMPBTN;
-                LoadOriginalICN( originalID );
+                loadICN( originalID );
 
                 if ( _icnVsSprite[originalID].size() < 8 ) {
                     return true;
@@ -4154,7 +4156,7 @@ namespace fheroes2
             }
             case ICN::EMPTY_GUILDWELL_BUTTON: {
                 const int originalID = ICN::WELLXTRA;
-                LoadOriginalICN( originalID );
+                loadICN( originalID );
 
                 if ( _icnVsSprite[originalID].size() < 3 ) {
                     return true;
@@ -4180,7 +4182,7 @@ namespace fheroes2
             case ICN::EMPTY_EVIL_MEDIUM_BUTTON: {
                 const bool isGoodInterface = ( id == ICN::EMPTY_GOOD_MEDIUM_BUTTON );
                 const int32_t originalId = isGoodInterface ? ICN::APANEL : ICN::APANELE;
-                LoadOriginalICN( originalId );
+                loadICN( originalId );
 
                 if ( _icnVsSprite[originalId].size() < 10 ) {
                     return true;
@@ -4204,7 +4206,7 @@ namespace fheroes2
             }
             case ICN::EMPTY_VERTICAL_GOOD_BUTTON: {
                 const int32_t originalId = ICN::HSBTNS;
-                LoadOriginalICN( originalId );
+                loadICN( originalId );
 
                 if ( _icnVsSprite[originalId].size() < 9 ) {
                     break;
@@ -4337,11 +4339,16 @@ namespace fheroes2
             return false;
         }
 
-        size_t GetMaximumICNIndex( int id )
+        void loadICN( const int id )
         {
             if ( _icnVsSprite[id].empty() && !LoadModifiedICN( id ) ) {
                 LoadOriginalICN( id );
             }
+        }
+
+        size_t GetMaximumICNIndex( int id )
+        {
+            loadICN( id );
 
             return _icnVsSprite[id].size();
         }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -4346,7 +4346,7 @@ namespace fheroes2
                 return;
             }
 
-            if (!LoadModifiedICN( id ) ) {
+            if ( !LoadModifiedICN( id ) ) {
                 LoadOriginalICN( id );
             }
         }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -4341,7 +4341,12 @@ namespace fheroes2
 
         void loadICN( const int id )
         {
-            if ( _icnVsSprite[id].empty() && !LoadModifiedICN( id ) ) {
+            if ( !_icnVsSprite[id].empty() ) {
+                // The images have been loaded.
+                return;
+            }
+
+            if (!LoadModifiedICN( id ) ) {
                 LoadOriginalICN( id );
             }
         }

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2291,6 +2291,13 @@ namespace fheroes2
 
         bool LoadModifiedICN( int id )
         {
+            // If this assertion blows up then you are calling this function in a recursion. Check your code!
+            assert( _icnVsSprite[id].empty() );
+
+            // IMPORTANT!!!
+            // Call LoadOriginalICN() function only if you are handling the same ICN.
+            // If you need to load a different ICN use loadICN() function.
+
             switch ( id ) {
             case ICN::ROUTERED:
                 CopyICNWithPalette( id, ICN::ROUTE, PAL::PaletteType::RED );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -550,6 +550,9 @@ namespace fheroes2
 
         void LoadOriginalICN( const int id )
         {
+            // If this assertion blows up then something wrong with your logic and you load resources more than once!
+            assert( _icnVsSprite[id].empty() );
+
             const std::vector<uint8_t> & body = ::AGG::getDataFromAggFile( ICN::GetString( id ) );
 
             if ( body.empty() ) {
@@ -4216,7 +4219,7 @@ namespace fheroes2
                 loadICN( originalId );
 
                 if ( _icnVsSprite[originalId].size() < 9 ) {
-                    break;
+                    return true;
                 }
 
                 _icnVsSprite[id].resize( 2 );
@@ -4274,7 +4277,7 @@ namespace fheroes2
                     FillTransform( pressed, pressed.width() - 1, 3, 1, pressed.height() - 6, 1 );
                 }
 
-                break;
+                return true;
             }
             case ICN::BRCREST: {
                 LoadOriginalICN( id );

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2292,7 +2292,8 @@ namespace fheroes2
             generateDefaultImages( id );
         }
 
-        bool LoadModifiedICN( int id )
+        // This function must return true is resources have been modified, false otherwise.
+        bool LoadModifiedICN( const int id )
         {
             // If this assertion blows up then you are calling this function in a recursion. Check your code!
             assert( _icnVsSprite[id].empty() );


### PR DESCRIPTION
fix #7987

We must use **LoadOriginalICN()** function only when dealing with the same ICN id.

As a side bonus: we won't load certain ICN resources twice as it was before the changes.