### PR TITLE
Optimize the AIPathfinder::getFogDiscoveryTile()

### DIFF
--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -86,7 +86,7 @@ public:
     bool AllTroopsAreTheSame() const;
 
     bool JoinTroop( const Troop & troop );
-    bool JoinTroop( const Monster & mons, uint32_t count, bool emptySlotFirst );
+    bool JoinTroop( const Monster & mons, const uint32_t count, const bool emptySlotFirst );
     bool CanJoinTroop( const Monster & ) const;
 
     virtual double GetStrength() const;

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -879,7 +879,7 @@ std::pair<int32_t, bool> AIWorldPathfinder::getFogDiscoveryTile( const Heroes & 
 {
     reEvaluateIfNeeded( hero );
 
-    const auto findBestTile = [this, scoutingDistance = hero.GetScoutingDistance()]( const auto nearbyTilesFilter ) {
+    const auto findBestTile = [this, scoutingDistance = hero.GetScoutingDistance()]( const auto nearbyTilePredicate ) {
         const Directions & directions = Direction::All();
 
         struct TileCharacteristics
@@ -909,7 +909,7 @@ std::pair<int32_t, bool> AIWorldPathfinder::getFogDiscoveryTile( const Heroes & 
                     continue;
                 }
 
-                if ( !nearbyTilesFilter( tileIdx + _mapOffset[i] ) ) {
+                if ( !nearbyTilePredicate( tileIdx + _mapOffset[i] ) ) {
                     continue;
                 }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -879,106 +879,82 @@ std::pair<int32_t, bool> AIWorldPathfinder::getFogDiscoveryTile( const Heroes & 
 {
     reEvaluateIfNeeded( hero );
 
-    const int scoutingDistance = hero.GetScoutingDistance();
-    const Directions & directions = Direction::All();
+    const auto findBestTile = [this, scoutingDistance = hero.GetScoutingDistance()]( const auto nearbyTilesFilter ) {
+        const Directions & directions = Direction::All();
 
-    struct TileCharacteristics
-    {
-        int32_t index{ -1 };
-        bool isFogNearby{ false };
-        uint32_t cost{ UINT32_MAX };
-        int32_t tilesToReveal{ 0 };
-    };
+        struct TileCharacteristics
+        {
+            int32_t index{ -1 };
+            uint32_t cost{ UINT32_MAX };
+            int32_t tilesToReveal{ 0 };
+        };
 
-    TileCharacteristics bestTile;
+        TileCharacteristics bestTile;
 
-    for ( size_t idx = 0; idx < _cache.size(); ++idx ) {
-        const uint32_t nodeCost = _cache[idx]._cost;
-        if ( nodeCost == 0 ) {
-            continue;
-        }
+        for ( size_t idx = 0; idx < _cache.size(); ++idx ) {
+            const uint32_t nodeCost = _cache[idx]._cost;
+            if ( nodeCost == 0 ) {
+                continue;
+            }
 
-        const int32_t tileIdx = static_cast<int32_t>( idx );
-        if ( !MP2::isSafeForFogDiscoveryObject( world.GetTiles( tileIdx ).GetObject( true ) ) ) {
-            continue;
-        }
+            const int32_t tileIdx = static_cast<int32_t>( idx );
+            if ( !MP2::isSafeForFogDiscoveryObject( world.GetTiles( tileIdx ).GetObject( true ) ) ) {
+                continue;
+            }
 
-        // It makes sense to consider only two types of accessible tiles for fog discovery: tiles that have at least one neighboring tile covered with fog, and tiles that
-        // have at least one neighboring tile inaccessible to the hero (since there may be unexplored tiles covered with fog on the other side of such an obstacle).
-        const auto [isFogNearby, isInaccessibleTileNearby] = [this, &directions, tileIdx]() {
-            std::pair<bool, bool> res{ false, false };
+            bool isTileSuitable = false;
 
             for ( size_t i = 0; i < directions.size(); ++i ) {
                 if ( !Maps::isValidDirection( tileIdx, directions[i] ) ) {
                     continue;
                 }
 
-                const int32_t nearbyIdx = tileIdx + _mapOffset[i];
-
-                // If at least one neighboring tile is covered with fog, then this is already enough to consider this tile
-                if ( world.GetTiles( nearbyIdx ).isFog( _color ) ) {
-                    res.first = true;
-
-                    break;
+                if ( !nearbyTilesFilter( tileIdx + _mapOffset[i] ) ) {
+                    continue;
                 }
 
-                // If some neighboring tile is inaccessible to the hero, then that's good, but maybe there will also be a neighboring tile covered with fog
-                if ( _cache[nearbyIdx]._cost == 0 ) {
-                    res.second = true;
-                }
+                isTileSuitable = true;
+
+                break;
             }
 
-            return res;
-        }();
+            if ( !isTileSuitable ) {
+                continue;
+            }
 
-        // If we have found at least one accessible tile, the neighboring tile of which is covered with fog, then we are no longer interested in tiles that simply reveal
-        // some new distant tiles.
-        if ( bestTile.isFogNearby ? !isFogNearby : ( !isFogNearby && !isInaccessibleTileNearby ) ) {
-            continue;
+            const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( tileIdx, scoutingDistance, _color );
+            assert( tilesToReveal >= 0 );
+
+            if ( tilesToReveal == 0 ) {
+                continue;
+            }
+
+            if ( nodeCost < bestTile.cost || ( nodeCost == bestTile.cost && tilesToReveal > bestTile.tilesToReveal ) ) {
+                bestTile = { tileIdx, nodeCost, tilesToReveal };
+            }
         }
 
-        const int32_t tilesToReveal = Maps::getFogTileCountToBeRevealed( tileIdx, scoutingDistance, _color );
-        assert( tilesToReveal >= 0 );
+        return bestTile.index;
+    };
 
-        // If visiting this tile does not reveal any new tiles, then we are not interested in this tile.
-        if ( tilesToReveal == 0 ) {
-            continue;
+    // First, consider the accessible tiles, one of the neighboring tiles of which is covered with fog. Most likely, some of these neighboring tiles are also accessible.
+    {
+        const int32_t bestTileIdx = findBestTile( [this]( const int32_t tileIdx ) { return world.GetTiles( tileIdx ).isFog( _color ); } );
+        if ( bestTileIdx != -1 ) {
+            return { bestTileIdx, true };
         }
-
-        const bool isBetterTile = [&bestTile = std::as_const( bestTile ), nodeCost, isFogNearby = isFogNearby, tilesToReveal]() {
-            if ( isFogNearby && !bestTile.isFogNearby ) {
-                return true;
-            }
-
-            if ( isFogNearby != bestTile.isFogNearby ) {
-                return false;
-            }
-
-            if ( nodeCost < bestTile.cost ) {
-                return true;
-            }
-
-            if ( nodeCost != bestTile.cost ) {
-                return false;
-            }
-
-            if ( tilesToReveal > bestTile.tilesToReveal ) {
-                return true;
-            }
-
-            return false;
-        }();
-
-        if ( !isBetterTile ) {
-            continue;
-        }
-
-        // If we have found an accessible tile, the neighboring tile of which is covered with fog, then, most likely, that neighboring tile is also accessible. Such
-        // tiles have priority over those that simply reveal some new distant tiles.
-        bestTile = { tileIdx, isFogNearby, nodeCost, tilesToReveal };
     }
 
-    return { bestTile.index, bestTile.isFogNearby };
+    // If we are unlucky, then we need to do the heavy lifting and consider the accessible tiles that have at least one neighboring tile that is inaccessible to the hero
+    // (since there may be unexplored tiles covered with fog on the other side of such an obstacle).
+    {
+        const int32_t bestTileIdx = findBestTile( [this]( const int32_t tileIdx ) { return _cache[tileIdx]._cost == 0; } );
+        if ( bestTileIdx != -1 ) {
+            return { bestTileIdx, false };
+        }
+    }
+
+    return { -1, false };
 }
 
 int AIWorldPathfinder::getNearestTileToMove( const Heroes & hero )


### PR DESCRIPTION
Related to https://github.com/ihhub/fheroes2/pull/8235#discussion_r1444103847

The difference with the `master` branch is that in the `master` branch, until at least one tile is found next to which there is fog, tiles next to which there is an obstacle are also considered, and there can be quite a lot of such tiles until a first tile with fog nearby is found (and then tiles without fog nearby will be discarded anyway). With this PR, there are two passes - during the first pass, only tiles are considered, next to which there is fog (and in the vast majority of cases this is the end of it), and during the second pass, the tiles next to which there is an obstacle will be considered. In a typical case, this speeds up the process, but in the worst case (when there is no fog near any of the accessible tiles), there will be two passes through the map tiles instead of one.

Profiler's call tree for the same XL map in the same circumstances as in the comment linked above:

![optimized](https://github.com/ihhub/fheroes2/assets/32623900/f07a7bde-783a-40b8-8c79-b5f55d4c0c96)
