### PR TITLE
Code cleanup for Maps::FileInfo structure

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -55,6 +55,7 @@
 #include "logging.h"
 #include "luck.h"
 #include "maps.h"
+#include "maps_fileinfo.h"
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"
 #include "math_base.h"

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -93,32 +93,32 @@ namespace
     {
         assert( art.isValid() );
 
-        const Settings & conf = Settings::Get();
+        const Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
 
-        if ( ( conf.ConditionWins() & GameOver::WINS_ARTIFACT ) == 0 ) {
+        if ( ( mapInfo.ConditionWins() & GameOver::WINS_ARTIFACT ) == 0 ) {
             return false;
         }
 
-        if ( conf.WinsFindUltimateArtifact() ) {
+        if ( mapInfo.WinsFindUltimateArtifact() ) {
             return art.isUltimate();
         }
 
-        return ( art.GetID() == conf.WinsFindArtifactID() );
+        return ( art.GetID() == mapInfo.WinsFindArtifactID() );
     }
 
     bool isCastleLossConditionForHuman( const Castle * castle )
     {
         assert( castle != nullptr );
 
-        const Settings & conf = Settings::Get();
+        const Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
         const bool isSinglePlayer = ( Colors( Players::HumanColors() ).size() == 1 );
 
-        if ( isSinglePlayer && ( conf.ConditionLoss() & GameOver::LOSS_TOWN ) != 0 && castle->GetCenter() == conf.LossMapsPositionObject() ) {
+        if ( isSinglePlayer && ( mapInfo.ConditionLoss() & GameOver::LOSS_TOWN ) != 0 && castle->GetCenter() == mapInfo.LossMapsPositionObject() ) {
             // It is a loss town condition for human.
             return true;
         }
 
-        if ( conf.WinsCompAlsoWins() && ( conf.ConditionWins() & GameOver::WINS_TOWN ) != 0 && castle->GetCenter() == conf.WinsMapsPositionObject() ) {
+        if ( mapInfo.WinsCompAlsoWins() && ( mapInfo.ConditionWins() & GameOver::WINS_TOWN ) != 0 && castle->GetCenter() == mapInfo.WinsMapsPositionObject() ) {
             // It is a town capture winning condition for AI.
             return true;
         }

--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -78,6 +78,7 @@ void Dialog::GameInfo()
 {
     fheroes2::Display & display = fheroes2::Display::instance();
     Settings & conf = Settings::Get();
+    const Maps::FileInfo & mapInfo = conf.getCurrentMapInfo();
 
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
@@ -91,7 +92,7 @@ void Dialog::GameInfo()
 
     fheroes2::Blit( window, display, dialogOffset.x, shadowOffset.y );
 
-    fheroes2::Text text( conf.getCurrentMapName(), fheroes2::FontType::normalWhite() );
+    fheroes2::Text text( mapInfo.name, fheroes2::FontType::normalWhite() );
     text.draw( shadowOffset.x, shadowOffset.y + 32, DIALOG_CONTENT_WIDTH, display );
 
     text.set( _( "Map\nDifficulty" ), fheroes2::FontType::smallWhite() );
@@ -106,7 +107,7 @@ void Dialog::GameInfo()
     text.set( _( "Map Size" ), fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + SCENARIO_MAP_SIZE_OFFSET, shadowOffset.y + 78 - text.height( SCENARIO_INFO_VALUES_BOX_WIDTH ), SCENARIO_INFO_VALUES_BOX_WIDTH, display );
 
-    text.set( Difficulty::String( conf.getCurrentMapDifficultyLevel() ), fheroes2::FontType::smallWhite() );
+    text.set( Difficulty::String( mapInfo.difficulty ), fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + SCENARIO_MAP_DIFFICULTY_OFFSET, shadowOffset.y + 84, SCENARIO_INFO_VALUES_BOX_WIDTH, display );
 
     text.set( Difficulty::String( Game::getDifficulty() ), fheroes2::FontType::smallWhite() );
@@ -115,10 +116,10 @@ void Dialog::GameInfo()
     text.set( std::to_string( Game::GetRating() ) + " %", fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + SCENARIO_RATING_OFFSET, shadowOffset.y + 84, SCENARIO_INFO_VALUES_BOX_WIDTH, display );
 
-    text.set( Maps::SizeString( conf.MapsSize().width ), fheroes2::FontType::smallWhite() );
+    text.set( Maps::SizeString( mapInfo.width ), fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + SCENARIO_MAP_SIZE_OFFSET, shadowOffset.y + 84, SCENARIO_INFO_VALUES_BOX_WIDTH, display );
 
-    text.set( conf.getCurrentMapDescription(), fheroes2::FontType::smallWhite() );
+    text.set( mapInfo.description, fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + SCENARIO_DESCRIPTION_OFFSET, shadowOffset.y + 107, SCENARIO_DESCRIPTION_WIDTH, display );
 
     text.set( _( "Opponents" ), fheroes2::FontType::smallWhite() );
@@ -136,13 +137,13 @@ void Dialog::GameInfo()
     text.set( _( "Victory\nConditions" ), fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + CONDITION_LABEL_OFFSET, shadowOffset.y + 347, CONDITION_LABEL_WIDTH, display );
 
-    text.set( GameOver::GetActualDescription( conf.ConditionWins() ), fheroes2::FontType::smallWhite() );
+    text.set( GameOver::GetActualDescription( mapInfo.ConditionWins() ), fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + CONDITION_DESCRIPTION_OFFSET, shadowOffset.y + 350, CONDITION_DESCRIPTION_WIDTH, display );
 
     text.set( _( "Loss\nConditions" ), fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + CONDITION_LABEL_OFFSET, shadowOffset.y + 392, CONDITION_LABEL_WIDTH, display );
 
-    text.set( GameOver::GetActualDescription( conf.ConditionLoss() ), fheroes2::FontType::smallWhite() );
+    text.set( GameOver::GetActualDescription( mapInfo.ConditionLoss() ), fheroes2::FontType::smallWhite() );
     text.draw( shadowOffset.x + CONDITION_DESCRIPTION_OFFSET, shadowOffset.y + 398, CONDITION_DESCRIPTION_WIDTH, display );
 
     const int buttonOkIcnId = ICN::BUTTON_SMALL_OKAY_GOOD;

--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -34,6 +34,7 @@
 #include "image.h"
 #include "localevent.h"
 #include "maps.h"
+#include "maps_fileinfo.h"
 #include "math_base.h"
 #include "player_info.h"
 #include "screen.h"

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -148,12 +148,12 @@ namespace
         {
             // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
             // To avoid this we have to replace all '\' symbols by '/' symbols.
-            std::string fullPath = info.file;
+            std::string fullPath = info.filename;
 
             // TODO: Make '\' symbol in small font to properly show file path in OS familiar style.
             StringReplace( fullPath, "\\", "/" );
 
-            const fheroes2::Text header( ResizeToShortName( info.file ), fheroes2::FontType::normalYellow() );
+            const fheroes2::Text header( ResizeToShortName( info.filename ), fheroes2::FontType::normalYellow() );
 
             fheroes2::MultiFontText body;
 
@@ -206,7 +206,7 @@ namespace
 
     void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, int32_t dstx, int32_t dsty, bool current )
     {
-        std::string savname( System::GetBasename( info.file ) );
+        std::string savname( System::GetBasename( info.filename ) );
 
         if ( savname.empty() ) {
             return;
@@ -358,7 +358,7 @@ namespace
 
             MapsFileInfoList::iterator it = lists.begin();
             for ( ; it != lists.end(); ++it ) {
-                if ( ( *it ).file == lastfile ) {
+                if ( ( *it ).filename == lastfile ) {
                     break;
                 }
             }
@@ -376,7 +376,7 @@ namespace
         }
 
         if ( filename.empty() && listbox.isSelected() ) {
-            filename = ResizeToShortName( listbox.GetCurrent().file );
+            filename = ResizeToShortName( listbox.GetCurrent().filename );
             charInsertPos = filename.size();
         }
 
@@ -431,7 +431,7 @@ namespace
                     result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
                 }
                 else if ( isListboxSelected ) {
-                    result = listbox.GetCurrent().file;
+                    result = listbox.GetCurrent().filename;
                 }
             }
             else if ( le.MouseClickLeft( buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
@@ -499,9 +499,9 @@ namespace
 
                 std::string msg( _( "Are you sure you want to delete file:" ) );
                 msg.append( "\n\n" );
-                msg.append( System::GetBasename( listbox.GetCurrent().file ) );
+                msg.append( System::GetBasename( listbox.GetCurrent().filename ) );
                 if ( Dialog::YES == fheroes2::showStandardTextMessage( _( "Warning!" ), msg, Dialog::YES | Dialog::NO ) ) {
-                    System::Unlink( listbox.GetCurrent().file );
+                    System::Unlink( listbox.GetCurrent().filename );
                     listbox.RemoveSelected();
                     if ( lists.empty() || filename.empty() ) {
                         buttonOk.disable();
@@ -531,7 +531,7 @@ namespace
             }
 
             if ( needRedraw ) {
-                const std::string selectedFileName = isListboxSelected ? ResizeToShortName( listbox.GetCurrent().file ) : "";
+                const std::string selectedFileName = isListboxSelected ? ResizeToShortName( listbox.GetCurrent().filename ) : "";
                 if ( isListboxSelected && lastSelectedSaveFileName != selectedFileName ) {
                     lastSelectedSaveFileName = selectedFileName;
                     filename = selectedFileName;

--- a/src/fheroes2/dialog/dialog_selectscenario.cpp
+++ b/src/fheroes2/dialog/dialog_selectscenario.cpp
@@ -96,7 +96,7 @@ namespace
     {
         // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
         // To avoid this we have to replace all '\' symbols by '/' symbols.
-        std::string fullPath = info.file;
+        std::string fullPath = info.filename;
         StringReplace( fullPath, "\\", "/" );
 
         fheroes2::Text header( info.name, fheroes2::FontType::normalYellow() );
@@ -130,7 +130,7 @@ namespace
     {
         std::string msg;
 
-        switch ( info.lossConditions ) {
+        switch ( info.lossConditionType ) {
         case Maps::FileInfo::LOSS_EVERYTHING:
             msg = _( "Lose all your heroes and towns." );
             break;
@@ -156,7 +156,7 @@ namespace
     {
         std::string msg;
 
-        switch ( info.victoryConditions ) {
+        switch ( info.victoryConditionType ) {
         case Maps::FileInfo::VICTORY_DEFEAT_EVERYONE:
             msg = _( "Defeat all enemy heroes and towns." );
             break;
@@ -185,13 +185,12 @@ namespace
 
     size_t GetInitialMapId( const MapsFileInfoList & lists )
     {
-        const Settings & conf = Settings::Get();
+        const Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
 
-        const std::string & mapName = conf.getCurrentMapInfo().name;
-        const std::string & mapFileName = System::GetBasename( conf.getCurrentMapInfo().file );
+        const std::string & mapFileName = System::GetBasename( mapInfo.filename );
         size_t mapId = 0;
         for ( MapsFileInfoList::const_iterator mapIter = lists.begin(); mapIter != lists.end(); ++mapIter, ++mapId ) {
-            if ( ( mapIter->name == mapName ) && ( System::GetBasename( mapIter->file ) == mapFileName ) ) {
+            if ( ( mapIter->name == mapInfo.name ) && ( System::GetBasename( mapIter->filename ) == mapFileName ) ) {
                 return mapId;
             }
         }
@@ -236,8 +235,8 @@ void ScenarioListBox::_renderScenarioListItem( const Maps::FileInfo & info, fher
     _renderMapIcon( info.width, display, _offsetX + SCENARIO_LIST_MAP_SIZE_OFFSET_X, dsty );
     fheroes2::Blit( _getMapTypeIcon( info.version ), display, _offsetX + SCENARIO_LIST_MAP_TYPE_OFFSET_X, dsty );
     _renderMapName( info, current, dsty, display );
-    fheroes2::Blit( _getWinConditionsIcon( info.victoryConditions ), display, _offsetX + SCENARIO_LIST_VICTORY_CONDITION_OFFSET_X, dsty );
-    fheroes2::Blit( _getLossConditionsIcon( info.lossConditions ), display, _offsetX + SCENARIO_LIST_LOSS_CONDITION_OFFSET_X, dsty );
+    fheroes2::Blit( _getWinConditionsIcon( info.victoryConditionType ), display, _offsetX + SCENARIO_LIST_VICTORY_CONDITION_OFFSET_X, dsty );
+    fheroes2::Blit( _getLossConditionsIcon( info.lossConditionType ), display, _offsetX + SCENARIO_LIST_LOSS_CONDITION_OFFSET_X, dsty );
 }
 
 void ScenarioListBox::_renderSelectedScenarioInfo( fheroes2::Display & display, const fheroes2::Point & dst )
@@ -252,9 +251,9 @@ void ScenarioListBox::_renderSelectedScenarioInfo( fheroes2::Display & display, 
     mapNameText.draw( GetCenteredTextXCoordinate( dst.x + SELECTED_SCENARIO_MAP_NAME_OFFSET_X, SELECTED_SCENARIO_MAP_NAME_WIDTH, mapNameText.width() ),
                       dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y + 2, display );
 
-    fheroes2::Blit( _getWinConditionsIcon( info.victoryConditions ), display, dst.x + SELECTED_SCENARIO_VICTORY_CONDITION_OFFSET_X,
+    fheroes2::Blit( _getWinConditionsIcon( info.victoryConditionType ), display, dst.x + SELECTED_SCENARIO_VICTORY_CONDITION_OFFSET_X,
                     dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
-    fheroes2::Blit( _getLossConditionsIcon( info.lossConditions ), display, dst.x + SELECTED_SCENARIO_LOSS_CONDITION_OFFSET_X,
+    fheroes2::Blit( _getLossConditionsIcon( info.lossConditionType ), display, dst.x + SELECTED_SCENARIO_LOSS_CONDITION_OFFSET_X,
                     dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
 
     fheroes2::Text difficultyLabelText( _( "Map difficulty:" ), fheroes2::FontType::normalWhite() );

--- a/src/fheroes2/editor/editor_mainmenu.cpp
+++ b/src/fheroes2/editor/editor_mainmenu.cpp
@@ -312,7 +312,7 @@ namespace Editor
         }
 
         Maps::Map_Format::MapFormat map;
-        if ( !Maps::Map_Format::loadMap( fileInfo->file, map ) ) {
+        if ( !Maps::Map_Format::loadMap( fileInfo->filename, map ) ) {
             fheroes2::showStandardTextMessage( _( "Warning!" ), "Failed to load the map.", Dialog::OK );
             return fheroes2::GameMode::CANCEL;
         }

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -363,10 +363,9 @@ void Game::restoreSoundsForCurrentFocus()
 
 uint32_t Game::GetRating()
 {
-    const Settings & conf = Settings::Get();
     uint32_t rating = 50;
 
-    switch ( conf.getCurrentMapDifficultyLevel() ) {
+    switch ( Settings::Get().getCurrentMapInfo().difficulty ) {
     case Difficulty::NORMAL:
         rating += 20;
         break;
@@ -403,11 +402,9 @@ uint32_t Game::GetRating()
 
 uint32_t Game::getGameOverScoreFactor()
 {
-    const Settings & conf = Settings::Get();
-
     uint32_t mapSizeFactor = 0;
 
-    switch ( conf.MapsSize().width ) {
+    switch ( Settings::Get().getCurrentMapInfo().width ) {
     case Maps::SMALL:
         mapSizeFactor = 140;
         break;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1601,7 +1601,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
 
             const bool isSWCampaign = ( chosenCampaignID == Campaign::ROLAND_CAMPAIGN ) || ( chosenCampaignID == Campaign::ARCHIBALD_CAMPAIGN );
 
-            if ( !world.LoadMapMP2( mapInfo.file, isSWCampaign ) ) {
+            if ( !world.LoadMapMP2( mapInfo.filename, isSWCampaign ) ) {
                 fheroes2::showStandardTextMessage( _( "Campaign Scenario loading failure" ), _( "Please make sure that campaign files are correct and present." ),
                                                    Dialog::OK );
 

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -266,7 +266,7 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
     }
 
     // Settings should contain the full path to the current map file, if this map is available
-    conf.SetMapsFile( Settings::GetLastFile( "maps", System::GetBasename( conf.getCurrentMapFileName() ) ) );
+    conf.getCurrentMapInfo().filename = Settings::GetLastFile( "maps", System::GetBasename( conf.getCurrentMapInfo().filename ) );
 
     if ( !conf.loadedFileLanguage().empty() && conf.loadedFileLanguage() != "en" && conf.loadedFileLanguage() != conf.getGameLanguage() ) {
         std::string warningMessage( _( "This saved game is localized to '" ) );
@@ -325,7 +325,7 @@ bool Game::LoadSAV2FileInfo( std::string filePath, Maps::FileInfo & fileInfo )
     }
 
     fileInfo = std::move( header.info );
-    fileInfo.file = std::move( filePath );
+    fileInfo.filename = std::move( filePath );
 
     return true;
 }

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -76,7 +76,7 @@ namespace
             case GameOver::WINS_TOWN: {
                 body = _( "You captured %{name}!\nYou are victorious." );
 
-                const Castle * town = world.getCastleEntrance( conf.WinsMapsPositionObject() );
+                const Castle * town = world.getCastleEntrance( conf.getCurrentMapInfo().WinsMapsPositionObject() );
                 assert( town != nullptr );
 
                 if ( town ) {
@@ -102,11 +102,11 @@ namespace
             case GameOver::WINS_ARTIFACT:
                 body = _( "You have found the %{name}.\nYour quest is complete." );
 
-                if ( conf.WinsFindUltimateArtifact() ) {
+                if ( conf.getCurrentMapInfo().WinsFindUltimateArtifact() ) {
                     StringReplace( body, "%{name}", _( "Ultimate Artifact" ) );
                 }
                 else {
-                    const Artifact art = conf.WinsFindArtifactID();
+                    const Artifact art = conf.getCurrentMapInfo().WinsFindArtifactID();
                     StringReplace( body, "%{name}", art.GetName() );
                 }
 
@@ -118,7 +118,7 @@ namespace
 
             case GameOver::WINS_GOLD:
                 body = _( "You have built up over %{count} gold in your treasury.\nAll enemies bow before your wealth and power." );
-                StringReplace( body, "%{count}", conf.getWinningGoldAccumulationValue() );
+                StringReplace( body, "%{count}", conf.getCurrentMapInfo().getWinningGoldAccumulationValue() );
                 break;
 
             default:
@@ -142,7 +142,7 @@ namespace
         case GameOver::LOSS_ENEMY_WINS_TOWN: {
             body = _( "The enemy has captured %{name}!\nThey are triumphant." );
 
-            const Castle * town = world.getCastleEntrance( conf.WinsMapsPositionObject() );
+            const Castle * town = world.getCastleEntrance( conf.getCurrentMapInfo().WinsMapsPositionObject() );
             assert( town != nullptr );
 
             if ( town ) {
@@ -154,7 +154,7 @@ namespace
 
         case GameOver::LOSS_ENEMY_WINS_GOLD:
             body = _( "The enemy has built up over %{count} gold in his treasury.\nYou must bow done in defeat before his wealth and power." );
-            StringReplace( body, "%{count}", conf.getWinningGoldAccumulationValue() );
+            StringReplace( body, "%{count}", conf.getCurrentMapInfo().getWinningGoldAccumulationValue() );
             break;
 
         case GameOver::LOSS_ALL:
@@ -164,7 +164,7 @@ namespace
         case GameOver::LOSS_TOWN: {
             body = _( "The enemy has captured %{name}!\nThey are triumphant." );
 
-            const Castle * town = world.getCastleEntrance( conf.LossMapsPositionObject() );
+            const Castle * town = world.getCastleEntrance( conf.getCurrentMapInfo().LossMapsPositionObject() );
             assert( town != nullptr );
 
             if ( town ) {
@@ -313,7 +313,7 @@ std::string GameOver::GetActualDescription( uint32_t cond )
         }
     }
     else if ( WINS_TOWN & cond ) {
-        const Castle * town = world.getCastleEntrance( conf.WinsMapsPositionObject() );
+        const Castle * town = world.getCastleEntrance( conf.getCurrentMapInfo().WinsMapsPositionObject() );
         assert( town != nullptr );
 
         if ( town ) {
@@ -331,11 +331,11 @@ std::string GameOver::GetActualDescription( uint32_t cond )
         }
     }
     else if ( WINS_ARTIFACT & cond ) {
-        if ( conf.WinsFindUltimateArtifact() ) {
+        if ( conf.getCurrentMapInfo().WinsFindUltimateArtifact() ) {
             msg = _( "Find the ultimate artifact." );
         }
         else {
-            const Artifact art = conf.WinsFindArtifactID();
+            const Artifact art = conf.getCurrentMapInfo().WinsFindArtifactID();
 
             msg = _( "Find the '%{name}' artifact." );
             StringReplace( msg, "%{name}", art.GetName() );
@@ -343,7 +343,7 @@ std::string GameOver::GetActualDescription( uint32_t cond )
     }
     else if ( WINS_GOLD & cond ) {
         msg = _( "Accumulate %{count} gold." );
-        StringReplace( msg, "%{count}", conf.getWinningGoldAccumulationValue() );
+        StringReplace( msg, "%{count}", conf.getCurrentMapInfo().getWinningGoldAccumulationValue() );
     }
 
     if ( WINS_ALL != cond && ( WINS_ALL & cond ) ) {
@@ -354,7 +354,7 @@ std::string GameOver::GetActualDescription( uint32_t cond )
         msg = GetString( LOSS_ALL );
     }
     else if ( LOSS_TOWN & cond ) {
-        const Castle * town = world.getCastleEntrance( conf.LossMapsPositionObject() );
+        const Castle * town = world.getCastleEntrance( conf.getCurrentMapInfo().LossMapsPositionObject() );
         assert( town != nullptr );
 
         if ( town ) {
@@ -372,7 +372,7 @@ std::string GameOver::GetActualDescription( uint32_t cond )
         }
     }
     else if ( LOSS_TIME & cond ) {
-        const uint32_t dayCount = conf.LossCountDays() - 1;
+        const uint32_t dayCount = conf.getCurrentMapInfo().LossCountDays() - 1;
         const uint32_t month = dayCount / ( DAYOFWEEK * WEEKOFMONTH );
         const uint32_t week = ( dayCount - month * ( DAYOFWEEK * WEEKOFMONTH ) ) / DAYOFWEEK;
         const uint32_t day = dayCount % DAYOFWEEK;

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -43,6 +43,7 @@
 #include "heroes.h"
 #include "highscores.h"
 #include "kingdom.h"
+#include "maps_fileinfo.h"
 #include "monster.h"
 #include "mus.h"
 #include "players.h"

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -86,7 +86,6 @@ namespace
 
     void RedrawScenarioStaticInfo( const fheroes2::Rect & rt, bool firstDraw = false )
     {
-        const Settings & conf = Settings::Get();
         fheroes2::Display & display = fheroes2::Display::instance();
 
         if ( firstDraw ) {
@@ -108,7 +107,7 @@ namespace
         text.draw( rt.x, rt.y + 25, rt.width, display );
 
         // maps name
-        text.set( conf.getCurrentMapName(), normalWhiteFont );
+        text.set( Settings::Get().getCurrentMapInfo().name, normalWhiteFont );
         text.draw( rt.x, rt.y + 48, rt.width, display );
 
         // text game difficulty
@@ -192,7 +191,7 @@ namespace
         fheroes2::drawMainMenuScreen();
 
         Settings & conf = Settings::Get();
-        bool resetStartingSettings = conf.getCurrentMapFileName().empty();
+        bool resetStartingSettings = conf.getCurrentMapInfo().filename.empty();
         Players & players = conf.GetPlayers();
         Interface::PlayersInfo playersInfo;
 
@@ -201,13 +200,13 @@ namespace
         if ( !resetStartingSettings ) { // verify that current map really exists in map's list
             resetStartingSettings = true;
             const std::string & mapName = conf.getCurrentMapInfo().name;
-            const std::string & mapFileName = System::GetBasename( conf.getCurrentMapInfo().file );
+            const std::string & mapFileName = System::GetBasename( conf.getCurrentMapInfo().filename );
             for ( const Maps::FileInfo & mapInfo : lists ) {
-                if ( ( mapInfo.name == mapName ) && ( System::GetBasename( mapInfo.file ) == mapFileName ) ) {
-                    if ( mapInfo.file == conf.getCurrentMapInfo().file ) {
+                if ( ( mapInfo.name == mapName ) && ( System::GetBasename( mapInfo.filename ) == mapFileName ) ) {
+                    if ( mapInfo.filename == conf.getCurrentMapInfo().filename ) {
                         conf.SetCurrentFileInfo( mapInfo );
                         updatePlayers( players, humanPlayerCount );
-                        Game::LoadPlayers( mapInfo.file, players );
+                        Game::LoadPlayers( mapInfo.filename, players );
                         resetStartingSettings = false;
                         break;
                     }
@@ -219,7 +218,7 @@ namespace
         if ( resetStartingSettings ) {
             conf.SetCurrentFileInfo( lists.front() );
             updatePlayers( players, humanPlayerCount );
-            Game::LoadPlayers( lists.front().file, players );
+            Game::LoadPlayers( lists.front().filename, players );
         }
 
         playersInfo.UpdateInfo( players, pointOpponentInfo, pointClassInfo );
@@ -285,9 +284,9 @@ namespace
                 const Maps::FileInfo * fi = Dialog::SelectScenario( lists );
 
                 if ( fi ) {
-                    Game::SavePlayers( conf.getCurrentMapInfo().file, conf.GetPlayers() );
+                    Game::SavePlayers( conf.getCurrentMapInfo().filename, conf.GetPlayers() );
                     conf.SetCurrentFileInfo( *fi );
-                    Game::LoadPlayers( fi->file, players );
+                    Game::LoadPlayers( fi->filename, players );
 
                     updatePlayers( players, humanPlayerCount );
                     playersInfo.UpdateInfo( players, pointOpponentInfo, pointClassInfo );
@@ -309,7 +308,7 @@ namespace
                 break;
             }
             else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) || le.MouseClickLeft( buttonOk.area() ) ) {
-                DEBUG_LOG( DBG_GAME, DBG_INFO, "select maps: " << conf.getCurrentMapFileName() << ", difficulty: " << Difficulty::String( Game::getDifficulty() ) )
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "select maps: " << conf.getCurrentMapInfo().filename << ", difficulty: " << Difficulty::String( Game::getDifficulty() ) )
                 result = fheroes2::GameMode::START_GAME;
 
                 // Fade-out screen before starting a scenario.
@@ -383,7 +382,7 @@ namespace
             }
         }
 
-        Game::SavePlayers( conf.getCurrentMapInfo().file, conf.GetPlayers() );
+        Game::SavePlayers( conf.getCurrentMapInfo().filename, conf.GetPlayers() );
 
         return result;
     }
@@ -394,7 +393,7 @@ namespace
 
         conf.GetPlayers().SetStartGame();
 
-        const std::string & filePath = conf.getCurrentMapFileName();
+        const std::string & filePath = conf.getCurrentMapInfo().filename;
         const size_t pos = filePath.rfind( '.' );
         if ( pos != std::string::npos ) {
             const std::string ext = StringLower( filePath.substr( pos + 1 ) );
@@ -408,7 +407,7 @@ namespace
         assert( 0 );
 
         DEBUG_LOG( DBG_GAME, DBG_WARN,
-                   conf.getCurrentMapName() << ", "
+                   conf.getCurrentMapInfo().name << ", "
                                             << "unknown map format" )
         return fheroes2::GameMode::MAIN_MENU;
     }

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -408,7 +408,7 @@ namespace
 
         DEBUG_LOG( DBG_GAME, DBG_WARN,
                    conf.getCurrentMapInfo().name << ", "
-                                            << "unknown map format" )
+                                                 << "unknown map format" )
         return fheroes2::GameMode::MAIN_MENU;
     }
 }

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -139,7 +139,7 @@ void Interface::PlayersInfo::UpdateInfo( Players & players, const fheroes2::Poin
 bool Interface::PlayersInfo::SwapPlayers( Player & player1, Player & player2 ) const
 {
     const Settings & conf = Settings::Get();
-    const Maps::FileInfo & fi = conf.getCurrentMapInfo();
+    const Maps::FileInfo & mapInfo = conf.getCurrentMapInfo();
 
     const int player1Color = player1.GetColor();
     const int player2Color = player2.GetColor();
@@ -149,7 +149,7 @@ bool Interface::PlayersInfo::SwapPlayers( Player & player1, Player & player2 ) c
     if ( player1.isControlAI() == player2.isControlAI() ) {
         swap = true;
     }
-    else if ( ( player1Color & fi.AllowCompHumanColors() ) && ( player2Color & fi.AllowCompHumanColors() ) ) {
+    else if ( ( player1Color & mapInfo.AllowCompHumanColors() ) && ( player2Color & mapInfo.AllowCompHumanColors() ) ) {
         const int humans = conf.GetPlayers().GetColors( CONTROL_HUMAN, true );
 
         if ( humans & player1Color ) {
@@ -174,7 +174,7 @@ bool Interface::PlayersInfo::SwapPlayers( Player & player1, Player & player2 ) c
         player2.setHandicapStatus( player1HandicapStatus );
         player1.setHandicapStatus( player2HandicapStatus );
 
-        if ( player1Race != player2Race && conf.AllowChangeRace( player1Color ) && conf.AllowChangeRace( player2Color ) ) {
+        if ( player1Race != player2Race && mapInfo.AllowChangeRace( player1Color ) && mapInfo.AllowChangeRace( player2Color ) ) {
             player1.SetRace( player2Race );
             player2.SetRace( player1Race );
         }
@@ -250,7 +250,7 @@ void Interface::PlayersInfo::RedrawInfo( const bool displayInGameInfo ) const
 {
     const Settings & conf = Settings::Get();
     fheroes2::Display & display = fheroes2::Display::instance();
-    const Maps::FileInfo & fi = conf.getCurrentMapInfo();
+    const Maps::FileInfo & mapInfo = conf.getCurrentMapInfo();
 
     const int32_t playerCount = static_cast<int32_t>( conf.GetPlayers().size() );
     const uint32_t humanColors = conf.GetPlayers().GetColors( CONTROL_HUMAN, true );
@@ -264,7 +264,7 @@ void Interface::PlayersInfo::RedrawInfo( const bool displayInGameInfo ) const
             // Current human.
             playerTypeIcnIndex = 9 + Color::GetIndex( info.player->GetColor() );
         }
-        else if ( fi.ComputerOnlyColors() & info.player->GetColor() ) {
+        else if ( mapInfo.ComputerOnlyColors() & info.player->GetColor() ) {
             // Computer only.
             playerTypeIcnIndex = 15 + Color::GetIndex( info.player->GetColor() );
         }
@@ -298,7 +298,7 @@ void Interface::PlayersInfo::RedrawInfo( const bool displayInGameInfo ) const
         name.draw( info.playerTypeRoi.x + 2 + ( maximumTextWidth - name.width() ) / 2, info.playerTypeRoi.y + info.playerTypeRoi.height + 1, display );
 
         // 2. redraw class
-        const bool isActivePlayer = displayInGameInfo ? info.player->isPlay() : conf.AllowChangeRace( info.player->GetColor() );
+        const bool isActivePlayer = displayInGameInfo ? info.player->isPlay() : mapInfo.AllowChangeRace( info.player->GetColor() );
 
         uint32_t classIcnIndex = 0;
         switch ( info.player->GetRace() ) {
@@ -425,7 +425,7 @@ bool Interface::PlayersInfo::QueueEventProcessing()
     if ( le.MouseWheelUp() ) {
         Player * player = GetFromClassClick( le.GetMouseCursor() );
         if ( player != nullptr ) {
-            if ( conf.AllowChangeRace( player->GetColor() ) ) {
+            if ( conf.getCurrentMapInfo().AllowChangeRace( player->GetColor() ) ) {
                 changeRaceToPrev( *player );
             }
 
@@ -438,7 +438,7 @@ bool Interface::PlayersInfo::QueueEventProcessing()
     if ( le.MouseWheelDn() ) {
         Player * player = GetFromClassClick( le.GetMouseCursor() );
         if ( player != nullptr ) {
-            if ( conf.AllowChangeRace( player->GetColor() ) ) {
+            if ( conf.getCurrentMapInfo().AllowChangeRace( player->GetColor() ) ) {
                 changeRaceToNext( *player );
             }
 
@@ -502,7 +502,7 @@ bool Interface::PlayersInfo::QueueEventProcessing()
 
     player = GetFromClassClick( le.GetMouseCursor() );
     if ( player != nullptr ) {
-        if ( conf.AllowChangeRace( player->GetColor() ) ) {
+        if ( conf.getCurrentMapInfo().AllowChangeRace( player->GetColor() ) ) {
             changeRaceToNext( *player );
         }
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -645,7 +645,7 @@ void Kingdom::ApplyPlayWithStartingHero()
         }
     }
 
-    if ( !foundHeroes && Settings::Get().GameStartWithHeroes() ) {
+    if ( !foundHeroes && Settings::Get().getCurrentMapInfo().startWithHeroInEachCastle ) {
         // get first castle
         const Castle * first = castles.GetFirstCastle();
         if ( nullptr == first )

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -246,7 +246,7 @@ namespace
             }
 
 #if defined( SAVE_WORLD_MAP )
-            fheroes2::Save( cachedImages[3], Settings::Get().getCurrentMapName() + saveFilePrefix + ".bmp" );
+            fheroes2::Save( cachedImages[3], Settings::Get().getCurrentMapInfo().name + saveFilePrefix + ".bmp" );
 #endif
         }
     };

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -61,7 +61,7 @@ namespace Maps
 
         bool operator==( const FileInfo & fi ) const
         {
-            return file == fi.file;
+            return filename == fi.filename;
         }
 
         bool ReadMP2( const std::string & filePath );
@@ -93,36 +93,46 @@ namespace Maps
         uint32_t ConditionWins() const;
         uint32_t ConditionLoss() const;
         bool WinsCompAlsoWins() const;
-        int WinsFindArtifactID() const;
+
+        int WinsFindArtifactID() const
+        {
+            // In the original game artifact IDs start from 0 but for the victory condition it starts from 1 which aligns with fheroes2 artifact enumeration.
+            return victoryConditionParams[0];
+        }
 
         bool WinsFindUltimateArtifact() const
         {
-            return 0 == victoryConditionsParam1;
+            return victoryConditionParams[0] == 0;
         }
 
         uint32_t getWinningGoldAccumulationValue() const
         {
-            return victoryConditionsParam1 * 1000;
+            return victoryConditionParams[0] * 1000;
         }
 
         fheroes2::Point WinsMapsPositionObject() const
         {
-            return { victoryConditionsParam1, victoryConditionsParam2 };
+            return { victoryConditionParams[0], victoryConditionParams[1] };
         }
 
         fheroes2::Point LossMapsPositionObject() const
         {
-            return { lossConditionsParam1, lossConditionsParam2 };
+            return { lossConditionParams[0], lossConditionParams[1] };
         }
 
         uint32_t LossCountDays() const
         {
-            return lossConditionsParam1;
+            return lossConditionParams[0];
         }
 
         void removeHumanColors( const int colors )
         {
             colorsAvailableForHumans &= ~colors;
+        }
+
+        bool AllowChangeRace( const int color ) const
+        {
+            return ( colorsOfRandomRaces & color ) != 0;
         }
 
         void Reset();
@@ -145,7 +155,7 @@ namespace Maps
             LOSS_OUT_OF_TIME = 3
         };
 
-        std::string file;
+        std::string filename;
         std::string name;
         std::string description;
 
@@ -162,16 +172,14 @@ namespace Maps
         uint8_t colorsOfRandomRaces;
 
         // Refer to the VictoryCondition
-        uint8_t victoryConditions;
+        uint8_t victoryConditionType;
         bool compAlsoWins;
         bool allowNormalVictory;
-        uint16_t victoryConditionsParam1;
-        uint16_t victoryConditionsParam2;
+        std::array<uint16_t, 2> victoryConditionParams;
 
         // Refer to the LossCondition
-        uint8_t lossConditions;
-        uint16_t lossConditionsParam1;
-        uint16_t lossConditionsParam2;
+        uint8_t lossConditionType;
+        std::array<uint16_t, 2> lossConditionParams;
 
         // Timestamp of the save file, only relevant for save files
         uint32_t timestamp;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -86,6 +86,11 @@ public:
         return current_maps_file;
     }
 
+    Maps::FileInfo & getCurrentMapInfo()
+    {
+        return current_maps_file;
+    }
+
     int HeroesMoveSpeed() const
     {
         return heroes_speed;
@@ -315,95 +320,9 @@ public:
 
     void SetPreferablyCountPlayers( int );
 
-    // from maps info
-    bool AllowChangeRace( int f ) const
-    {
-        return ( current_maps_file.colorsOfRandomRaces & f ) != 0;
-    }
-
-    const std::string & getCurrentMapFileName() const
-    {
-        return current_maps_file.file;
-    }
-
-    const std::string & getCurrentMapName() const
-    {
-        return current_maps_file.name;
-    }
-
-    const std::string & getCurrentMapDescription() const
-    {
-        return current_maps_file.description;
-    }
-
-    int getCurrentMapDifficultyLevel() const
-    {
-        return current_maps_file.difficulty;
-    }
-
-    fheroes2::Size MapsSize() const
-    {
-        return { current_maps_file.width, current_maps_file.height };
-    }
-
-    bool GameStartWithHeroes() const
-    {
-        return current_maps_file.startWithHeroInEachCastle;
-    }
-
-    uint32_t ConditionWins() const
-    {
-        return current_maps_file.ConditionWins();
-    }
-
-    uint32_t ConditionLoss() const
-    {
-        return current_maps_file.ConditionLoss();
-    }
-
-    bool WinsCompAlsoWins() const
-    {
-        return current_maps_file.WinsCompAlsoWins();
-    }
-
-    int WinsFindArtifactID() const
-    {
-        return current_maps_file.WinsFindArtifactID();
-    }
-
-    bool WinsFindUltimateArtifact() const
-    {
-        return current_maps_file.WinsFindUltimateArtifact();
-    }
-
-    uint32_t getWinningGoldAccumulationValue() const
-    {
-        return current_maps_file.getWinningGoldAccumulationValue();
-    }
-
-    fheroes2::Point WinsMapsPositionObject() const
-    {
-        return current_maps_file.WinsMapsPositionObject();
-    }
-
-    fheroes2::Point LossMapsPositionObject() const
-    {
-        return current_maps_file.LossMapsPositionObject();
-    }
-
-    uint32_t LossCountDays() const
-    {
-        return current_maps_file.LossCountDays();
-    }
-
     int controllerPointerSpeed() const
     {
         return _controllerPointerSpeed;
-    }
-
-    void SetMapsFile( const std::string & file )
-    {
-        current_maps_file.file = file;
     }
 
     ZoomLevel ViewWorldZoomLevel() const

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1035,12 +1035,12 @@ void World::RemoveMapObject( const MapObjectSimple * obj )
 
 const Heroes * World::GetHeroesCondWins() const
 {
-    return ( ( Settings::Get().ConditionWins() & GameOver::WINS_HERO ) != 0 ) ? GetHeroes( heroes_cond_wins ) : nullptr;
+    return ( ( Settings::Get().getCurrentMapInfo().ConditionWins() & GameOver::WINS_HERO ) != 0 ) ? GetHeroes( heroes_cond_wins ) : nullptr;
 }
 
 const Heroes * World::GetHeroesCondLoss() const
 {
-    return ( ( Settings::Get().ConditionLoss() & GameOver::LOSS_HERO ) != 0 ) ? GetHeroes( heroes_cond_loss ) : nullptr;
+    return ( ( Settings::Get().getCurrentMapInfo().ConditionLoss() & GameOver::LOSS_HERO ) != 0 ) ? GetHeroes( heroes_cond_loss ) : nullptr;
 }
 
 bool World::KingdomIsWins( const Kingdom & kingdom, const uint32_t wins ) const
@@ -1056,7 +1056,7 @@ bool World::KingdomIsWins( const Kingdom & kingdom, const uint32_t wins ) const
 #endif // WITH_DEBUG
 #endif // !NDEBUG
 
-    const Settings & conf = Settings::Get();
+    const Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
 
     switch ( wins ) {
     case GameOver::WINS_ALL:
@@ -1066,8 +1066,8 @@ bool World::KingdomIsWins( const Kingdom & kingdom, const uint32_t wins ) const
         return kingdom.GetColor() == vec_kingdoms.GetNotLossColors();
 
     case GameOver::WINS_TOWN: {
-        const Castle * town = getCastleEntrance( conf.WinsMapsPositionObject() );
-        return ( kingdom.isControlHuman() || conf.WinsCompAlsoWins() ) && ( town && town->GetColor() == kingdom.GetColor() );
+        const Castle * town = getCastleEntrance( mapInfo.WinsMapsPositionObject() );
+        return ( kingdom.isControlHuman() || mapInfo.WinsCompAlsoWins() ) && ( town && town->GetColor() == kingdom.GetColor() );
     }
 
     case GameOver::WINS_HERO: {
@@ -1090,11 +1090,11 @@ bool World::KingdomIsWins( const Kingdom & kingdom, const uint32_t wins ) const
         assert( kingdom.isControlHuman() || isKingdomInAIAutoControlMode );
 
         const VecHeroes & heroes = kingdom.GetHeroes();
-        if ( conf.WinsFindUltimateArtifact() ) {
+        if ( mapInfo.WinsFindUltimateArtifact() ) {
             return std::any_of( heroes.begin(), heroes.end(), []( const Heroes * hero ) { return hero->HasUltimateArtifact(); } );
         }
         else {
-            const Artifact art = conf.WinsFindArtifactID();
+            const Artifact art = mapInfo.WinsFindArtifactID();
             return std::any_of( heroes.begin(), heroes.end(), [&art]( const Heroes * hero ) { return hero->hasArtifact( art ); } );
         }
     }
@@ -1106,8 +1106,8 @@ bool World::KingdomIsWins( const Kingdom & kingdom, const uint32_t wins ) const
         return !( Game::GetActualKingdomColors() & ~Players::GetPlayerFriends( kingdom.GetColor() ) );
 
     case GameOver::WINS_GOLD:
-        return ( ( kingdom.isControlHuman() || conf.WinsCompAlsoWins() ) && 0 < kingdom.GetFunds().Get( Resource::GOLD )
-                 && static_cast<uint32_t>( kingdom.GetFunds().Get( Resource::GOLD ) ) >= conf.getWinningGoldAccumulationValue() );
+        return ( ( kingdom.isControlHuman() || mapInfo.WinsCompAlsoWins() ) && 0 < kingdom.GetFunds().Get( Resource::GOLD )
+                 && static_cast<uint32_t>( kingdom.GetFunds().Get( Resource::GOLD ) ) >= mapInfo.getWinningGoldAccumulationValue() );
 
     default:
         break;
@@ -1139,7 +1139,7 @@ bool World::KingdomIsLoss( const Kingdom & kingdom, const uint32_t loss ) const
         return kingdom.isLoss();
 
     case GameOver::LOSS_TOWN: {
-        const Castle * town = getCastleEntrance( conf.LossMapsPositionObject() );
+        const Castle * town = getCastleEntrance( conf.getCurrentMapInfo().LossMapsPositionObject() );
         return ( town && town->GetColor() != kingdom.GetColor() );
     }
 
@@ -1179,7 +1179,7 @@ bool World::KingdomIsLoss( const Kingdom & kingdom, const uint32_t loss ) const
     }
 
     case GameOver::LOSS_TIME:
-        return ( CountDay() > conf.LossCountDays() );
+        return ( CountDay() > conf.getCurrentMapInfo().LossCountDays() );
 
     default:
         break;
@@ -1222,7 +1222,7 @@ uint32_t World::CheckKingdomWins( const Kingdom & kingdom ) const
         = { GameOver::WINS_ALL, GameOver::WINS_TOWN, GameOver::WINS_HERO, GameOver::WINS_ARTIFACT, GameOver::WINS_SIDE, GameOver::WINS_GOLD };
 
     for ( const uint32_t cond : wins ) {
-        if ( ( ( conf.ConditionWins() & cond ) == cond ) && KingdomIsWins( kingdom, cond ) ) {
+        if ( ( ( conf.getCurrentMapInfo().ConditionWins() & cond ) == cond ) && KingdomIsWins( kingdom, cond ) ) {
             return cond;
         }
     }
@@ -1253,7 +1253,7 @@ uint32_t World::CheckKingdomLoss( const Kingdom & kingdom ) const
                                                                       std::make_pair<uint32_t, uint32_t>( GameOver::WINS_GOLD, GameOver::LOSS_ENEMY_WINS_GOLD ) };
 
     for ( const auto & item : enemy_wins ) {
-        if ( conf.ConditionWins() & item.first ) {
+        if ( conf.getCurrentMapInfo().ConditionWins() & item.first ) {
             const int color = vec_kingdoms.FindWins( item.first );
 
             if ( color && color != kingdom.GetColor() ) {
@@ -1284,7 +1284,7 @@ uint32_t World::CheckKingdomLoss( const Kingdom & kingdom ) const
     const std::array<uint32_t, 4> loss = { GameOver::LOSS_ALL, GameOver::LOSS_TOWN, GameOver::LOSS_HERO, GameOver::LOSS_TIME };
 
     for ( const uint32_t cond : loss ) {
-        if ( ( ( conf.ConditionLoss() & cond ) == cond ) && KingdomIsLoss( kingdom, cond ) ) {
+        if ( ( ( conf.getCurrentMapInfo().ConditionLoss() & cond ) == cond ) && KingdomIsLoss( kingdom, cond ) ) {
             return cond;
         }
     }

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -44,6 +44,7 @@
 #include "kingdom.h"
 #include "logging.h"
 #include "maps.h"
+#include "maps_fileinfo.h"
 #include "maps_objects.h"
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -644,11 +644,11 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
     // clear artifact flags to correctly generate random artifacts
     fheroes2::ResetArtifactStats();
 
-    const Settings & conf = Settings::Get();
+    const Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
 
     // do not let the player get a random artifact that allows him to win the game
-    if ( ( conf.ConditionWins() & GameOver::WINS_ARTIFACT ) == GameOver::WINS_ARTIFACT && !conf.WinsFindUltimateArtifact() ) {
-        fheroes2::ExcludeArtifactFromRandom( conf.WinsFindArtifactID() );
+    if ( ( mapInfo.ConditionWins() & GameOver::WINS_ARTIFACT ) == GameOver::WINS_ARTIFACT && !mapInfo.WinsFindUltimateArtifact() ) {
+        fheroes2::ExcludeArtifactFromRandom( mapInfo.WinsFindArtifactID() );
     }
 
     if ( !ProcessNewMap( filename, checkPoLObjects ) ) {
@@ -677,11 +677,11 @@ bool World::ProcessNewMap( const std::string & filename, const bool checkPoLObje
     // add castles to kingdoms
     vec_kingdoms.AddCastles( vec_castles );
 
-    const Settings & conf = Settings::Get();
+    const Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
 
     // update wins, loss conditions
-    if ( GameOver::WINS_HERO & conf.ConditionWins() ) {
-        const fheroes2::Point & pos = conf.WinsMapsPositionObject();
+    if ( GameOver::WINS_HERO & mapInfo.ConditionWins() ) {
+        const fheroes2::Point & pos = mapInfo.WinsMapsPositionObject();
 
         const Heroes * hero = GetHeroes( pos );
         if ( hero == nullptr ) {
@@ -693,8 +693,8 @@ bool World::ProcessNewMap( const std::string & filename, const bool checkPoLObje
         }
     }
 
-    if ( GameOver::LOSS_HERO & conf.ConditionLoss() ) {
-        const fheroes2::Point & pos = conf.LossMapsPositionObject();
+    if ( GameOver::LOSS_HERO & mapInfo.ConditionLoss() ) {
+        const fheroes2::Point & pos = mapInfo.LossMapsPositionObject();
 
         Heroes * hero = GetHeroes( pos );
         if ( hero == nullptr ) {

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -60,17 +60,17 @@ namespace
     {
         assert( art.isValid() );
 
-        const Settings & conf = Settings::Get();
+        const Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
 
-        if ( ( conf.ConditionWins() & GameOver::WINS_ARTIFACT ) == 0 ) {
+        if ( ( mapInfo.ConditionWins() & GameOver::WINS_ARTIFACT ) == 0 ) {
             return false;
         }
 
-        if ( conf.WinsFindUltimateArtifact() ) {
+        if ( mapInfo.WinsFindUltimateArtifact() ) {
             return art.isUltimate();
         }
 
-        return ( art.GetID() == conf.WinsFindArtifactID() );
+        return ( art.GetID() == mapInfo.WinsFindArtifactID() );
     }
 
     bool isTileAvailableForWalkThrough( const int tileIndex, const bool fromWater )

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -41,6 +41,7 @@
 #include "heroes.h"
 #include "kingdom.h"
 #include "maps.h"
+#include "maps_fileinfo.h"
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"
 #include "math_base.h"


### PR DESCRIPTION
- remove duplicated methods from Settings class. It shouldn't even have Maps::FileInfo object
- rename some Maps::FileInfo members to have more readable code