### PR TITLE
Allow only English to be used for text input within the Editor

### DIFF
--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -114,7 +114,8 @@ namespace Dialog
     int SelectSkillFromArena();
     bool SelectCount( std::string header, const uint32_t min, const uint32_t max, uint32_t & selectedValue, const uint32_t step = 1,
                       const fheroes2::Image & backgroundImage = {} );
-    bool inputString( std::string header, std::string & result, std::string title, const size_t charLimit, const bool isMultiLine, const bool restictVirtualKeyboard );
+    bool inputString( std::string header, std::string & result, std::string title, const size_t charLimit, const bool isMultiLine,
+                      const bool englishOnlyVirtualKeyboard );
     Troop RecruitMonster( const Monster & monster0, const uint32_t available, const bool allowDowngradedMonster, const int32_t windowOffsetY );
     void DwellingInfo( const Monster &, const uint32_t available );
     int ArmyInfo( const Troop & troop, int flags, bool isReflected = false, const int32_t windowOffsetY = 0 );

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -114,7 +114,7 @@ namespace Dialog
     int SelectSkillFromArena();
     bool SelectCount( std::string header, const uint32_t min, const uint32_t max, uint32_t & selectedValue, const uint32_t step = 1,
                       const fheroes2::Image & backgroundImage = {} );
-    bool inputString( std::string header, std::string & result, std::string title, const size_t charLimit, const bool isMultiLine );
+    bool inputString( std::string header, std::string & result, std::string title, const size_t charLimit, const bool isMultiLine, const bool restictVirtualKeyboard );
     Troop RecruitMonster( const Monster & monster0, const uint32_t available, const bool allowDowngradedMonster, const int32_t windowOffsetY );
     void DwellingInfo( const Monster &, const uint32_t available );
     int ArmyInfo( const Troop & troop, int flags, bool isReflected = false, const int32_t windowOffsetY = 0 );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -36,6 +36,7 @@
 #include "dialog.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
+#include "game_language.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -246,7 +246,8 @@ bool Dialog::SelectCount( std::string header, const uint32_t min, const uint32_t
     return result == Dialog::OK;
 }
 
-bool Dialog::inputString( std::string header, std::string & result, std::string title, const size_t charLimit, const bool isMultiLine, const bool restictVirtualKeyboard )
+bool Dialog::inputString( std::string header, std::string & result, std::string title, const size_t charLimit, const bool isMultiLine,
+                          const bool englishOnlyVirtualKeyboard )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -369,7 +370,7 @@ bool Dialog::inputString( std::string header, std::string & result, std::string 
 
         if ( le.MouseClickLeft( buttonVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( textInputArea ) ) ) {
             // TODO: remove this logic once the Editor is ready to support other languages.
-            if ( restictVirtualKeyboard ) {
+            if ( englishOnlyVirtualKeyboard ) {
                 const fheroes2::LanguageSwitcher switcher( fheroes2::SupportedLanguage::English );
                 fheroes2::openVirtualKeyboard( result );
             }

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -375,7 +375,7 @@ bool Dialog::inputString( std::string header, std::string & result, std::string 
             else {
                 fheroes2::openVirtualKeyboard( result );
             }
-            
+
             if ( charLimit > 0 && result.size() > charLimit ) {
                 result.resize( charLimit );
             }

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -48,6 +48,7 @@
 #include "ui_button.h"
 #include "ui_dialog.h"
 #include "ui_keyboard.h"
+#include "ui_language.h"
 #include "ui_text.h"
 #include "ui_tool.h"
 #include "ui_window.h"
@@ -244,7 +245,7 @@ bool Dialog::SelectCount( std::string header, const uint32_t min, const uint32_t
     return result == Dialog::OK;
 }
 
-bool Dialog::inputString( std::string header, std::string & result, std::string title, const size_t charLimit, const bool isMultiLine )
+bool Dialog::inputString( std::string header, std::string & result, std::string title, const size_t charLimit, const bool isMultiLine, const bool restictVirtualKeyboard )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -366,7 +367,15 @@ bool Dialog::inputString( std::string header, std::string & result, std::string 
         }
 
         if ( le.MouseClickLeft( buttonVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( textInputArea ) ) ) {
-            fheroes2::openVirtualKeyboard( result );
+            // TODO: remove this logic once the Editor is ready to support other languages.
+            if ( restictVirtualKeyboard ) {
+                const fheroes2::LanguageSwitcher switcher( fheroes2::SupportedLanguage::English );
+                fheroes2::openVirtualKeyboard( result );
+            }
+            else {
+                fheroes2::openVirtualKeyboard( result );
+            }
+            
             if ( charLimit > 0 && result.size() > charLimit ) {
                 result.resize( charLimit );
             }

--- a/src/fheroes2/editor/editor_castle_details_window.cpp
+++ b/src/fheroes2/editor/editor_castle_details_window.cpp
@@ -482,7 +482,7 @@ namespace Editor
                 bool redrawName = false;
                 if ( le.MouseClickLeft() ) {
                     std::string res = castleMetadata.customName;
-                    if ( Dialog::inputString( _( "Enter Castle name" ), res, {}, 30, false ) && !res.empty() ) {
+                    if ( Dialog::inputString( _( "Enter Castle name" ), res, {}, 30, false, true ) && !res.empty() ) {
                         castleMetadata.customName = std::move( res );
                         redrawName = true;
                     }

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -355,7 +355,7 @@ namespace Editor
             if ( le.MouseClickLeft( messageRoi ) ) {
                 std::string temp = eventMetadata.message;
 
-                if ( Dialog::inputString( _( "Message:" ), temp, {}, 200, true ) ) {
+                if ( Dialog::inputString( _( "Message:" ), temp, {}, 200, true, true ) ) {
                     eventMetadata.message = std::move( temp );
 
                     messageRoiRestorer.restore();

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1131,7 +1131,7 @@ namespace Interface
                     StringReplace( header, "%{object}", MP2::StringObject( objectType ) );
 
                     std::string signText = _mapFormat.signMetadata[object.id].message;
-                    if ( Dialog::inputString( std::move( header ), signText, {}, 0, true ) ) {
+                    if ( Dialog::inputString( std::move( header ), signText, {}, 0, true, true ) ) {
                         _mapFormat.signMetadata[object.id].message = std::move( signText );
                         action.commit();
                     }

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -612,7 +612,7 @@ namespace Editor
                 // TODO: Edit texts directly in this dialog.
 
                 std::string editableMapName = mapFormat.name;
-                if ( Dialog::inputString( _( "Change Map Name" ), editableMapName, {}, maxMapNameLength, false ) ) {
+                if ( Dialog::inputString( _( "Change Map Name" ), editableMapName, {}, maxMapNameLength, false, true ) ) {
                     mapFormat.name = std::move( editableMapName );
                     text.set( mapFormat.name, fheroes2::FontType::normalWhite() );
                     fheroes2::Copy( scenarioBox, 0, 0, display, scenarioBoxRoi );
@@ -626,7 +626,7 @@ namespace Editor
                 // TODO: Limit description to 5 text lines.
 
                 std::string signText = mapFormat.description;
-                if ( Dialog::inputString( _( "Change Map Description" ), signText, {}, 150, true ) ) {
+                if ( Dialog::inputString( _( "Change Map Description" ), signText, {}, 150, true, true ) ) {
                     mapFormat.description = std::move( signText );
 
                     text.set( mapFormat.description, fheroes2::FontType::normalWhite() );

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -33,6 +33,7 @@
 #include "dialog.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
+#include "game_language.h"
 #include "icn.h"
 #include "image.h"
 #include "interface_list.h"

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -48,6 +48,7 @@
 #include "ui_button.h"
 #include "ui_dialog.h"
 #include "ui_keyboard.h"
+#include "ui_language.h"
 #include "ui_scrollbar.h"
 #include "ui_text.h"
 #include "ui_tool.h"
@@ -354,7 +355,11 @@ namespace Editor
             bool needFileNameRedraw = listId != listbox.getCurrentId();
 
             if ( le.MouseClickLeft( buttonVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( fileNameRoi ) ) ) {
-                fheroes2::openVirtualKeyboard( fileName );
+                {
+                    // TODO: allow to use other languages once we add support of filesystem language support.
+                    const fheroes2::LanguageSwitcher switcher( fheroes2::SupportedLanguage::English );
+                    fheroes2::openVirtualKeyboard( fileName );
+                }
 
                 charInsertPos = fileName.size();
                 listbox.Unselect();
@@ -377,7 +382,7 @@ namespace Editor
             else if ( le.MouseClickLeft( mapNameRoi ) ) {
                 std::string editableMapName = mapName;
                 // In original Editor map name is limited to 17 characters. We keep this limit to fit Select Scenario dialog.
-                if ( Dialog::inputString( _( "Change Map Name" ), editableMapName, {}, 17, false ) ) {
+                if ( Dialog::inputString( _( "Change Map Name" ), editableMapName, {}, 17, false, true ) ) {
                     if ( editableMapName.empty() ) {
                         // Map should have a non empty name.
                         continue;

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -303,7 +303,7 @@ namespace Editor
             if ( le.MouseClickLeft( riddleRoi ) ) {
                 std::string temp = metadata.riddle;
 
-                if ( Dialog::inputString( _( "Riddle:" ), temp, {}, longestRiddle, true ) ) {
+                if ( Dialog::inputString( _( "Riddle:" ), temp, {}, longestRiddle, true, true ) ) {
                     metadata.riddle = std::move( temp );
 
                     riddleRoiRestorer.restore();
@@ -314,7 +314,7 @@ namespace Editor
             }
             else if ( le.MouseClickLeft( buttonAdd.area() ) ) {
                 std::string newAnswer;
-                if ( Dialog::inputString( _( "Answer:" ), newAnswer, {}, longestAnswer, false ) ) {
+                if ( Dialog::inputString( _( "Answer:" ), newAnswer, {}, longestAnswer, false, true ) ) {
                     if ( std::any_of( metadata.answers.begin(), metadata.answers.end(), [&newAnswer]( const auto & answer ) { return answer == newAnswer; } ) ) {
                         fheroes2::showStandardTextMessage( _( "Answer" ), _( "This answer exists in the list." ), Dialog::OK );
                         continue;
@@ -333,7 +333,7 @@ namespace Editor
                 }
 
                 std::string temp = answerList.GetCurrent();
-                if ( Dialog::inputString( _( "Answer:" ), temp, {}, longestAnswer, false ) ) {
+                if ( Dialog::inputString( _( "Answer:" ), temp, {}, longestAnswer, false, true ) ) {
                     const auto count = std::count_if( metadata.answers.begin(), metadata.answers.end(), [&temp]( const auto & answer ) { return answer == temp; } );
                     if ( answerList.GetCurrent() != temp && count > 0 ) {
                         fheroes2::showStandardTextMessage( _( "Answer" ), _( "This answer exists in the list." ), Dialog::OK );

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -267,7 +267,7 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
 
     if ( isAfterGameCompletion ) {
         const auto inputPlayerName = []( std::string & playerName ) {
-            Dialog::inputString( _( "Your Name" ), playerName, {}, 15, false );
+            Dialog::inputString( _( "Your Name" ), playerName, {}, 15, false, false );
             if ( playerName.empty() ) {
                 playerName = _( "Unknown Hero" );
             }

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -391,7 +391,7 @@ bool Interface::PlayersInfo::QueueEventProcessing()
         StringReplace( str, "%{color}", Color::String( player->GetColor() ) );
 
         std::string res = player->GetName();
-        if ( Dialog::inputString( str, res, {}, 0, false ) && !res.empty() ) {
+        if ( Dialog::inputString( str, res, {}, 0, false, false ) && !res.empty() ) {
             player->SetName( res );
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3411,7 +3411,7 @@ namespace
             StringReplace( question, "%{riddle}", riddle->riddle );
 
             std::string answer;
-            Dialog::inputString( question, answer, title, 0, false );
+            Dialog::inputString( question, answer, title, 0, false, false );
 
             if ( !riddle->isCorrectAnswer( answer ) ) {
                 fheroes2::showStandardTextMessage(

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -666,7 +666,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         else if ( isEditor ) {
             if ( le.MouseClickLeft( titleRoi ) ) {
                 std::string res = name;
-                if ( Dialog::inputString( _( "Enter hero's name" ), res, {}, 30, false ) && !res.empty() ) {
+                if ( Dialog::inputString( _( "Enter hero's name" ), res, {}, 30, false, true ) && !res.empty() ) {
                     name = std::move( res );
                     drawTitleText( name, _race, true );
                     needRedraw = true;


### PR DESCRIPTION
We need to figure out how to properly support texts for all languages.

relates to #6845