### PR TITLE
Fix too wide text rendering on buttons

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -444,8 +444,13 @@ namespace
 
         const char * textSupported = getSupportedText( text, releasedFont );
 
-        const fheroes2::Text releasedText( textSupported, releasedFont );
-        const fheroes2::Text pressedText( textSupported, pressedFont );
+        fheroes2::Text releasedText( textSupported, releasedFont );
+        fheroes2::Text pressedText( textSupported, pressedFont );
+
+        if ( releasedText.height( buttonSize.width ) > buttonSize.height || pressedText.height( buttonSize.width ) > buttonSize.height ) {
+            releasedText.fitToOneRow( buttonSize.width );
+            pressedText.fitToOneRow( buttonSize.width );
+        }
 
         const fheroes2::Size releasedTextSize( releasedText.width( buttonSize.width ), releasedText.height( buttonSize.width ) );
         const fheroes2::Size pressedTextSize( pressedText.width( buttonSize.width ), pressedText.height( buttonSize.width ) );


### PR DESCRIPTION
In German, for example both "Neustart" (Restart) and "Ablehnen" (Decline) don't fit into the button width.

![image](https://github.com/ihhub/fheroes2/assets/489601/5c294394-b643-433a-9cfd-fac0d754285f) ⇒ ![image](https://github.com/ihhub/fheroes2/assets/489601/02ca0f6b-14c0-41cb-aafc-ad2ac3e6f51e)

Ideally, the translation could be improved, but at least it looks less weird when it doesn't fit. :)

:santa: :gift: 