### PR TITLE
Adjust the difficulties of campaign scenarios that were hard-coded in the original game

### DIFF
--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -27,6 +27,7 @@
 
 #include "army.h"
 #include "campaign_data.h"
+#include "difficulty.h"
 #include "serialize.h"
 
 namespace Campaign
@@ -201,5 +202,34 @@ namespace Campaign
         }
 
         return ScenarioLossCondition::STANDARD;
+    }
+
+    std::optional<int> getCurrentScenarioDifficultyLevel()
+    {
+        static const std::map<std::pair<int, int>, int> adjustedDifficultyLevels = { // Roland
+                                                                                     { { ROLAND_CAMPAIGN, 1 }, Difficulty::EASY },
+                                                                                     // Archibald
+                                                                                     { { ARCHIBALD_CAMPAIGN, 1 }, Difficulty::EASY },
+                                                                                     // Descendants
+                                                                                     { { DESCENDANTS_CAMPAIGN, 0 }, Difficulty::EASY },
+                                                                                     { { DESCENDANTS_CAMPAIGN, 5 }, Difficulty::HARD },
+                                                                                     // Wizard's Isle
+                                                                                     { { WIZARDS_ISLE_CAMPAIGN, 3 }, Difficulty::HARD },
+                                                                                     // Voyage Home
+                                                                                     { { VOYAGE_HOME_CAMPAIGN, 0 }, Difficulty::EASY },
+                                                                                     // Price of Loyalty
+                                                                                     { { PRICE_OF_LOYALTY_CAMPAIGN, 0 }, Difficulty::EASY },
+                                                                                     { { PRICE_OF_LOYALTY_CAMPAIGN, 5 }, Difficulty::HARD },
+                                                                                     { { PRICE_OF_LOYALTY_CAMPAIGN, 6 }, Difficulty::HARD },
+                                                                                     { { PRICE_OF_LOYALTY_CAMPAIGN, 7 }, Difficulty::EXPERT } };
+
+        const CampaignSaveData & campaignData = CampaignSaveData::Get();
+
+        const auto iter = adjustedDifficultyLevels.find( { campaignData.getCampaignID(), campaignData.getCurrentScenarioID() } );
+        if ( iter == adjustedDifficultyLevels.end() ) {
+            return {};
+        }
+
+        return iter->second;
     }
 }

--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -23,7 +23,9 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <map>
 #include <memory>
+#include <utility>
 
 #include "army.h"
 #include "campaign_data.h"

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -22,6 +22,7 @@
 #define H2CAMPAIGN_SAVEDATA_H
 
 #include <cstdint>
+#include <optional>
 #include <vector>
 
 #include "army_troop.h"
@@ -143,6 +144,11 @@ namespace Campaign
 
     // Call this function only when playing campaign scenario.
     ScenarioLossCondition getCurrentScenarioLossCondition();
+
+    // For some scenarios of the original campaign, the difficulty of the scenario does not match the difficulty of the corresponding campaign map (these values are
+    // hard-coded in the game itself). This function returns either the adjusted difficulty for the currently active scenario, if required, or an empty result (and in
+    // that case the complexity of the corresponding campaign map should be used). Call this function only when playing campaign scenario.
+    std::optional<int> getCurrentScenarioDifficultyLevel();
 }
 
 #endif

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -147,7 +147,7 @@ namespace Campaign
 
     // For some scenarios of the original campaign, the difficulty of the scenario does not match the difficulty of the corresponding campaign map (these values are
     // hard-coded in the game itself). This function returns either the adjusted difficulty for the currently active scenario, if required, or an empty result (and in
-    // that case the complexity of the corresponding campaign map should be used). Call this function only when playing campaign scenario.
+    // that case the difficulty of the corresponding campaign map should be used). Call this function only when playing campaign scenario.
     std::optional<int> getCurrentScenarioDifficultyLevel();
 }
 

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -87,7 +87,7 @@ int Game::getDifficulty()
     }
 
     // Difficulty of campaign games depends on both the difficulty of a particular campaign map and the difficulty settings set by the player
-    int difficulty = configuration.getCurrentMapInfo().difficulty;
+    int difficulty = Campaign::getCurrentScenarioDifficultyLevel().value_or( configuration.getCurrentMapInfo().difficulty );
     const int difficultyAdjustment = Campaign::CampaignSaveData::Get().getDifficulty();
 
     difficulty += difficultyAdjustment;

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -27,6 +27,7 @@
 #include <cassert>
 #include <cmath>
 #include <map>
+#include <optional>
 #include <utility>
 #include <vector>
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1585,8 +1585,8 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
                 return bonusChoices[*scenarioBonusId];
             }();
 
-            // Scenario bonus related to the starting faction has to be set before calling players.SetStartGame(). If the scenario bonus includes the initial army, then
-            // only the initial faction should still be set.
+            // Scenario bonus related to the starting faction has to be set before calling players.SetStartGame(). If the scenario bonus includes the starting army, then
+            // only the starting faction should still be set.
             if ( scenarioBonus._type == Campaign::ScenarioBonusData::STARTING_RACE || scenarioBonus._type == Campaign::ScenarioBonusData::STARTING_RACE_AND_ARMY ) {
                 SetScenarioBonus( currentScenarioInfoId, { Campaign::ScenarioBonusData::STARTING_RACE, scenarioBonus._subType, scenarioBonus._amount } );
             }

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1585,9 +1585,9 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
                 return bonusChoices[*scenarioBonusId];
             }();
 
-            // starting faction scenario bonus has to be called before players.SetStartGame()
+            // Scenario bonus related to the starting faction has to be set before calling players.SetStartGame(). If the scenario bonus includes the initial army, then
+            // only the initial faction should still be set.
             if ( scenarioBonus._type == Campaign::ScenarioBonusData::STARTING_RACE || scenarioBonus._type == Campaign::ScenarioBonusData::STARTING_RACE_AND_ARMY ) {
-                // but the army has to be set after starting the game, so first only set the race
                 SetScenarioBonus( currentScenarioInfoId, { Campaign::ScenarioBonusData::STARTING_RACE, scenarioBonus._subType, scenarioBonus._amount } );
             }
 
@@ -1595,6 +1595,9 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             if ( isBetrayalScenario( currentScenarioInfoId ) ) {
                 campaignSaveData.removeAllAwards();
             }
+
+            // Scenario difficulty must be set before loading the map, because it is used during the map loading process.
+            campaignSaveData.setDifficulty( currentDifficulty );
 
             Players & players = conf.GetPlayers();
             players.SetStartGame();
@@ -1615,7 +1618,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             // Fade-out screen before loading a scenario.
             fheroes2::fadeOutDisplay();
 
-            // meanwhile, the others should be called after players.SetStartGame()
+            // The rest of the scenario bonuses should be set after calling players.SetStartGame().
             if ( scenarioBonus._type != Campaign::ScenarioBonusData::STARTING_RACE ) {
                 SetScenarioBonus( currentScenarioInfoId, scenarioBonus );
             }
@@ -1623,7 +1626,6 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             applyObtainedCampaignAwards( currentScenarioInfoId, campaignSaveData.getObtainedCampaignAwards() );
 
             campaignSaveData.setCurrentScenarioInfo( currentScenarioInfoId, scenarioBonusId.value_or( -1 ) );
-            campaignSaveData.setDifficulty( currentDifficulty );
 
             return fheroes2::GameMode::START_GAME;
         }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -117,23 +117,22 @@ Kingdom::Kingdom()
 void Kingdom::Init( int clr )
 {
     clear();
+
     color = clr;
 
-    if ( Color::ALL & color ) {
-        // Difficulty calculation is different for campaigns. Difficulty affects only on starting resources for human players.
-        const Settings & configuration = Settings::Get();
-        const int difficultyLevel = ( configuration.isCampaignGameType() ? configuration.getCurrentMapInfo().difficulty : configuration.GameDifficulty() );
+    if ( ( color & Color::ALL ) == 0 ) {
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown player: " << Color::String( color ) << "(" << static_cast<int>( color ) << ")" )
 
-        resource = _getKingdomStartingResources( difficultyLevel );
+        return;
+    }
 
-        // Some human players can have handicap for resources.
-        const Player * player = Players::Get( color );
-        assert( player != nullptr );
-        resource = getHandicapDependentIncome( resource, player->getHandicapStatus() );
-    }
-    else {
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "Kingdom: unknown player: " << Color::String( color ) << "(" << static_cast<int>( color ) << ")" )
-    }
+    resource = _getKingdomStartingResources( Game::getDifficulty() );
+
+    const Player * player = Players::Get( color );
+    assert( player != nullptr );
+
+    // Some human players can have handicap for resources.
+    resource = getHandicapDependentIncome( resource, player->getHandicapStatus() );
 }
 
 void Kingdom::clear()

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -114,7 +114,7 @@ Kingdom::Kingdom()
     // Do nothing.
 }
 
-void Kingdom::Init( int clr )
+void Kingdom::Init( const int clr )
 {
     clear();
 

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -74,7 +74,7 @@ public:
     Kingdom();
     ~Kingdom() override = default;
 
-    void Init( int color );
+    void Init( const int clr );
     void clear();
 
     void openOverviewDialog();


### PR DESCRIPTION
fix #8351

This PR also fixes a number of issues where the difficulty setting for the campaign was not taken into account. For example, in the `master` branch:

https://github.com/ihhub/fheroes2/assets/32623900/d6c2928f-17f8-4629-a79a-669f131a9e94

With this PR:

https://github.com/ihhub/fheroes2/assets/32623900/3ef52347-b339-4a2f-a01a-a180ee982cce
