### PR TITLE
Allow units that ignore retaliatory strikes to attack neighboring enemy units while covering archers

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -1632,7 +1632,7 @@ namespace AI
                 assert( Board::isValidIndex( target.cell ) );
 
                 // The unit is going to attack one of the enemy units that blocked the archer, nothing else needs to be done
-                if ( target.cell != bestCoverCellInfo.idx || target.unit != nullptr ) {
+                if ( target.unit != nullptr ) {
                     continue;
                 }
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -590,7 +590,7 @@ namespace AI
         // Step 1. Analyze current battle state and update variables
         analyzeBattleState( arena, currentUnit );
 
-        DEBUG_LOG( DBG_BATTLE, DBG_TRACE, currentUnit.GetName() << " begin the turn, color: " << Color::String( _myColor ) )
+        DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " begin the turn, color: " << Color::String( _myColor ) )
 
         // Step 2. Check retreat/surrender condition
         const Heroes * actualHero = dynamic_cast<const Heroes *>( _commander );
@@ -713,8 +713,6 @@ namespace AI
             }
 
             // Melee unit final stage - add actions to the queue
-            DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " melee phase end, target cell: " << target.cell )
-
             if ( target.cell != -1 ) {
                 // The target cell of the movement must be the cell that the unit's head will occupy
                 const int32_t moveTargetIdx = getUnitMovementTarget( arena, currentUnit, target.cell );
@@ -949,7 +947,7 @@ namespace AI
         // distance attack capabilities.
         _cautiousOffensive = ( enemyArcherRatio < 0.15 );
 
-        DEBUG_LOG( DBG_BATTLE, DBG_TRACE,
+        DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                    ( _defensiveTactics ? "Defensive" : ( _cautiousOffensive ? "Cautious offensive" : "Offensive" ) )
                        << " tactics have been chosen. Army strength: " << _myArmyStrength << ", shooters strength: " << _myShootersStrength
                        << ", enemy army strength: " << _enemyArmyStrength << ", enemy shooters strength: " << _enemyShootersStrength )
@@ -1314,12 +1312,16 @@ namespace AI
 
                     target.cell = outcome.fromIndex;
                     target.unit = enemy;
+
+                    DEBUG_LOG( DBG_BATTLE, DBG_TRACE,
+                               "- Set attack priority on " << enemy->GetName() << ", attack value: " << outcome.attackValue
+                                                           << ", position value: " << outcome.positionValue )
                 }
             }
         }
 
         if ( target.unit ) {
-            DEBUG_LOG( DBG_BATTLE, DBG_TRACE, currentUnit.GetName() << " attacking " << target.unit->GetName() << " from cell " << target.cell )
+            DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " attacking " << target.unit->GetName() << " from cell " << target.cell )
 
             return target;
         }
@@ -1617,6 +1619,10 @@ namespace AI
 
                             target.cell = outcome.fromIndex;
                             target.unit = outcome.canAttackImmediately ? enemy : nullptr;
+
+                            DEBUG_LOG( DBG_BATTLE, DBG_TRACE,
+                                       "- Set attack priority on " << enemy->GetName() << ", attack value: " << outcome.attackValue
+                                                                   << ", position value: " << outcome.positionValue )
                         }
                     }
                 }
@@ -1655,6 +1661,8 @@ namespace AI
                             bestAttackValue = attackValue;
 
                             target.unit = enemy;
+
+                            DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "- Set attack priority on " << enemy->GetName() << ", attack value: " << attackValue )
                         }
                     }
                 }
@@ -1663,7 +1671,7 @@ namespace AI
 
         if ( target.cell != -1 ) {
             if ( target.unit ) {
-                DEBUG_LOG( DBG_BATTLE, DBG_TRACE, currentUnit.GetName() << " attacking " << target.unit->GetName() << " from cell " << target.cell )
+                DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " attacking " << target.unit->GetName() << " from cell " << target.cell )
             }
             else {
                 DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " covering friendly archers, moving to cell " << target.cell )
@@ -1692,11 +1700,15 @@ namespace AI
 
                     target.cell = outcome.fromIndex;
                     target.unit = outcome.canAttackImmediately ? enemy : nullptr;
+
+                    DEBUG_LOG( DBG_BATTLE, DBG_TRACE,
+                               "- Set attack priority on " << enemy->GetName() << ", attack value: " << outcome.attackValue
+                                                           << ", position value: " << outcome.positionValue )
                 }
             }
 
             if ( target.unit ) {
-                DEBUG_LOG( DBG_BATTLE, DBG_TRACE, currentUnit.GetName() << " attacking " << target.unit->GetName() << " from cell " << target.cell )
+                DEBUG_LOG( DBG_BATTLE, DBG_INFO, currentUnit.GetName() << " attacking " << target.unit->GetName() << " from cell " << target.cell )
             }
         }
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -1637,7 +1637,7 @@ namespace AI
                 }
 
                 // It makes sense for a unit that ignores retaliation to attack neighboring enemy units, even if it is covering an archer, since in this case it will not
-                // receive unnecessary damage (which could affect the duration of the cover)
+                // receive unnecessary retaliatory damage (which could affect the duration of the cover)
                 if ( !currentUnit.isIgnoringRetaliation() ) {
                     continue;
                 }

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -107,7 +107,7 @@ namespace AI
 
     std::pair<int32_t, int> optimalAttackVector( const Unit & attacker, const Unit & target, const Position & attackPos )
     {
-        assert( attackPos.GetHead() != nullptr && ( !attacker.isWide() || attackPos.GetTail() != nullptr ) );
+        assert( attackPos.isValidForUnit( attacker ) );
         assert( Board::CanAttackTargetFromPosition( attacker, target, attackPos.GetHead()->GetIndex() ) );
 
         const Position & targetPos = target.GetPosition();
@@ -157,7 +157,7 @@ namespace AI
 
     int32_t optimalAttackValue( const Unit & attacker, const Unit & target, const Position & attackPos )
     {
-        assert( attackPos.GetHead() != nullptr && ( !attacker.isWide() || attackPos.GetTail() != nullptr ) );
+        assert( attackPos.isValidForUnit( attacker ) );
 
         if ( attacker.isAllAdjacentCellsAttack() ) {
             const Board * board = Arena::GetBoard();
@@ -225,7 +225,7 @@ namespace AI
                     continue;
                 }
 
-                assert( !attacker.isWide() || pos.GetTail() != nullptr );
+                assert( pos.isValidForUnit( attacker ) );
 
                 const uint32_t dist = Board::GetDistance( pos, enemyUnit->GetPosition() );
                 assert( dist > 0 );
@@ -284,7 +284,7 @@ namespace AI
                 continue;
             }
 
-            assert( !unit->isWide() || nearbyPos.GetTail() != nullptr );
+            assert( nearbyPos.isValidForUnit( unit ) );
 
             return true;
         }
@@ -404,7 +404,7 @@ namespace AI
         for ( const auto & [stepPos, stepThreatLevel] : pathStepsThreatLevels ) {
             // We need to get as close to the target as possible (taking into account the threat level)
             if ( targetIdx == -1 || stepThreatLevel < lowestThreat || std::fabs( stepThreatLevel - lowestThreat ) < 0.001 ) {
-                assert( stepPos.GetHead() != nullptr && ( !currentUnit.isWide() || stepPos.GetTail() != nullptr ) );
+                assert( stepPos.isValidForUnit( currentUnit ) );
 
                 lowestThreat = stepThreatLevel;
                 // When moving along the path, the direction of a wide unit at some steps may be reversed in relation to the target one. Detect this and use the proper
@@ -433,7 +433,7 @@ namespace AI
                 continue;
             }
 
-            assert( !currentUnit.isWide() || pos.GetTail() != nullptr );
+            assert( pos.isValidForUnit( currentUnit ) );
 
             const uint32_t dist = Board::GetDistance( pos, target.GetPosition() );
             assert( dist > 0 );
@@ -461,7 +461,7 @@ namespace AI
         {
             const Position pos = Position::GetReachable( currentUnit, idx );
             if ( pos.GetHead() != nullptr ) {
-                assert( !currentUnit.isWide() || pos.GetTail() != nullptr );
+                assert( pos.isValidForUnit( currentUnit ) );
 
                 return pos.GetHead()->GetIndex();
             }
@@ -469,10 +469,10 @@ namespace AI
 
         // If there is no such position, then use the last position on the path to the cell with the specified index
         const Position dstPos = Position::GetPosition( currentUnit, idx );
-        assert( dstPos.GetHead() != nullptr && ( !currentUnit.isWide() || dstPos.GetTail() != nullptr ) );
+        assert( dstPos.isValidForUnit( currentUnit ) );
 
         const Position pos = arena.getClosestReachablePosition( currentUnit, dstPos );
-        assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
+        assert( pos.isValidForUnit( currentUnit ) );
 
         return pos.GetHead()->GetIndex();
     }
@@ -719,7 +719,7 @@ namespace AI
 
                 if ( target.unit ) {
                     const Position attackPos = Position::GetReachable( currentUnit, moveTargetIdx );
-                    assert( attackPos.GetHead() != nullptr && ( !currentUnit.isWide() || attackPos.GetTail() != nullptr ) );
+                    assert( attackPos.isValidForUnit( currentUnit ) );
 
                     const auto [attackTargetIdx, attackDirection] = optimalAttackVector( currentUnit, *target.unit, attackPos );
 
@@ -988,7 +988,7 @@ namespace AI
                         const int32_t headIdx = unitToRemove.GetHeadIndex();
                         const int32_t tailIdx = unitToRemove.GetTailIndex();
 
-                        assert( headIdx != -1 && ( !unitToRemove.isWide() || tailIdx != -1 ) );
+                        assert( headIdx != -1 && ( unitToRemove.isWide() ? tailIdx != -1 : tailIdx == -1 ) );
 
                         unitToRestore = getUnitOnCell( headIdx );
                         assert( unitToRestore == &unitToRemove );
@@ -1011,7 +1011,7 @@ namespace AI
                         const int32_t headIdx = unitToRestore->GetHeadIndex();
                         const int32_t tailIdx = unitToRestore->GetTailIndex();
 
-                        assert( headIdx != -1 && ( !unitToRestore->isWide() || tailIdx != -1 ) );
+                        assert( headIdx != -1 && ( unitToRestore->isWide() ? tailIdx != -1 : tailIdx == -1 ) );
 
                         setUnitForCell( headIdx, unitToRestore );
 
@@ -1356,7 +1356,7 @@ namespace AI
                 maxPriority = unitPriority;
 
                 const Position pos = Position::GetPosition( currentUnit, nearestCellInfo.idx );
-                assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
+                assert( pos.isValidForUnit( currentUnit ) );
 
                 const Indexes path = arena.GetPath( currentUnit, pos );
                 assert( !path.empty() );
@@ -1395,7 +1395,7 @@ namespace AI
                     continue;
                 }
 
-                assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
+                assert( pos.isValidForUnit( currentUnit ) );
 
                 const uint32_t moveDist = arena.CalculateMoveDistance( currentUnit, pos );
                 if ( target.cell == -1 || moveDist < shortestDist ) {
@@ -1538,7 +1538,7 @@ namespace AI
                             continue;
                         }
 
-                        assert( !currentUnit.isWide() || pos.GetTail() != nullptr );
+                        assert( pos.isValidForUnit( currentUnit ) );
                         assert( Board::GetDistance( pos, frnd->GetPosition() ) == 1 );
 
                         if ( !arena.isPositionReachable( currentUnit, pos, false ) ) {
@@ -1654,7 +1654,7 @@ namespace AI
                         }
 
                         const Position pos = Position::GetReachable( currentUnit, target.cell );
-                        assert( pos.GetHead() != nullptr && ( !currentUnit.isWide() || pos.GetTail() != nullptr ) );
+                        assert( pos.isValidForUnit( currentUnit ) );
 
                         const int32_t attackValue = optimalAttackValue( currentUnit, *enemy, pos );
                         if ( bestAttackValue < attackValue ) {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -68,7 +68,7 @@ namespace
         const int32_t attackPositionHeadIdx = attackPosition.GetHead() ? attackPosition.GetHead()->GetIndex() : -1;
         const int32_t attackPositionTailIdx = attackPosition.GetTail() ? attackPosition.GetTail()->GetIndex() : -1;
 
-        assert( attackPositionHeadIdx != -1 && ( !attackingUnit.isWide() || attackPositionTailIdx != -1 ) );
+        assert( attackPositionHeadIdx != -1 && ( attackingUnit.isWide() ? attackPositionTailIdx != -1 : attackPositionTailIdx == -1 ) );
 
         if ( Battle::Board::CanAttackFromCell( attackingUnit, attackPositionHeadIdx ) ) {
             // The defender's head cell is near the head cell of the attack position
@@ -103,7 +103,7 @@ namespace
         const int32_t attackPositionHeadIdx = attackPosition.GetHead() ? attackPosition.GetHead()->GetIndex() : -1;
         const int32_t attackPositionTailIdx = attackPosition.GetTail() ? attackPosition.GetTail()->GetIndex() : -1;
 
-        assert( attackPositionHeadIdx != -1 && ( !attackingUnit.isWide() || attackPositionTailIdx != -1 ) );
+        assert( attackPositionHeadIdx != -1 && ( attackingUnit.isWide() ? attackPositionTailIdx != -1 : attackPositionTailIdx == -1 ) );
 
         // The target cell of the attack is near the head cell of the attack position
         if ( Battle::Board::CanAttackFromCell( attackingUnit, attackPositionHeadIdx ) && Battle::Board::isNearIndexes( attackPositionHeadIdx, attackTargetIdx ) ) {
@@ -133,7 +133,7 @@ namespace
             return false;
         }
 
-        assert( !unit->isWide() || pos.GetTail() != nullptr );
+        assert( pos.isValidForUnit( unit ) );
 
         // Index of the destination cell should correspond to the index of the head cell of the target position and nothing else
         if ( pos.GetHead()->GetIndex() != dst ) {
@@ -310,7 +310,7 @@ void Battle::Arena::moveUnit( Unit * unit, const int32_t dst )
     assert( checkMoveParams( unit, dst ) );
 
     Position pos = Position::GetReachable( *unit, dst );
-    assert( pos.GetHead() != nullptr && ( !unit->isWide() || pos.GetTail() != nullptr ) );
+    assert( pos.isValidForUnit( unit ) );
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE,
                unit->String() << ", dst: " << dst << ", (head: " << pos.GetHead()->GetIndex() << ", tail: " << ( unit->isWide() ? pos.GetTail()->GetIndex() : -1 )
@@ -559,7 +559,7 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
             return false;
         }
 
-        assert( !attacker->isWide() || attackPos.GetTail() != nullptr );
+        assert( attackPos.isValidForUnit( attacker ) );
 
         if ( tgt < 0 ) {
             tgt = calculateAttackTarget( *attacker, attackPos, *defender );
@@ -1510,7 +1510,7 @@ void Battle::Arena::ApplyActionSpellTeleport( Command & cmd )
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "src: " << src << ", dst: " << dst )
 
     const Position pos = Position::GetPosition( *unit, dst );
-    assert( pos.GetHead() != nullptr && ( !unit->isWide() || pos.GetTail() != nullptr ) );
+    assert( pos.isValidForUnit( unit ) );
 
     if ( _interface ) {
         const HeroBase * commander = GetCurrentCommander();
@@ -1633,7 +1633,7 @@ void Battle::Arena::ApplyActionSpellMirrorImage( Command & cmd )
         assert( mirrorUnit != nullptr );
 
         const Position pos = Position::GetPosition( *mirrorUnit, *it );
-        assert( pos.GetHead() != nullptr && ( !mirrorUnit->isWide() || pos.GetTail() != nullptr ) );
+        assert( pos.isValidForUnit( mirrorUnit ) );
 
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "set position: " << pos.GetHead()->GetIndex() )
 

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -198,7 +198,7 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t tgt
             attacker.UpdateDirection( board[tgt].GetPos() );
         }
 
-        if ( !attacker.ignoreRetaliation() && defender.AllowResponse() ) {
+        if ( !attacker.isIgnoringRetaliation() && defender.AllowResponse() ) {
             const int32_t responseTgt = calculateAttackTarget( defender, defender.GetPosition(), attacker );
             const int responseDir = calculateAttackDirection( defender, defender.GetPosition(), responseTgt );
 
@@ -626,7 +626,7 @@ void Battle::Arena::ApplyActionAttack( Command & cmd )
     BattleProcess( *attacker, *defender, tgt, dir );
 
     if ( defender->isValid() ) {
-        if ( handfighting && !attacker->ignoreRetaliation() && defender->AllowResponse() ) {
+        if ( handfighting && !attacker->isIgnoringRetaliation() && defender->AllowResponse() ) {
             BattleProcess( *defender, *attacker );
             defender->SetResponse();
         }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -125,7 +125,7 @@ Battle::Force::Force( Army & parent, bool opposite, TroopsUidGenerator & generat
         Position pos;
         pos.Set( idx, troop->isWide(), opposite );
 
-        assert( pos.GetHead() != nullptr && ( !troop->isWide() || pos.GetTail() != nullptr ) );
+        assert( pos.GetHead() != nullptr && ( troop->isWide() ? pos.GetTail() != nullptr : pos.GetTail() == nullptr ) );
 
         push_back( new Unit( *troop, pos, opposite, generator.GetUnique() ) );
         back()->SetArmy( army );

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -911,8 +911,7 @@ bool Battle::Board::isValidMirrorImageIndex( const int32_t index, const Unit * u
     }
 
     const Position mirrorPos = Position::GetPosition( *unit, index );
-
-    if ( mirrorPos.GetHead() == nullptr || ( unit->isWide() && mirrorPos.GetTail() == nullptr ) ) {
+    if ( !mirrorPos.isValidForUnit( unit ) ) {
         return false;
     }
 
@@ -935,7 +934,7 @@ bool Battle::Board::CanAttackFromCell( const Unit & unit, const int32_t from )
         return false;
     }
 
-    assert( !unit.isWide() || pos.GetTail() != nullptr );
+    assert( pos.isValidForUnit( unit ) );
 
     const Castle * castle = Arena::GetCastle();
 

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -60,6 +60,8 @@ namespace Battle
         Cell( const Cell & ) = delete;
         Cell( Cell && ) = default;
 
+        ~Cell() = default;
+
         Cell & operator=( const Cell & ) = delete;
         Cell & operator=( Cell && ) = delete;
 

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -53,7 +53,7 @@ namespace Battle
         AROUND = RIGHT_SIDE | LEFT_SIDE
     };
 
-    class Cell
+    class Cell final
     {
     public:
         explicit Cell( const int32_t idx );
@@ -93,7 +93,7 @@ namespace Battle
         std::array<fheroes2::Point, 7> _coord;
     };
 
-    class Position : protected std::pair<Cell *, Cell *>
+    class Position final : protected std::pair<Cell *, Cell *>
     {
     public:
         Position()
@@ -117,13 +117,40 @@ namespace Battle
         // the position reachability instead of the speed returned by 'unit'.
         static Position GetReachable( const Unit & unit, const int32_t dst, const std::optional<uint32_t> speed = {} );
 
+        bool isEmpty() const;
+
+        bool isValidForUnit( const Unit & unit ) const;
+
+        bool isValidForUnit( const Unit * unit ) const
+        {
+            if ( unit == nullptr ) {
+                return false;
+            }
+
+            return isValidForUnit( *unit );
+        }
+
         fheroes2::Rect GetRect() const;
 
-        const Cell * GetHead() const;
-        const Cell * GetTail() const;
+        const Cell * GetHead() const
+        {
+            return first;
+        }
 
-        Cell * GetHead();
-        Cell * GetTail();
+        const Cell * GetTail() const
+        {
+            return second;
+        }
+
+        Cell * GetHead()
+        {
+            return first;
+        }
+
+        Cell * GetTail()
+        {
+            return second;
+        }
 
         bool operator<( const Position & other ) const;
     };

--- a/src/fheroes2/battle/battle_grave.cpp
+++ b/src/fheroes2/battle/battle_grave.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -48,7 +48,7 @@ Battle::Indexes Battle::Graveyard::GetOccupiedCells() const
 
 void Battle::Graveyard::AddTroop( const Unit & unit )
 {
-    assert( Board::isValidIndex( unit.GetHeadIndex() ) && ( !unit.isWide() || Board::isValidIndex( unit.GetTailIndex() ) ) );
+    assert( Board::isValidIndex( unit.GetHeadIndex() ) && ( unit.isWide() ? Board::isValidIndex( unit.GetTailIndex() ) : !Board::isValidIndex( unit.GetTailIndex() ) ) );
 
     Graveyard & graveyard = *this;
 
@@ -61,7 +61,7 @@ void Battle::Graveyard::AddTroop( const Unit & unit )
 
 void Battle::Graveyard::RemoveTroop( const Unit & unit )
 {
-    assert( Board::isValidIndex( unit.GetHeadIndex() ) && ( !unit.isWide() || Board::isValidIndex( unit.GetTailIndex() ) ) );
+    assert( Board::isValidIndex( unit.GetHeadIndex() ) && ( unit.isWide() ? Board::isValidIndex( unit.GetTailIndex() ) : !Board::isValidIndex( unit.GetTailIndex() ) ) );
 
     const auto removeUIDFromIndex = [this]( const int32_t idx, const uint32_t uid ) {
         const auto idxIter = find( idx );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2232,9 +2232,8 @@ void Battle::Interface::_redrawCoverStatic()
 
         for ( const Cell & cell : board ) {
             const Position pos = Position::GetReachable( *_currentUnit, cell.GetIndex() );
-
             if ( pos.GetHead() != nullptr ) {
-                assert( !_currentUnit->isWide() || pos.GetTail() != nullptr );
+                assert( pos.isValidForUnit( _currentUnit ) );
 
                 fheroes2::Blit( shadowImage, _mainSurface, cell.GetPos().x, cell.GetPos().y );
             }
@@ -2529,9 +2528,8 @@ int Battle::Interface::GetBattleCursor( std::string & statusMsg ) const
 
         if ( unit == nullptr || _currentUnit == unit ) {
             const Position pos = Position::GetReachable( *_currentUnit, index_pos );
-
             if ( pos.GetHead() != nullptr ) {
-                assert( !_currentUnit->isWide() || pos.GetTail() != nullptr );
+                assert( pos.isValidForUnit( _currentUnit ) );
 
                 if ( pos.GetHead()->GetIndex() == _currentUnit->GetHeadIndex() ) {
                     assert( !_currentUnit->isWide() || pos.GetTail()->GetIndex() == _currentUnit->GetTailIndex() );

--- a/src/fheroes2/battle/battle_pathfinding.cpp
+++ b/src/fheroes2/battle/battle_pathfinding.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -44,7 +44,7 @@ namespace Battle
 {
     void BattlePathfinder::reEvaluateIfNeeded( const Unit & unit )
     {
-        assert( unit.GetHeadIndex() != -1 && ( !unit.isWide() || unit.GetTailIndex() != -1 ) );
+        assert( unit.GetHeadIndex() != -1 && ( unit.isWide() ? unit.GetTailIndex() != -1 : unit.GetTailIndex() == -1 ) );
 
         const Board * board = Arena::GetBoard();
         assert( board != nullptr );
@@ -85,7 +85,7 @@ namespace Battle
                     continue;
                 }
 
-                assert( !_isWide || pos.GetTail() != nullptr );
+                assert( pos.isValidForUnit( unit ) );
 
                 const int32_t headCellIdx = pos.GetHead()->GetIndex();
                 const int32_t tailCellIdx = pos.GetTail() ? pos.GetTail()->GetIndex() : -1;

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -1124,7 +1124,7 @@ int32_t Battle::Unit::evaluateThreatForUnit( const Unit & defender, const std::o
                 return false;
             }
 
-            if ( attacker.ignoreRetaliation() ) {
+            if ( attacker.isIgnoringRetaliation() ) {
                 return false;
             }
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -194,6 +194,9 @@ void Battle::Unit::SetPosition( const int32_t idx )
 
 void Battle::Unit::SetPosition( const Position & pos )
 {
+    // Position may be empty if this unit is a castle tower
+    assert( pos.isValidForUnit( this ) || pos.isEmpty() );
+
     if ( position.GetHead() ) {
         position.GetHead()->SetUnit( nullptr );
     }

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -266,7 +266,7 @@ public:
         return isAbilityPresent( fheroes2::MonsterAbilityType::ALL_ADJACENT_CELL_MELEE_ATTACK );
     }
 
-    bool ignoreRetaliation() const
+    bool isIgnoringRetaliation() const
     {
         return isAbilityPresent( fheroes2::MonsterAbilityType::NO_ENEMY_RETALIATION );
     }


### PR DESCRIPTION
Usually, units covering shooters do not attack neighboring enemy units if there are no enemy units directly threatening the covered shooters - this way they prolong their lives (and, accordingly, a cover for the shooters) without taking unnecessary retaliatory damage. However, units that ignore retaliation can safely attack any enemy.

`master` branch:

https://github.com/ihhub/fheroes2/assets/32623900/01666961-12ab-4f6e-a049-1f7bc60d8261

This PR:

https://github.com/ihhub/fheroes2/assets/32623900/a87b69c7-1a4a-4a18-9dca-dcd618da1d7c
