### PR TITLE
Fix Editor interface items positions when Hide Interface mode is enabled in the engine

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -583,8 +583,7 @@ namespace Interface
         Settings & settings = Settings::Get();
         const bool isHideInterfaceEnabled = settings.isHideInterfaceEnabled();
 
-        // In the case when Hide Interface mode is enabled we temporary disable it
-        // to allow editor properly place all interface items.
+        // If Hide Interface mode is enabled we temporary disable it to allow editor properly place all interface items.
         if ( isHideInterfaceEnabled ) {
             settings.setHideInterface( false );
         }
@@ -592,8 +591,7 @@ namespace Interface
         const fheroes2::Display & display = fheroes2::Display::instance();
 
         const int32_t xOffset = display.width() - BORDERWIDTH - RADARWIDTH;
-
-        _radar.SetPos( xOffset, Settings::Get().isHideInterfaceEnabled() ? 0 : BORDERWIDTH );
+        _radar.SetPos( xOffset, BORDERWIDTH );
 
         _editorPanel.setPos( xOffset, _radar.GetArea().y + _radar.GetArea().height + ( ( display.height() > display.DEFAULT_HEIGHT + BORDERWIDTH ) ? BORDERWIDTH : 0 ) );
 

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -88,6 +88,32 @@ namespace
 {
     const uint32_t mapUpdateFlags = Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR;
 
+    class HideInterfaceModeDisabler
+    {
+    public:
+        HideInterfaceModeDisabler()
+        {
+            // If Hide Interface mode is enabled we temporary disable it to allow editor properly place all interface items.
+            if ( _isHideInterfaceEnabled ) {
+                Settings::Get().setHideInterface( false );
+            }
+        }
+
+        HideInterfaceModeDisabler & operator=( const HideInterfaceModeDisabler & ) = delete;
+        HideInterfaceModeDisabler( const HideInterfaceModeDisabler & ) = delete;
+
+        ~HideInterfaceModeDisabler()
+        {
+            if ( _isHideInterfaceEnabled ) {
+                // Restore Hide Interface mode if it was enabled.
+                Settings::Get().setHideInterface( true );
+            }
+        }
+
+    private:
+        const bool _isHideInterfaceEnabled{ Settings::Get().isHideInterfaceEnabled() };
+    };
+
     fheroes2::Point getBrushAreaIndicies( const fheroes2::Rect & brushSize, const int32_t startIndex )
     {
         if ( brushSize.width <= 0 || brushSize.height <= 0 ) {
@@ -580,13 +606,7 @@ namespace Interface
 {
     void EditorInterface::reset()
     {
-        Settings & settings = Settings::Get();
-        const bool isHideInterfaceEnabled = settings.isHideInterfaceEnabled();
-
-        // If Hide Interface mode is enabled we temporary disable it to allow editor properly place all interface items.
-        if ( isHideInterfaceEnabled ) {
-            settings.setHideInterface( false );
-        }
+        const HideInterfaceModeDisabler hideInterfaceModeDisabler;
 
         const fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -604,11 +624,6 @@ namespace Interface
 
         _gameArea.SetCenterInPixels( prevCenter + fheroes2::Point( newRoi.x + newRoi.width / 2, newRoi.y + newRoi.height / 2 )
                                      - fheroes2::Point( prevRoi.x + prevRoi.width / 2, prevRoi.y + prevRoi.height / 2 ) );
-
-        if ( isHideInterfaceEnabled ) {
-            // Restore Hide Interface mode if it was enabled.
-            settings.setHideInterface( true );
-        }
     }
 
     void EditorInterface::redraw( const uint32_t force )

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -580,10 +580,20 @@ namespace Interface
 {
     void EditorInterface::reset()
     {
+        Settings & settings = Settings::Get();
+        const bool isHideInterfaceEnabled = settings.isHideInterfaceEnabled();
+
+        // In the case when Hide Interface mode is enabled we temporary disable it
+        // to allow editor properly place all interface items.
+        if ( isHideInterfaceEnabled ) {
+            settings.setHideInterface( false );
+        }
+
         const fheroes2::Display & display = fheroes2::Display::instance();
 
         const int32_t xOffset = display.width() - BORDERWIDTH - RADARWIDTH;
-        _radar.SetPos( xOffset, BORDERWIDTH );
+
+        _radar.SetPos( xOffset, Settings::Get().isHideInterfaceEnabled() ? 0 : BORDERWIDTH );
 
         _editorPanel.setPos( xOffset, _radar.GetArea().y + _radar.GetArea().height + ( ( display.height() > display.DEFAULT_HEIGHT + BORDERWIDTH ) ? BORDERWIDTH : 0 ) );
 
@@ -596,6 +606,11 @@ namespace Interface
 
         _gameArea.SetCenterInPixels( prevCenter + fheroes2::Point( newRoi.x + newRoi.width / 2, newRoi.y + newRoi.height / 2 )
                                      - fheroes2::Point( prevRoi.x + prevRoi.width / 2, prevRoi.y + prevRoi.height / 2 ) );
+
+        if ( isHideInterfaceEnabled ) {
+            // Restore Hide Interface mode if it was enabled.
+            settings.setHideInterface( true );
+        }
     }
 
     void EditorInterface::redraw( const uint32_t force )


### PR DESCRIPTION
If Hide Interface mode is enabled in the engine: temporary disable it while organizing the Editor's interface and then restore the setting.
