### PR TITLE
GitHub Actions: Request only the minimum necessary permissions for workflows

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -10,6 +10,9 @@ on:
       ANDROID_KEY_PASSWORD:
         required: false
 
+permissions:
+  contents: write
+
 env:
   KEYSTORE_BASE64: ${{ secrets.ANDROID_KEYSTORE }}
 

--- a/.github/workflows/clang_analyzer.yml
+++ b/.github/workflows/clang_analyzer.yml
@@ -3,6 +3,8 @@ name: Clang Analyzer
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   clang:
     name: Clang Analyzer

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -9,6 +9,8 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions: {}
+
 jobs:
   tidy:
     name: Clang-Tidy

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -22,29 +22,42 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: ${{ github.event.workflow_run.id }},
           });
-          let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+          const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "clang-tidy-result"
           })[0];
-          let download = await github.rest.actions.downloadArtifact({
+          const download = await github.rest.actions.downloadArtifact({
               owner: context.repo.owner,
               repo: context.repo.repo,
               artifact_id: matchArtifact.id,
               archive_format: "zip",
           });
-          let fs = require("fs");
+          const fs = require("fs");
           fs.writeFileSync("${{ github.workspace }}/clang-tidy-result.zip", Buffer.from(download.data));
-    - name: Set environment variables
+    - name: Extract analysis results
       run: |
         mkdir clang-tidy-result
         unzip -j clang-tidy-result.zip -d clang-tidy-result
-        echo "PR_ID=$(cat clang-tidy-result/pr-id.txt)" >> "$GITHUB_ENV"
-        echo "PR_HEAD_REPO=$(cat clang-tidy-result/pr-head-repo.txt)" >> "$GITHUB_ENV"
-        echo "PR_HEAD_SHA=$(cat clang-tidy-result/pr-head-sha.txt)" >> "$GITHUB_ENV"
+    - name: Set environment variables
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const assert = require("node:assert").strict;
+          const fs = require("fs");
+          function exportVar(varName, fileName, regEx) {
+              const val = fs.readFileSync("${{ github.workspace }}/clang-tidy-result/" + fileName, {
+                  encoding: "ascii"
+              }).trimEnd();
+              assert.ok(regEx.test(val), "Invalid value format for " + varName);
+              core.exportVariable(varName, val);
+          }
+          exportVar("PR_ID", "pr-id.txt", /^[0-9]+$/);
+          exportVar("PR_HEAD_REPO", "pr-head-repo.txt", /^[-./0-9A-Z_a-z]+$/);
+          exportVar("PR_HEAD_SHA", "pr-head-sha.txt", /^[0-9A-Fa-f]+$/);
     - uses: actions/checkout@v4
       with:
         repository: ${{ env.PR_HEAD_REPO }}
@@ -54,21 +67,21 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          let artifacts = await github.rest.actions.listWorkflowRunArtifacts({
+          const artifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
               run_id: ${{ github.event.workflow_run.id }},
           });
-          let matchArtifact = artifacts.data.artifacts.filter((artifact) => {
+          const matchArtifact = artifacts.data.artifacts.filter((artifact) => {
               return artifact.name == "clang-tidy-result"
           })[0];
-          let download = await github.rest.actions.downloadArtifact({
+          const download = await github.rest.actions.downloadArtifact({
               owner: context.repo.owner,
               repo: context.repo.repo,
               artifact_id: matchArtifact.id,
               archive_format: "zip",
           });
-          let fs = require("fs");
+          const fs = require("fs");
           fs.writeFileSync("${{ github.workspace }}/clang-tidy-result.zip", Buffer.from(download.data));
     - name: Extract analysis results
       run: |

--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -5,6 +5,9 @@ on:
     workflows: [ Clang-Tidy ]
     types: [ completed ]
 
+permissions:
+  pull-requests: write
+
 jobs:
   comment:
     name: Clang-Tidy comments

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -3,6 +3,8 @@ name: CMake
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   cmake:
     strategy:

--- a/.github/workflows/code_style_check.yml
+++ b/.github/workflows/code_style_check.yml
@@ -3,6 +3,8 @@ name: Code style check
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   style:
     name: Code style check

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -3,6 +3,8 @@ name: IWYU
 on:
   workflow_call:
 
+permissions: {}
+
 jobs:
   iwyu:
     name: IWYU

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -3,6 +3,9 @@ name: Make
 on:
   workflow_call:
 
+permissions:
+  contents: write
+
 jobs:
   make:
     strategy:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -3,6 +3,9 @@ name: MSVC
 on:
   workflow_call:
 
+permissions:
+  contents: write
+
 jobs:
   msvc:
     strategy:

--- a/.github/workflows/pr_author_auto_assign.yml
+++ b/.github/workflows/pr_author_auto_assign.yml
@@ -4,6 +4,9 @@ on:
   pull_request_target:
     types: [opened, reopened]
 
+permissions:
+  pull-requests: write
+
 jobs:
   assign:
     name: PR author auto assign

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+
 jobs:
   style:
     name: Code style check

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -8,6 +8,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   android:
     name: Android

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -6,6 +6,8 @@ on:
       SONAR_TOKEN:
         required: true
 
+permissions: {}
+
 jobs:
   sonarcloud:
     name: SonarCloud Analyzer

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -3,6 +3,10 @@ name: Translation update
 on:
   workflow_call:
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   translation:
     name: Translation update

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -90,20 +90,20 @@ jobs:
       uses: actions/github-script@v7
       with:
         script: |
-          let pr = await github.rest.pulls.create({
+          const pr = await github.rest.pulls.create({
               owner: context.repo.owner,
               repo: context.repo.repo,
               title: "Update translation files",
               head: "${{ env.PR_BRANCH }}",
               base: "${{ github.ref }}",
           });
-          let assigneesPromise = github.rest.issues.addAssignees({
+          const assigneesPromise = github.rest.issues.addAssignees({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.data.number,
               assignees: ["${{ github.actor }}"],
           });
-          let labelsPromise = github.rest.issues.addLabels({
+          const labelsPromise = github.rest.issues.addLabels({
               owner: context.repo.owner,
               repo: context.repo.repo,
               issue_number: pr.data.number,


### PR DESCRIPTION
Most workflows don't need any permissions at all.

* Workflows that use `ncipollo/release-action` need the `contents: write` to be able to upload releases;
* Workflows that create PRs (like `translation_update.yml`) and PR comments (like `clang_tidy_comments.yml`) need the `pull-requests: write` permission;
* `translation_update.yml` workflow also needs the `contents: write` permission to be able to create the PR branch;
* `pr_author_auto_assign.yml` workflow needs the `pull-requests: write` permission to be able to assign PR authors to their PRs.

I also recommend setting the minimum default permissions for the `GITHUB_TOKEN` in repo settings -> Actions -> General:

![permissions](https://github.com/ihhub/fheroes2/assets/32623900/ec895384-807e-47db-82ba-5102386f2af2)

This PR also uses `github-script` instead of `bash` to parse untrusted input and set environment variables and imposes additional checks on corresponding values.