### PR TITLE
Update CMakeLists.txt for a nicer fheroes2.exe

### DIFF
--- a/src/fheroes2/CMakeLists.txt
+++ b/src/fheroes2/CMakeLists.txt
@@ -60,7 +60,12 @@ else(MACOS_APP_BUNDLE)
 		OUTPUT_VARIABLE FHEROES2_DATA_ABSOLUTE
 		)
 
-	add_executable(fheroes2 ${FHEROES2_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.rc)
+	add_executable(
+        fheroes2
+        ${FHEROES2_SOURCES}
+        ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.manifest
+        ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.rc
+        )
 
 	target_compile_definitions(
 		fheroes2

--- a/src/fheroes2/CMakeLists.txt
+++ b/src/fheroes2/CMakeLists.txt
@@ -61,11 +61,11 @@ else(MACOS_APP_BUNDLE)
 		)
 
 	add_executable(
-        fheroes2
-        ${FHEROES2_SOURCES}
-        ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.manifest
-        ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.rc
-        )
+		fheroes2
+		${FHEROES2_SOURCES}
+		${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.manifest
+		${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.rc
+		)
 
 	target_compile_definitions(
 		fheroes2

--- a/src/fheroes2/CMakeLists.txt
+++ b/src/fheroes2/CMakeLists.txt
@@ -60,7 +60,7 @@ else(MACOS_APP_BUNDLE)
 		OUTPUT_VARIABLE FHEROES2_DATA_ABSOLUTE
 		)
 
-	add_executable(fheroes2 ${FHEROES2_SOURCES})
+	add_executable(fheroes2 ${FHEROES2_SOURCES} ${CMAKE_CURRENT_SOURCE_DIR}/../resources/fheroes2.rc)
 
 	target_compile_definitions(
 		fheroes2

--- a/src/fheroes2/CMakeLists.txt
+++ b/src/fheroes2/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2022 - 2023                                             #
+#   Copyright (C) 2022 - 2024                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #


### PR DESCRIPTION
This change fixes `fheroes2.exe` cosmetically, which was built without icon and details (Windows only).

Hopefully this will not break the compilation under e.g. Linux.