### PR TITLE
Minor improvements to 'showMessage()' function

### DIFF
--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -213,18 +213,15 @@ namespace fheroes2
         bool delayInEventHandling = true;
 
         while ( result == Dialog::ZERO && le.HandleEvents( delayInEventHandling ) ) {
-            if ( !isProperDialog ) {
-                if ( le.MousePressRight() ) {
-                    continue;
+            if ( isProperDialog ) {
+                elementId = 0;
+                for ( const DialogElement * element : elements ) {
+                    element->processEvents( elementOffsets[elementId] );
+                    ++elementId;
                 }
-
-                break;
             }
-
-            elementId = 0;
-            for ( const DialogElement * element : elements ) {
-                element->processEvents( elementOffsets[elementId] );
-                ++elementId;
+            else if ( !le.MousePressRight() ) {
+                break;
             }
 
             result = group.processEvents();

--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -89,8 +89,10 @@ namespace fheroes2
 
         const bool isProperDialog = ( buttons != 0 );
 
+        const int cusorTheme = isProperDialog ? ( ::Cursor::POINTER ) : ( ::Cursor::Get().Themes() );
+
         // setup cursor
-        const CursorRestorer cursorRestorer( isProperDialog, ::Cursor::POINTER );
+        const CursorRestorer cursorRestorer( isProperDialog, cusorTheme );
 
         const int32_t headerHeight = header.empty() ? 0 : header.height( BOXAREA_WIDTH ) + textOffsetY;
 
@@ -211,16 +213,18 @@ namespace fheroes2
         bool delayInEventHandling = true;
 
         while ( result == Dialog::ZERO && le.HandleEvents( delayInEventHandling ) ) {
-            if ( !buttons && !le.MousePressRight() ) {
+            if ( !isProperDialog ) {
+                if ( le.MousePressRight() ) {
+                    continue;
+                }
+
                 break;
             }
 
-            if ( isProperDialog ) {
-                elementId = 0;
-                for ( const DialogElement * element : elements ) {
-                    element->processEvents( elementOffsets[elementId] );
-                    ++elementId;
-                }
+            elementId = 0;
+            for ( const DialogElement * element : elements ) {
+                element->processEvents( elementOffsets[elementId] );
+                ++elementId;
             }
 
             result = group.processEvents();
@@ -235,7 +239,7 @@ namespace fheroes2
             }
 
             if ( !delayInEventHandling ) {
-                display.render();
+                display.render( pos );
             }
         }
 


### PR DESCRIPTION
These changes are made to work better with https://github.com/ihhub/fheroes2/pull/8615

When the cursor should be hidden (showing message by the right click) now we do not change the cursor theme to help https://github.com/ihhub/fheroes2/pull/8615 to show it quicker.

Also this PR slightly optimizes the render loop. (This dialog with animation can be checked, in example, in Tavern).