### PR TITLE
Fix the Nintendo Switch build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -142,9 +142,7 @@ endif
 
 # SDL_LIBS can already be defined in a platform-specific Makefile
 ifeq ($(origin SDL_LIBS),undefined)
-SDL_LIBS := $(shell sdl2-config --libs)
-# Insert -lSDL2_mixer before -lSDL2 or libSDL2.a, but after any previous -L/path/to/lib entries
-SDL_LIBS := $(subst $(firstword $(filter -l% %.a,$(SDL_LIBS))),-lSDL2_mixer $(firstword $(filter -l% %.a,$(SDL_LIBS))),$(SDL_LIBS))
+SDL_LIBS := -lSDL2_mixer $(shell sdl2-config --libs)
 
 ifdef FHEROES2_WITH_IMAGE
 SDL_LIBS := $(SDL_LIBS) -lSDL2_image $(shell libpng-config --libs)

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,6 +1,6 @@
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2021 - 2023                                             #
+#   Copyright (C) 2021 - 2024                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -143,8 +143,8 @@ endif
 # SDL_LIBS can already be defined in a platform-specific Makefile
 ifeq ($(origin SDL_LIBS),undefined)
 SDL_LIBS := $(shell sdl2-config --libs)
-# Insert -lSDL2_mixer before -lSDL2, but after any previous -L/path/to/lib entries
-SDL_LIBS := $(subst $(firstword $(filter -l%,$(SDL_LIBS))),-lSDL2_mixer $(firstword $(filter -l%,$(SDL_LIBS))),$(SDL_LIBS))
+# Insert -lSDL2_mixer before -lSDL2 or libSDL2.a, but after any previous -L/path/to/lib entries
+SDL_LIBS := $(subst $(firstword $(filter -l% %.a,$(SDL_LIBS))),-lSDL2_mixer $(firstword $(filter -l% %.a,$(SDL_LIBS))),$(SDL_LIBS))
 
 ifdef FHEROES2_WITH_IMAGE
 SDL_LIBS := $(SDL_LIBS) -lSDL2_image $(shell libpng-config --libs)

--- a/src/dist/Makefile
+++ b/src/dist/Makefile
@@ -1,6 +1,6 @@
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2021 - 2022                                             #
+#   Copyright (C) 2021 - 2024                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -35,7 +35,7 @@ endif
 endif
 
 SOURCEROOT := ../fheroes2
-SOURCEDIR  := $(filter %/, $(wildcard $(SOURCEROOT)/*/)) $(filter %/, $(wildcard $(SOURCEROOT)/*/*/))
+SOURCEDIR  := $(filter %/,$(wildcard $(SOURCEROOT)/*/)) $(filter %/,$(wildcard $(SOURCEROOT)/*/*/))
 POT        := $(TARGET).pot
 
 SEARCH     := $(wildcard $(SOURCEROOT)/*/*.cpp) $(wildcard $(SOURCEROOT)/*/*/*.cpp)


### PR DESCRIPTION
For some reason, in the latest `devkita64` Docker image `sdl2-config --libs` uses not the "canonical" way of linking the library (`-lSDL2`), but the "full path" way (`/opt/devkitpro/portlibs/switch/lib/libSDL2.a`), what our `SDL2_mixer` linkage heuristics was not designed for, and the linkage was made in the wrong sequence.

Before:

https://github.com/ihhub/fheroes2/actions/runs/7757283009/job/21156607398#step:5:282

Now:

https://github.com/ihhub/fheroes2/actions/runs/7760886470/job/21168314572#step:5:282