### PR TITLE
Add Tree of Knowledge claimed and cost info to quick info dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -275,7 +275,7 @@ namespace
             }
             else {
                 const auto rc = payment.getFirstValidResource();
-                str.append( std::to_string( rc.second ) + " " );
+                str.append( std::to_string( rc.second ) );
                 str += ' ';
                 str.append( Translation::StringLower( Resource::String( rc.first ) ) );
             }

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -266,6 +266,7 @@ namespace
     {
         const MP2::MapObjectType objectType = tile.GetObject( false );
         std::string str = MP2::StringObject( objectType );
+        const Heroes * hero = Interface::GetFocusHeroes();
 
         if ( isVisited ) {
             const Funds & payment = getTreeOfKnowledgeRequirement( tile );
@@ -281,10 +282,17 @@ namespace
             }
             str += ')';
 
-            const Heroes * hero = Interface::GetFocusHeroes();
             if ( hero ) {
-                str += '\n';
-                str.append( hero->isVisited( tile ) ? _( "(already gained)" ) : _( "(not gained)" ) );
+                str.append( "\n(" );
+                str.append( hero->isVisited( tile ) ? _( "already claimed" ) : _( "not claimed" ) );
+                str += ')';
+            }
+        }
+        else {
+            if ( hero ) {
+                str.append( "\n\n(" );
+                str.append( _( "not claimed" ) );
+                str += ')';
             }
         }
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -262,6 +262,34 @@ namespace
         return str;
     }
 
+    std::string showTreeOfKnowledgeInfo( const Maps::Tiles & tile, const bool isVisited )
+    {
+        const MP2::MapObjectType objectType = tile.GetObject( false );
+        std::string str = MP2::StringObject( objectType );
+
+        if ( isVisited ) {
+            const Funds & payment = getTreeOfKnowledgeRequirement( tile );
+            str.append( "\n\n(" );
+            if ( payment.GetValidItemsCount() == 0 ) {
+                str.append( "free" );
+            }
+            else {
+                const auto rc = payment.getFirstValidResource();
+                str.append( std::to_string( rc.second ) + " " );
+                str.append( Translation::StringLower( Resource::String( rc.first ) ) );
+            }
+            str += ')';
+
+            const Heroes * hero = Interface::GetFocusHeroes();
+            if ( hero ) {
+                str.append( "\n" );
+                str.append( hero->isObjectTypeVisited( objectType ) ? _( "(already gained)" ) : _( "(not gained)" ) );
+            }
+        }
+
+        return str;
+    }
+
     std::string showWitchHutInfo( const Maps::Tiles & tile, const bool isVisited )
     {
         std::string str = MP2::StringObject( tile.GetObject( false ) );
@@ -518,7 +546,6 @@ namespace
         case MP2::OBJ_MERCENARY_CAMP:
         case MP2::OBJ_WITCH_DOCTORS_HUT:
         case MP2::OBJ_STANDING_STONES:
-        case MP2::OBJ_TREE_OF_KNOWLEDGE:
             return showLocalVisitTileInfo( tile );
 
         case MP2::OBJ_MAGIC_WELL:
@@ -549,6 +576,8 @@ namespace
         case MP2::OBJ_TRAVELLER_TENT:
             return showTentInfo( tile, kingdom );
 
+        case MP2::OBJ_TREE_OF_KNOWLEDGE:
+            return showTreeOfKnowledgeInfo( tile, kingdom.isVisited( tile ) );
         // These objects does not have extra text for quick info.
         case MP2::OBJ_CAMPFIRE:
         case MP2::OBJ_ARTIFACT:

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -276,14 +276,15 @@ namespace
             else {
                 const auto rc = payment.getFirstValidResource();
                 str.append( std::to_string( rc.second ) + " " );
+                str += ' ';
                 str.append( Translation::StringLower( Resource::String( rc.first ) ) );
             }
             str += ')';
 
             const Heroes * hero = Interface::GetFocusHeroes();
             if ( hero ) {
-                str.append( "\n" );
-                str.append( hero->isVisited( tile ) ? _( "(level gained)" ) : _( "(level not gained)" ) );
+                str += '\n';
+                str.append( hero->isVisited( tile ) ? _( "(already gained)" ) : _( "(not gained)" ) );
             }
         }
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -271,7 +271,7 @@ namespace
             const Funds & payment = getTreeOfKnowledgeRequirement( tile );
             str.append( "\n\n(" );
             if ( payment.GetValidItemsCount() == 0 ) {
-                str.append( "free" );
+                str.append( _( "treeOfKnowledge|free" ) );
             }
             else {
                 const auto rc = payment.getFirstValidResource();

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -283,7 +283,7 @@ namespace
             const Heroes * hero = Interface::GetFocusHeroes();
             if ( hero ) {
                 str.append( "\n" );
-                str.append( hero->isObjectTypeVisited( objectType ) ? _( "(already gained)" ) : _( "(not gained)" ) );
+                str.append( hero->isVisited( tile ) ? _( "(already gained)" ) : _( "(not gained)" ) );
             }
         }
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -283,7 +283,7 @@ namespace
             const Heroes * hero = Interface::GetFocusHeroes();
             if ( hero ) {
                 str.append( "\n" );
-                str.append( hero->isVisited( tile ) ? _( "(already gained)" ) : _( "(not gained)" ) );
+                str.append( hero->isVisited( tile ) ? _( "(level gained)" ) : _( "(level not gained)" ) );
             }
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2858,6 +2858,7 @@ namespace
                         fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
                     }
                 }
+                hero.SetVisited( dst_index, Visit::GLOBAL );
             }
 
             if ( increaseExperience ) {


### PR DESCRIPTION
<img width="147" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/dcb6cbda-0c70-4417-af12-8772d70be6bc">

<img width="151" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/f7df88d3-7767-4920-899a-852c660e9acb">

<img width="148" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/05e4ff86-e3e7-4f17-b609-76e537969637">

