### PR TITLE
Android: implement the file manager for FH2M maps

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -85,9 +85,9 @@ dependencies {
     implementation project(':isotools')
     implementation project(':sdl2')
 
-    implementation group: 'commons-io', name: 'commons-io', version: '2.15.1'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.16.1'
 
-    implementation 'com.google.android.material:material:1.11.0'
+    implementation 'com.google.android.material:material:1.12.0'
 }
 
 tasks.register('copyH2D', Copy) {

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
 
     <!-- OpenGL ES 2.0 -->
@@ -46,7 +47,8 @@
             android:process=":GameActivityProcess"
             android:screenOrientation="sensorLandscape"
             android:taskAffinity="org.fheroes2.GameTask"
-            android:theme="@android:style/Theme.NoTitleBar.Fullscreen">
+            android:theme="@android:style/Theme.NoTitleBar.Fullscreen"
+            tools:ignore="DiscouragedApi,UnusedAttribute">
 
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -81,5 +81,13 @@
             android:label="@string/activity_save_file_manager_label"
             android:taskAffinity="org.fheroes2.ToolsetTask"
             android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar" />
+
+        <activity
+            android:name=".MapFileManagerActivity"
+            android:exported="false"
+            android:icon="@mipmap/ic_launcher_toolset"
+            android:label="@string/activity_map_file_manager_label"
+            android:taskAffinity="org.fheroes2.ToolsetTask"
+            android:theme="@style/Theme.MaterialComponents.DayNight.NoActionBar" />
     </application>
 </manifest>

--- a/android/app/src/main/java/org/fheroes2/FileManagement.java
+++ b/android/app/src/main/java/org/fheroes2/FileManagement.java
@@ -45,7 +45,7 @@ final class FileManagement
 
     static List<String> getFileList( final File fileDir, final List<String> allowedFileExtensions )
     {
-        final List<String> fileNames = new ArrayList<>();
+        final List<String> result = new ArrayList<>();
 
         final File[] fileList = fileDir.listFiles( ( dir, name ) -> {
             if ( !dir.equals( fileDir ) ) {
@@ -66,14 +66,14 @@ final class FileManagement
         if ( fileList != null ) {
             for ( final File file : fileList ) {
                 if ( file.isFile() ) {
-                    fileNames.add( file.getName() );
+                    result.add( file.getName() );
                 }
             }
 
-            Collections.sort( fileNames );
+            Collections.sort( result );
         }
 
-        return fileNames;
+        return result;
     }
 
     /**

--- a/android/app/src/main/java/org/fheroes2/FileManagement.java
+++ b/android/app/src/main/java/org/fheroes2/FileManagement.java
@@ -80,7 +80,9 @@ final class FileManagement
     }
 
     /**
-     * @return true if at least one file with the allowed extension was found and imported, otherwise returns false
+     * The directory structure will not be preserved when importing. All matching files will be imported directly into the target directory.
+     *
+     * @return true if at least one matching file was found and imported, otherwise returns false
      */
     static boolean importFilesFromZip( final File fileDir, final List<String> allowedFileExtensions, final Uri zipFileUri, final ContentResolver contentResolver )
         throws IOException

--- a/android/app/src/main/java/org/fheroes2/FileManagement.java
+++ b/android/app/src/main/java/org/fheroes2/FileManagement.java
@@ -1,0 +1,148 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2024                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+package org.fheroes2;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.function.Predicate;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import android.content.ContentResolver;
+import android.net.Uri;
+
+import org.apache.commons.io.IOUtils;
+
+final class FileManagement
+{
+    private FileManagement()
+    {
+        throw new IllegalStateException( "Instantiation is not allowed" );
+    }
+
+    static List<String> getFileList( final File fileDir, final List<String> allowedFileExtensions )
+    {
+        final List<String> fileNames = new ArrayList<>();
+
+        final File[] fileList = fileDir.listFiles( ( dir, name ) -> {
+            if ( !dir.equals( fileDir ) ) {
+                return false;
+            }
+
+            final String lowercaseName = name.toLowerCase( Locale.ROOT );
+
+            for ( final String extension : allowedFileExtensions ) {
+                if ( lowercaseName.endsWith( extension ) ) {
+                    return true;
+                }
+            }
+
+            return false;
+        } );
+
+        if ( fileList != null ) {
+            for ( final File file : fileList ) {
+                if ( file.isFile() ) {
+                    fileNames.add( file.getName() );
+                }
+            }
+
+            Collections.sort( fileNames );
+        }
+
+        return fileNames;
+    }
+
+    /**
+     * @return true if at least one file with the allowed extension was found and imported, otherwise returns false
+     */
+    static boolean importFilesFromZip( final File fileDir, final List<String> allowedFileExtensions, final Uri zipFileUri, final ContentResolver contentResolver )
+        throws IOException
+    {
+        final Predicate<String> checkExtension = ( String name ) ->
+        {
+            final String lowercaseName = name.toLowerCase( Locale.ROOT );
+
+            for ( final String extension : allowedFileExtensions ) {
+                if ( lowercaseName.endsWith( extension ) ) {
+                    return true;
+                }
+            }
+
+            return false;
+        };
+
+        boolean result = false;
+
+        try ( final InputStream in = contentResolver.openInputStream( zipFileUri ); final ZipInputStream zin = new ZipInputStream( in ) ) {
+            Files.createDirectories( fileDir.toPath() );
+
+            for ( ZipEntry zEntry = zin.getNextEntry(); zEntry != null; zEntry = zin.getNextEntry() ) {
+                if ( zEntry.isDirectory() ) {
+                    continue;
+                }
+
+                final String zEntryFileName = new File( zEntry.getName() ).getName();
+                if ( !checkExtension.test( zEntryFileName ) ) {
+                    continue;
+                }
+
+                try ( final OutputStream out = Files.newOutputStream( ( new File( fileDir, zEntryFileName ) ).toPath() ) ) {
+                    IOUtils.copy( zin, out );
+                }
+
+                result = true;
+            }
+        }
+
+        return result;
+    }
+
+    static void exportFilesToZip( final File fileDir, final List<String> fileNames, final Uri zipFileUri, final ContentResolver contentResolver ) throws IOException
+    {
+        try ( final OutputStream out = contentResolver.openOutputStream( zipFileUri ); final ZipOutputStream zout = new ZipOutputStream( out ) ) {
+            for ( final String fileName : fileNames ) {
+                zout.putNextEntry( new ZipEntry( fileName ) );
+
+                try ( final InputStream in = Files.newInputStream( ( new File( fileDir, fileName ) ).toPath() ) ) {
+                    IOUtils.copy( in, zout );
+                }
+            }
+        }
+    }
+
+    static void deleteFiles( final File fileDir, final List<String> fileNames ) throws IOException
+    {
+        for ( final String fileName : fileNames ) {
+            final File file = new File( fileDir, fileName );
+
+            Files.deleteIfExists( file.toPath() );
+        }
+    }
+}

--- a/android/app/src/main/java/org/fheroes2/FileManagement.java
+++ b/android/app/src/main/java/org/fheroes2/FileManagement.java
@@ -34,9 +34,6 @@ import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 import java.util.zip.ZipOutputStream;
 
-import android.content.ContentResolver;
-import android.net.Uri;
-
 import org.apache.commons.io.IOUtils;
 
 final class FileManagement
@@ -84,8 +81,7 @@ final class FileManagement
      *
      * @return true if at least one matching file was found and imported, otherwise returns false
      */
-    static boolean importFilesFromZip( final File fileDir, final List<String> allowedFileExtensions, final Uri zipFileUri, final ContentResolver contentResolver )
-        throws IOException
+    static boolean importFilesFromZip( final File fileDir, final List<String> allowedFileExtensions, final InputStream zipStream ) throws IOException
     {
         final Predicate<String> checkExtension = ( String name ) ->
         {
@@ -102,7 +98,7 @@ final class FileManagement
 
         boolean result = false;
 
-        try ( final InputStream in = contentResolver.openInputStream( zipFileUri ); final ZipInputStream zin = new ZipInputStream( in ) ) {
+        try ( final ZipInputStream zin = new ZipInputStream( zipStream ) ) {
             Files.createDirectories( fileDir.toPath() );
 
             for ( ZipEntry zEntry = zin.getNextEntry(); zEntry != null; zEntry = zin.getNextEntry() ) {
@@ -126,9 +122,9 @@ final class FileManagement
         return result;
     }
 
-    static void exportFilesToZip( final File fileDir, final List<String> fileNames, final Uri zipFileUri, final ContentResolver contentResolver ) throws IOException
+    static void exportFilesToZip( final File fileDir, final List<String> fileNames, final OutputStream zipStream ) throws IOException
     {
-        try ( final OutputStream out = contentResolver.openOutputStream( zipFileUri ); final ZipOutputStream zout = new ZipOutputStream( out ) ) {
+        try ( final ZipOutputStream zout = new ZipOutputStream( zipStream ) ) {
             for ( final String fileName : fileNames ) {
                 zout.putNextEntry( new ZipEntry( fileName ) );
 

--- a/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
@@ -21,6 +21,8 @@
 package org.fheroes2;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -126,8 +128,8 @@ public final class MapFileManagerActivity extends AppCompatActivity
                 boolean atLeastOneMapFileImported = false;
                 Exception caughtException = null;
 
-                try {
-                    atLeastOneMapFileImported = FileManagement.importFilesFromZip( mapFileDir, allowedMapFileExtensions, zipFileUri, contentResolver );
+                try ( final InputStream in = contentResolver.openInputStream( zipFileUri ) ) {
+                    atLeastOneMapFileImported = FileManagement.importFilesFromZip( mapFileDir, allowedMapFileExtensions, in );
                 }
                 catch ( final Exception ex ) {
                     Log.e( "fheroes2", "Failed to import map files.", ex );
@@ -170,8 +172,8 @@ public final class MapFileManagerActivity extends AppCompatActivity
             new Thread( () -> {
                 Exception caughtException = null;
 
-                try {
-                    FileManagement.exportFilesToZip( mapFileDir, mapFileNames, zipFileUri, contentResolver );
+                try ( final OutputStream out = contentResolver.openOutputStream( zipFileUri ) ) {
+                    FileManagement.exportFilesToZip( mapFileDir, mapFileNames, out );
                 }
                 catch ( final Exception ex ) {
                     Log.e( "fheroes2", "Failed to export map files.", ex );

--- a/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2024                                                    *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -23,6 +23,7 @@ package org.fheroes2;
 import java.io.File;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Queue;
@@ -39,7 +40,6 @@ import android.widget.ImageButton;
 import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
-import android.widget.ToggleButton;
 
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
@@ -48,15 +48,15 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
 
-public final class SaveFileManagerActivity extends AppCompatActivity
+public final class MapFileManagerActivity extends AppCompatActivity
 {
-    public static final class SaveFileManagerActivityViewModel extends ViewModel
+    public static final class MapFileManagerActivityViewModel extends ViewModel
     {
         private enum BackgroundTaskResult
         {
             RESULT_NONE,
             RESULT_SUCCESS,
-            RESULT_NO_SAVE_FILES,
+            RESULT_NO_MAP_FILES,
             RESULT_ERROR
         }
 
@@ -65,15 +65,15 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             private boolean isBackgroundTaskExecuting;
             private final BackgroundTaskResult backgroundTaskResult;
             private final String backgroundTaskError;
-            private final List<String> saveFileNames;
+            private final List<String> mapFileNames;
 
             private Status( final boolean isBackgroundTaskExecuting, final BackgroundTaskResult backgroundTaskResult, final String backgroundTaskError,
-                            final List<String> saveFileNames )
+                            final List<String> mapFileNames )
             {
                 this.isBackgroundTaskExecuting = isBackgroundTaskExecuting;
                 this.backgroundTaskResult = backgroundTaskResult;
                 this.backgroundTaskError = backgroundTaskError;
-                this.saveFileNames = saveFileNames;
+                this.mapFileNames = mapFileNames;
             }
 
             @SuppressWarnings( "SameParameterValue" )
@@ -90,7 +90,8 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         /**
          * This method should never be called directly. Call it only using the enqueueBackgroundTask() method.
          */
-        private void updateSaveFileList( final File saveFileDir, final List<String> allowedSaveFileExtensions )
+        @SuppressWarnings( "SameParameterValue" )
+        private void updateMapFileList( final File mapFileDir, final List<String> allowedMapFileExtensions )
         {
             final Status status = Objects.requireNonNull( liveStatus.getValue() );
             assert !status.isBackgroundTaskExecuting;
@@ -99,12 +100,11 @@ public final class SaveFileManagerActivity extends AppCompatActivity
 
             new Thread( () -> {
                 try {
-                    // Reading the list of save files should not by itself change the visible status of the last background task, unless an error occurred while reading
-                    liveStatus.postValue(
-                        new Status( false, BackgroundTaskResult.RESULT_NONE, "", FileManagement.getFileList( saveFileDir, allowedSaveFileExtensions ) ) );
+                    // Reading the list of map files should not by itself change the visible status of the last background task, unless an error occurred while reading
+                    liveStatus.postValue( new Status( false, BackgroundTaskResult.RESULT_NONE, "", FileManagement.getFileList( mapFileDir, allowedMapFileExtensions ) ) );
                 }
                 catch ( final Exception ex ) {
-                    Log.e( "fheroes2", "Failed to get a list of save files.", ex );
+                    Log.e( "fheroes2", "Failed to get a list of map files.", ex );
 
                     liveStatus.postValue( new Status( false, BackgroundTaskResult.RESULT_ERROR, String.format( "%s", ex ), new ArrayList<>() ) );
                 }
@@ -114,7 +114,8 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         /**
          * This method should never be called directly. Call it only using the enqueueBackgroundTask() method.
          */
-        private void importSaveFiles( final File saveFileDir, final List<String> allowedSaveFileExtensions, final Uri zipFileUri, final ContentResolver contentResolver )
+        @SuppressWarnings( "SameParameterValue" )
+        private void importMapFiles( final File mapFileDir, final List<String> allowedMapFileExtensions, final Uri zipFileUri, final ContentResolver contentResolver )
         {
             final Status status = Objects.requireNonNull( liveStatus.getValue() );
             assert !status.isBackgroundTaskExecuting;
@@ -122,14 +123,14 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             liveStatus.setValue( status.setIsBackgroundTaskExecuting( true ) );
 
             new Thread( () -> {
-                boolean atLeastOneSaveFileImported = false;
+                boolean atLeastOneMapFileImported = false;
                 Exception caughtException = null;
 
                 try {
-                    atLeastOneSaveFileImported = FileManagement.importFilesFromZip( saveFileDir, allowedSaveFileExtensions, zipFileUri, contentResolver );
+                    atLeastOneMapFileImported = FileManagement.importFilesFromZip( mapFileDir, allowedMapFileExtensions, zipFileUri, contentResolver );
                 }
                 catch ( final Exception ex ) {
-                    Log.e( "fheroes2", "Failed to import save files.", ex );
+                    Log.e( "fheroes2", "Failed to import map files.", ex );
 
                     caughtException = ex;
                 }
@@ -137,16 +138,16 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                     try {
                         if ( caughtException != null ) {
                             liveStatus.postValue( new Status( false, BackgroundTaskResult.RESULT_ERROR, String.format( "%s", caughtException ),
-                                                              FileManagement.getFileList( saveFileDir, allowedSaveFileExtensions ) ) );
+                                                              FileManagement.getFileList( mapFileDir, allowedMapFileExtensions ) ) );
                         }
                         else {
-                            liveStatus.postValue(
-                                new Status( false, atLeastOneSaveFileImported ? BackgroundTaskResult.RESULT_SUCCESS : BackgroundTaskResult.RESULT_NO_SAVE_FILES, "",
-                                            FileManagement.getFileList( saveFileDir, allowedSaveFileExtensions ) ) );
+                            liveStatus.postValue( new Status( false,
+                                                              atLeastOneMapFileImported ? BackgroundTaskResult.RESULT_SUCCESS : BackgroundTaskResult.RESULT_NO_MAP_FILES,
+                                                              "", FileManagement.getFileList( mapFileDir, allowedMapFileExtensions ) ) );
                         }
                     }
                     catch ( final Exception ex ) {
-                        Log.e( "fheroes2", "Failed to get a list of save files.", ex );
+                        Log.e( "fheroes2", "Failed to get a list of map files.", ex );
 
                         liveStatus.postValue( new Status( false, BackgroundTaskResult.RESULT_ERROR, String.format( "%s", ex ), new ArrayList<>() ) );
                     }
@@ -157,8 +158,9 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         /**
          * This method should never be called directly. Call it only using the enqueueBackgroundTask() method.
          */
-        private void exportSaveFiles( final File saveFileDir, final List<String> allowedSaveFileExtensions, final List<String> saveFileNames, final Uri zipFileUri,
-                                      final ContentResolver contentResolver )
+        @SuppressWarnings( "SameParameterValue" )
+        private void exportMapFiles( final File mapFileDir, final List<String> allowedMapFileExtensions, final List<String> mapFileNames, final Uri zipFileUri,
+                                     final ContentResolver contentResolver )
         {
             final Status status = Objects.requireNonNull( liveStatus.getValue() );
             assert !status.isBackgroundTaskExecuting;
@@ -169,10 +171,10 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                 Exception caughtException = null;
 
                 try {
-                    FileManagement.exportFilesToZip( saveFileDir, saveFileNames, zipFileUri, contentResolver );
+                    FileManagement.exportFilesToZip( mapFileDir, mapFileNames, zipFileUri, contentResolver );
                 }
                 catch ( final Exception ex ) {
-                    Log.e( "fheroes2", "Failed to export save files.", ex );
+                    Log.e( "fheroes2", "Failed to export map files.", ex );
 
                     caughtException = ex;
                 }
@@ -180,15 +182,15 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                     try {
                         if ( caughtException != null ) {
                             liveStatus.postValue( new Status( false, BackgroundTaskResult.RESULT_ERROR, String.format( "%s", caughtException ),
-                                                              FileManagement.getFileList( saveFileDir, allowedSaveFileExtensions ) ) );
+                                                              FileManagement.getFileList( mapFileDir, allowedMapFileExtensions ) ) );
                         }
                         else {
                             liveStatus.postValue(
-                                new Status( false, BackgroundTaskResult.RESULT_SUCCESS, "", FileManagement.getFileList( saveFileDir, allowedSaveFileExtensions ) ) );
+                                new Status( false, BackgroundTaskResult.RESULT_SUCCESS, "", FileManagement.getFileList( mapFileDir, allowedMapFileExtensions ) ) );
                         }
                     }
                     catch ( final Exception ex ) {
-                        Log.e( "fheroes2", "Failed to get a list of save files.", ex );
+                        Log.e( "fheroes2", "Failed to get a list of map files.", ex );
 
                         liveStatus.postValue( new Status( false, BackgroundTaskResult.RESULT_ERROR, String.format( "%s", ex ), new ArrayList<>() ) );
                     }
@@ -199,7 +201,8 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         /**
          * This method should never be called directly. Call it only using the enqueueBackgroundTask() method.
          */
-        private void deleteSaveFiles( final File saveFileDir, final List<String> allowedSaveFileExtensions, final List<String> saveFileNames )
+        @SuppressWarnings( "SameParameterValue" )
+        private void deleteMapFiles( final File mapFileDir, final List<String> allowedMapFileExtensions, final List<String> mapFileNames )
         {
             final Status status = Objects.requireNonNull( liveStatus.getValue() );
             assert !status.isBackgroundTaskExecuting;
@@ -210,10 +213,10 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                 Exception caughtException = null;
 
                 try {
-                    FileManagement.deleteFiles( saveFileDir, saveFileNames );
+                    FileManagement.deleteFiles( mapFileDir, mapFileNames );
                 }
                 catch ( final Exception ex ) {
-                    Log.e( "fheroes2", "Failed to delete save files.", ex );
+                    Log.e( "fheroes2", "Failed to delete map files.", ex );
 
                     caughtException = ex;
                 }
@@ -221,15 +224,15 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                     try {
                         if ( caughtException != null ) {
                             liveStatus.postValue( new Status( false, BackgroundTaskResult.RESULT_ERROR, String.format( "%s", caughtException ),
-                                                              FileManagement.getFileList( saveFileDir, allowedSaveFileExtensions ) ) );
+                                                              FileManagement.getFileList( mapFileDir, allowedMapFileExtensions ) ) );
                         }
                         else {
                             liveStatus.postValue(
-                                new Status( false, BackgroundTaskResult.RESULT_SUCCESS, "", FileManagement.getFileList( saveFileDir, allowedSaveFileExtensions ) ) );
+                                new Status( false, BackgroundTaskResult.RESULT_SUCCESS, "", FileManagement.getFileList( mapFileDir, allowedMapFileExtensions ) ) );
                         }
                     }
                     catch ( final Exception ex ) {
-                        Log.e( "fheroes2", "Failed to get a list of save files.", ex );
+                        Log.e( "fheroes2", "Failed to get a list of map files.", ex );
 
                         liveStatus.postValue( new Status( false, BackgroundTaskResult.RESULT_ERROR, String.format( "%s", ex ), new ArrayList<>() ) );
                     }
@@ -238,16 +241,14 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         }
     }
 
-    private File saveFileDir = null;
+    private static final List<String> allowedMapFileExtensions = new ArrayList<>( Collections.singletonList( ".fh2m" ) );
 
-    private ToggleButton filterStandardToggleButton = null;
-    private ToggleButton filterCampaignToggleButton = null;
-    private ToggleButton filterMultiplayerToggleButton = null;
+    private File mapFileDir = null;
 
-    private ListView saveFileListView = null;
-    private ArrayAdapter<String> saveFileListViewAdapter = null;
+    private ListView mapFileListView = null;
+    private ArrayAdapter<String> mapFileListViewAdapter = null;
 
-    private SaveFileManagerActivityViewModel viewModel = null;
+    private MapFileManagerActivityViewModel viewModel = null;
 
     private final ActivityResultLauncher<String> zipFileChooserLauncher = registerForActivityResult( new ActivityResultContracts.GetContent(), result -> {
         // No ZIP file was selected
@@ -255,11 +256,11 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             return;
         }
 
-        for ( int i = 0; i < saveFileListView.getCount(); ++i ) {
-            saveFileListView.setItemChecked( i, false );
+        for ( int i = 0; i < mapFileListView.getCount(); ++i ) {
+            mapFileListView.setItemChecked( i, false );
         }
 
-        enqueueBackgroundTask( () -> viewModel.importSaveFiles( saveFileDir, getAllowedSaveFileExtensions(), result, getContentResolver() ) );
+        enqueueBackgroundTask( () -> viewModel.importMapFiles( mapFileDir, allowedMapFileExtensions, result, getContentResolver() ) );
     } );
 
     private final ActivityResultLauncher<String> zipFileLocationChooserLauncher
@@ -269,15 +270,15 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                   return;
               }
 
-              final List<String> saveFileNames = new ArrayList<>();
+              final List<String> mapFileNames = new ArrayList<>();
 
-              for ( int i = 0; i < saveFileListView.getCount(); ++i ) {
-                  if ( saveFileListView.isItemChecked( i ) ) {
-                      saveFileNames.add( saveFileListViewAdapter.getItem( i ) );
+              for ( int i = 0; i < mapFileListView.getCount(); ++i ) {
+                  if ( mapFileListView.isItemChecked( i ) ) {
+                      mapFileNames.add( mapFileListViewAdapter.getItem( i ) );
                   }
               }
 
-              enqueueBackgroundTask( () -> viewModel.exportSaveFiles( saveFileDir, getAllowedSaveFileExtensions(), saveFileNames, result, getContentResolver() ) );
+              enqueueBackgroundTask( () -> viewModel.exportMapFiles( mapFileDir, allowedMapFileExtensions, mapFileNames, result, getContentResolver() ) );
           } );
 
     private final Queue<Runnable> backgroundTaskQueue = new ArrayDeque<>();
@@ -287,21 +288,17 @@ public final class SaveFileManagerActivity extends AppCompatActivity
     {
         super.onCreate( savedInstanceState );
 
-        setContentView( R.layout.activity_save_file_manager );
+        setContentView( R.layout.activity_map_file_manager );
 
-        saveFileDir = new File( getExternalFilesDir( null ), "files" + File.separator + "save" );
+        mapFileDir = new File( getExternalFilesDir( null ), "maps" );
 
-        filterStandardToggleButton = findViewById( R.id.activity_save_file_manager_filter_standard_btn );
-        filterCampaignToggleButton = findViewById( R.id.activity_save_file_manager_filter_campaign_btn );
-        filterMultiplayerToggleButton = findViewById( R.id.activity_save_file_manager_filter_multiplayer_btn );
+        mapFileListView = findViewById( R.id.activity_map_file_manager_map_file_list );
+        mapFileListViewAdapter = new ArrayAdapter<>( this, android.R.layout.simple_list_item_multiple_choice, new ArrayList<>() );
 
-        saveFileListView = findViewById( R.id.activity_save_file_manager_save_file_list );
-        saveFileListViewAdapter = new ArrayAdapter<>( this, android.R.layout.simple_list_item_multiple_choice, new ArrayList<>() );
+        mapFileListView.setAdapter( mapFileListViewAdapter );
+        mapFileListView.setEmptyView( findViewById( R.id.activity_map_file_manager_map_file_list_empty_lbl ) );
 
-        saveFileListView.setAdapter( saveFileListViewAdapter );
-        saveFileListView.setEmptyView( findViewById( R.id.activity_save_file_manager_save_file_list_empty_lbl ) );
-
-        viewModel = new ViewModelProvider( this ).get( SaveFileManagerActivityViewModel.class );
+        viewModel = new ViewModelProvider( this ).get( MapFileManagerActivityViewModel.class );
         viewModel.liveStatus.observe( this, this::runNextBackgroundTask );
         viewModel.liveStatus.observe( this, this::updateUI );
     }
@@ -311,45 +308,22 @@ public final class SaveFileManagerActivity extends AppCompatActivity
     {
         super.onResume();
 
-        enqueueBackgroundTask( () -> viewModel.updateSaveFileList( saveFileDir, getAllowedSaveFileExtensions() ) );
-    }
-
-    public void filterButtonClicked( final View view )
-    {
-        final ToggleButton filterToggleButton = (ToggleButton)view;
-
-        int activeFiltersCount = 0;
-
-        activeFiltersCount += filterStandardToggleButton.isChecked() ? 1 : 0;
-        activeFiltersCount += filterCampaignToggleButton.isChecked() ? 1 : 0;
-        activeFiltersCount += filterMultiplayerToggleButton.isChecked() ? 1 : 0;
-
-        // Do not allow all filters to be turned off at the same time.
-        // TODO: Try disabling the button instead and changing its style so that it doesn't look disabled.
-        if ( activeFiltersCount < 1 && !filterToggleButton.isChecked() ) {
-            filterToggleButton.setChecked( true );
-        }
-
-        for ( int i = 0; i < saveFileListView.getCount(); ++i ) {
-            saveFileListView.setItemChecked( i, false );
-        }
-
-        enqueueBackgroundTask( () -> viewModel.updateSaveFileList( saveFileDir, getAllowedSaveFileExtensions() ) );
+        enqueueBackgroundTask( () -> viewModel.updateMapFileList( mapFileDir, allowedMapFileExtensions ) );
     }
 
     @SuppressWarnings( "java:S1172" ) // SonarQube warning "Remove unused method parameter"
     public void selectAllButtonClicked( final View view )
     {
-        for ( int i = 0; i < saveFileListView.getCount(); ++i ) {
-            saveFileListView.setItemChecked( i, true );
+        for ( int i = 0; i < mapFileListView.getCount(); ++i ) {
+            mapFileListView.setItemChecked( i, true );
         }
     }
 
     @SuppressWarnings( "java:S1172" ) // SonarQube warning "Remove unused method parameter"
     public void unselectAllButtonClicked( final View view )
     {
-        for ( int i = 0; i < saveFileListView.getCount(); ++i ) {
-            saveFileListView.setItemChecked( i, false );
+        for ( int i = 0; i < mapFileListView.getCount(); ++i ) {
+            mapFileListView.setItemChecked( i, false );
         }
     }
 
@@ -362,30 +336,30 @@ public final class SaveFileManagerActivity extends AppCompatActivity
     @SuppressWarnings( "java:S1172" ) // SonarQube warning "Remove unused method parameter"
     public void exportButtonClicked( final View view )
     {
-        if ( saveFileListView.getCheckedItemCount() == 0 ) {
+        if ( mapFileListView.getCheckedItemCount() == 0 ) {
             ( new AlertDialog.Builder( this ) )
-                .setTitle( R.string.activity_save_file_manager_no_files_selected_for_export_title )
-                .setMessage( R.string.activity_save_file_manager_no_files_selected_for_export_message )
-                .setPositiveButton( R.string.activity_save_file_manager_no_files_selected_for_export_positive_btn_text, ( dialog, which ) -> {} )
+                .setTitle( R.string.activity_map_file_manager_no_files_selected_for_export_title )
+                .setMessage( R.string.activity_map_file_manager_no_files_selected_for_export_message )
+                .setPositiveButton( R.string.activity_map_file_manager_no_files_selected_for_export_positive_btn_text, ( dialog, which ) -> {} )
                 .create()
                 .show();
 
             return;
         }
 
-        zipFileLocationChooserLauncher.launch( getString( R.string.activity_save_file_manager_suggested_zip_file_name ) );
+        zipFileLocationChooserLauncher.launch( getString( R.string.activity_map_file_manager_suggested_zip_file_name ) );
     }
 
     @SuppressWarnings( "java:S1172" ) // SonarQube warning "Remove unused method parameter"
     public void deleteButtonClicked( final View view )
     {
-        final int selectedSaveFilesCount = saveFileListView.getCheckedItemCount();
+        final int selectedMapFilesCount = mapFileListView.getCheckedItemCount();
 
-        if ( selectedSaveFilesCount == 0 ) {
+        if ( selectedMapFilesCount == 0 ) {
             ( new AlertDialog.Builder( this ) )
-                .setTitle( R.string.activity_save_file_manager_no_files_selected_for_deletion_title )
-                .setMessage( R.string.activity_save_file_manager_no_files_selected_for_deletion_message )
-                .setPositiveButton( R.string.activity_save_file_manager_no_files_selected_for_deletion_positive_btn_text, ( dialog, which ) -> {} )
+                .setTitle( R.string.activity_map_file_manager_no_files_selected_for_deletion_title )
+                .setMessage( R.string.activity_map_file_manager_no_files_selected_for_deletion_message )
+                .setPositiveButton( R.string.activity_map_file_manager_no_files_selected_for_deletion_positive_btn_text, ( dialog, which ) -> {} )
                 .create()
                 .show();
 
@@ -395,47 +369,30 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         final Resources res = getResources();
 
         ( new AlertDialog.Builder( this ) )
-            .setTitle( res.getQuantityString( R.plurals.activity_save_file_manager_delete_confirmation_title, selectedSaveFilesCount ) )
-            .setMessage( res.getQuantityString( R.plurals.activity_save_file_manager_delete_confirmation_message, selectedSaveFilesCount, selectedSaveFilesCount ) )
-            .setPositiveButton( R.string.activity_save_file_manager_delete_confirmation_positive_btn_text,
+            .setTitle( res.getQuantityString( R.plurals.activity_map_file_manager_delete_confirmation_title, selectedMapFilesCount ) )
+            .setMessage( res.getQuantityString( R.plurals.activity_map_file_manager_delete_confirmation_message, selectedMapFilesCount, selectedMapFilesCount ) )
+            .setPositiveButton( R.string.activity_map_file_manager_delete_confirmation_positive_btn_text,
                                 ( dialog, which ) -> {
-                                    final List<String> saveFileNames = new ArrayList<>();
+                                    final List<String> mapFileNames = new ArrayList<>();
 
-                                    for ( int i = 0; i < saveFileListView.getCount(); ++i ) {
-                                        if ( saveFileListView.isItemChecked( i ) ) {
-                                            saveFileListView.setItemChecked( i, false );
+                                    for ( int i = 0; i < mapFileListView.getCount(); ++i ) {
+                                        if ( mapFileListView.isItemChecked( i ) ) {
+                                            mapFileListView.setItemChecked( i, false );
 
-                                            saveFileNames.add( saveFileListViewAdapter.getItem( i ) );
+                                            mapFileNames.add( mapFileListViewAdapter.getItem( i ) );
                                         }
                                     }
 
-                                    enqueueBackgroundTask( () -> viewModel.deleteSaveFiles( saveFileDir, getAllowedSaveFileExtensions(), saveFileNames ) );
+                                    enqueueBackgroundTask( () -> viewModel.deleteMapFiles( mapFileDir, allowedMapFileExtensions, mapFileNames ) );
                                 } )
-            .setNegativeButton( R.string.activity_save_file_manager_delete_confirmation_negative_btn_text, ( dialog, which ) -> {} )
+            .setNegativeButton( R.string.activity_map_file_manager_delete_confirmation_negative_btn_text, ( dialog, which ) -> {} )
             .create()
             .show();
     }
 
-    private List<String> getAllowedSaveFileExtensions()
-    {
-        final List<String> allowedSaveFileExtensions = new ArrayList<>();
-
-        if ( filterStandardToggleButton.isChecked() ) {
-            allowedSaveFileExtensions.add( ".sav" );
-        }
-        if ( filterCampaignToggleButton.isChecked() ) {
-            allowedSaveFileExtensions.add( ".savc" );
-        }
-        if ( filterMultiplayerToggleButton.isChecked() ) {
-            allowedSaveFileExtensions.add( ".savh" );
-        }
-
-        return allowedSaveFileExtensions;
-    }
-
     private void enqueueBackgroundTask( final Runnable task )
     {
-        final SaveFileManagerActivityViewModel.Status modelStatus = Objects.requireNonNull( viewModel.liveStatus.getValue() );
+        final MapFileManagerActivityViewModel.Status modelStatus = Objects.requireNonNull( viewModel.liveStatus.getValue() );
 
         if ( modelStatus.isBackgroundTaskExecuting ) {
             backgroundTaskQueue.add( task );
@@ -445,7 +402,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         }
     }
 
-    private void runNextBackgroundTask( final SaveFileManagerActivityViewModel.Status modelStatus )
+    private void runNextBackgroundTask( final MapFileManagerActivityViewModel.Status modelStatus )
     {
         if ( modelStatus.isBackgroundTaskExecuting ) {
             return;
@@ -458,22 +415,19 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         }
     }
 
-    private void updateUI( final SaveFileManagerActivityViewModel.Status modelStatus )
+    private void updateUI( final MapFileManagerActivityViewModel.Status modelStatus )
     {
-        final ImageButton selectAllButton = findViewById( R.id.activity_save_file_manager_select_all_btn );
-        final ImageButton unselectAllButton = findViewById( R.id.activity_save_file_manager_unselect_all_btn );
-        final ImageButton importButton = findViewById( R.id.activity_save_file_manager_import_btn );
-        final ImageButton exportButton = findViewById( R.id.activity_save_file_manager_export_btn );
-        final ImageButton deleteButton = findViewById( R.id.activity_save_file_manager_delete_btn );
+        final ImageButton selectAllButton = findViewById( R.id.activity_map_file_manager_select_all_btn );
+        final ImageButton unselectAllButton = findViewById( R.id.activity_map_file_manager_unselect_all_btn );
+        final ImageButton importButton = findViewById( R.id.activity_map_file_manager_import_btn );
+        final ImageButton exportButton = findViewById( R.id.activity_map_file_manager_export_btn );
+        final ImageButton deleteButton = findViewById( R.id.activity_map_file_manager_delete_btn );
 
-        final TextView lastTaskStatusTextView = findViewById( R.id.activity_save_file_manager_last_task_status_lbl );
+        final TextView lastTaskStatusTextView = findViewById( R.id.activity_map_file_manager_last_task_status_lbl );
 
-        final ProgressBar backgroundTaskProgressBar = findViewById( R.id.activity_save_file_manager_background_task_pb );
+        final ProgressBar backgroundTaskProgressBar = findViewById( R.id.activity_map_file_manager_background_task_pb );
 
-        filterStandardToggleButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
-        filterCampaignToggleButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
-        filterMultiplayerToggleButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
-        saveFileListView.setEnabled( !modelStatus.isBackgroundTaskExecuting );
+        mapFileListView.setEnabled( !modelStatus.isBackgroundTaskExecuting );
         selectAllButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
         unselectAllButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
         importButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
@@ -486,12 +440,12 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         case RESULT_SUCCESS:
             lastTaskStatusTextView.setText( "" );
             break;
-        case RESULT_NO_SAVE_FILES:
-            lastTaskStatusTextView.setText( getString( R.string.activity_save_file_manager_last_task_status_lbl_text_no_save_files_found ) );
+        case RESULT_NO_MAP_FILES:
+            lastTaskStatusTextView.setText( getString( R.string.activity_map_file_manager_last_task_status_lbl_text_no_map_files_found ) );
             break;
         case RESULT_ERROR:
             lastTaskStatusTextView.setText(
-                String.format( getString( R.string.activity_save_file_manager_last_task_status_lbl_text_failed ), modelStatus.backgroundTaskError ) );
+                String.format( getString( R.string.activity_map_file_manager_last_task_status_lbl_text_failed ), modelStatus.backgroundTaskError ) );
             break;
         default:
             assert false;
@@ -501,8 +455,8 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         lastTaskStatusTextView.setVisibility( lastTaskStatusTextView.getText().length() > 0 ? View.VISIBLE : View.GONE );
         backgroundTaskProgressBar.setVisibility( modelStatus.isBackgroundTaskExecuting ? View.VISIBLE : View.GONE );
 
-        saveFileListViewAdapter.clear();
-        saveFileListViewAdapter.addAll( modelStatus.saveFileNames );
-        saveFileListViewAdapter.notifyDataSetChanged();
+        mapFileListViewAdapter.clear();
+        mapFileListViewAdapter.addAll( modelStatus.mapFileNames );
+        mapFileListViewAdapter.notifyDataSetChanged();
     }
 }

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -292,7 +292,7 @@ public final class SaveFileManagerActivity extends AppCompatActivity
         {
             final List<String> saveFileNames = new ArrayList<>();
 
-            final File[] saveFilesList = saveFileDir.listFiles( ( dir, name ) -> {
+            final File[] saveFileList = saveFileDir.listFiles( ( dir, name ) -> {
                 if ( !dir.equals( saveFileDir ) ) {
                     return false;
                 }
@@ -308,8 +308,8 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                 return false;
             } );
 
-            if ( saveFilesList != null ) {
-                for ( final File saveFile : saveFilesList ) {
+            if ( saveFileList != null ) {
+                for ( final File saveFile : saveFileList ) {
                     if ( saveFile.isFile() ) {
                         saveFileNames.add( saveFile.getName() );
                     }

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -21,6 +21,8 @@
 package org.fheroes2;
 
 import java.io.File;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.List;
@@ -125,8 +127,8 @@ public final class SaveFileManagerActivity extends AppCompatActivity
                 boolean atLeastOneSaveFileImported = false;
                 Exception caughtException = null;
 
-                try {
-                    atLeastOneSaveFileImported = FileManagement.importFilesFromZip( saveFileDir, allowedSaveFileExtensions, zipFileUri, contentResolver );
+                try ( final InputStream in = contentResolver.openInputStream( zipFileUri ) ) {
+                    atLeastOneSaveFileImported = FileManagement.importFilesFromZip( saveFileDir, allowedSaveFileExtensions, in );
                 }
                 catch ( final Exception ex ) {
                     Log.e( "fheroes2", "Failed to import save files.", ex );
@@ -168,8 +170,8 @@ public final class SaveFileManagerActivity extends AppCompatActivity
             new Thread( () -> {
                 Exception caughtException = null;
 
-                try {
-                    FileManagement.exportFilesToZip( saveFileDir, saveFileNames, zipFileUri, contentResolver );
+                try ( final OutputStream out = contentResolver.openOutputStream( zipFileUri ) ) {
+                    FileManagement.exportFilesToZip( saveFileDir, saveFileNames, out );
                 }
                 catch ( final Exception ex ) {
                     Log.e( "fheroes2", "Failed to export save files.", ex );

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -195,12 +195,19 @@ public final class ToolsetActivity extends AppCompatActivity
         startActivity( new Intent( this, SaveFileManagerActivity.class ) );
     }
 
+    @SuppressWarnings( "java:S1172" ) // SonarQube warning "Remove unused method parameter"
+    public void mapFileManagerButtonClicked( final View view )
+    {
+        startActivity( new Intent( this, MapFileManagerActivity.class ) );
+    }
+
     private void updateUI( final ToolsetActivityViewModel.Status modelStatus )
     {
         final Button startGameButton = findViewById( R.id.activity_toolset_start_game_btn );
         final Button extractHoMM2AssetsButton = findViewById( R.id.activity_toolset_extract_homm2_assets_btn );
         final Button downloadHoMM2DemoButton = findViewById( R.id.activity_toolset_download_homm2_demo_btn );
         final Button saveFileManagerButton = findViewById( R.id.activity_toolset_save_file_manager_btn );
+        final Button mapFileManagerButton = findViewById( R.id.activity_toolset_map_file_manager_btn );
 
         final TextView gameStatusTextView = findViewById( R.id.activity_toolset_game_status_lbl );
         final TextView lastTaskStatusTextView = findViewById( R.id.activity_toolset_last_task_status_lbl );
@@ -211,6 +218,7 @@ public final class ToolsetActivity extends AppCompatActivity
         extractHoMM2AssetsButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
         downloadHoMM2DemoButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
         saveFileManagerButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
+        mapFileManagerButton.setEnabled( !modelStatus.isBackgroundTaskExecuting );
 
         switch ( modelStatus.backgroundTaskResult ) {
         case RESULT_NONE:

--- a/android/app/src/main/res/layout/activity_map_file_manager.xml
+++ b/android/app/src/main/res/layout/activity_map_file_manager.xml
@@ -1,0 +1,121 @@
+<?xml version="1.0" encoding="utf-8"?>
+
+<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:orientation="vertical">
+
+        <RelativeLayout
+            android:layout_width="match_parent"
+            android:layout_height="0dp"
+            android:layout_marginTop="8dp"
+            android:layout_marginBottom="4dp"
+            android:layout_weight="1">
+
+            <ListView
+                android:id="@+id/activity_map_file_manager_map_file_list"
+                android:layout_width="match_parent"
+                android:layout_height="match_parent"
+                android:choiceMode="multipleChoice" />
+
+            <TextView
+                android:id="@+id/activity_map_file_manager_map_file_list_empty_lbl"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_centerInParent="true"
+                android:text="@string/activity_map_file_manager_map_file_list_empty_lbl_text"
+                android:textAllCaps="true"
+                android:visibility="gone" />
+        </RelativeLayout>
+
+        <TextView
+            android:id="@+id/activity_map_file_manager_last_task_status_lbl"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="4dp"
+            android:freezesText="true"
+            android:gravity="center"
+            android:padding="8dp"
+            android:text=""
+            android:visibility="gone" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="8dp">
+
+            <ImageButton
+                android:id="@+id/activity_map_file_manager_select_all_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="12dp"
+                android:layout_marginRight="8dp"
+                android:background="@drawable/btn_select_all"
+                android:contentDescription="@string/activity_map_file_manager_select_all_btn_content_description"
+                android:onClick="selectAllButtonClicked" />
+
+            <ImageButton
+                android:id="@+id/activity_map_file_manager_unselect_all_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"
+                android:background="@drawable/btn_unselect_all"
+                android:contentDescription="@string/activity_map_file_manager_unselect_all_btn_content_description"
+                android:onClick="unselectAllButtonClicked" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <ImageButton
+                android:id="@+id/activity_map_file_manager_import_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"
+                android:background="@drawable/btn_import"
+                android:contentDescription="@string/activity_map_file_manager_import_btn_content_description"
+                android:onClick="importButtonClicked" />
+
+            <ImageButton
+                android:id="@+id/activity_map_file_manager_export_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="8dp"
+                android:background="@drawable/btn_export"
+                android:contentDescription="@string/activity_map_file_manager_export_btn_content_description"
+                android:onClick="exportButtonClicked" />
+
+            <Space
+                android:layout_width="0dp"
+                android:layout_height="0dp"
+                android:layout_weight="1" />
+
+            <ImageButton
+                android:id="@+id/activity_map_file_manager_delete_btn"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_marginLeft="8dp"
+                android:layout_marginRight="12dp"
+                android:background="@drawable/btn_delete"
+                android:contentDescription="@string/activity_map_file_manager_delete_btn_content_description"
+                android:onClick="deleteButtonClicked" />
+        </LinearLayout>
+    </LinearLayout>
+
+    <ProgressBar
+        android:id="@+id/activity_map_file_manager_background_task_pb"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_centerInParent="true"
+        android:visibility="gone" />
+</RelativeLayout>

--- a/android/app/src/main/res/layout/activity_toolset.xml
+++ b/android/app/src/main/res/layout/activity_toolset.xml
@@ -73,12 +73,24 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_marginTop="8dp"
-            android:layout_marginBottom="8dp"
+            android:layout_marginBottom="4dp"
             android:enabled="false"
             android:minWidth="256dp"
             android:onClick="saveFileManagerButtonClicked"
             android:padding="8dp"
             android:text="@string/activity_toolset_save_file_manager_btn_text" />
+
+        <Button
+            android:id="@+id/activity_toolset_map_file_manager_btn"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="4dp"
+            android:layout_marginBottom="8dp"
+            android:enabled="false"
+            android:minWidth="256dp"
+            android:onClick="mapFileManagerButtonClicked"
+            android:padding="8dp"
+            android:text="@string/activity_toolset_map_file_manager_btn_text" />
 
         <ProgressBar
             android:id="@+id/activity_toolset_background_task_pb"

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -47,9 +47,6 @@
     <string name="activity_save_file_manager_delete_confirmation_negative_btn_text">No</string>
     <string name="activity_save_file_manager_suggested_zip_file_name" translatable="false">fheroes2_save_files.zip</string>
     <string name="activity_map_file_manager_label">fh2 Map File Manager</string>
-    <string name="activity_map_file_manager_filter_standard_btn_text">Standard</string>
-    <string name="activity_map_file_manager_filter_campaign_btn_text">Campaign</string>
-    <string name="activity_map_file_manager_filter_multiplayer_btn_text">Multi</string>
     <string name="activity_map_file_manager_map_file_list_empty_lbl_text">No map files available</string>
     <string name="activity_map_file_manager_select_all_btn_content_description">Select all map files</string>
     <string name="activity_map_file_manager_unselect_all_btn_content_description">Unselect all map files</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -9,6 +9,7 @@
     <string name="activity_toolset_extract_homm2_assets_btn_text">Extract HoMM2 assets</string>
     <string name="activity_toolset_download_homm2_demo_btn_text">Download HoMM2 demo</string>
     <string name="activity_toolset_save_file_manager_btn_text">Save file manager</string>
+    <string name="activity_toolset_map_file_manager_btn_text">FH2M map file manager</string>
     <string name="activity_toolset_last_task_status_lbl_text_completed_successfully">Operation completed successfully.</string>
     <string name="activity_toolset_last_task_status_lbl_text_no_assets_found">Operation completed successfully, but no HoMM2 assets were found.</string>
     <string name="activity_toolset_last_task_status_lbl_text_failed">An error occurred during the operation: %s</string>
@@ -45,4 +46,33 @@
     <string name="activity_save_file_manager_delete_confirmation_positive_btn_text">Yes</string>
     <string name="activity_save_file_manager_delete_confirmation_negative_btn_text">No</string>
     <string name="activity_save_file_manager_suggested_zip_file_name" translatable="false">fheroes2_save_files.zip</string>
+    <string name="activity_map_file_manager_label">fh2 Map File Manager</string>
+    <string name="activity_map_file_manager_filter_standard_btn_text">Standard</string>
+    <string name="activity_map_file_manager_filter_campaign_btn_text">Campaign</string>
+    <string name="activity_map_file_manager_filter_multiplayer_btn_text">Multi</string>
+    <string name="activity_map_file_manager_map_file_list_empty_lbl_text">No map files available</string>
+    <string name="activity_map_file_manager_select_all_btn_content_description">Select all map files</string>
+    <string name="activity_map_file_manager_unselect_all_btn_content_description">Unselect all map files</string>
+    <string name="activity_map_file_manager_import_btn_content_description">Import map files</string>
+    <string name="activity_map_file_manager_export_btn_content_description">Export selected map files</string>
+    <string name="activity_map_file_manager_delete_btn_content_description">Delete selected map files</string>
+    <string name="activity_map_file_manager_last_task_status_lbl_text_no_map_files_found">Operation completed successfully, but no map files were found.</string>
+    <string name="activity_map_file_manager_last_task_status_lbl_text_failed">An error occurred during the operation: %s</string>
+    <string name="activity_map_file_manager_no_files_selected_for_export_title">No files selected for export</string>
+    <string name="activity_map_file_manager_no_files_selected_for_export_message">Please select the map files to export.</string>
+    <string name="activity_map_file_manager_no_files_selected_for_export_positive_btn_text">OK</string>
+    <string name="activity_map_file_manager_no_files_selected_for_deletion_title">No files selected for deletion</string>
+    <string name="activity_map_file_manager_no_files_selected_for_deletion_message">Please select the map files to delete.</string>
+    <string name="activity_map_file_manager_no_files_selected_for_deletion_positive_btn_text">OK</string>
+    <plurals name="activity_map_file_manager_delete_confirmation_title">
+        <item quantity="one">Delete map file</item>
+        <item quantity="other">Delete map files</item>
+    </plurals>
+    <plurals name="activity_map_file_manager_delete_confirmation_message">
+        <item quantity="one">Are you sure you want to delete the selected file?</item>
+        <item quantity="other">Are you sure you want to delete %d selected files?</item>
+    </plurals>
+    <string name="activity_map_file_manager_delete_confirmation_positive_btn_text">Yes</string>
+    <string name="activity_map_file_manager_delete_confirmation_negative_btn_text">No</string>
+    <string name="activity_map_file_manager_suggested_zip_file_name" translatable="false">fheroes2_map_files.zip</string>
 </resources>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.1'
+        classpath 'com.android.tools.build:gradle:8.4.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Thu Nov 11 18:20:34 PST 2021
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.6-bin.zip
 distributionPath=wrapper/dists
 zipStorePath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
close #8730

Nothing particularly complicated, Save File Manager-like UI. Only FH2M files are supported - maps in other formats could not be created by our Editor, they are "import-only", the "Extract HoMM2 assets" button in the Toolset itself successfully copes with this.