### PR TITLE
Mark fheroes2 as DPI-aware on Windows

### DIFF
--- a/VisualStudio/fheroes2/common.props
+++ b/VisualStudio/fheroes2/common.props
@@ -5,6 +5,9 @@
       <AdditionalIncludeDirectories>src\engine;src\fheroes2\gui;src\fheroes2\maps;src\fheroes2\kingdom;src\fheroes2\campaign;src\fheroes2\game;src\fheroes2\editor;src\fheroes2\dialog;src\fheroes2\system;src\fheroes2\spell;src\fheroes2\monster;src\fheroes2\castle;src\fheroes2\agg;src\fheroes2\heroes;src\fheroes2\resource;src\fheroes2\ai;src\fheroes2\army;src\fheroes2\battle;src\fheroes2\h2d;src\fheroes2\objects;src\fheroes2\world;src\fheroes2\audio;src\fheroes2\image;src\thirdparty\libsmacker;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(FHEROES2_BUILD_NUMBER)'!=''">BUILD_VERSION=$(FHEROES2_BUILD_NUMBER);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
+    <Manifest>
+      <AdditionalManifestFiles>src\resources\fheroes2.manifest %(AdditionalManifestFiles)</AdditionalManifestFiles>
+    </Manifest>
     <ResourceCompile>
       <AdditionalIncludeDirectories>src\fheroes2\system;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions Condition="'$(FHEROES2_BUILD_NUMBER)'!=''">BUILD_VERSION=$(FHEROES2_BUILD_NUMBER);%(PreprocessorDefinitions)</PreprocessorDefinitions>

--- a/VisualStudio/fheroes2/sources.props
+++ b/VisualStudio/fheroes2/sources.props
@@ -441,6 +441,9 @@
     <ClInclude Include="src\thirdparty\libsmacker\smk_malloc.h" />
   </ItemGroup>
   <ItemGroup>
+    <Manifest Include="src\resources\fheroes2.manifest" />
+  </ItemGroup>
+  <ItemGroup>
     <ResourceCompile Include="src\resources\fheroes2.rc" />
   </ItemGroup>
 </Project>

--- a/src/resources/fheroes2.manifest
+++ b/src/resources/fheroes2.manifest
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0" xmlns:asmv3="urn:schemas-microsoft-com:asm.v3">
+  <asmv3:application>
+    <asmv3:windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+    </asmv3:windowsSettings>
+  </asmv3:application>
+</assembly>

--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -51,7 +51,7 @@ BEGIN
             VALUE "FileDescription",  "Free implementation of the Heroes of Might and Magic II game engine\0"
             VALUE "FileVersion",      FH2_VERSION_STR
             VALUE "InternalName",     "fheroes2\0"
-            VALUE "LegalCopyright",   "\251 2023 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
+            VALUE "LegalCopyright",   "\251 2024 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
             VALUE "OriginalFilename", "fheroes2.exe\0"
             VALUE "ProductName",      "fheroes2 engine\0"
             VALUE "ProductVersion",   FH2_VERSION_STR


### PR DESCRIPTION
close #8209

According to my observations, this fix works just fine in case of 1 monitor and _almost_ fine in case of multiple monitors with different scale - sometimes, when transferring the app window between monitors having a different scale, the window size suddenly changes (in the direction of the monitor to which the transfer is carried out - that is, if the window is transferred from a monitor with a larger scale to a monitor with a smaller scale, then the window becomes smaller in size, and vice versa). This happens _sometimes_ and I was not able to find some kind of pattern. Probably this is due to some of pitfalls described here:

https://learn.microsoft.com/en-us/windows/win32/hidpi/high-dpi-desktop-application-development-on-windows?redirectedfrom=MSDN#common-pitfalls-win32

but since fheroes2 do not handle Windows messages by itself (this is all done inside the SDL), to be honest, I don't want to try to make some potential SDL fixes yet (it's probably already fixed or has yet to be fixed in SDL3), so the possibility of merging this PR is up for discussion.