### PR TITLE
Force use the non-typeable hotkeys for text input dialog and allow starting a new line in multiline texts

### DIFF
--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -35,7 +35,6 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "game_delays.h"
-#include "game_hotkeys.h"
 #include "game_language.h"
 #include "icn.h"
 #include "image.h"

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -359,11 +359,12 @@ bool Dialog::inputString( std::string header, std::string & result, std::string 
         buttonCancel.drawOnState( le.MousePressLeft( buttonCancel.area() ) );
         buttonVirtualKB.drawOnState( le.MousePressLeft( buttonVirtualKB.area() ) );
 
-        if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) || ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) ) {
+        // In this dialog we input text so we need to use hotkeys that cannot be use in text typing.
+        if ( ( !isMultiLine && le.KeyPress( fheroes2::Key::KEY_ENTER ) ) || ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) ) {
             return !result.empty();
         }
 
-        if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( buttonCancel.area() ) ) {
+        if ( le.KeyPress( fheroes2::Key::KEY_ESCAPE ) || le.MouseClickLeft( buttonCancel.area() ) ) {
             result.clear();
             return false;
         }
@@ -384,11 +385,16 @@ bool Dialog::inputString( std::string header, std::string & result, std::string 
             charInsertPos = result.size();
             redraw = true;
         }
-        else if ( le.KeyPress() ) {
-            if ( charLimit == 0 || charLimit > result.size() || le.KeyValue() == fheroes2::Key::KEY_BACKSPACE ) {
-                charInsertPos = InsertKeySym( result, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
-                redraw = true;
+        else if ( le.KeyPress() && ( charLimit == 0 || charLimit > result.size() || le.KeyValue() == fheroes2::Key::KEY_BACKSPACE ) ) {
+            // Handel new line input for multi-line texts only.
+            if ( isMultiLine && le.KeyValue() == fheroes2::Key::KEY_ENTER ) {
+                result.insert( charInsertPos, 1, '\n' );
+                ++charInsertPos;
             }
+            else {
+                charInsertPos = InsertKeySym( result, charInsertPos, le.KeyValue(), LocalEvent::getCurrentKeyModifiers() );
+            }
+            redraw = true;
         }
         else if ( le.MouseClickLeft( textInputArea ) ) {
             charInsertPos = fheroes2::getTextInputCursorPosition( text, charInsertPos, le.GetMouseCursor(), textInputArea );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -385,7 +385,7 @@ bool Dialog::inputString( std::string header, std::string & result, std::string 
             redraw = true;
         }
         else if ( le.KeyPress() && ( charLimit == 0 || charLimit > result.size() || le.KeyValue() == fheroes2::Key::KEY_BACKSPACE ) ) {
-            // Handel new line input for multi-line texts only.
+            // Handle new line input for multi-line texts only.
             if ( isMultiLine && le.KeyValue() == fheroes2::Key::KEY_ENTER ) {
                 result.insert( charInsertPos, 1, '\n' );
                 ++charInsertPos;


### PR DESCRIPTION
This PR forces not to use the customized hotkeys for OK and CANCEL as they can be set as input characters in text input dialog.
ESC will always be forced as a CANCEL hotkey.
ENTER will always be forced as an OK hotkey only for the single-line text.

Also the input of a new line (by pressing Enter key) is implemented for the multi-line texts.