### PR TITLE
Fix items list update after deleting an item: fix dismissing a hero from the Kingdom Overview dialog

### DIFF
--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -153,6 +153,7 @@ namespace Interface
         static int GetCursorFocusCastle( const Castle & castle, const Maps::Tiles & tile );
         static int GetCursorFocusHeroes( const Heroes & hero, const Maps::Tiles & tile );
         static int GetCursorFocusShipmaster( const Heroes & hero, const Maps::Tiles & tile );
+        static int _getCursorNoFocus( const Maps::Tiles & tile );
         static int GetCursorTileIndex( int32_t dstIndex );
 
         void ShowPathOrStartMoveHero( Heroes * hero, const int32_t destinationIdx );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -311,7 +311,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
             }
             break;
 
-        case Dialog::DISMISS:
+        case Dialog::DISMISS: {
             AudioManager::PlaySound( M82::KILLFADE );
 
             ( *it )->ShowPath( false );
@@ -330,12 +330,25 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
                 updateFocus = true;
             }
 
+            Heroes * selectedHero = Settings::Get().GetPlayers().GetCurrent()->GetFocus().GetHeroes();
+            const bool dismissedFocusedHero = ( selectedHero == *it );
+
             ( *it )->Dismiss( 0 );
             it = myHeroes.end();
 
+            if ( selectedHero != nullptr ) {
+                if ( dismissedFocusedHero ) {
+                    adventureMapInterface.ResetFocus( GameFocus::HEROES, false );
+                }
+                else {
+                    // If other hero was in focus before the dismiss we should properly keep the focus.
+                    adventureMapInterface.SetFocus( selectedHero, false );
+                }
+            }
+
             result = Dialog::CANCEL;
             break;
-
+        }
         case Dialog::CANCEL:
             needFade = true;
             break;
@@ -351,9 +364,6 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
         if ( updateFocus ) {
             if ( it != myHeroes.end() ) {
                 adventureMapInterface.SetFocus( *it, false );
-            }
-            else {
-                adventureMapInterface.ResetFocus( GameFocus::HEROES, false );
             }
         }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -524,6 +524,31 @@ int Interface::AdventureMap::GetCursorFocusShipmaster( const Heroes & hero, cons
     return Cursor::POINTER;
 }
 
+int Interface::AdventureMap::_getCursorNoFocus( const Maps::Tiles & tile )
+{
+    switch ( tile.GetObject() ) {
+    case MP2::OBJ_NON_ACTION_CASTLE:
+    case MP2::OBJ_CASTLE: {
+        const Castle * castle = world.getCastle( tile.GetCenter() );
+        if ( castle && castle->GetColor() == Settings::Get().CurrentColor() ) {
+            return Cursor::CASTLE;
+        }
+        break;
+    }
+    case MP2::OBJ_HEROES: {
+        const Heroes * hero = tile.getHero();
+        if ( hero && hero->GetColor() == Settings::Get().CurrentColor() ) {
+            return Cursor::HEROES;
+        }
+        break;
+    }
+    default:
+        break;
+    }
+
+    return Cursor::POINTER;
+}
+
 int Interface::AdventureMap::GetCursorFocusHeroes( const Heroes & hero, const Maps::Tiles & tile )
 {
     if ( hero.Modes( Heroes::ENABLEMOVE ) ) {
@@ -639,6 +664,9 @@ int Interface::AdventureMap::GetCursorTileIndex( int32_t dstIndex )
 
     case GameFocus::CASTLE:
         return GetCursorFocusCastle( *GetFocusCastle(), tile );
+
+    case GameFocus::UNSEL:
+        return _getCursorNoFocus( tile );
 
     default:
         break;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -336,8 +336,12 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
             ( *it )->Dismiss( 0 );
             it = myHeroes.end();
 
+            // A hero was dismissed. Update hero icons list including the slider image.
+            adventureMapInterface.GetIconsPanel().ResetIcons( ICON_HEROES );
+
             if ( selectedHero != nullptr ) {
                 if ( dismissedFocusedHero ) {
+                    // The selected hero was dismissed. Reset hero focus.
                     adventureMapInterface.ResetFocus( GameFocus::HEROES, false );
                 }
                 else {
@@ -361,10 +365,8 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
     // If Hero dialog background was not rendered than we have opened it from other dialog (Kingdom Overview or Castle dialog)
     // and there is no need update Adventure map interface at this time.
     if ( renderBackgroundDialog ) {
-        if ( updateFocus ) {
-            if ( it != myHeroes.end() ) {
-                adventureMapInterface.SetFocus( *it, false );
-            }
+        if ( updateFocus && it != myHeroes.end() ) {
+            adventureMapInterface.SetFocus( *it, false );
         }
 
         // The hero's army can change

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -263,6 +263,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */, con
 
         // The castle garrison can change
         adventureMapInterface.RedrawFocus();
+        adventureMapInterface.ResetFocus( Interface::GetFocusType(), false );
 
         // Fade-in game screen only for 640x480 resolution.
         if ( fheroes2::Display::instance().isDefaultSize() ) {
@@ -1249,9 +1250,6 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isload )
                             Interface::AdventureMap::RedrawLocker redrawLocker( Interface::AdventureMap::Get() );
 
                             _gameArea.SetCenter( hero->GetCenter() );
-                            ResetFocus( GameFocus::HEROES, true );
-
-                            RedrawFocus();
 
                             if ( stopHero ) {
                                 stopHero = false;
@@ -1270,9 +1268,6 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isload )
                                 heroAnimationOffset = movement;
                                 _gameArea.ShiftCenter( movement );
 
-                                Game::SetUpdateSoundsOnFocusUpdate( false );
-                                ResetFocus( GameFocus::HEROES, true );
-                                Game::SetUpdateSoundsOnFocusUpdate( true );
                                 heroAnimationFrameCount = 32 - heroMovementSkipValue;
                                 heroAnimationSpriteId = hero->GetSpriteIndex();
                                 if ( heroMovementSkipValue < 4 ) {

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -311,7 +311,7 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
             }
             break;
 
-        case Dialog::DISMISS: {
+        case Dialog::DISMISS:
             AudioManager::PlaySound( M82::KILLFADE );
 
             ( *it )->ShowPath( false );
@@ -330,29 +330,12 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
                 updateFocus = true;
             }
 
-            Heroes * selectedHero = Settings::Get().GetPlayers().GetCurrent()->GetFocus().GetHeroes();
-            const bool dismissedFocusedHero = ( selectedHero == *it );
-
             ( *it )->Dismiss( 0 );
             it = myHeroes.end();
 
-            // A hero was dismissed. Update hero icons list including the slider image.
-            adventureMapInterface.GetIconsPanel().ResetIcons( ICON_HEROES );
-
-            if ( selectedHero != nullptr ) {
-                if ( dismissedFocusedHero ) {
-                    // The selected hero was dismissed. Reset hero focus.
-                    adventureMapInterface.ResetFocus( GameFocus::HEROES, false );
-                }
-                else {
-                    // If other hero was in focus before the dismiss we should properly keep the focus.
-                    adventureMapInterface.SetFocus( selectedHero, false );
-                }
-            }
-
             result = Dialog::CANCEL;
             break;
-        }
+
         case Dialog::CANCEL:
             needFade = true;
             break;
@@ -365,10 +348,14 @@ void Game::OpenHeroesDialog( Heroes & hero, bool updateFocus, const bool renderB
     // If Hero dialog background was not rendered than we have opened it from other dialog (Kingdom Overview or Castle dialog)
     // and there is no need update Adventure map interface at this time.
     if ( renderBackgroundDialog ) {
-        if ( updateFocus && it != myHeroes.end() ) {
-            adventureMapInterface.SetFocus( *it, false );
+        if ( updateFocus ) {
+            if ( it != myHeroes.end() ) {
+                adventureMapInterface.SetFocus( *it, false );
+            }
+            else {
+                adventureMapInterface.ResetFocus( GameFocus::HEROES, false );
+            }
         }
-
         // The hero's army can change
         adventureMapInterface.RedrawFocus();
 

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -65,6 +65,7 @@ void Interface::AdventureMap::SetFocus( Heroes * hero, const bool retainScrollBa
 
     Heroes * focusedHero = focus.GetHeroes();
     if ( focusedHero && focusedHero != hero ) {
+        // Focus has been changed to another hero. Hide the path of the previous hero.
         focusedHero->ShowPath( false );
     }
 
@@ -175,19 +176,24 @@ void Interface::AdventureMap::ResetFocus( const int priority, const bool retainS
     switch ( priority ) {
     case GameFocus::FIRSTHERO: {
         const VecHeroes & heroes = myKingdom.GetHeroes();
-        // skip sleeping
-        VecHeroes::const_iterator it = std::find_if( heroes.begin(), heroes.end(), []( const Heroes * hero ) { return !hero->Modes( Heroes::SLEEPER ); } );
+        // Find first hero excluding sleeping ones.
+        const VecHeroes::const_iterator it = std::find_if( heroes.begin(), heroes.end(), []( const Heroes * hero ) { return !hero->Modes( Heroes::SLEEPER ); } );
 
-        if ( it != heroes.end() )
+        if ( it != heroes.end() ) {
             SetFocus( *it, false );
-        else
+        }
+        else {
+            // There are no non-sleeping heroes. Focus on the castle instead.
             ResetFocus( GameFocus::CASTLE, retainScrollBarPosition );
+        }
         break;
     }
 
     case GameFocus::HEROES:
-        if ( focus.GetHeroes() && focus.GetHeroes()->GetColor() == player->GetColor() )
-            SetFocus( focus.GetHeroes(), retainScrollBarPosition );
+        if ( Heroes * hero = focus.GetHeroes(); ( hero != nullptr ) && ( hero->GetColor() == player->GetColor() ) ) {
+            // Set focus on the previously focused hero.
+            SetFocus( hero, retainScrollBarPosition );
+        }
         else if ( !myKingdom.GetHeroes().empty() ) {
             // Reset scrollbar here because the current focused hero might have
             // lost a battle and is not in the heroes list anymore.
@@ -195,26 +201,33 @@ void Interface::AdventureMap::ResetFocus( const int priority, const bool retainS
             SetFocus( myKingdom.GetHeroes().front(), false );
         }
         else if ( !myKingdom.GetCastles().empty() ) {
+            // There are no heroes left in the kingdom. Reset the heroes scrollbar and focus on the first castle.
             iconsPanel.SetRedraw( ICON_HEROES );
             SetFocus( myKingdom.GetCastles().front() );
         }
-        else
+        else {
             focus.Reset();
+        }
         break;
 
     case GameFocus::CASTLE:
-        if ( focus.GetCastle() && focus.GetCastle()->GetColor() == player->GetColor() )
-            SetFocus( focus.GetCastle() );
+        if ( Castle * castle = focus.GetCastle(); ( castle != nullptr ) && ( castle->GetColor() == player->GetColor() ) ) {
+            // Focus on the previously focused castle.
+            SetFocus( castle );
+        }
         else if ( !myKingdom.GetCastles().empty() ) {
+            // The previously focused castle is lost, so we update the castles scrollbar.
             iconsPanel.ResetIcons( ICON_CASTLES );
             SetFocus( myKingdom.GetCastles().front() );
         }
         else if ( !myKingdom.GetHeroes().empty() ) {
+            // There are no castles left in the kingdom. Reset the castles scrollbar and focus on the first hero.
             iconsPanel.SetRedraw( ICON_CASTLES );
             SetFocus( myKingdom.GetHeroes().front(), false );
         }
-        else
+        else {
             focus.Reset();
+        }
         break;
 
     default:
@@ -230,10 +243,12 @@ int Interface::GetFocusType()
     if ( player ) {
         Focus & focus = player->GetFocus();
 
-        if ( focus.GetHeroes() )
+        if ( focus.GetHeroes() ) {
             return GameFocus::HEROES;
-        if ( focus.GetCastle() )
+        }
+        if ( focus.GetCastle() ) {
             return GameFocus::CASTLE;
+        }
     }
 
     return GameFocus::UNSEL;
@@ -255,7 +270,7 @@ Heroes * Interface::GetFocusHeroes()
 
 void Interface::AdventureMap::RedrawFocus()
 {
-    int type = GetFocusType();
+    const int type = GetFocusType();
 
     if ( type != FOCUS_HEROES && iconsPanel.IsSelected( ICON_HEROES ) ) {
         iconsPanel.ResetIcons( ICON_HEROES );
@@ -277,10 +292,12 @@ void Interface::AdventureMap::RedrawFocus()
 
     setRedraw( REDRAW_GAMEAREA | REDRAW_RADAR_CURSOR );
 
-    if ( type == FOCUS_HEROES )
+    if ( type == FOCUS_HEROES ) {
         iconsPanel.SetRedraw( ICON_HEROES );
-    else if ( type == FOCUS_CASTLE )
+    }
+    else if ( type == FOCUS_CASTLE ) {
         iconsPanel.SetRedraw( ICON_CASTLES );
+    }
 
     _statusWindow.SetRedraw();
 }

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -76,7 +76,7 @@ void Interface::AdventureMap::SetFocus( Heroes * hero, const bool retainScrollBa
     hero->ShowPath( true );
     focus.Set( hero );
 
-    redraw( REDRAW_BUTTONS );
+    setRedraw( REDRAW_BUTTONS );
 
     if ( !retainScrollBarPosition ) {
         iconsPanel.Select( hero );
@@ -120,7 +120,7 @@ void Interface::AdventureMap::SetFocus( Castle * castle )
 
     focus.Set( castle );
 
-    redraw( REDRAW_BUTTONS );
+    setRedraw( REDRAW_BUTTONS );
 
     iconsPanel.Select( castle );
     _gameArea.SetCenter( castle->GetCenter() );

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -43,13 +43,11 @@
 
 namespace
 {
-    enum : int32_t
-    {
-        ICONS_WIDTH = 46,
-        ICONS_HEIGHT = 22,
-        ICONS_CURSOR_WIDTH = 56,
-        ICONS_CURSOR_HEIGHT = 32
-    };
+    const int32_t iconsWidth = 46;
+    const int32_t iconsHeight = 22;
+    const int32_t iconsCursorWidth = 56;
+    const int32_t iconsCursorHeight = 32;
+
 }
 
 bool Interface::IconsBar::IsVisible()
@@ -60,12 +58,12 @@ bool Interface::IconsBar::IsVisible()
 
 int32_t Interface::IconsBar::GetItemWidth()
 {
-    return ICONS_WIDTH;
+    return iconsWidth;
 }
 
 int32_t Interface::IconsBar::GetItemHeight()
 {
-    return ICONS_HEIGHT;
+    return iconsHeight;
 }
 
 void Interface::RedrawCastleIcon( const Castle & castle, int32_t sx, int32_t sy )
@@ -178,20 +176,20 @@ void Interface::CastleIcons::SetPos( int32_t px, int32_t py )
 
     _topLeftCorner = fheroes2::Point( px, py );
     SetTopLeft( _topLeftCorner );
-    setScrollBarArea( { px + ICONS_CURSOR_WIDTH + 3, py + 19, 10, ICONS_CURSOR_HEIGHT * iconsCount - 38 } );
+    setScrollBarArea( { px + iconsCursorWidth + 3, py + 19, 10, iconsCursorHeight * iconsCount - 38 } );
 
     VecCastles & castles = world.GetKingdom( Settings::Get().CurrentColor() ).GetCastles();
 
     const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );
     const fheroes2::Image scrollbarSlider
-        = fheroes2::generateScrollbarSlider( originalSlider, false, ICONS_CURSOR_HEIGHT * iconsCount - 38, iconsCount, static_cast<int32_t>( castles.size() ),
+        = fheroes2::generateScrollbarSlider( originalSlider, false, iconsCursorHeight * iconsCount - 38, iconsCount, static_cast<int32_t>( castles.size() ),
                                              { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
 
     setScrollBarImage( scrollbarSlider );
-    SetScrollButtonUp( icnscroll, 0, 1, { px + ICONS_CURSOR_WIDTH + 1, py + 1 } );
-    SetScrollButtonDn( icnscroll, 2, 3, { px + ICONS_CURSOR_WIDTH + 1, py + iconsCount * ICONS_CURSOR_HEIGHT - 15 } );
+    SetScrollButtonUp( icnscroll, 0, 1, { px + iconsCursorWidth + 1, py + 1 } );
+    SetScrollButtonDn( icnscroll, 2, 3, { px + iconsCursorWidth + 1, py + iconsCount * iconsCursorHeight - 15 } );
     SetAreaMaxItems( iconsCount );
-    SetAreaItems( { px, py, ICONS_CURSOR_WIDTH, iconsCount * ICONS_CURSOR_HEIGHT } );
+    SetAreaItems( { px, py, iconsCursorWidth, iconsCount * iconsCursorHeight } );
     DisableHotkeys( true );
 
     SetListContent( castles );
@@ -271,20 +269,20 @@ void Interface::HeroesIcons::SetPos( int32_t px, int32_t py )
 
     _topLeftCorner = fheroes2::Point( px, py );
     SetTopLeft( _topLeftCorner );
-    setScrollBarArea( { px + ICONS_CURSOR_WIDTH + 3, py + 19, 10, ICONS_CURSOR_HEIGHT * iconsCount - 38 } );
+    setScrollBarArea( { px + iconsCursorWidth + 3, py + 19, 10, iconsCursorHeight * iconsCount - 38 } );
 
     VecHeroes & heroes = world.GetKingdom( Settings::Get().CurrentColor() ).GetHeroes();
 
     const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );
     const fheroes2::Image scrollbarSlider
-        = fheroes2::generateScrollbarSlider( originalSlider, false, ICONS_CURSOR_HEIGHT * iconsCount - 38, iconsCount, static_cast<int32_t>( heroes.size() ),
+        = fheroes2::generateScrollbarSlider( originalSlider, false, iconsCursorHeight * iconsCount - 38, iconsCount, static_cast<int32_t>( heroes.size() ),
                                              { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
 
     setScrollBarImage( scrollbarSlider );
-    SetScrollButtonUp( icnscroll, 0, 1, { px + ICONS_CURSOR_WIDTH + 1, py + 1 } );
-    SetScrollButtonDn( icnscroll, 2, 3, { px + ICONS_CURSOR_WIDTH + 1, py + iconsCount * ICONS_CURSOR_HEIGHT - 15 } );
+    SetScrollButtonUp( icnscroll, 0, 1, { px + iconsCursorWidth + 1, py + 1 } );
+    SetScrollButtonDn( icnscroll, 2, 3, { px + iconsCursorWidth + 1, py + iconsCount * iconsCursorHeight - 15 } );
     SetAreaMaxItems( iconsCount );
-    SetAreaItems( { px, py, ICONS_CURSOR_WIDTH, iconsCount * ICONS_CURSOR_HEIGHT } );
+    SetAreaItems( { px, py, iconsCursorWidth, iconsCount * iconsCursorHeight } );
     DisableHotkeys( true );
 
     SetListContent( heroes );
@@ -301,7 +299,7 @@ Interface::IconsPanel::IconsPanel( AdventureMap & basic )
     , castleIcons( 4, sfMarker )
     , heroesIcons( 4, sfMarker )
 {
-    sfMarker.resize( ICONS_CURSOR_WIDTH, ICONS_CURSOR_HEIGHT );
+    sfMarker.resize( iconsCursorWidth, iconsCursorHeight );
     sfMarker.reset();
     fheroes2::DrawBorder( sfMarker, fheroes2::GetColorId( 0xA0, 0xE0, 0xE0 ) );
 }
@@ -316,20 +314,22 @@ void Interface::IconsPanel::SavePosition()
 
 void Interface::IconsPanel::SetRedraw( const icons_t type ) const
 {
-    // is visible
-    if ( IconsBar::IsVisible() ) {
-        switch ( type ) {
-        case ICON_HEROES:
-            interface.setRedraw( REDRAW_HEROES );
-            break;
-        case ICON_CASTLES:
-            interface.setRedraw( REDRAW_CASTLES );
-            break;
-        default:
-            break;
-        }
+    if ( !IconsBar::IsVisible() ) {
+        return;
+    }
 
+    switch ( type ) {
+    case ICON_HEROES:
+        interface.setRedraw( REDRAW_HEROES );
+        break;
+    case ICON_CASTLES:
+        interface.setRedraw( REDRAW_CASTLES );
+        break;
+    case ICON_ANY:
         interface.setRedraw( REDRAW_ICONS );
+        break;
+    default:
+        break;
     }
 }
 
@@ -350,7 +350,7 @@ void Interface::IconsPanel::SetPos( int32_t ox, int32_t oy )
         iconsCount = count_h > 3 ? 8 : ( count_h < 3 ? 4 : 7 );
     }
 
-    BorderWindow::SetPosition( ox, oy, 144, iconsCount * ICONS_CURSOR_HEIGHT );
+    BorderWindow::SetPosition( ox, oy, 144, iconsCount * iconsCursorHeight );
 
     heroesIcons.SetIconsCount( iconsCount );
     castleIcons.SetIconsCount( iconsCount );
@@ -363,15 +363,16 @@ void Interface::IconsPanel::SetPos( int32_t ox, int32_t oy )
 
 void Interface::IconsPanel::_redraw()
 {
-    // is visible
-    if ( IconsBar::IsVisible() ) {
-        // redraw border
-        if ( Settings::Get().isHideInterfaceEnabled() )
-            BorderWindow::Redraw();
-
-        heroesIcons.Redraw();
-        castleIcons.Redraw();
+    if ( !IconsBar::IsVisible() ) {
+        return;
     }
+
+    if ( Settings::Get().isHideInterfaceEnabled() ) {
+        BorderWindow::Redraw();
+    }
+
+    heroesIcons.Redraw();
+    castleIcons.Redraw();
 }
 
 void Interface::IconsPanel::QueueEventProcessing()
@@ -418,57 +419,67 @@ void Interface::IconsPanel::ResetIcons( const icons_t type )
         const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );
 
         if ( type & ICON_HEROES ) {
-            const fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, ICONS_CURSOR_HEIGHT * heroesIcons.getIconsCount() - 38,
+            const fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, iconsCursorHeight * heroesIcons.getIconsCount() - 38,
                                                                                        heroesIcons.getIconsCount(), static_cast<int32_t>( kingdom.GetHeroes().size() ),
                                                                                        { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
             heroesIcons.setScrollBarImage( scrollbarSlider );
-
             heroesIcons.SetListContent( kingdom.GetHeroes() );
-            heroesIcons.Reset();
+
+            // SetListContent() selects the first item (hero) in the list. We reset it by unselecting.
+            heroesIcons.Unselect();
         }
 
         if ( type & ICON_CASTLES ) {
-            const fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, ICONS_CURSOR_HEIGHT * castleIcons.getIconsCount() - 38,
+            const fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, iconsCursorHeight * castleIcons.getIconsCount() - 38,
                                                                                        castleIcons.getIconsCount(), static_cast<int32_t>( kingdom.GetCastles().size() ),
                                                                                        { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
             castleIcons.setScrollBarImage( scrollbarSlider );
-
             castleIcons.SetListContent( kingdom.GetCastles() );
-            castleIcons.Reset();
+
+            // SetListContent() selects the first item (castle/town) in the list. We reset it by unselecting.
+            castleIcons.Unselect();
         }
     }
 }
 
 void Interface::IconsPanel::HideIcons( const icons_t type )
 {
-    if ( type & ICON_HEROES )
+    if ( type & ICON_HEROES ) {
         heroesIcons.SetShow( false );
-    if ( type & ICON_CASTLES )
+    }
+    if ( type & ICON_CASTLES ) {
         castleIcons.SetShow( false );
+    }
 }
 
 void Interface::IconsPanel::ShowIcons( const icons_t type )
 {
-    if ( type & ICON_HEROES )
+    if ( type & ICON_HEROES ) {
         heroesIcons.SetShow( true );
-    if ( type & ICON_CASTLES )
+    }
+    if ( type & ICON_CASTLES ) {
         castleIcons.SetShow( true );
+    }
 }
 
 void Interface::IconsPanel::_redrawIcons( const icons_t type )
 {
-    if ( type & ICON_HEROES )
+    if ( type & ICON_HEROES ) {
         heroesIcons.Redraw();
-    if ( type & ICON_CASTLES )
+    }
+    if ( type & ICON_CASTLES ) {
         castleIcons.Redraw();
+    }
 }
 
 bool Interface::IconsPanel::IsSelected( const icons_t type ) const
 {
-    if ( type & ICON_HEROES )
+    if ( type & ICON_HEROES ) {
         return heroesIcons.isSelected();
-    else if ( type & ICON_CASTLES )
+    }
+    if ( type & ICON_CASTLES ) {
         return castleIcons.isSelected();
+    }
 
     return false;
 }

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -47,7 +47,6 @@ namespace
     const int32_t iconsHeight = 22;
     const int32_t iconsCursorWidth = 56;
     const int32_t iconsCursorHeight = 32;
-
 }
 
 bool Interface::IconsBar::IsVisible()

--- a/src/fheroes2/gui/interface_icons.h
+++ b/src/fheroes2/gui/interface_icons.h
@@ -35,7 +35,7 @@
 class Castle;
 class Heroes;
 
-enum icons_t
+enum icons_t : uint8_t
 {
     ICON_HEROES = 0x01,
     ICON_CASTLES = 0x02,

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -160,12 +160,8 @@ namespace Interface
                 _currentId = -1; // no selection
                 _topId = 0;
 
-                if ( maxItems < _size() ) {
-                    _scrollbar.setRange( 0, _size() - maxItems );
-                }
-                else {
-                    _scrollbar.setRange( 0, 0 );
-                }
+                const int newMaxValue = std::max( _size() - maxItems, 0 );
+                _scrollbar.setRange( 0, newMaxValue );
             }
         }
 

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -35,13 +35,6 @@ namespace Interface
     class ListBasic
     {
     public:
-        ListBasic()
-            : _currentId( -1 )
-            , _topId( -1 )
-        {
-            // Do nothing.
-        }
-
         virtual ~ListBasic() = default;
         virtual bool IsNeedRedraw() const = 0;
         virtual void Redraw() = 0;
@@ -53,9 +46,9 @@ namespace Interface
         }
 
     protected:
-        int _currentId;
+        int _currentId{ -1 };
 
-        int _topId;
+        int _topId{ -1 };
     };
 
     template <class Item>
@@ -63,12 +56,7 @@ namespace Interface
     {
     public:
         explicit ListBox( const fheroes2::Point & pt = fheroes2::Point() )
-            : needRedraw( false )
-            , content( nullptr )
-            , maxItems( 0 )
-            , ptRedraw( pt )
-            , useHotkeys( true )
-            , _updateScrollbar( false )
+            : ptRedraw( pt )
             , _timedButtonPgUp( [this]() { return buttonPgUp.isPressed(); } )
             , _timedButtonPgDn( [this]() { return buttonPgDn.isPressed(); } )
         {
@@ -102,7 +90,7 @@ namespace Interface
             ActionListPressRight( item );
         }
 
-        virtual bool ActionListCursor( Item &, const fheroes2::Point & )
+        virtual bool ActionListCursor( Item & /* item */, const fheroes2::Point & /* cursor */ )
         {
             return false;
         }
@@ -155,13 +143,15 @@ namespace Interface
             content = &list;
             Reset();
 
-            if ( IsValid() )
+            if ( IsValid() ) {
                 _currentId = 0;
+            }
         }
 
         void Reset()
         {
-            if ( content == nullptr || content->empty() ) { // empty content. Must be non-initialized array
+            if ( content == nullptr || content->empty() ) {
+                // Empty content. It is non-initialized array, initialize it.
                 _currentId = -1;
                 _topId = -1;
                 _scrollbar.setRange( 0, 0 );
@@ -199,8 +189,9 @@ namespace Interface
             if ( IsValid() ) { // we have something to display
                 int id = _topId;
                 const int end = ( _topId + maxItems ) > _size() ? _size() - _topId : _topId + maxItems;
-                for ( ; id < end; ++id )
+                for ( ; id < end; ++id ) {
                     RedrawItem( ( *content )[id], rtAreaItems.x, rtAreaItems.y + ( id - _topId ) * rtAreaItems.height / maxItems, id == _currentId );
+                }
             }
         }
 
@@ -222,26 +213,34 @@ namespace Interface
         Item * GetFromPosition( const fheroes2::Point & mp )
         {
             Verify();
-            if ( !IsValid() )
+            if ( !IsValid() ) {
                 return nullptr;
+            }
 
-            if ( mp.y < rtAreaItems.y || mp.y >= rtAreaItems.y + rtAreaItems.height ) // out of boundaries
+            if ( mp.y < rtAreaItems.y || mp.y >= rtAreaItems.y + rtAreaItems.height ) {
+                // Out of boundaries.
                 return nullptr;
+            }
 
-            if ( mp.x < rtAreaItems.x || mp.x >= rtAreaItems.x + rtAreaItems.width ) // out of boundaries
+            if ( mp.x < rtAreaItems.x || mp.x >= rtAreaItems.x + rtAreaItems.width ) {
+                // Out of boundaries.
                 return nullptr;
+            }
 
             const int id = ( mp.y - rtAreaItems.y ) * maxItems / rtAreaItems.height;
-            if ( _topId + id >= _size() ) // out of items
+            if ( _topId + id >= _size() ) {
+                // Out of items.
                 return nullptr;
+            }
 
             return &( *content )[_topId + id];
         }
 
         void SetCurrent( size_t posId )
         {
-            if ( posId < content->size() )
+            if ( posId < content->size() ) {
                 _currentId = static_cast<int>( posId );
+            }
 
             SetCurrentVisible();
         }
@@ -256,10 +255,12 @@ namespace Interface
             }
 
             if ( _currentId >= 0 && ( _topId > _currentId || _topId + maxItems <= _currentId ) ) { // out of view
-                if ( _topId > _currentId ) { // scroll up, put current id on top
+                if ( _topId > _currentId ) {
+                    // Scroll up, put current id on top.
                     _topId = _currentId;
                 }
-                else if ( _topId + maxItems <= _currentId ) { // scroll down, put current id at bottom
+                else if ( _topId + maxItems <= _currentId ) {
+                    // Scroll down, put current id at bottom.
                     _topId = _currentId + 1 - maxItems;
                 }
             }
@@ -286,11 +287,13 @@ namespace Interface
 
         void SetCurrent( const Item & item )
         {
-            typename std::vector<Item>::iterator pos = std::find( content->begin(), content->end(), item );
-            if ( pos == content->end() )
+            const typename std::vector<Item>::iterator pos = std::find( content->begin(), content->end(), item );
+            if ( pos == content->end() ) {
                 Reset();
-            else
+            }
+            else {
                 _currentId = static_cast<int>( pos - content->begin() );
+            }
 
             SetCurrentVisible();
         }
@@ -328,16 +331,19 @@ namespace Interface
             le.MousePressLeft( buttonPgUp.area() ) ? buttonPgUp.drawOnPress() : buttonPgUp.drawOnRelease();
             le.MousePressLeft( buttonPgDn.area() ) ? buttonPgDn.drawOnPress() : buttonPgDn.drawOnRelease();
 
-            if ( !IsValid() )
+            if ( !IsValid() ) {
                 return false;
+            }
 
             if ( useHotkeys && le.KeyPress( fheroes2::Key::KEY_PAGE_UP ) && ( _topId > 0 ) ) {
                 needRedraw = true;
 
-                if ( _topId > maxItems )
+                if ( _topId > maxItems ) {
                     _topId -= maxItems;
-                else
+                }
+                else {
                     _topId = 0;
+                }
 
                 UpdateScrollbarRange();
                 _scrollbar.moveToIndex( _topId );
@@ -348,8 +354,9 @@ namespace Interface
                 needRedraw = true;
 
                 _topId += maxItems;
-                if ( _topId + maxItems >= _size() )
+                if ( _topId + maxItems >= _size() ) {
                     _topId = _size() - maxItems;
+                }
 
                 UpdateScrollbarRange();
                 _scrollbar.moveToIndex( _topId );
@@ -468,7 +475,8 @@ namespace Interface
                         }
                         return true;
                     }
-                    else if ( le.MousePressRight( rtAreaItems ) ) {
+
+                    if ( le.MousePressRight( rtAreaItems ) ) {
                         ActionListPressRight( item, mousePos, rtAreaItems.x, rtAreaItems.y + offsetY );
                         return true;
                     }
@@ -481,7 +489,7 @@ namespace Interface
         }
 
     protected:
-        bool needRedraw;
+        bool needRedraw{ false };
 
         fheroes2::Rect rtAreaItems;
 
@@ -501,14 +509,14 @@ namespace Interface
         }
 
     private:
-        std::vector<Item> * content;
-        int maxItems;
+        std::vector<Item> * content{ nullptr };
+        int maxItems{ 0 };
 
         fheroes2::Point ptRedraw;
 
-        bool useHotkeys;
+        bool useHotkeys{ true };
 
-        bool _updateScrollbar;
+        bool _updateScrollbar{ false };
 
         fheroes2::TimedEventValidator _timedButtonPgUp;
         fheroes2::TimedEventValidator _timedButtonPgDn;
@@ -520,18 +528,40 @@ namespace Interface
                 _topId = -1;
             }
             else {
-                if ( _currentId >= _size() )
+                const int listSize = _size();
+                const int maxTopId = std::max( listSize - maxItems, 0 );
+
+                if ( _currentId >= listSize ) {
                     _currentId = -1;
-                if ( _topId < 0 || _topId >= _size() )
-                    _topId = 0;
+                }
+
+                if ( _topId < 0 || _topId > maxTopId ) {
+                    // Top position is out of list boundaries.
+                    if ( _currentId == -1 ) {
+                        // There is no item selected. Show the list from its very top.
+                        _topId = 0;
+                    }
+                    else {
+                        // Set top position to show the selected item.
+                        _topId = std::min( _currentId - maxItems / 2, maxTopId );
+                    }
+                }
+
+                // Update scrollbar range if needed.
+                if ( _scrollbar.maxIndex() != maxTopId ) {
+                    _scrollbar.setRange( 0, maxTopId );
+                    _scrollbar.moveToIndex( _topId );
+                }
             }
         }
 
         void UpdateScrollbarRange()
         {
-            const int maxValue = ( content != nullptr && maxItems < _size() ) ? static_cast<int>( _size() - maxItems ) : 0;
-            if ( _scrollbar.maxIndex() != maxValue )
+            const int newMaxValue = _size() - maxItems;
+            const int maxValue = ( content != nullptr && newMaxValue > 0 ) ? newMaxValue : 0;
+            if ( _scrollbar.maxIndex() != maxValue ) {
                 _scrollbar.setRange( 0, maxValue );
+            }
         }
     };
 }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3260,7 +3260,9 @@ namespace
                 _( "In a dazzling display of daring, you break into the local jail and free the hero imprisoned there, who, in return, pledges loyalty to your cause." ),
                 Dialog::OK );
 
-            Interface::AdventureMap::Get().getGameArea().runSingleObjectAnimation(
+            Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();
+
+            adventureMapInterface.getGameArea().runSingleObjectAnimation(
                 std::make_shared<Interface::ObjectFadingOutInfo>( tile.GetObjectUID(), tile.GetIndex(), tile.GetObject() ) );
 
             // TODO: add hero fading in animation together with jail animation.
@@ -3268,6 +3270,7 @@ namespace
 
             if ( prisoner ) {
                 prisoner->Recruit( hero.GetColor(), Maps::GetPoint( dst_index ) );
+                adventureMapInterface.GetIconsPanel().ResetIcons( ICON_HEROES );
             }
         }
         else {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -52,6 +52,7 @@
 #include "image.h"
 #include "interface_base.h"
 #include "interface_gamearea.h"
+#include "interface_icons.h"
 #include "interface_radar.h"
 #include "interface_status.h"
 #include "kingdom.h"
@@ -3270,6 +3271,8 @@ namespace
 
             if ( prisoner ) {
                 prisoner->Recruit( hero.GetColor(), Maps::GetPoint( dst_index ) );
+
+                // Update the kingdom heroes list including the scrollbar.
                 adventureMapInterface.GetIconsPanel().ResetIcons( ICON_HEROES );
             }
         }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -315,12 +315,9 @@ void Kingdom::AddHero( Heroes * hero )
         return;
     }
 
-    if ( heroes.end() == std::find( heroes.begin(), heroes.end(), hero ) )
+    if ( heroes.end() == std::find( heroes.begin(), heroes.end(), hero ) ) {
         heroes.push_back( hero );
-
-    const Player * player = Settings::Get().GetPlayers().GetCurrent();
-    if ( player && player->isColor( GetColor() ) && player->isControlHuman() )
-        Interface::AdventureMap::Get().GetIconsPanel().ResetIcons( ICON_HEROES );
+    }
 
     AI::Get().HeroesAdd( *hero );
 }

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -908,6 +908,7 @@ void Kingdom::openOverviewDialog()
         // So, it's equivalent to check if hero list changed.
         if ( listHeroes.Refresh( heroes ) ) {
             worldMapRedrawMask |= Interface::AdventureMap::Get().getRedrawMask();
+            worldMapRedrawMask |= Interface::REDRAW_HEROES;
 
             // Update army bars in Castles.
             listCastles.updateHeroArmyBars();
@@ -938,7 +939,12 @@ void Kingdom::openOverviewDialog()
     _topHeroInKingdomView = listHeroes.getTopId();
 
     if ( worldMapRedrawMask != 0 ) {
+        Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();
+
         // Force redraw of all UI elements that changed, that were masked by Kingdom window
-        Interface::AdventureMap::Get().setRedraw( worldMapRedrawMask );
+        adventureMapInterface.setRedraw( worldMapRedrawMask );
+
+        // Update focus because there were some changes made in the Kingdom overview dialog.
+        adventureMapInterface.ResetFocus( Interface::GetFocusType(), false );
     }
 }

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -44,6 +44,7 @@
 #include "heroes_base.h"
 #include "icn.h"
 #include "image.h"
+#include "interface_base.h"
 #include "interface_icons.h"
 #include "interface_list.h"
 #include "kingdom.h"
@@ -759,6 +760,8 @@ void RedrawFundsInfo( const fheroes2::Point & pt, const Kingdom & myKingdom )
 
 void Kingdom::openOverviewDialog()
 {
+    Game::SetUpdateSoundsOnFocusUpdate( false );
+
     fheroes2::Display & display = fheroes2::Display::instance();
 
     // setup cursor
@@ -937,6 +940,8 @@ void Kingdom::openOverviewDialog()
 
     _topCastleInKingdomView = listCastles.getTopId();
     _topHeroInKingdomView = listHeroes.getTopId();
+
+    Game::SetUpdateSoundsOnFocusUpdate( true );
 
     if ( worldMapRedrawMask != 0 ) {
         Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -88,6 +88,33 @@ namespace
 
         return output;
     }
+
+    void redrawCommonBackground( const fheroes2::Point & dst, const int visibleItems, fheroes2::Image & output )
+    {
+        // Scrollbar background.
+        const fheroes2::Sprite & scrollbar = fheroes2::AGG::GetICN( ICN::OVERVIEW, 13 );
+        fheroes2::Copy( scrollbar, 0, 0, output, dst.x + scrollbarOffset + 1, dst.y + 17, scrollbar.width(), scrollbar.height() );
+
+        // Items background.
+        const fheroes2::Sprite & itemsBack = fheroes2::AGG::GetICN( ICN::OVERVIEW, 8 );
+        const fheroes2::Sprite & overback = fheroes2::AGG::GetICN( ICN::OVERBACK, 0 );
+        const int32_t itemsBackWidth = itemsBack.width();
+        const int32_t itemsBackHeight = itemsBack.height();
+        const int32_t offsetX = dst.x + 30;
+        int32_t offsetY = dst.y + 17;
+        const int32_t stepY = itemsBackHeight + 4;
+        const int32_t overbackOffsetX = dst.x + 29;
+        int32_t overbackOffsetY = dst.y + 13;
+
+        for ( int i = 0; i < visibleItems; ++i, offsetY += stepY, overbackOffsetY += stepY ) {
+            fheroes2::Copy( itemsBack, 0, 0, output, offsetX, offsetY, itemsBackWidth, itemsBackHeight );
+            // Horizontal yellow "grid" lines.
+            fheroes2::Copy( overback, 29, 13, output, overbackOffsetX, overbackOffsetY, 595, 4 );
+        }
+
+        // Copy one vertical line in case of previous army selection.
+        fheroes2::Copy( overback, 29, 12, output, overbackOffsetX, dst.y + 12, 1, 357 );
+    }
 }
 
 struct HeroRow
@@ -361,22 +388,7 @@ void StatsHeroesList::RedrawBackground( const fheroes2::Point & dst )
     text.set( _( "Artifacts" ), fheroes2::FontType::smallWhite() );
     text.draw( dst.x + 500 - text.width() / 2, offsetY, display );
 
-    // Scrollbar background.
-    const fheroes2::Sprite & scrollbar = fheroes2::AGG::GetICN( ICN::OVERVIEW, 13 );
-    fheroes2::Copy( scrollbar, 0, 0, display, dst.x + scrollbarOffset + 1, dst.y + 17, scrollbar.width(), scrollbar.height() );
-
-    // Items background.
-    const fheroes2::Sprite & itemsBack = fheroes2::AGG::GetICN( ICN::OVERVIEW, 8 );
-    const int32_t itemsBackWidth = itemsBack.width();
-    const int32_t itemsBackHeight = itemsBack.height();
-    const int32_t offsetX = dst.x + 30;
-    offsetY = dst.y + 17;
-    const int32_t stepY = itemsBackHeight + 4;
-    const int visibleItems = VisibleItemCount();
-
-    for ( int ii = 0; ii < visibleItems; ++ii, offsetY += stepY ) {
-        fheroes2::Copy( itemsBack, 0, 0, display, offsetX, offsetY, itemsBackWidth, itemsBackHeight );
-    }
+    redrawCommonBackground( dst, VisibleItemCount(), display );
 }
 
 struct CstlRow
@@ -667,30 +679,7 @@ void StatsCastlesList::RedrawBackground( const fheroes2::Point & dst )
     text.set( _( "Available" ), fheroes2::FontType::smallWhite() );
     text.draw( dst.x + 500 - text.width() / 2, offsetY, display );
 
-    // Scrollbar background.
-    const fheroes2::Sprite & scrollbar = fheroes2::AGG::GetICN( ICN::OVERVIEW, 13 );
-    fheroes2::Copy( scrollbar, 0, 0, display, dst.x + scrollbarOffset + 1, dst.y + 17, scrollbar.width(), scrollbar.height() );
-
-    // items background
-    const fheroes2::Sprite & itemsBack = fheroes2::AGG::GetICN( ICN::OVERVIEW, 8 );
-    const fheroes2::Sprite & overback = fheroes2::AGG::GetICN( ICN::OVERBACK, 0 );
-    const int32_t itemsBackWidth = itemsBack.width();
-    const int32_t itemsBackHeight = itemsBack.height();
-    const int32_t offsetX = dst.x + 30;
-    offsetY = dst.y + 17;
-    const int32_t stepY = itemsBackHeight + 4;
-    const int32_t overbackOffsetX = dst.x + 29;
-    int32_t overbackOffsetY = dst.y + 13;
-    const int visibleItems = VisibleItemCount();
-
-    for ( int i = 0; i < visibleItems; ++i, offsetY += stepY, overbackOffsetY += stepY ) {
-        fheroes2::Copy( itemsBack, 0, 0, display, offsetX, offsetY, itemsBackWidth, itemsBackHeight );
-        // fix bar
-        fheroes2::Copy( overback, 29, 13, display, overbackOffsetX, overbackOffsetY, 595, 4 );
-    }
-
-    // Copy one vertical line in case of previous army selection
-    fheroes2::Copy( overback, 29, 12, display, overbackOffsetX, dst.y + 12, 1, 357 );
+    redrawCommonBackground( dst, VisibleItemCount(), display );
 }
 
 void RedrawIncomeInfo( const fheroes2::Point & pt, const Kingdom & myKingdom )

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -943,13 +943,16 @@ void Kingdom::openOverviewDialog()
 
     Game::SetUpdateSoundsOnFocusUpdate( true );
 
-    if ( worldMapRedrawMask != 0 ) {
-        Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();
+    Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();
 
+    if ( worldMapRedrawMask != 0 ) {
         // Force redraw of all UI elements that changed, that were masked by Kingdom window
         adventureMapInterface.setRedraw( worldMapRedrawMask );
 
         // Update focus because there were some changes made in the Kingdom overview dialog.
         adventureMapInterface.ResetFocus( Interface::GetFocusType(), false );
     }
+
+    // The army of the selected hero / castle may have been changed.
+    adventureMapInterface.RedrawFocus();
 }


### PR DESCRIPTION
Fix #7989

This PR:
- fixes update for all types of lists (in example, save file lists) after item remove;
- disables the forced rendering of game buttons (next hero, move hero, ...) on hero focus change and castle focus change;
- removes redundant `ResetFocus()` for every frame of hero movement: `ResetFocus()` is called by `~FocusUpdater()` in `Action()` method for move to each tile;
- adds hero/castle cursor setting when no hero or castle is in focus;
- fixes redraw type setting for heroes/castles icons: in master build both lists were updated regardless of which one was specified in redraw mask;
- changes icons and focus update behavior on hero recruitment (including rescuing from Jail) and dismiss/loss;
- includes minor code clean-up;
- fixes a bug of Kingdom Overview when a hero was dismissed and there are less than 4 heroes left in the kingdom:
![bug](https://github.com/ihhub/fheroes2/assets/113276641/12349947-92ca-4087-8caa-9c31b565b4e4)

https://github.com/ihhub/fheroes2/assets/113276641/89e93106-a074-4789-b37b-a490d90e0e37

When testing this PR please pay attention to icons and slider rendering and ambient sound and music update when:
- selecting a hero/castle;
- switching heroes/castles opened from Kingdom overview;
- losing battles by hero/castle;
- recruiting/rescuing a hero;
- dismissing a hero;
- moving a hero.