### PR TITLE
Migrate the build workflow from macOS 11 to 12

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -102,7 +102,7 @@ jobs:
             CXX: aarch64-linux-gnu-g++
             AR: aarch64-linux-gnu-ar
         - name: macOS SDL2
-          os: macos-11
+          os: macos-12
           dependencies: sdl2 sdl2_mixer sdl2_image
           env:
             FHEROES2_STRICT_COMPILATION: ON


### PR DESCRIPTION
macOS 11 image is [deprecated](https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/) and will be removed by June 2024. Binaries are still x86_64.