### PR TITLE
Fix slider render: limit minimum slider length

### DIFF
--- a/src/fheroes2/gui/ui_scrollbar.cpp
+++ b/src/fheroes2/gui/ui_scrollbar.cpp
@@ -207,10 +207,10 @@ namespace fheroes2
         int32_t height = originalSlider.height();
 
         if ( horizontalSlider ) {
-            width += middleLength;
+            width = std::max( width + middleLength, startSliderArea.width * 2 );
         }
         else {
-            height += middleLength;
+            height = std::max( height + middleLength, startSliderArea.height * 2 );
         }
 
         Image output( width, height );


### PR DESCRIPTION
Fix #8644

Limit minimum slider length by the size of start part + end part ( = 2 * startPartLength )