### PR TITLE
Convenient list scrolling for touch screens

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -667,6 +667,7 @@ LocalEvent::LocalEvent()
     : modes( 0 )
     , key_value( fheroes2::Key::NONE )
     , mouse_button( 0 )
+    , _isDragInProgress( false )
     , _mouseButtonLongPressDelay( mouseButtonLongPressTimeout )
 {}
 
@@ -705,6 +706,9 @@ void LocalEvent::OpenTouchpad()
 LocalEvent & LocalEvent::Get()
 {
     static LocalEvent le;
+    if ( !le.MousePressLeft() ) {
+        le._isDragInProgress = false;
+    }
 
     return le;
 }

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -706,9 +706,6 @@ void LocalEvent::OpenTouchpad()
 LocalEvent & LocalEvent::Get()
 {
     static LocalEvent le;
-    if ( !le.MousePressLeft() ) {
-        le._isDragInProgress = false;
-    }
 
     return le;
 }
@@ -991,6 +988,7 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
 
                 ResetModes( MOUSE_PRESSED );
                 SetModes( MOUSE_RELEASED );
+                _isDragInProgress = false;
             }
 
             mouse_button = SDL_BUTTON_LEFT;
@@ -1016,6 +1014,7 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
             ResetModes( MOUSE_PRESSED );
             SetModes( MOUSE_RELEASED );
             SetModes( MOUSE_TOUCH );
+            _isDragInProgress = false;
         }
 
         mouse_button = SDL_BUTTON_RIGHT;
@@ -1085,6 +1084,7 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
         else {
             ResetModes( MOUSE_PRESSED );
             SetModes( MOUSE_RELEASED );
+            _isDragInProgress = false;
         }
 
         if ( button.button == SDL_CONTROLLER_BUTTON_A ) {
@@ -1314,6 +1314,7 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
     else {
         ResetModes( MOUSE_PRESSED );
         SetModes( MOUSE_RELEASED );
+        _isDragInProgress = false;
     }
 
     mouse_button = button.button;

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -667,7 +667,6 @@ LocalEvent::LocalEvent()
     : modes( 0 )
     , key_value( fheroes2::Key::NONE )
     , mouse_button( 0 )
-    , _isDragInProgress( false )
     , _mouseButtonLongPressDelay( mouseButtonLongPressTimeout )
 {}
 
@@ -988,7 +987,7 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
 
                 ResetModes( MOUSE_PRESSED );
                 SetModes( MOUSE_RELEASED );
-                _isDragInProgress = false;
+                ResetModes( DRAG_ONGOING );
             }
 
             mouse_button = SDL_BUTTON_LEFT;
@@ -1014,7 +1013,7 @@ void LocalEvent::HandleTouchEvent( const SDL_TouchFingerEvent & event )
             ResetModes( MOUSE_PRESSED );
             SetModes( MOUSE_RELEASED );
             SetModes( MOUSE_TOUCH );
-            _isDragInProgress = false;
+            ResetModes( DRAG_ONGOING );
         }
 
         mouse_button = SDL_BUTTON_RIGHT;
@@ -1084,7 +1083,7 @@ void LocalEvent::HandleControllerButtonEvent( const SDL_ControllerButtonEvent & 
         else {
             ResetModes( MOUSE_PRESSED );
             SetModes( MOUSE_RELEASED );
-            _isDragInProgress = false;
+            ResetModes( DRAG_ONGOING );
         }
 
         if ( button.button == SDL_CONTROLLER_BUTTON_A ) {
@@ -1314,7 +1313,7 @@ void LocalEvent::HandleMouseButtonEvent( const SDL_MouseButtonEvent & button )
     else {
         ResetModes( MOUSE_PRESSED );
         SetModes( MOUSE_RELEASED );
-        _isDragInProgress = false;
+        ResetModes( DRAG_ONGOING );
     }
 
     mouse_button = button.button;

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2008 by Josh Matthews <josh@joshmatthews.net>           *
@@ -306,6 +306,16 @@ public:
         }
     }
 
+    bool isDragInProgress() const
+    {
+        return _isDragInProgress;
+    }
+
+    void setDragStatus( const bool inProgress )
+    {
+        _isDragInProgress = inProgress;
+    }
+
 private:
     LocalEvent();
 
@@ -364,6 +374,7 @@ private:
     uint32_t modes;
     fheroes2::Key key_value;
     int mouse_button;
+    bool _isDragInProgress;
 
     fheroes2::Point mouse_pl; // press left
     fheroes2::Point mouse_pm; // press middle

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -353,7 +353,7 @@ private:
         MOUSE_TOUCH = 0x0020,
         // Key on the keyboard is currently being held down
         KEY_HOLD = 0x0040,
-        // Key on the keyboard is currently being held down
+        // Some UI component registered the start of drag motion
         DRAG_ONGOING = 0x0080,
     };
 

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -308,12 +308,12 @@ public:
 
     bool isDragInProgress() const
     {
-        return _isDragInProgress;
+        return modes & DRAG_ONGOING;
     }
 
-    void setDragStatus( const bool inProgress )
+    void RegisterDrag()
     {
-        _isDragInProgress = inProgress;
+        SetModes( DRAG_ONGOING );
     }
 
 private:
@@ -353,6 +353,8 @@ private:
         MOUSE_TOUCH = 0x0020,
         // Key on the keyboard is currently being held down
         KEY_HOLD = 0x0040,
+        // Key on the keyboard is currently being held down
+        DRAG_ONGOING = 0x0080,
     };
 
     enum
@@ -374,7 +376,6 @@ private:
     uint32_t modes;
     fheroes2::Key key_value;
     int mouse_button;
-    bool _isDragInProgress;
 
     fheroes2::Point mouse_pl; // press left
     fheroes2::Point mouse_pm; // press middle

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -311,7 +311,7 @@ public:
         return modes & DRAG_ONGOING;
     }
 
-    void RegisterDrag()
+    void registerDrag()
     {
         SetModes( DRAG_ONGOING );
     }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2796,6 +2796,8 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
     // Add offsets to inner objects
     const fheroes2::Rect mainTowerRect = main_tower + _interfacePosition.getPosition();
     const fheroes2::Rect turnOrderRect = _turnOrder + _interfacePosition.getPosition();
+    const int32_t battleFieldHeight = _interfacePosition.height - status.height - ( listlog->isOpenLog() ? listlog->GetArea().height : 0 );
+    const fheroes2::Rect battleFieldRect{ _interfacePosition.x, _interfacePosition.y, _interfacePosition.width, battleFieldHeight };
     if ( Arena::GetTower( TowerType::TWR_CENTER ) && le.MouseCursor( mainTowerRect ) ) {
         cursor.SetThemes( Cursor::WAR_INFO );
         msg = _( "View Ballista info" );
@@ -2924,7 +2926,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
         listlog->QueueEventProcessing();
     }
-    else if ( le.MouseCursor( { _interfacePosition.x, _interfacePosition.y, _interfacePosition.width, _interfacePosition.height - status.height } ) ) {
+    else if ( le.MouseCursor( battleFieldRect ) ) {
         const int themes = GetBattleCursor( msg );
         cursor.SetThemes( themes );
 
@@ -2939,7 +2941,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
             boardActionIntentUpdater.setIntent( { themes, index_pos } );
 
-            if ( le.MouseClickLeft() ) {
+            if ( le.MouseClickLeft( battleFieldRect ) ) {
                 MouseLeftClickBoardAction( themes, *cell, boardActionIntentUpdater.isConfirmed(), actions );
             }
             else if ( le.MousePressRight() ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2798,8 +2798,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
     const fheroes2::Rect turnOrderRect = _turnOrder + _interfacePosition.getPosition();
     const int32_t battleFieldHeight = _interfacePosition.height - status.height - ( listlog->isOpenLog() ? listlog->GetArea().height : 0 );
     const fheroes2::Rect battleFieldRect{ _interfacePosition.x, _interfacePosition.y, _interfacePosition.width, battleFieldHeight };
-    if ( listlog && listlog->isOpenLog() && ( le.MouseCursor( listlog->GetArea() ) || le.MousePressLeft( listlog->GetArea() ) ) )
-    {
+    if ( listlog && listlog->isOpenLog() && ( le.MouseCursor( listlog->GetArea() ) || le.MousePressLeft( listlog->GetArea() ) ) ) {
         cursor.SetThemes( Cursor::WAR_POINTER );
 
         listlog->QueueEventProcessing();

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2798,7 +2798,13 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
     const fheroes2::Rect turnOrderRect = _turnOrder + _interfacePosition.getPosition();
     const int32_t battleFieldHeight = _interfacePosition.height - status.height - ( listlog->isOpenLog() ? listlog->GetArea().height : 0 );
     const fheroes2::Rect battleFieldRect{ _interfacePosition.x, _interfacePosition.y, _interfacePosition.width, battleFieldHeight };
-    if ( Arena::GetTower( TowerType::TWR_CENTER ) && le.MouseCursor( mainTowerRect ) ) {
+    if ( listlog && listlog->isOpenLog() && ( le.MouseCursor( listlog->GetArea() ) || le.MousePressLeft( listlog->GetArea() ) ) )
+    {
+        cursor.SetThemes( Cursor::WAR_POINTER );
+
+        listlog->QueueEventProcessing();
+    }
+    else if ( Arena::GetTower( TowerType::TWR_CENTER ) && le.MouseCursor( mainTowerRect ) ) {
         cursor.SetThemes( Cursor::WAR_INFO );
         msg = _( "View Ballista info" );
 
@@ -2920,11 +2926,6 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             arena.DialogBattleHero( *_opponent2->GetHero(), false, status );
             humanturn_redraw = true;
         }
-    }
-    else if ( listlog && listlog->isOpenLog() && le.MouseCursor( listlog->GetArea() ) ) {
-        cursor.SetThemes( Cursor::WAR_POINTER );
-
-        listlog->QueueEventProcessing();
     }
     else if ( le.MouseCursor( battleFieldRect ) ) {
         const int themes = GetBattleCursor( msg );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1188,6 +1188,12 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isload )
                 stopHero = true;
             }
         }
+        // cursor is over the icons panel
+        else if ( ( !isHiddenInterface || conf.ShowIcons() ) && ( le.MouseCursor( iconsPanel.GetRect() ) || le.MousePressLeft( iconsPanel.GetRect() ) ) ) {
+            cursor.SetThemes( Cursor::POINTER );
+
+            iconsPanel.QueueEventProcessing();
+        }
         // cursor is over the status window
         else if ( ( !isHiddenInterface || conf.ShowStatus() ) && le.MouseCursor( _statusWindow.GetRect() ) ) {
             cursor.SetThemes( Cursor::POINTER );
@@ -1200,12 +1206,6 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isload )
 
             res = buttonsArea.QueueEventProcessing();
             isCursorOverButtons = true;
-        }
-        // cursor is over the icons panel
-        else if ( ( !isHiddenInterface || conf.ShowIcons() ) && le.MouseCursor( iconsPanel.GetRect() ) ) {
-            cursor.SetThemes( Cursor::POINTER );
-
-            iconsPanel.QueueEventProcessing();
         }
         // cursor is over the radar
         else if ( ( !isHiddenInterface || conf.ShowRadar() ) && le.MouseCursor( _radar.GetRect() ) ) {

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -1028,7 +1028,7 @@ void Interface::GameArea::QueueEventProcessing( bool isCursorOverGamearea )
         _mouseDraggingMovement = true;
     }
 
-    if ( _mouseDraggingMovement ) {
+    if ( _mouseDraggingMovement && le.MousePressLeft( GetROI() ) ) {
         if ( _lastMouseDragPosition == mousePosition ) {
             _needRedrawByMouseDragging = false;
         }

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -417,7 +417,7 @@ namespace Interface
 
                 return true;
             }
-            if ( ( le.MousePressLeft( _scrollbar.getArea() ) || le.MousePressLeft( rtAreaItems ) ) && ( _size() > maxItems ) ) {
+            if ( le.MousePressLeft( _scrollbar.getArea() ) || le.MousePressLeft( rtAreaItems ) ) {
                 const fheroes2::Point mousePosition = le.GetMouseCursor();
 
                 const int32_t prevScrollbarX = _scrollbar.x();
@@ -425,7 +425,7 @@ namespace Interface
 
                 UpdateScrollbarRange();
 
-                if ( le.MousePressLeft( _scrollbar.getArea() ) ) {
+                if ( le.MousePressLeft( _scrollbar.getArea() ) && ( _size() > maxItems ) ) {
                     _scrollbar.moveToPos( mousePosition );
                 }
 

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -433,7 +433,7 @@ namespace Interface
                     if ( !le.isDragInProgress() ) {
                         // Remember where has the drag started.
                         _dragStartPos = mousePosition;
-                        le.setDragStatus( true );
+                        le.RegisterDrag();
 
                         // We have just started the drag, it might as well be a legitimate click.
                         _lockClick = false;

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -433,14 +433,13 @@ namespace Interface
                     if ( !le.isDragInProgress() ) {
                         // Remember where has the drag started.
                         _dragStartPos = mousePosition;
-                        le.RegisterDrag();
+                        le.registerDrag();
 
                         // We have just started the drag, it might as well be a legitimate click.
                         _lockClick = false;
                     }
 
-                    const fheroes2::Point deltaPoint = _dragStartPos - mousePosition;
-                    const int delta = ( _scrollbar.isVertical() ? deltaPoint.y : deltaPoint.x );
+                    const int delta = ( _scrollbar.isVertical() ? ( _dragStartPos.y - mousePosition.y ) : ( _dragStartPos.x - mousePosition.x ) );
                     const int itemSize = ( _scrollbar.isVertical() ? rtAreaItems.height : rtAreaItems.width ) / maxItems;
 
                     // We have dragged past the size of one list-item.

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -438,6 +438,9 @@ namespace Interface
                         // Remember where has the drag started.
                         ptReference = mousePosition;
                         _dragInProgress = true;
+
+                        // We have just started the drag, it might as well be a legitimate click.
+                        _lockClick = false;
                     }
 
                     fheroes2::Point deltaPoint = ptReference - mousePosition;
@@ -489,22 +492,16 @@ namespace Interface
                     if ( ActionListCursor( item, mousePos ) )
                         return true;
 
-                    if ( le.MouseClickLeft( rtAreaItems ) ) {
-                        if ( !_lockClick ) {
-                            // This is a legitimate click.
-                            if ( id == _currentId ) {
-                                ActionListDoubleClick( item, mousePos, rtAreaItems.x, rtAreaItems.y + offsetY );
-                            }
-                            else {
-                                _currentId = id;
-                                ActionListSingleClick( item, mousePos, rtAreaItems.x, rtAreaItems.y + offsetY );
-                            }
-                            return true;
+                    if ( le.MouseClickLeft( rtAreaItems ) && !_lockClick ) {
+                        // This is a legitimate click and not a mouse-up on a finished drag.
+                        if ( id == _currentId ) {
+                            ActionListDoubleClick( item, mousePos, rtAreaItems.x, rtAreaItems.y + offsetY );
                         }
                         else {
-                            // This was a pseudo-click triggered by mouse-up when finishing the drag.
-                            _lockClick = false;
+                            _currentId = id;
+                            ActionListSingleClick( item, mousePos, rtAreaItems.x, rtAreaItems.y + offsetY );
                         }
+                        return true;
                     }
 
                     if ( le.MousePressRight( rtAreaItems ) ) {
@@ -514,10 +511,6 @@ namespace Interface
                 }
 
                 needRedraw = false;
-            }
-            if ( le.MouseReleaseLeft() ) {
-                // There is definitely no drag in progress, we make sure not to disable legitimate clicks.
-                _lockClick = false;
             }
 
             return false;

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -327,10 +327,6 @@ namespace Interface
             le.MousePressLeft( buttonPgUp.area() ) ? buttonPgUp.drawOnPress() : buttonPgUp.drawOnRelease();
             le.MousePressLeft( buttonPgDn.area() ) ? buttonPgDn.drawOnPress() : buttonPgDn.drawOnRelease();
 
-            if ( !le.MousePressLeft() ) {
-                _dragInProgress = false;
-            }
-
             if ( !IsValid() ) {
                 return false;
             }
@@ -434,10 +430,10 @@ namespace Interface
                 }
 
                 if ( le.MousePressLeft( rtAreaItems ) ) {
-                    if ( !_dragInProgress ) {
+                    if ( !le.isDragInProgress() ) {
                         // Remember where has the drag started.
                         ptReference = mousePosition;
-                        _dragInProgress = true;
+                        le.setDragStatus( true );
 
                         // We have just started the drag, it might as well be a legitimate click.
                         _lockClick = false;
@@ -546,7 +542,6 @@ namespace Interface
         bool useHotkeys{ true };
 
         bool _updateScrollbar{ false };
-        bool _dragInProgress{ false };
         bool _lockClick{ false };
 
         fheroes2::TimedEventValidator _timedButtonPgUp;

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -432,22 +432,22 @@ namespace Interface
                 if ( le.MousePressLeft( rtAreaItems ) ) {
                     if ( !le.isDragInProgress() ) {
                         // Remember where has the drag started.
-                        ptReference = mousePosition;
+                        _dragStartPos = mousePosition;
                         le.setDragStatus( true );
 
                         // We have just started the drag, it might as well be a legitimate click.
                         _lockClick = false;
                     }
 
-                    fheroes2::Point deltaPoint = ptReference - mousePosition;
-                    int delta = ( _scrollbar.isVertical() ? deltaPoint.y : deltaPoint.x );
-                    int itemSize = ( _scrollbar.isVertical() ? rtAreaItems.height : rtAreaItems.width ) / maxItems;
+                    const fheroes2::Point deltaPoint = _dragStartPos - mousePosition;
+                    const int delta = ( _scrollbar.isVertical() ? deltaPoint.y : deltaPoint.x );
+                    const int itemSize = ( _scrollbar.isVertical() ? rtAreaItems.height : rtAreaItems.width ) / maxItems;
 
                     // We have dragged past the size of one list-item.
                     if ( std::abs( delta ) > itemSize ) {
                         // Scroll the list accordingly, update the drag start reference point.
                         _scrollbar.moveToIndex( _scrollbar.currentIndex() + delta / itemSize );
-                        ptReference = mousePosition;
+                        _dragStartPos = mousePosition;
 
                         // Disable the leftclick on the list, so finishing the drag does not result in clicking on the list-item.
                         _lockClick = true;
@@ -488,7 +488,7 @@ namespace Interface
                     if ( ActionListCursor( item, mousePos ) )
                         return true;
 
-                    if ( le.MouseClickLeft( rtAreaItems ) && !_lockClick ) {
+                    if ( !_lockClick && le.MouseClickLeft( rtAreaItems ) ) {
                         // This is a legitimate click and not a mouse-up on a finished drag.
                         if ( id == _currentId ) {
                             ActionListDoubleClick( item, mousePos, rtAreaItems.x, rtAreaItems.y + offsetY );
@@ -537,7 +537,7 @@ namespace Interface
         int maxItems{ 0 };
 
         fheroes2::Point ptRedraw;
-        fheroes2::Point ptReference;
+        fheroes2::Point _dragStartPos;
 
         bool useHotkeys{ true };
 

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -479,7 +479,7 @@ void Interface::Radar::QueueEventProcessing()
     }
     else if ( le.MouseCursor( rect ) ) {
         // move cursor
-        if ( le.MouseClickLeft() || le.MousePressLeft() ) {
+        if ( le.MouseClickLeft( rect ) || le.MousePressLeft( rect ) ) {
             _mouseDraggingMovement = true;
             const fheroes2::Point & pt = le.GetMouseCursor();
 
@@ -508,7 +508,7 @@ bool Interface::Radar::QueueEventProcessingForWorldView( ViewWorld::ZoomROIs & r
 
     // move cursor
     if ( le.MouseCursor( rect ) ) {
-        if ( le.MouseClickLeft() || le.MousePressLeft() ) {
+        if ( le.MouseClickLeft( rect ) || le.MousePressLeft( rect ) ) {
             const fheroes2::Point & pt = le.GetMouseCursor();
 
             if ( rect & pt ) {

--- a/src/fheroes2/gui/ui_scrollbar.cpp
+++ b/src/fheroes2/gui/ui_scrollbar.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -56,7 +56,7 @@ namespace fheroes2
             setPosition( _area.x + ( _area.width - width() ) / 2, _area.y + ( _area.height - height() ) / 2 );
         }
         else {
-            if ( _isVertical() ) {
+            if ( isVertical() ) {
                 setPosition( _area.x + ( _area.width - width() ) / 2, _area.y );
             }
             else {
@@ -103,7 +103,7 @@ namespace fheroes2
 
         Point newPosition;
 
-        if ( _isVertical() ) {
+        if ( isVertical() ) {
             newPosition.x = _area.x + roiWidth / 2;
             newPosition.y = _area.y + ( _currentIndex - _minIndex ) * roiHeight / ( _maxIndex - _minIndex );
         }
@@ -129,7 +129,7 @@ namespace fheroes2
         const int roiWidth = _area.width - width();
         const int roiHeight = _area.height - height();
 
-        if ( _isVertical() ) {
+        if ( isVertical() ) {
             const int32_t scrollbarImageMiddle = height() / 2;
             const int32_t minYPos = _area.y + scrollbarImageMiddle;
             const int32_t maxYPos = _area.y + roiHeight + scrollbarImageMiddle;

--- a/src/fheroes2/gui/ui_scrollbar.h
+++ b/src/fheroes2/gui/ui_scrollbar.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -81,16 +81,16 @@ namespace fheroes2
             return _area;
         }
 
+        bool isVertical() const
+        {
+            return _area.width < _area.height;
+        }
+
     private:
         Rect _area;
         int _minIndex;
         int _maxIndex;
         int _currentIndex;
-
-        bool _isVertical() const
-        {
-            return _area.width < _area.height;
-        }
     };
 
     // The original scrollbar slider has fixed size. This is a not user-friendly solution as on big screens it might look extremely tiny.


### PR DESCRIPTION
On the smaller touch screens (mobile phones) it is quite difficult to navigate scenario list dialogs or load game dialogs if there are a lot of list items in them. Using a thin scrollbar or small arrows is the only possible way. Hero/castle lists are even harder to operate. Having more than 4 heroes/castles requires the user to fight with even smaller scrollbars.

This PR addresses this inconvenience, as presented on a video below.



https://github.com/ihhub/fheroes2/assets/84446398/da0b5d9c-1264-4230-b4a4-6d53bcf00fbc

close #2420