### PR TITLE
Fix text editing crash

### DIFF
--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -945,7 +945,8 @@ namespace fheroes2
 
         if ( pointerLine >= static_cast<int32_t>( lineInfos.size() ) ) {
             // Pointer is lower than the last text line.
-            return textSize;
+            // Reduce textSize by 1 because the cursor character ('_') was added to the line.
+            return textSize - 1;
         }
 
         size_t cursorPosition = 0;
@@ -980,7 +981,8 @@ namespace fheroes2
             }
         }
 
-        return textSize;
+        // Reduce textSize by 1 because the cursor character ('_') was added to the line.
+        return textSize - 1;
     }
 
     bool isFontAvailable( const std::string & text, const FontType fontType )


### PR DESCRIPTION
Fix #8716 

When clicking lower than the already entered text the cursor position must be at the end of text, but not at the end of ( text + cursor_character ).