### PR TITLE
Add missing AI team alliance to Evil campaign's 6th scenario

### DIFF
--- a/src/fheroes2/campaign/campaign_data.cpp
+++ b/src/fheroes2/campaign/campaign_data.cpp
@@ -727,7 +727,7 @@ namespace Campaign
             }
             break;
         case ARCHIBALD_CAMPAIGN:
-            if ( scenarioInfoId.scenarioId == 10 ) {
+            if ( scenarioInfoId.scenarioId == 5 || scenarioInfoId.scenarioId == 10 ) {
                 allAIPlayersInAlliance = true;
             }
             break;


### PR DESCRIPTION
This adds the hardcoded alliance to scenario 6 of the Archibald campaign called Rebellion. The description text for this map states that the enemies are allied.

Will add any other I can find that are missing.

EDIT: Checked every mission for every campaign and all of them work already.

It should be noted that the original game's AI is known to attack allied heroes and flag allied mines at times. I checked whether they went and captured each other's castles.

Here are the notes I made during testing

<details>

Check scenarios:
Evil scenarios:
1 - f4a (free 4 all)
2 - f4a
3 - 1 enemy
4 - 1 enemy
5 - 1 enemy
6 - missing alliance
7 - 1 enemy
8 - 1 enemy
9 - 1 enemy
10 - 1 enemy

Good scenarios
1 - f4a
2 - f4a
3 - 1 enemy
4 - working alliance
5 - 1 enemy
6 - working alliance
7 - 1 enemy
8 - 1 enemy
9 - working alliance


POL

1 - f4a
2 - working alliance
3 - f4a
4 - 1 enemy
5 - 1 enemy
6 - f4a
7 - f4a
8 - working alliance

Wizard's Isle
All working

Voyage Home
All working


Descendants

1 - f4a
2 - 1 enemy
3 - no enemies
4 - no enemies
5 - working alliance
6 - f4a
7 - no enemies
8 - working alliance


</details>