### PR TITLE
Simplify passability rules

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -731,31 +731,18 @@ void Maps::Tiles::setInitialPassability()
 
 void Maps::Tiles::updatePassability()
 {
-    if ( !Maps::isValidDirection( _index, Direction::LEFT ) ) {
-        _tilePassabilityDirections &= ~( Direction::LEFT | Direction::TOP_LEFT | Direction::BOTTOM_LEFT );
-    }
-    if ( !Maps::isValidDirection( _index, Direction::RIGHT ) ) {
-        _tilePassabilityDirections &= ~( Direction::RIGHT | Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT );
-    }
-    if ( !Maps::isValidDirection( _index, Direction::TOP ) ) {
-        _tilePassabilityDirections &= ~( Direction::TOP | Direction::TOP_LEFT | Direction::TOP_RIGHT );
-    }
-    if ( !Maps::isValidDirection( _index, Direction::BOTTOM ) ) {
-        _tilePassabilityDirections &= ~( Direction::BOTTOM | Direction::BOTTOM_LEFT | Direction::BOTTOM_RIGHT );
-    }
-
+    // Get object type but ignore heroes as they are "temporary" objects.
     const MP2::MapObjectType objectType = GetObject( false );
+
     const bool isActionObject = MP2::isActionObject( objectType );
-    if ( !isActionObject && ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && _mainAddon._imageIndex < 255 && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0
-         && !isShadow() ) {
+    if ( !isActionObject && ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 && !isShadow() ) {
         // This is a non-action object.
         if ( Maps::isValidDirection( _index, Direction::BOTTOM ) ) {
             const Tiles & bottomTile = world.GetTiles( Maps::GetDirectionIndex( _index, Direction::BOTTOM ) );
 
             // If a bottom tile has the same object ID then this tile is inaccessible.
             std::vector<uint32_t> tileUIDs;
-            if ( ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && _mainAddon._imageIndex < 255 && _mainAddon._uid != 0
-                 && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 ) {
+            if ( ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && _mainAddon._uid != 0 && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 ) {
                 tileUIDs.emplace_back( _mainAddon._uid );
             }
 
@@ -792,8 +779,7 @@ void Maps::Tiles::updatePassability()
             const bool isBottomTileObject = ( ( bottomTile._mainAddon._layerType >> 1 ) & 1 ) == 0;
 
             // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
-            if ( !singleObjectTile && !isDetachedObject() && isBottomTileObject && ( bottomTile._mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN )
-                 && bottomTile._mainAddon._imageIndex < 255 ) {
+            if ( !singleObjectTile && !isDetachedObject() && isBottomTileObject && ( bottomTile._mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) ) {
                 const MP2::MapObjectType bottomTileObjectType = bottomTile.GetObject( false );
                 const bool isBottomTileActionObject = MP2::isActionObject( bottomTileObjectType );
                 const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( bottomTileObjectType );
@@ -1682,7 +1668,7 @@ bool Maps::Tiles::isTallObject() const
     }
 
     std::vector<uint32_t> tileUIDs;
-    if ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && _mainAddon._imageIndex < 255 && _mainAddon._uid != 0 && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 ) {
+    if ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && _mainAddon._uid != 0 && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 ) {
         tileUIDs.emplace_back( _mainAddon._uid );
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -754,12 +754,15 @@ void Maps::Tiles::updatePassability()
 
         // If a bottom tile has the same object ID then this tile must be marked as inaccessible because it is a continuation of the same object.
         std::vector<uint32_t> tileUIDs;
-        if ( _mainAddon._uid != 0 ) {
-            tileUIDs.emplace_back( _mainAddon._uid );
-        }
+
+        // If this assertion blows up then the object is not set properly. An object must have a valid UID!
+        assert( _mainAddon._uid != 0 );
+        tileUIDs.emplace_back( _mainAddon._uid );
 
         for ( const TilesAddon & addon : _addonBottomLayer ) {
-            if ( addon._uid != 0 && ( ( addon._layerType >> 1 ) & 1 ) == 0 ) {
+            if ( ( ( addon._layerType >> 1 ) & 1 ) == 0 ) {
+                // If this assertion blows up then the object is not set properly. An object must have a valid UID!
+                assert( addon._uid != 0 );
                 tileUIDs.emplace_back( addon._uid );
             }
         }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -737,82 +737,82 @@ void Maps::Tiles::updatePassability()
     const bool isActionObject = MP2::isActionObject( objectType );
     if ( !isActionObject && ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 && !isShadow() ) {
         // This is a non-action object.
-        if ( Maps::isValidDirection( _index, Direction::BOTTOM ) ) {
-            const Tiles & bottomTile = world.GetTiles( Maps::GetDirectionIndex( _index, Direction::BOTTOM ) );
 
-            // If a bottom tile has the same object ID then this tile is inaccessible.
-            std::vector<uint32_t> tileUIDs;
-            if ( ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && _mainAddon._uid != 0 && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 ) {
-                tileUIDs.emplace_back( _mainAddon._uid );
+        if ( !Maps::isValidDirection( _index, Direction::BOTTOM ) ) {
+            // This object "touches" the bottom part of the map. Mark is as inaccessible.
+            _tilePassabilityDirections = 0;
+            return;
+        }
+
+        const Tiles & bottomTile = world.GetTiles( Maps::GetDirectionIndex( _index, Direction::BOTTOM ) );
+        // If an object locates on land and the bottom tile is water mark the current tile as impassable. It's done for cases that a hero won't be able to
+        // disembark on the tile.
+        if ( !isWater() && bottomTile.isWater() ) {
+            _tilePassabilityDirections = 0;
+            return;
+        }
+
+        // If a bottom tile has the same object ID then this tile must be marked as inaccessible because it is a continuation of the same object.
+        std::vector<uint32_t> tileUIDs;
+        if ( ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && _mainAddon._uid != 0 && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 ) {
+            tileUIDs.emplace_back( _mainAddon._uid );
+        }
+
+        for ( const TilesAddon & addon : _addonBottomLayer ) {
+            if ( addon._uid != 0 && ( ( addon._layerType >> 1 ) & 1 ) == 0 ) {
+                tileUIDs.emplace_back( addon._uid );
             }
+        }
 
-            for ( const TilesAddon & addon : _addonBottomLayer ) {
-                if ( addon._uid != 0 && ( ( addon._layerType >> 1 ) & 1 ) == 0 ) {
-                    tileUIDs.emplace_back( addon._uid );
-                }
-            }
-
-            for ( const uint32_t objectId : tileUIDs ) {
-                if ( bottomTile.doesObjectExist( objectId ) ) {
-                    _tilePassabilityDirections = 0;
-                    return;
-                }
-            }
-
-            // If an object locates on land and the bottom tile is water mark the current tile as impassable. It's done for cases that a hero won't be able to
-            // disembark on the tile.
-            if ( !isWater() && bottomTile.isWater() ) {
+        for ( const uint32_t objectId : tileUIDs ) {
+            if ( bottomTile.doesObjectExist( objectId ) ) {
                 _tilePassabilityDirections = 0;
                 return;
             }
+        }
 
-            // Count how many objects are there excluding shadows, roads and river streams.
-            const std::ptrdiff_t validLevel1ObjectCount = std::count_if( _addonBottomLayer.begin(), _addonBottomLayer.end(), []( const TilesAddon & addon ) {
-                if ( isAddonShadow( addon ) ) {
-                    return false;
-                }
+        // Count how many objects are there excluding shadows, roads and river streams.
+        const std::ptrdiff_t validBottomLayerObjects = std::count_if( _addonBottomLayer.begin(), _addonBottomLayer.end(), []( const TilesAddon & addon ) {
+            if ( isAddonShadow( addon ) ) {
+                return false;
+            }
 
-                return addon._objectIcnType != MP2::OBJ_ICN_TYPE_ROAD && addon._objectIcnType != MP2::OBJ_ICN_TYPE_STREAM;
-            } );
+            return addon._objectIcnType != MP2::OBJ_ICN_TYPE_ROAD && addon._objectIcnType != MP2::OBJ_ICN_TYPE_STREAM;
+        } );
 
-            const bool singleObjectTile = validLevel1ObjectCount == 0 && _addonTopLayer.empty() && ( bottomTile._mainAddon._objectIcnType != _mainAddon._objectIcnType );
-            const bool isBottomTileObject = ( ( bottomTile._mainAddon._layerType >> 1 ) & 1 ) == 0;
+        const bool singleObjectTile = validBottomLayerObjects == 0 && _addonTopLayer.empty() && ( bottomTile._mainAddon._objectIcnType != _mainAddon._objectIcnType );
+        const bool isBottomTileObject = ( ( bottomTile._mainAddon._layerType >> 1 ) & 1 ) == 0;
 
-            // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
-            if ( !singleObjectTile && !isDetachedObject() && isBottomTileObject && ( bottomTile._mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) ) {
-                const MP2::MapObjectType bottomTileObjectType = bottomTile.GetObject( false );
-                const bool isBottomTileActionObject = MP2::isActionObject( bottomTileObjectType );
-                const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( bottomTileObjectType );
+        // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
+        if ( !singleObjectTile && !isDetachedObject() && isBottomTileObject && ( bottomTile._mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) ) {
+            const MP2::MapObjectType bottomTileObjectType = bottomTile.GetObject( false );
+            const bool isBottomTileActionObject = MP2::isActionObject( bottomTileObjectType );
+            const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( bottomTileObjectType );
 
-                if ( isBottomTileActionObject ) {
-                    if ( ( MP2::getActionObjectDirection( bottomTileObjectType ) & Direction::TOP ) == 0 ) {
-                        if ( isShortObject( bottomTileObjectType ) ) {
-                            _tilePassabilityDirections &= ~Direction::BOTTOM;
-                        }
-                        else {
-                            _tilePassabilityDirections = 0;
-                            return;
-                        }
+            if ( isBottomTileActionObject ) {
+                if ( ( MP2::getActionObjectDirection( bottomTileObjectType ) & Direction::TOP ) == 0 ) {
+                    if ( isShortObject( bottomTileObjectType ) ) {
+                        _tilePassabilityDirections &= ~Direction::BOTTOM;
+                    }
+                    else {
+                        _tilePassabilityDirections = 0;
+                        return;
                     }
                 }
-                else if ( bottomTile._mainObjectType != MP2::OBJ_NONE && correctedObjectType != bottomTileObjectType && MP2::isActionObject( correctedObjectType )
-                          && isShortObject( correctedObjectType ) && ( bottomTile.getOriginalPassability() & Direction::TOP ) == 0 ) {
-                    _tilePassabilityDirections &= ~Direction::BOTTOM;
-                }
-                else if ( isShortObject( bottomTileObjectType )
-                          || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() )
-                               && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
-                    _tilePassabilityDirections &= ~Direction::BOTTOM;
-                }
-                else {
-                    _tilePassabilityDirections = 0;
-                    return;
-                }
             }
-        }
-        else {
-            _tilePassabilityDirections = 0;
-            return;
+            else if ( bottomTile._mainObjectType != MP2::OBJ_NONE && correctedObjectType != bottomTileObjectType && MP2::isActionObject( correctedObjectType )
+                      && isShortObject( correctedObjectType ) && ( bottomTile.getOriginalPassability() & Direction::TOP ) == 0 ) {
+                _tilePassabilityDirections &= ~Direction::BOTTOM;
+            }
+            else if ( isShortObject( bottomTileObjectType )
+                      || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() )
+                           && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
+                _tilePassabilityDirections &= ~Direction::BOTTOM;
+            }
+            else {
+                _tilePassabilityDirections = 0;
+                return;
+            }
         }
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -754,7 +754,7 @@ void Maps::Tiles::updatePassability()
 
         // If a bottom tile has the same object ID then this tile must be marked as inaccessible because it is a continuation of the same object.
         std::vector<uint32_t> tileUIDs;
-        if ( ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && _mainAddon._uid != 0 && ( ( _mainAddon._layerType >> 1 ) & 1 ) == 0 ) {
+        if ( _mainAddon._uid != 0 ) {
             tileUIDs.emplace_back( _mainAddon._uid );
         }
 


### PR DESCRIPTION
Passability rules are complex. It is hard to understand how they work. This pull request slightly brushes up the logic by doing 3 things:
- remove leftover code related to image index checks as it is not needed at all.
- remove passability rules update along the sides of a map. This is an important to do as we are going to implement passability rendering in the Editor and we should display proper things. This change does not affect anything as a hero cannot come outside the map.
- reduces code complexity by removing incapsulated loops and checks.

This is how Broken Alliance map passabilities were before the changes (click to enlarge):
![image](https://github.com/ihhub/fheroes2/assets/19829520/e7705fea-fc3e-495f-9f28-179eb6013073)

and after:
![image](https://github.com/ihhub/fheroes2/assets/19829520/c5b7ac10-65a6-4ddf-a7a5-de6481a90391)

I tested multiple maps to compare with master branch and the passability rules remain the same.