### PR TITLE
Fix a crash when rendering a multi-font text with very long words

### DIFF
--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -192,27 +192,25 @@ namespace
                             data -= lastWordLength;
                         }
                     }
+                    else if ( isSpaceChar( *data ) ) {
+                        // Current character could be a space character then current line is over.
+                        // For the characters count we take this space into the account.
+                        lineInfo->characterCount = lineLength + 1;
+                        lineInfo->offset.x = lineWidth;
+
+                        // We skip this space character.
+                        ++data;
+                    }
+                    else if ( lastWordLength > 0 ) {
+                        // Exclude last word from this line.
+                        data -= lastWordLength;
+
+                        lineInfo->characterCount = lineLength - lastWordLength;
+                        lineInfo->offset.x = lineWidth - getLineWidth( data, lastWordLength, fontType );
+                    }
                     else {
-                        if ( isSpaceChar( *data ) ) {
-                            // Current character could be a space character then current line is over.
-                            // For the characters count we take this space into the account.
-                            lineInfo->characterCount = lineLength + 1;
-                            lineInfo->offset.x = lineWidth;
-
-                            // We skip this space character.
-                            ++data;
-                        }
-                        else if ( lastWordLength > 0 ) {
-                            // Exclude last word from this line.
-                            data -= lastWordLength;
-
-                            lineInfo->characterCount = lineLength - lastWordLength;
-                            lineInfo->offset.x = lineWidth - getLineWidth( data, lastWordLength, fontType );
-                        }
-                        else {
-                            lineInfo->characterCount = lineLength;
-                            lineInfo->offset.x = lineWidth;
-                        }
+                        lineInfo->characterCount = lineLength;
+                        lineInfo->offset.x = lineWidth;
                     }
 
                     lineLength = 0;
@@ -391,22 +389,20 @@ namespace
                             data -= lastWordLength;
                         }
                     }
+                    else if ( isSpaceChar( *data ) ) {
+                        // Current character could be a space character then current line is over.
+                        renderLine( line, lineLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType, align );
+
+                        // We skip this space character.
+                        ++data;
+                    }
                     else {
-                        if ( isSpaceChar( *data ) ) {
-                            // Current character could be a space character then current line is over.
-                            renderLine( line, lineLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType, align );
+                        // Exclude last word from this line.
+                        renderLine( line, lineLength - lastWordLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType,
+                                    align );
 
-                            // We skip this space character.
-                            ++data;
-                        }
-                        else {
-                            // Exclude last word from this line.
-                            renderLine( line, lineLength - lastWordLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType,
-                                        align );
-
-                            // Go back to the start of the word.
-                            data -= lastWordLength;
-                        }
+                        // Go back to the start of the word.
+                        data -= lastWordLength;
                     }
 
                     lineLength = 0;

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -398,8 +398,7 @@ namespace
                     }
                     else {
                         // Exclude last word from this line.
-                        renderLine( line, lineLength - lastWordLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType,
-                                    align );
+                        renderLine( line, lineLength - lastWordLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType, align );
 
                         // Go back to the start of the word.
                         data -= lastWordLength;

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -182,12 +182,12 @@ namespace
                             ++data;
                         }
                         else {
-                            if ( lineInfo->offset.x == 0 ) {
+                            if ( lineInfo->offset.x < maxWidth / 2 ) {
                                 lineInfo->characterCount = lineLength;
                                 lineInfo->offset.x = lineWidth;
                             }
                             else {
-                                // This word was not the first in the line so we can move it to the next line.
+                                // This first word starts from the end of the line so we can move it to the next line.
                                 // It can happen in the case of the multi-font text.
                                 data -= lastWordLength;
                             }
@@ -381,11 +381,11 @@ namespace
                             ++data;
                         }
                         else {
-                            if ( lineInfo->offset.x == 0 ) {
+                            if ( lineInfo->offset.x < maxWidth / 2 ) {
                                 renderLine( line, lineLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType, align );
                             }
                             else {
-                                // This word was not the first in the line so we can move it to the next line.
+                                // This first word starts from the end of the line so we can move it to the next line.
                                 // It can happen in the case of the multi-font text.
                                 data -= lastWordLength;
                             }

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -182,12 +182,12 @@ namespace
                             ++data;
                         }
                         else {
-                            if ( lineInfo->offset.x < maxWidth / 2 ) {
+                            if ( lineInfo->offset.x == 0 ) {
                                 lineInfo->characterCount = lineLength;
                                 lineInfo->offset.x = lineWidth;
                             }
                             else {
-                                // This first word starts from the end of the line so we can move it to the next line.
+                                // This word was not the first in the line so we can move it to the next line.
                                 // It can happen in the case of the multi-font text.
                                 data -= lastWordLength;
                             }

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -181,16 +181,14 @@ namespace
                             data = hyphenPos;
                             ++data;
                         }
+                        else if ( lineInfo->characterCount == 0 ) {
+                            lineInfo->characterCount = lineLength;
+                            lineInfo->offset.x = lineWidth;
+                        }
                         else {
-                            if ( lineInfo->offset.x == 0 ) {
-                                lineInfo->characterCount = lineLength;
-                                lineInfo->offset.x = lineWidth;
-                            }
-                            else {
-                                // This word was not the first in the line so we can move it to the next line.
-                                // It can happen in the case of the multi-font text.
-                                data -= lastWordLength;
-                            }
+                            // This word was not the first in the line so we can move it to the next line.
+                            // It can happen in the case of the multi-font text.
+                            data -= lastWordLength;
                         }
                     }
                     else {
@@ -380,15 +378,16 @@ namespace
                             data = hyphenPos;
                             ++data;
                         }
+                        else if ( lineInfo->offset.x < maxWidth / 2 ) {
+                            // TODO: this is a wrong way to do as renderer should not care about special cases
+                            //       but rather just follow 'instructions'.
+                            //       This check is done to fix possible crashes while rendering multi-font text.
+                            renderLine( line, lineLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType, align );
+                        }
                         else {
-                            if ( lineInfo->offset.x < maxWidth / 2 ) {
-                                renderLine( line, lineLength, x + lineInfo->offset.x, yPos + lineInfo->offset.y, maxWidth, output, imageRoi, fontType, align );
-                            }
-                            else {
-                                // This first word starts from the end of the line so we can move it to the next line.
-                                // It can happen in the case of the multi-font text.
-                                data -= lastWordLength;
-                            }
+                            // This first word starts from the end of the line so we can move it to the next line.
+                            // It can happen in the case of the multi-font text.
+                            data -= lastWordLength;
                         }
                     }
                     else {

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -143,6 +143,7 @@ namespace
             if ( isLineSeparator( *data ) ) {
                 if ( lineLength > 0 ) {
                     lineInfo->offset.x = lineWidth;
+                    lineInfo->characterCount = lineLength;
                     lineLength = 0;
                     lastWordLength = 0;
                     lineWidth = 0;


### PR DESCRIPTION
This PR fixes a regression after https://github.com/ihhub/fheroes2/pull/8604: If a multi-font text contains a very-long word (e.g. a path to file that contains no spaces) the render of such text will crash if this word is not left-aligned.
It is because previously to detect that the word really is the first in the sentence the condition `x == 0` (offset from the left in text ROI) was checked. But it is not always true.
Now the engine will check if the "first" word that not fits the line starts from the right part of the line than it will be moved to the next line.

To check the issue just press right mouse button on every save file in Load game dialog.
