### PR TITLE
Store Map Format within Editor to allow any changes to be done directly within the format

### DIFF
--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -27,6 +27,7 @@
 #include "game_mode.h"
 #include "history_manager.h"
 #include "interface_base.h"
+#include "map_format_info.h"
 
 namespace Maps
 {
@@ -83,6 +84,8 @@ namespace Interface
             _cursorUpdater = cursorUpdater;
         }
 
+        bool loadMap( const std::string & filePath );
+
     private:
         EditorInterface()
             : BaseInterface( true )
@@ -103,5 +106,7 @@ namespace Interface
         std::function<void( const int32_t )> _cursorUpdater;
 
         fheroes2::HistoryManager _historyManager;
+
+        Maps::Map_Format::MapFormat _mapFormat;
     };
 }

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <functional>
+#include <string>
 
 #include "editor_interface_panel.h"
 #include "game_mode.h"

--- a/src/fheroes2/editor/editor_mainmenu.cpp
+++ b/src/fheroes2/editor/editor_mainmenu.cpp
@@ -38,8 +38,6 @@
 #include "icn.h"
 #include "localevent.h"
 #include "logging.h"
-#include "map_format_helper.h"
-#include "map_format_info.h"
 #include "maps.h"
 #include "maps_fileinfo.h"
 #include "math_base.h"
@@ -311,14 +309,8 @@ namespace Editor
             return fheroes2::GameMode::EDITOR_MAIN_MENU;
         }
 
-        Maps::Map_Format::MapFormat map;
-        if ( !Maps::Map_Format::loadMap( fileInfo->filename, map ) ) {
-            fheroes2::showStandardTextMessage( _( "Warning!" ), "Failed to load the map.", Dialog::OK );
-            return fheroes2::GameMode::CANCEL;
-        }
-
-        if ( !Maps::readMapInEditor( map ) ) {
-            fheroes2::showStandardTextMessage( _( "Warning!" ), "Failed to read the map.", Dialog::OK );
+        Interface::EditorInterface & editorInterface = Interface::EditorInterface::Get();
+        if ( !editorInterface.loadMap( fileInfo->filename ) ) {
             return fheroes2::GameMode::CANCEL;
         }
 

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -42,7 +42,7 @@ namespace
             : _mapFormat( mapFormat )
             , _latestObjectUIDBefore( Maps::getLastObjectUID() )
         {
-            if ( Maps::saveMapInEditor( _mapFormat ) ) {
+            if ( !Maps::saveMapInEditor( _mapFormat ) ) {
                 // If this assertion blows up then something is really wrong with the Editor.
                 assert( 0 );
             }
@@ -52,7 +52,7 @@ namespace
 
         bool prepare()
         {
-            if ( Maps::saveMapInEditor( _mapFormat ) ) {
+            if ( !Maps::saveMapInEditor( _mapFormat ) ) {
                 // If this assertion blows up then something is really wrong with the Editor.
                 assert( 0 );
                 return false;
@@ -66,7 +66,7 @@ namespace
         bool redo() override
         {
             _mapFormat = _afterMapFormat;
-            if ( Maps::readMapInEditor( _mapFormat ) ) {
+            if ( !Maps::readMapInEditor( _mapFormat ) ) {
                 // If this assertion blows up then something is really wrong with the Editor.
                 assert( 0 );
                 return false;
@@ -80,7 +80,7 @@ namespace
         bool undo() override
         {
             _mapFormat = _beforeMapFormat;
-            if ( Maps::readMapInEditor( _mapFormat ) ) {
+            if ( !Maps::readMapInEditor( _mapFormat ) ) {
                 // If this assertion blows up then something is really wrong with the Editor.
                 assert( 0 );
                 return false;

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -22,10 +22,9 @@
 
 #include <cassert>
 #include <cstdint>
-#include <vector>
 
 #include "map_format_helper.h"
-#include "maps_tiles.h"
+#include "map_format_info.h"
 #include "world_object_uid.h"
 
 namespace

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -39,7 +39,7 @@ namespace
     class MapAction : public fheroes2::Action
     {
     public:
-        MapAction( Maps::Map_Format::MapFormat & mapFormat )
+        explicit MapAction( Maps::Map_Format::MapFormat & mapFormat )
             : _mapFormat( mapFormat )
             , _latestObjectUIDBefore( Maps::getLastObjectUID() )
         {

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -27,7 +27,10 @@
 #include <memory>
 #include <utility>
 
-#include "map_format_info.h"
+namespace Maps::Map_Format
+{
+    struct MapFormat;
+}
 
 namespace fheroes2
 {

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -27,6 +27,8 @@
 #include <memory>
 #include <utility>
 
+#include "map_format_info.h"
+
 namespace fheroes2
 {
     class HistoryManager;
@@ -45,7 +47,7 @@ namespace fheroes2
     class ActionCreator
     {
     public:
-        explicit ActionCreator( HistoryManager & manager );
+        explicit ActionCreator( HistoryManager & manager, Maps::Map_Format::MapFormat & mapFormat );
 
         ~ActionCreator();
 

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -43,6 +43,14 @@ namespace Maps
 
         assert( static_cast<size_t>( world.w() ) * world.h() == map.tiles.size() );
 
+        // We must clear all tiles before writing something on them.
+        for ( size_t i = 0; i < map.tiles.size(); ++i ) {
+            auto & tile = world.GetTiles( static_cast<int32_t>( i ) );
+            tile = {};
+
+            tile.setIndex( static_cast<int32_t>( i ) );
+        }
+
         for ( size_t i = 0; i < map.tiles.size(); ++i ) {
             readTile( world.GetTiles( static_cast<int32_t>( i ) ), map.tiles[i] );
         }
@@ -93,6 +101,9 @@ namespace Maps
 
     void writeTile( const Tiles & tile, Map_Format::TileInfo & info )
     {
+        // Clear all data before writing new one.
+        info = {};
+
         // Only bottom layer addons / objects parts can be stored within the map format.
         ObjectGroup group;
         uint32_t index;


### PR DESCRIPTION
relates to #6845

This will allow us to modify object properties, validate correlation between map format and World class and also edit map properties such as description or victory condition.