### PR TITLE
Fix the troops carry over mechanics for campaign

### DIFF
--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -472,15 +472,6 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
             necromancySkillAction( *winnerHero, result.killed, winnerHero->isControlHuman() );
         }
 
-        if ( winnerHero ) {
-            const Heroes * kingdomHero = dynamic_cast<const Heroes *>( winnerHero );
-            if ( kingdomHero ) {
-                Kingdom & kingdom = kingdomHero->GetKingdom();
-
-                kingdom.SetLastBattleWinHero( *kingdomHero );
-            }
-        }
-
         break;
     }
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -499,8 +499,17 @@ namespace
     void replaceArmy( Army & army, const std::vector<Troop> & troops )
     {
         army.Clean();
-        for ( size_t i = 0; i < troops.size(); ++i )
-            army.GetTroop( i )->Set( troops[i] );
+
+        const size_t size = std::min( army.Size(), troops.size() );
+
+        for ( size_t i = 0; i < size; ++i ) {
+            Troop * troop = army.GetTroop( i );
+            assert( troop != nullptr );
+
+            troop->Set( troops[i] );
+        }
+
+        assert( army.isValid() );
     }
 
     void setHeroAndArmyBonus( Heroes * hero, const Campaign::ScenarioInfoId & scenarioInfoId )

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1205,7 +1205,7 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
 
             const VecHeroes & humanKingdomHeroes = world.GetKingdom( humanColor ).GetHeroes();
 
-            // In the original game, carry-over troops are taken from a hero who was hired least recently and who is still in the kingdom (I.E. still "alive"). A starting 
+            // In the original game, carry-over troops are taken from a hero who was hired least recently and who is still in the kingdom (I.E. still "alive"). A starting
             // hero will count as first if they are still alive since the beginning, but if they are rehired then they take a new place in the queue of heroes.
             if ( !humanKingdomHeroes.empty() ) {
                 const Heroes * hero = humanKingdomHeroes.front();

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1196,12 +1196,16 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
         }
 
         if ( awardType == Campaign::CampaignAwardData::AwardType::TYPE_CARRY_OVER_FORCES ) {
-            const Kingdom & humanKingdom = world.GetKingdom( Players::HumanColors() );
+            const VecHeroes & humanKingdomHeroes = world.GetKingdom( Players::HumanColors() ).GetHeroes();
 
-            const Heroes * lastBattleWinHero = humanKingdom.GetLastBattleWinHero();
+            // In the original game, troops for carry over are taken from the one of the heroes available in the kingdom who was hired first (including the hero
+            // originally present on the map at the beginning of the scenario).
+            if ( !humanKingdomHeroes.empty() ) {
+                const Heroes * hero = humanKingdomHeroes.front();
+                assert( hero != nullptr );
 
-            if ( lastBattleWinHero )
-                saveData.setCarryOverTroops( lastBattleWinHero->GetArmy() );
+                saveData.setCarryOverTroops( hero->GetArmy() );
+            }
         }
 
         saveData.addCampaignAward( obtainableAward._id );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -41,6 +41,7 @@
 #include "campaign_data.h"
 #include "campaign_savedata.h"
 #include "campaign_scenariodata.h"
+#include "color.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -754,7 +754,15 @@ namespace
                 assert( hero != nullptr );
 
                 if ( hero != nullptr ) {
-                    replaceArmy( hero->GetArmy(), Campaign::CampaignSaveData::Get().getCarryOverTroops() );
+                    Army & heroArmy = hero->GetArmy();
+                    const std::vector<Troop> & carryOverTroops = Campaign::CampaignSaveData::Get().getCarryOverTroops();
+
+                    if ( std::any_of( carryOverTroops.begin(), carryOverTroops.end(), []( const Troop & troop ) { return troop.isValid(); } ) ) {
+                        replaceArmy( heroArmy, carryOverTroops );
+                    }
+                    else {
+                        heroArmy.Reset();
+                    }
                 }
 
                 break;

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -701,8 +701,11 @@ namespace
     // the rest will be applied based on the situation required
     void applyObtainedCampaignAwards( const Campaign::ScenarioInfoId & currentScenarioInfoId, const std::vector<Campaign::CampaignAwardData> & awards )
     {
+        const int humanColor = Players::HumanColors();
+        assert( Color::Count( humanColor ) == 1 );
+
         const Players & sortedPlayers = Settings::Get().GetPlayers();
-        const Kingdom & humanKingdom = world.GetKingdom( Players::HumanColors() );
+        const Kingdom & humanKingdom = world.GetKingdom( humanColor );
 
         for ( size_t i = 0; i < awards.size(); ++i ) {
             if ( currentScenarioInfoId.scenarioId < awards[i]._startScenarioID ) {
@@ -1196,7 +1199,10 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
         }
 
         if ( awardType == Campaign::CampaignAwardData::AwardType::TYPE_CARRY_OVER_FORCES ) {
-            const VecHeroes & humanKingdomHeroes = world.GetKingdom( Players::HumanColors() ).GetHeroes();
+            const int humanColor = Players::HumanColors();
+            assert( Color::Count( humanColor ) == 1 );
+
+            const VecHeroes & humanKingdomHeroes = world.GetKingdom( humanColor ).GetHeroes();
 
             // In the original game, troops for carry over are taken from the one of the heroes available in the kingdom who was hired first (including the hero
             // originally present on the map at the beginning of the scenario).

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1205,8 +1205,8 @@ fheroes2::GameMode Game::CompleteCampaignScenario( const bool isLoadingSaveFile 
 
             const VecHeroes & humanKingdomHeroes = world.GetKingdom( humanColor ).GetHeroes();
 
-            // In the original game, troops for carry over are taken from the one of the heroes available in the kingdom who was hired first (including the hero
-            // originally present on the map at the beginning of the scenario).
+            // In the original game, carry-over troops are taken from a hero who was hired least recently and who is still in the kingdom (I.E. still "alive"). A starting 
+            // hero will count as first if they are still alive since the beginning, but if they are rehired then they take a new place in the queue of heroes.
             if ( !humanKingdomHeroes.empty() ) {
                 const Heroes * hero = humanKingdomHeroes.front();
                 assert( hero != nullptr );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2283,9 +2283,9 @@ StreamBase & operator>>( StreamBase & msg, Heroes & hero )
     // Heroes
     msg >> hero.name >> col >> hero.experience >> hero.secondary_skills >> hero.army >> hero._id >> hero.portrait >> hero._race;
 
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1100_RELEASE, "Remove the logic below." );
-    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1100_RELEASE ) {
-        // Before FORMAT_VERSION_1100_RELEASE we did not check that a custom hero name is empty set inside the original map.
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1100_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1100_RELEASE ) {
+        // Before FORMAT_VERSION_PRE1_1100_RELEASE we did not check that a custom hero name is empty set inside the original map.
         // This leads to assertion rise while rendering text. Also, it is incorrect to have a hero with no name.
         if ( hero.name.empty() ) {
             hero.name = Heroes::GetName( hero._id );

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -105,7 +105,6 @@ bool HeroesStrongestArmy( const Heroes * h1, const Heroes * h2 )
 
 Kingdom::Kingdom()
     : color( Color::NONE )
-    , _lastBattleWinHeroID( Heroes::UNKNOWN )
     , lost_town_days( 0 )
     , visited_tents_colors( 0 )
     , _topCastleInKingdomView( -1 )
@@ -320,32 +319,33 @@ void Kingdom::AddHero( Heroes * hero )
 
 void Kingdom::RemoveHero( const Heroes * hero )
 {
-    if ( hero != nullptr ) {
-        if ( !heroes.empty() ) {
-            auto it = std::find( heroes.begin(), heroes.end(), hero );
-            assert( it != heroes.end() );
-            if ( it != heroes.end() ) {
-                heroes.erase( it );
-            }
-        }
-
-        Player * player = Players::Get( GetColor() );
-
-        if ( player && player->GetFocus().GetHeroes() == hero ) {
-            player->GetFocus().Reset();
-        }
-
-        assert( hero != nullptr );
-
-        AI::Get().HeroesRemove( *hero );
-    }
-    else {
+    if ( hero == nullptr ) {
         // Why are trying to delete a non existing hero?
         assert( 0 );
+        return;
     }
 
-    if ( isLoss() )
+    if ( !heroes.empty() ) {
+        auto it = std::find( heroes.begin(), heroes.end(), hero );
+        assert( it != heroes.end() );
+        if ( it != heroes.end() ) {
+            heroes.erase( it );
+        }
+    }
+
+    Player * player = Players::Get( GetColor() );
+
+    if ( player && player->GetFocus().GetHeroes() == hero ) {
+        player->GetFocus().Reset();
+    }
+
+    assert( hero != nullptr );
+
+    AI::Get().HeroesRemove( *hero );
+
+    if ( isLoss() ) {
         LossPostActions();
+    }
 }
 
 void Kingdom::AddCastle( const Castle * castle )
@@ -838,16 +838,6 @@ Kingdom & Kingdoms::GetKingdom( int color )
     return kingdoms[6];
 }
 
-void Kingdom::SetLastBattleWinHero( const Heroes & hero )
-{
-    _lastBattleWinHeroID = hero.GetID();
-}
-
-Heroes * Kingdom::GetLastBattleWinHero() const
-{
-    return Heroes::UNKNOWN != _lastBattleWinHeroID ? world.GetHeroes( _lastBattleWinHeroID ) : nullptr;
-}
-
 void Kingdom::appendSurrenderedHero( Heroes & hero )
 {
     recruits.appendSurrenderedHero( hero, world.CountDay() );
@@ -1009,18 +999,19 @@ cost_t Kingdom::_getKingdomStartingResources( const int difficulty ) const
 StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )
 {
     return msg << kingdom.modes << kingdom.color << kingdom.resource << kingdom.lost_town_days << kingdom.castles << kingdom.heroes << kingdom.recruits
-               << kingdom.visit_object << kingdom.puzzle_maps << kingdom.visited_tents_colors << kingdom._lastBattleWinHeroID << kingdom._topCastleInKingdomView
-               << kingdom._topHeroInKingdomView;
+               << kingdom.visit_object << kingdom.puzzle_maps << kingdom.visited_tents_colors << kingdom._topCastleInKingdomView << kingdom._topHeroInKingdomView;
 }
 
 StreamBase & operator>>( StreamBase & msg, Kingdom & kingdom )
 {
     msg >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits >> kingdom.visit_object
-        >> kingdom.puzzle_maps >> kingdom.visited_tents_colors >> kingdom._lastBattleWinHeroID;
+        >> kingdom.puzzle_maps >> kingdom.visited_tents_colors;
 
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
-    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
-        ++kingdom._lastBattleWinHeroID;
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1100_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1100_RELEASE ) {
+        int dummy;
+
+        msg >> dummy;
     }
 
     return msg >> kingdom._topCastleInKingdomView >> kingdom._topHeroInKingdomView;

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -320,7 +320,7 @@ void Kingdom::AddHero( Heroes * hero )
 void Kingdom::RemoveHero( const Heroes * hero )
 {
     if ( hero == nullptr ) {
-        // Why are trying to delete a non existing hero?
+        // Why are you trying to delete a non-existing hero?
         assert( 0 );
         return;
     }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -105,7 +105,7 @@ bool HeroesStrongestArmy( const Heroes * h1, const Heroes * h2 )
 
 Kingdom::Kingdom()
     : color( Color::NONE )
-    , _lastBattleWinHeroID( 0 )
+    , _lastBattleWinHeroID( Heroes::UNKNOWN )
     , lost_town_days( 0 )
     , visited_tents_colors( 0 )
     , _topCastleInKingdomView( -1 )

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -84,15 +84,14 @@ public:
     bool AllowPayment( const Funds & ) const;
     bool AllowRecruitHero( bool check_payment ) const;
 
-    // Return true if this kingdom can recruit heroes, false otherwise. For
-    // example this function will return false when kingdom has one town that
-    // cannot be upgraded to a castle.
+    // Returns true if this kingdom can recruit heroes, false otherwise. For example, this function returns false if there is only one town in the kingdom that cannot be
+    // upgraded to a castle.
     bool canRecruitHeroes() const
     {
         return std::any_of( castles.begin(), castles.end(), []( const Castle * castle ) { return ( castle->isCastle() || castle->Modes( Castle::ALLOWCASTLE ) ); } );
     }
 
-    // Return true if this kingdom has any heroes, false otherwise.
+    // Returns true if this kingdom has any heroes, false otherwise.
     bool hasHeroes() const
     {
         return !heroes.empty();

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -97,9 +97,6 @@ public:
         return !heroes.empty();
     }
 
-    void SetLastBattleWinHero( const Heroes & hero );
-    Heroes * GetLastBattleWinHero() const;
-
     void appendSurrenderedHero( Heroes & hero );
 
     Heroes * GetBestHero() const;
@@ -207,7 +204,6 @@ private:
     friend StreamBase & operator>>( StreamBase &, Kingdom & );
 
     int color;
-    int _lastBattleWinHeroID;
     Funds resource;
 
     uint32_t lost_town_days;

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -28,7 +28,8 @@ enum SaveFileFormat : uint16_t
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
 
-    FORMAT_VERSION_1100_RELEASE = 10016,
+    FORMAT_VERSION_1100_RELEASE = 10017,
+    FORMAT_VERSION_PRE1_1100_RELEASE = 10016,
     FORMAT_VERSION_1010_RELEASE = 10015,
     FORMAT_VERSION_1009_RELEASE = 10014,
     FORMAT_VERSION_PRE2_1009_RELEASE = 10013,


### PR DESCRIPTION
fix #8418

According to my observations, in the original game, troops for carry over are always taken from the one of the heroes available in the kingdom who was hired first (including the hero originally present on the map at the beginning of the scenario). That is, if nothing happened to the hero initially present on the map, then his troops will be taken. If this hero was lost, the troops of the hero who was hired after him will be taken. If this hero was lost, but then rehired, then the troops of the hero who was hired after him will still be taken. It doesn't matter which hero won the last battle of the campaign scenario.

If the scenario was won, but there is not a single hero in the human player's kingdom, then no troops are carried over, and in the mission to which they were supposed to be carried, the corresponding hero starts with the minimum initial army.