### PR TITLE
Fix crash when selecting mines in the map editor

### DIFF
--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -1476,15 +1476,9 @@ void Dialog::selectMineType( int32_t & type, int32_t & color )
 
     fheroes2::ImageRestorer appearanceTextBackground( display, 0, 0, 0, 0 );
     // Mine appearance selection text.
-    auto redrawAppearanceText = [selectedResourceType, &appearanceTextBackground, &listRoi, &display]( const Maps::ObjectInfo & info ) {
+    auto redrawAppearanceText = [&appearanceTextBackground, &listRoi, &display]( const Maps::ObjectInfo & info ) {
         std::string mineText( _( "%{mineName} appearance:" ) );
         if ( info.objectType == MP2::OBJ_MINE ) {
-            assert( selectedResourceType < 7 );
-
-#ifdef NDEBUG
-            (void)selectedResourceType;
-#endif
-
             StringReplace( mineText, "%{mineName}", Maps::GetMineName( static_cast<int>( info.metadata[0] ) ) );
         }
         else {


### PR DESCRIPTION
Relates to #6845 
This PR removes the leftover of initial variant of mine select dialog.
There is no need to check `selectedResourceType` since it is not used in `redrawAppearanceText()`. The `selectedResourceType` variable is changed to the correct value when the mine is changed. But the changed value was not properly transferred to the `redrawAppearanceText()` lambda.