### PR TITLE
Change the logic to handle the future map loading

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -472,16 +472,20 @@ namespace Interface
                 if ( isCursorOverGamearea && _editorPanel.getBrushArea().width == 0 ) {
                     if ( _editorPanel.isTerrainEdit() ) {
                         // Fill the selected area in terrain edit mode.
-                        const fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
                         const int groundId = _editorPanel.selectedGroundType();
                         Maps::setTerrainOnTiles( _selectedTile, _tileUnderCursor, groundId );
+
+                        action.commit();
                     }
                     else if ( _editorPanel.isEraseMode() ) {
                         // Erase objects in the selected area.
-                        const fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
                         Maps::eraseObjectsOnTiles( _selectedTile, _tileUnderCursor, _editorPanel.getEraseTypes() );
+
+                        action.commit();
                     }
                 }
 
@@ -667,7 +671,7 @@ namespace Interface
 
             const int groundId = _editorPanel.selectedGroundType();
 
-            const fheroes2::ActionCreator action( _historyManager, _mapFormat );
+            fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
             if ( brushSize.width > 0 ) {
                 const fheroes2::Point indices = getBrushAreaIndicies( brushSize, tileIndex );
@@ -684,37 +688,47 @@ namespace Interface
             }
 
             _redraw |= mapUpdateFlags;
+
+            action.commit();
         }
         else if ( _editorPanel.isRoadDraw() ) {
-            const fheroes2::ActionCreator action( _historyManager, _mapFormat );
+            fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
             if ( Maps::updateRoadOnTile( tile, true ) ) {
                 _redraw |= mapUpdateFlags;
+
+                action.commit();
             }
         }
         else if ( _editorPanel.isStreamDraw() ) {
-            const fheroes2::ActionCreator action( _historyManager, _mapFormat );
+            fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
             if ( Maps::updateStreamOnTile( tile, true ) ) {
                 _redraw |= mapUpdateFlags;
+
+                action.commit();
             }
         }
         else if ( _editorPanel.isEraseMode() ) {
             const fheroes2::Rect brushSize = _editorPanel.getBrushArea();
             assert( brushSize.width == brushSize.height );
 
-            const fheroes2::ActionCreator action( _historyManager, _mapFormat );
+            fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
             if ( brushSize.width > 1 ) {
                 const fheroes2::Point indices = getBrushAreaIndicies( brushSize, tileIndex );
 
                 if ( Maps::eraseObjectsOnTiles( indices.x, indices.y, _editorPanel.getEraseTypes() ) ) {
                     _redraw |= mapUpdateFlags;
+
+                    action.commit();
                 }
             }
             else {
                 if ( Maps::eraseOjects( tile, _editorPanel.getEraseTypes() ) ) {
                     _redraw |= mapUpdateFlags;
+
+                    action.commit();
                 }
 
                 if ( brushSize.width == 0 ) {
@@ -993,7 +1007,6 @@ namespace Interface
             fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
             if ( !setObjectOnTile( tile, Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS, basementId ) ) {
-                action.abort();
                 return;
             }
 
@@ -1006,7 +1019,6 @@ namespace Interface
             Maps::setLastObjectUID( objectId );
 
             if ( !setObjectOnTile( tile, groupType, type ) ) {
-                action.abort();
                 return;
             }
 
@@ -1015,16 +1027,16 @@ namespace Interface
             Maps::setLastObjectUID( objectId );
 
             if ( !setObjectOnTile( world.GetTiles( tile.GetIndex() - 1 ), Maps::ObjectGroup::LANDSCAPE_FLAGS, color * 2 ) ) {
-                action.abort();
                 return;
             }
 
             Maps::setLastObjectUID( objectId );
 
             if ( !setObjectOnTile( world.GetTiles( tile.GetIndex() + 1 ), Maps::ObjectGroup::LANDSCAPE_FLAGS, color * 2 + 1 ) ) {
-                action.abort();
                 return;
             }
+
+            action.commit();
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_MINES ) {
             int32_t type = -1;
@@ -1057,11 +1069,11 @@ namespace Interface
             fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
             if ( !setObjectOnTile( tile, groupType, type ) ) {
-                action.abort();
                 return;
             }
 
             // TODO: Place owner flag according to the color state.
+            action.commit();
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_DWELLINGS ) {
             const auto & objectInfo = getObjectInfo( groupType, _editorPanel.getSelectedObjectType() );
@@ -1164,8 +1176,8 @@ namespace Interface
     {
         fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
-        if ( !setObjectOnTile( tile, groupType, objectIndex ) ) {
-            action.abort();
+        if ( setObjectOnTile( tile, groupType, objectIndex ) ) {
+            action.commit();
         }
     }
 

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -134,7 +134,7 @@ namespace Interface
             // Do nothing.
         }
 
-        void setObjectOnTile( Maps::Tiles & tile, const Maps::ObjectGroup groupType, const int32_t objectIndex );
+        bool setObjectOnTile( Maps::Tiles & tile, const Maps::ObjectGroup groupType, const int32_t objectIndex );
 
         void setObjectOnTileAsAction( Maps::Tiles & tile, const Maps::ObjectGroup groupType, const int32_t objectIndex );
 

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -112,7 +112,6 @@ namespace fheroes2
 
     ActionCreator::~ActionCreator()
     {
-
         auto * action = dynamic_cast<MapAction *>( _action.get() );
         if ( action == nullptr ) {
             // How is it even possible?

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -112,6 +112,7 @@ namespace fheroes2
 
     ActionCreator::~ActionCreator()
     {
+
         auto * action = dynamic_cast<MapAction *>( _action.get() );
         if ( action == nullptr ) {
             // How is it even possible?
@@ -120,6 +121,11 @@ namespace fheroes2
         }
 
         try {
+            if ( _aborted ) {
+                action->undo();
+                return;
+            }
+
             if ( action->prepare() ) {
                 _manager.add( std::move( _action ) );
             }

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -110,21 +110,16 @@ namespace fheroes2
         _action = std::make_unique<MapAction>( mapFormat );
     }
 
-    ActionCreator::~ActionCreator()
+    void ActionCreator::commit()
     {
         auto * action = dynamic_cast<MapAction *>( _action.get() );
         if ( action == nullptr ) {
-            // How is it even possible?
+            // How is it even possible? Did you call this method twice?
             assert( 0 );
             return;
         }
 
         try {
-            if ( _aborted ) {
-                action->undo();
-                return;
-            }
-
             if ( action->prepare() ) {
                 _manager.add( std::move( _action ) );
             }

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -119,14 +119,8 @@ namespace fheroes2
             return;
         }
 
-        try {
-            if ( action->prepare() ) {
-                _manager.add( std::move( _action ) );
-            }
-        }
-        catch ( ... ) {
-            // If an exception happens here then something is very wrong with the code.
-            assert( 0 );
+        if ( action->prepare() ) {
+            _manager.add( std::move( _action ) );
         }
     }
 }

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -52,23 +52,24 @@ namespace fheroes2
     public:
         explicit ActionCreator( HistoryManager & manager, Maps::Map_Format::MapFormat & mapFormat );
 
-        ~ActionCreator();
+        ~ActionCreator()
+        {
+            if ( _action ) {
+                // The action wasn't committed. Undo all the changes.
+                _action->undo();
+            }
+        }
 
         ActionCreator( const ActionCreator & ) = delete;
 
         ActionCreator & operator=( const ActionCreator & ) = delete;
 
-        void abort()
-        {
-            _aborted = true;
-        }
+        void commit();
 
     private:
         HistoryManager & _manager;
 
         std::unique_ptr<Action> _action;
-
-        bool _aborted{ false };
     };
 
     class HistoryManager

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -58,10 +58,17 @@ namespace fheroes2
 
         ActionCreator & operator=( const ActionCreator & ) = delete;
 
+        void abort()
+        {
+            _aborted = true;
+        }
+
     private:
         HistoryManager & _manager;
 
         std::unique_ptr<Action> _action;
+
+        bool _aborted{ false };
     };
 
     class HistoryManager

--- a/src/fheroes2/maps/map_format_helper.h
+++ b/src/fheroes2/maps/map_format_helper.h
@@ -36,11 +36,12 @@ namespace Maps
     enum class ObjectGroup : int32_t;
 
     bool readMapInEditor( const Map_Format::MapFormat & map );
+    bool readAllTiles( const Map_Format::MapFormat & map );
 
     bool saveMapInEditor( Map_Format::MapFormat & map );
 
     void readTileTerrain( Tiles & tile, const Map_Format::TileInfo & info );
-    void readTileObject( Tiles & tile, const Map_Format::ObjectInfo & object );
+    bool readTileObject( Tiles & tile, const Map_Format::ObjectInfo & object );
 
     void writeTile( const Tiles & tile, Map_Format::TileInfo & info );
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -3268,7 +3268,7 @@ namespace Maps
             if ( updateMapPassabilities ) {
                 world.updatePassabilities();
             }
-            return true;;
+            return true;
         default:
             break;
         }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1203,19 +1203,40 @@ namespace
         }
     }
 
-    void placeObjectOnTile( const Maps::Tiles & tile, const Maps::ObjectInfo & info )
+    bool placeObjectOnTile( const Maps::Tiles & tile, const Maps::ObjectInfo & info )
     {
         assert( !info.empty() );
 
-        const uint32_t uid = Maps::getNewObjectUID();
+        // Verify that the object is allowed to be placed.
         const fheroes2::Point mainTilePos = tile.GetCenter();
 
         for ( const auto & partInfo : info.groundLevelParts ) {
             const fheroes2::Point pos = mainTilePos + partInfo.tileOffset;
             const bool isMainObject = ( partInfo.layerType != Maps::SHADOW_LAYER && partInfo.layerType != Maps::TERRAIN_LAYER );
 
-            if ( !Maps::isValidAbsPoint( pos.x, pos.y ) ) {
+            if ( !Maps::isValidAbsPoint( pos.x, pos.y ) && isMainObject ) {
                 // Only shadow and terrain layer object parts are allowed not to be placed.
+                assert( 0 );
+                return false;
+            }
+        }
+
+        for ( const auto & partInfo : info.topLevelParts ) {
+            const fheroes2::Point pos = mainTilePos + partInfo.tileOffset;
+            if ( !Maps::isValidAbsPoint( pos.x, pos.y ) ) {
+                // This shouldn't happen as the object must be verified before placement.
+                assert( 0 );
+                return false;
+            }
+        }
+
+        const uint32_t uid = Maps::getNewObjectUID();
+
+        for ( const auto & partInfo : info.groundLevelParts ) {
+            const fheroes2::Point pos = mainTilePos + partInfo.tileOffset;
+            const bool isMainObject = ( partInfo.layerType != Maps::SHADOW_LAYER && partInfo.layerType != Maps::TERRAIN_LAYER );
+
+            if ( !Maps::isValidAbsPoint( pos.x, pos.y ) ) {
                 assert( !isMainObject );
                 continue;
             }
@@ -1273,6 +1294,8 @@ namespace
                 currentTile.SetObject( partInfo.objectType );
             }
         }
+
+        return true;
     }
 }
 
@@ -3208,7 +3231,7 @@ namespace Maps
         return needRedraw;
     }
 
-    void setObjectOnTile( Tiles & tile, const ObjectInfo & info, const bool updateMapPassabilities )
+    bool setObjectOnTile( Tiles & tile, const ObjectInfo & info, const bool updateMapPassabilities )
     {
         assert( !info.empty() );
 
@@ -3217,21 +3240,27 @@ namespace Maps
             setMonsterOnTile( tile, static_cast<int32_t>( info.metadata[0] ), 0 );
             // Since setMonsterOnTile() function interprets 0 as a random number of monsters it is important to set the correct value.
             setMonsterCountOnTile( tile, 0 );
-            return;
+            return true;
         case MP2::OBJ_RESOURCE:
             // Setting just 1 resource is enough. It doesn't matter as we are not saving this value into the map format.
-            placeObjectOnTile( tile, info );
+            if ( !placeObjectOnTile( tile, info ) ) {
+                return false;
+            }
             setResourceOnTile( tile, static_cast<int>( info.metadata[0] ), 1 );
-            return;
+            return true;
         case MP2::OBJ_ARTIFACT:
-            placeObjectOnTile( tile, info );
+            if ( !placeObjectOnTile( tile, info ) ) {
+                return false;
+            }
             // The artifact ID is stored in metadata[0]. It is used by the other engine functions.
             tile.metadata()[0] = info.metadata[0];
-            return;
+            return true;
         case MP2::OBJ_ALCHEMIST_LAB:
         case MP2::OBJ_MINE:
         case MP2::OBJ_SAWMILL:
-            placeObjectOnTile( tile, info );
+            if ( !placeObjectOnTile( tile, info ) ) {
+                return false;
+            }
             // Set resource type and income per day.
             tile.metadata()[0] = info.metadata[0];
             tile.metadata()[1] = info.metadata[1];
@@ -3239,15 +3268,19 @@ namespace Maps
             if ( updateMapPassabilities ) {
                 world.updatePassabilities();
             }
-            return;
+            return true;;
         default:
             break;
         }
 
-        placeObjectOnTile( tile, info );
+        if ( !placeObjectOnTile( tile, info ) ) {
+            return false;
+        }
 
         if ( updateMapPassabilities ) {
             world.updatePassabilities();
         }
+
+        return true;
     }
 }

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -188,5 +188,5 @@ namespace Maps
     bool eraseObjectsOnTiles( const int32_t startTileId, const int32_t endTileId, const uint32_t objectTypesToErase );
     bool eraseOjects( Tiles & tile, const uint32_t objectTypesToErase );
 
-    void setObjectOnTile( Tiles & tile, const ObjectInfo & info, const bool updateMapPassabilities );
+    bool setObjectOnTile( Tiles & tile, const ObjectInfo & info, const bool updateMapPassabilities );
 }

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -676,7 +676,7 @@ bool World::loadResurrectionMap( const std::string & filename )
     width = map.size;
     height = map.size;
 
-    vec_tiles.resize( width * height );
+    vec_tiles.resize( static_cast<size_t>( width ) * height );
 
     if ( !Maps::readAllTiles( map ) ) {
         return false;

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -43,6 +43,7 @@
 #include "heroes.h"
 #include "kingdom.h"
 #include "logging.h"
+#include "map_format_helper.h"
 #include "map_format_info.h"
 #include "maps.h"
 #include "maps_fileinfo.h"
@@ -669,6 +670,15 @@ bool World::loadResurrectionMap( const std::string & filename )
     Maps::Map_Format::MapFormat map;
     if ( !Maps::Map_Format::loadMap( filename, map ) ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Map file '" << filename << "' is corrupted or missing." )
+        return false;
+    }
+
+    width = map.size;
+    height = map.size;
+
+    vec_tiles.resize( width * height );
+
+    if ( !Maps::readAllTiles( map ) ) {
         return false;
     }
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -682,8 +682,16 @@ bool World::loadResurrectionMap( const std::string & filename )
         return false;
     }
 
-    // TODO: return true once we add logic for loading an entire map.
-    return false;
+    // Clear artifact flags to correctly generate random artifacts.
+    fheroes2::ResetArtifactStats();
+
+    if ( !ProcessNewMap( filename, false ) ) {
+        return false;
+    }
+
+    DEBUG_LOG( DBG_GAME, DBG_INFO, "Loading of FH2 map is completed." )
+
+    return true;
 }
 
 bool World::ProcessNewMap( const std::string & filename, const bool checkPoLObjects )


### PR DESCRIPTION
- add checks for objects placement on the Adventure Map
- add abort logic for history manager to revert changes back to the previous state if there is an error
- add logic to load objects on the Adventure Map for the future map loading

relates to #6845