### PR TITLE
Add a window to change Monster properties

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -273,6 +273,13 @@ namespace
                     objectIter = mapTile.objects.erase( objectIter );
                     needRedraw = true;
                 }
+                else if ( objectIter->group == Maps::ObjectGroup::MONSTERS ) {
+                    assert( mapFormat.standardMetadata.find( objectIter->id ) != mapFormat.standardMetadata.end() );
+                    mapFormat.standardMetadata.erase( objectIter->id );
+
+                    objectIter = mapTile.objects.erase( objectIter );
+                    needRedraw = true;
+                }
                 else {
                     objectIter = mapTile.objects.erase( objectIter );
                     needRedraw = true;

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -856,7 +856,7 @@ namespace Interface
                     }
 
                     std::string str = _( "Set %{monster} Count" );
-                    StringReplace( str, "%{monster}", Monster( object.index + 1 ).GetName() );
+                    StringReplace( str, "%{monster}", Monster( static_cast<int>( object.index ) + 1 ).GetName() );
 
                     fheroes2::ActionCreator action( _historyManager, _mapFormat );
                     if ( Dialog::SelectCount( str, 0, 500000, monsterCount ) ) {

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -846,6 +846,20 @@ namespace Interface
                         action.commit();
                     }
                 }
+                else if ( objectType == MP2::OBJ_MONSTER ) {
+                    uint32_t monsterCount = 0;
+
+                    auto monsterMetadata = _mapFormat.standardMetadata.find( object.id );
+                    if ( monsterMetadata != _mapFormat.standardMetadata.end() ) {
+                        monsterCount = monsterMetadata->second.metadata[0];
+                    }
+
+                    fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                    if ( Dialog::SelectCount( _( "Set Monster Count" ), 0, 500000, monsterCount ) ) {
+                        _mapFormat.standardMetadata[object.id] = { monsterCount, Monster::JOIN_CONDITION_UNSET, 0 };
+                        action.commit();
+                    }
+                }
             }
         }
         else if ( _editorPanel.isTerrainEdit() ) {

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -860,7 +860,7 @@ namespace Interface
 
                     fheroes2::ActionCreator action( _historyManager, _mapFormat );
                     if ( Dialog::SelectCount( str, 0, 500000, monsterCount ) ) {
-                        _mapFormat.standardMetadata[object.id] = { monsterCount, Monster::JOIN_CONDITION_UNSET, 0 };
+                        _mapFormat.standardMetadata[object.id] = { static_cast<int32_t>( monsterCount ), Monster::JOIN_CONDITION_UNSET, 0 };
                         action.commit();
                     }
                 }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -58,6 +58,7 @@
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"
 #include "math_base.h"
+#include "monster.h"
 #include "mp2.h"
 #include "render_processor.h"
 #include "screen.h"

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -847,7 +847,7 @@ namespace Interface
                         action.commit();
                     }
                 }
-                else if ( objectType == MP2::OBJ_MONSTER ) {
+                else if ( object.group == Maps::ObjectGroup::MONSTERS ) {
                     uint32_t monsterCount = 0;
 
                     auto monsterMetadata = _mapFormat.standardMetadata.find( object.id );
@@ -860,7 +860,7 @@ namespace Interface
 
                     fheroes2::ActionCreator action( _historyManager, _mapFormat );
                     if ( Dialog::SelectCount( str, 0, 500000, monsterCount ) ) {
-                        _mapFormat.standardMetadata[object.id] = { static_cast<int32_t>( monsterCount ), Monster::JOIN_CONDITION_UNSET, 0 };
+                        _mapFormat.standardMetadata[object.id] = { static_cast<int32_t>( monsterCount ), 0, Monster::JOIN_CONDITION_UNSET };
                         action.commit();
                     }
                 }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -855,8 +855,11 @@ namespace Interface
                         monsterCount = monsterMetadata->second.metadata[0];
                     }
 
+                    std::string str = _( "Set %{monster} Count" );
+                    StringReplace( str, "%{monster}", Monster( object.index + 1 ).GetName() );
+
                     fheroes2::ActionCreator action( _historyManager, _mapFormat );
-                    if ( Dialog::SelectCount( _( "Set Monster Count" ), 0, 500000, monsterCount ) ) {
+                    if ( Dialog::SelectCount( str, 0, 500000, monsterCount ) ) {
                         _mapFormat.standardMetadata[object.id] = { monsterCount, Monster::JOIN_CONDITION_UNSET, 0 };
                         action.commit();
                     }

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -54,7 +54,7 @@ namespace Maps::Map_Format
     // This structure should be used for any object that require simple data to be saved into map.
     struct StandardObjectMetadata
     {
-        std::array<uint32_t, 3> metadata{ 0 };
+        std::array<int32_t, 3> metadata{ 0 };
     };
 
     struct CastleMetadata

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -38,7 +38,8 @@ public:
     {
         JOIN_CONDITION_SKIP = 0,
         JOIN_CONDITION_MONEY = 1,
-        JOIN_CONDITION_FREE = 2
+        JOIN_CONDITION_FREE = 2,
+        JOIN_CONDITION_UNSET = 3
     };
 
     enum class LevelType : int

--- a/src/fheroes2/monster/monster.h
+++ b/src/fheroes2/monster/monster.h
@@ -36,10 +36,10 @@ class Monster
 public:
     enum
     {
+        JOIN_CONDITION_UNSET = -1,
         JOIN_CONDITION_SKIP = 0,
         JOIN_CONDITION_MONEY = 1,
-        JOIN_CONDITION_FREE = 2,
-        JOIN_CONDITION_UNSET = 3
+        JOIN_CONDITION_FREE = 2
     };
 
     enum class LevelType : int

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -738,6 +738,14 @@ bool World::loadResurrectionMap( const std::string & filename )
                     }
                 }
             }
+            else if ( object.group == Maps::ObjectGroup::MONSTERS ) {
+                const std::array<int32_t, 3> & source = map.standardMetadata[object.id].metadata;
+                std::array<uint32_t, 3> & tileData = vec_tiles[static_cast<int32_t>( tileId )].metadata();
+
+                for ( size_t idx = 0; idx < source.size(); idx++ ) {
+                    tileData[idx] = static_cast<uint32_t>( source[idx] );
+                }
+            }
         }
     }
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -747,6 +747,7 @@ bool World::loadResurrectionMap( const std::string & filename )
 
                 for ( size_t idx = 0; idx < source.size(); idx++ ) {
                     tileData[idx] = static_cast<uint32_t>( source[idx] );
+            }
             else if ( Maps::isJailObject( object.group, object.index ) ) {
                 assert( map.heroMetadata.find( object.id ) != map.heroMetadata.end() );
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -747,6 +747,7 @@ bool World::loadResurrectionMap( const std::string & filename )
 
                 for ( size_t idx = 0; idx < source.size(); idx++ ) {
                     tileData[idx] = static_cast<uint32_t>( source[idx] );
+                }
             }
             else if ( Maps::isJailObject( object.group, object.index ) ) {
                 assert( map.heroMetadata.find( object.id ) != map.heroMetadata.end() );


### PR DESCRIPTION
relates to #6845

Later we can make it's own dialog window to control monster join condition, but it outside of OG scope.

![Screenshot 2024-04-03 032143](https://github.com/ihhub/fheroes2/assets/1373638/5ce963bb-6c5c-4268-9d8d-51cb97e5328d)
