### PR TITLE
Fix fog sprite selection for several conditions

### DIFF
--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -29,6 +29,7 @@
 #include <map>
 #include <memory>
 #include <ostream>
+#include <string>
 #include <utility>
 
 #include "agg_image.h"

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -812,7 +812,7 @@ namespace Maps
             }
             else if ( contains( fogDirection, DIRECTION_CENTER_ROW | Direction::BOTTOM | Direction::TOP )
                       && !( fogDirection & ( Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT | Direction::BOTTOM_LEFT | Direction::TOP_LEFT ) ) ) {
-                index = 22;
+                index = 21;
             }
             else if ( contains( fogDirection, DIRECTION_CENTER_ROW | Direction::BOTTOM | Direction::BOTTOM_LEFT )
                       && !( fogDirection & ( Direction::TOP | Direction::BOTTOM_RIGHT ) ) ) {
@@ -855,16 +855,15 @@ namespace Maps
                 index = 27;
             }
             else if ( contains( fogDirection, Direction::BOTTOM | Direction::RIGHT )
-                      && !( fogDirection & ( Direction::TOP | Direction::TOP_LEFT | Direction::LEFT | Direction::BOTTOM_RIGHT ) ) ) {
+                      && !( fogDirection & ( Direction::TOP | Direction::LEFT | Direction::BOTTOM_RIGHT ) ) ) {
                 index = 27;
                 revert = true;
             }
-            else if ( contains( fogDirection, Direction::LEFT | Direction::TOP )
-                      && !( fogDirection & ( Direction::TOP_LEFT | Direction::RIGHT | Direction::BOTTOM | Direction::BOTTOM_RIGHT ) ) ) {
+            else if ( contains( fogDirection, Direction::LEFT | Direction::TOP ) && !( fogDirection & ( Direction::TOP_LEFT | Direction::RIGHT | Direction::BOTTOM ) ) ) {
                 index = 28;
             }
             else if ( contains( fogDirection, Direction::RIGHT | Direction::TOP )
-                      && !( fogDirection & ( Direction::TOP_RIGHT | Direction::LEFT | Direction::BOTTOM | Direction::BOTTOM_LEFT ) ) ) {
+                      && !( fogDirection & ( Direction::TOP_RIGHT | Direction::LEFT | Direction::BOTTOM ) ) ) {
                 index = 28;
                 revert = true;
             }
@@ -900,7 +899,7 @@ namespace Maps
             }
             else {
                 // unknown
-                DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid direction for fog: " << fogDirection << ". Tile index: " << tile.GetIndex() )
+                DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid direction for fog: " << Direction::String( fogDirection ) << ". Tile index: " << tile.GetIndex() )
                 const fheroes2::Image & sf = fheroes2::AGG::GetTIL( TIL::CLOF32, ( mp.x + mp.y ) % 4, 0 );
                 area.DrawTile( dst, sf, mp );
                 return;


### PR DESCRIPTION
Close #8223 

![fix](https://github.com/ihhub/fheroes2/assets/113276641/4312db87-13b4-41b1-82cb-d50c1485dc81)


This PR fixes fog generation for the next cases (V - has fog; X - no fog; ? - any fog state):
```
XVX  XV?  ?VX  ?X?
VVV  VVX  XVV  XVV
XVX  ?X?  ?X?  ?VX
  ```
For the fist case there was a typo in the code, for the others the fog directions analyzer is corrected according to the code for this case:
```
?X?  
VVX  
XV?  
```