### PR TITLE
Fix wrong name for Neutral race troops

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1231,7 +1231,7 @@ int Army::GetMoraleModificator( std::string * strs ) const
             ++result;
             if ( strs ) {
                 std::string str = _( "All %{race} troops +1" );
-                StringReplace( str, "%{race}", *races.begin() == Race::NONE ? _( "Multiple" ) : Race::String( *races.begin() ) );
+                StringReplace( str, "%{race}", *races.begin() == Race::NONE ? _( "NeutralRaceTroops|Neutral" ) : Race::String( *races.begin() ) );
                 strs->append( str );
                 *strs += '\n';
             }


### PR DESCRIPTION
If your army is only composed of Neutral troops, then this is what is displayed in current `Master`:
![image](https://github.com/ihhub/fheroes2/assets/12501091/10f80157-e624-4392-b997-f17784b841c8)

I've corrected it to Neutral in this PR as that is what those troops are called.

![image](https://github.com/ihhub/fheroes2/assets/12501091/fa3b86a4-429e-46b9-b084-987fd4d4401f)


Note that in the OG this dialog would display "Multiple", but IMO that is wrong.
