### PR TITLE
Speed up OG map format reading

### DIFF
--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -227,30 +227,24 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
     // fs.get();
 
     // Victory conditions
-    fs.seek( 0x1D );
+    fs.seek( 29 );
     victoryConditions = fs.get();
-    // Do the victory conditions apply to AI too
+    // Do the victory conditions apply to AI too?
     compAlsoWins = ( fs.get() != 0 );
     // Is "normal victory" (defeating all other players) applicable here
     allowNormalVictory = ( fs.get() != 0 );
     // Additional parameter of victory conditions
     victoryConditionsParam1 = fs.getLE16();
-    // Additional parameter of victory conditions
-    fs.seek( 0x2c );
-    victoryConditionsParam2 = fs.getLE16();
-
-    // Loss conditions
-    fs.seek( 0x22 );
+    // Loss conditions.
     lossConditions = fs.get();
-    // Additional parameter of loss conditions
+    // Additional parameter of loss conditions.
     lossConditionsParam1 = fs.getLE16();
-    // Additional parameter of loss conditions
-    fs.seek( 0x2e );
-    lossConditionsParam2 = fs.getLE16();
-
-    // Does the game start with heroes in castles automatically
-    fs.seek( 0x25 );
+    // Does the game start with heroes in castles automatically?
     startWithHeroInEachCastle = ( 0 == fs.get() );
+    // Additional parameter of victory conditions.
+    victoryConditionsParam2 = fs.getLE16();
+    // Additional parameter of loss conditions.
+    lossConditionsParam2 = fs.getLE16();
 
     static_assert( std::is_same_v<decltype( races ), std::array<uint8_t, KINGDOMMAX>>, "Type of races has been changed, check the logic below" );
 
@@ -294,11 +288,11 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
     }
 
     // Map name
-    fs.seek( 0x3A );
+    fs.seek( 58 );
     name = fs.toString( mapNameLength );
 
     // Map description
-    fs.seek( 0x76 );
+    fs.seek( 118 );
     description = fs.toString( mapDescriptionLength );
 
     // Alliances of kingdoms
@@ -362,6 +356,12 @@ bool Maps::FileInfo::readResurrectionMap( std::string filePath )
 
     name = std::move( map.name );
     description = std::move( map.description );
+
+    kingdomColors = map.availablePlayerColors;
+    colorsAvailableForHumans = map.humanPlayerColors;
+    colorsAvailableForComp = map.computerPlayerColors;
+
+    version = GameVersion::RESURRECTION;
 
     return true;
 }

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -227,17 +227,17 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
     // fs.get();
 
     fs.seek( 29 );
-    // Victory conditions.
+    // Victory condition type.
     victoryConditions = fs.get();
     // Do the victory conditions apply to AI too?
     compAlsoWins = ( fs.get() != 0 );
     // Is "normal victory" (defeating all other players) applicable here?
     allowNormalVictory = ( fs.get() != 0 );
-    // Additional parameter of victory conditions.
+    // Parameter of victory condition.
     victoryConditionsParam1 = fs.getLE16();
-    // Loss conditions
+    // Loss condition type.
     lossConditions = fs.get();
-    // Additional parameter of loss conditions
+    // Parameter of loss condition.
     lossConditionsParam1 = fs.getLE16();
     // Does the game start with heroes in castles automatically?
     startWithHeroInEachCastle = ( 0 == fs.get() );
@@ -257,9 +257,9 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
         }
     }
 
-    // Additional parameter of victory conditions.
+    // Additional parameter of victory condition.
     victoryConditionsParam2 = fs.getLE16();
-    // Additional parameter of loss conditions.
+    // Additional parameter of loss condition.
     lossConditionsParam2 = fs.getLE16();
 
     bool skipUnionSetup = false;

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -226,29 +226,25 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
     // fs.seekg(0x1A, std::ios_base::beg);
     // fs.get();
 
-    // Victory conditions
     fs.seek( 29 );
+    // Victory conditions.
     victoryConditions = fs.get();
     // Do the victory conditions apply to AI too?
     compAlsoWins = ( fs.get() != 0 );
-    // Is "normal victory" (defeating all other players) applicable here
+    // Is "normal victory" (defeating all other players) applicable here?
     allowNormalVictory = ( fs.get() != 0 );
-    // Additional parameter of victory conditions
+    // Additional parameter of victory conditions.
     victoryConditionsParam1 = fs.getLE16();
-    // Loss conditions.
+    // Loss conditions
     lossConditions = fs.get();
-    // Additional parameter of loss conditions.
+    // Additional parameter of loss conditions
     lossConditionsParam1 = fs.getLE16();
     // Does the game start with heroes in castles automatically?
     startWithHeroInEachCastle = ( 0 == fs.get() );
-    // Additional parameter of victory conditions.
-    victoryConditionsParam2 = fs.getLE16();
-    // Additional parameter of loss conditions.
-    lossConditionsParam2 = fs.getLE16();
 
     static_assert( std::is_same_v<decltype( races ), std::array<uint8_t, KINGDOMMAX>>, "Type of races has been changed, check the logic below" );
 
-    // Initial races
+    // Initial races.
     for ( const int color : colors ) {
         const uint8_t race = Race::IndexToRace( fs.get() );
         const int idx = Color::GetIndex( color );
@@ -260,6 +256,11 @@ bool Maps::FileInfo::ReadMP2( const std::string & filePath )
             colorsOfRandomRaces |= color;
         }
     }
+
+    // Additional parameter of victory conditions.
+    victoryConditionsParam2 = fs.getLE16();
+    // Additional parameter of loss conditions.
+    lossConditionsParam2 = fs.getLE16();
 
     bool skipUnionSetup = false;
     // If loss conditions are LOSS_HERO and victory conditions are VICTORY_DEFEAT_EVERYONE then we have to verify the color to which this object belongs to.


### PR DESCRIPTION
The data should be read sequentially, jumping within a file is a bad way of reading it. I have no idea how fast file loading would become but logically it should be faster.

Also, this pull request adds a bit of data population for the new format as well.

relates to #6681