### PR TITLE
Allow the AI-controlled hero to surrender if his kingdom has sufficient gold reserves

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -613,7 +613,7 @@ namespace AI
 
             enum class Outcome
             {
-                None,
+                ContinueBattle,
                 Retreat,
                 Surrender
             };
@@ -626,11 +626,11 @@ namespace AI
 
                 if ( !canRetreat ) {
                     if ( !canSurrender ) {
-                        return Outcome::None;
+                        return Outcome::ContinueBattle;
                     }
 
                     if ( !kingdom.AllowPayment( { Resource::GOLD, arena.getForce( _myColor ).GetSurrenderCost() } ) ) {
-                        return Outcome::None;
+                        return Outcome::ContinueBattle;
                     }
 
                     return Outcome::Surrender;

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -642,14 +642,12 @@ namespace AI
                     return Outcome::Retreat;
                 }
 
-                const uint32_t surrenderCost = force.GetSurrenderCost();
-                const uint32_t averageStartingArmySurrenderCost = force.GetSurrenderCost( Army::getCostOfAverageStartingArmy( actualHero ) );
-
-                if ( surrenderCost < averageStartingArmySurrenderCost ) {
+                if ( force.getStrengthOfArmyRemainingInCaseOfSurrender() < Army::getStrengthOfAverageStartingArmy( actualHero ) ) {
                     return Outcome::Retreat;
                 }
 
-                if ( !kingdom.AllowPayment( Funds{ Resource::GOLD, surrenderCost } * Difficulty::getGoldReserveRatioForAISurrender( Game::getDifficulty() ) ) ) {
+                if ( !kingdom.AllowPayment( Funds{ Resource::GOLD, force.GetSurrenderCost() }
+                                            * Difficulty::getGoldReserveRatioForAISurrender( Game::getDifficulty() ) ) ) {
                     return Outcome::Retreat;
                 }
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -619,6 +619,7 @@ namespace AI
             };
 
             const Outcome outcome = [this, &arena, actualHero]() {
+                const Force & force = arena.getForce( _myColor );
                 const Kingdom & kingdom = actualHero->GetKingdom();
 
                 const bool canRetreat = arena.CanRetreatOpponent( _myColor );
@@ -629,7 +630,7 @@ namespace AI
                         return Outcome::ContinueBattle;
                     }
 
-                    if ( !kingdom.AllowPayment( { Resource::GOLD, arena.getForce( _myColor ).GetSurrenderCost() } ) ) {
+                    if ( !kingdom.AllowPayment( { Resource::GOLD, force.GetSurrenderCost() } ) ) {
                         return Outcome::ContinueBattle;
                     }
 
@@ -640,8 +641,14 @@ namespace AI
                     return Outcome::Retreat;
                 }
 
-                if ( !kingdom.AllowPayment( Funds{ Resource::GOLD, arena.getForce( _myColor ).GetSurrenderCost() }
-                                            * Difficulty::getGoldReserveRatioForAISurrender( Game::getDifficulty() ) ) ) {
+                const uint32_t surrenderCost = force.GetSurrenderCost();
+                const uint32_t averageStartingArmySurrenderCost = force.GetSurrenderCost( Army::getCostOfAverageStartingArmy( actualHero ) );
+
+                if ( surrenderCost < averageStartingArmySurrenderCost ) {
+                    return Outcome::Retreat;
+                }
+
+                if ( !kingdom.AllowPayment( Funds{ Resource::GOLD, surrenderCost } * Difficulty::getGoldReserveRatioForAISurrender( Game::getDifficulty() ) ) ) {
                     return Outcome::Retreat;
                 }
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -649,6 +649,8 @@ namespace AI
             }();
 
             switch ( outcome ) {
+            case Outcome::ContinueBattle:
+                break;
             case Outcome::Retreat:
                 farewellSpellcast();
 
@@ -666,6 +668,7 @@ namespace AI
 
                 return actions;
             default:
+                assert( 0 );
                 break;
             }
         }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -38,6 +38,7 @@
 
 #include "ai.h"
 #include "ai_normal.h"
+#include "army.h"
 #include "artifact.h"
 #include "artifact_info.h"
 #include "battle.h"

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -640,14 +640,6 @@ namespace AI
                     return Outcome::Retreat;
                 }
 
-                if ( !arena.getForce( _myColor ).hasUnitFromOriginalArmy( []( const Unit * unit ) {
-                         assert( unit != nullptr );
-
-                         return unit->GetMonsterLevel() > 4;
-                     } ) ) {
-                    return Outcome::Retreat;
-                }
-
                 if ( !kingdom.AllowPayment( Funds{ Resource::GOLD, arena.getForce( _myColor ).GetSurrenderCost() }
                                             * Difficulty::getGoldReserveRatioForAISurrender( Game::getDifficulty() ) ) ) {
                     return Outcome::Retreat;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1292,13 +1292,14 @@ double Army::GetStrength() const
     return result;
 }
 
-Funds Army::getCostOfAverageStartingArmy( const Heroes * hero )
+double Army::getStrengthOfAverageStartingArmy( const Heroes * hero )
 {
     assert( hero != nullptr );
 
     const int race = hero->GetRace();
+    const Army & army = hero->GetArmy();
 
-    Funds result;
+    double result = 0.0;
 
     for ( uint32_t dwelling : std::array<uint32_t, 2>{ DWELLING_MONSTER1, DWELLING_MONSTER2 } ) {
         const Monster monster{ race, dwelling };
@@ -1306,7 +1307,7 @@ Funds Army::getCostOfAverageStartingArmy( const Heroes * hero )
 
         const auto [min, max] = getNumberOfMonstersInStartingArmy( monster );
 
-        result += monster.GetCost() * ( ( min + max ) / 2 );
+        result += ArmyTroop{ &army, { monster, ( min + max ) / 2 } }.GetStrength();
     }
 
     return result;

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -63,76 +63,113 @@
 #include "translations.h"
 #include "world.h"
 
-namespace fheroes2
+namespace
 {
-    class Image;
-}
+    enum class ArmySize : uint32_t
+    {
+        ARMY_FEW = 1,
+        ARMY_SEVERAL = 5,
+        ARMY_PACK = 10,
+        ARMY_LOTS = 20,
+        ARMY_HORDE = 50,
+        ARMY_THRONG = 100,
+        ARMY_SWARM = 250,
+        ARMY_ZOUNDS = 500,
+        ARMY_LEGION = 1000
+    };
 
-enum armysize_t
-{
-    ARMY_FEW = 1,
-    ARMY_SEVERAL = 5,
-    ARMY_PACK = 10,
-    ARMY_LOTS = 20,
-    ARMY_HORDE = 50,
-    ARMY_THRONG = 100,
-    ARMY_SWARM = 250,
-    ARMY_ZOUNDS = 500,
-    ARMY_LEGION = 1000
-};
+    ArmySize getArmySize( const uint32_t count )
+    {
+        const ArmySize countAsEnum = static_cast<ArmySize>( count );
 
-armysize_t ArmyGetSize( uint32_t count )
-{
-    if ( ARMY_LEGION <= count )
-        return ARMY_LEGION;
-    else if ( ARMY_ZOUNDS <= count )
-        return ARMY_ZOUNDS;
-    else if ( ARMY_SWARM <= count )
-        return ARMY_SWARM;
-    else if ( ARMY_THRONG <= count )
-        return ARMY_THRONG;
-    else if ( ARMY_HORDE <= count )
-        return ARMY_HORDE;
-    else if ( ARMY_LOTS <= count )
-        return ARMY_LOTS;
-    else if ( ARMY_PACK <= count )
-        return ARMY_PACK;
-    else if ( ARMY_SEVERAL <= count )
-        return ARMY_SEVERAL;
+        if ( ArmySize::ARMY_LEGION <= countAsEnum ) {
+            return ArmySize::ARMY_LEGION;
+        }
+        if ( ArmySize::ARMY_ZOUNDS <= countAsEnum ) {
+            return ArmySize::ARMY_ZOUNDS;
+        }
+        if ( ArmySize::ARMY_SWARM <= countAsEnum ) {
+            return ArmySize::ARMY_SWARM;
+        }
+        if ( ArmySize::ARMY_THRONG <= countAsEnum ) {
+            return ArmySize::ARMY_THRONG;
+        }
+        if ( ArmySize::ARMY_HORDE <= countAsEnum ) {
+            return ArmySize::ARMY_HORDE;
+        }
+        if ( ArmySize::ARMY_LOTS <= countAsEnum ) {
+            return ArmySize::ARMY_LOTS;
+        }
+        if ( ArmySize::ARMY_PACK <= countAsEnum ) {
+            return ArmySize::ARMY_PACK;
+        }
+        if ( ArmySize::ARMY_SEVERAL <= countAsEnum ) {
+            return ArmySize::ARMY_SEVERAL;
+        }
+        return ArmySize::ARMY_FEW;
+    }
 
-    return ARMY_FEW;
+    std::pair<uint32_t, uint32_t> getNumberOfMonstersInStartingArmy( const Monster & monster )
+    {
+        switch ( monster.GetMonsterLevel() ) {
+        case 1:
+            switch ( monster.GetID() ) {
+            case Monster::PEASANT:
+                return { 30, 50 };
+            case Monster::GOBLIN:
+                return { 15, 25 };
+            case Monster::SPRITE:
+                return { 10, 20 };
+            default:
+                return { 6, 10 };
+            }
+        case 2:
+            switch ( monster.GetID() ) {
+            case Monster::ARCHER:
+            case Monster::ORC:
+                return { 3, 5 };
+            default:
+                return { 2, 4 };
+            }
+        default:
+            assert( 0 );
+            break;
+        }
+
+        return { 0, 0 };
+    }
 }
 
 std::string Army::TroopSizeString( const Troop & troop )
 {
     std::string str;
 
-    switch ( ArmyGetSize( troop.GetCount() ) ) {
-    case ARMY_FEW:
+    switch ( getArmySize( troop.GetCount() ) ) {
+    case ArmySize::ARMY_FEW:
         str = _( "A few\n%{monster}" );
         break;
-    case ARMY_SEVERAL:
+    case ArmySize::ARMY_SEVERAL:
         str = _( "Several\n%{monster}" );
         break;
-    case ARMY_PACK:
+    case ArmySize::ARMY_PACK:
         str = _( "A pack of\n%{monster}" );
         break;
-    case ARMY_LOTS:
+    case ArmySize::ARMY_LOTS:
         str = _( "Lots of\n%{monster}" );
         break;
-    case ARMY_HORDE:
+    case ArmySize::ARMY_HORDE:
         str = _( "A horde of\n%{monster}" );
         break;
-    case ARMY_THRONG:
+    case ArmySize::ARMY_THRONG:
         str = _( "A throng of\n%{monster}" );
         break;
-    case ARMY_SWARM:
+    case ArmySize::ARMY_SWARM:
         str = _( "A swarm of\n%{monster}" );
         break;
-    case ARMY_ZOUNDS:
+    case ArmySize::ARMY_ZOUNDS:
         str = _( "Zounds...\n%{monster}" );
         break;
-    case ARMY_LEGION:
+    case ArmySize::ARMY_LEGION:
         str = _( "A legion of\n%{monster}" );
         break;
     default:
@@ -147,24 +184,24 @@ std::string Army::TroopSizeString( const Troop & troop )
 
 std::string Army::SizeString( uint32_t size )
 {
-    switch ( ArmyGetSize( size ) ) {
-    case ARMY_FEW:
+    switch ( getArmySize( size ) ) {
+    case ArmySize::ARMY_FEW:
         return _( "army|Few" );
-    case ARMY_SEVERAL:
+    case ArmySize::ARMY_SEVERAL:
         return _( "army|Several" );
-    case ARMY_PACK:
+    case ArmySize::ARMY_PACK:
         return _( "army|Pack" );
-    case ARMY_LOTS:
+    case ArmySize::ARMY_LOTS:
         return _( "army|Lots" );
-    case ARMY_HORDE:
+    case ArmySize::ARMY_HORDE:
         return _( "army|Horde" );
-    case ARMY_THRONG:
+    case ArmySize::ARMY_THRONG:
         return _( "army|Throng" );
-    case ARMY_SWARM:
+    case ArmySize::ARMY_SWARM:
         return _( "army|Swarm" );
-    case ARMY_ZOUNDS:
+    case ArmySize::ARMY_ZOUNDS:
         return _( "army|Zounds" );
-    case ARMY_LEGION:
+    case ArmySize::ARMY_LEGION:
         return _( "army|Legion" );
     default:
         // Are you passing the correct value?
@@ -1249,47 +1286,57 @@ double Army::GetStrength() const
     return result;
 }
 
-void Army::Reset( const bool soft /* = false */ )
+Funds Army::getCostOfAverageStartingArmy( const Heroes * hero )
+{
+    assert( hero != nullptr );
+
+    const int race = hero->GetRace();
+
+    Funds result;
+
+    for ( uint32_t dwelling : std::array<uint32_t, 2>{ DWELLING_MONSTER1, DWELLING_MONSTER2 } ) {
+        const Monster monster{ race, dwelling };
+        assert( monster.isValid() );
+
+        const auto [min, max] = getNumberOfMonstersInStartingArmy( monster );
+
+        result += monster.GetCost() * ( ( min + max ) / 2 );
+    }
+
+    return result;
+}
+
+void Army::Reset( const bool defaultArmy /* = false */ )
 {
     Troops::Clean();
 
-    if ( commander && commander->isHeroes() ) {
-        const Monster mons1( commander->GetRace(), DWELLING_MONSTER1 );
-
-        if ( soft ) {
-            const Monster mons2( commander->GetRace(), DWELLING_MONSTER2 );
-
-            switch ( mons1.GetID() ) {
-            case Monster::PEASANT:
-                JoinTroop( mons1, Rand::Get( 30, 50 ), false );
-                break;
-            case Monster::GOBLIN:
-                JoinTroop( mons1, Rand::Get( 15, 25 ), false );
-                break;
-            case Monster::SPRITE:
-                JoinTroop( mons1, Rand::Get( 10, 20 ), false );
-                break;
-            default:
-                JoinTroop( mons1, Rand::Get( 6, 10 ), false );
-                break;
-            }
-
-            if ( Rand::Get( 1, 10 ) != 1 ) {
-                switch ( mons2.GetID() ) {
-                case Monster::ARCHER:
-                case Monster::ORC:
-                    JoinTroop( mons2, Rand::Get( 3, 5 ), false );
-                    break;
-                default:
-                    JoinTroop( mons2, Rand::Get( 2, 4 ), false );
-                    break;
-                }
-            }
-        }
-        else {
-            JoinTroop( mons1, 1, false );
-        }
+    if ( commander == nullptr || !commander->isHeroes() ) {
+        return;
     }
+
+    const int race = commander->GetRace();
+
+    if ( !defaultArmy ) {
+        JoinTroop( { race, DWELLING_MONSTER1 }, 1, false );
+
+        return;
+    }
+
+    const auto joinMonsters = [this]( const Monster & monster ) {
+        const auto [min, max] = getNumberOfMonstersInStartingArmy( monster );
+
+        if ( !JoinTroop( monster, Rand::Get( min, max ), false ) ) {
+            assert( 0 );
+        }
+    };
+
+    joinMonsters( { race, DWELLING_MONSTER1 } );
+
+    if ( Rand::Get( 1, 10 ) == 1 ) {
+        return;
+    }
+
+    joinMonsters( { race, DWELLING_MONSTER2 } );
 }
 
 HeroBase * Army::GetCommander()

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -24,6 +24,7 @@
 #include "army.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cmath>
 #include <map>
@@ -62,6 +63,11 @@
 #include "tools.h"
 #include "translations.h"
 #include "world.h"
+
+namespace fheroes2
+{
+    class Image;
+}
 
 namespace
 {

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1297,7 +1297,6 @@ double Army::getStrengthOfAverageStartingArmy( const Heroes * hero )
     assert( hero != nullptr );
 
     const int race = hero->GetRace();
-    const Army & army = hero->GetArmy();
 
     double result = 0.0;
 
@@ -1307,7 +1306,7 @@ double Army::getStrengthOfAverageStartingArmy( const Heroes * hero )
 
         const auto [min, max] = getNumberOfMonstersInStartingArmy( monster );
 
-        result += ArmyTroop{ &army, { monster, ( min + max ) / 2 } }.GetStrength();
+        result += Troop{ monster, ( min + max ) / 2 }.GetStrength();
     }
 
     return result;

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -32,7 +32,6 @@
 
 #include "monster.h"
 #include "players.h"
-#include "resource.h"
 
 class StreamBase;
 

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -173,6 +173,9 @@ public:
 
     static NeutralMonsterJoiningCondition GetJoinSolution( const Heroes &, const Maps::Tiles &, const Troop & );
 
+    // Returns the cost of the average starting army for a given hero
+    static Funds getCostOfAverageStartingArmy( const Heroes * hero );
+
     static void drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, int32_t width );
     static void drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_t posY, int32_t lineWidth, bool isCompact, const bool isDetailedView,
                                           const bool isGarrisonView = false, const uint32_t thievesGuildsCount = 0 );
@@ -189,9 +192,11 @@ public:
     ~Army() override = default;
 
     const Troops & getTroops() const;
-    // Soft reset means reset to the default army (a few T1 and T2 units).
-    // Hard reset means reset to the minimum army (strictly one T1 unit).
-    void Reset( const bool soft = false );
+
+    // Resets the army. If the army doesn't have a commanding hero, then it makes the army empty. Otherwise, if 'defaultArmy' is set to true, then it creates a default
+    // army of the commanding hero's faction (several units of level 1 and 2). Otherwise, a minimum army is created, consisting of exactly one monster of the first level
+    // of the commanding hero's faction.
+    void Reset( const bool defaultArmy = false );
     void setFromTile( const Maps::Tiles & tile );
 
     int GetColor() const;

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -32,6 +32,7 @@
 
 #include "monster.h"
 #include "players.h"
+#include "resource.h"
 
 class StreamBase;
 

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -174,8 +174,8 @@ public:
 
     static NeutralMonsterJoiningCondition GetJoinSolution( const Heroes &, const Maps::Tiles &, const Troop & );
 
-    // Returns the cost of the average starting army for a given hero
-    static Funds getCostOfAverageStartingArmy( const Heroes * hero );
+    // Returns the strength of the average starting army for a given hero (taking into account the hero's bonuses)
+    static double getStrengthOfAverageStartingArmy( const Heroes * hero );
 
     static void drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, int32_t width );
     static void drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_t posY, int32_t lineWidth, bool isCompact, const bool isDetailedView,

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -173,7 +173,7 @@ public:
 
     static NeutralMonsterJoiningCondition GetJoinSolution( const Heroes &, const Maps::Tiles &, const Troop & );
 
-    // Returns the strength of the average starting army for a given hero (taking into account the hero's bonuses)
+    // Returns the strength of the average starting army for a given hero (not taking into account the hero's bonuses)
     static double getStrengthOfAverageStartingArmy( const Heroes * hero );
 
     static void drawSingleDetailedMonsterLine( const Troops & troops, int32_t cx, int32_t cy, int32_t width );

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -340,3 +340,28 @@ void Battle::Force::SyncArmyCount()
         }
     }
 }
+
+bool Battle::Force::hasUnitFromOriginalArmy( const std::function<bool( const Unit * )> & predicate ) const
+{
+    for ( size_t index = 0; index < army.Size(); ++index ) {
+        const Troop * troop = army.GetTroop( index );
+        assert( troop != nullptr );
+
+        if ( !troop->isValid() ) {
+            continue;
+        }
+
+        const Unit * unit = FindUID( uids.at( index ) );
+        assert( unit != nullptr );
+
+        if ( unit->GetDead() >= unit->GetInitialCount() ) {
+            continue;
+        }
+
+        if ( predicate( unit ) ) {
+            return true;
+        }
+    }
+
+    return false;
+}

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -340,28 +340,3 @@ void Battle::Force::SyncArmyCount()
         }
     }
 }
-
-bool Battle::Force::hasUnitFromOriginalArmy( const std::function<bool( const Unit * )> & predicate ) const
-{
-    for ( size_t index = 0; index < army.Size(); ++index ) {
-        const Troop * troop = army.GetTroop( index );
-        assert( troop != nullptr );
-
-        if ( !troop->isValid() ) {
-            continue;
-        }
-
-        const Unit * unit = FindUID( uids.at( index ) );
-        assert( unit != nullptr );
-
-        if ( unit->GetDead() >= unit->GetInitialCount() ) {
-            continue;
-        }
-
-        if ( predicate( unit ) ) {
-            return true;
-        }
-    }
-
-    return false;
-}

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -364,9 +364,7 @@ double Battle::Force::getStrengthOfArmyRemainingInCaseOfSurrender() const
 
         // Consider only the number of units that will remain in the army after the end of the battle (in particular, don't take into account the number of
         // non-true-resurrected units)
-        result += ArmyTroop{ &static_cast<const Army &>( army ),
-                             { unit->GetMonster(), unit->GetDead() > unit->GetInitialCount() ? 0 : unit->GetInitialCount() - unit->GetDead() } }
-                      .GetStrength();
+        result += Troop{ unit->GetMonster(), unit->GetDead() > unit->GetInitialCount() ? 0 : unit->GetInitialCount() - unit->GetDead() }.GetStrength();
     }
 
     return result;

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -90,8 +90,9 @@ namespace Battle
 
         // Returns the cost of surrender (in units of gold) for the current army on the battlefield
         uint32_t GetSurrenderCost() const;
-        // Returns the cost of surrender (in units of gold) as if there were an army on the battlefield with a total cost of 'armyCost'
-        uint32_t GetSurrenderCost( const Funds & armyCost ) const;
+
+        // Returns the strength of the army that will remain in case of surrender (taking into account the hero's bonuses)
+        double getStrengthOfArmyRemainingInCaseOfSurrender() const;
 
         Troops GetKilledTroops() const;
 

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -80,17 +80,24 @@ namespace Battle
 
         bool isValid( const bool considerBattlefieldArmy = true ) const;
         bool HasMonster( const Monster & ) const;
+
         uint32_t GetDeadHitPoints() const;
         uint32_t GetDeadCounts() const;
+
         int GetColor() const;
         int GetControl() const;
+
         uint32_t GetSurrenderCost() const;
+
         Troops GetKilledTroops() const;
+
         bool animateIdleUnits() const;
         void resetIdleAnimation() const;
 
         void NewTurn();
         void SyncArmyCount();
+
+        bool hasUnitFromOriginalArmy( const std::function<bool( const Unit * )> & predicate ) const;
 
     private:
         Army & army;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -97,8 +97,6 @@ namespace Battle
         void NewTurn();
         void SyncArmyCount();
 
-        bool hasUnitFromOriginalArmy( const std::function<bool( const Unit * )> & predicate ) const;
-
     private:
         Army & army;
         std::vector<uint32_t> uids;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -31,6 +31,7 @@
 #include "bitmodes.h"
 #include "monster.h"
 
+class Funds;
 class HeroBase;
 
 namespace Battle

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -31,7 +31,6 @@
 #include "bitmodes.h"
 #include "monster.h"
 
-class Funds;
 class HeroBase;
 
 namespace Battle

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -90,7 +90,7 @@ namespace Battle
         // Returns the cost of surrender (in units of gold) for the current army on the battlefield
         uint32_t GetSurrenderCost() const;
 
-        // Returns the strength of the army that will remain in case of surrender (taking into account the hero's bonuses)
+        // Returns the strength of the army that will remain in case of surrender (not taking into account the hero's bonuses)
         double getStrengthOfArmyRemainingInCaseOfSurrender() const;
 
         Troops GetKilledTroops() const;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -87,7 +87,10 @@ namespace Battle
         int GetColor() const;
         int GetControl() const;
 
+        // Returns the cost of surrender (in units of gold) for the current army on the battlefield
         uint32_t GetSurrenderCost() const;
+        // Returns the cost of surrender (in units of gold) as if there were an army on the battlefield with a total cost of 'armyCost'
+        uint32_t GetSurrenderCost( const Funds & armyCost ) const;
 
         Troops GetKilledTroops() const;
 

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -490,7 +490,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
     army1.resetInvalidMonsters();
     army2.resetInvalidMonsters();
 
-    // reset the hero's army to the minimum army if the hero retreated or was defeated
+    // Reset the hero's army to the minimum army if the hero retreated or was defeated
     if ( commander1 && commander1->isHeroes() && ( !army1.isValid() || ( result.army1 & RESULT_RETREAT ) ) ) {
         army1.Reset( false );
     }

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -262,6 +262,19 @@ namespace
         assert( 0 );
         return nullptr;
     }
+
+    void restoreFundsOfCommandersKingdom( const HeroBase * commander, const Funds & initialFunds )
+    {
+        Kingdom * kingdom = getKingdomOfCommander( commander );
+        assert( kingdom != nullptr );
+
+        const Funds fundsDiff = kingdom->GetFunds() - initialFunds;
+        assert( kingdom->AllowPayment( fundsDiff ) );
+
+        kingdom->OddFundsResource( fundsDiff );
+
+        assert( kingdom->GetFunds() == initialFunds );
+    }
 }
 
 Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
@@ -394,28 +407,12 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
             if ( commander1 ) {
                 commander1->SetSpellPoints( initialSpellPoints1 );
 
-                Kingdom * kingdom = getKingdomOfCommander( commander1 );
-                assert( kingdom != nullptr );
-
-                const Funds fundsDiff = kingdom->GetFunds() - initialFunds1;
-                assert( kingdom->AllowPayment( fundsDiff ) );
-
-                kingdom->OddFundsResource( fundsDiff );
-
-                assert( kingdom->GetFunds() == initialFunds1 );
+                restoreFundsOfCommandersKingdom( commander1, initialFunds1 );
             }
             if ( commander2 ) {
                 commander2->SetSpellPoints( initialSpellPoints2 );
 
-                Kingdom * kingdom = getKingdomOfCommander( commander2 );
-                assert( kingdom != nullptr );
-
-                const Funds fundsDiff = kingdom->GetFunds() - initialFunds2;
-                assert( kingdom->AllowPayment( fundsDiff ) );
-
-                kingdom->OddFundsResource( fundsDiff );
-
-                assert( kingdom->GetFunds() == initialFunds2 );
+                restoreFundsOfCommandersKingdom( commander2, initialFunds2 );
             }
 
             continue;

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -389,7 +389,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
             // If dialog returns true we will restart battle in manual mode
             showBattle = true;
 
-            // Reset the status of army commanders and the state of their kingdoms' finances (one of them could spend gold to surrender, and the other could accept this
+            // Reset the state of army commanders and the state of their kingdoms' finances (one of them could spend gold to surrender, and the other could accept this
             // gold). Please note that heroes can also surrender to castle captains.
             if ( commander1 ) {
                 commander1->SetSpellPoints( initialSpellPoints1 );

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -389,8 +389,8 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
             // If dialog returns true we will restart battle in manual mode
             showBattle = true;
 
-            // Reset the status of army commanders and the state of their kingdoms' finances (some of them could have spent gold to surrender). Please note that heroes
-            // are able to surrender to castle captains.
+            // Reset the status of army commanders and the state of their kingdoms' finances (one of them could spend gold to surrender, and the other could accept this
+            // gold). Please note that heroes can also surrender to castle captains.
             if ( commander1 ) {
                 commander1->SetSpellPoints( initialSpellPoints1 );
 

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
@@ -38,6 +39,7 @@
 #include "battle_arena.h"
 #include "battle_army.h"
 #include "campaign_savedata.h"
+#include "captain.h"
 #include "dialog.h"
 #include "game.h"
 #include "heroes.h"
@@ -47,6 +49,7 @@
 #include "monster.h"
 #include "players.h"
 #include "rand.h"
+#include "resource.h"
 #include "settings.h"
 #include "skill.h"
 #include "spell.h"

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -182,7 +182,7 @@ namespace Battle
         uint32_t GetHitPoints() const;
 
         // Returns the cost of this unit, suitable for calculating the cost of surrendering the army (see
-        // the implementation for details). No coefficients are applied to this cost.
+        // the implementation for details). No discounts are applied to this cost.
         Funds GetSurrenderCost() const;
 
         uint32_t GetShots() const override

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -182,7 +182,7 @@ namespace Battle
         uint32_t GetHitPoints() const;
 
         // Returns the cost of this unit, suitable for calculating the cost of surrendering the army (see
-        // the implementation for details). No discounts are applied to this cost.
+        // the implementation for details). Discounts are not applied when calculating this cost.
         Funds GetSurrenderCost() const;
 
         uint32_t GetShots() const override

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -181,6 +181,8 @@ namespace Battle
         uint32_t GetDead() const;
         uint32_t GetHitPoints() const;
 
+        // Returns the cost of this unit, suitable for calculating the cost of surrendering the army (see
+        // the implementation for details). No coefficients are applied to this cost.
         Funds GetSurrenderCost() const;
 
         uint32_t GetShots() const override
@@ -271,7 +273,9 @@ namespace Battle
         int GetSpellMagic( Rand::DeterministicRandomGenerator & randomGenerator ) const;
 
         const HeroBase * GetCommander() const;
-        const HeroBase * GetCurrentOrArmyCommander() const; // commander of the army with the current unit color (if valid), commander of the unit's army otherwise
+        // If the color of the current unit is valid (i.e. this unit is not under the influence of a Berserker spell), then returns the commander of the army with the
+        // corresponding color. Otherwise, returns the commander of the unit's army.
+        const HeroBase * GetCurrentOrArmyCommander() const;
 
         // Checks whether the attacker will fight the defender in melee
         static bool isHandFighting( const Unit & attacker, const Unit & defender );

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -128,7 +128,7 @@ int Difficulty::GetHeroMovementBonus( int difficulty )
     return 0;
 }
 
-double Difficulty::GetAIRetreatRatio( int difficulty )
+double Difficulty::getArmyStrengthRatioForAIRetreat( const int difficulty )
 {
     switch ( difficulty ) {
     case Difficulty::NORMAL:
@@ -142,6 +142,11 @@ double Difficulty::GetAIRetreatRatio( int difficulty )
         break;
     }
     return 100.0 / 6.0;
+}
+
+uint32_t Difficulty::getGoldReserveRatioForAISurrender( const int /* difficulty */ )
+{
+    return 10;
 }
 
 uint32_t Difficulty::GetDimensionDoorLimit( int difficulty )

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -50,7 +50,9 @@ namespace Difficulty
     double GetUnitGrowthBonusForAI( const int difficulty );
 
     int GetHeroMovementBonus( int difficulty );
-    double GetAIRetreatRatio( int difficulty );
+
+    double getArmyStrengthRatioForAIRetreat( const int difficulty );
+    uint32_t getGoldReserveRatioForAISurrender( const int difficulty );
 
     uint32_t GetDimensionDoorLimit( int difficulty );
 

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -54,7 +54,7 @@ namespace Difficulty
     // Returns the ratio of the strength of the enemy army to the strength of the AI army, above which the AI decides to retreat from the battlefield
     double getArmyStrengthRatioForAIRetreat( const int difficulty );
 
-    // Returns the ratio of the AI kingdom's gold reserve to the cost of surrender, above which the AI will prefer surrender to retreat from the battlefield
+    // Returns the minimum ratio of the AI kingdom's gold reserve to the cost of surrender, at which the AI will prefer surrender to retreat from the battlefield
     uint32_t getGoldReserveRatioForAISurrender( const int difficulty );
 
     uint32_t GetDimensionDoorLimit( int difficulty );

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -54,7 +54,7 @@ namespace Difficulty
     // Returns the ratio of the strength of the enemy army to the strength of the AI army, above which the AI decides to retreat from the battlefield
     double getArmyStrengthRatioForAIRetreat( const int difficulty );
 
-    // Returns the minimum ratio of the kingdom's gold reserve to the cost of surrender, at which the AI will prefer surrender to retreat from the battlefield
+    // Returns the minimum ratio of the AI kingdom's gold reserve to the cost of surrender, at which the AI will prefer surrender to retreat from the battlefield
     uint32_t getGoldReserveRatioForAISurrender( const int difficulty );
 
     uint32_t GetDimensionDoorLimit( int difficulty );

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -54,7 +54,7 @@ namespace Difficulty
     // Returns the ratio of the strength of the enemy army to the strength of the AI army, above which the AI decides to retreat from the battlefield
     double getArmyStrengthRatioForAIRetreat( const int difficulty );
 
-    // Returns the minimum ratio of the AI kingdom's gold reserve to the cost of surrender, at which the AI will prefer surrender to retreat from the battlefield
+    // Returns the ratio of the AI kingdom's gold reserve to the cost of surrender, above which the AI will prefer surrender to retreat from the battlefield
     uint32_t getGoldReserveRatioForAISurrender( const int difficulty );
 
     uint32_t GetDimensionDoorLimit( int difficulty );

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -51,7 +51,10 @@ namespace Difficulty
 
     int GetHeroMovementBonus( int difficulty );
 
+    // Returns the ratio of the strength of the enemy army to the strength of the AI army, above which the AI decides to retreat from the battlefield
     double getArmyStrengthRatioForAIRetreat( const int difficulty );
+
+    // Returns the minimum ratio of the kingdom's gold reserve to the cost of surrender, at which the AI will prefer surrender to retreat from the battlefield
     uint32_t getGoldReserveRatioForAISurrender( const int difficulty );
 
     uint32_t GetDimensionDoorLimit( int difficulty );

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -28,6 +28,7 @@
 #include <cstddef>
 #include <memory>
 #include <ostream>
+#include <tuple>
 #include <utility>
 #include <vector>
 
@@ -355,8 +356,8 @@ Funds & Funds::operator/=( const int32_t div )
 
 bool Funds::operator==( const Funds & other ) const
 {
-    return wood == other.wood && mercury == other.mercury && ore == other.ore && sulfur == other.sulfur && crystal == other.crystal && gems == other.gems
-           && gold == other.gold;
+    return std::tie( wood, mercury, ore, sulfur, crystal, gems, gold )
+           == std::tie( other.wood, other.mercury, other.ore, other.sulfur, other.crystal, other.gems, other.gold );
 }
 
 bool Funds::operator>=( const Funds & other ) const

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -353,9 +353,16 @@ Funds & Funds::operator/=( const int32_t div )
     return *this;
 }
 
-bool Funds::operator>=( const Funds & pm ) const
+bool Funds::operator==( const Funds & other ) const
 {
-    return wood >= pm.wood && mercury >= pm.mercury && ore >= pm.ore && sulfur >= pm.sulfur && crystal >= pm.crystal && gems >= pm.gems && gold >= pm.gold;
+    return wood == other.wood && mercury == other.mercury && ore == other.ore && sulfur == other.sulfur && crystal == other.crystal && gems == other.gems
+           && gold == other.gold;
+}
+
+bool Funds::operator>=( const Funds & other ) const
+{
+    return wood >= other.wood && mercury >= other.mercury && ore >= other.ore && sulfur >= other.sulfur && crystal >= other.crystal && gems >= other.gems
+           && gold >= other.gold;
 }
 
 std::string Funds::String() const

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -83,10 +83,12 @@ public:
     Funds & operator-=( const Funds & );
     Funds & operator=( const cost_t & );
 
-    bool operator>=( const Funds & ) const;
-    bool operator<( const Funds & funds ) const
+    bool operator==( const Funds & other ) const;
+    bool operator>=( const Funds & other ) const;
+
+    bool operator<( const Funds & other ) const
     {
-        return !operator>=( funds );
+        return !operator>=( other );
     }
 
     Funds max( const Funds & ) const;

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *


### PR DESCRIPTION
After some thought, I decided it was worth trying the approach described by @Alucard648 in [this comment](https://github.com/ihhub/fheroes2/issues/8221#issuecomment-1875625475). Indeed, there are situations when it is a pity to lose an existing AI army during a retreat, sometimes it may even contain high-level units.