### PR TITLE
Auto combat toggling improvements.

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1249,8 +1249,17 @@ bool Battle::Arena::EnemyOfAIHasAutoBattleInProgress() const
         return false;
     }
 
-    return ( GetCurrentForce().GetControl() & CONTROL_AI ) && !( getEnemyForce( GetCurrentColor() ).GetControl() & CONTROL_AI )
-           && ( _autoBattleColors & getEnemyForce( GetCurrentColor() ).GetColor() );
+    if ( !( GetCurrentForce().GetControl() & CONTROL_AI ) ) {
+        return false;
+    }
+
+    const auto & enemyForce = getEnemyForce( GetCurrentColor() );
+
+    if ( enemyForce.GetControl() & CONTROL_AI ) {
+        return false;
+    }
+
+    return ( _autoBattleColors & enemyForce.GetColor() );
 }
 
 bool Battle::Arena::CanToggleAutoBattle() const

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1253,7 +1253,7 @@ bool Battle::Arena::EnemyOfAIHasAutoBattleInProgress() const
         return false;
     }
 
-    const auto & enemyForce = getEnemyForce( GetCurrentColor() );
+    const Force & enemyForce = getEnemyForce( GetCurrentColor() );
 
     if ( enemyForce.GetControl() & CONTROL_AI ) {
         return false;

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1243,6 +1243,20 @@ bool Battle::Arena::AutoBattleInProgress() const
     return false;
 }
 
+bool Battle::Arena::EnemyOfAIHasAutoBattleInProgress() const
+{
+    if ( _currentUnit == nullptr ) {
+        return false;
+    }
+
+    if ( ( GetCurrentForce().GetControl() & CONTROL_AI ) && !( getEnemyForce( GetCurrentColor() ).GetControl() & CONTROL_AI )
+         && ( _autoBattleColors & getEnemyForce( GetCurrentColor() ).GetColor() ) ) {
+        return true;
+    }
+
+    return false;
+}
+
 bool Battle::Arena::CanToggleAutoBattle() const
 {
     if ( _currentUnit == nullptr ) {

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1249,12 +1249,8 @@ bool Battle::Arena::EnemyOfAIHasAutoBattleInProgress() const
         return false;
     }
 
-    if ( ( GetCurrentForce().GetControl() & CONTROL_AI ) && !( getEnemyForce( GetCurrentColor() ).GetControl() & CONTROL_AI )
-         && ( _autoBattleColors & getEnemyForce( GetCurrentColor() ).GetColor() ) ) {
-        return true;
-    }
-
-    return false;
+    return ( GetCurrentForce().GetControl() & CONTROL_AI ) && !( getEnemyForce( GetCurrentColor() ).GetControl() & CONTROL_AI )
+           && ( _autoBattleColors & getEnemyForce( GetCurrentColor() ).GetColor() );
 }
 
 bool Battle::Arena::CanToggleAutoBattle() const

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -98,6 +98,7 @@ namespace Battle
         bool BattleValid() const;
 
         bool AutoBattleInProgress() const;
+        bool EnemyOfAIHasAutoBattleInProgress() const;
         bool CanToggleAutoBattle() const;
 
         uint32_t GetTurnNumber() const

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6318,15 +6318,26 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
         }
     }
 
-    // Interrupting auto battle
-    if ( ( arena.AutoBattleInProgress() || arena.EnemyOfAIHasAutoBattleInProgress() )
-         && ( ( le.MouseClickLeft() || le.MouseClickRight()
-                || ( le.KeyPress()
-                     && ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) ) )
-              && fheroes2::showMessage( fheroes2::Text( "", {} ),
-                                        fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
-                                        Dialog::YES | Dialog::NO )
-                     == Dialog::YES ) ) {
+    // Check if auto battle interruption was requested.
+    InterruptAutoBattle( le );
+}
+
+void Battle::Interface::InterruptAutoBattle( LocalEvent & le )
+{
+    // Interrupt only if automation is currently on.
+    if ( !arena.AutoBattleInProgress() && !arena.EnemyOfAIHasAutoBattleInProgress() ) {
+        return;
+    }
+
+    if ( !le.MouseClickLeft() && !le.MouseClickRight() && !Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH )
+         && !Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
+        return;
+    }
+
+    auto interrupt = fheroes2::showMessage( fheroes2::Text( "", {} ),
+                                            fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
+                                            Dialog::YES | Dialog::NO );
+    if ( interrupt == Dialog::YES ) {
         // Identify which color requested the auto battle interrupt.
         auto color = arena.GetCurrentColor();
         if ( arena.GetCurrentForce().GetControl() & CONTROL_AI ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6320,7 +6320,7 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
 
     // Interrupting auto battle
     if ( ( arena.AutoBattleInProgress() || arena.EnemyOfAIHasAutoBattleInProgress() )
-         && ( ( le.MouseClickLeft( btn_auto.area() )
+         && ( ( le.MouseClickLeft() || le.MouseClickRight()
                 || ( le.KeyPress()
                      && ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) ) )
               && fheroes2::showMessage( fheroes2::Text( "", {} ),

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3109,9 +3109,8 @@ void Battle::Interface::EventShowOptions()
 
 void Battle::Interface::EventAutoSwitch( const Unit & unit, Actions & actions )
 {
-    if ( !arena.CanToggleAutoBattle() ) {
-        return;
-    }
+    // TODO: remove this temporary assertion
+    assert( arena.CanToggleAutoBattle() );
 
     actions.emplace_back( Command::AUTO_SWITCH, unit.GetCurrentOrArmyColor() );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6333,12 +6333,12 @@ void Battle::Interface::InterruptAutoBattle( LocalEvent & le )
         return;
     }
 
-    auto interrupt = fheroes2::showMessage( fheroes2::Text( "", {} ),
-                                            fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
-                                            Dialog::YES | Dialog::NO );
+    const int interrupt = fheroes2::showMessage( fheroes2::Text( "", {} ),
+                                                 fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
+                                                 Dialog::YES | Dialog::NO );
     if ( interrupt == Dialog::YES ) {
         // Identify which color requested the auto battle interrupt.
-        auto color = arena.GetCurrentColor();
+        int color = arena.GetCurrentColor();
         if ( arena.GetCurrentForce().GetControl() & CONTROL_AI ) {
             color = arena.GetOppositeColor( color );
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6319,7 +6319,7 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
     }
 
     // Interrupting auto battle
-    if ( arena.AutoBattleInProgress() && arena.CanToggleAutoBattle()
+    if ( ( arena.AutoBattleInProgress() || arena.EnemyOfAIHasAutoBattleInProgress() )
          && ( ( le.MouseClickLeft( btn_auto.area() )
                 || ( le.KeyPress()
                      && ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) ) )
@@ -6327,7 +6327,16 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
                                         fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
                                         Dialog::YES | Dialog::NO )
                      == Dialog::YES ) ) {
-        _interruptAutoBattleForColor = arena.GetCurrentColor();
+        // Identify which color requested the auto battle interrupt.
+        auto color = arena.GetCurrentColor();
+        if ( arena.GetCurrentForce().GetControl() & CONTROL_AI ) {
+            color = arena.GetOppositeColor( color );
+        }
+
+        // Interrupt, but only if the color identified belongs to a human player.
+        if ( !( arena.getForce( color ).GetControl() & CONTROL_AI ) ) {
+            _interruptAutoBattleForColor = color;
+        }
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6318,10 +6318,10 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
     }
 
     // Check if auto battle interruption was requested.
-    InterruptAutoBattle( le );
+    InterruptAutoBattleIfRequested( le );
 }
 
-void Battle::Interface::InterruptAutoBattle( LocalEvent & le )
+void Battle::Interface::InterruptAutoBattleIfRequested( LocalEvent & le )
 {
     // Interrupt only if automation is currently on.
     if ( !arena.AutoBattleInProgress() && !arena.EnemyOfAIHasAutoBattleInProgress() ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6320,14 +6320,13 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
 
     // Interrupting auto battle
     if ( arena.AutoBattleInProgress() && arena.CanToggleAutoBattle()
-         && ( le.MouseClickLeft( btn_auto.area() )
-              || ( le.KeyPress()
-                   && ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH )
-                        || ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL )
-                             && fheroes2::showMessage( fheroes2::Text( "", {} ),
-                                                       fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
-                                                       Dialog::YES | Dialog::NO )
-                                    == Dialog::YES ) ) ) ) ) {
+         && ( ( le.MouseClickLeft( btn_auto.area() )
+                || ( le.KeyPress()
+                     && ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) ) )
+              && fheroes2::showMessage( fheroes2::Text( "", {} ),
+                                        fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
+                                        Dialog::YES | Dialog::NO )
+                     == Dialog::YES ) ) {
         _interruptAutoBattleForColor = arena.GetCurrentColor();
     }
 }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3109,8 +3109,9 @@ void Battle::Interface::EventShowOptions()
 
 void Battle::Interface::EventStartAutoBattle( const Unit & unit, Actions & actions )
 {
-    // TODO: remove this temporary assertion
+    // TODO: remove these temporary assertions
     assert( arena.CanToggleAutoBattle() );
+    assert( !arena.AutoBattleInProgress() );
 
     int startAutoBattle
         = fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "Are you sure you want to enable auto combat?" ), fheroes2::FontType::normalWhite() ),

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2773,7 +2773,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
         }
         // Switch the auto battle mode on/off
         else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH ) ) {
-            EventAutoSwitch( unit, actions );
+            EventStartAutoBattle( unit, actions );
         }
         // Finish the battle in auto mode
         else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_FINISH ) ) {
@@ -3107,10 +3107,17 @@ void Battle::Interface::EventShowOptions()
     humanturn_redraw = true;
 }
 
-void Battle::Interface::EventAutoSwitch( const Unit & unit, Actions & actions )
+void Battle::Interface::EventStartAutoBattle( const Unit & unit, Actions & actions )
 {
     // TODO: remove this temporary assertion
     assert( arena.CanToggleAutoBattle() );
+
+    int startAutoBattle
+        = fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "Are you sure you want to enable auto combat?" ), fheroes2::FontType::normalWhite() ),
+                                 Dialog::YES | Dialog::NO );
+    if ( startAutoBattle != Dialog::YES ) {
+        return;
+    }
 
     actions.emplace_back( Command::AUTO_SWITCH, unit.GetCurrentOrArmyColor() );
 
@@ -3140,13 +3147,7 @@ void Battle::Interface::ButtonAutoAction( const Unit & unit, Actions & actions )
     le.MousePressLeft( btn_auto.area() ) ? btn_auto.drawOnPress() : btn_auto.drawOnRelease();
 
     if ( le.MouseClickLeft( btn_auto.area() ) ) {
-        if ( fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "Are you sure you want to enable auto combat?" ), fheroes2::FontType::normalWhite() ),
-                                    Dialog::YES | Dialog::NO )
-             != Dialog::YES ) {
-            return;
-        }
-
-        EventAutoSwitch( unit, actions );
+        EventStartAutoBattle( unit, actions );
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6333,16 +6333,21 @@ void Battle::Interface::InterruptAutoBattleIfRequested( LocalEvent & le )
         return;
     }
 
+    // Identify which color requested the auto battle interrupt.
+    int color = arena.GetCurrentColor();
+    if ( arena.GetCurrentForce().GetControl() & CONTROL_AI ) {
+        color = arena.GetOppositeColor( color );
+    }
+
+    // The battle interruption is already scheduled, no need for the dialog.
+    if (color == _interruptAutoBattleForColor) {
+        return;
+    }
+
     const int interrupt = fheroes2::showMessage( fheroes2::Text( "", {} ),
                                                  fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
                                                  Dialog::YES | Dialog::NO );
     if ( interrupt == Dialog::YES ) {
-        // Identify which color requested the auto battle interrupt.
-        int color = arena.GetCurrentColor();
-        if ( arena.GetCurrentForce().GetControl() & CONTROL_AI ) {
-            color = arena.GetOppositeColor( color );
-        }
-
         // Interrupt, but only if the color identified belongs to a human player.
         if ( !( arena.getForce( color ).GetControl() & CONTROL_AI ) ) {
             _interruptAutoBattleForColor = color;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6353,10 +6353,7 @@ void Battle::Interface::InterruptAutoBattleIfRequested( LocalEvent & le )
                                                  fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
                                                  Dialog::YES | Dialog::NO );
     if ( interrupt == Dialog::YES ) {
-        // Interrupt, but only if the color identified belongs to a human player.
-        if ( !( arena.getForce( color ).GetControl() & CONTROL_AI ) ) {
-            _interruptAutoBattleForColor = color;
-        }
+        _interruptAutoBattleForColor = color;
     }
 }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2771,7 +2771,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
         else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_OPTIONS ) ) {
             EventShowOptions();
         }
-        // Switch the auto battle mode on/off
+        // Switch the auto battle mode on
         else if ( Game::HotKeyPressEvent( Game::HotKeyEvent::BATTLE_AUTO_SWITCH ) ) {
             EventStartAutoBattle( unit, actions );
         }
@@ -6341,7 +6341,7 @@ void Battle::Interface::InterruptAutoBattleIfRequested( LocalEvent & le )
     }
 
     // The battle interruption is already scheduled, no need for the dialog.
-    if (color == _interruptAutoBattleForColor) {
+    if ( color == _interruptAutoBattleForColor ) {
         return;
     }
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6345,6 +6345,9 @@ void Battle::Interface::InterruptAutoBattleIfRequested( LocalEvent & le )
         return;
     }
 
+    // Right now there should be no pending auto battle interruptions.
+    assert( _interruptAutoBattleForColor == 0 );
+
     const int interrupt = fheroes2::showMessage( fheroes2::Text( "", {} ),
                                                  fheroes2::Text( _( "Are you sure you want to interrupt the auto battle?" ), fheroes2::FontType::normalWhite() ),
                                                  Dialog::YES | Dialog::NO );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -386,6 +386,7 @@ namespace Battle
         void SwitchAllUnitsAnimation( const int32_t animationState ) const;
         void UpdateContourColor();
         void CheckGlobalEvents( LocalEvent & );
+        void InterruptAutoBattle( LocalEvent & );
         void SetHeroAnimationReactionToTroopDeath( const int32_t deathColor ) const;
 
         void ProcessingHeroDialogResult( const int result, Actions & actions );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -386,7 +386,7 @@ namespace Battle
         void SwitchAllUnitsAnimation( const int32_t animationState ) const;
         void UpdateContourColor();
         void CheckGlobalEvents( LocalEvent & );
-        void InterruptAutoBattle( LocalEvent & );
+        void InterruptAutoBattleIfRequested( LocalEvent & le );
         void SetHeroAnimationReactionToTroopDeath( const int32_t deathColor ) const;
 
         void ProcessingHeroDialogResult( const int result, Actions & actions );

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -392,7 +392,7 @@ namespace Battle
         void ProcessingHeroDialogResult( const int result, Actions & actions );
 
         void _openBattleSettingsDialog();
-        void EventAutoSwitch( const Unit & unit, Actions & actions );
+        void EventStartAutoBattle( const Unit & unit, Actions & actions );
         void EventAutoFinish( Actions & actions );
         void EventShowOptions();
         void ButtonAutoAction( const Unit & unit, Actions & actions );


### PR DESCRIPTION
Three improvements in this PR:

1. Conditions for showing interrupt dialog streamlined - we always show the confirmation dialog, regardless which kind of input has triggered the interrupt.
2. It is now possible to interrupt your own auto battle mode on AI's turn.
3. It is now possible to interrupt with left/right mouse click anywhere on the screen.

AI vs AI debug mode battles are unaffected - we are making sure that the color requesting the interrupt belongs to a human.
Human vs human behaves as it suppose to, meaning you can only interrupt your own auto battle status.

Fix #4387 