### PR TITLE
Correct the Statesman's Quill's effect to 20%

### DIFF
--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2023                                             *
+ *   Copyright (C) 2022 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
According to @LeHerosInconnu's [tests of the OG](https://github.com/ihhub/fheroes2/issues/2260#issuecomment-735281489) and [this article from handbookhmm](https://handbookhmm.ru/2-diplomacy) (see part number 4), the Statesman's Quill should reduce the cost **to** 20%, not 10%.

Note that the handbook article lists the wrong values for diplomacy's effect, which is correct in fheroes2.

This PR also changes the artifact description to match the change, which in the OG was wrong since it said 10% when it was 20%.