### PR TITLE
Allow picking-up the Magic Book artifact from the Adventure Map

### DIFF
--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2108,7 +2108,7 @@ namespace Maps
         case MP2::OBJ_ARTIFACT: {
             assert( isFirstLoad );
 
-            const int art = Artifact::FromMP2IndexSprite( tile.GetObjectSpriteIndex() ).GetID();
+            const int art = Artifact::getArtifactFromMapSpriteIndex( tile.GetObjectSpriteIndex() ).GetID();
             if ( Artifact::UNKNOWN == art ) {
                 // This is an unknown artifact. Did you add a new one?
                 assert( 0 );

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -459,29 +459,38 @@ int Artifact::Rand( level_t lvl )
     return res;
 }
 
-Artifact Artifact::FromMP2IndexSprite( uint32_t index )
+Artifact Artifact::getArtifactFromMapSpriteIndex( const uint32_t index )
 {
     // Add 1 to all values to properly convert from the old map format.
-    if ( 0xA2 > index )
+    if ( ( index < 162 ) || ( Settings::Get().isPriceOfLoyaltySupported() && index > 171 && index < 206 ) ) {
         return { static_cast<int32_t>( index - 1 ) / 2 + 1 };
+    }
 
-    if ( Settings::Get().isPriceOfLoyaltySupported() && 0xAB < index && 0xCE > index )
-        return { static_cast<int32_t>( index - 1 ) / 2 + 1 };
+    // The original game does not have the Magic Book adventure map sprite. But it uses the ID that is taken for "Dummy" sprite.
+    // The Resurrection map format allows to place a Magic Book and it has its own sprite that does not correlate with the original Magic Book artifact ID.
+    if ( Settings::Get().getCurrentMapInfo().version == GameVersion::RESURRECTION && index == 207 ) {
+        return { MAGIC_BOOK };
+    }
 
-    if ( 0xA3 == index )
+    if ( index == 163 ) {
         return { Rand( ART_LEVEL_ALL_NORMAL ) };
+    }
 
-    if ( 0xA4 == index )
+    if ( index == 164 ) {
         return { Rand( ART_ULTIMATE ) };
+    }
 
-    if ( 0xA7 == index )
+    if ( index == 167 ) {
         return { Rand( ART_LEVEL_TREASURE ) };
+    }
 
-    if ( 0xA9 == index )
+    if ( index == 169 ) {
         return { Rand( ART_LEVEL_MINOR ) };
+    }
 
-    if ( 0xAB == index )
-        return { ART_LEVEL_MAJOR };
+    if ( index == 171 ) {
+        return { Rand( ART_LEVEL_MAJOR ) };
+    }
 
     DEBUG_LOG( DBG_GAME, DBG_WARN, "Unknown Artifact object index: " << index )
 

--- a/src/fheroes2/resource/artifact.h
+++ b/src/fheroes2/resource/artifact.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -251,7 +251,7 @@ public:
     }
 
     static int Rand( level_t );
-    static Artifact FromMP2IndexSprite( uint32_t );
+    static Artifact getArtifactFromMapSpriteIndex( const uint32_t index );
     static const char * getDiscoveryDescription( const Artifact & );
 
 private:

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -478,7 +478,12 @@ namespace
               {} },
 
             // Magic Book cannot be located on the original map. The Resurrection map format allows to place it on the map.
-            { gettext_noop( "Magic Book" ), gettext_noop( "The %{name} enables the hero to cast spells." ), gettext_noop( "You have found the Magic Book!" ), {}, {} },
+            { gettext_noop( "Magic Book" ),
+              gettext_noop( "The %{name} enables the hero to cast spells." ),
+              gettext_noop(
+                  "A young man approaches you with words: \"Let me show you my newest invention for spreading knowledge!\" Upon entering his workshop, you see a large wooden and metal device with levers and cranks, partially covered with a black stuff. \"Here it is, the Printing Press!\" he said, offering you the Magic Book for free." ),
+              {},
+              {} },
 
             // These are artifacts used only for map editor (?).
             { gettext_noop( "Dummy 1" ), gettext_noop( "The reserved artifact." ), nullptr, {}, {} },
@@ -541,19 +546,19 @@ namespace
                   "You spy a gleaming object poking up out of the ground. You send a member of your party over to investigate. He comes back with a golden helmet in his hands. You realize that it must be the helmet of the legendary Anduran, the only man who was known to wear solid gold armor." ),
               {},
               {} },
-            { gettext_noop( "Holy Hammer" ),
-              gettext_noop( "The %{name} increases the hero's attack skill by %{count}." ),
-              gettext_noop(
-                  "You come upon a battle where a Paladin has been mortally wounded by a group of Zombies. He asks you to take his hammer and finish what he started. As you pick it up, it begins to hum, and then everything becomes a blur. The Zombies lie dead, the hammer dripping with blood. You strap it to your belt." ),
-              {},
-              {} },
+            { gettext_noop( "Holy Hammer" ), gettext_noop( "The %{name} increases the hero's attack skill by %{count}." ), gettext_noop( "You come upon a battle where a Paladin has been mortally wounded by a group of Zombies. He asks you to take his hammer and finish what he started. As you pick it up, it begins to hum, and then everything becomes a blur. The Zombies lie dead, the hammer dripping with blood. You strap it to your belt." ), {}, {} },
             { gettext_noop( "Legendary Scepter" ),
               gettext_noop( "The %{name} adds %{count} points to all attributes." ),
               gettext_noop(
                   "Upon cresting a small hill, you come upon a ridiculous looking sight. A Sprite is attempting to carry a Scepter that is almost as big as it is. Trying not to laugh, you ask, \"Need help?\" The Sprite glares at you and answers: \"You think this is funny? Fine. You can carry it. I much prefer flying anyway.\"" ),
               {},
               {} },
-            { gettext_noop( "Masthead" ), gettext_noop( "The %{name} boosts the hero's troops' luck and morale by %{count} each in sea combat." ), gettext_noop( "An old seaman tells you a tale of an enchanted masthead that he used in his youth to rally his crew during times of trouble. He then hands you a faded map that shows where he hid it. After much exploring, you find it stashed underneath a nearby dock." ), {}, {} },
+            { gettext_noop( "Masthead" ),
+              gettext_noop( "The %{name} boosts the hero's troops' luck and morale by %{count} each in sea combat." ),
+              gettext_noop(
+                  "An old seaman tells you a tale of an enchanted masthead that he used in his youth to rally his crew during times of trouble. He then hands you a faded map that shows where he hid it. After much exploring, you find it stashed underneath a nearby dock." ),
+              {},
+              {} },
             { gettext_noop( "Sphere of Negation" ),
               gettext_noop( "The %{name} disables all spell casting, for both sides, in combat." ),
               gettext_noop(

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -477,8 +477,8 @@ namespace
               {},
               {} },
 
-            // Magic Book cannot be located on a map.
-            { gettext_noop( "Magic Book" ), gettext_noop( "The %{name} enables the hero to cast spells." ), nullptr, {}, {} },
+            // Magic Book cannot be located on the original map. The Resurrection map format allows to place it on the map.
+            { gettext_noop( "Magic Book" ), gettext_noop( "The %{name} enables the hero to cast spells." ), gettext_noop( "You have found the Magic Book!" ), {}, {} },
 
             // These are artifacts used only for map editor (?).
             { gettext_noop( "Dummy 1" ), gettext_noop( "The reserved artifact." ), nullptr, {}, {} },

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -481,7 +481,7 @@ namespace
             { gettext_noop( "Magic Book" ),
               gettext_noop( "The %{name} enables the hero to cast spells." ),
               gettext_noop(
-                  R"(A young man approaches you with words: "Let me show you my newest invention for spreading knowledge!" Upon entering his workshop, you see a large wooden and metal device with levers and cranks, partially covered with a black stuff. "Here it is, the Printing Press!" he said, offering you the Magic Book for free.)" ),
+                  "A young man approaches you with words: \"Let me show you my newest invention for spreading knowledge!\" Upon entering his workshop, you see a large wooden and metal device with levers and cranks, partially covered with a black stuff. \"Here it is, the Printing Press!\" he said, offering you the Magic Book for free." ),
               {},
               {} },
 

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -481,7 +481,7 @@ namespace
             { gettext_noop( "Magic Book" ),
               gettext_noop( "The %{name} enables the hero to cast spells." ),
               gettext_noop(
-                  "A young man approaches you with words: \"Let me show you my newest invention for spreading knowledge!\" Upon entering his workshop, you see a large wooden and metal device with levers and cranks, partially covered with a black stuff. \"Here it is, the Printing Press!\" he said, offering you the Magic Book for free." ),
+                  R"(A young man approaches you with words: "Let me show you my newest invention for spreading knowledge!" Upon entering his workshop, you see a large wooden and metal device with levers and cranks, partially covered with a black stuff. "Here it is, the Printing Press!" he said, offering you the Magic Book for free.)" ),
               {},
               {} },
 


### PR DESCRIPTION
Relates to https://github.com/ihhub/fheroes2/issues/6845

The Editor allows to placing the Magic Book on the Adventure Map.

This PR fixes the game logic that allows placing such artifacts on the map when starting a new game from the Resurrection map.
It also adds a simple Magic Book picking-up phrase.

