### PR TITLE
Use the same name for terrain objects within the Editor

### DIFF
--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -696,6 +696,10 @@ namespace
 
         std::string getObjectName( const Maps::ObjectInfo & info ) override
         {
+            if ( info.objectType == MP2::OBJ_NONE ) {
+                return _( "Terrain object" );
+            }
+
             return MP2::StringObject( info.objectType );
         }
     };


### PR DESCRIPTION
![image](https://github.com/ihhub/fheroes2/assets/19829520/932074a8-ebe8-4b85-a4c9-fdbca0c33c26)

relates to #6845 