### PR TITLE
AI: implement the logic to transfer the slowest troops to the garrison at the end of the turn to try to get a movement bonus on the next turn

### DIFF
--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -86,6 +86,8 @@ namespace AI
     class Base
     {
     public:
+        virtual ~Base() = default;
+
         virtual void KingdomTurn( Kingdom & kingdom ) = 0;
         virtual void BattleTurn( Battle::Arena & arena, const Battle::Unit & unit, Battle::Actions & actions ) = 0;
 
@@ -118,8 +120,6 @@ namespace AI
         // Should be called at the beginning of the battle even if no AI-controlled players are
         // involved in the battle - because of the possibility of using instant or auto battle
         virtual void battleBegins() = 0;
-
-        virtual ~Base() = default;
 
         virtual void tradingPostVisitEvent( Kingdom & kingdom ) = 0;
 
@@ -165,7 +165,12 @@ namespace AI
     // returns false.
     bool BuildIfEnoughFunds( Castle & castle, const building_t building, const uint32_t fundsMultiplier );
 
-    void OptimizeTroopsOrder( Army & hero );
+    // Performs the pre-battle arrangement of the given army, see the implementation for details
+    void OptimizeTroopsOrder( Army & army );
+
+    // Transfers the slowest troops from the hero's army to the garrison to try to get a movement bonus on the next turn
+    void transferSlowestTroopsToGarrison( Army & army, Army & garrison );
+
     bool CanPurchaseHero( const Kingdom & kingdom );
 
     // Calculates a marketplace transaction, after which the kingdom would be able to make a payment in the amount of

--- a/src/fheroes2/ai/ai.h
+++ b/src/fheroes2/ai/ai.h
@@ -169,7 +169,7 @@ namespace AI
     void OptimizeTroopsOrder( Army & army );
 
     // Transfers the slowest troops from the hero's army to the garrison to try to get a movement bonus on the next turn
-    void transferSlowestTroopsToGarrison( Army & army, Army & garrison );
+    void transferSlowestTroopsToGarrison( Heroes * hero, Castle * castle );
 
     bool CanPurchaseHero( const Kingdom & kingdom );
 

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -124,13 +124,15 @@ namespace AI
         // 2. Comparison by type (flying units first);
         // 3. Comparison by strength.
         std::sort( others.begin(), others.end(), []( const Troop & left, const Troop & right ) {
-            if ( left.GetSpeed() == right.GetSpeed() ) {
-                if ( left.isFlying() == right.isFlying() ) {
-                    return left.GetStrength() < right.GetStrength();
-                }
+            if ( left.GetSpeed() != right.GetSpeed() ) {
+                return left.GetSpeed() < right.GetSpeed();
+            }
+
+            if ( left.isFlying() != right.isFlying() ) {
                 return right.isFlying();
             }
-            return left.GetSpeed() < right.GetSpeed();
+
+            return left.GetStrength() < right.GetStrength();
         } );
 
         // Archers are sorted solely by strength

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -211,7 +211,7 @@ namespace AI
         // Move the slowest units first
         std::sort( armyTroops.begin(), armyTroops.end(), Army::SlowestTroop );
 
-        // At least one fastest unit should remain in the hero's army
+        // At least one of the fastest units should remain in the hero's army
         armyTroops.pop_back();
 
         for ( Troop * troop : armyTroops ) {

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -181,9 +181,12 @@ namespace AI
         }
     }
 
-    void transferSlowestTroopsToGarrison( Army & army, Army & garrison )
+    void transferSlowestTroopsToGarrison( Heroes * hero, Castle * castle )
     {
-        assert( &army != &garrison );
+        assert( hero != nullptr && castle != nullptr );
+
+        Army & army = hero->GetArmy();
+        Army & garrison = castle->GetArmy();
 
         // Make efforts to get free slots in the garrison to move troops there
         garrison.MergeSameMonsterTroops();

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -35,6 +35,7 @@
 #include "color.h"
 #include "difficulty.h"
 #include "game.h"
+#include "heroes.h"
 #include "kingdom.h"
 #include "logging.h"
 #include "normal/ai_normal.h"

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -271,18 +271,21 @@ namespace AI
         // Implements the logic of transparent casting of the Summon Boat spell during the hero's movement
         void HeroesActionNewPosition( Heroes & hero ) override;
 
+        void CastlePreBattle( Castle & castle ) override;
+
         bool recruitHero( Castle & castle, bool buyArmy, bool underThreat );
         void reinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget );
         void evaluateRegionSafety();
         std::vector<AICastle> getSortedCastleList( const VecCastles & castles, const std::set<int> & castlesInDanger );
 
-        bool isValidHeroObject( const Heroes & hero, const int32_t index, const bool underHero ) override;
-        double getObjectValue( const Heroes & hero, const int index, const int objectType, const double valueToIgnore, const uint32_t distanceToObject ) const;
-        int getPriorityTarget( const HeroToMove & heroInfo, double & maxPriority );
         void resetPathfinder() override;
+        bool isValidHeroObject( const Heroes & hero, const int32_t index, const bool underHero ) override;
 
         void battleBegins() override;
 
+        void tradingPostVisitEvent( Kingdom & kingdom ) override;
+
+        double getObjectValue( const Heroes & hero, const int index, const int objectType, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getTargetArmyStrength( const Maps::Tiles & tile, const MP2::MapObjectType objectType );
 
         bool isPriorityTask( const int32_t index ) const
@@ -300,27 +303,13 @@ namespace AI
             return iter->second.type == PriorityTaskType::ATTACK || iter->second.type == PriorityTaskType::DEFEND;
         }
 
-        void tradingPostVisitEvent( Kingdom & kingdom ) override;
-
     private:
-        // following data won't be saved/serialized
-        double _combinedHeroStrength = 0;
-        std::vector<IndexObject> _mapActionObjects;
-        std::map<int32_t, PriorityTask> _priorityTargets;
-        std::map<int32_t, EnemyArmy> _enemyArmies;
-        std::vector<RegionStats> _regions;
-        std::array<BudgetEntry, 7> _budget = { Resource::WOOD, Resource::MERCURY, Resource::ORE, Resource::SULFUR, Resource::CRYSTAL, Resource::GEMS, Resource::GOLD };
-        AIWorldPathfinder _pathfinder;
-        BattlePlanner _battlePlanner;
-
-        // Monster strength is constant over the same turn for AI but its calculation is a heavy operation.
-        // In order to avoid extra computations during AI turn it is important to keep cache of monster strength but update it when an action on a monster is taken.
-        std::map<int32_t, double> _neutralMonsterStrengthCache;
-
         void CastleTurn( Castle & castle, const bool defensiveStrategy );
 
         // Returns true if heroes can still do tasks but they have no move points.
         bool HeroesTurn( VecHeroes & heroes, const uint32_t startProgressValue, const uint32_t endProgressValue );
+
+        int getPriorityTarget( const HeroToMove & heroInfo, double & maxPriority );
 
         double getGeneralObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
@@ -354,6 +343,20 @@ namespace AI
         void removePriorityAttackTarget( const int32_t tileIndex );
 
         void updatePriorityAttackTarget( const Kingdom & kingdom, const Maps::Tiles & tile );
+
+        // The following member variables should not be saved or serialized
+        double _combinedHeroStrength = 0;
+        std::vector<IndexObject> _mapActionObjects;
+        std::map<int32_t, PriorityTask> _priorityTargets;
+        std::map<int32_t, EnemyArmy> _enemyArmies;
+        std::vector<RegionStats> _regions;
+        std::array<BudgetEntry, 7> _budget = { Resource::WOOD, Resource::MERCURY, Resource::ORE, Resource::SULFUR, Resource::CRYSTAL, Resource::GEMS, Resource::GOLD };
+        AIWorldPathfinder _pathfinder;
+        BattlePlanner _battlePlanner;
+
+        // Monster strength is constant over the same turn for AI but its calculation is a heavy operation.
+        // In order to avoid extra computations during AI turn it is important to keep cache of monster strength but update it when an action on a monster is taken.
+        std::map<int32_t, double> _neutralMonsterStrengthCache;
     };
 }
 

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -345,7 +345,6 @@ namespace AI
         void updatePriorityAttackTarget( const Kingdom & kingdom, const Maps::Tiles & tile );
 
         // The following member variables should not be saved or serialized
-        double _combinedHeroStrength = 0;
         std::vector<IndexObject> _mapActionObjects;
         std::map<int32_t, PriorityTask> _priorityTargets;
         std::map<int32_t, EnemyArmy> _enemyArmies;

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -236,6 +236,22 @@ namespace AI
         return Build( castle, supportingDefensiveStructures, 10 );
     }
 
+    void Normal::CastlePreBattle( Castle & castle )
+    {
+        Heroes * hero = world.GetHero( castle );
+        if ( hero == nullptr ) {
+            return;
+        }
+
+        if ( !hero->GetArmy().ArrangeForCastleDefense( castle.GetArmy() ) ) {
+            return;
+        }
+
+        // Optimization cannot be performed if we have not received any reinforcements from the garrison, otherwise the actual placement of units during the battle will
+        // differ from that observed by the enemy player before the start of the battle
+        OptimizeTroopsOrder( hero->GetArmy() );
+    }
+
     void Normal::updateKingdomBudget( const Kingdom & kingdom )
     {
         // clean up first

--- a/src/fheroes2/ai/normal/ai_normal_castle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_castle.cpp
@@ -243,13 +243,15 @@ namespace AI
             return;
         }
 
-        if ( !hero->GetArmy().ArrangeForCastleDefense( castle.GetArmy() ) ) {
+        Army & army = hero->GetArmy();
+
+        if ( !army.ArrangeForCastleDefense( castle.GetArmy() ) ) {
             return;
         }
 
         // Optimization cannot be performed if we have not received any reinforcements from the garrison, otherwise the actual placement of units during the battle will
         // differ from that observed by the enemy player before the start of the battle
-        OptimizeTroopsOrder( hero->GetArmy() );
+        OptimizeTroopsOrder( army );
     }
 
     void Normal::updateKingdomBudget( const Kingdom & kingdom )

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -919,7 +919,7 @@ namespace AI
                 continue;
             }
 
-            transferSlowestTroopsToGarrison( hero->GetArmy(), castle->GetArmy() );
+            transferSlowestTroopsToGarrison( hero, castle );
         }
 
         status.DrawAITurnProgress( 10 );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -716,7 +716,7 @@ namespace AI
             return;
         }
 
-        // reset indicator
+        // Reset the turn progress indicator
         Interface::StatusWindow & status = Interface::AdventureMap::Get().getStatusWindow();
         status.DrawAITurnProgress( 0 );
 
@@ -754,12 +754,13 @@ namespace AI
             underViewSpell = true;
         }
 
-        const int mapSize = world.w() * world.h();
         _priorityTargets.clear();
         _enemyArmies.clear();
         _mapActionObjects.clear();
         _regions.clear();
         _regions.resize( world.getRegionCount() );
+
+        const int mapSize = world.w() * world.h();
 
         for ( int idx = 0; idx < mapSize; ++idx ) {
             const Maps::Tiles & tile = world.GetTiles( idx );
@@ -899,7 +900,7 @@ namespace AI
 
         status.DrawAITurnProgress( 9 );
 
-        // sync up castle list (if conquered new ones during the turn)
+        // Sync the list of castles (if new ones were captured during the turn)
         if ( castles.size() != sortedCastleList.size() ) {
             evaluateRegionSafety();
             sortedCastleList = getSortedCastleList( castles, castlesInDanger );
@@ -910,6 +911,16 @@ namespace AI
             if ( entry.castle != nullptr ) {
                 CastleTurn( *entry.castle, entry.underThreat );
             }
+        }
+
+        // For heroes in castles or towns, transfer their slowest troops to the garrison at the end of the turn to try to get a movement bonus on the next turn
+        for ( Heroes * hero : heroes ) {
+            Castle * castle = hero->inCastleMutable();
+            if ( castle == nullptr ) {
+                continue;
+            }
+
+            transferSlowestTroopsToGarrison( hero->GetArmy(), castle->GetArmy() );
         }
 
         status.DrawAITurnProgress( 10 );

--- a/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_kingdom.cpp
@@ -740,10 +740,9 @@ namespace AI
             hero->ResetModes( Heroes::SLEEPER );
             hero->setDimensionDoorUsage( 0 );
 
-            const double strength = hero->GetArmy().GetStrength();
-            _combinedHeroStrength += strength;
-            if ( !hero->Modes( Heroes::PATROL ) )
+            if ( !hero->Modes( Heroes::PATROL ) ) {
                 ++availableHeroCount;
+            }
 
             if ( hero->HaveSpell( Spell::VIEWALL ) && ( !bestHeroToViewAll || hero->HasSecondarySkill( Skill::Secondary::MYSTICISM ) ) ) {
                 bestHeroToViewAll = hero;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1656,7 +1656,7 @@ void Army::resetInvalidMonsters() const
     }
 }
 
-void Army::ArrangeForCastleDefense( Army & garrison )
+bool Army::ArrangeForCastleDefense( Army & garrison )
 {
     assert( this != &garrison );
     assert( size() == maximumTroopCount && garrison.size() == maximumTroopCount );
@@ -1665,6 +1665,8 @@ void Army::ArrangeForCastleDefense( Army & garrison )
     // This method is designed to take reinforcements only from the garrison, because
     // it can leave the garrison empty
     assert( garrison.commander == nullptr || garrison.commander->isCaptain() );
+
+    bool result = false;
 
     // If the guest hero's army is controlled by AI, then try to squeeze as many garrison troops in as possible
     if ( isControlAI() ) {
@@ -1688,6 +1690,8 @@ void Army::ArrangeForCastleDefense( Army & garrison )
             if ( JoinTroop( *troop ) ) {
                 troop->Reset();
 
+                result = true;
+
                 continue;
             }
 
@@ -1696,6 +1700,8 @@ void Army::ArrangeForCastleDefense( Army & garrison )
                 // ... and try again
                 if ( JoinTroop( *troop ) ) {
                     troop->Reset();
+
+                    result = true;
                 }
                 else {
                     assert( 0 );
@@ -1705,7 +1711,7 @@ void Army::ArrangeForCastleDefense( Army & garrison )
 
         assert( size() == maximumTroopCount );
 
-        return;
+        return result;
     }
 
     // Otherwise, try to move the garrison troops to exactly the same slots of the guest hero's army, provided
@@ -1726,7 +1732,11 @@ void Army::ArrangeForCastleDefense( Army & garrison )
         troop->Set( garrisonTroop->GetMonster(), garrisonTroop->GetCount() );
 
         garrisonTroop->Reset();
+
+        result = true;
     }
+
+    return result;
 }
 
 void Army::ArrangeForWhirlpool()

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -246,9 +246,10 @@ public:
 
     void resetInvalidMonsters() const;
 
-    // Performs the pre-battle arrangement for the castle (or town) defense, trying to add reinforcements from the garrison. The
-    // logic of combining troops for the castle defense differs from the original game, see the implementation for details.
-    void ArrangeForCastleDefense( Army & garrison );
+    // Performs the pre-battle arrangement for the castle (or town) defense, trying to add reinforcements from the garrison. Returns
+    // true if at least one unit from the garrison was moved to the army as reinforcements, otherwise returns false. The logic of
+    // combining troops for the castle defense differs from the original game, see the implementation for details.
+    bool ArrangeForCastleDefense( Army & garrison );
     // Optimizes the arrangement of troops to pass through the whirlpool (moves one weakest unit to a separate slot, if possible)
     void ArrangeForWhirlpool();
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2731,14 +2731,18 @@ void Castle::JoinRNDArmy()
 
 void Castle::ActionPreBattle()
 {
-    Heroes * hero = world.GetHero( *this );
-    if ( hero ) {
-        hero->GetArmy().ArrangeForCastleDefense( army );
-    }
-
     if ( isControlAI() ) {
         AI::Get().CastlePreBattle( *this );
+
+        return;
     }
+
+    Heroes * hero = world.GetHero( *this );
+    if ( hero == nullptr ) {
+        return;
+    }
+
+    hero->GetArmy().ArrangeForCastleDefense( army );
 }
 
 void Castle::ActionAfterBattle( bool attacker_wins )

--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -51,7 +51,7 @@ BEGIN
             VALUE "FileDescription",  "Free implementation of the Heroes of Might and Magic II game engine\0"
             VALUE "FileVersion",      FH2_VERSION_STR
             VALUE "InternalName",     "fheroes2\0"
-            VALUE "LegalCopyright",   "\251 2023 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
+            VALUE "LegalCopyright",   "\251 2024 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
             VALUE "OriginalFilename", "fheroes2.exe\0"
             VALUE "ProductName",      "fheroes2 engine\0"
             VALUE "ProductVersion",   FH2_VERSION_STR


### PR DESCRIPTION
close #8207

Demo video:

https://github.com/ihhub/fheroes2/assets/32623900/dc1d3998-a340-4eab-ab07-5c9943f98ff3

In the `master` branch AI hero has not enough movement points to attack my hero after dismissing the Dragons:

https://github.com/ihhub/fheroes2/assets/32623900/9d076999-c7c2-4f62-a0a9-f5ae4c1806c8
