### PR TITLE
Clang-Tidy workflow: use head ref instead of the ref of virtual merge commit

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -20,7 +20,12 @@ jobs:
     steps:
     - uses: actions/checkout@v4
       with:
-        fetch-depth: 50
+        ref: ${{ github.event.pull_request.head.sha }}
+        fetch-depth: 0
+    - name: Fetch base branch
+      run: |
+        git remote add upstream "https://github.com/${{ github.event.pull_request.base.repo.full_name }}"
+        git fetch --no-tags --no-recurse-submodules upstream "${{ github.event.pull_request.base.ref }}"
     - name: Install dependencies and clang-tidy
       run: |
         sudo apt-get -y update
@@ -37,12 +42,12 @@ jobs:
         mkdir clang-tidy-result
     - name: Analyze
       run: |
-        git diff -U0 HEAD^ | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
+        git diff -U0 "$(git merge-base HEAD "upstream/${{ github.event.pull_request.base.ref }}")" | clang-tidy-diff -p1 -path build -export-fixes clang-tidy-result/fixes.yml
     - name: Save PR metadata
       run: |
         echo "${{ github.event.number }}" > clang-tidy-result/pr-id.txt
         echo "${{ github.event.pull_request.head.repo.full_name }}" > clang-tidy-result/pr-head-repo.txt
-        echo "${{ github.event.pull_request.head.ref }}" > clang-tidy-result/pr-head-ref.txt
+        echo "${{ github.event.pull_request.head.sha }}" > clang-tidy-result/pr-head-sha.txt
     - uses: actions/upload-artifact@v3
       with:
         name: clang-tidy-result

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -41,11 +41,11 @@ jobs:
         unzip clang-tidy-result.zip -d clang-tidy-result
         echo "PR_ID=$(cat clang-tidy-result/pr-id.txt)" >> "$GITHUB_ENV"
         echo "PR_HEAD_REPO=$(cat clang-tidy-result/pr-head-repo.txt)" >> "$GITHUB_ENV"
-        echo "PR_HEAD_REF=$(cat clang-tidy-result/pr-head-ref.txt)" >> "$GITHUB_ENV"
+        echo "PR_HEAD_SHA=$(cat clang-tidy-result/pr-head-sha.txt)" >> "$GITHUB_ENV"
     - uses: actions/checkout@v4
       with:
         repository: ${{ env.PR_HEAD_REPO }}
-        ref: ${{ env.PR_HEAD_REF }}
+        ref: ${{ env.PR_HEAD_SHA }}
         persist-credentials: false
     - name: Redownload analysis results
       uses: actions/github-script@v6


### PR DESCRIPTION
### Background

Without special configuration, `actions/checkout` checks out so-called "virtual merge commit", which is an imaginary commit that merges PR branch into target base branch (usually `master` branch):

```
  PR branch
  |
  V
  A - B - C
 /        |
M         |
 \        |
  D - E - F
  ^
  |
  base branch (master)
```

and Clang-Tidy checks are running on this commit. But there is a problem: if the same file was changed both in PR branch and in the base branch, then `fixes.yml` generated by Clang-Tidy will not be applicable to the pull request diff, because pull request diff is created between the PR branch and so-called "best common ancestor" of PR branch and base branch (this is just my guess, but it seems that it is). In the example above, pull request diff is generated between `A` and `F`, and changes in `D` and `E` will not affect the PR diff, while these changes will affect diff between `M` and `D`.

### Example

Let's make a PR branch and in this branch introduce the following changes in the middle of the file `ai_common.cpp`:

![pr-changes](https://github.com/ihhub/fheroes2/assets/32623900/b2811e1a-995c-4047-b211-562bd80e1002)

<details>
<summary>Clang-Tidy output and contents of fixes.yml</summary>

```
/home/runner/work/fheroes2/fheroes2/src/fheroes2/ai/ai_common.cpp:233:40: warning: narrowing conversion from 'uint32_t' (aka 'unsigned int') to signed type 'int32_t' (aka 'int') is implementation-defined [bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions]
            const int32_t tradeCost =  fheroes2::getTradeCost( marketplaceCount, fromRes, toRes );

                                       ^
```
```
Diagnostics:
- BuildDirectory: /home/runner/work/fheroes2/fheroes2/build/src/fheroes2
  DiagnosticMessage:
    FileOffset: 8389
    FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/ai/ai_common.cpp
    Message: narrowing conversion from 'uint32_t' (aka 'unsigned int') to signed type
      'int32_t' (aka 'int') is implementation-defined
    Replacements: []
  DiagnosticName: bugprone-narrowing-conversions
  Level: Warning
MainSourceFile: ''
```
</details>

So far so good, we have correct line number and sane `FileOffset` value. Then, let's add some changes to the same `ai_common.cpp` file at its beginning (for example, duplicate our copyright header once again), but in the `master` branch, push these changes and trigger the Clang-Tidy workflow for our PR:

<details>
<summary>Clang-Tidy output and contents of fixes.yml</summary>

```
/home/runner/work/fheroes2/fheroes2/src/fheroes2/ai/ai_common.cpp:252:40: warning: narrowing conversion from 'uint32_t' (aka 'unsigned int') to signed type 'int32_t' (aka 'int') is implementation-defined [bugprone-narrowing-conversions,cppcoreguidelines-narrowing-conversions]
            const int32_t tradeCost =  fheroes2::getTradeCost( marketplaceCount, fromRes, toRes );
                                       ^
```
```
Diagnostics:
- BuildDirectory: /home/runner/work/fheroes2/fheroes2/build/src/fheroes2
  DiagnosticMessage:
    FileOffset: 9853
    FilePath: /home/runner/work/fheroes2/fheroes2/src/fheroes2/ai/ai_common.cpp
    Message: narrowing conversion from 'uint32_t' (aka 'unsigned int') to signed type
      'int32_t' (aka 'int') is implementation-defined
    Replacements: []
  DiagnosticName: bugprone-narrowing-conversions
  Level: Warning
MainSourceFile: ''
```
</details>

Now, the warning is at different line number (line number in the PR diff is still 233, but in the Clang-Tidy output it's 252), and the `FileOffset` value is also wrong, because in our imaginary merge commit line numbers will be shifted because of changes in the beginning of this file in the `master` branch. Clang-Tidy Comments workflow tries to deal with this but gives up:

```
Warnings found but none in lines changed by this pull request.
```

### This PR

With this PR, Clang-Tidy checks will run according to pull request diff (at least I hope so, because I'm not 100% sure about the mechanism of its generation) and not according to diff between commits `M` and `D`.

This should fix the nonsense like this one:

https://github.com/ihhub/fheroes2/pull/7958#pullrequestreview-1696152465