### PR TITLE
Prevent a crash when a hero is killed defending a castle

### DIFF
--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2463,10 +2463,11 @@ namespace AI
                 assert( tile.GetObject( false ) == MP2::OBJ_CASTLE && hero.GetColor() == Maps::getColorFromTile( tile ) );
                 assert( Maps::isValidDirection( tileIndex, Direction::BOTTOM ) && hero.GetIndex() == Maps::GetDirectionIndex( tileIndex, Direction::BOTTOM ) );
 
-                // In case the castle has just been captured, we need to update the information related to the object on the corresponding tile...
+                // In case the castle has just been captured, we need to update the information related to the object on the corresponding tile.
                 updateTile();
 
-                // ... but the corresponding task is not considered completed and should not be removed yet.
+                // Since the hero has not yet reached the tile associated with the corresponding task, this task is not considered completed and should not be removed
+                // yet.
                 return;
             }
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2455,15 +2455,13 @@ namespace AI
         case PriorityTaskType::DEFEND:
         case PriorityTaskType::REINFORCE: {
             if ( hero.GetIndex() != tileIndex ) {
+                // Either the castle has just been captured, or the hero meets the guest hero of a friendly castle. No task should be updated.
+                // If any of these assertions blow up, then this is not one of these cases.
 #ifndef NDEBUG
                 const Maps::Tiles & tile = world.GetTiles( tileIndex );
 #endif
                 assert( tile.GetObject( false ) == MP2::OBJ_CASTLE && hero.GetColor() == Maps::getColorFromTile( tile ) );
                 assert( Maps::isValidDirection( tileIndex, Direction::BOTTOM ) && hero.GetIndex() == Maps::GetDirectionIndex( tileIndex, Direction::BOTTOM ) );
-
-                // If the castle was just captured, we must remove capturing it as a task and the enemy army too
-                _priorityTargets.erase( tileIndex );
-                _enemyArmies.erase( tileIndex );
 
                 return;
             }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2455,13 +2455,15 @@ namespace AI
         case PriorityTaskType::DEFEND:
         case PriorityTaskType::REINFORCE: {
             if ( hero.GetIndex() != tileIndex ) {
-                // Either the castle has just been captured, or the hero meets the guest hero of a friendly castle. No task should be updated.
-                // If any of these assertions blow up, then this is not one of these cases.
 #ifndef NDEBUG
                 const Maps::Tiles & tile = world.GetTiles( tileIndex );
 #endif
                 assert( tile.GetObject( false ) == MP2::OBJ_CASTLE && hero.GetColor() == Maps::getColorFromTile( tile ) );
                 assert( Maps::isValidDirection( tileIndex, Direction::BOTTOM ) && hero.GetIndex() == Maps::GetDirectionIndex( tileIndex, Direction::BOTTOM ) );
+
+                // If the castle was just captured, we must remove capturing it as a task and the enemy army too
+                _priorityTargets.erase( tileIndex );
+                _enemyArmies.erase( tileIndex );
 
                 return;
             }

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2476,9 +2476,6 @@ namespace AI
             // How is it even possible that a hero died while simply moving into a castle?
             assert( hero.isActive() );
 
-            // TODO: sort the army between the castle and hero to have maximum movement points for the next day
-            // TODO: but also have enough army to defend the castle.
-
             hero.SetModes( Heroes::SLEEPER );
             _priorityTargets.erase( tileIndex );
 

--- a/src/fheroes2/ai/normal/ai_normal_hero.cpp
+++ b/src/fheroes2/ai/normal/ai_normal_hero.cpp
@@ -2455,14 +2455,18 @@ namespace AI
         case PriorityTaskType::DEFEND:
         case PriorityTaskType::REINFORCE: {
             if ( hero.GetIndex() != tileIndex ) {
-                // Either the castle has just been captured, or the hero meets the guest hero of a friendly castle. No task should be updated.
-                // If any of these assertions blow up, then this is not one of these cases.
+                // Either the castle has just been captured, or the hero meets the guest hero of a friendly castle. If any of these assertions blow up, then this is not
+                // one of these cases.
 #ifndef NDEBUG
                 const Maps::Tiles & tile = world.GetTiles( tileIndex );
 #endif
                 assert( tile.GetObject( false ) == MP2::OBJ_CASTLE && hero.GetColor() == Maps::getColorFromTile( tile ) );
                 assert( Maps::isValidDirection( tileIndex, Direction::BOTTOM ) && hero.GetIndex() == Maps::GetDirectionIndex( tileIndex, Direction::BOTTOM ) );
 
+                // In case the castle has just been captured, we need to update the information related to the object on the corresponding tile...
+                updateTile();
+
+                // ... but the corresponding task is not considered completed and should not be removed yet.
                 return;
             }
 


### PR DESCRIPTION
Fix #8809

I think both the task and the list of enemy armies should be updated.

I'm not totally confident this is the right place for `_enemyArmies` (i.e. this might hide a problem elsewhere).