### PR TITLE
Update hashes for Android & Windows dependency packages

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.1'
+        classpath 'com.android.tools.build:gradle:8.2.2'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -1,6 +1,6 @@
 :: ###########################################################################
 :: #   fheroes2: https://github.com/ihhub/fheroes2                           #
-:: #   Copyright (C) 2022 - 2023                                             #
+:: #   Copyright (C) 2022 - 2024                                             #
 :: #                                                                         #
 :: #   This program is free software; you can redistribute it and/or modify  #
 :: #   it under the terms of the GNU General Public License as published by  #

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=E7A2DA0C8FFF84732245BEAE78B2A337FEC2201F6BFB197DD9270C2A02FB5553
+set PKG_FILE_SHA256=F2D8EA526594F0CE8569ED003EA3BA28D17DAC6B5A57337DA99742F580DF19B0
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -23,7 +23,7 @@
 set -e -o pipefail
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="e7a2da0c8fff84732245beae78b2a337fec2201f6bfb197dd9270c2a02fb5553"
+PKG_FILE_SHA256="f2d8ea526594f0ce8569ed003ea3ba28d17dac6b5a57337da99742f580df19b0"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -2,7 +2,7 @@
 
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2022 - 2023                                             #
+#   Copyright (C) 2022 - 2024                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=D2E1577E53E28E143FA2AE014A4D7A5E32A8CF11F7F8BE835E6DE9FC05640866
+set PKG_FILE_SHA256=78D47801C6E0C951FB85BD79A1EFE3BB3CCE7D651CD95F3F6F2B76FE4D19330C
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
fix #6154

See https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/48 for details.

Also update AGP to 8.2.2.