### PR TITLE
Add surrender cost to battle result dialog

### DIFF
--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -133,7 +133,7 @@ namespace Battle
 
         const SpellStorage & GetUsageSpells() const;
 
-        bool DialogBattleSummary( const Result & res, const std::vector<Artifact> & artifacts, bool allowToCancel ) const;
+        bool DialogBattleSummary( const Result & res, const std::vector<Artifact> & artifacts, const bool allowToCancel ) const;
         int DialogBattleHero( const HeroBase & hero, const bool buttons, Status & status ) const;
         static void DialogBattleNecromancy( const uint32_t raiseCount );
 

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -133,7 +133,7 @@ namespace Battle
 
         const SpellStorage & GetUsageSpells() const;
 
-        bool DialogBattleSummary( const Result & res, const std::vector<Artifact> & artifacts, const bool allowToCancel ) const;
+        bool DialogBattleSummary( const Result & res, const std::vector<Artifact> & artifacts, const bool allowToRestart ) const;
         int DialogBattleHero( const HeroBase & hero, const bool buttons, Status & status ) const;
         static void DialogBattleNecromancy( const uint32_t raiseCount );
 

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -442,7 +442,6 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
         if ( res2 & RESULT_SURRENDER ) {
             title.append( _( "The enemy has surrendered!" ) );
             surrenderMessage.append( _( "Safe passage is granted for %{gold} gold." ) );
-            StringReplace( surrenderMessage, "%{heroName}", hero->GetName() );
             StringReplace( surrenderMessage, "%{gold}", std::to_string( surrenderCost ) );
         }
         else if ( res2 & RESULT_RETREAT ) {

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -442,7 +442,7 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
 
         if ( res2 & RESULT_SURRENDER ) {
             title.append( _( "The enemy has surrendered!" ) );
-            surrenderText.append( _( "They hand over %{gold} gold in shame." ) );
+            surrenderText.append( _( "Their cowardice costs them %{gold} gold." ) );
             StringReplace( surrenderText, "%{gold}", surrenderCost );
         }
         else if ( res2 & RESULT_RETREAT ) {
@@ -508,15 +508,16 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     // Set the cursor image. After this dialog the Game Area or the Battlefield will be shown, so it does not require a cursor restorer.
     Cursor::Get().SetThemes( Cursor::POINTER );
 
-    fheroes2::StandardWindow background( bsTextWidth + 16, 424, true, display );
+    fheroes2::StandardWindow background( bsTextWidth + 25, 424, true, display );
 
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
-    const fheroes2::Sprite animationBorder = Crop( fheroes2::AGG::GetICN( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE, 0 ), 43, 32, 231, 133 );
+    const fheroes2::Sprite & originalBorderImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE, 0 );
+    const fheroes2::Rect animationBorderRoi{ 43, 32, 231, 133 };
 
-    const fheroes2::Rect roi( background.activeArea() );
-    const fheroes2::Rect animationRoi( roi.x + ( ( roi.width - animationBorder.width() ) / 2 ) + 4, roi.y + 21, animationBorder.width(), animationBorder.height() );
-    Copy( animationBorder, 0, 0, display, animationRoi.x - 4, animationRoi.y - 4, animationRoi.width, animationRoi.height );
+    const fheroes2::Rect & roi( background.activeArea() );
+    const fheroes2::Rect animationRoi( roi.x + ( ( roi.width - animationBorderRoi.width ) / 2 ) + 4, roi.y + 21, animationBorderRoi.width, animationBorderRoi.height );
+    Copy( originalBorderImage, animationBorderRoi.x, animationBorderRoi.y, display, animationRoi.x - 4, animationRoi.y - 4, animationRoi.width, animationRoi.height );
 
     // Setup summary texts according to results and get the corresponding animation sequence.
     std::string surrenderText;

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -441,7 +441,7 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
 
         if ( res2 & RESULT_SURRENDER ) {
             title.append( _( "The enemy has surrendered!" ) );
-            surrenderMessage.append( _( "They are granted safe passage for %{gold} gold." ) );
+            surrenderMessage.append( _( "Safe passage is granted for %{gold} gold." ) );
             StringReplace( surrenderMessage, "%{heroName}", hero->GetName() );
             StringReplace( surrenderMessage, "%{gold}", std::to_string( surrenderCost ) );
         }

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -722,6 +722,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
             const char * currentArtifact = art.GetName();
             if ( previousArtifact == currentArtifact ) {
+                // Sound is never played for Ultimate Artifact messages.
                 if ( isWinnerHuman && !art.isUltimate() ) {
                     Game::PlayPickupSound();
                 }

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -508,7 +508,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     // Set the cursor image. After this dialog the Game Area or the Battlefield will be shown, so it does not require a cursor restorer.
     Cursor::Get().SetThemes( Cursor::POINTER );
 
-    fheroes2::StandardWindow background( bsTextWidth + 25, 424, true, display );
+    fheroes2::StandardWindow background( bsTextWidth + 32, 424, true, display );
 
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
@@ -572,32 +572,35 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
         summaryBodyOffset += box.height( summaryRoi.width );
         remainingSummaryBodyHeight -= box.height( summaryRoi.width );
     }
+
+    const fheroes2::FontType bodyFont = fheroes2::FontType::normalWhite();
     if ( !outcomeText.empty() ) {
         if ( !surrenderText.empty() ) {
             // Divide the main text area evenly between the two texts bodies by splitting it into 3 equal parts.
-            const fheroes2::Text upperText( surrenderText, fheroes2::FontType::normalWhite() );
-            const fheroes2::Text lowerText( outcomeText, fheroes2::FontType::normalWhite() );
+            const fheroes2::Text upperText( surrenderText, bodyFont );
+            const fheroes2::Text lowerText( outcomeText, bodyFont );
             const int32_t inbetweenSpace = ( remainingSummaryBodyHeight - upperText.height( summaryRoi.width ) - lowerText.height( summaryRoi.width ) ) / 3;
             upperText.draw( summaryRoi.x, summaryBodyOffset + inbetweenSpace, summaryRoi.width, display );
 
             lowerText.draw( summaryRoi.x, summaryBodyOffset + upperText.height( summaryRoi.width ) + inbetweenSpace * 2, summaryRoi.width, display );
         }
         else {
-            const fheroes2::Text upperText( outcomeText, fheroes2::FontType::normalWhite() );
+            const fheroes2::Text upperText( outcomeText, bodyFont );
             upperText.draw( summaryRoi.x, summaryBodyOffset + remainingSummaryBodyHeight / 2 - ( upperText.height( summaryRoi.width ) / 2 ), summaryRoi.width, display );
         }
     }
     else if ( !surrenderText.empty() ) {
-        const fheroes2::Text upperText( surrenderText, fheroes2::FontType::normalWhite() );
+        const fheroes2::Text upperText( surrenderText, bodyFont );
         upperText.draw( summaryRoi.x, summaryBodyOffset + remainingSummaryBodyHeight / 2 - ( upperText.height( summaryRoi.width ) / 2 ), summaryRoi.width, display );
     }
 
     // Battlefield casualties
-    fheroes2::Text text( _( "Battlefield Casualties" ), fheroes2::FontType::smallWhite() );
+    const fheroes2::FontType casualtiesFont = fheroes2::FontType::smallWhite();
+    fheroes2::Text text( _( "Battlefield Casualties" ), casualtiesFont );
     text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY, display );
 
     // Attacker
-    text.set( _( "Attacker" ), fheroes2::FontType::smallWhite() );
+    text.set( _( "Attacker" ), casualtiesFont );
     text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY + 15, display );
 
     const Troops killed1 = _army1->GetKilledTroops();
@@ -607,19 +610,19 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
         Army::drawSingleDetailedMonsterLine( killed1, summaryRoi.x + 13, casualtiesOffsetY + 36, roi.width - 47 );
     }
     else {
-        text.set( _( "None" ), fheroes2::FontType::smallWhite() );
+        text.set( _( "None" ), casualtiesFont );
         text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY + 30, display );
     }
 
     // defender
-    text.set( _( "Defender" ), fheroes2::FontType::smallWhite() );
+    text.set( _( "Defender" ), casualtiesFont );
     text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY + 75, display );
 
     if ( killed2.isValid() ) {
         Army::drawSingleDetailedMonsterLine( killed2, summaryRoi.x + 13, casualtiesOffsetY + 96, roi.width - 47 );
     }
     else {
-        text.set( _( "None" ), fheroes2::FontType::smallWhite() );
+        text.set( _( "None" ), casualtiesFont );
         text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY + 90, display );
     }
 

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -76,7 +76,7 @@ namespace
     // DialogBattleSummary text related values
     const int bsTextWidth = 270;
     const int bsTextXOffset = 25;
-    const int bsTextYOffset = 175;
+    const int bsTextYOffset = 174;
     const int bsTextIndent = 30;
 
     class LoopedAnimation
@@ -442,7 +442,7 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
         if ( res2 & RESULT_SURRENDER ) {
             title.append( _( "The enemy has surrendered!" ) );
             surrenderText.append( _( "Safe passage is granted for %{gold} gold." ) );
-            StringReplace( surrenderText, "%{gold}", std::to_string( surrenderCost ) );
+            StringReplace( surrenderText, "%{gold}", surrenderCost );
         }
         else if ( res2 & RESULT_RETREAT ) {
             title.append( _( "The enemy has fled!" ) );
@@ -569,8 +569,8 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     }
     if ( !surrenderText.empty() ) {
         const fheroes2::Text box( surrenderText, fheroes2::FontType::normalWhite() );
-        box.draw( pos_rt.x + bsTextXOffset, pos_rt.y + bsTextYOffset + 2 + messageYOffset, bsTextWidth, display );
-        messageYOffset += box.height( bsTextWidth );
+        box.draw( pos_rt.x + bsTextXOffset, pos_rt.y + bsTextYOffset + 2 + messageYOffset + 5, bsTextWidth, display );
+        messageYOffset += box.height( bsTextWidth ) + 5;
     }
     if ( !outcomeText.empty() ) {
         const fheroes2::Text box( outcomeText, fheroes2::FontType::normalWhite() );
@@ -1129,8 +1129,9 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdo
         if ( btnMarket.isEnabled() )
             le.MousePressLeft( btnMarket.area() ) ? btnMarket.drawOnPress() : btnMarket.drawOnRelease();
 
-        if ( btnAccept.isEnabled() && le.MouseClickLeft( btnAccept.area() ) )
+        if ( btnAccept.isEnabled() && ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) || le.MouseClickLeft( btnAccept.area() ) ) ) {
             result = true;
+        }
 
         if ( btnMarket.isEnabled() && le.MouseClickLeft( btnMarket.area() ) ) {
             Dialog::Marketplace( kingdom, false );

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -441,7 +441,7 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
 
         if ( res2 & RESULT_SURRENDER ) {
             title.append( _( "The enemy has surrendered!" ) );
-            surrenderText.append( _( "In shame, they hand over %{gold} gold." ) );
+            surrenderText.append( _( "They hand over %{gold} gold in shame." ) );
             StringReplace( surrenderText, "%{gold}", surrenderCost );
         }
         else if ( res2 & RESULT_RETREAT ) {

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -434,15 +434,15 @@ void Battle::DialogBattleSettings()
 }
 
 void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const HeroBase * hero, const uint32_t exp, const uint32_t surrenderCost,
-                               LoopedAnimationSequence & sequence, std::string & title, std::string & surrenderMessage, std::string & outcomeText )
+                               LoopedAnimationSequence & sequence, std::string & title, std::string & surrenderText, std::string & outcomeText )
 {
     if ( res1 & RESULT_WINS ) {
         sequence.push( ICN::WINCMBT, true );
 
         if ( res2 & RESULT_SURRENDER ) {
             title.append( _( "The enemy has surrendered!" ) );
-            surrenderMessage.append( _( "Safe passage is granted for %{gold} gold." ) );
-            StringReplace( surrenderMessage, "%{gold}", std::to_string( surrenderCost ) );
+            surrenderText.append( _( "Safe passage is granted for %{gold} gold." ) );
+            StringReplace( surrenderText, "%{gold}", std::to_string( surrenderCost ) );
         }
         else if ( res2 & RESULT_RETREAT ) {
             title.append( _( "The enemy has fled!" ) );
@@ -472,8 +472,8 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
 
         sequence.push( ICN::CMBTSURR, true );
 
-        surrenderMessage.append( _( "%{name} surrenders to the enemy, and departs in shame." ) );
-        StringReplace( surrenderMessage, "%{name}", hero->GetName() );
+        surrenderText.append( _( "%{name} surrenders to the enemy, and departs in shame." ) );
+        StringReplace( surrenderText, "%{name}", hero->GetName() );
     }
     else {
         sequence.push( ICN::CMBTLOS1, false );

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -398,8 +398,8 @@ namespace
 
 namespace Battle
 {
-    void GetSummaryParams( const uint32_t res1, const uint32_t res2, const HeroBase * hero, const uint32_t exp, const uint32_t surrenderCost, LoopedAnimationSequence & sequence,
-                           std::string & title, std::string & surrenderMessage, std::string & msg );
+    void GetSummaryParams( const uint32_t res1, const uint32_t res2, const HeroBase * hero, const uint32_t exp, const uint32_t surrenderCost,
+                           LoopedAnimationSequence & sequence, std::string & title, std::string & surrenderText, std::string & outcomeText );
 }
 
 void Battle::DialogBattleSettings()
@@ -433,8 +433,8 @@ void Battle::DialogBattleSettings()
     }
 }
 
-void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const HeroBase * hero, const uint32_t exp, const uint32_t surrenderCost, LoopedAnimationSequence & sequence,
-                               std::string & title, std::string & surrenderMessage, std::string & outcomeText )
+void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const HeroBase * hero, const uint32_t exp, const uint32_t surrenderCost,
+                               LoopedAnimationSequence & sequence, std::string & title, std::string & surrenderMessage, std::string & outcomeText )
 {
     if ( res1 & RESULT_WINS ) {
         sequence.push( ICN::WINCMBT, true );
@@ -481,7 +481,7 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
         sequence.push( ICN::CMBTLOS3, true );
 
         if ( hero && hero->isHeroes() ) {
-            outcomeText.append( _( "Your force suffer a bitter defeat, and %{name} abandons your cause." ) );
+            outcomeText.append( _( "Your forces suffer a bitter defeat, and %{name} abandons your cause." ) );
             StringReplace( outcomeText, "%{name}", hero->GetName() );
         }
         else {

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -653,7 +653,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
         if ( Game::HotKeyCloseWindow() || le.MouseClickLeft( buttonOk.area() ) ) {
             break;
         }
-        else if ( le.MousePressRight( buttonOk.area() ) ) {
+        if ( le.MousePressRight( buttonOk.area() ) ) {
             fheroes2::showStandardTextMessage( _( "Okay" ), _( "Click to leave the battle results." ), Dialog::ZERO );
         }
         else if ( allowToRestart ) {
@@ -661,7 +661,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
                 // Skip artifact transfer and return to restart the battle in manual mode
                 return true;
             }
-            else if ( le.MousePressRight( buttonRestart->area() ) ) {
+            if ( le.MousePressRight( buttonRestart->area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Restart" ), _( "Click to restart the battle in manual mode." ), Dialog::ZERO );
             }
         }

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -434,7 +434,7 @@ void Battle::DialogBattleSettings()
 }
 
 void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const HeroBase * hero, const uint32_t exp, const uint32_t surrenderCost, LoopedAnimationSequence & sequence,
-                               std::string & title, std::string & surrenderMessage, std::string & msg )
+                               std::string & title, std::string & surrenderMessage, std::string & outcomeText )
 {
     if ( res1 & RESULT_WINS ) {
         sequence.push( ICN::WINCMBT, true );
@@ -452,9 +452,9 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
         }
 
         if ( hero && hero->isHeroes() ) {
-            msg.append( _( "For valor in combat, %{name} receives %{exp} experience." ) );
-            StringReplace( msg, "%{name}", hero->GetName() );
-            StringReplace( msg, "%{exp}", exp );
+            outcomeText.append( _( "For valor in combat, %{name} receives %{exp} experience." ) );
+            StringReplace( outcomeText, "%{name}", hero->GetName() );
+            StringReplace( outcomeText, "%{exp}", exp );
         }
     }
     else if ( res1 & RESULT_RETREAT ) {
@@ -464,16 +464,16 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
         sequence.push( ICN::CMBTFLE2, false );
         sequence.push( ICN::CMBTFLE3, false );
 
-        msg.append( _( "The cowardly %{name} flees from battle." ) );
-        StringReplace( msg, "%{name}", hero->GetName() );
+        outcomeText.append( _( "The cowardly %{name} flees from battle." ) );
+        StringReplace( outcomeText, "%{name}", hero->GetName() );
     }
     else if ( res1 & RESULT_SURRENDER ) {
         assert( hero != nullptr );
 
         sequence.push( ICN::CMBTSURR, true );
 
-        msg.append( _( "%{name} surrenders to the enemy, and departs in shame." ) );
-        StringReplace( msg, "%{name}", hero->GetName() );
+        surrenderMessage.append( _( "%{name} surrenders to the enemy, and departs in shame." ) );
+        StringReplace( surrenderMessage, "%{name}", hero->GetName() );
     }
     else {
         sequence.push( ICN::CMBTLOS1, false );
@@ -481,11 +481,11 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
         sequence.push( ICN::CMBTLOS3, true );
 
         if ( hero && hero->isHeroes() ) {
-            msg.append( _( "Your force suffer a bitter defeat, and %{name} abandons your cause." ) );
-            StringReplace( msg, "%{name}", hero->GetName() );
+            outcomeText.append( _( "Your force suffer a bitter defeat, and %{name} abandons your cause." ) );
+            StringReplace( outcomeText, "%{name}", hero->GetName() );
         }
         else {
-            msg.append( _( "Your force suffer a bitter defeat." ) );
+            outcomeText.append( _( "Your force suffer a bitter defeat." ) );
         }
     }
 }
@@ -510,25 +510,25 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     // Set the cursor image. After this dialog the Game Area or the Battlefield will be shown, so it does not require a cursor restorer.
     Cursor::Get().SetThemes( Cursor::POINTER );
 
-    std::string firstMessage;
-    std::string secondMessage;
+    std::string surrenderText;
+    std::string outcomeText;
     std::string title;
     LoopedAnimationSequence sequence;
 
     if ( ( res.army1 & RESULT_WINS ) && ( attackerIsHuman ) ) {
-        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, _army2.get()->GetSurrenderCost(), sequence, title, firstMessage, secondMessage );
+        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, _army2.get()->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( ( res.army2 & RESULT_WINS ) && ( defenderIsHuman ) ) {
-        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, _army1.get()->GetSurrenderCost(), sequence, title, firstMessage, secondMessage );
+        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, _army1.get()->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( attackerIsHuman ) {
-        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, 0, sequence, title, firstMessage, secondMessage );
+        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, 0, sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( defenderIsHuman ) {
-        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, 0, sequence, title, firstMessage, secondMessage );
+        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, 0, sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
 
@@ -567,13 +567,13 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
         box.draw( pos_rt.x + bsTextXOffset, pos_rt.y + bsTextYOffset + 2, bsTextWidth, display );
         messageYOffset = box.height( bsTextWidth );
     }
-    if ( !firstMessage.empty() ) {
-        const fheroes2::Text box( firstMessage, fheroes2::FontType::normalWhite() );
+    if ( !surrenderText.empty() ) {
+        const fheroes2::Text box( surrenderText, fheroes2::FontType::normalWhite() );
         box.draw( pos_rt.x + bsTextXOffset, pos_rt.y + bsTextYOffset + 2 + messageYOffset, bsTextWidth, display );
         messageYOffset += box.height( bsTextWidth );
     }
-    if ( !secondMessage.empty() ) {
-        const fheroes2::Text box( secondMessage, fheroes2::FontType::normalWhite() );
+    if ( !outcomeText.empty() ) {
+        const fheroes2::Text box( outcomeText, fheroes2::FontType::normalWhite() );
         box.draw( pos_rt.x + bsTextXOffset, pos_rt.y + bsTextYOffset + 2 + messageYOffset + 5, bsTextWidth, display );
     }
 

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -649,7 +649,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
         if ( allowToRestart ) {
             le.MousePressLeft( buttonRestart->area() ) ? buttonRestart->drawOnPress() : buttonRestart->drawOnRelease();
         }
-        
+
         if ( Game::HotKeyCloseWindow() || le.MouseClickLeft( buttonOk.area() ) ) {
             break;
         }
@@ -671,7 +671,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
             const fheroes2::Sprite & base = fheroes2::AGG::GetICN( sequence.id(), 0 );
             const fheroes2::Sprite & sequenceCurrent = fheroes2::AGG::GetICN( sequence.id(), sequence.frameId() );
 
-            Copy( base, 0, 0, display, animationRoi.x + sequenceBase.x(), animationRoi.y + sequenceBase.y(), base.width(),base.height() );
+            Copy( base, 0, 0, display, animationRoi.x + sequenceBase.x(), animationRoi.y + sequenceBase.y(), base.width(), base.height() );
             fheroes2::Blit( sequenceCurrent, display, animationRoi.x + sequenceCurrent.x(), animationRoi.y + sequenceCurrent.y() );
             display.render( animationRoi );
         }

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -526,12 +526,12 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     LoopedAnimationSequence sequence;
 
     fheroes2::FontType summaryTitleFont = fheroes2::FontType::normalWhite();
-    if ( ( res.army1 & RESULT_WINS ) && ( attackerIsHuman ) ) {
+    if ( ( res.army1 & RESULT_WINS ) && attackerIsHuman ) {
         GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, _army2->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
         summaryTitleFont = fheroes2::FontType::normalYellow();
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
-    else if ( ( res.army2 & RESULT_WINS ) && ( defenderIsHuman ) ) {
+    else if ( ( res.army2 & RESULT_WINS ) && defenderIsHuman ) {
         GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, _army1->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
         summaryTitleFont = fheroes2::FontType::normalYellow();
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
@@ -645,6 +645,8 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
     LocalEvent & le = LocalEvent::Get();
 
+    int sequenceId = sequence.id();
+
     while ( le.HandleEvents() ) {
         le.MousePressLeft( buttonOk.area() ) ? buttonOk.drawOnPress() : buttonOk.drawOnRelease();
         if ( allowToRestart ) {
@@ -669,10 +671,14 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
         // animation
         if ( Game::validateAnimationDelay( Game::BATTLE_DIALOG_DELAY ) && !sequence.nextFrame() ) {
-            const fheroes2::Sprite & base = fheroes2::AGG::GetICN( sequence.id(), 0 );
+            if ( sequenceId != sequence.id() ) {
+                sequenceId = sequence.id();
+                const fheroes2::Sprite & base = fheroes2::AGG::GetICN( sequenceId, 0 );
+
+                Copy( base, 0, 0, display, animationRoi.x + base.x(), animationRoi.y + base.y(), base.width(), base.height() );
+            }
             const fheroes2::Sprite & sequenceCurrent = fheroes2::AGG::GetICN( sequence.id(), sequence.frameId() );
 
-            Copy( base, 0, 0, display, animationRoi.x + sequenceBase.x(), animationRoi.y + sequenceBase.y(), base.width(), base.height() );
             fheroes2::Blit( sequenceCurrent, display, animationRoi.x + sequenceCurrent.x(), animationRoi.y + sequenceCurrent.y() );
             display.render( animationRoi );
         }
@@ -751,10 +757,14 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
                     }
                     // animation
                     if ( Game::validateAnimationDelay( Game::BATTLE_DIALOG_DELAY ) && !sequence.nextFrame() ) {
-                        const fheroes2::Sprite & base = fheroes2::AGG::GetICN( sequence.id(), 0 );
+                        if ( sequenceId != sequence.id() ) {
+                            sequenceId = sequence.id();
+                            const fheroes2::Sprite & base = fheroes2::AGG::GetICN( sequenceId, 0 );
+
+                            Copy( base, 0, 0, display, animationRoi.x + base.x(), animationRoi.y + base.y(), base.width(), base.height() );
+                        }
                         const fheroes2::Sprite & sequenceCurrent = fheroes2::AGG::GetICN( sequence.id(), sequence.frameId() );
 
-                        Copy( base, 0, 0, display, animationRoi.x + sequenceBase.x(), animationRoi.y + sequenceBase.y(), base.width(), base.height() );
                         fheroes2::Blit( sequenceCurrent, display, animationRoi.x + sequenceCurrent.x(), animationRoi.y + sequenceCurrent.y() );
                         display.render( animationRoi );
                     }

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -556,7 +556,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     Copy( sequenceStart, 0, 0, display, animationRoi.x, animationRoi.y, sequenceStart.width(), sequenceStart.height() );
 
     const fheroes2::Rect summaryRoi( roi.x + 11, roi.y + bsTextYOffset, roi.width - 22, roi.height - bsTextYOffset - 46 );
-    const uint32_t casualtiesOffsetY = summaryRoi.y + 96;
+    const int32_t casualtiesOffsetY = summaryRoi.y + 96;
     int32_t summaryBodyOffset = summaryRoi.y;
     int32_t remainingSummaryBodyHeight = casualtiesOffsetY - summaryBodyOffset;
     if ( !title.empty() ) {
@@ -678,7 +678,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
         for ( const Artifact & art : artifacts ) {
             if ( isWinnerHuman || art.isUltimate() ) { // always show the message for ultimate artifacts
-                background.renderBackgroundImage( display, summaryRoi, 0, isEvilInterface );
+                fheroes2::StandardWindow::renderBackgroundImage( display, summaryRoi, 0, isEvilInterface );
 
                 std::string artMsg;
                 if ( art.isUltimate() ) {

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -516,11 +516,11 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     LoopedAnimationSequence sequence;
 
     if ( ( res.army1 & RESULT_WINS ) && ( attackerIsHuman ) ) {
-        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, _army2.get()->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
+        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, _army2->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( ( res.army2 & RESULT_WINS ) && ( defenderIsHuman ) ) {
-        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, _army1.get()->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
+        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, _army1->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( attackerIsHuman ) {

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -592,11 +592,11 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
         upperText.draw( summaryRoi.x, summaryBodyOffset + remainingSummaryBodyHeight / 2 - ( upperText.height( summaryRoi.width ) / 2 ), summaryRoi.width, display );
     }
 
-    // battlefield casualties
+    // Battlefield casualties
     fheroes2::Text text( _( "Battlefield Casualties" ), fheroes2::FontType::smallWhite() );
     text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY, display );
 
-    // attacker
+    // Attacker
     text.set( _( "Attacker" ), fheroes2::FontType::smallWhite() );
     text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY + 15, display );
 
@@ -668,7 +668,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
             }
         }
 
-        // animation
+        // Animation
         if ( Game::validateAnimationDelay( Game::BATTLE_DIALOG_DELAY ) && !sequence.nextFrame() ) {
             if ( sequenceId != sequence.id() ) {
                 sequenceId = sequence.id();
@@ -719,6 +719,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
             if ( !isWinnerHuman && !art.isUltimate() ) {
                 continue;
             }
+
             const char * currentArtifact = art.GetName();
             if ( previousArtifact == currentArtifact ) {
                 if ( isWinnerHuman && !art.isUltimate() ) {
@@ -726,7 +727,20 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
                 }
                 continue;
             }
-            if ( art.isUltimate() ) {
+
+            if ( !art.isUltimate() ) {
+                // Only draw the regular artifact header once.
+                if ( !needHeaderRedraw ) {
+                    artMsg = _( "You have captured an enemy artifact!" );
+
+                    const fheroes2::Text box( artMsg, fheroes2::FontType::normalYellow() );
+                    box.draw( summaryRoi.x, summaryRoi.y, summaryRoi.width, display );
+
+                    needHeaderRedraw = true;
+                }
+                Game::PlayPickupSound();
+            }
+            else {
                 // Ultimate artifacts are always displayed after all the regular artifacts.
                 if ( needHeaderRedraw ) {
                     artifactHeader.restore();
@@ -744,25 +758,11 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
                 needHeaderRedraw = true;
             }
-            // Only draw the regular artifact header once.
-            else if ( !needHeaderRedraw ) {
-                Game::PlayPickupSound();
-                artMsg = _( "You have captured an enemy artifact!" );
-
-                const fheroes2::Text box( artMsg, fheroes2::FontType::normalYellow() );
-                box.draw( summaryRoi.x, summaryRoi.y, summaryRoi.width, display );
-
-                needHeaderRedraw = true;
-            }
-            else {
-                Game::PlayPickupSound();
-            }
-
-            artifactName.restore();
 
             const fheroes2::Sprite & artifact = fheroes2::AGG::GetICN( ICN::ARTIFACT, art.IndexSprite64() );
-
             Copy( artifact, 0, 0, display, artifactArea.x + 8, artifactArea.y + 8, artifact.width(), artifact.height() );
+
+            artifactName.restore();
 
             const fheroes2::Text artName( currentArtifact, fheroes2::FontType::smallWhite() );
             artName.draw( summaryRoi.x, artifactArea.y + border.height() + 7, summaryRoi.width, display );
@@ -774,7 +774,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
             while ( le.HandleEvents() ) {
                 le.MousePressLeft( buttonOk.area() ) ? buttonOk.drawOnPress() : buttonOk.drawOnRelease();
 
-                // display captured artifact info on right click
+                // Display captured artifact info on right click
                 if ( le.MousePressRight( artifactArea ) ) {
                     fheroes2::ArtifactDialogElement( art ).showPopup( Dialog::ZERO );
                 }
@@ -784,7 +784,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
                 else if ( le.MousePressRight( buttonOk.area() ) ) {
                     fheroes2::showStandardTextMessage( _( "Okay" ), _( "Exit this menu." ), Dialog::ZERO );
                 }
-                // animation
+                // Animation
                 if ( Game::validateAnimationDelay( Game::BATTLE_DIALOG_DELAY ) && !sequence.nextFrame() ) {
                     if ( sequenceId != sequence.id() ) {
                         sequenceId = sequence.id();

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -485,7 +485,7 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
             StringReplace( outcomeText, "%{name}", hero->GetName() );
         }
         else {
-            outcomeText.append( _( "Your force suffer a bitter defeat." ) );
+            outcomeText.append( _( "Your forces suffer a bitter defeat." ) );
         }
     }
 }


### PR DESCRIPTION
The window had to be widened to allow having two strings. This is better than increasing the height of the window since there's barely anything left to use in standard 640x480.

This phrasing was come up with thanks to the help of native speaker ObsessiveRepulsive:
<img width="381" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/115ac54a-f9fa-40e5-adff-d00963b7a8f8">

Close #8221 