### PR TITLE
Speed up save file loading and saving operations

### DIFF
--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -708,7 +708,7 @@ StreamBuf StreamFile::toStreamBuf( const size_t size )
 
     StreamBuf buffer( chunkSize );
 
-    if ( std::fread( buffer.data(), chunkSize, 1, _file.get() ) != 1 ) {
+    if ( std::fread( buffer.dataForWriting(), chunkSize, 1, _file.get() ) != 1 ) {
         setfail( true );
 
         return StreamBuf{};

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -699,7 +699,7 @@ void StreamFile::putRaw( const void * ptr, size_t sz )
     }
 }
 
-StreamBuf StreamFile::toStreamBuf( const size_t size )
+StreamBuf StreamFile::toStreamBuf( const size_t size /* = 0 */ )
 {
     const size_t chunkSize = size > 0 ? size : sizeg();
     if ( chunkSize == 0 || !_file ) {

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -317,7 +317,9 @@ public:
 
     std::string toString( const size_t size = 0 );
 
-protected:
+private:
+    friend class StreamFile;
+
     void reset();
 
     size_t tellg() override;
@@ -330,26 +332,22 @@ protected:
     uint8_t get8() override;
     void put8( const uint8_t v ) override;
 
-    friend class ZStreamBuf;
-
-    uint8_t * itbeg{ nullptr };
-    uint8_t * itget{ nullptr };
-    uint8_t * itput{ nullptr };
-    uint8_t * itend{ nullptr };
-
-private:
-    friend class StreamFile;
-
-    // If you use this method to write data update the cursor by calling advance() method.
+    // After using this method to write data, update the cursor by calling the advance() method.
     uint8_t * dataForWriting()
     {
         return itput;
     }
 
+    // Advances the cursor intended for writing data forward by a specified number of bytes.
     void advance( const size_t size )
     {
         itput += size;
     }
+
+    uint8_t * itbeg{ nullptr };
+    uint8_t * itget{ nullptr };
+    uint8_t * itput{ nullptr };
+    uint8_t * itend{ nullptr };
 };
 
 class StreamFile final : public StreamBase
@@ -392,7 +390,7 @@ public:
 
     std::string toString( const size_t size = 0 );
 
-protected:
+private:
     size_t sizeg() override;
     size_t sizep() override;
     size_t tellg() override;
@@ -400,9 +398,6 @@ protected:
 
     uint8_t get8() override;
     void put8( const uint8_t v ) override;
-
-private:
-    std::unique_ptr<std::FILE, std::function<int( std::FILE * )>> _file{ nullptr, std::fclose };
 
     template <typename T>
     T getUint()
@@ -433,6 +428,8 @@ private:
             setfail( true );
         }
     }
+
+    std::unique_ptr<std::FILE, std::function<int( std::FILE * )>> _file{ nullptr, std::fclose };
 };
 
 namespace fheroes2

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -266,7 +266,7 @@ private:
     uint32_t _flags{ 0 };
 };
 
-class StreamBuf : public StreamBase
+class StreamBuf final : public StreamBase
 {
 public:
     explicit StreamBuf( const size_t sz = 0 );
@@ -283,17 +283,6 @@ public:
     const uint8_t * data() const
     {
         return itget;
-    }
-
-    // If you use this method to write data update the cursor by calling advance() method.
-    uint8_t * data()
-    {
-        return itget;
-    }
-
-    void advance( const size_t size )
-    {
-        itput += size;
     }
 
     size_t size()
@@ -347,9 +336,23 @@ protected:
     uint8_t * itget{ nullptr };
     uint8_t * itput{ nullptr };
     uint8_t * itend{ nullptr };
+
+private:
+    friend class StreamFile;
+
+    // If you use this method to write data update the cursor by calling advance() method.
+    uint8_t * dataForWriting()
+    {
+        return itput;
+    }
+
+    void advance( const size_t size )
+    {
+        itput += size;
+    }
 };
 
-class StreamFile : public StreamBase
+class StreamFile final : public StreamBase
 {
 public:
     StreamFile() = default;

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -48,8 +48,9 @@ namespace Compression
     // it to the end of the buffer. Returns true on success or false on error.
     bool readFromFileStream( StreamFile & fileStream, StreamBuf & output );
 
-    // Zips the contents of the buffer from the current read position to the end of the buffer and
-    // writes it to the specified file stream. Returns true on success and false on error.
+    // Zips the contents of the buffer from the current read position to the end of the buffer and writes
+    // it to the specified file stream. The current read position of the buffer does not change. Returns
+    // true on success and false on error.
     bool writeIntoFileStream( StreamFile & fileStream, StreamBuf & data );
 
     fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -32,6 +32,7 @@
 #include "image.h"
 
 class StreamBuf;
+class StreamFile;
 
 namespace Compression
 {
@@ -44,15 +45,13 @@ namespace Compression
     // zero, the size of the decompressed data will be determined automatically.
     std::vector<uint8_t> decompressData( const uint8_t * src, const size_t srcSize, size_t realSize = 0 );
 
-    // Reads & unzips the zipped chunk from the specified file at the specified offset and appends
-    // it to the end of the buffer. The current read position of the buffer does not change. Returns
-    // true on success or false on error.
-    bool readFile( StreamBuf & output, const std::string & fn, const size_t offset = 0 );
+    // Reads & unzips the zipped chunk from the specified file stream and appends
+    // it to the end of the buffer. Returns true on success or false on error.
+    bool readFromFileStream( StreamFile & fileStream, StreamBuf & output );
 
     // Zips the contents of the buffer from the current read position to the end of the buffer and
-    // writes (or appends) it to the specified file. The current read position of the buffer does
-    // not change. Returns true on success and false on error.
-    bool writeFile( StreamBuf & input, const std::string & fn, const bool append = false );
+    // writes it to the specified file stream. Returns true on success and false on error.
+    bool writeIntoFileStream( StreamFile & fileStream, StreamBuf & data );
 
     fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );
 }

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -49,8 +49,8 @@ namespace Compression
     bool readFromFileStream( StreamFile & fileStream, StreamBuf & output );
 
     // Zips the contents of the buffer from the current read position to the end of the buffer and writes
-    // it to the specified file stream. The current read position of the buffer does not change.
-    // The current read position of the buffer does not change. Returns true on success and false on error.
+    // it to the specified file stream. The current read position of the buffer does not change. Returns
+    // true on success and false on error.
     bool writeIntoFileStream( StreamFile & fileStream, StreamBuf & data );
 
     fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -49,8 +49,8 @@ namespace Compression
     bool readFromFileStream( StreamFile & fileStream, StreamBuf & output );
 
     // Zips the contents of the buffer from the current read position to the end of the buffer and writes
-    // it to the specified file stream. The current read position of the buffer does not change. Returns
-    // true on success and false on error.
+    // it to the specified file stream. The current read position of the buffer does not change.
+    // The current read position of the buffer does not change. Returns true on success and false on error.
     bool writeIntoFileStream( StreamFile & fileStream, StreamBuf & data );
 
     fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -26,7 +26,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <string>
 #include <vector>
 
 #include "image.h"

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -338,7 +338,7 @@ bool Game::LoadSAV2FileInfo( std::string filePath, Maps::FileInfo & fileInfo )
     fileInfo = std::move( header.info );
     fileInfo.filename = std::move( filePath );
 
-    return true;
+    return !fs.fail();
 }
 
 void Game::SetVersionOfCurrentSaveFile( const uint16_t version )

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -147,11 +147,7 @@ bool Game::Save( const std::string & filePath, const bool autoSave /* = false */
 
     // End-of-data marker
     dataStream << SAV2ID3;
-    if ( dataStream.fail() ) {
-        return false;
-    }
-
-    if ( !Compression::writeIntoFileStream( fileStream, dataStream ) ) {
+    if ( dataStream.fail() || !Compression::writeIntoFileStream( fileStream, dataStream ) ) {
         return false;
     }
 
@@ -265,14 +261,8 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
 
     uint16_t endOfDataMarker = 0;
     dataStream >> endOfDataMarker;
-    if ( dataStream.fail() ) {
+    if ( dataStream.fail() || endOfDataMarker != SAV2ID3 ) {
         showGenericErrorMessage();
-        return fheroes2::GameMode::CANCEL;
-    }
-
-    if ( endOfDataMarker != SAV2ID3 ) {
-        showGenericErrorMessage();
-
         return fheroes2::GameMode::CANCEL;
     }
 
@@ -331,6 +321,10 @@ bool Game::LoadSAV2FileInfo( std::string filePath, Maps::FileInfo & fileInfo )
     HeaderSAV header;
     fs >> header;
 
+    if ( fs.fail() ) {
+        return false;
+    }
+
     if ( ( Settings::Get().GameType() & header.gameType ) == 0 ) {
         return false;
     }
@@ -338,7 +332,7 @@ bool Game::LoadSAV2FileInfo( std::string filePath, Maps::FileInfo & fileInfo )
     fileInfo = std::move( header.info );
     fileInfo.filename = std::move( filePath );
 
-    return !fs.fail();
+    return true;
 }
 
 void Game::SetVersionOfCurrentSaveFile( const uint16_t version )

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -133,25 +133,25 @@ bool Game::Save( const std::string & filePath, const bool autoSave /* = false */
         return false;
     }
 
-    StreamBuf compressed;
-    compressed.setbigendian( true );
+    StreamBuf dataStream;
+    dataStream.setbigendian( true );
 
-    compressed << World::Get() << Settings::Get() << GameOver::Result::Get();
-    if ( compressed.fail() ) {
+    dataStream << World::Get() << Settings::Get() << GameOver::Result::Get();
+    if ( dataStream.fail() ) {
         return false;
     }
 
     if ( conf.isCampaignGameType() ) {
-        compressed << Campaign::CampaignSaveData::Get();
+        dataStream << Campaign::CampaignSaveData::Get();
     }
 
     // End-of-data marker
-    compressed << SAV2ID3;
-    if ( compressed.fail() ) {
+    dataStream << SAV2ID3;
+    if ( dataStream.fail() ) {
         return false;
     }
 
-    if ( !Compression::writeIntoFileStream( fileStream, compressed ) ) {
+    if ( !Compression::writeIntoFileStream( fileStream, dataStream ) ) {
         return false;
     }
 
@@ -229,10 +229,10 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
         return fheroes2::GameMode::CANCEL;
     }
 
-    StreamBuf decompressed;
-    decompressed.setbigendian( true );
+    StreamBuf dataStream;
+    dataStream.setbigendian( true );
 
-    if ( !Compression::readFromFileStream( fileStream, decompressed ) ) {
+    if ( !Compression::readFromFileStream( fileStream, dataStream ) ) {
         showGenericErrorMessage();
         return fheroes2::GameMode::CANCEL;
     }
@@ -245,8 +245,8 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
         return fheroes2::GameMode::CANCEL;
     }
 
-    decompressed >> World::Get() >> conf >> GameOver::Result::Get();
-    if ( decompressed.fail() ) {
+    dataStream >> World::Get() >> conf >> GameOver::Result::Get();
+    if ( dataStream.fail() ) {
         showGenericErrorMessage();
         return fheroes2::GameMode::CANCEL;
     }
@@ -255,7 +255,7 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
 
     if ( conf.isCampaignGameType() ) {
         Campaign::CampaignSaveData & saveData = Campaign::CampaignSaveData::Get();
-        decompressed >> saveData;
+        dataStream >> saveData;
 
         if ( !saveData.isStarting() && saveData.getCurrentScenarioInfoId() == saveData.getLastCompletedScenarioInfoID() ) {
             // This is the end of the current scenario. We should show next scenario selection.
@@ -264,8 +264,8 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
     }
 
     uint16_t endOfDataMarker = 0;
-    decompressed >> endOfDataMarker;
-    if ( decompressed.fail() ) {
+    dataStream >> endOfDataMarker;
+    if ( dataStream.fail() ) {
         showGenericErrorMessage();
         return fheroes2::GameMode::CANCEL;
     }

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -129,12 +129,19 @@ namespace fheroes2
 
     bool HighScoreDataContainer::load( const std::string & fileName )
     {
-        StreamBuf hdata;
-        if ( !Compression::readFile( hdata, fileName ) ) {
+        StreamFile fileStream;
+        fileStream.setbigendian( true );
+        if ( !fileStream.open( fileName, "rb" ) ) {
             return false;
         }
 
+        StreamBuf hdata;
         hdata.setbigendian( true );
+
+        if ( !Compression::readFromFileStream( fileStream, hdata ) ) {
+            return false;
+        }
+
         uint32_t magicValue = 0;
 
         hdata >> magicValue;
@@ -194,11 +201,18 @@ namespace fheroes2
 
     bool HighScoreDataContainer::save( const std::string & fileName ) const
     {
+        StreamFile fileStream;
+        fileStream.setbigendian( true );
+
+        if ( !fileStream.open( fileName, "wb" ) ) {
+            return false;
+        }
+
         StreamBuf hdata;
         hdata.setbigendian( true );
         hdata << highscoreFileMagicValueV2 << _highScoresStandard << _highScoresCampaign;
 
-        return !hdata.fail() && Compression::writeFile( hdata, fileName );
+        return !hdata.fail() && Compression::writeIntoFileStream( fileStream, hdata );
     }
 
     int32_t HighScoreDataContainer::registerScoreStandard( HighscoreData && data )


### PR DESCRIPTION
We must avoid opening a file twice for reading and writing as it is unsafe and inefficient. Additionally, I added extra checks for stream operation failure.