### PR TITLE
Add infos on the cost of surrender

### DIFF
--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -225,8 +225,8 @@ uint32_t Battle::Force::GetSurrenderCost() const
         }
         const int diplomacyLevel = commander->GetLevelSkill( Skill::Secondary::DIPLOMACY );
         if ( diplomacyLevel > Skill::Level::NONE ) {
-            // The modifier is always multiplied by two, normally to negate the 0.5 modifier from regular surrender, but also when there are artifacts present
-            // even if the 0.5 modifier for normal surrender has already been negated by setting mod = 1.
+            // The modifier is always multiplied by two, normally to negate the 0.5 modifier from regular surrender, but also when there are
+            // artifacts present, even if the 0.5 modifier for normal surrender already has been negated by setting mod = 1.
             mod *= 2;
             mod *= ( Skill::GetDiplomacySurrenderPercent( commander->GetLevelSkill( Skill::Secondary::DIPLOMACY ) ) / 100.0 );
         }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -228,7 +228,7 @@ uint32_t Battle::Force::GetSurrenderCost() const
             // The modifier is always multiplied by two, normally to negate the 0.5 modifier from regular surrender, but also when there are
             // artifacts present, even if the 0.5 modifier for normal surrender already has been negated by setting mod = 1.
             mod *= 2;
-            mod *= ( Skill::GetDiplomacySurrenderPercent( commander->GetLevelSkill( Skill::Secondary::DIPLOMACY ) ) / 100.0 );
+            mod *= ( Skill::GetDiplomacySurrenderCostDiscount( commander->GetLevelSkill( Skill::Secondary::DIPLOMACY ) ) / 100.0 );
         }
 
         result *= mod;

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -223,19 +223,9 @@ uint32_t Battle::Force::GetSurrenderCost() const
                 mod = mod * value / 100;
             }
         }
-
-        switch ( commander->GetLevelSkill( Skill::Secondary::DIPLOMACY ) ) {
-        case Skill::Level::BASIC:
-            mod *= 0.8;
-            break;
-        case Skill::Level::ADVANCED:
-            mod *= 0.6;
-            break;
-        case Skill::Level::EXPERT:
-            mod *= 0.4;
-            break;
-        default:
-            break;
+        const int diplomacyLevel = commander->GetLevelSkill( Skill::Secondary::DIPLOMACY );
+        if ( diplomacyLevel > Skill::Level::NONE ) {
+            mod *= ( Skill::GetDiplomacySurrenderPercent( diplomacyLevel ) * 0.02 );
         }
 
         result *= mod;

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -225,7 +225,10 @@ uint32_t Battle::Force::GetSurrenderCost() const
         }
         const int diplomacyLevel = commander->GetLevelSkill( Skill::Secondary::DIPLOMACY );
         if ( diplomacyLevel > Skill::Level::NONE ) {
-            mod *= ( Skill::GetDiplomacySurrenderPercent( diplomacyLevel ) * 0.02 );
+            // The modifier is always multiplied by two, normally to negate the 0.5 modifier from regular surrender, but also when there are artifacts present
+            // even if the 0.5 modifier for normal surrender has already been negated by setting mod = 1.
+            mod *= 2;
+            mod *= ( Skill::GetDiplomacySurrenderPercent( commander->GetLevelSkill( Skill::Secondary::DIPLOMACY ) ) / 100.0 );
         }
 
         result *= mod;

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -1000,7 +1000,7 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
         else if ( le.MousePressRight( btnSurrender.area() ) && _currentColor == hero.GetColor() && !hero.isCaptain() ) {
             fheroes2::showStandardTextMessage(
                 _( "Surrender" ),
-                _( "Surrendering costs gold. However if you pay the ransom, the hero and all of his or her surviving creatures will be available to recruit again." ),
+                _( "Surrendering costs gold. However if you pay the ransom, the hero and all of his or her surviving creatures will be available to recruit again. The cost of surrender is half of the total cost of the troops remaining in the army." ),
                 Dialog::ZERO );
         }
         else if ( le.MousePressRight( portraitArea ) && actionHero != nullptr ) {

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -1000,7 +1000,7 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
         else if ( le.MousePressRight( btnSurrender.area() ) && _currentColor == hero.GetColor() && !hero.isCaptain() ) {
             fheroes2::showStandardTextMessage(
                 _( "Surrender" ),
-                _( "Surrendering costs gold. However if you pay the ransom, the hero and all of his or her surviving creatures will be available to recruit again. The cost of surrender is half of the total cost of the troops remaining in the army." ),
+                _( "Surrendering costs gold. However if you pay the ransom, the hero and all of his or her surviving creatures will be available to recruit again. The cost of surrender is half of the total cost of the non-temporary troops remaining in the army." ),
                 Dialog::ZERO );
         }
         else if ( le.MousePressRight( portraitArea ) && actionHero != nullptr ) {

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -523,7 +523,7 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         }
         str += "\n\n";
         str.append( _( "The cost of surrender is reduced to %{percent} percent of the total cost of troops in the army." ) );
-        StringReplace( str, "%{percent}", GetDiplomacySurrenderPercent( Level() ) );
+        StringReplace( str, "%{percent}", GetDiplomacySurrenderCostDiscount( Level() ) );
         break;
     }
     case NAVIGATION: {
@@ -863,7 +863,7 @@ uint32_t Skill::GetNecromancyPercent( const HeroBase & hero )
     return std::min( percent, 100u );
 }
 
-uint32_t Skill::GetDiplomacySurrenderPercent( const int level )
+uint32_t Skill::GetDiplomacySurrenderCostDiscount( const int level )
 {
     switch ( level ) {
     case Level::BASIC:

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -508,8 +508,7 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         break;
     }
     case DIPLOMACY: {
-        str = _(
-            "%{skill} allows the hero to negotiate with monsters who are weaker than their army, and reduces the cost of surrender." );
+        str = _( "%{skill} allows the hero to negotiate with monsters who are weaker than their army, and reduces the cost of surrender." );
         str += "\n\n";
         uint32_t percent = 40;
         switch ( Level() ) {

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -875,7 +875,6 @@ uint32_t Skill::GetDiplomacySurrenderPercent( const int level )
     default:
         return 0;
     }
-    
 }
 
 StreamBase & Skill::operator<<( StreamBase & msg, const Primary & skill )

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -507,20 +507,33 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         str = _n( "%{skill} increases the hero's viewable area by one square.", "%{skill} increases the hero's viewable area by %{count} squares.", count );
         break;
     }
-    case DIPLOMACY:
-        str = _( "%{skill} allows the hero to negotiate with monsters who are weaker than their army." );
+    case DIPLOMACY: {
+        str = _(
+            "%{skill} allows the hero to negotiate with monsters who are weaker than their army, and reduces the cost of surrender." );
+        str += "\n\n";
+        uint32_t percent = 40;
         switch ( Level() ) {
         case Level::BASIC:
         case Level::ADVANCED:
             str.append( _( "Approximately %{count} percent of the creatures may offer to join the hero." ) );
+            str += "\n\n";
+            str.append( _( "The cost of surrender is reduced to %{percent} percent of the total cost of troops in the army." ) );
+            if ( Level() == Level::ADVANCED ) {
+                percent = 30;
+            }
             break;
         case Level::EXPERT:
             str.append( _( "All of the creatures may offer to join the hero." ) );
+            str += "\n\n";
+            str.append( _( "The cost of surrender is reduced to %{percent} percent of the total cost of troops in the army." ) );
+            percent = 20;
             break;
         default:
             break;
         }
+        StringReplace( str, "%{percent}", percent );
         break;
+    }
     case NAVIGATION: {
         str = _( "%{skill} increases the hero's movement points over water by %{count} percent." );
         break;
@@ -554,7 +567,7 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         str = _( "%{skill} increases the hero's luck by %{count}." );
         break;
     }
-    case BALLISTICS:
+    case BALLISTICS: {
         switch ( Level() ) {
         case Level::BASIC:
             str = _( "%{skill} gives the hero's catapult shots a greater chance to hit and do damage to castle walls." );
@@ -569,7 +582,8 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
             break;
         }
         break;
-    case EAGLE_EYE:
+    }
+    case EAGLE_EYE: {
         switch ( Level() ) {
         case Level::BASIC:
             str = _( "%{skill} gives the hero a %{count} percent chance to learn any given 1st or 2nd level spell that was cast by an enemy during combat." );
@@ -584,15 +598,17 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
             break;
         }
         break;
+    }
     case NECROMANCY: {
         count += Skill::GetNecromancyPercent( hero ) - hero.GetSecondaryValues( Skill::Secondary::NECROMANCY );
         name = GetNameWithBonus( hero );
         str = _( "%{skill} allows %{count} percent of the creatures killed in combat to be brought back from the dead as Skeletons." );
         break;
     }
-    case ESTATES:
+    case ESTATES: {
         str = _( "The hero produces %{count} gold pieces per day as tax revenue from estates." );
         break;
+    }
     default:
         // Are you sure that you are passing the correct secondary skill type?
         assert( 0 );

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -510,25 +510,20 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
     case DIPLOMACY: {
         str = _( "%{skill} allows the hero to negotiate with monsters who are weaker than their army, and reduces the cost of surrender." );
         str += "\n\n";
-        uint32_t percent = 40;
         switch ( Level() ) {
         case Level::BASIC:
         case Level::ADVANCED:
             str.append( _( "Approximately %{count} percent of the creatures may offer to join the hero." ) );
-            if ( Level() == Level::ADVANCED ) {
-                percent = 30;
-            }
             break;
         case Level::EXPERT:
             str.append( _( "All of the creatures may offer to join the hero." ) );
-            percent = 20;
             break;
         default:
             break;
         }
         str += "\n\n";
         str.append( _( "The cost of surrender is reduced to %{percent} percent of the total cost of troops in the army." ) );
-        StringReplace( str, "%{percent}", percent );
+        StringReplace( str, "%{percent}", GetDiplomacySurrenderPercent( Level() ) );
         break;
     }
     case NAVIGATION: {
@@ -866,6 +861,21 @@ uint32_t Skill::GetNecromancyPercent( const HeroBase & hero )
     percent += 10 * GetNecromancyBonus( hero );
     // cap at 100% bonus
     return std::min( percent, 100u );
+}
+
+uint32_t Skill::GetDiplomacySurrenderPercent( const int level )
+{
+    switch ( level ) {
+    case Level::BASIC:
+        return 40;
+    case Level::ADVANCED:
+        return 30;
+    case Level::EXPERT:
+        return 20;
+    default:
+        return 0;
+    }
+    
 }
 
 StreamBase & Skill::operator<<( StreamBase & msg, const Primary & skill )

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -516,21 +516,19 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         case Level::BASIC:
         case Level::ADVANCED:
             str.append( _( "Approximately %{count} percent of the creatures may offer to join the hero." ) );
-            str += "\n\n";
-            str.append( _( "The cost of surrender is reduced to %{percent} percent of the total cost of troops in the army." ) );
             if ( Level() == Level::ADVANCED ) {
                 percent = 30;
             }
             break;
         case Level::EXPERT:
             str.append( _( "All of the creatures may offer to join the hero." ) );
-            str += "\n\n";
-            str.append( _( "The cost of surrender is reduced to %{percent} percent of the total cost of troops in the army." ) );
             percent = 20;
             break;
         default:
             break;
         }
+        str += "\n\n";
+        str.append( _( "The cost of surrender is reduced to %{percent} percent of the total cost of troops in the army." ) );
         StringReplace( str, "%{percent}", percent );
         break;
     }

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -44,6 +44,7 @@ namespace Skill
 
     uint32_t GetNecromancyBonus( const HeroBase & hero );
     uint32_t GetNecromancyPercent( const HeroBase & hero );
+    uint32_t GetDiplomacySurrenderPercent( const int level );
 
     namespace Level
     {

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -44,7 +44,7 @@ namespace Skill
 
     uint32_t GetNecromancyBonus( const HeroBase & hero );
     uint32_t GetNecromancyPercent( const HeroBase & hero );
-    uint32_t GetDiplomacySurrenderPercent( const int level );
+    uint32_t GetDiplomacySurrenderCostDiscount( const int level );
 
     namespace Level
     {


### PR DESCRIPTION
This discloses how much the diplomacy skill affects the cost of surrender, and adds that the cost of surrender is under normal circumstances half the total cost of troops remaining in the army, in gold only.

<img width="313" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/bbb6814c-cce6-4206-98ac-1011241f3d93">
