### PR TITLE
Allow AI heroes to surrender if the conditions of retreat have been met, but it is impossible to retreat

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -57,6 +57,7 @@
 #include "kingdom.h"
 #include "logging.h"
 #include "monster_info.h"
+#include "resource.h"
 #include "settings.h"
 #include "speed.h"
 #include "spell.h"

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -584,11 +584,16 @@ void Battle::Arena::Turns()
         result_game.exp1 = _army2->GetDeadHitPoints();
         result_game.exp2 = _army1->GetDeadHitPoints();
 
+        // Attacker (or defender) gets an experience bonus if the enemy army was under the command of a hero who was defeated (i.e. did not retreat or surrender)
         if ( _army1->GetCommander() && !( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             result_game.exp2 += 500;
         }
-        // Attacker always gets an experience bonus when besieging a town or castle, even if the defender fled or surrendered
-        if ( _isTown || ( _army2->GetCommander() && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) ) {
+        if ( _army2->GetCommander() && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+            result_game.exp1 += 500;
+        }
+
+        // Attacker gets an additional experience bonus after successfully besieging a town or castle
+        if ( _isTown ) {
             result_game.exp1 += 500;
         }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -587,7 +587,8 @@ void Battle::Arena::Turns()
         if ( _army1->GetCommander() && !( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             result_game.exp2 += 500;
         }
-        if ( ( _isTown || _army2->GetCommander() ) && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+        // Attacker always gets an experience bonus when besieging a castle, even if the defender surrendered
+        if ( _isTown || ( _army2->GetCommander() && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) ) {
             result_game.exp1 += 500;
         }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -584,7 +584,8 @@ void Battle::Arena::Turns()
         result_game.exp1 = _army2->GetDeadHitPoints();
         result_game.exp2 = _army1->GetDeadHitPoints();
 
-        // Attacker (or defender) gets an experience bonus if the enemy army was under the command of a hero who was defeated (i.e. did not retreat or surrender)
+        // Attacker (or defender) gets an experience bonus if the enemy army was under the command of a hero (or captain) who was defeated (i.e. did not retreat or
+        // surrender)
         if ( _army1->GetCommander() && !( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             result_game.exp2 += 500;
         }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -584,12 +584,14 @@ void Battle::Arena::Turns()
         result_game.exp1 = _army2->GetDeadHitPoints();
         result_game.exp2 = _army1->GetDeadHitPoints();
 
-        // Attacker (or defender) gets an experience bonus if the enemy army was under the command of a hero (or captain) who was defeated (i.e. did not retreat or
-        // surrender)
-        if ( _army1->GetCommander() && !( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+        const HeroBase * army1Commander = _army1->GetCommander();
+        const HeroBase * army2Commander = _army2->GetCommander();
+
+        // Attacker (or defender) gets an experience bonus if the enemy army was under the command of a hero who was defeated (i.e. did not retreat or surrender)
+        if ( army1Commander && army1Commander->isHeroes() && !( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             result_game.exp2 += 500;
         }
-        if ( _army2->GetCommander() && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+        if ( army2Commander && army2Commander->isHeroes() && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             result_game.exp1 += 500;
         }
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -587,7 +587,7 @@ void Battle::Arena::Turns()
         if ( _army1->GetCommander() && !( result_game.army1 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             result_game.exp2 += 500;
         }
-        // Attacker always gets an experience bonus when besieging a castle, even if the defender surrendered
+        // Attacker always gets an experience bonus when besieging a town or castle, even if the defender fled or surrendered
         if ( _isTown || ( _army2->GetCommander() && !( result_game.army2 & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) ) {
             result_game.exp1 += 500;
         }


### PR DESCRIPTION
Related to #8221

In this video the pumped-up AI-controlled hero surrenders (after a farewell spellcast), and is rehired by AI on the next turn:

https://github.com/ihhub/fheroes2/assets/32623900/93ab4a32-ad8f-423f-a090-de42539ed3e3

I did not introduce any special coefficients for the necessary gold reserve, because currently, when AI is going to retreat, it already has a little army, and the value of a pumped hero, and even with artifacts, in any case exceeds the value of those remnants of his army at the time of surrender.

This PR does not address a suggestion to improve the UI regarding the display of the amount of gold received due to surrender.