### PR TITLE
Add info about ranged penalty elimination to archery skill description

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -61,6 +61,7 @@
 #include "monster_info.h"
 #include "resource.h"
 #include "settings.h"
+#include "skill.h"
 #include "speed.h"
 #include "spell.h"
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -933,8 +933,20 @@ namespace AI
 
         // Mark as castle siege only if any tower is present. If no towers present then nothing to defend and most likely all walls are destroyed as well.
         if ( castle && Arena::isAnyTowerPresent() ) {
-            const bool attackerIgnoresCover
-                = arena.GetForce1().GetCommander()->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::NO_SHOOTING_PENALTY );
+            const bool attackerIgnoresCover = [&arena]() {
+                const HeroBase * commander = arena.GetForce1().GetCommander();
+                assert( commander != nullptr );
+
+                if ( commander->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::NO_SHOOTING_PENALTY ) ) {
+                    return true;
+                }
+
+                if ( commander->GetLevelSkill( Skill::Secondary::ARCHERY ) != Skill::Level::NONE ) {
+                    return true;
+                }
+
+                return false;
+            }();
 
             const auto getTowerStrength = []( const Tower * tower ) { return ( tower && tower->isValid() ) ? tower->GetStrength() : 0; };
 

--- a/src/fheroes2/ai/normal/ai_normal_battle.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_battle.cpp
@@ -53,6 +53,7 @@
 #include "color.h"
 #include "difficulty.h"
 #include "game.h"
+#include "game_static.h"
 #include "heroes.h"
 #include "heroes_base.h"
 #include "kingdom.h"
@@ -951,7 +952,7 @@ namespace AI
                 _myShootersStrength += towerStr;
 
                 if ( !attackerIgnoresCover ) {
-                    _enemyShootersStrength /= 1.5;
+                    _enemyShootersStrength /= 1 + ( GameStatic::getCastleWallRangedPenalty() / 100.0 );
                 }
             }
             else {
@@ -959,7 +960,7 @@ namespace AI
                 _enemyShootersStrength += towerStr;
 
                 if ( !attackerIgnoresCover ) {
-                    _myShootersStrength /= 1.5;
+                    _myShootersStrength /= 1 + ( GameStatic::getCastleWallRangedPenalty() / 100.0 );
                 }
             }
         }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -547,7 +547,7 @@ uint32_t Battle::Unit::CalculateDamageUnit( const Unit & enemy, double dmg ) con
 
             // Penalty for damage to castle defenders behind the castle walls
             if ( arena->IsShootingPenalty( *this, enemy ) ) {
-                dmg *= GameStatic::getCastleWallRangedPenalty() / 100.0;
+                dmg *= 1 - ( GameStatic::getCastleWallRangedPenalty() / 100.0 );
             }
 
             // The Shield spell does not affect the damage of the castle towers

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -547,7 +547,7 @@ uint32_t Battle::Unit::CalculateDamageUnit( const Unit & enemy, double dmg ) con
 
             // Penalty for damage to castle defenders behind the castle walls
             if ( arena->IsShootingPenalty( *this, enemy ) ) {
-                dmg /= 2;
+                dmg *= GameStatic::getCastleWallRangedPenalty() / 100.0;
             }
 
             // The Shield spell does not affect the damage of the castle towers

--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -270,6 +270,11 @@ int GameStatic::GetBattleMoatReduceDefense()
     return 3;
 }
 
+uint32_t GameStatic::getCastleWallRangedPenalty()
+{
+    return 50;
+}
+
 uint32_t GameStatic::getMovementPointBonus( const MP2::MapObjectType objectType )
 {
     switch ( objectType ) {

--- a/src/fheroes2/game/game_static.h
+++ b/src/fheroes2/game/game_static.h
@@ -63,6 +63,7 @@ namespace GameStatic
     int32_t ObjectVisitedModifiers( const MP2::MapObjectType objectType );
 
     int GetBattleMoatReduceDefense();
+    // Returns the percentage penalty for the damage dealt by shooters firing at targets protected by castle walls.
     uint32_t getCastleWallRangedPenalty();
 
     const Skill::stats_t * GetSkillStats( int race );

--- a/src/fheroes2/game/game_static.h
+++ b/src/fheroes2/game/game_static.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -63,6 +63,7 @@ namespace GameStatic
     int32_t ObjectVisitedModifiers( const MP2::MapObjectType objectType );
 
     int GetBattleMoatReduceDefense();
+    uint32_t getCastleWallRangedPenalty();
 
     const Skill::stats_t * GetSkillStats( int race );
     const Skill::values_t * GetSkillValues( int skill );

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -496,7 +496,8 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         }
         break;
     case ARCHERY: {
-        str = _( "%{skill} increases the damage done by the hero's range attacking creatures by %{count} percent and eliminates the %{penalty} percent penalty for the hero's troops shooting past obstacles (e.g. castle walls)." );
+        str = _(
+            "%{skill} increases the damage done by the hero's range attacking creatures by %{count} percent and eliminates the %{penalty} percent penalty for the hero's troops shooting past obstacles (e.g. castle walls)." );
         StringReplace( str, "%{penalty}", GameStatic::getCastleWallRangedPenalty() );
         break;
     }

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -496,7 +496,8 @@ std::string Skill::Secondary::GetDescription( const Heroes & hero ) const
         }
         break;
     case ARCHERY: {
-        str = _( "%{skill} increases the damage done by the hero's range attacking creatures by %{count} percent." );
+        str = _( "%{skill} increases the damage done by the hero's range attacking creatures by %{count} percent and eliminates the %{penalty} percent penalty for the hero's troops shooting past obstacles (e.g. castle walls)." );
+        StringReplace( str, "%{penalty}", GameStatic::getCastleWallRangedPenalty() );
         break;
     }
     case LOGISTICS: {

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -27,6 +27,7 @@
 #include <sstream>
 
 #include "artifact.h"
+#include "game_static.h"
 #include "spell.h"
 #include "tools.h"
 #include "translations.h"
@@ -722,7 +723,7 @@ namespace
 
         artifactData[Artifact::WAND_NEGATION].bonuses.emplace_back( fheroes2::ArtifactBonusType::DISPEL_SPELL_IMMUNITY );
 
-        artifactData[Artifact::GOLDEN_BOW].bonuses.emplace_back( fheroes2::ArtifactBonusType::NO_SHOOTING_PENALTY, 50 );
+        artifactData[Artifact::GOLDEN_BOW].bonuses.emplace_back( fheroes2::ArtifactBonusType::NO_SHOOTING_PENALTY, GameStatic::getCastleWallRangedPenalty() );
 
         artifactData[Artifact::TELESCOPE].bonuses.emplace_back( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE, 1 );
 


### PR DESCRIPTION
Add a description about ranged penalty being when having the archery skill.
Add ranged penalty Get function to `GameStatic` and use in relevant places in the code.

Fix #8398 

<img width="327" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/67e78c2e-6eb5-4b3e-b0e4-8426829fc369">
