### PR TITLE
Cursor update code improvements

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -579,7 +579,7 @@ namespace
 
     void showQuickInfo( const Castle & castle, const fheroes2::Point & position, const bool showOnRadar, const fheroes2::Rect & areaToRestore )
     {
-        const CursorRestorer cursorRestorer( false, Cursor::POINTER );
+        const CursorRestorer cursorRestorer( false );
 
         // Update radar if needed
         RadarUpdater radarUpdater( showOnRadar, castle.GetCenter(), areaToRestore );
@@ -701,7 +701,7 @@ namespace
     void showQuickInfo( const HeroBase & hero, const fheroes2::Point & position, const bool showOnRadar, const fheroes2::Rect & areaToRestore,
                         const std::optional<bool> showFullInfo )
     {
-        const CursorRestorer cursorRestorer( false, Cursor::POINTER );
+        const CursorRestorer cursorRestorer( false );
 
         // Update radar if needed
         RadarUpdater radarUpdater( showOnRadar, hero.GetCenter(), areaToRestore );

--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -654,7 +654,7 @@ void Dialog::DwellingInfo( const Monster & monster, const uint32_t available )
     fheroes2::Display & display = fheroes2::Display::instance();
 
     // Set cursor.
-    const CursorRestorer cursorRestorer( false, Cursor::POINTER );
+    const CursorRestorer cursorRestorer( false );
 
     const fheroes2::Point dialogOffset( ( display.width() - windowSize.width ) / 2, display.height() / 2 - display.DEFAULT_HEIGHT / 2 + BORDERWIDTH );
 

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -692,7 +692,7 @@ void Game::ShowCredits( const bool keepMainMenuBorders )
     const fheroes2::Rect creditsRoi( mainMenuBackground.x(), mainMenuBackground.y(), mainMenuBackground.width(), mainMenuBackground.height() );
 
     // Hide mouse cursor.
-    const CursorRestorer cursorRestorer( false, Cursor::POINTER );
+    const CursorRestorer cursorRestorer( false );
 
     std::unique_ptr<fheroes2::ImageRestorer> restorer;
 

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -123,7 +123,7 @@ namespace Video
         const bool isLooped = ( action == VideoAction::LOOP_VIDEO || action == VideoAction::PLAY_TILL_AUDIO_END );
 
         // Hide mouse cursor.
-        const CursorRestorer cursorRestorer( false, Cursor::Get().Themes() );
+        const CursorRestorer cursorRestorer( false );
 
         fheroes2::Display & display = fheroes2::Display::instance();
         display.fill( 0 );

--- a/src/fheroes2/gui/cursor.cpp
+++ b/src/fheroes2/gui/cursor.cpp
@@ -223,12 +223,14 @@ int Cursor::WithoutDistanceThemes( const int theme )
     return theme;
 }
 
+CursorRestorer::CursorRestorer( const bool visible )
+{
+    fheroes2::cursor().show( visible );
+}
+
 CursorRestorer::CursorRestorer( const bool visible, const int theme )
 {
-    if ( visible ) {
-        // Theme update is needed only if cursor is visible.
-        Cursor::Get().SetThemes( theme );
-    }
+    Cursor::Get().SetThemes( theme );
 
     fheroes2::cursor().show( visible );
 }

--- a/src/fheroes2/gui/cursor.h
+++ b/src/fheroes2/gui/cursor.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -23,9 +23,11 @@
 #ifndef H2CURSOR_H
 #define H2CURSOR_H
 
+#include <cassert>
 #include <cstdint>
 
 #include "math_base.h"
+#include "screen.h"
 
 namespace fheroes2
 {
@@ -185,7 +187,12 @@ public:
     static int WithoutDistanceThemes( const int theme );
     static void Refresh();
 
-    int Themes() const;
+    int Themes() const
+    {
+        assert( _theme <= CURSOR_HERO_BOAT_ACTION_8 );
+        return _theme;
+    }
+
     bool SetThemes( int name, bool force = false );
 
     void setCustomImage( const fheroes2::Image & image, const fheroes2::Point & offset );
@@ -200,23 +207,23 @@ public:
     }
 
 private:
-    Cursor();
+    Cursor() = default;
     ~Cursor() = default;
 
     void SetOffset( int name, const fheroes2::Point & defaultOffset );
     void Move( int32_t x, int32_t y ) const;
 
-    int theme;
+    int _theme{ Cursor::CursorType::NONE };
 
     fheroes2::Point _offset;
 
-    bool _monochromeCursorThemes;
+    bool _monochromeCursorThemes{ false };
 };
 
 class CursorRestorer
 {
 public:
-    CursorRestorer();
+    CursorRestorer() = default;
     CursorRestorer( const bool visible, const int theme ); // For convenience, also sets visibility and theme of the cursor
     CursorRestorer( const CursorRestorer & ) = delete;
 
@@ -225,8 +232,8 @@ public:
     CursorRestorer & operator=( const CursorRestorer & ) = delete;
 
 private:
-    const int _theme;
-    const bool _visible;
+    const int _theme{ Cursor::Get().Themes() };
+    const bool _visible{ fheroes2::cursor().isVisible() };
 };
 
 #endif

--- a/src/fheroes2/gui/cursor.h
+++ b/src/fheroes2/gui/cursor.h
@@ -224,7 +224,10 @@ class CursorRestorer
 {
 public:
     CursorRestorer() = default;
-    CursorRestorer( const bool visible, const int theme ); // For convenience, also sets visibility and theme of the cursor
+    // Use only to hide a cursor. Previous cursor visibility and theme will be restored when this object is destroyed.
+    explicit CursorRestorer( const bool visible );
+    // Use to set cursor visibility and theme of the cursor. Previous cursor visibility and theme will be restored when this object is destroyed.
+    CursorRestorer( const bool visible, const int theme );
     CursorRestorer( const CursorRestorer & ) = delete;
 
     ~CursorRestorer();

--- a/src/fheroes2/gui/ui_map_interface.cpp
+++ b/src/fheroes2/gui/ui_map_interface.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/ui_map_interface.cpp
+++ b/src/fheroes2/gui/ui_map_interface.cpp
@@ -54,7 +54,7 @@ namespace Interface
 
     void displayStandardPopupWindow( std::string text, const fheroes2::Rect & interfaceArea )
     {
-        const CursorRestorer cursorRestorer( false, Cursor::POINTER );
+        const CursorRestorer cursorRestorer( false );
 
         const fheroes2::Sprite & windowImage = fheroes2::AGG::GetICN( ICN::QWIKINFO, 0 );
 


### PR DESCRIPTION
This PR is a part of #8012. It contains:
- fixes for some Clang-Tidy and SonarQube issues;
- minor optimization of CursorRestorer:
    - update cursor theme only if cursor visibility is true. There is no difference what theme the invisible cursor uses so theme update is redundant;
    - do not do checks for theme and visibility in destructor because it is done in `SetThemes()` for themes and `show()` method for visibility is inlined.