### PR TITLE
Implement makeShadow() to work with single-layer images

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -2568,14 +2568,14 @@ namespace fheroes2
 
         assert( !out.empty() );
 
-        const int32_t widthOut = out.width();
-
         if ( in.singleLayer() ) {
             // In this case we add a shadow of the fully non-transparent rectangular 'in' image.
             FillTransform( out, 0, shadowOffset.y, width, height, transformId );
 
             return out;
         }
+
+        const int32_t widthOut = out.width();
 
         const uint8_t * transformInY = in.transform();
         const uint8_t * transformInYEnd = transformInY + width * height;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -2573,21 +2573,22 @@ namespace fheroes2
         if ( in.singleLayer() ) {
             // In this case we add a shadow of the fully non-transparent rectangular 'in' image.
             FillTransform( out, 0, shadowOffset.y, width, height, transformId );
+
+            return out;
         }
-        else {
-            const uint8_t * transformInY = in.transform();
-            const uint8_t * transformInYEnd = transformInY + width * height;
-            uint8_t * transformOutY = out.transform() + shadowOffset.y * widthOut;
 
-            for ( ; transformInY != transformInYEnd; transformInY += width, transformOutY += widthOut ) {
-                const uint8_t * transformInX = transformInY;
-                uint8_t * transformOutX = transformOutY;
-                const uint8_t * transformInXEnd = transformInX + width;
+        const uint8_t * transformInY = in.transform();
+        const uint8_t * transformInYEnd = transformInY + width * height;
+        uint8_t * transformOutY = out.transform() + shadowOffset.y * widthOut;
 
-                for ( ; transformInX != transformInXEnd; ++transformInX, ++transformOutX ) {
-                    if ( *transformInX == 0 ) {
-                        *transformOutX = transformId;
-                    }
+        for ( ; transformInY != transformInYEnd; transformInY += width, transformOutY += widthOut ) {
+            const uint8_t * transformInX = transformInY;
+            uint8_t * transformOutX = transformOutY;
+            const uint8_t * transformInXEnd = transformInX + width;
+
+            for ( ; transformInX != transformInXEnd; ++transformInX, ++transformOutX ) {
+                if ( *transformInX == 0 ) {
+                    *transformOutX = transformId;
                 }
             }
         }

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -2555,7 +2555,7 @@ namespace fheroes2
 
     Sprite makeShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId )
     {
-        if ( in.empty() || in.singleLayer() || shadowOffset.x > 0 || shadowOffset.y < 0 ) {
+        if ( in.empty() || shadowOffset.x > 0 || shadowOffset.y < 0 ) {
             return {};
         }
 
@@ -2570,18 +2570,24 @@ namespace fheroes2
 
         const int32_t widthOut = out.width();
 
-        const uint8_t * transformInY = in.transform();
-        const uint8_t * transformInYEnd = transformInY + width * height;
-        uint8_t * transformOutY = out.transform() + shadowOffset.y * widthOut;
+        if ( in.singleLayer() ) {
+            // In this case we add a shadow of the fully non-transparent rectangular 'in' image.
+            FillTransform( out, 0, shadowOffset.y, width, height, transformId );
+        }
+        else {
+            const uint8_t * transformInY = in.transform();
+            const uint8_t * transformInYEnd = transformInY + width * height;
+            uint8_t * transformOutY = out.transform() + shadowOffset.y * widthOut;
 
-        for ( ; transformInY != transformInYEnd; transformInY += width, transformOutY += widthOut ) {
-            const uint8_t * transformInX = transformInY;
-            uint8_t * transformOutX = transformOutY;
-            const uint8_t * transformInXEnd = transformInX + width;
+            for ( ; transformInY != transformInYEnd; transformInY += width, transformOutY += widthOut ) {
+                const uint8_t * transformInX = transformInY;
+                uint8_t * transformOutX = transformOutY;
+                const uint8_t * transformInXEnd = transformInX + width;
 
-            for ( ; transformInX != transformInXEnd; ++transformInX, ++transformOutX ) {
-                if ( *transformInX == 0 ) {
-                    *transformOutX = transformId;
+                for ( ; transformInX != transformInXEnd; ++transformInX, ++transformOutX ) {
+                    if ( *transformInX == 0 ) {
+                        *transformOutX = transformId;
+                    }
                 }
             }
         }


### PR DESCRIPTION
This PR makes `makeShadow()` to make a shadow for the input single-layer image like for the fully non-transparent double-layer image.