### PR TITLE
Increased width and height of the Campaign Difficulty selection dialog

### DIFF
--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -888,7 +888,8 @@ namespace
 
     int32_t setCampaignDifficulty( int32_t currentDifficulty, const int32_t maximumAllowedDifficulty )
     {
-        const fheroes2::StandardWindow frameborder( 234, 270, true );
+        // It's better to have frameborder width value divisible to 2 and 3 w/o remainder
+        const fheroes2::StandardWindow frameborder( 300, 270, true );
         const fheroes2::Rect & windowRoi = frameborder.activeArea();
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
@@ -906,15 +907,40 @@ namespace
 
         const fheroes2::Text caption( _( "Campaign Difficulty" ), fheroes2::FontType::normalYellow() );
         caption.draw( windowRoi.x + ( windowRoi.width - caption.width() ) / 2, windowRoi.y + 10, display );
+        
+        const uint32_t iconWidth = 64;
+        const int32_t iconRecenterX = -5;
 
-        const fheroes2::Rect copyFromArea{ 20, 94, 223, 69 };
-        const fheroes2::Point copyToOffset{ windowRoi.x + 4, windowRoi.y + 40 };
-        fheroes2::Copy( fheroes2::AGG::GetICN( ICN::NGHSBKG, 0 ), copyFromArea.x, copyFromArea.y, display, copyToOffset.x, copyToOffset.y, copyFromArea.width,
-                        copyFromArea.height );
+        const uint32_t pawnIconOffsetX = windowRoi.x + iconRecenterX + ( windowRoi.width - iconWidth ) / 2 - windowRoi.width / 3;
+        const uint32_t horseIconOffsetX = windowRoi.x + iconRecenterX + ( windowRoi.width - iconWidth ) / 2;
+        const uint32_t rookIconOffsetX = windowRoi.x + iconRecenterX + ( windowRoi.width - iconWidth ) / 2 + windowRoi.width / 3;
+        
+        const std::array<fheroes2::Rect, 3> copyFromArea { fheroes2::Rect( 20, 94, 70, 69 ),
+                                                           fheroes2::Rect( 97, 94, 70, 69 ), 
+                                                           fheroes2::Rect( 173, 94, 70, 69 ) };
+
+        const std::array<fheroes2::Point, 3> copyToOffset{ fheroes2::Point( pawnIconOffsetX, windowRoi.y + 40 ),
+                                                           fheroes2::Point( horseIconOffsetX, windowRoi.y + 40 ),
+                                                           fheroes2::Point( rookIconOffsetX, windowRoi.y + 40 ) };
+
+        const fheroes2::Sprite chessIcon = fheroes2::AGG::GetICN( ICN::NGHSBKG, 0 );
+
+        fheroes2::Copy( chessIcon, copyFromArea[0].x, copyFromArea[0].y, display, copyToOffset[0].x, copyToOffset[0].y,
+                        copyFromArea[0].width, copyFromArea[0].height );
+        fheroes2::Copy( chessIcon, copyFromArea[1].x, copyFromArea[1].y, display, copyToOffset[1].x, copyToOffset[1].y,
+                        copyFromArea[1].width, copyFromArea[1].height );
+        fheroes2::Copy( chessIcon, copyFromArea[2].x, copyFromArea[2].y, display, copyToOffset[2].x, copyToOffset[2].y,
+                        copyFromArea[2].width, copyFromArea[2].height );
 
         if ( isEvilInterface ) {
-            fheroes2::ApplyPalette( display, copyToOffset.x, copyToOffset.y, display, copyToOffset.x, copyToOffset.y, copyFromArea.width, copyFromArea.height,
-                                    PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_INTERFACE ) );
+            const std::vector<uint8_t> goodToEvilPalette = PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_INTERFACE );
+
+            fheroes2::ApplyPalette( display, copyToOffset[0].x, copyToOffset[0].y, display, copyToOffset[0].x, copyToOffset[0].y,
+                                    copyFromArea[0].width, copyFromArea[0].height, goodToEvilPalette );
+            fheroes2::ApplyPalette( display, copyToOffset[1].x, copyToOffset[1].y, display, copyToOffset[1].x, copyToOffset[1].y,
+                                    copyFromArea[1].width, copyFromArea[1].height, goodToEvilPalette );
+            fheroes2::ApplyPalette( display, copyToOffset[2].x, copyToOffset[2].y, display, copyToOffset[2].x, copyToOffset[2].y,
+                                    copyFromArea[2].width, copyFromArea[2].height, goodToEvilPalette );
         }
 
         const fheroes2::Sprite & selectionImage = fheroes2::AGG::GetICN( ICN::NGEXTRA, 62 );
@@ -925,9 +951,9 @@ namespace
         const char * normalDescription = _( "Choose this difficulty to enjoy the campaign as per the original design." );
         const char * hardDescription = _( "Choose this difficulty if you want challenge. AI is stronger in comparison with normal difficulty." );
 
-        const std::array<fheroes2::Rect, 3> difficultyArea{ fheroes2::Rect( windowRoi.x + 5, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
-                                                            fheroes2::Rect( windowRoi.x + 82, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
-                                                            fheroes2::Rect( windowRoi.x + 158, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ) };
+        const std::array<fheroes2::Rect, 3> difficultyArea{ fheroes2::Rect( copyToOffset[0].x, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
+                                                            fheroes2::Rect( copyToOffset[1].x, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
+                                                            fheroes2::Rect( copyToOffset[2].x, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ) };
 
         const std::array<fheroes2::Rect, 3> iconArea{ fheroes2::Rect( difficultyArea[0].x + 4, difficultyArea[0].y + 4, 63, 63 ),
                                                       fheroes2::Rect( difficultyArea[1].x + 4, difficultyArea[1].y + 4, 63, 63 ),
@@ -937,15 +963,15 @@ namespace
         switch ( currentDifficulty ) {
         case Campaign::CampaignDifficulty::Easy:
             currentDescription = easyDescription;
-            selection.setPosition( difficultyArea[0].x, difficultyArea[0].y );
+            selection.setPosition( difficultyArea[0].x + 1, difficultyArea[0].y );
             break;
         case Campaign::CampaignDifficulty::Normal:
             currentDescription = normalDescription;
-            selection.setPosition( difficultyArea[1].x, difficultyArea[1].y );
+            selection.setPosition( difficultyArea[1].x + 1, difficultyArea[1].y );
             break;
         case Campaign::CampaignDifficulty::Hard:
             currentDescription = hardDescription;
-            selection.setPosition( difficultyArea[2].x, difficultyArea[2].y );
+            selection.setPosition( difficultyArea[2].x + 1, difficultyArea[2].y );
             break;
         default:
             // Did you add a new difficulty level for campaigns? Add the logic above!
@@ -957,6 +983,7 @@ namespace
                                                     ( maximumAllowedDifficulty >= Campaign::CampaignDifficulty::Normal ),
                                                     ( maximumAllowedDifficulty >= Campaign::CampaignDifficulty::Hard ) };
 
+        // TODO: Check this!
         if ( !allowedSelection[0] ) {
             fheroes2::ApplyPalette( display, iconArea[0].x, iconArea[0].y, display, iconArea[0].x, iconArea[0].y, iconArea[0].width, iconArea[0].height,
                                     PAL::GetPalette( PAL::PaletteType::GRAY ) );
@@ -1024,19 +1051,19 @@ namespace
 
             if ( allowedSelection[0] && le.MouseClickLeft( difficultyArea[0] ) ) {
                 currentDescription = easyDescription;
-                selection.setPosition( difficultyArea[0].x, difficultyArea[0].y );
+                selection.setPosition( difficultyArea[0].x + 1, difficultyArea[0].y );
                 currentDifficulty = Campaign::CampaignDifficulty::Easy;
                 updateInfo = true;
             }
             else if ( allowedSelection[1] && le.MouseClickLeft( difficultyArea[1] ) ) {
                 currentDescription = normalDescription;
-                selection.setPosition( difficultyArea[1].x, difficultyArea[1].y );
+                selection.setPosition( difficultyArea[1].x + 1, difficultyArea[1].y );
                 currentDifficulty = Campaign::CampaignDifficulty::Normal;
                 updateInfo = true;
             }
             else if ( allowedSelection[2] && le.MouseClickLeft( difficultyArea[2] ) ) {
                 currentDescription = hardDescription;
-                selection.setPosition( difficultyArea[2].x, difficultyArea[2].y );
+                selection.setPosition( difficultyArea[2].x + 1, difficultyArea[2].y );
                 currentDifficulty = Campaign::CampaignDifficulty::Hard;
                 updateInfo = true;
             }

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -908,16 +908,17 @@ namespace
         const fheroes2::Text caption( _( "Campaign Difficulty" ), fheroes2::FontType::normalYellow() );
         caption.draw( windowRoi.x + ( windowRoi.width - caption.width() ) / 2, windowRoi.y + 10, display );
         
-        const uint32_t iconWidth = 64;
-        const int32_t iconRecenterX = -5;
+        const uint32_t iconSize = 65;
+        const uint32_t iconShadowSize = 4;
+        const uint32_t fullIconSize = iconSize + iconShadowSize;
 
-        const uint32_t pawnIconOffsetX = windowRoi.x + iconRecenterX + ( windowRoi.width - iconWidth ) / 2 - windowRoi.width / 3;
-        const uint32_t horseIconOffsetX = windowRoi.x + iconRecenterX + ( windowRoi.width - iconWidth ) / 2;
-        const uint32_t rookIconOffsetX = windowRoi.x + iconRecenterX + ( windowRoi.width - iconWidth ) / 2 + windowRoi.width / 3;
+        const uint32_t pawnIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 - windowRoi.width / 3;
+        const uint32_t horseIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2;
+        const uint32_t rookIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 + windowRoi.width / 3;
         
-        const std::array<fheroes2::Rect, 3> copyFromArea { fheroes2::Rect( 20, 94, 70, 69 ),
-                                                           fheroes2::Rect( 97, 94, 70, 69 ), 
-                                                           fheroes2::Rect( 173, 94, 70, 69 ) };
+        const std::array<fheroes2::Rect, 3> copyFromArea{ fheroes2::Rect( 20, 94, fullIconSize, fullIconSize ),
+                                                          fheroes2::Rect( 97, 94, fullIconSize, fullIconSize ),
+                                                          fheroes2::Rect( 173, 94, fullIconSize, fullIconSize ) };
 
         const std::array<fheroes2::Point, 3> copyToOffset{ fheroes2::Point( pawnIconOffsetX, windowRoi.y + 40 ),
                                                            fheroes2::Point( horseIconOffsetX, windowRoi.y + 40 ),
@@ -951,27 +952,27 @@ namespace
         const char * normalDescription = _( "Choose this difficulty to enjoy the campaign as per the original design." );
         const char * hardDescription = _( "Choose this difficulty if you want challenge. AI is stronger in comparison with normal difficulty." );
 
-        const std::array<fheroes2::Rect, 3> difficultyArea{ fheroes2::Rect( copyToOffset[0].x, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
-                                                            fheroes2::Rect( copyToOffset[1].x, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
-                                                            fheroes2::Rect( copyToOffset[2].x, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ) };
+        const std::array<fheroes2::Rect, 3> difficultyArea{ fheroes2::Rect( copyToOffset[0].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
+                                                            fheroes2::Rect( copyToOffset[1].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
+                                                            fheroes2::Rect( copyToOffset[2].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ) };
 
-        const std::array<fheroes2::Rect, 3> iconArea{ fheroes2::Rect( difficultyArea[0].x + 4, difficultyArea[0].y + 4, 63, 63 ),
-                                                      fheroes2::Rect( difficultyArea[1].x + 4, difficultyArea[1].y + 4, 63, 63 ),
-                                                      fheroes2::Rect( difficultyArea[2].x + 4, difficultyArea[2].y + 4, 63, 63 ) };
+        const std::array<fheroes2::Rect, 3> iconArea{ fheroes2::Rect( difficultyArea[0].x + iconShadowSize, difficultyArea[0].y + iconShadowSize, iconSize - 1, iconSize - 1 ),
+                                                      fheroes2::Rect( difficultyArea[1].x + iconShadowSize, difficultyArea[1].y + iconShadowSize, iconSize - 1, iconSize - 1 ),
+                                                      fheroes2::Rect( difficultyArea[2].x + iconShadowSize, difficultyArea[2].y + iconShadowSize, iconSize - 1, iconSize - 1 ) };
 
         const char * currentDescription = nullptr;
         switch ( currentDifficulty ) {
         case Campaign::CampaignDifficulty::Easy:
             currentDescription = easyDescription;
-            selection.setPosition( difficultyArea[0].x + 1, difficultyArea[0].y );
+            selection.setPosition( difficultyArea[0].x, difficultyArea[0].y );
             break;
         case Campaign::CampaignDifficulty::Normal:
             currentDescription = normalDescription;
-            selection.setPosition( difficultyArea[1].x + 1, difficultyArea[1].y );
+            selection.setPosition( difficultyArea[1].x, difficultyArea[1].y );
             break;
         case Campaign::CampaignDifficulty::Hard:
             currentDescription = hardDescription;
-            selection.setPosition( difficultyArea[2].x + 1, difficultyArea[2].y );
+            selection.setPosition( difficultyArea[2].x, difficultyArea[2].y );
             break;
         default:
             // Did you add a new difficulty level for campaigns? Add the logic above!
@@ -983,7 +984,6 @@ namespace
                                                     ( maximumAllowedDifficulty >= Campaign::CampaignDifficulty::Normal ),
                                                     ( maximumAllowedDifficulty >= Campaign::CampaignDifficulty::Hard ) };
 
-        // TODO: Check this!
         if ( !allowedSelection[0] ) {
             fheroes2::ApplyPalette( display, iconArea[0].x, iconArea[0].y, display, iconArea[0].x, iconArea[0].y, iconArea[0].width, iconArea[0].height,
                                     PAL::GetPalette( PAL::PaletteType::GRAY ) );
@@ -1051,19 +1051,19 @@ namespace
 
             if ( allowedSelection[0] && le.MouseClickLeft( difficultyArea[0] ) ) {
                 currentDescription = easyDescription;
-                selection.setPosition( difficultyArea[0].x + 1, difficultyArea[0].y );
+                selection.setPosition( difficultyArea[0].x, difficultyArea[0].y );
                 currentDifficulty = Campaign::CampaignDifficulty::Easy;
                 updateInfo = true;
             }
             else if ( allowedSelection[1] && le.MouseClickLeft( difficultyArea[1] ) ) {
                 currentDescription = normalDescription;
-                selection.setPosition( difficultyArea[1].x + 1, difficultyArea[1].y );
+                selection.setPosition( difficultyArea[1].x, difficultyArea[1].y );
                 currentDifficulty = Campaign::CampaignDifficulty::Normal;
                 updateInfo = true;
             }
             else if ( allowedSelection[2] && le.MouseClickLeft( difficultyArea[2] ) ) {
                 currentDescription = hardDescription;
-                selection.setPosition( difficultyArea[2].x + 1, difficultyArea[2].y );
+                selection.setPosition( difficultyArea[2].x, difficultyArea[2].y );
                 currentDifficulty = Campaign::CampaignDifficulty::Hard;
                 updateInfo = true;
             }

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -888,7 +888,7 @@ namespace
 
     int32_t setCampaignDifficulty( int32_t currentDifficulty, const int32_t maximumAllowedDifficulty )
     {
-        // It's better to have frameborder width value divisible to 2 and 3 w/o remainder
+        // It's better to have frame border width value divisible to 2 and 3 w/o remainder.
         const fheroes2::StandardWindow frameborder( 300, 284, true );
         const fheroes2::Rect & windowRoi = frameborder.activeArea();
 
@@ -916,27 +916,26 @@ namespace
         const int32_t horseIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2;
         const int32_t rookIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 + windowRoi.width / 3;
 
-        const std::array<fheroes2::Rect, 3> copyFromArea{ fheroes2::Rect( 20, 94, fullIconSize, fullIconSize ), fheroes2::Rect( 97, 94, fullIconSize, fullIconSize ),
-                                                          fheroes2::Rect( 173, 94, fullIconSize, fullIconSize ) };
+        const std::array<fheroes2::Rect, 3> copyFromArea{ fheroes2::Rect{ 20, 94, fullIconSize, fullIconSize }, fheroes2::Rect{ 97, 94, fullIconSize, fullIconSize },
+                                                          fheroes2::Rect{ 173, 94, fullIconSize, fullIconSize } };
 
-        const std::array<fheroes2::Point, 3> copyToOffset{ fheroes2::Point( pawnIconOffsetX, windowRoi.y + 40 ), fheroes2::Point( horseIconOffsetX, windowRoi.y + 40 ),
-                                                           fheroes2::Point( rookIconOffsetX, windowRoi.y + 40 ) };
+        const std::array<fheroes2::Point, 3> copyToOffset{ fheroes2::Point{ pawnIconOffsetX, windowRoi.y + 40 }, fheroes2::Point{ horseIconOffsetX, windowRoi.y + 40 },
+                                                           fheroes2::Point{ rookIconOffsetX, windowRoi.y + 40 } };
 
-        const fheroes2::Sprite chessIcon = fheroes2::AGG::GetICN( ICN::NGHSBKG, 0 );
+        const fheroes2::Sprite & chessIcon = fheroes2::AGG::GetICN( ICN::NGHSBKG, 0 );
 
-        fheroes2::Copy( chessIcon, copyFromArea[0].x, copyFromArea[0].y, display, copyToOffset[0].x, copyToOffset[0].y, copyFromArea[0].width, copyFromArea[0].height );
-        fheroes2::Copy( chessIcon, copyFromArea[1].x, copyFromArea[1].y, display, copyToOffset[1].x, copyToOffset[1].y, copyFromArea[1].width, copyFromArea[1].height );
-        fheroes2::Copy( chessIcon, copyFromArea[2].x, copyFromArea[2].y, display, copyToOffset[2].x, copyToOffset[2].y, copyFromArea[2].width, copyFromArea[2].height );
+        for ( size_t i = 0; i < copyToOffset.size(); ++i ) {
+            fheroes2::Copy( chessIcon, copyFromArea[i].x, copyFromArea[i].y, display, copyToOffset[i].x, copyToOffset[i].y, copyFromArea[i].width,
+                            copyFromArea[i].height );
+        }
 
         if ( isEvilInterface ) {
-            const std::vector<uint8_t> goodToEvilPalette = PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_INTERFACE );
+            const std::vector<uint8_t> & goodToEvilPalette = PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_INTERFACE );
 
-            fheroes2::ApplyPalette( display, copyToOffset[0].x, copyToOffset[0].y, display, copyToOffset[0].x, copyToOffset[0].y, copyFromArea[0].width,
-                                    copyFromArea[0].height, goodToEvilPalette );
-            fheroes2::ApplyPalette( display, copyToOffset[1].x, copyToOffset[1].y, display, copyToOffset[1].x, copyToOffset[1].y, copyFromArea[1].width,
-                                    copyFromArea[1].height, goodToEvilPalette );
-            fheroes2::ApplyPalette( display, copyToOffset[2].x, copyToOffset[2].y, display, copyToOffset[2].x, copyToOffset[2].y, copyFromArea[2].width,
-                                    copyFromArea[2].height, goodToEvilPalette );
+            for ( size_t i = 0; i < copyToOffset.size(); ++i ) {
+                fheroes2::ApplyPalette( display, copyToOffset[i].x, copyToOffset[i].y, display, copyToOffset[i].x, copyToOffset[i].y, copyFromArea[i].width,
+                                        copyFromArea[i].height, goodToEvilPalette );
+            }
         }
 
         const fheroes2::Sprite & selectionImage = fheroes2::AGG::GetICN( ICN::NGEXTRA, 62 );
@@ -982,17 +981,11 @@ namespace
                                                     ( maximumAllowedDifficulty >= Campaign::CampaignDifficulty::Normal ),
                                                     ( maximumAllowedDifficulty >= Campaign::CampaignDifficulty::Hard ) };
 
-        if ( !allowedSelection[0] ) {
-            fheroes2::ApplyPalette( display, iconArea[0].x, iconArea[0].y, display, iconArea[0].x, iconArea[0].y, iconArea[0].width, iconArea[0].height,
-                                    PAL::GetPalette( PAL::PaletteType::GRAY ) );
-        }
-        if ( !allowedSelection[1] ) {
-            fheroes2::ApplyPalette( display, iconArea[1].x, iconArea[1].y, display, iconArea[1].x, iconArea[1].y, iconArea[1].width, iconArea[1].height,
-                                    PAL::GetPalette( PAL::PaletteType::GRAY ) );
-        }
-        if ( !allowedSelection[2] ) {
-            fheroes2::ApplyPalette( display, iconArea[2].x, iconArea[2].y, display, iconArea[2].x, iconArea[2].y, iconArea[2].width, iconArea[2].height,
-                                    PAL::GetPalette( PAL::PaletteType::GRAY ) );
+        for ( size_t i = 0; i < allowedSelection.size(); ++i ) {
+            if ( !allowedSelection[i] ) {
+                fheroes2::ApplyPalette( display, iconArea[i].x, iconArea[i].y, display, iconArea[i].x, iconArea[i].y, iconArea[i].width, iconArea[i].height,
+                                        PAL::GetPalette( PAL::PaletteType::GRAY ) );
+            }
         }
 
         const int32_t textWidth = windowRoi.width - 16;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -907,7 +907,7 @@ namespace
 
         const fheroes2::Text caption( _( "Campaign Difficulty" ), fheroes2::FontType::normalYellow() );
         caption.draw( windowRoi.x + ( windowRoi.width - caption.width() ) / 2, windowRoi.y + 10, display );
-        
+
         const int32_t iconSize = 65;
         const int32_t iconShadowSize = 4;
         const int32_t fullIconSize = iconSize + iconShadowSize;
@@ -915,33 +915,28 @@ namespace
         const int32_t pawnIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 - windowRoi.width / 3;
         const int32_t horseIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2;
         const int32_t rookIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 + windowRoi.width / 3;
-        
-        const std::array<fheroes2::Rect, 3> copyFromArea{ fheroes2::Rect( 20, 94, fullIconSize, fullIconSize ),
-                                                          fheroes2::Rect( 97, 94, fullIconSize, fullIconSize ),
+
+        const std::array<fheroes2::Rect, 3> copyFromArea{ fheroes2::Rect( 20, 94, fullIconSize, fullIconSize ), fheroes2::Rect( 97, 94, fullIconSize, fullIconSize ),
                                                           fheroes2::Rect( 173, 94, fullIconSize, fullIconSize ) };
 
-        const std::array<fheroes2::Point, 3> copyToOffset{ fheroes2::Point( pawnIconOffsetX, windowRoi.y + 40 ),
-                                                           fheroes2::Point( horseIconOffsetX, windowRoi.y + 40 ),
+        const std::array<fheroes2::Point, 3> copyToOffset{ fheroes2::Point( pawnIconOffsetX, windowRoi.y + 40 ), fheroes2::Point( horseIconOffsetX, windowRoi.y + 40 ),
                                                            fheroes2::Point( rookIconOffsetX, windowRoi.y + 40 ) };
 
         const fheroes2::Sprite chessIcon = fheroes2::AGG::GetICN( ICN::NGHSBKG, 0 );
 
-        fheroes2::Copy( chessIcon, copyFromArea[0].x, copyFromArea[0].y, display, copyToOffset[0].x, copyToOffset[0].y,
-                        copyFromArea[0].width, copyFromArea[0].height );
-        fheroes2::Copy( chessIcon, copyFromArea[1].x, copyFromArea[1].y, display, copyToOffset[1].x, copyToOffset[1].y,
-                        copyFromArea[1].width, copyFromArea[1].height );
-        fheroes2::Copy( chessIcon, copyFromArea[2].x, copyFromArea[2].y, display, copyToOffset[2].x, copyToOffset[2].y,
-                        copyFromArea[2].width, copyFromArea[2].height );
+        fheroes2::Copy( chessIcon, copyFromArea[0].x, copyFromArea[0].y, display, copyToOffset[0].x, copyToOffset[0].y, copyFromArea[0].width, copyFromArea[0].height );
+        fheroes2::Copy( chessIcon, copyFromArea[1].x, copyFromArea[1].y, display, copyToOffset[1].x, copyToOffset[1].y, copyFromArea[1].width, copyFromArea[1].height );
+        fheroes2::Copy( chessIcon, copyFromArea[2].x, copyFromArea[2].y, display, copyToOffset[2].x, copyToOffset[2].y, copyFromArea[2].width, copyFromArea[2].height );
 
         if ( isEvilInterface ) {
             const std::vector<uint8_t> goodToEvilPalette = PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_INTERFACE );
 
-            fheroes2::ApplyPalette( display, copyToOffset[0].x, copyToOffset[0].y, display, copyToOffset[0].x, copyToOffset[0].y,
-                                    copyFromArea[0].width, copyFromArea[0].height, goodToEvilPalette );
-            fheroes2::ApplyPalette( display, copyToOffset[1].x, copyToOffset[1].y, display, copyToOffset[1].x, copyToOffset[1].y,
-                                    copyFromArea[1].width, copyFromArea[1].height, goodToEvilPalette );
-            fheroes2::ApplyPalette( display, copyToOffset[2].x, copyToOffset[2].y, display, copyToOffset[2].x, copyToOffset[2].y,
-                                    copyFromArea[2].width, copyFromArea[2].height, goodToEvilPalette );
+            fheroes2::ApplyPalette( display, copyToOffset[0].x, copyToOffset[0].y, display, copyToOffset[0].x, copyToOffset[0].y, copyFromArea[0].width,
+                                    copyFromArea[0].height, goodToEvilPalette );
+            fheroes2::ApplyPalette( display, copyToOffset[1].x, copyToOffset[1].y, display, copyToOffset[1].x, copyToOffset[1].y, copyFromArea[1].width,
+                                    copyFromArea[1].height, goodToEvilPalette );
+            fheroes2::ApplyPalette( display, copyToOffset[2].x, copyToOffset[2].y, display, copyToOffset[2].x, copyToOffset[2].y, copyFromArea[2].width,
+                                    copyFromArea[2].height, goodToEvilPalette );
         }
 
         const fheroes2::Sprite & selectionImage = fheroes2::AGG::GetICN( ICN::NGEXTRA, 62 );
@@ -956,9 +951,12 @@ namespace
                                                             fheroes2::Rect( copyToOffset[1].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
                                                             fheroes2::Rect( copyToOffset[2].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ) };
 
-        const std::array<fheroes2::Rect, 3> iconArea{ fheroes2::Rect( difficultyArea[0].x + iconShadowSize, difficultyArea[0].y + iconShadowSize, iconSize - 1, iconSize - 1 ),
-                                                      fheroes2::Rect( difficultyArea[1].x + iconShadowSize, difficultyArea[1].y + iconShadowSize, iconSize - 1, iconSize - 1 ),
-                                                      fheroes2::Rect( difficultyArea[2].x + iconShadowSize, difficultyArea[2].y + iconShadowSize, iconSize - 1, iconSize - 1 ) };
+        const std::array<fheroes2::Rect, 3> iconArea{ fheroes2::Rect( difficultyArea[0].x + iconShadowSize, difficultyArea[0].y + iconShadowSize, iconSize - 1,
+                                                                      iconSize - 1 ),
+                                                      fheroes2::Rect( difficultyArea[1].x + iconShadowSize, difficultyArea[1].y + iconShadowSize, iconSize - 1,
+                                                                      iconSize - 1 ),
+                                                      fheroes2::Rect( difficultyArea[2].x + iconShadowSize, difficultyArea[2].y + iconShadowSize, iconSize - 1,
+                                                                      iconSize - 1 ) };
 
         const char * currentDescription = nullptr;
         switch ( currentDifficulty ) {

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -889,7 +889,7 @@ namespace
     int32_t setCampaignDifficulty( int32_t currentDifficulty, const int32_t maximumAllowedDifficulty )
     {
         // It's better to have frameborder width value divisible to 2 and 3 w/o remainder
-        const fheroes2::StandardWindow frameborder( 300, 270, true );
+        const fheroes2::StandardWindow frameborder( 300, 284, true );
         const fheroes2::Rect & windowRoi = frameborder.activeArea();
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
@@ -998,7 +998,7 @@ namespace
         }
 
         const int32_t textWidth = windowRoi.width - 16;
-        const fheroes2::Point textOffset{ windowRoi.x + 8, windowRoi.y + 135 };
+        const fheroes2::Point textOffset{ windowRoi.x + 8, windowRoi.y + 140 };
 
         fheroes2::Text description( currentDescription, fheroes2::FontType::normalWhite() );
         fheroes2::ImageRestorer restorer( display, textOffset.x, textOffset.y, textWidth, description.height( textWidth ) );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -908,13 +908,13 @@ namespace
         const fheroes2::Text caption( _( "Campaign Difficulty" ), fheroes2::FontType::normalYellow() );
         caption.draw( windowRoi.x + ( windowRoi.width - caption.width() ) / 2, windowRoi.y + 10, display );
         
-        const uint32_t iconSize = 65;
-        const uint32_t iconShadowSize = 4;
-        const uint32_t fullIconSize = iconSize + iconShadowSize;
+        const int32_t iconSize = 65;
+        const int32_t iconShadowSize = 4;
+        const int32_t fullIconSize = iconSize + iconShadowSize;
 
-        const uint32_t pawnIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 - windowRoi.width / 3;
-        const uint32_t horseIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2;
-        const uint32_t rookIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 + windowRoi.width / 3;
+        const int32_t pawnIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 - windowRoi.width / 3;
+        const int32_t horseIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2;
+        const int32_t rookIconOffsetX = windowRoi.x - iconShadowSize + ( windowRoi.width - iconSize ) / 2 + windowRoi.width / 3;
         
         const std::array<fheroes2::Rect, 3> copyFromArea{ fheroes2::Rect( 20, 94, fullIconSize, fullIconSize ),
                                                           fheroes2::Rect( 97, 94, fullIconSize, fullIconSize ),


### PR DESCRIPTION
This one resolves #7511.

## Changes:

- Splitted difficulty icons for separate rendering to allow further changes.
- Recalculated things based on difficulty icon size and its shadow size.
- Increased dialog width, slightly inreased top margin for description text and also dialog height.

## Screenshots:

English, good interface:

![camp_difficulty_good_en_1](https://github.com/ihhub/fheroes2/assets/5691178/ee53895a-7303-4119-97d7-e94f495ee1ad)

Bulgarian, evil interface:

![camp_difficulty_evil_bg_1](https://github.com/ihhub/fheroes2/assets/5691178/80324896-ad87-477e-8cd8-73eefd2c3091)

Some difficulty options disabled (test):

![camp_difficulty_good_bg_dis_3](https://github.com/ihhub/fheroes2/assets/5691178/2f338e7b-ec91-4bec-94f6-d4a0b379d233)

![camp_difficulty_evil_bg_dis_2](https://github.com/ihhub/fheroes2/assets/5691178/092b6d5d-c77c-45a0-9f82-57da5877c536)

Dialog window width increased to 600 (test):

![camp_difficulty_good_en_2](https://github.com/ihhub/fheroes2/assets/5691178/08abde0b-b04b-4841-80f5-9a99622876d5)
