### PR TITLE
Add multiline stats in hero info window in battle

### DIFF
--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -965,19 +965,23 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
     text.draw( tp.x, tp.y + 2, display );
     str = _( "Morale" ) + std::string( ": " ) + Morale::String( hero.GetMorale() );
     text.set( str, fheroes2::FontType::smallWhite() );
-    tp.x = statsTextOffset.x + ( maxStatsTextWidth - text.width() ) / 2;
+    tp.x = statsTextOffset.x;
     tp.y += statsTextRowHeight;
-    text.draw( tp.x, tp.y + 2, display );
+    text.setUniformVerticalAlignment( false );
+    text.draw( tp.x, tp.y + 2, maxStatsTextWidth, display );
+    tp.y += text.height( maxStatsTextWidth );
     str = _( "Luck" ) + std::string( ": " ) + Luck::String( hero.GetLuck() );
     text.set( str, fheroes2::FontType::smallWhite() );
-    tp.x = statsTextOffset.x + ( maxStatsTextWidth - text.width() ) / 2;
-    tp.y += statsTextRowHeight;
-    text.draw( tp.x, tp.y + 2, display );
+    tp.x = statsTextOffset.x;
+    text.draw( tp.x, tp.y + 2, maxStatsTextWidth, display );
+    tp.y += text.height( maxStatsTextWidth );
     str = _( "Spell Points" ) + std::string( ": " ) + std::to_string( hero.GetSpellPoints() ) + "/" + std::to_string( hero.GetMaxSpellPoints() );
     text.set( str, fheroes2::FontType::smallWhite() );
-    tp.x = statsTextOffset.x + ( maxStatsTextWidth - text.width() ) / 2;
-    tp.y += statsTextRowHeight * 2;
-    text.draw( tp.x, tp.y + 2, display );
+    tp.x = statsTextOffset.x;
+    // By default the spell points should have one line of space between it and the Luck, but if there isn't
+    // any space due to morale and luck taking up four lines, then move it down to the lowest line.
+    const int32_t compensation = ( tp.y - ( statsTextOffset.y + 88 ) ) == 0 ? 11 : 0;
+    text.draw( tp.x, statsTextOffset.y + 79 + compensation, maxStatsTextWidth, display );
 
     fheroes2::Button btnCast( pos_rt.x + 15, pos_rt.y + 148, ICN::VIEWGEN, 9, 10 );
     fheroes2::Button btnRetreat( pos_rt.x + 74, pos_rt.y + 148, ICN::VIEWGEN, 11, 12 );

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -940,7 +940,7 @@ int Battle::Arena::DialogBattleHero( const HeroBase & hero, const bool buttons, 
     text.draw( tp.x, tp.y + 2, display );
 
     const fheroes2::Point statsTextOffset{ pos_rt.x + 148 - dialogShadow.x, pos_rt.y + 40 };
-    const int32_t maxStatsTextWidth{ 111 };
+    const int32_t maxStatsTextWidth{ 109 };
     const int32_t statsTextRowHeight{ 11 };
 
     str = _( "Attack" ) + std::string( ": " ) + std::to_string( hero.GetAttack() );


### PR DESCRIPTION
Master:

<img width="281" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/fbdc406b-e8d3-45eb-bff2-cc2e0a98e258">
<img width="284" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/f383b267-690b-473a-bc47-2e1264f53e38">


This PR:
<img width="274" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/4f7033a3-28a3-4c83-b2aa-c05a8f20747c"> <img width="279" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/785b1e9a-4e47-4f01-9324-e5ea9a18bd64">
