### PR TITLE
Rename the Maps::Map_Format::ObjectInfo structure to TileObjectInfo

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -258,7 +258,7 @@ namespace
 
                     auto findTownPart = [objectId]( const Maps::Map_Format::TileInfo & tileToSearch, const Maps::ObjectGroup group ) {
                         auto foundObjectIter = std::find_if( tileToSearch.objects.begin(), tileToSearch.objects.end(),
-                                                             [objectId, group]( const Maps::Map_Format::ObjectInfo & mapObject ) {
+                                                             [objectId, group]( const Maps::Map_Format::TileObjectInfo & mapObject ) {
                                                                  return mapObject.group == group && mapObject.id == objectId;
                                                              } );
 
@@ -296,7 +296,7 @@ namespace
                     auto & bottomTileObjects = mapFormat.tiles[bottomTileIndex].objects;
                     const bool isRoadAtBottom
                         = std::find_if( bottomTileObjects.begin(), bottomTileObjects.end(),
-                                        []( const Maps::Map_Format::ObjectInfo & mapObject ) { return mapObject.group == Maps::ObjectGroup::ROADS; } )
+                                        []( const Maps::Map_Format::TileObjectInfo & mapObject ) { return mapObject.group == Maps::ObjectGroup::ROADS; } )
                           != bottomTileObjects.end();
                     if ( isRoadAtBottom ) {
                         // TODO: Update (not remove) the road. It may be done properly only after roads handling will be moved from 'world' tiles to 'Map_Format' tiles.

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -60,7 +60,7 @@ namespace
     {
         int32_t tileIndex{ -1 };
 
-        const Maps::Map_Format::ObjectInfo * info{ nullptr };
+        const Maps::Map_Format::TileObjectInfo * info{ nullptr };
     };
 
     void loadArmyFromMetadata( Army & army, const std::array<int32_t, 5> & unitType, const std::array<int32_t, 5> & unitCount )
@@ -166,7 +166,7 @@ namespace Maps
         tile.setTerrain( info.terrainIndex, info.terrainFlag & 2, info.terrainFlag & 1 );
     }
 
-    bool readTileObject( Tiles & tile, const Map_Format::ObjectInfo & object )
+    bool readTileObject( Tiles & tile, const Map_Format::TileObjectInfo & object )
     {
         const auto & objectInfos = getObjectsByGroup( object.group );
         if ( object.index >= objectInfos.size() ) {
@@ -211,7 +211,7 @@ namespace Maps
             if ( object.group == ObjectGroup::ROADS ) {
                 if ( roadParts.empty() ) {
                     // This tile was removed. Delete the object.
-                    info.objects.erase( info.objects.begin() + static_cast<std::vector<Maps::Map_Format::ObjectInfo>::difference_type>( objectIndex ) );
+                    info.objects.erase( info.objects.begin() + static_cast<std::vector<Maps::Map_Format::TileObjectInfo>::difference_type>( objectIndex ) );
                     continue;
                 }
 
@@ -222,7 +222,7 @@ namespace Maps
             else if ( object.group == ObjectGroup::STREAMS ) {
                 if ( streamParts.empty() ) {
                     // This tile was removed. Delete the object.
-                    info.objects.erase( info.objects.begin() + static_cast<std::vector<Maps::Map_Format::ObjectInfo>::difference_type>( objectIndex ) );
+                    info.objects.erase( info.objects.begin() + static_cast<std::vector<Maps::Map_Format::TileObjectInfo>::difference_type>( objectIndex ) );
                     continue;
                 }
 

--- a/src/fheroes2/maps/map_format_helper.h
+++ b/src/fheroes2/maps/map_format_helper.h
@@ -34,7 +34,7 @@ namespace Maps
     {
         struct MapFormat;
         struct TileInfo;
-        struct ObjectInfo;
+        struct TileObjectInfo;
         struct CastleMetadata;
         struct HeroMetadata;
     }
@@ -47,7 +47,7 @@ namespace Maps
     bool saveMapInEditor( Map_Format::MapFormat & map );
 
     void readTileTerrain( Tiles & tile, const Map_Format::TileInfo & info );
-    bool readTileObject( Tiles & tile, const Map_Format::ObjectInfo & object );
+    bool readTileObject( Tiles & tile, const Map_Format::TileObjectInfo & object );
 
     void writeTile( const Tiles & tile, Map_Format::TileInfo & info );
 

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -42,14 +42,14 @@ namespace
 
 namespace Maps::Map_Format
 {
-    StreamBase & operator<<( StreamBase & msg, const ObjectInfo & object )
+    StreamBase & operator<<( StreamBase & msg, const TileObjectInfo & object )
     {
         using GroupUnderlyingType = std::underlying_type_t<decltype( object.group )>;
 
         return msg << object.id << static_cast<GroupUnderlyingType>( object.group ) << object.index;
     }
 
-    StreamBase & operator>>( StreamBase & msg, ObjectInfo & object )
+    StreamBase & operator>>( StreamBase & msg, TileObjectInfo & object )
     {
         msg >> object.id;
 

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -33,7 +33,7 @@
 
 namespace Maps::Map_Format
 {
-    struct ObjectInfo
+    struct TileObjectInfo
     {
         uint32_t id{ 0 };
 
@@ -47,7 +47,7 @@ namespace Maps::Map_Format
         uint16_t terrainIndex{ 0 };
         uint8_t terrainFlag{ 0 };
 
-        std::vector<ObjectInfo> objects;
+        std::vector<TileObjectInfo> objects;
     };
 
     // This structure should be used for any object that require simple data to be saved into map.


### PR DESCRIPTION
Rename the Maps::Map_Format::ObjectInfo structure to TileObjectInfo to avoid confusion with Maps::ObjectInfo.