### PR TITLE
Revert changes related to fast scroll

### DIFF
--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -36,7 +36,7 @@
 
 #include "battle_arena.h"
 #include "dialog.h"
-#include "game_interface.h"
+#include "game_language.h"
 #include "localevent.h"
 #include "logging.h"
 #include "players.h"

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -37,8 +37,6 @@
 #include "battle_arena.h"
 #include "dialog.h"
 #include "game_interface.h"
-#include "game_language.h"
-#include "interface_gamearea.h"
 #include "localevent.h"
 #include "logging.h"
 #include "players.h"
@@ -354,10 +352,6 @@ namespace
 bool Game::HotKeyPressEvent( const HotKeyEvent eventID )
 {
     const LocalEvent & le = LocalEvent::Get();
-    if ( le.KeyPress() ) {
-        // We should disable the fast scroll, because the cursor might be on one of the borders when a dialog gets dismissed.
-        Interface::AdventureMap::Get().getGameArea().setFastScrollStatus( false );
-    }
     return le.KeyPress() && le.KeyValue() == hotKeyEventInfo[hotKeyEventToInt( eventID )].key;
 }
 


### PR DESCRIPTION
This code is for general use. Here we are doing some weird magic for a specific case. Moreover, it is not correct for the Editor.

Relates to #8253. This change might break the previous logic.