### PR TITLE
Fix invalid focus update after AI hero battle

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -458,7 +458,7 @@ namespace
 
         // The attacker was defeated
         if ( !res.AttackerWins() ) {
-            AIBattleLose( hero, res, true, &( otherHero->GetCenter() ), playVanishingHeroSound );
+            AIBattleLose( hero, res, true, ( otherHero->isActive() ? &( otherHero->GetCenter() ) : nullptr ), playVanishingHeroSound );
         }
 
         // The attacker won


### PR DESCRIPTION
Focus update should be done only if the defender is still alive. This wasn't the case in the related ticket.

close #7881