### PR TITLE
Corrected icons alignment on the meeting screen.

### DIFF
--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -66,7 +66,7 @@ namespace
     const int32_t primarySkillIconSize{ 33 };
 
     const std::array<int32_t, 2> playerColor{ Color::BLUE, Color::RED };
-    const std::array<int32_t, 2> moraleAndLuckOffsetX{ 34, 566 };
+    const std::array<int32_t, 2> moraleAndLuckOffsetX{ 34, 571 };
     const std::array<int32_t, 2> primarySkillOffsetX{ 216, 389 };
     const std::array<int32_t, 2> secondarySkillOffsetX{ 22, 353 };
     const std::array<int32_t, 2> artifactOffsetX{ 23, 367 };

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -271,7 +271,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     text.draw( cur_pt.x + 320 - text.width() / 2, cur_pt.y + 29, display );
 
     const int iconsH1XOffset = 34;
-    const int iconsH2XOffset = 566;
+    const int iconsH2XOffset = 570;
     const int portraitYOffset = 72;
 
     // portrait

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -271,7 +271,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     text.draw( cur_pt.x + 320 - text.width() / 2, cur_pt.y + 29, display );
 
     const int iconsH1XOffset = 34;
-    const int iconsH2XOffset = 570;
+    const int iconsH2XOffset = 571;
     const int portraitYOffset = 72;
 
     // portrait


### PR DESCRIPTION
Shifted second hero's morale and luck indicators 4px to the right.

Fix #7660