### PR TITLE
Small improvements over image loading

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -194,7 +194,7 @@ namespace
 
     bool IsValidICNId( int id )
     {
-        return id >= 0 && static_cast<size_t>( id ) < _icnVsSprite.size();
+        return id > ICN::UNKNOWN && static_cast<size_t>( id ) < _icnVsSprite.size();
     }
 
     bool IsValidTILId( int id )
@@ -648,7 +648,7 @@ namespace fheroes2
         }
 
         // Helper function for LoadModifiedICN
-        void CopyICNWithPalette( int icnId, int originalIcnId, const PAL::PaletteType paletteType )
+        void CopyICNWithPalette( const int icnId, const int originalIcnId, const PAL::PaletteType paletteType )
         {
             assert( icnId != originalIcnId );
 
@@ -4643,6 +4643,12 @@ namespace fheroes2
             if ( !LoadModifiedICN( id ) ) {
                 LoadOriginalICN( id );
             }
+
+            if ( _icnVsSprite[id].empty() ) {
+                // This could happen by one reason: asking to render an ICN that simply doesn't exist within the resources.
+                // In order to avoid subsequent attempts to get resources from this ICN we are making it as non-empty.
+                _icnVsSprite[id].resize( 1 );
+            }
         }
 
         size_t GetMaximumICNIndex( int id )
@@ -4652,10 +4658,12 @@ namespace fheroes2
             return _icnVsSprite[id].size();
         }
 
-        size_t GetMaximumTILIndex( int id )
+        size_t GetMaximumTILIndex( const int id )
         {
-            if ( _tilVsImage[id].empty() ) {
-                _tilVsImage[id].resize( 4 ); // 4 possible sides
+            auto & tilImages = _tilVsImage[id];
+
+            if ( tilImages.empty() ) {
+                tilImages.resize( 4 ); // 4 possible sides
 
                 const std::vector<uint8_t> & data = ::AGG::getDataFromAggFile( tilFileName[id] );
                 if ( data.size() < headerSize ) {
@@ -4673,23 +4681,29 @@ namespace fheroes2
                     return 0;
                 }
 
-                std::vector<Image> & originalTIL = _tilVsImage[id][0];
+                std::vector<Image> & originalTIL = tilImages[0];
                 decodeTILImages( data.data() + headerSize, count, width, height, originalTIL );
 
                 for ( uint32_t shapeId = 1; shapeId < 4; ++shapeId ) {
-                    std::vector<Image> & currentTIL = _tilVsImage[id][shapeId];
-                    currentTIL.resize( count );
+                    tilImages[shapeId].resize( count );
+                }
 
-                    const bool horizontalFlip = ( shapeId & 2 ) != 0;
-                    const bool verticalFlip = ( shapeId & 1 ) != 0;
+                for ( size_t i = 0; i < count; ++i ) {
+                    for ( uint32_t shapeId = 1; shapeId < 4; ++shapeId ) {
+                        Image & image = tilImages[shapeId][i];
 
-                    for ( size_t i = 0; i < count; ++i ) {
-                        currentTIL[i] = Flip( originalTIL[i], horizontalFlip, verticalFlip );
+                        const bool horizontalFlip = ( shapeId & 2 ) != 0;
+                        const bool verticalFlip = ( shapeId & 1 ) != 0;
+
+                        image._disableTransformLayer();
+                        image.resize( width, height );
+
+                        Flip( originalTIL[i], 0, 0, image, 0, 0, width, height, horizontalFlip, verticalFlip );
                     }
                 }
             }
 
-            return _tilVsImage[id][0].size();
+            return tilImages[0].size();
         }
 
         // We have few ICNs which we need to scale like some related to main screen

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -438,18 +438,20 @@ namespace Battle
         void RedrawBackground( const fheroes2::Point & /* unused*/ ) override
         {
             fheroes2::Display & display = fheroes2::Display::instance();
-            const fheroes2::Sprite & sp1 = fheroes2::AGG::GetICN( ICN::DROPLISL, 10 );
-            const fheroes2::Sprite & sp2 = fheroes2::AGG::GetICN( ICN::DROPLISL, 12 );
-            const fheroes2::Sprite & sp3 = fheroes2::AGG::GetICN( ICN::DROPLISL, 11 );
+
             const int32_t ax = buttonPgUp.area().x;
             const int32_t ah = buttonPgDn.area().y - ( buttonPgUp.area().y + buttonPgUp.area().height );
 
             const fheroes2::Rect & borderRect = border.GetRect();
             Dialog::FrameBorder::RenderOther( fheroes2::AGG::GetICN( ICN::TEXTBAK2, 0 ), borderRect );
 
+            const fheroes2::Sprite & sp3 = fheroes2::AGG::GetICN( ICN::DROPLISL, 11 );
             for ( int32_t i = 0; i < ( ah / sp3.height() ); ++i ) {
                 fheroes2::Copy( sp3, 0, 0, display, ax, buttonPgUp.area().y + buttonPgUp.area().height + ( sp3.height() * i ), sp3.width(), sp3.height() );
             }
+
+            const fheroes2::Sprite & sp1 = fheroes2::AGG::GetICN( ICN::DROPLISL, 10 );
+            const fheroes2::Sprite & sp2 = fheroes2::AGG::GetICN( ICN::DROPLISL, 12 );
 
             fheroes2::Copy( sp1, 0, 0, display, ax, buttonPgUp.area().y + buttonPgUp.area().height, sp1.width(), sp1.height() );
             fheroes2::Copy( sp2, 0, 0, display, ax, buttonPgDn.area().y - sp2.height(), sp2.width(), sp2.height() );

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -231,7 +231,7 @@ namespace
         text.draw( dst_pt.x, dst_pt.y + 2, display );
     }
 
-    fheroes2::Sprite GetModesSprite( uint32_t mod )
+    const fheroes2::Sprite & GetModesSprite( const uint32_t mod )
     {
         switch ( mod ) {
         case Battle::SP_BLOODLUST:
@@ -268,7 +268,7 @@ namespace
             break;
         }
 
-        return {};
+        return fheroes2::AGG::GetICN( ICN::UNKNOWN, 0 );
     }
 
     std::vector<std::pair<fheroes2::Rect, Spell>> DrawBattleStats( const fheroes2::Point & dst, const Troop & b )

--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -51,7 +51,7 @@ BEGIN
             VALUE "FileDescription",  "Free implementation of the Heroes of Might and Magic II game engine\0"
             VALUE "FileVersion",      FH2_VERSION_STR
             VALUE "InternalName",     "fheroes2\0"
-            VALUE "LegalCopyright",   "\251 2023 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
+            VALUE "LegalCopyright",   "\251 2024 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
             VALUE "OriginalFilename", "fheroes2.exe\0"
             VALUE "ProductName",      "fheroes2 engine\0"
             VALUE "ProductVersion",   FH2_VERSION_STR


### PR DESCRIPTION
- speed up TIL images. Previously most of images were made as 2-layered images causing extra operations being executed. Also, rearranging loops improves CPU caching.
- change the ICN image validation conditions. ICN::UNKNOWN shouldn't be even called.
- `GetModesSprite()` function should return a const reference instead of making a copy of an image
- reduce the scope of ICN images