### PR TITLE
Puzzle dialog rendering improvement

### DIFF
--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -93,9 +93,8 @@ namespace
             return;
         }
 
-        const uint32_t puzzleSize = static_cast<uint32_t>( pzl.size() );
-        for ( uint32_t i = 0; i < puzzleSize; ++i ) {
-            const fheroes2::Sprite & piece = fheroes2::AGG::GetICN( ICN::PUZZLE, i );
+        for ( size_t i = 0; i < pzl.size(); ++i ) {
+            const fheroes2::Sprite & piece = fheroes2::AGG::GetICN( ICN::PUZZLE, static_cast<uint32_t>( i ) );
 
             fheroes2::Blit( piece, display, dstx + piece.x() - BORDERWIDTH, dsty + piece.y() - BORDERWIDTH );
         }
@@ -118,7 +117,6 @@ namespace
         const std::vector<Game::DelayType> delayTypes = { Game::PUZZLE_FADE_DELAY };
         Game::passAnimationDelay( Game::PUZZLE_FADE_DELAY );
 
-        const uint32_t puzzleSize = static_cast<uint32_t>( pzl.size() );
         int alpha = 250;
 
         while ( alpha >= 0 && le.HandleEvents( Game::isDelayNeeded( delayTypes ) ) ) {
@@ -131,8 +129,8 @@ namespace
             if ( Game::validateAnimationDelay( Game::PUZZLE_FADE_DELAY ) ) {
                 fheroes2::Copy( sf, 0, 0, display, dstx, dsty, sf.width(), sf.height() );
 
-                for ( uint32_t i = 0; i < puzzleSize; ++i ) {
-                    const fheroes2::Sprite & piece = fheroes2::AGG::GetICN( ICN::PUZZLE, i );
+                for ( size_t i = 0; i < pzl.size(); ++i ) {
+                    const fheroes2::Sprite & piece = fheroes2::AGG::GetICN( ICN::PUZZLE, static_cast<uint32_t>( i ) );
 
                     uint8_t pieceAlpha = 255;
                     if ( pzl.test( i ) )

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -86,6 +86,8 @@ namespace
 
         // Immediately reveal the entire puzzle in developer mode
         if ( IS_DEVEL() ) {
+            assert( sf.singleLayer() );
+
             fheroes2::Copy( sf, 0, 0, display, dstx, dsty, sf.width(), sf.height() );
 
             return;
@@ -106,6 +108,9 @@ namespace
         if ( IS_DEVEL() ) {
             return false;
         }
+
+        // The game area puzzle image should be single-layer.
+        assert( sf.singleLayer() );
 
         fheroes2::Display & display = fheroes2::Display::instance();
         LocalEvent & le = LocalEvent::Get();
@@ -219,7 +224,7 @@ namespace
         const fheroes2::StandardWindow border( gameAreaRoi.x + ( gameAreaRoi.width - sf.width() ) / 2, gameAreaRoi.y + ( gameAreaRoi.height - sf.height() ) / 2,
                                                sf.width(), sf.height(), false );
 
-        const fheroes2::Rect puzzleArea = border.activeArea();
+        const fheroes2::Rect & puzzleArea = border.activeArea();
 
         fheroes2::Image background( puzzleArea.width, puzzleArea.height );
 

--- a/src/fheroes2/kingdom/puzzle.h
+++ b/src/fheroes2/kingdom/puzzle.h
@@ -41,10 +41,10 @@ public:
     void Update( uint32_t open, uint32_t total );
     void ShowMapsDialog() const;
 
-    std::vector<uint8_t> zone1_order;
-    std::vector<uint8_t> zone2_order;
-    std::vector<uint8_t> zone3_order;
-    std::vector<uint8_t> zone4_order;
+    std::vector<uint8_t> zone1_order{ 0, 1, 2, 3, 4, 5, 6, 11, 12, 17, 18, 23, 24, 29, 30, 35, 36, 41, 42, 43, 44, 45, 46, 47 };
+    std::vector<uint8_t> zone2_order{ 7, 8, 9, 10, 13, 16, 19, 22, 25, 28, 31, 34, 37, 38, 39, 40 };
+    std::vector<uint8_t> zone3_order{ 14, 15, 32, 33 };
+    std::vector<uint8_t> zone4_order{ 20, 21, 26, 27 };
 };
 
 StreamBase & operator<<( StreamBase &, const Puzzle & );

--- a/src/fheroes2/kingdom/puzzle.h
+++ b/src/fheroes2/kingdom/puzzle.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *


### PR DESCRIPTION
This PR is a part of #8012 and includes:
- fix of some SonarQube and Clang-Tidy issues;
- fix of control panel (EXIT in radar area) render when opening a Puzzle dialog: in master branch it is often rendered with a delay;
- use `Copy()` instead of `Blit()` where possible;
- schedule the cursor update after Puzzle dialog is closed.