### PR TITLE
Take into an account SHIFT and CAPS LOCK being used at the same time

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -340,8 +340,12 @@ namespace
         return modifier;
     }
 
-    char getCharacterFromPressedKey( const fheroes2::Key key, const int32_t mod )
+    char getCharacterFromPressedKey( const fheroes2::Key key, int32_t mod )
     {
+        if ( ( mod & fheroes2::KeyModifier::KEY_MODIFIER_SHIFT ) && ( mod & fheroes2::KeyModifier::KEY_MODIFIER_CAPS ) ) {
+            mod = mod & ~( fheroes2::KeyModifier::KEY_MODIFIER_SHIFT | fheroes2::KeyModifier::KEY_MODIFIER_CAPS );
+        }
+
         switch ( key ) {
         case fheroes2::Key::KEY_1:
             return ( fheroes2::KeyModifier::KEY_MODIFIER_SHIFT & mod ? '!' : '1' );


### PR DESCRIPTION
relates to #8098 I decided to extract this part of the code as the original pull request needs a lot of extra work.

If a user has active CAPS LOCK and uses SHIFT while typing, the letters must be non-capital.