### PR TITLE
Workaround for misbehaved iconv on MacOS 14

### DIFF
--- a/files/lang/lt.po
+++ b/files/lang/lt.po
@@ -3908,6 +3908,7 @@ msgstr ""
 msgid "Hard"
 msgstr ""
 
+# -----
 #, fuzzy
 msgid "Campaign Difficulty"
 msgstr ""


### PR DESCRIPTION
Added few filler characters to the `lt.po` translation file in a form of a dummy comment to work around `iconv` issues on MacOS 14 (Sonoma).

Issue: #8237

Tested on MacOS 14.2.1