### PR TITLE
Small change of phrasing of creature seperation

### DIFF
--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -405,12 +405,12 @@ int Dialog::ArmySplitTroop( uint32_t freeSlots, const uint32_t redistributeMax, 
     const fheroes2::Text header( troopName, fheroes2::FontType::normalYellow() );
     const int32_t headerHeight = header.height() + 6;
 
-    const std::string msg( _( "How many units do you wish to move?" ) );
+    const std::string msg( _( "How many creatures do you wish to move?" ) );
     fheroes2::Text titleText( msg, fheroes2::FontType::normalWhite() );
     titleText.setUniformVerticalAlignment( false );
     const int32_t titleHeight = headerHeight + titleText.rows( BOXAREA_WIDTH ) * titleText.height();
 
-    fheroes2::Text slotSeparationText( _( "Select how many slots to separate into:" ), fheroes2::FontType::normalWhite() );
+    fheroes2::Text slotSeparationText( _( "Select how many units to separate into:" ), fheroes2::FontType::normalWhite() );
     slotSeparationText.setUniformVerticalAlignment( false );
     const int32_t bodyHeight = slotSeparationText.rows( BOXAREA_WIDTH ) * slotSeparationText.height();
 


### PR DESCRIPTION
This changes _units_ into _creatures_ because in the rest of the game a unit is refered to as a stack of creatues not a single creature. Keeping the game more consistent.

Also changes _slot_ into _unit_ to be more inline of the rest of the terminology of the game. Though keeping instead of _unit_ are also fine. Keeping slots might be more clear, but the image selector makes it clear enough in my mind.

Example: Current on top and this suggestion down below

![example](https://github.com/ihhub/fheroes2/assets/93934125/97cf101e-5f09-4a21-83ed-a89d95c5fb6b)
