### PR TITLE
Fix software cursor show delay

### DIFF
--- a/src/fheroes2/gui/cursor.cpp
+++ b/src/fheroes2/gui/cursor.cpp
@@ -239,7 +239,7 @@ CursorRestorer::~CursorRestorer()
 {
     fheroes2::Cursor & cursorRenderer = fheroes2::cursor();
 
-    const bool isShown = _visible && ( cursorRenderer.isVisible() == false );
+    const bool isShown = _visible && !cursorRenderer.isVisible();
 
     cursorRenderer.show( _visible );
 

--- a/src/fheroes2/gui/cursor.cpp
+++ b/src/fheroes2/gui/cursor.cpp
@@ -237,7 +237,22 @@ CursorRestorer::CursorRestorer( const bool visible, const int theme )
 
 CursorRestorer::~CursorRestorer()
 {
-    Cursor::Get().SetThemes( _theme );
+    fheroes2::Cursor & cursorRenderer = fheroes2::cursor();
 
-    fheroes2::cursor().show( _visible );
+    const bool isShown = _visible && ( cursorRenderer.isVisible() == false );
+
+    cursorRenderer.show( _visible );
+
+    Cursor & cursor = Cursor::Get();
+
+    const bool noThemeChange = ( cursor.Themes() == _theme );
+
+    cursor.SetThemes( _theme );
+
+    // In case of software emulated cursor when cursor theme is not changed and it is shown after it was hidden
+    // we force render the cursor area. It is needed to reduce the cursor show delay.
+    if ( isShown && noThemeChange && cursorRenderer.isSoftwareEmulation() ) {
+        const fheroes2::Point & pos = LocalEvent::Get().GetMouseCursor();
+        fheroes2::Display::instance().render( { pos.x, pos.y, 1, 1 } );
+    }
 }


### PR DESCRIPTION
Relates to https://github.com/ihhub/fheroes2/issues/6845

To reproduce the issue on 'master' branch disable Animation within the Editor and use software rendering mode (`cursor soft rendering = on` in **fheroes2.cfg**).

When cursor image is not changed and the cursor must be shown after closing info dialog the **CursorRestorer** destructor now will now force display render to show the cursor.

https://github.com/ihhub/fheroes2/assets/113276641/07bac4c4-3282-4af5-94ec-be0d19e5617a


The cases when cursor image is changed we should be handled in the corresponding code: the corresponding cursor handler must be called. This case is not fixed in this PR.