### PR TITLE
Use proper name for PoL campaign in High Scores

### DIFF
--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -843,7 +843,7 @@ namespace Campaign
         case Campaign::ARCHIBALD_CAMPAIGN:
             return _( "Archibald" );
         case Campaign::PRICE_OF_LOYALTY_CAMPAIGN:
-            return _( "The Price of Loyalty" );
+            return _( "Price of Loyalty" );
         case Campaign::VOYAGE_HOME_CAMPAIGN:
             return _( "Voyage Home" );
         case Campaign::WIZARDS_ISLE_CAMPAIGN:


### PR DESCRIPTION
The OG never refers to it as "The Price of Loyalty" iirc:
<img width="280" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/a52d81c3-b1d4-4023-b2b4-8188f02d3b3a">

This fixes this issue:
![image](https://github.com/ihhub/fheroes2/assets/12501091/61eda35f-2cf8-42c1-b402-abf56edad5f9)

