### PR TITLE
Improve AI heroes interaction with Witch's Hut object

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -996,6 +996,7 @@ namespace
 
     void AIToWitchsHut( Heroes & hero, const MP2::MapObjectType objectType, const int32_t dst_index )
     {
+        (void)objectType;
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) )
 
         const Skill::Secondary & skill = getSecondarySkillFromWitchsHut( world.GetTiles( dst_index ) );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -994,24 +994,23 @@ namespace
         }
     }
 
-    void AIToWitchsHut( Heroes & hero, const MP2::MapObjectType objectType, const int32_t dst_index )
+    void AIToWitchsHut( Heroes & hero, const int32_t dst_index )
     {
-        (void)objectType;
-        DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) )
+        DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() )
 
         const Skill::Secondary & skill = getSecondarySkillFromWitchsHut( world.GetTiles( dst_index ) );
-        if ( !skill.isValid() ) {
+        if ( skill.isValid() ) {
+            if ( !hero.HasMaxSecondarySkill() && !hero.HasSecondarySkill( skill.Skill() ) ) {
+                hero.LearnSkill( skill );
+
+                if ( skill.Skill() == Skill::Secondary::SCOUTING ) {
+                    hero.Scout( hero.GetIndex() );
+                }
+            }
+        }
+        else {
             // A broken object?
             assert( 0 );
-            return;
-        }
-
-        if ( !hero.HasMaxSecondarySkill() && !hero.HasSecondarySkill( skill.Skill() ) ) {
-            hero.LearnSkill( skill );
-
-            if ( skill.Skill() == Skill::Secondary::SCOUTING ) {
-                hero.Scout( hero.GetIndex() );
-            }
         }
 
         // It is important to mark it globally so other heroes will know about the object.
@@ -1843,7 +1842,7 @@ namespace AI
 
         // Witch's hut
         case MP2::OBJ_WITCHS_HUT:
-            AIToWitchsHut( hero, objectType, dst_index );
+            AIToWitchsHut( hero, dst_index );
             break;
 
         // shrine circle

--- a/src/fheroes2/ai/normal/ai_normal.h
+++ b/src/fheroes2/ai/normal/ai_normal.h
@@ -314,6 +314,7 @@ namespace AI
         double getGeneralObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getCourierObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
+        double getScoutObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         int getCourierMainTarget( const Heroes & hero, const AIWorldPathfinder & pathfinder, double lowestPossibleValue ) const;
         double getResourcePriorityModifier( const int resource, const bool isMine ) const;
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1832,9 +1832,12 @@ namespace AI
             }
 
             double value = getGeneralObjectValue( hero, index, valueToIgnore, distanceToObject );
-            if ( skillType == Skill::Secondary::SCOUTING || skillType == Skill::Secondary::PATHFINDING ) {
+            if ( skillType == Skill::Secondary::SCOUTING || skillType == Skill::Secondary::LOGISTICS ) {
                 // Scouts should focus on scouting so these skills must have much higher priority.
                 value = value * 3;
+            }
+            else if ( skillType == Skill::Secondary::PATHFINDING ) {
+                value = value * 2;
             }
 
             return value;

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -1812,6 +1812,11 @@ namespace AI
 
         switch ( objectType ) {
         case MP2::OBJ_WITCHS_HUT: {
+            if ( !hero.isVisited( tile, Visit::GLOBAL ) ) {
+                // Since this object has not been visited use general value estimation.
+                return getGeneralObjectValue( hero, index, valueToIgnore, distanceToObject );
+            }
+
             const Skill::Secondary & skill = getSecondarySkillFromWitchsHut( tile );
             if ( !skill.isValid() || hero.HasMaxSecondarySkill() ) {
                 // This mustn't happen as these checks are done prior this code.
@@ -1821,7 +1826,8 @@ namespace AI
 
             const int skillType = skill.Skill();
             if ( hero.HasSecondarySkill( skillType ) ) {
-                // This can actually happen since AI heroes don't have prior knowledge about the skill.
+                // This mustn't happen as these checks are done prior this code.
+                assert( 0 );
                 return -dangerousTaskPenalty;
             }
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -385,8 +385,22 @@ namespace
         case MP2::OBJ_WITCHS_HUT: {
             const Skill::Secondary & skill = getSecondarySkillFromWitchsHut( tile );
             const int skillType = skill.Skill();
+            if ( !skill.isValid() ) {
+                // How is it possible that no skill exist?
+                assert( 0 );
+                return false;
+            }
 
-            if ( !skill.isValid() || hero.HasMaxSecondarySkill() || hero.HasSecondarySkill( skillType ) ) {
+            if ( hero.HasMaxSecondarySkill() ) {
+                return false;
+            }
+
+            if ( !hero.isVisited( tile, Visit::GLOBAL ) ) {
+                // The AI heroes should not have prior knowledge what skill this object has.
+                return true;
+            }
+
+            if ( hero.HasSecondarySkill( skillType ) ) {
                 return false;
             }
 
@@ -395,7 +409,7 @@ namespace
                 return false;
             }
 
-            if ( !hero.HaveSpellBook() && skillType == Skill::Secondary::MYSTICISM ) {
+            if ( !hero.HaveSpellBook() && ( skillType == Skill::Secondary::MYSTICISM || skillType == Skill::Secondary::EAGLE_EYE ) ) {
                 // It's useless to have Mysticism with no magic book in hands.
                 return false;
             }
@@ -1788,6 +1802,44 @@ namespace AI
         return getGeneralObjectValue( hero, index, valueToIgnore, distanceToObject );
     }
 
+    double Normal::getScoutObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const
+    {
+        // Courier should focus on its main task and visit other objects only if it's close to the destination
+        assert( hero.getAIRole() == Heroes::Role::SCOUT );
+
+        const Maps::Tiles & tile = world.GetTiles( index );
+        const MP2::MapObjectType objectType = tile.GetObject();
+
+        switch ( objectType ) {
+        case MP2::OBJ_WITCHS_HUT: {
+            const Skill::Secondary & skill = getSecondarySkillFromWitchsHut( tile );
+            if ( !skill.isValid() || hero.HasMaxSecondarySkill() ) {
+                // This mustn't happen as these checks are done prior this code.
+                assert( 0 );
+                return -dangerousTaskPenalty;
+            }
+
+            const int skillType = skill.Skill();
+            if ( hero.HasSecondarySkill( skillType ) ) {
+                // This can actually happen since AI heroes don't have prior knowledge about the skill.
+                return -dangerousTaskPenalty;
+            }
+
+            double value = getGeneralObjectValue( hero, index, valueToIgnore, distanceToObject );
+            if ( skillType == Skill::Secondary::SCOUTING || skillType == Skill::Secondary::PATHFINDING ) {
+                // Scouts should focus on scouting so these skills must have much higher priority.
+                value = value * 3;
+            }
+
+            return value;
+        }
+        default:
+            break;
+        }
+
+        return getGeneralObjectValue( hero, index, valueToIgnore, distanceToObject );
+    }
+
     double Normal::getObjectValue( const Heroes & hero, const int index, const int objectType, const double valueToIgnore, const uint32_t distanceToObject ) const
     {
         assert( objectType == world.GetTiles( index ).GetObject() );
@@ -1798,8 +1850,9 @@ namespace AI
 
         switch ( hero.getAIRole() ) {
         case Heroes::Role::HUNTER:
-        case Heroes::Role::SCOUT:
             return getGeneralObjectValue( hero, index, valueToIgnore, distanceToObject );
+        case Heroes::Role::SCOUT:
+            return getScoutObjectValue( hero, index, valueToIgnore, distanceToObject );
         case Heroes::Role::CHAMPION:
         case Heroes::Role::FIGHTER:
             return getFighterObjectValue( hero, index, valueToIgnore, distanceToObject );

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -175,7 +175,7 @@ namespace
         SpellStorage new_spells;
         new_spells.reserve( 10 );
 
-        const Skill::Secondary eagleeye( Skill::Secondary::EAGLEEYE, hero.GetLevelSkill( Skill::Secondary::EAGLEEYE ) );
+        const Skill::Secondary eagleeye( Skill::Secondary::EAGLE_EYE, hero.GetLevelSkill( Skill::Secondary::EAGLE_EYE ) );
 
         // filter spells
         for ( const Spell & sp : spells ) {
@@ -464,7 +464,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
             }
         }
 
-        if ( winnerHero && loserHero && winnerHero->GetLevelSkill( Skill::Secondary::EAGLEEYE ) && loserHero->isHeroes() ) {
+        if ( winnerHero && loserHero && winnerHero->GetLevelSkill( Skill::Secondary::EAGLE_EYE ) && loserHero->isHeroes() ) {
             eagleEyeSkillAction( *winnerHero, arena.GetUsageSpells(), winnerHero->isControlHuman(), randomGenerator );
         }
 

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -464,7 +464,7 @@ namespace
                 assert( 0 );
                 return {};
             }
-        case Skill::Secondary::EAGLEEYE:
+        case Skill::Secondary::EAGLE_EYE:
             switch ( secondarySkillLevel ) {
             case Skill::Level::BASIC:
                 return _( "campaignBonus|Basic Eagle Eye" );

--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -247,7 +247,7 @@ const Skill::values_t * GameStatic::GetSkillValues( int type )
         return &Skill::_values[9];
     case Skill::Secondary::BALLISTICS:
         return &Skill::_values[10];
-    case Skill::Secondary::EAGLEEYE:
+    case Skill::Secondary::EAGLE_EYE:
         return &Skill::_values[11];
     case Skill::Secondary::NECROMANCY:
         return &Skill::_values[12];

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -985,10 +985,6 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
         const Skill::Secondary & skill = getSecondarySkillFromWitchsHut( world.GetTiles( dst_index ) );
-
-        // If this assertion blows up the object is not set properly.
-        assert( skill.isValid() );
-
         if ( skill.isValid() ) {
             std::string msg = _( "You approach the hut and observe a witch inside studying an ancient tome on %{skill}.\n\n" );
             const std::string & skill_name = Skill::Secondary::String( skill.Skill() );
@@ -1027,6 +1023,10 @@ namespace
                                            Dialog::OK, { &secondarySkillUI } );
                 }
             }
+        }
+        else {
+            // A broken object?
+            assert( 0 );
         }
 
         hero.SetVisited( dst_index, Visit::GLOBAL );

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -49,7 +49,7 @@ namespace Skill
 
     const int secskills[]
         = { Secondary::PATHFINDING, Secondary::ARCHERY,   Secondary::LOGISTICS, Secondary::SCOUTING,   Secondary::DIPLOMACY, Secondary::NAVIGATION, Secondary::LEADERSHIP,
-            Secondary::WISDOM,      Secondary::MYSTICISM, Secondary::LUCK,      Secondary::BALLISTICS, Secondary::EAGLEEYE,  Secondary::NECROMANCY, Secondary::ESTATES };
+            Secondary::WISDOM,      Secondary::MYSTICISM, Secondary::LUCK,      Secondary::BALLISTICS, Secondary::EAGLE_EYE, Secondary::NECROMANCY, Secondary::ESTATES };
 }
 
 uint32_t Skill::Secondary::GetValues() const
@@ -311,7 +311,7 @@ int Skill::Secondary::RandForWitchsHut()
         if ( sec->diplomacy )
             v.push_back( DIPLOMACY );
         if ( sec->eagleeye )
-            v.push_back( EAGLEEYE );
+            v.push_back( EAGLE_EYE );
         if ( sec->estates )
             v.push_back( ESTATES );
         if ( sec->leadership )
@@ -372,7 +372,7 @@ const char * Skill::Secondary::String( int skill )
         return _( "Luck" );
     case BALLISTICS:
         return _( "Ballistics" );
-    case EAGLEEYE:
+    case EAGLE_EYE:
         return _( "Eagle Eye" );
     case NECROMANCY:
         return _( "Necromancy" );
@@ -505,7 +505,7 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
             break;
         }
         break;
-    case EAGLEEYE:
+    case EAGLE_EYE:
         switch ( Level() ) {
         case Level::BASIC:
             str = _( "%{skill} gives the hero a %{count} percent chance to learn any given 1st or 2nd level spell that was cast by an enemy during combat." );
@@ -559,7 +559,7 @@ Skill::SecSkills::SecSkills( int race )
             if ( ptr->initial_secondary.diplomacy )
                 AddSkill( Secondary( Secondary::DIPLOMACY, ptr->initial_secondary.diplomacy ) );
             if ( ptr->initial_secondary.eagleeye )
-                AddSkill( Secondary( Secondary::EAGLEEYE, ptr->initial_secondary.eagleeye ) );
+                AddSkill( Secondary( Secondary::EAGLE_EYE, ptr->initial_secondary.eagleeye ) );
             if ( ptr->initial_secondary.estates )
                 AddSkill( Secondary( Secondary::ESTATES, ptr->initial_secondary.estates ) );
             if ( ptr->initial_secondary.logistics )
@@ -696,7 +696,7 @@ int Skill::SecondaryGetWeightSkillFromRace( int race, int skill )
             return ptr->mature_secondary.luck;
         else if ( skill == Secondary::BALLISTICS )
             return ptr->mature_secondary.ballistics;
-        else if ( skill == Secondary::EAGLEEYE )
+        else if ( skill == Secondary::EAGLE_EYE )
             return ptr->mature_secondary.eagleeye;
         else if ( skill == Secondary::NECROMANCY )
             return ptr->mature_secondary.necromancy;

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -76,7 +76,7 @@ namespace Skill
             MYSTICISM = 9,
             LUCK = 10,
             BALLISTICS = 11,
-            EAGLEEYE = 12,
+            EAGLE_EYE = 12,
             NECROMANCY = 13,
             ESTATES = 14
         };


### PR DESCRIPTION
- AI heroes should not know what skill Witch's Hut contains till they visit it
- change the logic for Scout AI heroes to prioritize skills needed for their role
- scout territory for AI hero when he receives Scouting skill

I am not sure whether it is worth adding logic for save files in order to fix incorrect visited object information for Witch's Hut. One point against it is that heroes are loaded before kingdom.