### PR TITLE
Make Oracle dialog use selected interface mode (Good/Evil)

### DIFF
--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -267,7 +267,7 @@ void Dialog::ThievesGuild( const bool oracle )
         fheroes2::fadeOutDisplay( dialogRoi, !isDefaultScreenSize );
     }
 
-    const bool isEvilInterfaceTown = !oracle && Settings::Get().isEvilInterfaceEnabled();
+    const bool isEvilInterfaceTown = Settings::Get().isEvilInterfaceEnabled();
 
     const fheroes2::Sprite & backgroundSprite = fheroes2::AGG::GetICN( isEvilInterfaceTown ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
     fheroes2::Copy( backgroundSprite, 0, 0, display, dialogRoi.x, dialogRoi.y, backgroundSprite.width(), backgroundSprite.height() );


### PR DESCRIPTION
As discussed in https://github.com/ihhub/fheroes2/pull/8006, now the Oracle dialog`s background will use the selected in options interface to be consistent with the dialog borders and many other dialogs in the game.

![oracle](https://github.com/ihhub/fheroes2/assets/113276641/34e18922-722f-48dc-9372-22efdf70c229)
