### PR TITLE
Fix sphinx title offset

### DIFF
--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -254,7 +254,7 @@ bool Dialog::InputString( const std::string & header, std::string & res, const s
     const fheroes2::Rect & box_rt = box.GetArea();
 
     if ( !title.empty() ) {
-        titlebox.draw( box_rt.x + ( box_rt.width - textbox.width() ) / 2, box_rt.y + 12, BOXAREA_WIDTH, display );
+        titlebox.draw( box_rt.x, box_rt.y + 12, BOXAREA_WIDTH, display );
     }
 
     // text


### PR DESCRIPTION

Before:
![image](https://github.com/ihhub/fheroes2/assets/12501091/96da94e1-f243-40df-8803-e2dbd0db2cb5)


After:
<img width="335" alt="image" src="https://github.com/ihhub/fheroes2/assets/12501091/9f28760f-b8c1-45d5-a08a-560f8b9e15f0">

