### PR TITLE
Avoid using different string for the same purpose in Editor's castle …

### DIFF
--- a/src/fheroes2/editor/editor_castle_details_window.cpp
+++ b/src/fheroes2/editor/editor_castle_details_window.cpp
@@ -372,7 +372,7 @@ namespace Editor
         // Default buildings checkbox indicator.
         dstPt.y += 30;
         fheroes2::MovableSprite defaultBuildingsSign;
-        const fheroes2::Rect defaultBuildingsArea = drawCheckboxBackground( defaultBuildingsSign, _( "Default buildings" ), dstPt.x, dstPt.y, isEvilInterface );
+        const fheroes2::Rect defaultBuildingsArea = drawCheckboxBackground( defaultBuildingsSign, _( "Default Buildings" ), dstPt.x, dstPt.y, isEvilInterface );
         castleMetadata.customBuildings ? defaultBuildingsSign.hide() : defaultBuildingsSign.show();
 
         // Build restrict mode button.


### PR DESCRIPTION
…dialog

`Default Buildings` and `Default buildings` are the same strings. However, they are going to be translated separately which is wrong.

relates #6845