### PR TITLE
Fix some bugs in save/load game dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -381,6 +381,17 @@ namespace
             charInsertPos = filename.size();
         }
 
+        auto buttoOkdisabler = [&buttonOk, &filename]() {
+            if ( filename.empty() ) {
+                buttonOk.disable();
+                buttonOk.draw();
+            }
+            else if ( buttonOk.isDisabled() ) {
+                buttonOk.enable();
+                buttonOk.draw();
+            }
+        };
+
         listbox.Redraw();
         redrawTextInputField( filename, textInputRoi, isEditing );
 
@@ -481,13 +492,7 @@ namespace
                     isListboxSelected = false;
                     needRedraw = true;
 
-                    if ( filename.empty() ) {
-                        buttonOk.disable();
-                    }
-                    else {
-                        buttonOk.enable();
-                    }
-                    buttonOk.draw();
+                    buttoOkdisabler();
 
                     // Set the whole screen to redraw next time to properly restore image under the Virtual Keyboard dialog.
                     display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
@@ -506,14 +511,8 @@ namespace
                           && ( !isTextLimit || fheroes2::Key::KEY_BACKSPACE == le.KeyValue() || fheroes2::Key::KEY_DELETE == le.KeyValue() )
                           && le.KeyValue() != fheroes2::Key::KEY_UP && le.KeyValue() != fheroes2::Key::KEY_DOWN ) {
                     charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
-                    if ( filename.empty() ) {
-                        buttonOk.disable();
-                        buttonOk.draw();
-                    }
-                    else {
-                        buttonOk.enable();
-                        buttonOk.draw();
-                    }
+
+                    buttoOkdisabler();
 
                     needRedraw = true;
                     listbox.Unselect();
@@ -556,6 +555,8 @@ namespace
                     lastSelectedSaveFileName = selectedFileName;
                     filename = selectedFileName;
                     charInsertPos = filename.size();
+
+                    buttoOkdisabler();
                 }
                 else if ( isEditing ) {
                     // Empty last selected save file name so that we can replace the input field's name if we select the same save file again.

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -430,8 +430,41 @@ namespace
 
             bool needRedraw = listId != listbox.getCurrentId();
 
-            if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY )
-                 || listbox.isDoubleClicked() ) {
+            if ( le.KeyPress( fheroes2::Key::KEY_DELETE ) && isListboxSelected ) {
+                listbox.SetCurrent( listId );
+                listbox.Redraw();
+
+                std::string msg( _( "Are you sure you want to delete file:" ) );
+                msg.append( "\n\n" );
+                msg.append( System::GetBasename( listbox.GetCurrent().filename ) );
+                if ( Dialog::YES == fheroes2::showStandardTextMessage( _( "Warning!" ), msg, Dialog::YES | Dialog::NO ) ) {
+                    System::Unlink( listbox.GetCurrent().filename );
+                    listbox.RemoveSelected();
+                    if ( lists.empty() ) {
+                        listbox.Redraw();
+
+                        if ( !isEditing ) {
+                            textInputAndDateBackground.restore();
+                            fheroes2::showStandardTextMessage( _( "Load Game" ), _( "No save files to load." ), Dialog::OK );
+                            return {};
+                        }
+
+                        isListboxSelected = false;
+                        charInsertPos = 0;
+                        filename.clear();
+
+                        buttonOk.disable();
+                        buttonOk.draw();
+                    }
+
+                    listbox.updateScrollBarImage();
+                    listbox.SetCurrent( std::max( listId - 1, 0 ) );
+                }
+
+                needRedraw = true;
+            }
+            else if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY )
+                      || listbox.isDoubleClicked() ) {
                 if ( !filename.empty() ) {
                     result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
                 }
@@ -459,21 +492,19 @@ namespace
                     // Set the whole screen to redraw next time to properly restore image under the Virtual Keyboard dialog.
                     display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
                 }
-                else if ( le.MouseClickLeft( textInputRoi ) ) {
+                else if ( !filename.empty() && le.MouseClickLeft( textInputRoi ) ) {
                     const fheroes2::Text text( filename, fheroes2::FontType::normalWhite() );
                     const int32_t textStartOffsetX = isTextLimit ? 8 : ( textInputRoi.width - text.width() ) / 2;
                     charInsertPos = fheroes2::getTextInputCursorPosition( filename, fheroes2::FontType::normalWhite(), charInsertPos, le.GetMouseCursor().x,
                                                                           textInputRoi.x + textStartOffsetX );
-                    if ( filename.empty() ) {
-                        buttonOk.disable();
-                    }
 
                     listbox.Unselect();
                     isListboxSelected = false;
                     needRedraw = true;
                 }
                 else if ( !listboxEvent && le.KeyPress()
-                          && ( !isTextLimit || fheroes2::Key::KEY_BACKSPACE == le.KeyValue() || fheroes2::Key::KEY_DELETE == le.KeyValue() ) ) {
+                          && ( !isTextLimit || fheroes2::Key::KEY_BACKSPACE == le.KeyValue() || fheroes2::Key::KEY_DELETE == le.KeyValue() )
+                          && le.KeyValue() != fheroes2::Key::KEY_UP && le.KeyValue() != fheroes2::Key::KEY_DOWN ) {
                     charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
                     if ( filename.empty() ) {
                         buttonOk.disable();
@@ -503,30 +534,6 @@ namespace
             }
             else if ( isEditing && le.MousePressRight( buttonVirtualKB->area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Open Virtual Keyboard" ), _( "Click to open the Virtual Keyboard dialog." ), Dialog::ZERO );
-            }
-
-            if ( !isEditing && le.KeyPress( fheroes2::Key::KEY_DELETE ) && isListboxSelected ) {
-                listbox.SetCurrent( listId );
-                listbox.Redraw();
-
-                std::string msg( _( "Are you sure you want to delete file:" ) );
-                msg.append( "\n\n" );
-                msg.append( System::GetBasename( listbox.GetCurrent().filename ) );
-                if ( Dialog::YES == fheroes2::showStandardTextMessage( _( "Warning!" ), msg, Dialog::YES | Dialog::NO ) ) {
-                    System::Unlink( listbox.GetCurrent().filename );
-                    listbox.RemoveSelected();
-                    if ( lists.empty() ) {
-                        listbox.Redraw();
-                        textInputAndDateBackground.restore();
-                        fheroes2::showStandardTextMessage( _( "Load Game" ), _( "No save files to load." ), Dialog::OK );
-                        return {};
-                    }
-
-                    listbox.updateScrollBarImage();
-                    listbox.SetCurrent( std::max( listId - 1, 0 ) );
-                }
-
-                needRedraw = true;
             }
 
             // Text input cursor blink.

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -381,7 +381,7 @@ namespace
             charInsertPos = filename.size();
         }
 
-        auto buttoOkDisabler = [&buttonOk, &filename]() {
+        auto buttonOkDisabler = [&buttonOk, &filename]() {
             if ( filename.empty() && buttonOk.isEnabled() ) {
                 buttonOk.disable();
                 buttonOk.draw();
@@ -492,7 +492,7 @@ namespace
                     isListboxSelected = false;
                     needRedraw = true;
 
-                    buttoOkDisabler();
+                    buttonOkDisabler();
 
                     // Set the whole screen to redraw next time to properly restore image under the Virtual Keyboard dialog.
                     display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
@@ -512,7 +512,7 @@ namespace
                           && le.KeyValue() != fheroes2::Key::KEY_UP && le.KeyValue() != fheroes2::Key::KEY_DOWN ) {
                     charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
 
-                    buttoOkDisabler();
+                    buttonOkDisabler();
 
                     needRedraw = true;
                     listbox.Unselect();
@@ -556,7 +556,7 @@ namespace
                     filename = selectedFileName;
                     charInsertPos = filename.size();
 
-                    buttoOkDisabler();
+                    buttonOkDisabler();
                 }
                 else if ( isEditing ) {
                     // Empty last selected save file name so that we can replace the input field's name if we select the same save file again.

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -381,12 +381,12 @@ namespace
             charInsertPos = filename.size();
         }
 
-        auto buttoOkdisabler = [&buttonOk, &filename]() {
-            if ( filename.empty() ) {
+        auto buttoOkDisabler = [&buttonOk, &filename]() {
+            if ( filename.empty() && buttonOk.isEnabled() ) {
                 buttonOk.disable();
                 buttonOk.draw();
             }
-            else if ( buttonOk.isDisabled() ) {
+            else if ( !filename.empty() && buttonOk.isDisabled() ) {
                 buttonOk.enable();
                 buttonOk.draw();
             }
@@ -492,7 +492,7 @@ namespace
                     isListboxSelected = false;
                     needRedraw = true;
 
-                    buttoOkdisabler();
+                    buttoOkDisabler();
 
                     // Set the whole screen to redraw next time to properly restore image under the Virtual Keyboard dialog.
                     display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
@@ -512,7 +512,7 @@ namespace
                           && le.KeyValue() != fheroes2::Key::KEY_UP && le.KeyValue() != fheroes2::Key::KEY_DOWN ) {
                     charInsertPos = InsertKeySym( filename, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
 
-                    buttoOkdisabler();
+                    buttoOkDisabler();
 
                     needRedraw = true;
                     listbox.Unselect();
@@ -556,7 +556,7 @@ namespace
                     filename = selectedFileName;
                     charInsertPos = filename.size();
 
-                    buttoOkdisabler();
+                    buttoOkDisabler();
                 }
                 else if ( isEditing ) {
                     // Empty last selected save file name so that we can replace the input field's name if we select the same save file again.


### PR DESCRIPTION
This PR fixes bugs observed in #8613 :
- deletion of the last file in the Load Game dialog results in game crash;
- deleting the save name in Save Game dialog does not show that the OK button is disabled (but it is);
- deleting the save name in Virtual Keyboard in Save Game dialog does not disable the OK button;
- if the Virtual Keyboard was opened for an empty save name and the non-empty name was given the OK button remains disabled after the keyboard dialog closes.