### PR TITLE
added possibility to "draw" the attack angle between two hexes

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2800,7 +2800,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
     const fheroes2::Rect battleFieldRect{ _interfacePosition.x, _interfacePosition.y, _interfacePosition.width, battleFieldHeight };
 
     // Swipe attack motion finished, but the destination was outside the arena. We need to clear the swipe attack state.
-    if ( !le.isDragInProgress() && Board::isValidIndex( _swipeAttack.swipeSrcCellIndex ) && !Board::isValidIndex( index_pos ) ) {
+    if ( !le.isDragInProgress() && Board::isValidIndex( _swipeAttack.srcCellIndex ) && !Board::isValidIndex( index_pos ) ) {
         _swipeAttack = {};
     }
 
@@ -2935,11 +2935,11 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
     else if ( le.MouseCursor( battleFieldRect ) ) {
         int themes = GetBattleCursor( msg );
 
-        if ( _swipeAttack.isValid ) {
+        if ( _swipeAttack.isValid() ) {
             // The swipe attack motion is either in progress or has finished.
-            if ( index_pos == _swipeAttack.swipeDstCellIndex ) {
+            if ( index_pos == _swipeAttack.dstCellIndex ) {
                 // The cursor is above the stored destination, we should display the stored attack theme.
-                themes = _swipeAttack.swipeDstTheme;
+                themes = _swipeAttack.dstTheme;
             }
             else {
                 // The cursor has left the destination. Abort the swipe attack.
@@ -2947,12 +2947,12 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
                 _boardActionIntent = {};
             }
         }
-        else if ( _swipeAttack.isValidSwipeAttackDestination( themes, index_pos, _currentUnit->GetHeadIndex(), _currentUnit->GetTailIndex() ) ) {
+        else if ( _swipeAttack.isValidDestination( themes, index_pos ) ) {
             // Valid swipe attack target cell. Calculate the attack angle based on destination and source cells.
-            themes = GetSwordCursorDirection( Board::GetDirection( index_pos, _swipeAttack.swipeSrcCellIndex ) );
+            themes = GetSwordCursorDirection( Board::GetDirection( index_pos, _swipeAttack.srcCellIndex ) );
 
             // Remember the swipe destination cell and theme.
-            _swipeAttack.storeDst( themes, index_pos );
+            _swipeAttack.setDst( themes, index_pos );
 
             // Clear any pending intents. We don't want to confirm previous actions by performing swipe attack motion.
             _boardActionIntent = {};
@@ -2985,12 +2985,12 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
                 MousePressRightBoardAction( *cell );
             }
             else if ( le.MousePressLeft( battleFieldRect ) ) {
-                if ( !le.isDragInProgress() && !_swipeAttack.isValid ) {
+                if ( !le.isDragInProgress() && !_swipeAttack.isValid() ) {
                     le.registerDrag();
 
                     // Remember the swipe source cell and theme.
                     _swipeAttack = {};
-                    _swipeAttack.storeSrc( themes, index_pos );
+                    _swipeAttack.setSrc( themes, index_pos, _currentUnit );
                 }
             }
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2972,7 +2972,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             boardActionIntentUpdater.setIntent( { themes, index_pos } );
 
             if ( le.MouseClickLeft( battleFieldRect ) ) {
-                bool isConfirmed = boardActionIntentUpdater.isConfirmed();
+                const bool isConfirmed = boardActionIntentUpdater.isConfirmed();
 
                 if ( isConfirmed ) {
                     // Intent is confirmed, it is safe to clear the swipe state (regardless of the intent and the input method).

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2949,8 +2949,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
         }
         else if ( _swipeAttack.isValidSwipeAttackDestination( themes, index_pos, _currentUnit->GetHeadIndex(), _currentUnit->GetTailIndex() ) ) {
             // Valid swipe attack target cell. Calculate the attack angle based on destination and source cells.
-            int direction = Board::GetDirection( index_pos, _swipeAttack.swipeSrcCellIndex );
-            themes = GetSwordCursorDirection( direction );
+            themes = GetSwordCursorDirection( Board::GetDirection( index_pos, _swipeAttack.swipeSrcCellIndex ) );
 
             // Remember the swipe destination cell and theme.
             _swipeAttack.storeDst( themes, index_pos );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1171,7 +1171,6 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     , _teleportSpellSrcIdx( -1 )
     , listlog( nullptr )
     , _bridgeAnimation( { false, BridgeMovementAnimation::UP_POSITION } )
-    , _swipeAttack( { -1, -1, false, 0, 0 } )
 {
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
 
@@ -2802,7 +2801,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
     // Swipe attack motion finished, but the destination was outside the arena. We need to clear the swipe attack state.
     if ( !le.isDragInProgress() && Board::isValidIndex( _swipeAttack.swipeSrcCellIndex ) && !Board::isValidIndex( index_pos ) ) {
-        _swipeAttack.clear();
+        _swipeAttack = {};
     }
 
     if ( listlog && listlog->isOpenLog() && ( le.MouseCursor( listlog->GetArea() ) || le.MousePressLeft( listlog->GetArea() ) ) ) {
@@ -2944,8 +2943,8 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             }
             else {
                 // The cursor has left the destination. Abort the swipe attack.
-                _swipeAttack.clear();
-                boardActionIntentUpdater.clearStoredIntent();
+                _swipeAttack = {};
+                _boardActionIntent = {};
             }
         }
         else if ( _swipeAttack.isValidSwipeAttackDestination( themes, index_pos, _currentUnit->GetHeadIndex(), _currentUnit->GetTailIndex() ) ) {
@@ -2957,7 +2956,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             _swipeAttack.storeDst( themes, index_pos );
 
             // Clear any pending intents. We don't want to confirm previous actions by performing swipe attack motion.
-            boardActionIntentUpdater.clearStoredIntent();
+            _boardActionIntent = {};
         }
 
         cursor.SetThemes( themes );
@@ -2978,7 +2977,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
                 if ( isConfirmed ) {
                     // Intent is confirmed, it is safe to clear the swipe state (regardless of the intent and the input method).
-                    _swipeAttack.clear();
+                    _swipeAttack = {};
                 }
 
                 MouseLeftClickBoardAction( themes, *cell, isConfirmed, actions );
@@ -2991,6 +2990,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
                     le.registerDrag();
 
                     // Remember the swipe source cell and theme.
+                    _swipeAttack = {};
                     _swipeAttack.storeSrc( themes, index_pos );
                 }
             }

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -34,6 +34,7 @@
 #include "battle.h"
 #include "battle_animation.h"
 #include "battle_board.h"
+#include "battle_troop.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "icn.h"
@@ -479,22 +480,26 @@ namespace Battle
 
         struct SwipeAttack
         {
-            void storeSrc( int theme, int32_t index )
+            void setSrc( int theme, int32_t index, const Unit * unit )
             {
-                swipeSrcTheme = theme;
-                swipeSrcCellIndex = index;
+                currentUnit = unit;
+                srcTheme = theme;
+                srcCellIndex = index;
             }
 
-            void storeDst( int theme, int32_t index )
+            void setDst( int theme, int32_t index )
             {
-                isValid = true;
-                swipeDstTheme = theme;
-                swipeDstCellIndex = index;
+                dstTheme = theme;
+                dstCellIndex = index;
             }
 
-            bool isValidSwipeAttackDestination( int theme, int32_t index, int32_t head, int32_t tail ) const
+            bool isValidDestination( int theme, int32_t index ) const
             {
-                if ( !Board::isNearIndexes( swipeSrcCellIndex, index ) ) {
+                if ( !currentUnit ) {
+                    return false;
+                }
+
+                if ( !Board::isNearIndexes( srcCellIndex, index ) ) {
                     return false;
                 }
 
@@ -502,18 +507,24 @@ namespace Battle
                     return false;
                 }
 
-                if ( swipeSrcTheme != Cursor::WAR_MOVE && swipeSrcTheme != Cursor::WAR_FLY && swipeSrcCellIndex != head && swipeSrcCellIndex != tail ) {
+                if ( srcTheme != Cursor::WAR_MOVE && srcTheme != Cursor::WAR_FLY && srcCellIndex != currentUnit->GetHeadIndex()
+                     && srcCellIndex != currentUnit->GetTailIndex() ) {
                     return false;
                 }
 
                 return true;
             }
 
-            int32_t swipeSrcCellIndex{ -1 };
-            int32_t swipeDstCellIndex{ -1 };
-            bool isValid{ false };
-            int swipeSrcTheme{ Cursor::NONE };
-            int swipeDstTheme{ Cursor::NONE };
+            bool isValid() const
+            {
+                return isValidDestination( dstTheme, dstCellIndex );
+            }
+
+            const Unit * currentUnit{ nullptr };
+            int32_t srcCellIndex{ -1 };
+            int32_t dstCellIndex{ -1 };
+            int srcTheme{ Cursor::NONE };
+            int dstTheme{ Cursor::NONE };
         };
 
         SwipeAttack _swipeAttack;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -477,6 +477,57 @@ namespace Battle
 
         BridgeMovementAnimation _bridgeAnimation;
 
+        struct SwipeAttack
+        {
+            void clear()
+            {
+                swipeSrcCellIndex = -1;
+                swipeDstCellIndex = -1;
+                isValid = false;
+                swipeSrcTheme = 0;
+                swipeDstTheme = 0;
+            }
+
+            void storeSrc( int theme, int32_t index )
+            {
+                clear();
+                swipeSrcTheme = theme;
+                swipeSrcCellIndex = index;
+            }
+
+            void storeDst( int theme, int32_t index )
+            {
+                isValid = true;
+                swipeDstTheme = theme;
+                swipeDstCellIndex = index;
+            }
+
+            bool isValidSwipeAttackDestination( int theme, int32_t index, int32_t head, int32_t tail )
+            {
+                if ( !Board::isNearIndexes( swipeSrcCellIndex, index ) ) {
+                    return false;
+                }
+
+                if ( theme < Cursor::SWORD_TOPRIGHT || theme > Cursor::SWORD_BOTTOM ) {
+                    return false;
+                }
+
+                if ( swipeSrcTheme != Cursor::WAR_MOVE && swipeSrcTheme != Cursor::WAR_FLY && swipeSrcCellIndex != head && swipeSrcCellIndex != tail ) {
+                    return false;
+                }
+
+                return true;
+            }
+
+            int32_t swipeSrcCellIndex;
+            int32_t swipeDstCellIndex;
+            bool isValid;
+            int swipeSrcTheme;
+            int swipeDstTheme;
+        };
+
+        SwipeAttack _swipeAttack;
+
         // TODO: While currently we don't need to persist 'UnitSpellEffectInfos' between render functions,
         // this may be needed in the future (for example, in expansion) to display some sprites over
         // troops for some time (e.g. long duration spell effects or other permanent effects).
@@ -521,6 +572,11 @@ namespace Battle
             void setIntent( const BoardActionIntent & intent )
             {
                 _intent = intent;
+            }
+
+            void clearStoredIntent()
+            {
+                _storedIntent = BoardActionIntent{};
             }
 
             bool isConfirmed()

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -502,7 +502,7 @@ namespace Battle
                 swipeDstCellIndex = index;
             }
 
-            bool isValidSwipeAttackDestination( int theme, int32_t index, int32_t head, int32_t tail )
+            bool isValidSwipeAttackDestination( int theme, int32_t index, int32_t head, int32_t tail ) const
             {
                 if ( !Board::isNearIndexes( swipeSrcCellIndex, index ) ) {
                     return false;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -479,18 +479,8 @@ namespace Battle
 
         struct SwipeAttack
         {
-            void clear()
-            {
-                swipeSrcCellIndex = -1;
-                swipeDstCellIndex = -1;
-                isValid = false;
-                swipeSrcTheme = 0;
-                swipeDstTheme = 0;
-            }
-
             void storeSrc( int theme, int32_t index )
             {
-                clear();
                 swipeSrcTheme = theme;
                 swipeSrcCellIndex = index;
             }
@@ -519,11 +509,11 @@ namespace Battle
                 return true;
             }
 
-            int32_t swipeSrcCellIndex;
-            int32_t swipeDstCellIndex;
-            bool isValid;
-            int swipeSrcTheme;
-            int swipeDstTheme;
+            int32_t swipeSrcCellIndex{ -1 };
+            int32_t swipeDstCellIndex{ -1 };
+            bool isValid{ false };
+            int swipeSrcTheme{ Cursor::NONE };
+            int swipeDstTheme{ Cursor::NONE };
         };
 
         SwipeAttack _swipeAttack;
@@ -572,11 +562,6 @@ namespace Battle
             void setIntent( const BoardActionIntent & intent )
             {
                 _intent = intent;
-            }
-
-            void clearStoredIntent()
-            {
-                _storedIntent = BoardActionIntent{};
             }
 
             bool isConfirmed()

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -62,7 +62,6 @@ namespace Battle
     class Position;
     class StatusListBox;
     class Tower;
-    class Unit;
     class Units;
 
     void DialogBattleSettings();


### PR DESCRIPTION
On the smaller touch screens (mobile phones) it is quite difficult to input the correct attack angle. Currently the only option is to click on the appropriate sub-region of a target hex, which is an extremely small area on mobile phones.

This PR addresses this inconvenience, as presented on a video below. An additional input method is introduced, namely "drawing" an attack angle between the source cell and the target cell of attack. Once the attack direction sword is drawn by this method, it gets confirmed by tapping the target cell.

https://github.com/ihhub/fheroes2/assets/84446398/b4ec84f1-b297-43f2-924a-7deb1bb9f97b

Close #7070