### PR TITLE
Use small font for labels, increase dialog height in the Campaign Difficulty selection dialog

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -888,7 +888,7 @@ namespace
 
     int32_t setCampaignDifficulty( int32_t currentDifficulty, const int32_t maximumAllowedDifficulty )
     {
-        const fheroes2::StandardWindow frameborder( 234, 270, true );
+        const fheroes2::StandardWindow frameborder( 234, 312, true );
         const fheroes2::Rect & windowRoi = frameborder.activeArea();
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
@@ -977,9 +977,9 @@ namespace
         fheroes2::ImageRestorer restorer( display, textOffset.x, textOffset.y, textWidth, description.height( textWidth ) );
         description.draw( textOffset.x, textOffset.y, textWidth, display );
 
-        const fheroes2::Text easyName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Easy ), fheroes2::FontType::normalWhite() );
-        const fheroes2::Text normalName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Normal ), fheroes2::FontType::normalWhite() );
-        const fheroes2::Text hardName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Hard ), fheroes2::FontType::normalWhite() );
+        const fheroes2::Text easyName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Easy ), fheroes2::FontType::smallWhite() );
+        const fheroes2::Text normalName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Normal ), fheroes2::FontType::smallWhite() );
+        const fheroes2::Text hardName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Hard ), fheroes2::FontType::smallWhite() );
 
         easyName.draw( difficultyArea[0].x + ( difficultyArea[0].width - easyName.width() ) / 2, difficultyArea[0].y + difficultyArea[0].height + 5, display );
         normalName.draw( difficultyArea[1].x + ( difficultyArea[1].width - normalName.width() ) / 2, difficultyArea[1].y + difficultyArea[1].height + 5, display );


### PR DESCRIPTION
Using small font for difficulty labels resolve width issues. Note that difficulty selection part of the scenario dialog also use small font for same labels.

![game_campaign_en](https://github.com/ihhub/fheroes2/assets/5691178/7d2c1c10-58b8-4d3b-b4dc-75a0041fafa6)

Seems like Norwegian translation were updated and currently does not have mentioned issues with incufficent dialog height:

![game_campaign_nb](https://github.com/ihhub/fheroes2/assets/5691178/c380364b-942a-4595-a727-bfd6049b5f78)

But still I've increased dialog height to resolve similar issue with Bulgarian translation (easy diffuculty description):

![game_campaign_bg](https://github.com/ihhub/fheroes2/assets/5691178/6c729b29-03a0-426f-b120-1ad863f76c66)

The only remaining issue is the Bulgarian translation of dialog title slightly overlaps internal dialog borders - but this one not looks that critical to me.





