### PR TITLE
Reset hero path after digging and update hero buttons

### DIFF
--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -424,6 +424,7 @@ fheroes2::GameMode Interface::AdventureMap::EventDigArtifact()
         AudioManager::PlaySound( M82::DIGSOUND );
 
         hero->ResetMovePoints();
+        hero->GetPath().Reset();
 
         if ( world.DiggingForUltimateArtifact( hero->GetCenter() ) ) {
             const AudioManager::MusicRestorer musicRestorer;
@@ -452,7 +453,7 @@ fheroes2::GameMode Interface::AdventureMap::EventDigArtifact()
             fheroes2::showStandardTextMessage( "", _( "Nothing here. Where could it be?" ), Dialog::OK );
         }
 
-        redraw( REDRAW_HEROES );
+        redraw( REDRAW_HEROES | REDRAW_BUTTONS );
         fheroes2::Display::instance().render();
 
         // check if the game is over due to conditions related to the ultimate artifact


### PR DESCRIPTION
This PR fixes this issue:

              Minor issue found: after the hero diggs, the "Hero movement" button doesn't change its state to disabled if it was active before digging.

_Originally posted by @drevoborod in https://github.com/ihhub/fheroes2/issues/8000#issuecomment-1791301681_