### PR TITLE
Modify ObjectGroup underlying type

### DIFF
--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -36,7 +36,7 @@ namespace Maps
 {
     class Tiles;
 
-    enum class ObjectGroup : int32_t;
+    enum class ObjectGroup : uint8_t;
 }
 
 namespace Interface

--- a/src/fheroes2/maps/map_format_helper.h
+++ b/src/fheroes2/maps/map_format_helper.h
@@ -39,7 +39,7 @@ namespace Maps
         struct HeroMetadata;
     }
 
-    enum class ObjectGroup : int32_t;
+    enum class ObjectGroup : uint8_t;
 
     bool readMapInEditor( const Map_Format::MapFormat & map );
     bool readAllTiles( const Map_Format::MapFormat & map );

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -37,7 +37,7 @@ namespace Maps::Map_Format
     {
         uint32_t id{ 0 };
 
-        ObjectGroup group{ ObjectGroup::LANDSCAPE_MOUNTAINS };
+        ObjectGroup group{ ObjectGroup::NONE };
 
         uint32_t index{ 0 };
     };

--- a/src/fheroes2/maps/map_object_info.h
+++ b/src/fheroes2/maps/map_object_info.h
@@ -118,9 +118,11 @@ namespace Maps
     //
     // !!! IMPORTANT !!!
     // Do NOT change the order of the items as they are used for the map format.
-    enum class ObjectGroup : int32_t
+    enum class ObjectGroup : uint8_t
     {
         // These groups are not being used by the Editor directly but they are still a part of a tile.
+        NONE,
+
         ROADS,
         STREAMS,
 


### PR DESCRIPTION
To reduce the amount of data to be stored in map files.

Also, add NONE entry to indicate empty group.

This is a format breaking change. All old maps will not work after.

relates to #6845 