### PR TITLE
Defensive tactics in battle: allow units covering archers with the AREA_SHOT capability to attack neighboring units on their own

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -1637,8 +1637,10 @@ namespace AI
                 }
 
                 // It makes sense for a unit that ignores retaliation to attack neighboring enemy units, even if it is covering an archer, since in this case it will not
-                // receive unnecessary retaliatory damage (which could affect the duration of the cover)
-                if ( !currentUnit.isIgnoringRetaliation() ) {
+                // receive unnecessary retaliatory damage (which could affect the duration of the cover). Also, archers with the ability to shoot at area may not always
+                // attack enemy units in close proximity to friendly units due to fear of friendly fire, so covering friendly units should help by attacking enemy units
+                // next to them.
+                if ( !currentUnit.isIgnoringRetaliation() && !frnd->isAbilityPresent( fheroes2::MonsterAbilityType::AREA_SHOT ) ) {
                     continue;
                 }
 


### PR DESCRIPTION
Such archers may not always attack enemy units in close proximity to friendly units due to fear of friendly fire, so covering friendly units should help by attacking enemy units.

Currently in the `master` branch:

https://github.com/ihhub/fheroes2/assets/32623900/c0c659fd-8c7a-4ed1-a8f6-d8b531bbcf65

With this PR:

https://github.com/ihhub/fheroes2/assets/32623900/13e23882-fd04-4d8b-821a-10d2dab9f92d
