### PR TITLE
Fix some unused variable cases

### DIFF
--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -414,6 +414,7 @@ namespace Maps
             }
         }
 
+        // Update map format settings based on the gathered information.
         map.availablePlayerColors = 0;
         for ( size_t i = 0; i < mainColors; ++i ) {
             if ( heroColorsPresent[i] || townColorsPresent[i] ) {

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -283,8 +283,12 @@ namespace Maps
             heroMetadata->second.race = Race::RAND;
         }
         else if ( group == ObjectGroup::MONSTERS ) {
-            auto [monsterMetadata, isMetadataEmplaced] = map.standardMetadata.try_emplace( uid );
+            const auto [dummy, isMetadataEmplaced] = map.standardMetadata.try_emplace( uid );
             assert( isMetadataEmplaced );
+
+#ifdef NDEBUG
+            (void)isMetadataEmplaced;
+#endif
         }
         else if ( group == Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS ) {
             const auto & objects = Maps::getObjectsByGroup( group );
@@ -294,18 +298,30 @@ namespace Maps
 
             switch ( objectType ) {
             case MP2::OBJ_EVENT: {
-                auto [metadata, isMetadataEmplaced] = map.adventureMapEventMetadata.try_emplace( uid );
+                const auto [dummy, isMetadataEmplaced] = map.adventureMapEventMetadata.try_emplace( uid );
                 assert( isMetadataEmplaced );
+
+#ifdef NDEBUG
+                (void)isMetadataEmplaced;
+#endif
                 break;
             }
             case MP2::OBJ_SIGN: {
-                auto [metadata, isMetadataEmplaced] = map.signMetadata.try_emplace( uid );
+                const auto [dummy, isMetadataEmplaced] = map.signMetadata.try_emplace( uid );
                 assert( isMetadataEmplaced );
+
+#ifdef NDEBUG
+                (void)isMetadataEmplaced;
+#endif
                 break;
             }
             case MP2::OBJ_SPHINX: {
-                auto [metadata, isMetadataEmplaced] = map.sphinxMetadata.try_emplace( uid );
+                const auto [dummy, isMetadataEmplaced] = map.sphinxMetadata.try_emplace( uid );
                 assert( isMetadataEmplaced );
+
+#ifdef NDEBUG
+                (void)isMetadataEmplaced;
+#endif
                 break;
             }
             default:
@@ -318,15 +334,23 @@ namespace Maps
             assert( index < objects.size() );
             const auto objectType = objects[index].objectType;
             if ( objectType == MP2::OBJ_BOTTLE ) {
-                auto [metadata, isMetadataEmplaced] = map.signMetadata.try_emplace( uid );
+                const auto [dummy, isMetadataEmplaced] = map.signMetadata.try_emplace( uid );
                 assert( isMetadataEmplaced );
+
+#ifdef NDEBUG
+                (void)isMetadataEmplaced;
+#endif
             }
         }
         else if ( group == Maps::ObjectGroup::ADVENTURE_ARTIFACTS ) {
             assert( index < Maps::getObjectsByGroup( group ).size() );
 
-            auto [metadata, isMetadataEmplaced] = map.standardMetadata.try_emplace( uid );
+            const auto [dummy, isMetadataEmplaced] = map.standardMetadata.try_emplace( uid );
             assert( isMetadataEmplaced );
+
+#ifdef NDEBUG
+            (void)isMetadataEmplaced;
+#endif
         }
     }
 

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -414,18 +414,12 @@ namespace Maps
             }
         }
 
-        // Update map format settings based on the gathered information.
-        uint8_t numberOfColorsPresent = 0;
-
         map.availablePlayerColors = 0;
         for ( size_t i = 0; i < mainColors; ++i ) {
             if ( heroColorsPresent[i] || townColorsPresent[i] ) {
                 assert( heroRacesPresent[i] != 0 || townRacesPresent[i] != 0 );
 
                 map.availablePlayerColors += static_cast<uint8_t>( 1 << i );
-
-                ++numberOfColorsPresent;
-
                 map.playerRace[i] &= ( heroRacesPresent[i] | townRacesPresent[i] );
 
                 if ( map.playerRace[i] == 0 ) {

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -479,9 +479,8 @@ bool Maps::FileInfo::readResurrectionMap( std::string filePath, const bool isFor
         // As of now only 2 alliances are supported.
         assert( map.alliances.size() == 2 );
 
-        for ( const uint8_t color : map.alliances ) {
-            assert( ( color & map.availablePlayerColors ) == color );
-        }
+        assert( std::all_of( map.alliances.begin(), map.alliances.end(),
+                             [&map = std::as_const( map )]( const uint8_t color ) { return ( color & map.availablePlayerColors ) == color; } ) );
 
         FillUnions( map.alliances[0], map.alliances[1] );
         break;


### PR DESCRIPTION
`numberOfColorsPresent` variable was introduced in #8348, but then the validation of the value of this variable was removed in #8560, so now this variable is only written and never read, which is detected by (newer?) compilers as unused variable and breaks the build in strict mode.