### PR TITLE
Fix Dwelling 5 text accidentally named as Dwelling 6

### DIFF
--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -669,9 +669,9 @@ namespace
         case DWELLING_UPGRADE4:
             return _( "Upg. Dwelling 4" );
         case DWELLING_MONSTER5:
-            return _( "Dwelling 6" );
+            return _( "Dwelling 5" );
         case DWELLING_UPGRADE5:
-            return _( "Upg. Dwelling 6" );
+            return _( "Upg. Dwelling 5" );
         case DWELLING_MONSTER6:
             return _( "Dwelling 6" );
         case DWELLING_UPGRADE6:


### PR DESCRIPTION
Fix the "copy-paste" typo in random dwelling name text