### PR TITLE
Properly handle objects while changing terrain

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -542,12 +542,7 @@ namespace
             const auto & townObjectInfo = Maps::getObjectInfo( groupType, objectType );
             const auto & basementObjectInfo = Maps::getObjectInfo( Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS, basementId );
 
-            if ( !isObjectPlacementAllowed( townObjectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isObjectPlacementAllowed( basementObjectInfo, tilePos ) ) {
+            if ( !isObjectPlacementAllowed( townObjectInfo, tilePos ) || !isObjectPlacementAllowed( basementObjectInfo, tilePos ) ) {
                 errorMessage = _( "Objects cannot be placed outside the map." );
                 return false;
             }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1764,7 +1764,7 @@ namespace Interface
                     continue;
                 }
 
-                if ( !verifyTerrainPlacement( pos, object.group, object.index, errorMessage ) ) {
+                if ( !verifyTerrainPlacement( pos, object.group, static_cast<int32_t>( object.index ), errorMessage ) ) {
                     uids.emplace( object.id );
                 }
             }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1619,15 +1619,32 @@ namespace Interface
         for ( size_t i = 0; i < _mapFormat.tiles.size(); ++i ) {
             const fheroes2::Point pos{ static_cast<int32_t>( i ) % world.w(), static_cast<int32_t>( i ) / world.w() };
 
+            bool removeRoadAndStream = false;
+
             for ( const auto & object : _mapFormat.tiles[i].objects ) {
                 if ( object.group == Maps::ObjectGroup::LANDSCAPE_FLAGS || object.group == Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS ) {
                     // These objects belong to the main objects and will be checked with them.
                     continue;
                 }
 
+                if ( object.group == Maps::ObjectGroup::ROADS || object.group == Maps::ObjectGroup::STREAMS ) {
+                    if ( world.GetTiles( static_cast<int32_t>( i ) ).isWater() ) {
+                        removeRoadAndStream = true;
+                    }
+
+                    continue;
+                }
+
                 if ( !verifyTerrainPlacement( pos, object.group, static_cast<int32_t>( object.index ), errorMessage ) ) {
                     uids.emplace( object.id );
                 }
+            }
+
+            if ( removeRoadAndStream ) {
+                auto & worldTile = world.GetTiles( static_cast<int32_t>( i ) );
+
+                Maps::updateRoadOnTile( worldTile, false );
+                Maps::updateStreamOnTile( worldTile, false );
             }
         }
 

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -548,8 +548,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_TREASURES ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -563,8 +561,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::KINGDOM_HEROES ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -578,8 +574,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_ARTIFACTS ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -593,8 +587,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::LANDSCAPE_MOUNTAINS ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -608,8 +600,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::LANDSCAPE_ROCKS ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -623,8 +613,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::LANDSCAPE_TREES ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -638,8 +626,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_WATER || groupType == Maps::ObjectGroup::LANDSCAPE_WATER ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -653,8 +639,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -668,8 +652,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::KINGDOM_TOWNS ) {
             Maps::Tiles & tile = world.GetTiles( tilePos.x, tilePos.y );
@@ -699,8 +681,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_MINES ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -714,8 +694,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_DWELLINGS ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -729,8 +707,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_POWER_UPS ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -744,8 +720,6 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS ) {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
@@ -759,15 +733,14 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
-
-            return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
         }
         else {
             // Did you add a new object group? Add the logic for it!
             assert( 0 );
+            return false;
         }
 
-        return true;
+        return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );
     }
 }
 

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1617,9 +1617,9 @@ namespace Interface
         std::set<uint32_t> uids;
 
         for ( size_t i = 0; i < _mapFormat.tiles.size(); ++i ) {
-            fheroes2::Point pos{ static_cast<int32_t>( i ) % world.w(), static_cast<int32_t>( i ) / world.w() };
+            const fheroes2::Point pos{ static_cast<int32_t>( i ) % world.w(), static_cast<int32_t>( i ) / world.w() };
 
-            for ( auto & object : _mapFormat.tiles[i].objects ) {
+            for ( const auto & object : _mapFormat.tiles[i].objects ) {
                 if ( object.group == Maps::ObjectGroup::LANDSCAPE_FLAGS || object.group == Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS ) {
                     // These objects belong to the main objects and will be checked with them.
                     continue;

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -395,63 +395,38 @@ namespace
 
     bool verifyTerrainPlacement( const fheroes2::Point & tilePos, const Maps::ObjectGroup groupType, const int32_t objectType, std::string & errorMessage )
     {
-        if ( groupType == Maps::ObjectGroup::MONSTERS ) {
+        switch ( groupType ) {
+        case Maps::ObjectGroup::ADVENTURE_ARTIFACTS:
+        case Maps::ObjectGroup::ADVENTURE_DWELLINGS:
+        case Maps::ObjectGroup::ADVENTURE_MINES:
+        case Maps::ObjectGroup::ADVENTURE_POWER_UPS:
+        case Maps::ObjectGroup::ADVENTURE_TREASURES:
+        case Maps::ObjectGroup::KINGDOM_HEROES:
+        case Maps::ObjectGroup::LANDSCAPE_MOUNTAINS:
+        case Maps::ObjectGroup::LANDSCAPE_ROCKS:
+        case Maps::ObjectGroup::LANDSCAPE_TREES:
+        case Maps::ObjectGroup::MONSTERS: {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
             if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Monsters cannot be placed on water." );
+                errorMessage = _( "%{objects} cannot be placed on water." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
                 return false;
             }
+
+            break;
         }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_TREASURES ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Treasures cannot be placed on water." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::KINGDOM_HEROES ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Heroes cannot be placed on water." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_ARTIFACTS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Artifacts cannot be placed on water." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::LANDSCAPE_MOUNTAINS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Mountains cannot be placed on water." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::LANDSCAPE_ROCKS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Rocks cannot be placed on water." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::LANDSCAPE_TREES ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Trees cannot be placed on water." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_WATER || groupType == Maps::ObjectGroup::LANDSCAPE_WATER ) {
+        case Maps::ObjectGroup::ADVENTURE_WATER:
+        case Maps::ObjectGroup::LANDSCAPE_WATER: {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
             if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Ocean object must be placed on water." );
+                errorMessage = _( "%{objects} must be placed on water." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
                 return false;
             }
+
+            break;
         }
-        else if ( groupType == Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS ) {
+        case Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS: {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
 
             assert( !objectInfo.groundLevelParts.empty() );
@@ -463,15 +438,19 @@ namespace
                 // This is a river delta. Just don't check the terrain type.
             }
             else if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Landscape objects cannot be placed on water." );
+                errorMessage = _( "%{objects} cannot be placed on water." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
                 return false;
             }
+
+            break;
         }
-        else if ( groupType == Maps::ObjectGroup::KINGDOM_TOWNS ) {
+        case Maps::ObjectGroup::KINGDOM_TOWNS: {
             const Maps::Tiles & tile = world.GetTiles( tilePos.x, tilePos.y );
 
             if ( tile.isWater() ) {
-                errorMessage = _( "Towns cannot be placed on water." );
+                errorMessage = _( "%{objects} cannot be placed on water." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
                 return false;
             }
 
@@ -482,53 +461,37 @@ namespace
             const auto & basementObjectInfo = Maps::getObjectInfo( Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS, basementId );
 
             if ( !checkConditionForUsedTiles( townObjectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Towns cannot be placed on water." );
+                errorMessage = _( "%{objects} cannot be placed on water." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
                 return false;
             }
 
             if ( !checkConditionForUsedTiles( basementObjectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Towns cannot be placed on water." );
+                errorMessage = _( "%{objects} cannot be placed on water." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
                 return false;
             }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_MINES ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
 
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Mines cannot be placed on water." );
-                return false;
-            }
+            break;
         }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_DWELLINGS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Dwellings cannot be placed on water." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_POWER_UPS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Power-ups cannot be placed on water." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS ) {
+        case Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS: {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
 
             if ( objectInfo.objectType == MP2::OBJ_EVENT ) {
                 // Only event objects are allowed to be placed anywhere.
             }
             else if ( !checkConditionForUsedTiles( objectInfo, tilePos, []( const Maps::Tiles & tileToCheck ) { return !tileToCheck.isWater(); } ) ) {
-                errorMessage = _( "Adventure objects cannot be placed on water." );
+                errorMessage = _( "%{objects} cannot be placed on water." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
                 return false;
             }
+
+            break;
         }
-        else {
+        default:
             // Did you add a new object group? Add the logic for it!
             assert( 0 );
+            break;
         }
 
         return true;
@@ -568,7 +531,8 @@ namespace
             const Maps::Tiles & tile = world.GetTiles( tilePos.x, tilePos.y );
 
             if ( tile.isWater() ) {
-                errorMessage = _( "Towns cannot be placed on water." );
+                errorMessage = _( "%{objects} cannot be placed on water." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
                 return false;
             }
 

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -536,7 +536,21 @@ namespace
 
     bool verifyObjectPlacement( const fheroes2::Point & tilePos, const Maps::ObjectGroup groupType, const int32_t objectType, std::string & errorMessage )
     {
-        if ( groupType == Maps::ObjectGroup::MONSTERS ) {
+        switch ( groupType ) {
+        case Maps::ObjectGroup::ADVENTURE_ARTIFACTS:
+        case Maps::ObjectGroup::ADVENTURE_DWELLINGS:
+        case Maps::ObjectGroup::ADVENTURE_MINES:
+        case Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS:
+        case Maps::ObjectGroup::ADVENTURE_POWER_UPS:
+        case Maps::ObjectGroup::ADVENTURE_TREASURES:
+        case Maps::ObjectGroup::ADVENTURE_WATER:
+        case Maps::ObjectGroup::KINGDOM_HEROES:
+        case Maps::ObjectGroup::LANDSCAPE_MOUNTAINS:
+        case Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS:
+        case Maps::ObjectGroup::LANDSCAPE_ROCKS:
+        case Maps::ObjectGroup::LANDSCAPE_TREES:
+        case Maps::ObjectGroup::LANDSCAPE_WATER:
+        case Maps::ObjectGroup::MONSTERS: {
             const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
 
             if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
@@ -548,112 +562,9 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
+            break;
         }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_TREASURES ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::KINGDOM_HEROES ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_ARTIFACTS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::LANDSCAPE_MOUNTAINS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::LANDSCAPE_ROCKS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::LANDSCAPE_TREES ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_WATER || groupType == Maps::ObjectGroup::LANDSCAPE_WATER ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::KINGDOM_TOWNS ) {
+        case Maps::ObjectGroup::KINGDOM_TOWNS: {
             Maps::Tiles & tile = world.GetTiles( tilePos.x, tilePos.y );
 
             if ( tile.isWater() ) {
@@ -681,63 +592,13 @@ namespace
                 errorMessage = _( "Action objects must be placed on clear tiles." );
                 return false;
             }
+            break;
         }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_MINES ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_DWELLINGS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_POWER_UPS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else if ( groupType == Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS ) {
-            const auto & objectInfo = Maps::getObjectInfo( groupType, objectType );
-
-            if ( !isObjectPlacementAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Objects cannot be placed outside the map." );
-                return false;
-            }
-
-            if ( !isActionObjectAllowed( objectInfo, tilePos ) ) {
-                errorMessage = _( "Action objects must be placed on clear tiles." );
-                return false;
-            }
-        }
-        else {
+        default: {
             // Did you add a new object group? Add the logic for it!
             assert( 0 );
             return false;
+        }
         }
 
         return verifyTerrainPlacement( tilePos, groupType, objectType, errorMessage );

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -468,7 +468,7 @@ namespace
             }
         }
         else if ( groupType == Maps::ObjectGroup::KINGDOM_TOWNS ) {
-            Maps::Tiles & tile = world.GetTiles( tilePos.x, tilePos.y );
+            const Maps::Tiles & tile = world.GetTiles( tilePos.x, tilePos.y );
 
             if ( tile.isWater() ) {
                 errorMessage = _( "Towns cannot be placed on water." );
@@ -565,7 +565,7 @@ namespace
             break;
         }
         case Maps::ObjectGroup::KINGDOM_TOWNS: {
-            Maps::Tiles & tile = world.GetTiles( tilePos.x, tilePos.y );
+            const Maps::Tiles & tile = world.GetTiles( tilePos.x, tilePos.y );
 
             if ( tile.isWater() ) {
                 errorMessage = _( "Towns cannot be placed on water." );

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -142,6 +142,8 @@ namespace Interface
 
         void handleObjectMouseLeftClick( Maps::Tiles & tile );
 
+        void validateObjectsOnTerrainUpdate();
+
         EditorPanel _editorPanel;
 
         int32_t _selectedTile{ -1 };

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -195,20 +195,15 @@ namespace
 
 namespace Interface
 {
-    const std::array<Maps::ObjectGroup, Interface::EditorPanel::LandscapeObjectBrush::LANDSCAPE_COUNT> EditorPanel::_selectedLandscapeObjectGroup{ Maps::ObjectGroup::LANDSCAPE_MOUNTAINS,
-                                                                                                                  Maps::ObjectGroup::LANDSCAPE_ROCKS,
-                                                                                                                  Maps::ObjectGroup::LANDSCAPE_TREES,
-                                                                                                                  Maps::ObjectGroup::LANDSCAPE_WATER,
-                                                                                                                  Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS };
-    const std::array<Maps::ObjectGroup, Interface::EditorPanel::AdventureObjectBrush::ADVENTURE_COUNT> EditorPanel::_selectedAdventureObjectGroup{ Maps::ObjectGroup::ADVENTURE_ARTIFACTS,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_DWELLINGS,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_MINES,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_POWER_UPS,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_TREASURES,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_WATER,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS };
-    const std::array<Maps::ObjectGroup, Interface::EditorPanel::KingdomObjectBrush::KINGDOM_OBJECTS_COUNT> EditorPanel::_selectedKingdomObjectGroup{ Maps::ObjectGroup::KINGDOM_HEROES,
-                                                                                                                    Maps::ObjectGroup::KINGDOM_TOWNS };
+    const std::array<Maps::ObjectGroup, Interface::EditorPanel::LandscapeObjectBrush::LANDSCAPE_COUNT>
+        EditorPanel::_selectedLandscapeObjectGroup{ Maps::ObjectGroup::LANDSCAPE_MOUNTAINS, Maps::ObjectGroup::LANDSCAPE_ROCKS, Maps::ObjectGroup::LANDSCAPE_TREES,
+                                                    Maps::ObjectGroup::LANDSCAPE_WATER, Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS };
+    const std::array<Maps::ObjectGroup, Interface::EditorPanel::AdventureObjectBrush::ADVENTURE_COUNT>
+        EditorPanel::_selectedAdventureObjectGroup{ Maps::ObjectGroup::ADVENTURE_ARTIFACTS,    Maps::ObjectGroup::ADVENTURE_DWELLINGS, Maps::ObjectGroup::ADVENTURE_MINES,
+                                                    Maps::ObjectGroup::ADVENTURE_POWER_UPS,    Maps::ObjectGroup::ADVENTURE_TREASURES, Maps::ObjectGroup::ADVENTURE_WATER,
+                                                    Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS };
+    const std::array<Maps::ObjectGroup, Interface::EditorPanel::KingdomObjectBrush::KINGDOM_OBJECTS_COUNT>
+        EditorPanel::_selectedKingdomObjectGroup{ Maps::ObjectGroup::KINGDOM_HEROES, Maps::ObjectGroup::KINGDOM_TOWNS };
 
     EditorPanel::EditorPanel( EditorInterface & interface_ )
         : _interface( interface_ )

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -195,6 +195,21 @@ namespace
 
 namespace Interface
 {
+    const std::array<Maps::ObjectGroup, Interface::EditorPanel::LandscapeObjectBrush::LANDSCAPE_COUNT> EditorPanel::_selectedLandscapeObjectGroup{ Maps::ObjectGroup::LANDSCAPE_MOUNTAINS,
+                                                                                                                  Maps::ObjectGroup::LANDSCAPE_ROCKS,
+                                                                                                                  Maps::ObjectGroup::LANDSCAPE_TREES,
+                                                                                                                  Maps::ObjectGroup::LANDSCAPE_WATER,
+                                                                                                                  Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS };
+    const std::array<Maps::ObjectGroup, Interface::EditorPanel::AdventureObjectBrush::ADVENTURE_COUNT> EditorPanel::_selectedAdventureObjectGroup{ Maps::ObjectGroup::ADVENTURE_ARTIFACTS,
+                                                                                                                  Maps::ObjectGroup::ADVENTURE_DWELLINGS,
+                                                                                                                  Maps::ObjectGroup::ADVENTURE_MINES,
+                                                                                                                  Maps::ObjectGroup::ADVENTURE_POWER_UPS,
+                                                                                                                  Maps::ObjectGroup::ADVENTURE_TREASURES,
+                                                                                                                  Maps::ObjectGroup::ADVENTURE_WATER,
+                                                                                                                  Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS };
+    const std::array<Maps::ObjectGroup, Interface::EditorPanel::KingdomObjectBrush::KINGDOM_OBJECTS_COUNT> EditorPanel::_selectedKingdomObjectGroup{ Maps::ObjectGroup::KINGDOM_HEROES,
+                                                                                                                    Maps::ObjectGroup::KINGDOM_TOWNS };
+
     EditorPanel::EditorPanel( EditorInterface & interface_ )
         : _interface( interface_ )
     {
@@ -520,7 +535,7 @@ namespace Interface
                                        { _rectInstrumentPanel.x + 7, _rectInstrumentPanel.y + 48 }, display );
         }
         else if ( _selectedInstrument == Instrument::MONSTERS ) {
-            const fheroes2::Text instrumentName( _( "Monsters" ), fheroes2::FontType::normalWhite() );
+            const fheroes2::Text instrumentName( getObjectGroupName( Maps::ObjectGroup::MONSTERS ), fheroes2::FontType::normalWhite() );
             instrumentName.draw( _rectInstrumentPanel.x + ( _rectInstrumentPanel.width - instrumentName.width() ) / 2, _rectInstrumentPanel.y + 8, display );
 
             if ( _selectedMonsterType < 0 ) {
@@ -545,11 +560,11 @@ namespace Interface
             instrumentName.draw( _rectInstrumentPanel.x + 5, _rectInstrumentPanel.y + 8, _rectInstrumentPanel.width - 10, display );
         }
         else if ( _selectedInstrument == Instrument::ROAD ) {
-            const fheroes2::Text instrumentName( _( "Roads" ), fheroes2::FontType::normalWhite() );
+            const fheroes2::Text instrumentName( getObjectGroupName( Maps::ObjectGroup::ROADS ), fheroes2::FontType::normalWhite() );
             instrumentName.draw( _rectInstrumentPanel.x + ( _rectInstrumentPanel.width - instrumentName.width() ) / 2, _rectInstrumentPanel.y + 8, display );
         }
         else if ( _selectedInstrument == Instrument::STREAM ) {
-            const fheroes2::Text instrumentName( _( "Streams" ), fheroes2::FontType::normalWhite() );
+            const fheroes2::Text instrumentName( getObjectGroupName( Maps::ObjectGroup::STREAMS ), fheroes2::FontType::normalWhite() );
             instrumentName.draw( _rectInstrumentPanel.x + ( _rectInstrumentPanel.width - instrumentName.width() ) / 2, _rectInstrumentPanel.y + 8, display );
         }
         else if ( _selectedInstrument == Instrument::ERASE ) {
@@ -647,6 +662,56 @@ namespace Interface
         }
     }
 
+    const char * EditorPanel::getObjectGroupName( const Maps::ObjectGroup groupName )
+    {
+        switch ( groupName ) {
+        case Maps::ObjectGroup::ROADS:
+            return _( "Roads" );
+        case Maps::ObjectGroup::STREAMS:
+            return _( "Streams" );
+        case Maps::ObjectGroup::LANDSCAPE_MOUNTAINS:
+            return _( "Mountains" );
+        case Maps::ObjectGroup::LANDSCAPE_ROCKS:
+            return _( "Rocks" );
+        case Maps::ObjectGroup::LANDSCAPE_TREES:
+            return _( "Trees" );
+        case Maps::ObjectGroup::ADVENTURE_WATER:
+        case Maps::ObjectGroup::LANDSCAPE_WATER:
+            return _( "Water Objects" );
+        case Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS:
+        case Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS:
+            return _( "Miscellaneous" );
+        case Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS:
+            // You shouldn't call this path!
+            assert( 0 );
+            return "Towns";
+        case Maps::ObjectGroup::LANDSCAPE_FLAGS:
+            // You shouldn't call this path!
+            assert( 0 );
+            return "Flags";
+        case Maps::ObjectGroup::ADVENTURE_ARTIFACTS:
+            return _( "Artifacts" );
+        case Maps::ObjectGroup::ADVENTURE_DWELLINGS:
+            return _( "Dwellings" );
+        case Maps::ObjectGroup::ADVENTURE_MINES:
+            return _( "Mines" );
+        case Maps::ObjectGroup::ADVENTURE_POWER_UPS:
+            return _( "Power-ups" );
+        case Maps::ObjectGroup::ADVENTURE_TREASURES:
+            return _( "Treasures" );
+        case Maps::ObjectGroup::KINGDOM_HEROES:
+            return _( "Heroes" );
+        case Maps::ObjectGroup::KINGDOM_TOWNS:
+            return _( "Towns" );
+        case Maps::ObjectGroup::MONSTERS:
+            return _( "Monsters" );
+        default:
+            // Did you add a new group? Add the logic for it!
+            assert( 0 );
+            return "Unknown objects";
+        }
+    }
+
     int EditorPanel::_getGroundId( const uint8_t brushId )
     {
         switch ( brushId ) {
@@ -678,66 +743,29 @@ namespace Interface
 
     const char * EditorPanel::_getLandscapeObjectTypeName( const uint8_t brushId )
     {
-        switch ( brushId ) {
-        case LandscapeObjectBrush::MOUNTAINS:
-            return _( "Mountains" );
-        case LandscapeObjectBrush::ROCKS:
-            return _( "Rocks" );
-        case LandscapeObjectBrush::TREES:
-            return _( "Trees" );
-        case LandscapeObjectBrush::WATER_OBJECTS:
-            return _( "Water Objects" );
-        case LandscapeObjectBrush::LANDSCAPE_MISC:
-            return _( "Miscellaneous" );
-        default:
-            // Have you added a new object type? Add the logic above!
-            assert( 0 );
-            break;
+        if ( brushId >= _selectedLandscapeObjectGroup.size() ) {
+            return "Unknown object type";
         }
 
-        return "Unknown object type";
+        return getObjectGroupName( _selectedLandscapeObjectGroup[brushId] );
     }
 
     const char * EditorPanel::_getAdventureObjectTypeName( const uint8_t brushId )
     {
-        switch ( brushId ) {
-        case AdventureObjectBrush::ARTIFACTS:
-            return _( "Artifacts" );
-        case AdventureObjectBrush::DWELLINGS:
-            return _( "Dwellings" );
-        case AdventureObjectBrush::MINES:
-            return _( "Mines" );
-        case AdventureObjectBrush::POWER_UPS:
-            return _( "Power-ups" );
-        case AdventureObjectBrush::TREASURES:
-            return _( "Treasures" );
-        case AdventureObjectBrush::WATER_ADVENTURE:
-            return _( "Water Objects" );
-        case AdventureObjectBrush::ADVENTURE_MISC:
-            return _( "Miscellaneous" );
-        default:
-            // Have you added a new object type? Add the logic above!
-            assert( 0 );
-            break;
+        if ( brushId >= _selectedAdventureObjectGroup.size() ) {
+            return "Unknown object type";
         }
 
-        return "Unknown object type";
+        return getObjectGroupName( _selectedAdventureObjectGroup[brushId] );
     }
 
     const char * EditorPanel::_getKingdomObjectTypeName( const uint8_t brushId )
     {
-        switch ( brushId ) {
-        case KingdomObjectBrush::TOWNS:
-            return _( "Towns" );
-        case KingdomObjectBrush::HEROES:
-            return _( "Heroes" );
-        default:
-            // Have you added a new object type? Add the logic above!
-            assert( 0 );
-            break;
+        if ( brushId >= _selectedKingdomObjectGroup.size() ) {
+            return "Unknown object type";
         }
 
-        return "Unknown object type";
+        return getObjectGroupName( _selectedKingdomObjectGroup[brushId] );
     }
 
     const char * EditorPanel::_getEraseObjectTypeName( const uint32_t eraseObjectType )

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -123,6 +123,8 @@ namespace Interface
         void getTownObjectProperties( int32_t & type, int32_t & color ) const;
         void getMineObjectProperties( int32_t & type, int32_t & color ) const;
 
+        static const char * getObjectGroupName( const Maps::ObjectGroup groupName );
+
     private:
         static int _getGroundId( const uint8_t brushId );
 
@@ -292,19 +294,8 @@ namespace Interface
         std::array<int32_t, KingdomObjectBrush::KINGDOM_OBJECTS_COUNT> _selectedKingdomObjectType;
         int32_t _selectedMonsterType{ -1 };
 
-        const std::array<Maps::ObjectGroup, LandscapeObjectBrush::LANDSCAPE_COUNT> _selectedLandscapeObjectGroup{ Maps::ObjectGroup::LANDSCAPE_MOUNTAINS,
-                                                                                                                  Maps::ObjectGroup::LANDSCAPE_ROCKS,
-                                                                                                                  Maps::ObjectGroup::LANDSCAPE_TREES,
-                                                                                                                  Maps::ObjectGroup::LANDSCAPE_WATER,
-                                                                                                                  Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS };
-        const std::array<Maps::ObjectGroup, AdventureObjectBrush::ADVENTURE_COUNT> _selectedAdventureObjectGroup{ Maps::ObjectGroup::ADVENTURE_ARTIFACTS,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_DWELLINGS,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_MINES,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_POWER_UPS,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_TREASURES,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_WATER,
-                                                                                                                  Maps::ObjectGroup::ADVENTURE_MISCELLANEOUS };
-        const std::array<Maps::ObjectGroup, KingdomObjectBrush::KINGDOM_OBJECTS_COUNT> _selectedKingdomObjectGroup{ Maps::ObjectGroup::KINGDOM_HEROES,
-                                                                                                                    Maps::ObjectGroup::KINGDOM_TOWNS };
+        static const std::array<Maps::ObjectGroup, LandscapeObjectBrush::LANDSCAPE_COUNT> _selectedLandscapeObjectGroup;
+        static const std::array<Maps::ObjectGroup, AdventureObjectBrush::ADVENTURE_COUNT> _selectedAdventureObjectGroup;
+        static const std::array<Maps::ObjectGroup, KingdomObjectBrush::KINGDOM_OBJECTS_COUNT> _selectedKingdomObjectGroup;
     };
 }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1315,7 +1315,7 @@ namespace Maps
 
     bool updateRoadOnTile( Tiles & tile, const bool setRoad )
     {
-        if ( setRoad == tile.isRoad() || ( tile.GetGround() == Ground::WATER ) ) {
+        if ( setRoad == tile.isRoad() || ( tile.GetGround() == Ground::WATER && setRoad ) ) {
             // We cannot place roads on the water or above already placed roads.
             return false;
         }
@@ -1351,7 +1351,7 @@ namespace Maps
 
     bool updateStreamOnTile( Tiles & tile, const bool setStream )
     {
-        if ( setStream == tile.isStream() || ( tile.GetGround() == Ground::WATER ) ) {
+        if ( setStream == tile.isStream() || ( tile.GetGround() == Ground::WATER && setStream ) ) {
             // We cannot place streams on the water or on already placed streams.
             return false;
         }


### PR DESCRIPTION
- remove objects that do not belong to the new terrain
- update castles' basements according to the new terrain

relates to #6845

Things to test:
- erasure tool works as intended
- placing water over objects that cannot be placed on water (and vice versa) results in their removal
- town basements should be updated according to new terrain
- general object placement on different terrain types