### PR TITLE
Improve AI heroes behavior on the Adventure Map

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1305,7 +1305,8 @@ namespace
             Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
-                hero.GetKingdom().AddFundsResource( Maps::getFundsFromTile( tile ) );
+                // Daemon Cave always gives 2500 Gold after a battle
+                hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, 2500 ) );
             }
             else {
                 AIBattleLose( hero, res, true );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1305,8 +1305,7 @@ namespace
             Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
-                // Daemon Cave always gives 2500 Gold after a battle
-                hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, 2500 ) );
+                hero.GetKingdom().AddFundsResource( Maps::getFundsFromTile( tile ) );
             }
             else {
                 AIBattleLose( hero, res, true );
@@ -1655,9 +1654,10 @@ namespace
         if ( !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
             hero.SetVisited( tileIndex, Visit::GLOBAL );
 
-            const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI, true );
+            const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI );
+            const uint32_t distance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
             for ( const int32_t index : eyeMagiIndexes ) {
-                Maps::ClearFog( index, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES ), hero.GetColor() );
+                Maps::ClearFog( index, distance, hero.GetColor() );
             }
         }
     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -334,11 +334,10 @@ namespace
         }
 
         case MP2::OBJ_OBSERVATION_TOWER: {
-            const int32_t fogCountToUncoverByHero = Maps::getFogTileCountToBeRevealed( index, hero.GetScoutingDistance(), hero.GetColor() );
             const int32_t fogCountToUncoverByTower
                 = Maps::getFogTileCountToBeRevealed( index, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), hero.GetColor() );
 
-            return fogCountToUncoverByTower > fogCountToUncoverByHero;
+            return fogCountToUncoverByTower > 0;
         }
 
         case MP2::OBJ_OBELISK:
@@ -846,7 +845,7 @@ namespace
         return fogDiscoveryBaseValue;
     }
 
-    uint32_t getFogDiscoveryMaximizingPeriod( const Heroes & hero )
+    uint32_t getTimeoutBeforeFogDiscoveryIntensification( const Heroes & hero )
     {
         switch ( hero.getAIRole() ) {
         case Heroes::Role::SCOUT:
@@ -1245,13 +1244,11 @@ namespace AI
             const int32_t fogCountToUncoverByTower
                 = Maps::getFogTileCountToBeRevealed( index, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), hero.GetColor() );
 
-            const int32_t fogCountToUncoverByHero = Maps::getFogTileCountToBeRevealed( index, hero.GetScoutingDistance(), hero.GetColor() );
-
-            if ( fogCountToUncoverByTower - fogCountToUncoverByHero <= 0 ) {
+            if ( fogCountToUncoverByTower == 0 ) {
                 // Nothing to uncover.
                 return -dangerousTaskPenalty;
             }
-            return fogCountToUncoverByTower - fogCountToUncoverByHero;
+            return fogCountToUncoverByTower;
         }
         case MP2::OBJ_MAGELLANS_MAPS: {
             // Very valuable object.
@@ -2148,14 +2145,14 @@ namespace AI
 
             if ( isTerritoryExpansion ) {
                 // Over time the AI should focus more on territory expansion.
-                const uint32_t period = getFogDiscoveryMaximizingPeriod( hero );
+                const uint32_t period = getTimeoutBeforeFogDiscoveryIntensification( hero );
+                assert( period > 0 );
 
                 if ( fogDiscoveryValue < 0 ) {
                     // This is actually a very useful fog discovery action which might lead to finding of new objects.
                     // Increase the value of this action.
                     fogDiscoveryValue /= 2;
 
-                    assert( period > 0 );
                     if ( world.CountDay() > period ) {
                         fogDiscoveryValue = 0;
                     }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -333,9 +333,13 @@ namespace
             return true;
         }
 
-        case MP2::OBJ_OBSERVATION_TOWER:
-            return Maps::getFogTileCountToBeRevealed( index, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), hero.GetColor() )
-                   > 0;
+        case MP2::OBJ_OBSERVATION_TOWER: {
+            const int32_t fogCountToUncoverByHero = Maps::getFogTileCountToBeRevealed( index, hero.GetScoutingDistance(), hero.GetColor() );
+            const int32_t fogCountToUncoverByTower
+                = Maps::getFogTileCountToBeRevealed( index, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), hero.GetColor() );
+
+            return fogCountToUncoverByTower > fogCountToUncoverByHero;
+        }
 
         case MP2::OBJ_OBELISK:
             // TODO: add the logic to dig an Ultimate artifact when a digging tile is visible.
@@ -528,6 +532,10 @@ namespace
                 return true;
             }
 
+            if ( hero.isObjectTypeVisited( objectType ) ) {
+                return false;
+            }
+
             const uint32_t distance = getDistanceToObject( hero, pathfinder, index );
             if ( distance == 0 ) {
                 return false;
@@ -536,7 +544,7 @@ namespace
             const int daysActive = DAYOFWEEK - world.GetDay() + 1;
             const double movementBonus = daysActive * GameStatic::getMovementPointBonus( objectType ) - 2.0 * distance;
 
-            return !hero.isObjectTypeVisited( objectType ) && movementBonus > 0;
+            return movementBonus > 0;
         }
 
         // Objects that give goods but curse with bad morale when visiting them for subsequent times.
@@ -603,7 +611,7 @@ namespace
         case MP2::OBJ_JAIL:
             return kingdom.GetHeroes().size() < Kingdom::GetMaxHeroes();
         case MP2::OBJ_HUT_OF_MAGI:
-            return !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) && !Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI, true ).empty();
+            return !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) && Maps::doesObjectExistOnMap( MP2::OBJ_EYE_OF_MAGI );
 
         case MP2::OBJ_ALCHEMIST_TOWER: {
             const BagArtifacts & bag = hero.GetBagArtifacts();
@@ -799,14 +807,19 @@ namespace
         return 1.0;
     }
 
-    double ScaleWithDistance( const double value, const uint32_t distance, const MP2::MapObjectType objectType )
+    double scaleWithDistanceAndTime( const double value, const uint32_t distance, const MP2::MapObjectType objectType )
     {
         if ( distance == 0 ) {
             return value;
         }
 
         // Some objects do not loose their value drastically over distances. This allows AI heroes to keep focus on important targets.
-        const double correctedDistance = distance * getDistanceModifier( objectType );
+        double correctedDistance = distance * getDistanceModifier( objectType );
+
+        // Distances should be corrected over time as AI heroes should focus on keeping important objects in focus.
+        // This value shouldn't be big but very slowly increases over time.
+        const double timeCorrectionCoeff = 1 - std::min( 0.5, world.CountDay() * 0.0001 );
+        correctedDistance *= timeCorrectionCoeff;
 
         // Scale non-linearly (more value lost as distance increases)
         return value - ( correctedDistance * std::log10( correctedDistance ) );
@@ -816,12 +829,13 @@ namespace
     {
         switch ( hero.getAIRole() ) {
         case Heroes::Role::SCOUT:
+            // Scouts do not have any penalty on map exploration as it is their main priority.
             return 0;
         case Heroes::Role::HUNTER:
-            return fogDiscoveryBaseValue;
-        case Heroes::Role::COURIER:
         case Heroes::Role::FIGHTER:
         case Heroes::Role::CHAMPION:
+            return fogDiscoveryBaseValue;
+        case Heroes::Role::COURIER:
             return fogDiscoveryBaseValue * 2;
         default:
             // If you set a new type of a hero you must add the logic here.
@@ -830,6 +844,27 @@ namespace
         }
 
         return fogDiscoveryBaseValue;
+    }
+
+    uint32_t getFogDiscoveryMaximizingPeriod( const Heroes & hero )
+    {
+        switch ( hero.getAIRole() ) {
+        case Heroes::Role::SCOUT:
+            return 30;
+        case Heroes::Role::HUNTER:
+            return 90;
+        case Heroes::Role::FIGHTER:
+        case Heroes::Role::CHAMPION:
+            return 60;
+        case Heroes::Role::COURIER:
+            return 120;
+        default:
+            // If you set a new type of a hero you must add the logic here.
+            assert( 0 );
+            break;
+        }
+
+        return 30;
     }
 }
 
@@ -1207,13 +1242,16 @@ namespace AI
             return -dangerousTaskPenalty;
         }
         case MP2::OBJ_OBSERVATION_TOWER: {
-            const int fogCountToUncover
+            const int32_t fogCountToUncoverByTower
                 = Maps::getFogTileCountToBeRevealed( index, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), hero.GetColor() );
-            if ( fogCountToUncover <= 0 ) {
+
+            const int32_t fogCountToUncoverByHero = Maps::getFogTileCountToBeRevealed( index, hero.GetScoutingDistance(), hero.GetColor() );
+
+            if ( fogCountToUncoverByTower - fogCountToUncoverByHero <= 0 ) {
                 // Nothing to uncover.
                 return -dangerousTaskPenalty;
             }
-            return fogCountToUncover;
+            return fogCountToUncoverByTower - fogCountToUncoverByHero;
         }
         case MP2::OBJ_MAGELLANS_MAPS: {
             // Very valuable object.
@@ -1269,13 +1307,19 @@ namespace AI
         case MP2::OBJ_STABLES: {
             const int daysActive = DAYOFWEEK - world.GetDay() + 1;
             double movementBonus = daysActive * GameStatic::getMovementPointBonus( objectType ) - 2.0 * distanceToObject;
-            if ( movementBonus < 0 ) {
-                // Looks like this is too far away.
-                movementBonus = 0;
-            }
 
             const double upgradeValue = getMonsterUpgradeValue( hero.GetArmy(), Monster::CHAMPION );
-            return movementBonus + freeMonsterUpgradeModifier * upgradeValue;
+            if ( upgradeValue > 0.0001 ) {
+                // Even if no movement bonus exist it is worth to visit just to upgrade monsters.
+                return std::max( movementBonus, 0.0 ) + freeMonsterUpgradeModifier * upgradeValue;
+            }
+
+            if ( movementBonus < 0 ) {
+                // Don't waste movement to even visit this object.
+                return -dangerousTaskPenalty;
+            }
+
+            return movementBonus;
         }
         case MP2::OBJ_FREEMANS_FOUNDRY: {
             const double upgradePikemanValue = getMonsterUpgradeValue( hero.GetArmy(), Monster::PIKEMAN );
@@ -1298,14 +1342,21 @@ namespace AI
         }
         case MP2::OBJ_OASIS:
         case MP2::OBJ_WATERING_HOLE: {
-            return std::max( GameStatic::getMovementPointBonus( objectType ) - 2.0 * distanceToObject, 0.0 );
+            const double movementBonus = GameStatic::getMovementPointBonus( objectType ) - 2.0 * distanceToObject;
+            if ( movementBonus < 0 ) {
+                // Don't waste movement to even visit this object.
+                return -dangerousTaskPenalty;
+            }
+
+            return movementBonus;
         }
         case MP2::OBJ_JAIL: {
-            // A free hero is always good and it could be very powerful.
+            // A free hero is always good and he could be very powerful.
             return 3000;
         }
         case MP2::OBJ_HUT_OF_MAGI: {
-            const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI, true );
+            // TODO: cache Maps::GetObjectPositions() call as this is a very heavy operation.
+            const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI );
             int fogCountToUncover = 0;
             const int heroColor = hero.GetColor();
             const int eyeViewDistance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
@@ -2023,7 +2074,7 @@ namespace AI
                 distance = hero.GetMovePoints() + ( distance - hero.GetMovePoints() ) * 2;
             }
 
-            value = ScaleWithDistance( value, distance, type );
+            value = scaleWithDistanceAndTime( value, distance, type );
         };
 
         // Set baseline target if it's a special role
@@ -2095,10 +2146,28 @@ namespace AI
                 useDimensionDoor = true;
             }
 
-            if ( isTerritoryExpansion && fogDiscoveryValue < 0 ) {
-                // This is actually a very useful fog discovery action which might lead to finding of new objects.
-                // Increase the value of this action.
-                fogDiscoveryValue /= 2;
+            if ( isTerritoryExpansion ) {
+                // Over time the AI should focus more on territory expansion.
+                const uint32_t period = getFogDiscoveryMaximizingPeriod( hero );
+
+                if ( fogDiscoveryValue < 0 ) {
+                    // This is actually a very useful fog discovery action which might lead to finding of new objects.
+                    // Increase the value of this action.
+                    fogDiscoveryValue /= 2;
+
+                    assert( period > 0 );
+                    if ( world.CountDay() > period ) {
+                        fogDiscoveryValue = 0;
+                    }
+                    else {
+                        fogDiscoveryValue = fogDiscoveryValue * ( period - world.CountDay() ) / period;
+                    }
+                }
+                else {
+                    // Over time the AI should focus more on territory expansion.
+                    // Scouts must focus on expansion so they should reach maximum "attention" in a month.
+                    fogDiscoveryValue += std::min( 1000.0 * world.CountDay() / period, 1000.0 );
+                }
             }
 
             getObjectValue( fogDiscoveryTarget, distanceToFogDiscovery, fogDiscoveryValue, MP2::OBJ_NONE, useDimensionDoor );

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2130,8 +2130,7 @@ namespace AI
         }
 
         double fogDiscoveryValue = getFogDiscoveryValue( hero );
-        bool isTerritoryExpansion = false;
-        const int fogDiscoveryTarget = _pathfinder.getFogDiscoveryTile( hero, isTerritoryExpansion );
+        const auto [fogDiscoveryTarget, isTerritoryExpansion] = _pathfinder.getFogDiscoveryTile( hero );
         if ( fogDiscoveryTarget >= 0 ) {
             uint32_t distanceToFogDiscovery = _pathfinder.getDistance( fogDiscoveryTarget );
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2150,13 +2150,12 @@ namespace AI
                 if ( fogDiscoveryValue < 0 ) {
                     // This is actually a very useful fog discovery action which might lead to finding of new objects.
                     // Increase the value of this action.
-                    fogDiscoveryValue /= 2;
 
                     if ( world.CountDay() > period ) {
                         fogDiscoveryValue = 0;
                     }
                     else {
-                        fogDiscoveryValue = fogDiscoveryValue * ( period - world.CountDay() ) / period;
+                        fogDiscoveryValue = fogDiscoveryValue / 2 * ( period - world.CountDay() ) / period;
                     }
                 }
                 else {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3296,7 +3296,7 @@ namespace
         if ( !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
             hero.SetVisited( dst_index, Visit::GLOBAL );
 
-            const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI, true );
+            const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI );
             if ( !eyeMagiIndexes.empty() ) {
                 Interface::AdventureMap & I = Interface::AdventureMap::Get();
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -120,9 +120,6 @@ void Kingdom::Init( int clr )
     color = clr;
 
     if ( Color::ALL & color ) {
-        heroes.reserve( GetMaxHeroes() );
-        castles.reserve( 15 );
-
         // Difficulty calculation is different for campaigns. Difficulty affects only on starting resources for human players.
         const Settings & configuration = Settings::Get();
         const int difficultyLevel = ( configuration.isCampaignGameType() ? configuration.getCurrentMapInfo().difficulty : configuration.GameDifficulty() );

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -57,7 +57,7 @@ namespace
         return result;
     }
 
-    Maps::Indexes MapsIndexesObject( const MP2::MapObjectType objectType, const bool ignoreHeroes = true )
+    Maps::Indexes MapsIndexesObject( const MP2::MapObjectType objectType, const bool ignoreHeroes )
     {
         Maps::Indexes result;
         const int32_t size = static_cast<int32_t>( world.getSize() );
@@ -487,9 +487,21 @@ Maps::Indexes Maps::ScanAroundObjectWithDistance( const int32_t center, const ui
     return MapsIndexesFilteredObject( results, objectType );
 }
 
-Maps::Indexes Maps::GetObjectPositions( const MP2::MapObjectType objectType, bool ignoreHeroes )
+bool Maps::doesObjectExistOnMap( const MP2::MapObjectType objectType )
 {
-    return MapsIndexesObject( objectType, ignoreHeroes );
+    const int32_t size = static_cast<int32_t>( world.getSize() );
+    for ( int32_t idx = 0; idx < size; ++idx ) {
+        if ( world.GetTiles( idx ).GetObject( false ) == objectType ) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+Maps::Indexes Maps::GetObjectPositions( const MP2::MapObjectType objectType )
+{
+    return MapsIndexesObject( objectType, true );
 }
 
 Maps::Indexes Maps::GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes )

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -84,7 +84,12 @@ namespace Maps
     // tile without triggering a monster attack.
     Indexes getMonstersProtectingTile( const int32_t tileIndex, const bool checkObjectOnTile = true );
 
-    Indexes GetObjectPositions( const MP2::MapObjectType objectType, bool ignoreHeroes );
+    // This function always ignores heroes.
+    bool doesObjectExistOnMap( const MP2::MapObjectType objectType );
+
+    // This function always ignores heroes.
+    Indexes GetObjectPositions( const MP2::MapObjectType objectType );
+
     Indexes GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes );
 
     void ClearFog( const int32_t tileIndex, int scoutingDistance, const int playerColor );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1318,14 +1318,14 @@ void World::PostLoad( const bool setTilePassabilities )
     // Cache all tiles that that contain stone liths of a certain type (depending on object sprite index).
     _allTeleports.clear();
 
-    for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_STONE_LITHS, true ) ) {
+    for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_STONE_LITHS ) ) {
         _allTeleports[GetTiles( index ).GetObjectSpriteIndex()].push_back( index );
     }
 
     // Cache all tiles that contain a certain part of the whirlpool (depending on object sprite index).
     _allWhirlpools.clear();
 
-    for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_WHIRLPOOL, true ) ) {
+    for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_WHIRLPOOL ) ) {
         _allWhirlpools[GetTiles( index ).GetObjectSpriteIndex()].push_back( index );
     }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -954,6 +954,9 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, bool & isTerrit
                 bestIndex = newIndex;
                 maxTilesToReveal = tilesToReveal;
             }
+            else if ( maxTilesToReveal > 0 && tilesToReveal == maxTilesToReveal && _cache[newIndex]._cost < _cache[bestIndex]._cost ) {
+                bestIndex = newIndex;
+            }
             else {
                 nodesToExplore.push_back( newIndex );
             }
@@ -988,8 +991,11 @@ int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, bool & isTerrit
                 }
 
                 if ( tilesToReveal > maxTilesToReveal ) {
-                    bestIndex = newIndex;
+                    bestIndex = teleportIndex;
                     maxTilesToReveal = tilesToReveal;
+                }
+                else if ( maxTilesToReveal > 0 && tilesToReveal == maxTilesToReveal && _cache[teleportIndex]._cost < _cache[bestIndex]._cost ) {
+                    bestIndex = teleportIndex;
                 }
                 else {
                     nodesToExplore.push_back( teleportIndex );

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -27,7 +27,6 @@
 #include <memory>
 #include <set>
 #include <tuple>
-#include <type_traits>
 #include <utility>
 
 #include "army.h"
@@ -876,141 +875,110 @@ uint32_t AIWorldPathfinder::getMovementPenalty( const int from, const int to, co
     return defaultPenalty;
 }
 
-int AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero, bool & isTerritoryExpansion )
+std::pair<int32_t, bool> AIWorldPathfinder::getFogDiscoveryTile( const Heroes & hero )
 {
-    isTerritoryExpansion = false;
-
-    // paths have to be pre-calculated to find a spot where we're able to move
     reEvaluateIfNeeded( hero );
 
-    const int start = hero.GetIndex();
     const int scoutingDistance = hero.GetScoutingDistance();
-
     const Directions & directions = Direction::All();
-    std::vector<bool> tilesVisited( world.getSize(), false );
-    std::vector<int> nodesToExplore;
 
-    tilesVisited[start] = true;
+    struct TileCharacteristics
+    {
+        int32_t index{ -1 };
+        bool isFogNearby{ false };
+        uint32_t cost{ UINT32_MAX };
+        int32_t tilesToReveal{ 0 };
+    };
 
-    nodesToExplore.push_back( start );
+    TileCharacteristics bestTile;
 
-    int bestIndex = -1;
-
-    for ( size_t lastProcessedNode = 0; lastProcessedNode < nodesToExplore.size(); ++lastProcessedNode ) {
-        const int currentNodeIdx = nodesToExplore[lastProcessedNode];
-
-        if ( bestIndex == -1 && start != currentNodeIdx ) {
-            int32_t maxTilesToReveal = Maps::getFogTileCountToBeRevealed( currentNodeIdx, scoutingDistance, _color );
-            if ( maxTilesToReveal > 0 ) {
-                // Found a tile where we can reveal fog. Check for other tiles in the queue to find the one with the highest value.
-                bestIndex = currentNodeIdx;
-                for ( size_t i = lastProcessedNode + 1; i < nodesToExplore.size(); ++i ) {
-                    const int nodeIdx = nodesToExplore[i];
-                    const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( nodeIdx, scoutingDistance, _color );
-
-                    if ( std::make_tuple( maxTilesToReveal, _cache[nodeIdx]._cost ) < std::make_tuple( tilesToReveal, _cache[bestIndex]._cost ) ) {
-                        maxTilesToReveal = tilesToReveal;
-                        bestIndex = nodeIdx;
-                    }
-                }
-            }
+    for ( size_t idx = 0; idx < _cache.size(); ++idx ) {
+        const uint32_t nodeCost = _cache[idx]._cost;
+        if ( nodeCost == 0 ) {
+            continue;
         }
 
-        int32_t maxTilesToReveal = 0;
+        const int32_t tileIdx = static_cast<int32_t>( idx );
+        if ( !MP2::isSafeForFogDiscoveryObject( world.GetTiles( tileIdx ).GetObject( true ) ) ) {
+            continue;
+        }
 
-        for ( size_t i = 0; i < directions.size(); ++i ) {
-            if ( !Maps::isValidDirection( currentNodeIdx, directions[i] ) ) {
-                continue;
-            }
+        // It makes sense to consider only two types of accessible tiles for fog discovery: tiles that have at least one neighboring tile covered with fog, and tiles that
+        // have at least one neighboring tile inaccessible to the hero (since there may be unexplored tiles covered with fog on the other side of such an obstacle).
+        const auto [isFogNearby, isInaccessibleTileNearby] = [this, &directions, tileIdx]() {
+            std::pair<bool, bool> res{ false, false };
 
-            const int newIndex = currentNodeIdx + _mapOffset[i];
-
-            if ( tilesVisited[newIndex] ) {
-                continue;
-            }
-
-            tilesVisited[newIndex] = true;
-
-            if ( !MP2::isSafeForFogDiscoveryObject( world.GetTiles( newIndex ).GetObject( true ) ) ) {
-                continue;
-            }
-
-            // Tile is unreachable (maybe because it is guarded by too strong an army)
-            if ( _cache[newIndex]._cost == 0 ) {
-                continue;
-            }
-
-            int32_t tilesToReveal = 0;
-
-            for ( const int32_t tileIndex : Maps::getAroundIndexes( newIndex ) ) {
-                if ( world.GetTiles( tileIndex ).isFog( _color ) ) {
-                    // We found a tile which has a neighboring tile covered in fog.
-                    // Since the current tile is accessible for the hero, the tile covered by fog most likely is accessible too.
-                    ++tilesToReveal;
-                }
-            }
-
-            if ( tilesToReveal > maxTilesToReveal ) {
-                bestIndex = newIndex;
-                maxTilesToReveal = tilesToReveal;
-            }
-            else if ( maxTilesToReveal > 0 && tilesToReveal == maxTilesToReveal && _cache[newIndex]._cost < _cache[bestIndex]._cost ) {
-                bestIndex = newIndex;
-            }
-            else {
-                nodesToExplore.push_back( newIndex );
-            }
-
-            // If there is a teleport on this tile, we should also consider the endpoints
-            MapsIndexes teleports = world.GetTeleportEndPoints( newIndex );
-
-            if ( teleports.empty() ) {
-                teleports = world.GetWhirlpoolEndPoints( newIndex );
-            }
-
-            for ( const int teleportIndex : teleports ) {
-                if ( tilesVisited[teleportIndex] ) {
+            for ( size_t i = 0; i < directions.size(); ++i ) {
+                if ( !Maps::isValidDirection( tileIdx, directions[i] ) ) {
                     continue;
                 }
 
-                tilesVisited[teleportIndex] = true;
+                const int32_t nearbyIdx = tileIdx + _mapOffset[i];
 
-                // Teleport endpoint is unreachable (maybe because it is guarded by too strong an army)
-                if ( _cache[teleportIndex]._cost == 0 ) {
-                    continue;
+                // If at least one neighboring tile is covered with fog, then this is already enough to consider this tile
+                if ( world.GetTiles( nearbyIdx ).isFog( _color ) ) {
+                    res.first = true;
+
+                    break;
                 }
 
-                tilesToReveal = 0;
-
-                for ( const int32_t tileIndex : Maps::getAroundIndexes( teleportIndex ) ) {
-                    if ( world.GetTiles( tileIndex ).isFog( _color ) ) {
-                        // We found a tile which has a neighboring tile covered in fog.
-                        // Since the current tile is accessible for the hero, the tile covered by fog most likely is accessible too.
-                        ++tilesToReveal;
-                    }
-                }
-
-                if ( tilesToReveal > maxTilesToReveal ) {
-                    bestIndex = teleportIndex;
-                    maxTilesToReveal = tilesToReveal;
-                }
-                else if ( maxTilesToReveal > 0 && tilesToReveal == maxTilesToReveal && _cache[teleportIndex]._cost < _cache[bestIndex]._cost ) {
-                    bestIndex = teleportIndex;
-                }
-                else {
-                    nodesToExplore.push_back( teleportIndex );
+                // If some neighboring tile is inaccessible to the hero, then that's good, but maybe there will also be a neighboring tile covered with fog
+                if ( _cache[nearbyIdx]._cost == 0 ) {
+                    res.second = true;
                 }
             }
+
+            return res;
+        }();
+
+        // If we have found at least one accessible tile, the neighboring tile of which is covered with fog, then we are no longer interested in tiles that simply reveal
+        // some new distant tiles.
+        if ( bestTile.isFogNearby ? !isFogNearby : ( !isFogNearby && !isInaccessibleTileNearby ) ) {
+            continue;
         }
 
-        if ( maxTilesToReveal > 0 ) {
-            isTerritoryExpansion = true;
-            return bestIndex;
+        const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( tileIdx, scoutingDistance, _color );
+        assert( tilesToReveal >= 0 );
+
+        // If visiting this tile does not reveal any new tiles, then we are not interested in this tile.
+        if ( tilesToReveal == 0 ) {
+            continue;
         }
+
+        const bool isBetterTile = [&bestTile = std::as_const( bestTile ), nodeCost, isFogNearby = isFogNearby, tilesToReveal]() {
+            if ( isFogNearby && !bestTile.isFogNearby ) {
+                return true;
+            }
+
+            if ( isFogNearby != bestTile.isFogNearby ) {
+                return false;
+            }
+
+            if ( nodeCost < bestTile.cost ) {
+                return true;
+            }
+
+            if ( nodeCost != bestTile.cost ) {
+                return false;
+            }
+
+            if ( tilesToReveal > bestTile.tilesToReveal ) {
+                return true;
+            }
+
+            return false;
+        }();
+
+        if ( !isBetterTile ) {
+            continue;
+        }
+
+        // If we have found an accessible tile, the neighboring tile of which is covered with fog, then, most likely, that neighboring tile is also accessible. Such
+        // tiles have priority over those that simply reveal some new distant tiles.
+        bestTile = { tileIdx, isFogNearby, nodeCost, tilesToReveal };
     }
 
-    // If we reach here it means that no tiles covered by fog are really useful. Let's at least uncover something even if it's useless.
-    return bestIndex;
+    return { bestTile.index, bestTile.isFogNearby };
 }
 
 int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero )

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,6 +22,7 @@
 
 #include <cstdint>
 #include <list>
+#include <utility>
 #include <vector>
 
 #include "color.h"
@@ -161,7 +162,10 @@ public:
     void reEvaluateIfNeeded( const Heroes & hero );
     void reEvaluateIfNeeded( const int start, const int color, const double armyStrength, const uint8_t skill );
 
-    int getFogDiscoveryTile( const Heroes & hero, bool & isTerritoryExpansion );
+    // Finds the most profitable tile for fog discovery. Returns a pair consisting of the tile index (-1 if no suitable tile
+    // was found) and a boolean value, which takes the value true if there is fog next to this tile (that is, most likely,
+    // through this tile hero can get into some new areas), and false otherwise.
+    std::pair<int32_t, bool> getFogDiscoveryTile( const Heroes & hero );
 
     // Used for cases when heroes are stuck because one hero might be blocking the way and we have to move him.
     int getNearestTileToMove( const Heroes & hero );


### PR DESCRIPTION
- speed up decision making regarding Hut of Magi
- add correction coefficient for object value calculation that depends on time. The longer AI heroes play the lesser distance penalty.
- adjust fog discovery priorities for different AI hero roles
- add fog discovery value correction over time for AI heroes. In other words AI heroes will tend to uncover more fog over time.
- ~~adjust Observation Tower evaluation to exclude fog that can be uncover just by hero stepping on the object~~
- speed up Stables evaluation
- ~~remove hardcoded bonus values for Daemon Cave~~
- avoid visiting Oasis and Watering Hole if they bring no benefit
- improve picking correct tile index for fog discovery. Previously, AI heroes will choose any first tile that allows to uncover fog. Now the search continues to check all neighbouring tiles to find the best one.