### PR TITLE
Add treasure placement in the Editor

### DIFF
--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -153,8 +153,8 @@ public:
         fheroes2::Display & display = fheroes2::Display::instance();
 
         if ( !itemSprite.empty() ) {
-            fheroes2::Blit(
-                itemSprite, display, destination.x + middleImageOffsetX - ( itemSprite.width() / 2 ), destination.y + itemOffsetY - ( itemSprite.height() / 2 ) );
+            fheroes2::Blit( itemSprite, display, destination.x + middleImageOffsetX - ( itemSprite.width() / 2 ),
+                            destination.y + itemOffsetY - ( itemSprite.height() / 2 ) );
         }
 
         fheroes2::Text text( itemText, current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -250,7 +250,7 @@ public:
     }
 
 private:
-    const int32_t _offsetY{ 43 };
+    static const int32_t _offsetY{ 43 };
 };
 
 class SelectEnumHeroes : public SelectEnum
@@ -277,7 +277,7 @@ public:
     }
 
 private:
-    const int32_t _offsetY{ 35 };
+    static const int32_t _offsetY{ 35 };
 };
 
 class SelectEnumArtifact : public SelectEnum
@@ -305,7 +305,7 @@ public:
     }
 
 private:
-    const int32_t _offsetY{ 42 };
+    static const int32_t _offsetY{ 42 };
 };
 
 class SelectEnumSpell : public SelectEnum
@@ -333,7 +333,7 @@ public:
     }
 
 private:
-    const int32_t _offsetY{ 55 };
+    static const int32_t _offsetY{ 55 };
 };
 
 class SelectEnumSecSkill : public SelectEnum
@@ -371,7 +371,7 @@ public:
     }
 
 private:
-    const int32_t _offsetY{ 42 };
+    static const int32_t _offsetY{ 42 };
 };
 
 namespace

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -158,7 +158,7 @@ public:
         }
 
         fheroes2::Text text( itemText, current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );
-        text.fitToOneRow( background->activeArea().width - textOffsetX - 10 );
+        text.fitToOneRow( background->activeArea().width - textOffsetX - 55 );
         text.draw( destination.x + textOffsetX, destination.y + itemOffsetY - ( text.height() / 2 ) + 2, display );
     }
 
@@ -225,7 +225,7 @@ public:
     explicit SelectEnumMonster( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
+        SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -259,7 +259,7 @@ public:
     explicit SelectEnumHeroes( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
+        SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -286,7 +286,7 @@ public:
     explicit SelectEnumArtifact( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
+        SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -314,7 +314,7 @@ public:
     explicit SelectEnumSpell( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
+        SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -352,8 +352,7 @@ public:
     explicit SelectEnumSecSkill( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        const int offset = 42;
-        SetAreaMaxItems( ( rtAreaItems.height + offset ) / offset );
+        SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -389,7 +388,7 @@ namespace
             , _textOffsetX( textOffsetX )
             , _offsetY( offsetY )
         {
-            SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
+            SetAreaMaxItems( rtAreaItems.height / _offsetY );
         }
 
         using SelectEnum::ActionListPressRight;
@@ -663,7 +662,7 @@ int Dialog::selectMonsterType( const int monsterType )
 {
     const auto & objectInfo = Maps::getObjectsByGroup( Maps::ObjectGroup::Monster );
 
-    MonsterTypeSelection listbox( objectInfo, { 280, fheroes2::Display::instance().height() - 200 } );
+    MonsterTypeSelection listbox( objectInfo, { 350, fheroes2::Display::instance().height() - 200 } );
 
     return selectObjectType( monsterType, objectInfo.size(), listbox, _( "Select Monster:" ) );
 }
@@ -672,7 +671,7 @@ int Dialog::selectTreasureType( const int resourceType )
 {
     const auto & objectInfo = Maps::getObjectsByGroup( Maps::ObjectGroup::Treasure );
 
-    TreasureTypeSelection listbox( objectInfo, { 280, fheroes2::Display::instance().height() - 200 } );
+    TreasureTypeSelection listbox( objectInfo, { 350, fheroes2::Display::instance().height() - 200 } );
 
     return selectObjectType( resourceType, objectInfo.size(), listbox, _( "Select Treasure:" ) );
 }

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -483,7 +483,8 @@ namespace
             switch ( info.objectType ) {
             case MP2::OBJ_RESOURCE:
                 fheroes2::showResourceMessage( fheroes2::Text{ getObjectName( info ), fheroes2::FontType::normalYellow() },
-                    fheroes2::Text{ Resource::getDescription(), fheroes2::FontType::normalWhite() }, Dialog::ZERO, Funds{ static_cast<int>( info.metadata[0] ), 0 } );
+                                               fheroes2::Text{ Resource::getDescription(), fheroes2::FontType::normalWhite() }, Dialog::ZERO,
+                                               Funds{ static_cast<int>( info.metadata[0] ), 0 } );
                 break;
             case MP2::OBJ_GENIE_LAMP:
             case MP2::OBJ_RANDOM_RESOURCE:

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -47,6 +47,7 @@
 #include "localevent.h"
 #include "map_object_info.h"
 #include "math_base.h"
+#include "mp2.h"
 #include "race.h"
 #include "resource.h"
 #include "screen.h"
@@ -145,18 +146,20 @@ public:
         _scrollbar.moveToIndex( _topId );
     }
 
-    void renderItem( const fheroes2::Sprite & itemSprite, const std::string & itemText, const fheroes2::Point & destination, const fheroes2::Point & offset,
-                     const bool current ) const
+    // An image with text should have offset of 10 pixels from all left and right edges.
+    void renderItem( const fheroes2::Sprite & itemSprite, const std::string & itemText, const fheroes2::Point & destination, const int32_t middleImageOffsetX,
+                     const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
         if ( !itemSprite.empty() ) {
-            fheroes2::Blit( itemSprite, display, destination.x + ( offset.x - itemSprite.width() ) / 2, destination.y + ( offset.y - itemSprite.height() ) / 2 );
+            fheroes2::Blit(
+                itemSprite, display, destination.x + middleImageOffsetX - ( itemSprite.width() / 2 ), destination.y + itemOffsetY - ( itemSprite.height() / 2 ) );
         }
 
         fheroes2::Text text( itemText, current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );
-        text.fitToOneRow( background->activeArea().width - offset.x - 55 );
-        text.draw( destination.x + offset.x + 5, destination.y + ( offset.y - text.height() ) / 2 + 2, display );
+        text.fitToOneRow( background->activeArea().width - textOffsetX - 10 );
+        text.draw( destination.x + textOffsetX, destination.y + itemOffsetY - ( text.height() / 2 ) + 2, display );
     }
 
     int32_t selectItemsEventProcessing( const char * caption )
@@ -222,8 +225,7 @@ public:
     explicit SelectEnumMonster( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        const int offset = 43;
-        SetAreaMaxItems( ( rtAreaItems.height + offset ) / offset );
+        SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -233,7 +235,7 @@ public:
         const Monster mons( index );
         const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( ICN::MONS32, mons.GetSpriteIndex() );
 
-        renderItem( monsterSprite, mons.GetName(), { dstx, dsty }, { 45, 43 }, current );
+        renderItem( monsterSprite, mons.GetName(), { dstx, dsty }, 45 / 2, 50, _offsetY / 2, current );
     }
 
     void ActionListPressRight( int & index ) override
@@ -246,6 +248,9 @@ public:
 
         Dialog::ArmyInfo( Troop( monster, 0 ), Dialog::ZERO );
     }
+
+private:
+    const int32_t _offsetY{ 43 };
 };
 
 class SelectEnumHeroes : public SelectEnum
@@ -254,8 +259,7 @@ public:
     explicit SelectEnumHeroes( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        const int offset = 35;
-        SetAreaMaxItems( ( rtAreaItems.height + offset ) / offset );
+        SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -264,13 +268,16 @@ public:
     {
         const fheroes2::Sprite & port = Heroes::GetPortrait( index, PORT_SMALL );
 
-        renderItem( port, Heroes::GetName( index ), { dstx, dsty }, { 45, 35 }, current );
+        renderItem( port, Heroes::GetName( index ), { dstx, dsty }, 45 / 2, 50, _offsetY / 2, current );
     }
 
     void ActionListPressRight( int & index ) override
     {
         Dialog::QuickInfo( *world.GetHeroes( index ) );
     }
+
+private:
+    const int32_t _offsetY{ 35 };
 };
 
 class SelectEnumArtifact : public SelectEnum
@@ -279,8 +286,7 @@ public:
     explicit SelectEnumArtifact( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        const int offset = 42;
-        SetAreaMaxItems( ( rtAreaItems.height + offset ) / offset );
+        SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -290,13 +296,16 @@ public:
         const Artifact art( index );
         const fheroes2::Sprite & artifactSprite = fheroes2::AGG::GetICN( ICN::ARTFX, art.IndexSprite32() );
 
-        renderItem( artifactSprite, art.GetName(), { dstx, dsty }, { 45, 42 }, current );
+        renderItem( artifactSprite, art.GetName(), { dstx, dsty }, 45 / 2, 50, _offsetY / 2, current );
     }
 
     void ActionListPressRight( int & index ) override
     {
         fheroes2::ArtifactDialogElement( Artifact( index ) ).showPopup( Dialog::ZERO );
     }
+
+private:
+    const int32_t _offsetY{ 42 };
 };
 
 class SelectEnumSpell : public SelectEnum
@@ -305,8 +314,7 @@ public:
     explicit SelectEnumSpell( const fheroes2::Size & rt )
         : SelectEnum( rt )
     {
-        const int offset = 55;
-        SetAreaMaxItems( ( rtAreaItems.height + offset ) / offset );
+        SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
     }
 
     using SelectEnum::ActionListPressRight;
@@ -316,13 +324,16 @@ public:
         const Spell spell( index );
         const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( ICN::SPELLS, spell.IndexSprite() );
 
-        renderItem( spellSprite, spell.GetName(), { dstx, dsty }, { 75, 55 }, current );
+        renderItem( spellSprite, spell.GetName(), { dstx, dsty }, 75 / 2, 80, _offsetY / 2, current );
     }
 
     void ActionListPressRight( int & index ) override
     {
         fheroes2::SpellDialogElement( Spell( index ), nullptr ).showPopup( Dialog::ZERO );
     }
+
+private:
+    const int32_t _offsetY{ 55 };
 };
 
 class SelectEnumSecSkill : public SelectEnum
@@ -352,13 +363,16 @@ public:
         const Skill::Secondary skill( getSkillFromListIndex( index ), getLevelFromListIndex( index ) );
         const fheroes2::Sprite & skillSprite = fheroes2::AGG::GetICN( ICN::MINISS, skill.GetIndexSprite2() );
 
-        renderItem( skillSprite, skill.GetName(), { dstx, dsty }, { 45, 42 }, current );
+        renderItem( skillSprite, skill.GetName(), { dstx, dsty }, 45 / 2, 50, _offsetY / 2, current );
     }
 
     void ActionListPressRight( int & index ) override
     {
         fheroes2::SecondarySkillDialogElement( Skill::Secondary( getSkillFromListIndex( index ), getLevelFromListIndex( index ) ), Heroes() ).showPopup( Dialog::ZERO );
     }
+
+private:
+    const int32_t _offsetY{ 42 };
 };
 
 namespace
@@ -367,22 +381,26 @@ namespace
     class ObjectTypeSelection : public SelectEnum
     {
     public:
-        ObjectTypeSelection( const std::vector<Maps::ObjectInfo> & objectInfo, const fheroes2::Size & size, const int32_t offset )
+        ObjectTypeSelection( const std::vector<Maps::ObjectInfo> & objectInfo, const fheroes2::Size & size, const int32_t imageOffsetX, const int32_t textOffsetX,
+                             const int32_t offsetY )
             : SelectEnum( size )
             , _objectInfo( objectInfo )
+            , _imageOffsetX( imageOffsetX )
+            , _textOffsetX( textOffsetX )
+            , _offsetY( offsetY )
         {
-            SetAreaMaxItems( ( rtAreaItems.height + offset - 1 ) / offset );
+            SetAreaMaxItems( ( rtAreaItems.height + _offsetY ) / _offsetY );
         }
 
         using SelectEnum::ActionListPressRight;
 
-        void RedrawItem( const int & objectId, int32_t offsetX, int32_t offsetY, bool isSelected ) override
+        void RedrawItem( const int & objectId, int32_t posX, int32_t posY, bool isSelected ) override
         {
             // If this assertion blows up then you are setting different number of items.
             assert( objectId >= 0 && objectId < static_cast<int>( _objectInfo.size() ) );
 
             const fheroes2::Sprite & image = fheroes2::generateMapObjectImage( _objectInfo[objectId] );
-            renderItem( image, getObjectName( _objectInfo[objectId] ), { offsetX, offsetY }, getImageOffset(), isSelected );
+            renderItem( image, getObjectName( _objectInfo[objectId] ), { posX, posY }, _imageOffsetX, _textOffsetX, _offsetY / 2, isSelected );
         }
 
         void ActionListPressRight( int & objectId ) override
@@ -398,16 +416,20 @@ namespace
 
         virtual std::string getObjectName( const Maps::ObjectInfo & info ) = 0;
 
-        virtual fheroes2::Point getImageOffset() = 0;
-
         const std::vector<Maps::ObjectInfo> & _objectInfo;
+
+        const int32_t _imageOffsetX{ 0 };
+
+        const int32_t _textOffsetX{ 0 };
+
+        const int32_t _offsetY{ 0 };
     };
 
     class HeroTypeSelection : public ObjectTypeSelection
     {
     public:
         HeroTypeSelection( const std::vector<Maps::ObjectInfo> & objectInfo, const fheroes2::Size & size )
-            : ObjectTypeSelection( objectInfo, size, fheroes2::AGG::GetICN( ICN::MINIHERO, 0 ).height() + 2 )
+            : ObjectTypeSelection( objectInfo, size, 21, 47, fheroes2::AGG::GetICN( ICN::MINIHERO, 0 ).height() + 2 )
         {
             // Do nothing.
         }
@@ -429,18 +451,13 @@ namespace
 
             return name;
         }
-
-        fheroes2::Point getImageOffset() override
-        {
-            return { 40, 52 };
-        }
     };
 
     class MonsterTypeSelection : public ObjectTypeSelection
     {
     public:
         MonsterTypeSelection( const std::vector<Maps::ObjectInfo> & objectInfo, const fheroes2::Size & size )
-            : ObjectTypeSelection( objectInfo, size, 43 )
+            : ObjectTypeSelection( objectInfo, size, 45 / 2, 50, 43 )
         {
             // Do nothing.
         }
@@ -461,18 +478,13 @@ namespace
         {
             return Monster( static_cast<int32_t>( info.metadata[0] ) ).GetName();
         }
-
-        fheroes2::Point getImageOffset() override
-        {
-            return { 45, 43 };
-        }
     };
 
     class TreasureTypeSelection : public ObjectTypeSelection
     {
     public:
         TreasureTypeSelection( const std::vector<Maps::ObjectInfo> & objectInfo, const fheroes2::Size & size )
-            : ObjectTypeSelection( objectInfo, size, 40 )
+            : ObjectTypeSelection( objectInfo, size, 17, 60, 40 )
         {
             // Do nothing.
         }
@@ -514,11 +526,6 @@ namespace
             }
 
             return {};
-        }
-
-        fheroes2::Point getImageOffset() override
-        {
-            return { 32, 40 };
         }
     };
 

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -503,7 +503,7 @@ namespace
                 fheroes2::showStandardTextMessage( getObjectName( info ), "", Dialog::ZERO );
                 break;
             default:
-                // Did you expand the list of resources? Add the corresponding logic!
+                // Did you expand the list of treasures? Add the corresponding logic!
                 assert( 0 );
                 break;
             }
@@ -519,7 +519,7 @@ namespace
             case MP2::OBJ_TREASURE_CHEST:
                 return MP2::StringObject( info.objectType );
             default:
-                // Did you expand the list of resources? Add the corresponding logic!
+                // Did you expand the list of treasures? Add the corresponding logic!
                 assert( 0 );
                 break;
             }

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -514,7 +514,7 @@ namespace
         {
             switch ( info.objectType ) {
             case MP2::OBJ_RESOURCE:
-                return Resource::String( info.metadata[0] );
+                return Resource::String( static_cast<int>( info.metadata[0] ) );
             case MP2::OBJ_GENIE_LAMP:
             case MP2::OBJ_RANDOM_RESOURCE:
             case MP2::OBJ_TREASURE_CHEST:

--- a/src/fheroes2/dialog/dialog_selectitems.h
+++ b/src/fheroes2/dialog/dialog_selectitems.h
@@ -46,6 +46,8 @@ namespace Dialog
     int selectHeroType( const int heroType );
 
     int selectMonsterType( const int monsterType );
+
+    int selectTreasureType( const int resourceType );
 }
 
 #endif

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -605,6 +605,17 @@ namespace Interface
                 setObjectOnTile( tile, Maps::ObjectGroup::Monster, _editorPanel.getMonsterType() );
             }
         }
+        else if ( _editorPanel.isTreasureSettingMode() ) {
+            if ( tile.isWater() ) {
+                fheroes2::showStandardTextMessage( _( "Treasure" ), _( "Treasures cannot be placed on water." ), Dialog::OK );
+            }
+            else if ( !Maps::isClearGround( tile ) ) {
+                fheroes2::showStandardTextMessage( _( "Treasure" ), _( "Choose a tile which does not contain any objects." ), Dialog::OK );
+            }
+            else {
+                setObjectOnTile( tile, Maps::ObjectGroup::Treasure, _editorPanel.getTreasureType() );
+            }
+        }
         else if ( _editorPanel.isHeroSettingMode() ) {
             if ( tile.isWater() ) {
                 fheroes2::showStandardTextMessage( _( "Heroes" ), _( "Heroes cannot be placed on water." ), Dialog::OK );

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -48,7 +48,8 @@
 
 namespace
 {
-    void setCustomCursor( const Maps::ObjectGroup group, const int32_t type ) {
+    void setCustomCursor( const Maps::ObjectGroup group, const int32_t type )
+    {
         const auto & objectInfo = Maps::getObjectsByGroup( group );
         if ( type < 0 || type >= static_cast<int32_t>( objectInfo.size() ) ) {
             // You are trying to render some unknown stuff!
@@ -509,9 +510,7 @@ namespace Interface
                 if ( monsterType >= 0 ) {
                     _monsterType = monsterType;
 
-                    _interface.setCursorUpdater( [type = _monsterType]( const int32_t /*tileIndex*/ ) {
-                        setCustomCursor( Maps::ObjectGroup::Monster, type );
-                    } );
+                    _interface.setCursorUpdater( [type = _monsterType]( const int32_t /*tileIndex*/ ) { setCustomCursor( Maps::ObjectGroup::Monster, type ); } );
 
                     _interface.updateCursor( 0 );
                     return res;
@@ -522,9 +521,7 @@ namespace Interface
                 if ( treasureType >= 0 ) {
                     _treasureType = treasureType;
 
-                    _interface.setCursorUpdater( [type = _treasureType]( const int32_t /*tileIndex*/ ) {
-                        setCustomCursor( Maps::ObjectGroup::Treasure, type );
-                    } );
+                    _interface.setCursorUpdater( [type = _treasureType]( const int32_t /*tileIndex*/ ) { setCustomCursor( Maps::ObjectGroup::Treasure, type ); } );
 
                     _interface.updateCursor( 0 );
                     return res;

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -87,10 +87,15 @@ namespace Interface
             return ( _selectedInstrument == OBJECT ) && ( _selectedObject == HEROES );
         }
 
+        bool isTreasureSettingMode() const
+        {
+            return ( _selectedInstrument == OBJECT ) && ( _selectedObject == TREASURES );
+        }
+
         bool showAreaSelectRect() const
         {
             return _selectedInstrument == Instrument::TERRAIN || _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD
-                   || _selectedInstrument == Instrument::ERASE || isMonsterSettingMode() || isHeroSettingMode();
+                   || _selectedInstrument == Instrument::ERASE || isMonsterSettingMode() || isHeroSettingMode() || isTreasureSettingMode();
         }
 
         bool useMouseDragMovement() const
@@ -118,6 +123,11 @@ namespace Interface
         int32_t getHeroType() const
         {
             return _heroType;
+        }
+
+        int32_t getTreasureType() const
+        {
+            return _treasureType;
         }
 
     private:
@@ -230,5 +240,7 @@ namespace Interface
         int32_t _monsterType{ -1 };
 
         int32_t _heroType{ -1 };
+
+        int32_t _treasureType{ -1 };
     };
 }

--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -29,6 +29,7 @@
 
 #include "artifact.h"
 #include "monster.h"
+#include "resource.h"
 
 namespace
 {
@@ -195,15 +196,19 @@ namespace
         }
     }
 
-    void populateResourceData( std::vector<Maps::ObjectInfo> & objects )
+    void populateTreasureData( std::vector<Maps::ObjectInfo> & objects )
     {
         // Normal resources.
-        for ( const uint32_t imageIndex : { 1, 3, 5, 7, 9, 11, 13 } ) {
+        int32_t resourceImageIndex = 1;
+        for ( const uint32_t resource : { Resource::WOOD, Resource::MERCURY, Resource::ORE, Resource::SULFUR, Resource::CRYSTAL, Resource::GEMS, Resource::GOLD } ) {
             Maps::ObjectInfo object{ MP2::OBJ_RESOURCE };
-            object.groundLevelParts.emplace_back( MP2::OBJ_ICN_TYPE_OBJNRSRC, imageIndex, fheroes2::Point{ 0, 0 }, MP2::OBJ_RESOURCE, Maps::OBJECT_LAYER );
-            object.groundLevelParts.emplace_back( MP2::OBJ_ICN_TYPE_OBJNRSRC, imageIndex - 1, fheroes2::Point{ -1, 0 }, MP2::OBJ_NONE, Maps::SHADOW_LAYER );
+            object.groundLevelParts.emplace_back( MP2::OBJ_ICN_TYPE_OBJNRSRC, resourceImageIndex, fheroes2::Point{ 0, 0 }, MP2::OBJ_RESOURCE, Maps::OBJECT_LAYER );
+            object.groundLevelParts.emplace_back( MP2::OBJ_ICN_TYPE_OBJNRSRC, resourceImageIndex - 1, fheroes2::Point{ -1, 0 }, MP2::OBJ_NONE, Maps::SHADOW_LAYER );
+            object.metadata[0] = resource;
 
             objects.emplace_back( std::move( object ) );
+
+            resourceImageIndex += 2;
         }
 
         // Genie's Lamp.
@@ -217,7 +222,7 @@ namespace
 
         // Random resource.
         {
-            Maps::ObjectInfo object{ MP2::OBJ_GENIE_LAMP };
+            Maps::ObjectInfo object{ MP2::OBJ_RANDOM_RESOURCE };
             object.groundLevelParts.emplace_back( MP2::OBJ_ICN_TYPE_OBJNRSRC, 17, fheroes2::Point{ 0, 0 }, MP2::OBJ_RANDOM_RESOURCE, Maps::OBJECT_LAYER );
             object.groundLevelParts.emplace_back( MP2::OBJ_ICN_TYPE_OBJNRSRC, 16, fheroes2::Point{ -1, 0 }, MP2::OBJ_NONE, Maps::SHADOW_LAYER );
 
@@ -226,7 +231,7 @@ namespace
 
         // Treasure chest.
         {
-            Maps::ObjectInfo object{ MP2::OBJ_GENIE_LAMP };
+            Maps::ObjectInfo object{ MP2::OBJ_TREASURE_CHEST };
             object.groundLevelParts.emplace_back( MP2::OBJ_ICN_TYPE_OBJNRSRC, 19, fheroes2::Point{ 0, 0 }, MP2::OBJ_TREASURE_CHEST, Maps::OBJECT_LAYER );
             object.groundLevelParts.emplace_back( MP2::OBJ_ICN_TYPE_OBJNRSRC, 18, fheroes2::Point{ -1, 0 }, MP2::OBJ_NONE, Maps::SHADOW_LAYER );
 
@@ -262,7 +267,7 @@ namespace
         populateArtifactData( objectData[static_cast<size_t>( Maps::ObjectGroup::Artifact )] );
         populateHeroData( objectData[static_cast<size_t>( Maps::ObjectGroup::Hero )] );
         populateMonsterData( objectData[static_cast<size_t>( Maps::ObjectGroup::Monster )] );
-        populateResourceData( objectData[static_cast<size_t>( Maps::ObjectGroup::Resource )] );
+        populateTreasureData( objectData[static_cast<size_t>( Maps::ObjectGroup::Treasure )] );
         populateWaterObjectData( objectData[static_cast<size_t>( Maps::ObjectGroup::Water_Object )] );
 
         isPopulated = true;

--- a/src/fheroes2/maps/map_object_info.h
+++ b/src/fheroes2/maps/map_object_info.h
@@ -106,7 +106,7 @@ namespace Maps
         Artifact,
         Hero,
         Monster,
-        Resource,
+        Treasure,
         Water_Object,
 
         // IMPORTANT!!!

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -3128,6 +3128,11 @@ namespace Maps
             // Since setMonsterOnTile() function interprets 0 as a random number of monsters it is important to set the correct value.
             setMonsterCountOnTile( tile, 0 );
             return;
+        case MP2::OBJ_RESOURCE:
+            // Setting just 1 resource is enough. It doesn't matter as we are not saving this value into the map format.
+            placeObjectOnTile( tile, info );
+            setResourceOnTile( tile, info.metadata[0], 1 );
+            return;
         default:
             break;
         }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -3131,7 +3131,7 @@ namespace Maps
         case MP2::OBJ_RESOURCE:
             // Setting just 1 resource is enough. It doesn't matter as we are not saving this value into the map format.
             placeObjectOnTile( tile, info );
-            setResourceOnTile( tile, info.metadata[0], 1 );
+            setResourceOnTile( tile, static_cast<int>( info.metadata[0] ), 1 );
             return;
         default:
             break;

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -813,6 +813,7 @@ int MP2::getActionObjectDirection( const MapObjectType objectType )
     case OBJ_RANDOM_MONSTER_VERY_STRONG:
     case OBJ_RANDOM_MONSTER_WEAK:
     case OBJ_RANDOM_ULTIMATE_ARTIFACT:
+    case OBJ_RANDOM_RESOURCE:
     case OBJ_RESOURCE:
     case OBJ_SEA_CHEST:
     case OBJ_SHIPWRECK_SURVIVOR:


### PR DESCRIPTION
This pull request adds an ability to place Treasure type objects on the Adventure Map within the Editor.
![image](https://github.com/ihhub/fheroes2/assets/19829520/e2304195-d1df-4dac-9b03-42835b8d5f79)

The new and old item lists were rendering images and text incorrectly. This pull request fixes it. To verify the changes add these lines:
```cpp
        fheroes2::DrawRect( display, { destination.x + middleImageOffsetX - ( itemSprite.width() / 2 ),
                                       destination.y, itemSprite.width(), itemOffsetY * 2 }, 80 );
        fheroes2::DrawRect( display, { destination.x + textOffsetX, destination.y, background->activeArea().width - textOffsetX - 55, itemOffsetY * 2 }, 96 );
```
at line 159 in **dialog_selectitems.cpp** file (`void renderItem()` method) to observe how text and item rendering is done.

**Note**: object erasure is not handled in this pull request and requires a set of changes that should be done separately.
