### PR TITLE
Small memory optimizations

### DIFF
--- a/src/engine/render_processor.h
+++ b/src/engine/render_processor.h
@@ -85,13 +85,13 @@ namespace fheroes2
         std::function<void()> _preRenderer;
         std::function<void()> _postRenderer;
 
-        bool _enableRenderers{ false };
-        bool _enableCycling{ false };
-
         fheroes2::Time _cyclingTimer;
         fheroes2::Time _lastRenderCall;
 
         uint32_t _cyclingCounter{ 0 };
+
+        bool _enableRenderers{ false };
+        bool _enableCycling{ false };
 
         static const uint64_t _cyclingInterval{ 220 };
     };

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -191,7 +191,7 @@ StreamBase & StreamBase::operator<<( const std::string & v )
 {
     put32( static_cast<uint32_t>( v.size() ) );
     // A string is a container of bytes so it doesn't matter which endianess is being used.
-    putRaw( v.c_str(), v.size() );
+    putRaw( v.data(), v.size() );
 
     return *this;
 }

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -190,9 +190,8 @@ StreamBase & StreamBase::operator<<( const uint32_t v )
 StreamBase & StreamBase::operator<<( const std::string & v )
 {
     put32( static_cast<uint32_t>( v.size() ) );
-
-    for ( std::string::const_iterator it = v.begin(); it != v.end(); ++it )
-        put8( *it );
+    // A string is a container of bytes so it doesn't matter which endianess is being used.
+    putRaw( v.c_str(), v.size() );
 
     return *this;
 }

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -420,11 +420,11 @@ namespace Maps
 
         uint8_t _fogColors{ Color::ALL };
 
-        // Fog direction to render fog in Game Area.
-        uint16_t _fogDirection{ DIRECTION_ALL };
-
         // Heroes can only summon neutral empty boats or empty boats belonging to their kingdom.
         uint8_t _boatOwnerColor{ Color::NONE };
+
+        // Fog direction to render fog in Game Area.
+        uint16_t _fogDirection{ DIRECTION_ALL };
 
         // This field does not persist in savegame.
         uint32_t _region{ REGION_NODE_BLOCKED };


### PR DESCRIPTION
- restructure few structures / classes to reduce padding. Maps::Tiles size was reduced from 96 to 88 bytes so it saves 288 KB on XL maps for 64-bit builds
- use single write operation for writing a string into a stream