### PR TITLE
Set the last edited map file as a default for the new Standard game

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1607,6 +1607,11 @@ namespace Interface
 
         _loadedFileName = System::truncateFileExtensionAndPath( filePath );
 
+        // Set the loaded map as a default map for the new Standard Game.
+        Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
+        mapInfo.filename = filePath;
+        mapInfo.name = _mapFormat.name;
+
         return true;
     }
 
@@ -1651,6 +1656,11 @@ namespace Interface
         _loadedFileName = std::move( fileName );
 
         if ( Maps::Map_Format::saveMap( fullPath, _mapFormat ) ) {
+            // Set the saved map as a default map for the new Standard Game.
+            Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
+            mapInfo.filename = fullPath;
+            mapInfo.name = _mapFormat.name;
+
             // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
             // To avoid this we have to replace all '\' symbols with '/' symbols.
             StringReplace( fullPath, "\\", "/" );

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -61,6 +61,7 @@
 #include "map_format_helper.h"
 #include "map_object_info.h"
 #include "maps.h"
+#include "maps_fileinfo.h"
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"
 #include "math_base.h"

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -693,7 +693,7 @@ namespace Interface
     {
         // The Editor has a special option to disable animation. This affects cycling animation as well.
         // First, we disable it to make sure to enable it back while exiting this function.
-        fheroes2::ScreenPaletteRestorer restorer;
+        const fheroes2::ScreenPaletteRestorer restorer;
 
         const Settings & conf = Settings::Get();
 
@@ -1171,7 +1171,7 @@ namespace Interface
                         monsterCount = monsterMetadata->second.metadata[0];
                     }
 
-                    Monster tempMonster( static_cast<int>( object.index ) + 1 );
+                    const Monster tempMonster( static_cast<int>( object.index ) + 1 );
 
                     std::string str = _( "Set %{monster} Count" );
                     StringReplace( str, "%{monster}", tempMonster.GetName() );
@@ -1609,9 +1609,13 @@ namespace Interface
         _loadedFileName = System::truncateFileExtensionAndPath( filePath );
 
         // Set the loaded map as a default map for the new Standard Game.
-        Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
-        mapInfo.filename = filePath;
-        mapInfo.name = _mapFormat.name;
+        Maps::FileInfo fi;
+        if ( fi.loadResurrectionMap( _mapFormat, filePath ) ) {
+            Settings::Get().SetCurrentFileInfo( std::move( fi ) );
+        }
+        else {
+            assert( 0 );
+        }
 
         return true;
     }
@@ -1658,9 +1662,13 @@ namespace Interface
 
         if ( Maps::Map_Format::saveMap( fullPath, _mapFormat ) ) {
             // Set the saved map as a default map for the new Standard Game.
-            Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
-            mapInfo.filename = fullPath;
-            mapInfo.name = _mapFormat.name;
+            Maps::FileInfo fi;
+            if ( fi.loadResurrectionMap( _mapFormat, fullPath ) ) {
+                Settings::Get().SetCurrentFileInfo( std::move( fi ) );
+            }
+            else {
+                assert( 0 );
+            }
 
             // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
             // To avoid this we have to replace all '\' symbols with '/' symbols.

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -393,10 +393,27 @@ bool Maps::FileInfo::readResurrectionMap( std::string filePath, const bool isFor
 {
     Reset();
 
-    Maps::Map_Format::MapFormat map;
+    Maps::Map_Format::BaseMapFormat map;
     if ( !Maps::Map_Format::loadBaseMap( filePath, map ) ) {
         return false;
     }
+
+    if ( !loadResurrectionMap( map, std::move( filePath ) ) ) {
+        return false;
+    }
+
+    if ( !isForEditor && colorsAvailableForHumans == 0 ) {
+        // This is not a valid map since no human players exist so it cannot be played.
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Map " << filename << " does not contain any human players." )
+        return false;
+    }
+
+    return true;
+}
+
+bool Maps::FileInfo::loadResurrectionMap( const Map_Format::BaseMapFormat & map, std::string filePath )
+{
+    Reset();
 
     filename = std::move( filePath );
 
@@ -405,8 +422,8 @@ bool Maps::FileInfo::readResurrectionMap( std::string filePath, const bool isFor
     width = static_cast<uint16_t>( map.size );
     height = static_cast<uint16_t>( map.size );
 
-    name = std::move( map.name );
-    description = std::move( map.description );
+    name = map.name;
+    description = map.description;
 
     assert( ( map.availablePlayerColors & map.humanPlayerColors ) == map.humanPlayerColors );
     assert( ( map.availablePlayerColors & map.computerPlayerColors ) == map.computerPlayerColors );
@@ -497,12 +514,6 @@ bool Maps::FileInfo::readResurrectionMap( std::string filePath, const bool isFor
     }
 
     version = GameVersion::RESURRECTION;
-
-    if ( !isForEditor && colorsAvailableForHumans == 0 ) {
-        // This is not a valid map since no human players exist so it cannot be played.
-        DEBUG_LOG( DBG_GAME, DBG_WARN, "Map " << filename << " does not contain any human players." )
-        return false;
-    }
 
     return true;
 }

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -43,6 +43,11 @@ enum class GameVersion : int
 
 namespace Maps
 {
+    namespace Map_Format
+    {
+        struct BaseMapFormat;
+    }
+
     struct FileInfo
     {
     public:
@@ -67,6 +72,8 @@ namespace Maps
         bool readMP2Map( std::string filePath, const bool isForEditor );
 
         bool readResurrectionMap( std::string filePath, const bool isForEditor );
+
+        bool loadResurrectionMap( const Map_Format::BaseMapFormat & map, std::string filePath );
 
         bool isAllowCountPlayers( int playerCount ) const;
 

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -495,9 +495,9 @@ std::string Settings::String() const
     return os.str();
 }
 
-void Settings::SetCurrentFileInfo( const Maps::FileInfo & fi )
+void Settings::SetCurrentFileInfo( Maps::FileInfo fi )
 {
-    current_maps_file = fi;
+    current_maps_file = std::move( fi );
 
     players.Init( current_maps_file );
 

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -79,7 +79,7 @@ public:
     bool Save( const std::string_view fileName ) const;
 
     std::string String() const;
-    void SetCurrentFileInfo( const Maps::FileInfo & );
+    void SetCurrentFileInfo( Maps::FileInfo fi );
 
     const Maps::FileInfo & getCurrentMapInfo() const
     {

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -374,7 +374,7 @@ void World::generateBattleOnlyMap()
         fi.version = GameVersion::PRICE_OF_LOYALTY;
     }
 
-    conf.SetCurrentFileInfo( fi );
+    conf.SetCurrentFileInfo( std::move( fi ) );
 
     Defaults();
 
@@ -409,7 +409,7 @@ void World::generateForEditor( const int32_t size )
 
     fi.version = GameVersion::PRICE_OF_LOYALTY;
 
-    conf.SetCurrentFileInfo( fi );
+    conf.SetCurrentFileInfo( std::move( fi ) );
 
     Defaults();
 


### PR DESCRIPTION
This PR sets the last loaded or saved map in Editor as a default selected map for the new Standard Game. It will be selected only if the map can be played.