### PR TITLE
Do not redraw save dialog fully when only editing the save name

### DIFF
--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -567,7 +567,7 @@ namespace
                 display.render( area );
             }
             else {
-                display.render( { textInputRoi.x, textInputRoi.y, listRoi.width, textInputRoi.height } );
+                display.render( textInputAndDateBackground.rect() );
             }
         }
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -535,10 +535,6 @@ namespace
                 continue;
             }
 
-            if ( listbox.IsNeedRedraw() ) {
-                listbox.Redraw();
-            }
-
             if ( needRedraw ) {
                 const std::string selectedFileName = isListboxSelected ? System::truncateFileExtensionAndPath( listbox.GetCurrent().filename ) : "";
                 if ( isListboxSelected && lastSelectedSaveFileName != selectedFileName ) {
@@ -566,7 +562,13 @@ namespace
                 }
             }
 
-            display.render( area );
+            if ( listbox.IsNeedRedraw() ) {
+                listbox.Redraw();
+                display.render( area );
+            }
+            else {
+                display.render( { textInputRoi.x, textInputRoi.y, listRoi.width, textInputRoi.height } );
+            }
         }
 
         return result;

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -449,10 +449,6 @@ namespace Editor
                 continue;
             }
 
-            if ( listbox.IsNeedRedraw() ) {
-                listbox.Redraw();
-            }
-
             if ( needFileNameRedraw ) {
                 const std::string selectedFileName = isListboxSelected ? System::truncateFileExtensionAndPath( listbox.GetCurrent().filename ) : "";
                 if ( isListboxSelected && lastSelectedSaveFileName != selectedFileName ) {
@@ -473,7 +469,13 @@ namespace Editor
                 isTextLimit = redrawSaveFileName( insertCharToString( fileName, charInsertPos, isCursorVisible ? '_' : '\x7F' ), fileNameRoi );
             }
 
-            display.render( area );
+            if ( listbox.IsNeedRedraw() ) {
+                listbox.Redraw();
+                display.render( area );
+            }
+            else {
+                display.render( fileNameRoi );
+            }
         }
 
         return false;


### PR DESCRIPTION
This PR optimizes save game/map dialog not to render the whole dialog when only the save name was changed.