### PR TITLE
Fix crash when using quick switch to hero when castle is current object 

### DIFF
--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -57,6 +57,7 @@
 #include "maps_tiles.h"
 #include "mp2.h"
 #include "mus.h"
+#include "players.h"
 #include "puzzle.h"
 #include "route.h"
 #include "screen.h"

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -132,8 +132,7 @@ void Interface::AdventureMap::_startHeroMove( Heroes & hero )
 void Interface::AdventureMap::EventSwitchFocusedHero( const int32_t tileIndex )
 {
     Heroes * selectedHero = world.GetTiles( tileIndex ).getHero();
-    const Heroes * currentHero = GetFocusHeroes();
-    if ( selectedHero == nullptr || selectedHero == currentHero || selectedHero->GetColor() != Settings::Get().GetPlayers().getCurrentColor() ) {
+    if ( selectedHero == nullptr || selectedHero == GetFocusHeroes() || selectedHero->GetColor() != Settings::Get().GetPlayers().getCurrentColor() ) {
         return;
     }
     SetFocus( selectedHero, false );

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -132,7 +132,7 @@ void Interface::AdventureMap::EventSwitchFocusedHero( const int32_t tileIndex )
 {
     Heroes * selectedHero = world.GetTiles( tileIndex ).getHero();
     const Heroes * currentHero = GetFocusHeroes();
-    if ( selectedHero == nullptr || selectedHero == currentHero || selectedHero->GetColor() != currentHero->GetColor() ) {
+    if ( selectedHero == nullptr || selectedHero == currentHero || selectedHero->GetColor() != Settings::Get().GetPlayers().getCurrentColor() ) {
         return;
     }
     SetFocus( selectedHero, false );


### PR DESCRIPTION
This changes the check to see what is current color according to the settings. Thanks to @Districh-ru for solution.
Fix #8723