### PR TITLE
Add checks to verify object layer type

### DIFF
--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -4803,7 +4803,7 @@ namespace
             }
         }
 
-        // Check that the same image part is set to the same layer type for all objects.
+        // Check that an image part is set to the same layer type for all objects.
         std::map<std::pair<MP2::ObjectIcnType, uint32_t>, Maps::ObjectLayerType> groundObjectInfoVsLayerType;
         std::set<std::pair<MP2::ObjectIcnType, uint32_t>> topObjectInfo;
 

--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <cstddef>
 #include <initializer_list>
+#include <map>
 #include <memory>
 #include <utility>
 
@@ -4798,6 +4799,29 @@ namespace
 
             for ( const auto & objectInfo : objects ) {
                 assert( MP2::isOffGameActionObject( objectInfo.objectType ) );
+            }
+        }
+
+        // Check that the same image part is set to the same layer type for all objects.
+        std::map<std::pair<MP2::ObjectIcnType, uint32_t>, Maps::ObjectLayerType> groundObjectInfoVsLayerType;
+        std::set<std::pair<MP2::ObjectIcnType, uint32_t>> topObjectInfo;
+
+        for ( const auto & objects : objectData ) {
+            for ( const auto & objectInfo : objects ) {
+                for ( const auto & info : objectInfo.groundLevelParts ) {
+                    const auto [iter, inserted] = groundObjectInfoVsLayerType.emplace( std::make_pair( info.icnType, info.icnIndex ), info.layerType );
+                    if ( !inserted ) {
+                        assert( iter->second == info.layerType );
+                    }
+
+                    assert( topObjectInfo.find( std::make_pair( info.icnType, info.icnIndex ) ) == topObjectInfo.end() );
+                }
+
+                for ( const auto & info : objectInfo.topLevelParts ) {
+                    topObjectInfo.emplace( info.icnType, info.icnIndex );
+
+                    assert( groundObjectInfoVsLayerType.find( std::make_pair( info.icnType, info.icnIndex ) ) == groundObjectInfoVsLayerType.end() );
+                }
             }
         }
 #endif

--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -27,6 +27,7 @@
 #include <initializer_list>
 #include <map>
 #include <memory>
+#include <set>
 #include <utility>
 
 #include "artifact.h"


### PR DESCRIPTION
To make sure that all objects handle object parts in the same way,