### PR TITLE
Minor code clean in 'maps_tiles'

### DIFF
--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -943,7 +943,7 @@ namespace Maps
         size_t postRenderAddonCount = 0;
 
         for ( const TilesAddon & addon : tile.getBottomLayerAddons() ) {
-            if ( ( addon._layerType & 0x03 ) != level ) {
+            if ( addon._layerType != level ) {
                 continue;
             }
 
@@ -963,7 +963,7 @@ namespace Maps
             renderAddonObject( dst, area, mp, addon );
         }
 
-        if ( tile.getObjectIcnType() != MP2::OBJ_ICN_TYPE_UNKNOWN && ( tile.getLayerType() & 0x03 ) == level
+        if ( tile.getObjectIcnType() != MP2::OBJ_ICN_TYPE_UNKNOWN && tile.getLayerType() == level
              && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( tile.GetGround(), tile.getObjectIcnType(), tile.GetObjectSpriteIndex() ) ) ) {
             renderMainObject( dst, area, mp, tile );
         }


### PR DESCRIPTION
This PR:
- replaces the `( ( ( addon._layerType >> 1 ) & 1 ) == 0 )` to more explicit and  an easier-to-understand form:
    this change affects the tile passability determination when starting a new map;
- removes redundant `& 0x03` from `_layerType & 0x03` in Bottom layer objects rendering function:
    this change affects map (game area) rendering;
- fixes `containsSprite()` function: currently used only for setting the sound to the ROCK object.

<details><summary>Broken Alliance map comparison</summary>
<p>

Master build:
![brokena_old](https://github.com/ihhub/fheroes2/assets/113276641/6fb8c5e2-d3a8-4744-890b-f141674ee094)

This PR:
![brokena_new](https://github.com/ihhub/fheroes2/assets/113276641/e79ebc67-3a4b-4440-aba6-aa5a41ace10c)

</p>
</details> 

