### PR TITLE
View World rendering improvement

### DIFF
--- a/src/fheroes2/kingdom/view_world.h
+++ b/src/fheroes2/kingdom/view_world.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/kingdom/view_world.h
+++ b/src/fheroes2/kingdom/view_world.h
@@ -50,25 +50,42 @@ class ViewWorld
 public:
     static void ViewWorldWindow( const int32_t color, const ViewWorldMode mode, Interface::BaseInterface & interface );
 
-    struct ZoomROIs
+    class ZoomROIs
     {
-        ZoomROIs( const ZoomLevel zoomLevel, const fheroes2::Point & centerInPixels );
+    public:
+        ZoomROIs( const ZoomLevel zoomLevel, const fheroes2::Point & centerInPixels, const fheroes2::Rect & visibleScreenInPixels );
 
         bool zoomIn( const bool cycle );
         bool zoomOut( const bool cycle );
         bool ChangeCenter( const fheroes2::Point & centerInPixels );
 
-        const fheroes2::Rect & GetROIinPixels() const;
+        const fheroes2::Rect & GetROIinPixels() const
+        {
+            return _roiForZoomLevels[static_cast<uint8_t>( _zoomLevel )];
+        }
+
         fheroes2::Rect GetROIinTiles() const;
+
+        ZoomLevel getZoomLevel() const
+        {
+            return _zoomLevel;
+        }
+
+        fheroes2::Point getCenter() const
+        {
+            return _center;
+        }
+
+    private:
+        void _updateZoomLevels();
+
+        bool _updateCenter();
+        bool _changeZoom( const ZoomLevel newLevel );
 
         ZoomLevel _zoomLevel{ ZoomLevel::ZoomLevel1 };
         fheroes2::Point _center;
         std::array<fheroes2::Rect, 4> _roiForZoomLevels;
-
-    private:
-        void _updateZoomLevels();
-        bool _updateCenter();
-        bool _changeZoom( const ZoomLevel newLevel );
+        fheroes2::Rect _visibleROI;
     };
 };
 

--- a/src/fheroes2/kingdom/view_world.h
+++ b/src/fheroes2/kingdom/view_world.h
@@ -71,7 +71,7 @@ public:
             return _zoomLevel;
         }
 
-        fheroes2::Point getCenter() const
+        const fheroes2::Point & getCenter() const
         {
             return _center;
         }


### PR DESCRIPTION
This PR is a part of #8012 and includes:
- fix of some SonarQube and Clang-Tidy issues;
- make View World use reference to the gameArea of given interface (AdventureMap / EditorInterface);
- do not make gameArea copies for the View World (use reference).
- schedule the cursor update after View World is closed.