### PR TITLE
Hide swap army/artifact buttons in the Battle Only

### DIFF
--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -465,8 +465,8 @@ void Battle::Only::RedrawBaseInfo( const fheroes2::Point & top ) const
 
     // hide the swap army/artifact arrows
     const fheroes2::Sprite & moveButtonBackground = fheroes2::AGG::GetICN( ICN::STONEBAK, 0 );
-    fheroes2::Blit( moveButtonBackground, 292, 270, display, top.x + 292, top.y + 270, 48, 44 );
-    fheroes2::Blit( moveButtonBackground, 292, 363, display, top.x + 292, top.y + 363, 48, 44 );
+    fheroes2::Copy( moveButtonBackground, 292, 270, display, top.x + 292, top.y + 270, 48, 44 );
+    fheroes2::Copy( moveButtonBackground, 292, 363, display, top.x + 292, top.y + 363, 48, 44 );
 }
 
 void Battle::Only::StartBattle()

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -462,6 +462,11 @@ void Battle::Only::RedrawBaseInfo( const fheroes2::Point & top ) const
     }
 
     fheroes2::RedrawPrimarySkillInfo( top, armyInfo[0].ui.primarySkill.get(), armyInfo[1].ui.primarySkill.get() );
+
+    // hide the swap army/artifact arrows
+    const fheroes2::Sprite & moveButtonBackground = fheroes2::AGG::GetICN( ICN::STONEBAK, 0 );
+    fheroes2::Blit( moveButtonBackground, 292, 270, display, top.x + 292, top.y + 270, 48, 44 );
+    fheroes2::Blit( moveButtonBackground, 292, 363, display, top.x + 292, top.y + 363, 48, 44 );
 }
 
 void Battle::Only::StartBattle()


### PR DESCRIPTION
The buttons are not actually active, so it's confusing to have them there:

- Before:
   ![image](https://github.com/ihhub/fheroes2/assets/489601/7543002a-075d-4627-96c3-79683400fa69)
- After:
  ![image](https://github.com/ihhub/fheroes2/assets/489601/099e48cd-576b-4d49-a6aa-8705e5004653)

Related: #4352 