### PR TITLE
Bring the logic of the Summon Boat spell for the human player in line with its logic of operation in the case of AI

### DIFF
--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -461,13 +461,6 @@ Maps::Indexes Maps::ScanAroundObject( const int32_t center, const MP2::MapObject
     return MapsIndexesFilteredObject( results, objectType, ignoreHeroes );
 }
 
-Maps::Indexes Maps::GetFreeIndexesAroundTile( const int32_t center )
-{
-    Indexes results = getAroundIndexes( center );
-    results.erase( std::remove_if( results.begin(), results.end(), []( const int32_t tile ) { return !isClearGround( world.GetTiles( tile ) ); } ), results.end() );
-    return results;
-}
-
 bool Maps::isValidForDimensionDoor( int32_t targetIndex, bool isWater )
 {
     const Maps::Tiles & tile = world.GetTiles( targetIndex );

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -74,7 +74,6 @@ namespace Maps
     Indexes ScanAroundObject( const int32_t center, const MP2::MapObjectType objectType );
     Indexes ScanAroundObjectWithDistance( const int32_t center, const uint32_t dist, const MP2::MapObjectType objectType );
     Indexes ScanAroundObject( const int32_t center, const MP2::MapObjectType objectType, const bool ignoreHeroes );
-    Indexes GetFreeIndexesAroundTile( const int32_t center );
 
     bool isValidForDimensionDoor( int32_t targetIndex, bool isWater );
     // Checks if the tile is guarded by a monster

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -340,12 +340,7 @@ namespace fheroes2
             }
 
             const Maps::Tiles & tile = world.GetTiles( tileIdx );
-
-            if ( !tile.isWater() ) {
-                continue;
-            }
-
-            if ( tile.GetObject() != MP2::OBJ_NONE ) {
+            if ( !tile.isWater() || tile.GetObject() != MP2::OBJ_NONE ) {
                 continue;
             }
 

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -325,17 +325,17 @@ namespace fheroes2
             return -1;
         }
 
-        const int32_t center = hero.GetIndex();
-        const int tilePassability = world.GetTiles( center ).GetPassable();
+        const int32_t heroTileIdx = hero.GetIndex();
+        const int heroTilePassability = world.GetTiles( heroTileIdx ).GetPassable();
 
         std::vector<int32_t> possibleBoatPositions;
         possibleBoatPositions.reserve( 8 );
 
-        for ( const int32_t tileIdx : Maps::getAroundIndexes( center ) ) {
-            const int direction = Maps::GetDirection( center, tileIdx );
+        for ( const int32_t tileIdx : Maps::getAroundIndexes( heroTileIdx ) ) {
+            const int direction = Maps::GetDirection( heroTileIdx, tileIdx );
             assert( direction != Direction::UNKNOWN && direction != Direction::CENTER );
 
-            if ( ( tilePassability & direction ) == 0 ) {
+            if ( ( heroTilePassability & direction ) == 0 ) {
                 continue;
             }
 
@@ -356,14 +356,14 @@ namespace fheroes2
             return -1;
         }
 
-        std::sort( possibleBoatPositions.begin(), possibleBoatPositions.end(), [centerPoint = Maps::GetPoint( center )]( const int32_t left, const int32_t right ) {
-            const fheroes2::Point & leftPoint = Maps::GetPoint( left );
-            const fheroes2::Point & rightPoint = Maps::GetPoint( right );
+        std::sort( possibleBoatPositions.begin(), possibleBoatPositions.end(), [heroPoint = Maps::GetPoint( heroTileIdx )]( const int32_t left, const int32_t right ) {
+            const fheroes2::Point leftPoint = Maps::GetPoint( left );
+            const fheroes2::Point rightPoint = Maps::GetPoint( right );
 
-            const int32_t leftDiffX = leftPoint.x - centerPoint.x;
-            const int32_t leftDiffY = leftPoint.y - centerPoint.y;
-            const int32_t rightDiffX = rightPoint.x - centerPoint.x;
-            const int32_t rightDiffY = rightPoint.y - centerPoint.y;
+            const int32_t leftDiffX = leftPoint.x - heroPoint.x;
+            const int32_t leftDiffY = leftPoint.y - heroPoint.y;
+            const int32_t rightDiffX = rightPoint.x - heroPoint.x;
+            const int32_t rightDiffY = rightPoint.y - heroPoint.y;
 
             return ( leftDiffX * leftDiffX + leftDiffY * leftDiffY ) < ( rightDiffX * rightDiffX + rightDiffY * rightDiffY );
         } );

--- a/src/fheroes2/spell/spell_info.cpp
+++ b/src/fheroes2/spell/spell_info.cpp
@@ -352,23 +352,23 @@ namespace fheroes2
             possibleBoatPositions.emplace_back( tileIdx );
         }
 
-        if ( possibleBoatPositions.empty() ) {
+        const auto iter = std::min_element( possibleBoatPositions.begin(), possibleBoatPositions.end(),
+                                            [heroPoint = Maps::GetPoint( heroTileIdx )]( const int32_t left, const int32_t right ) {
+                                                const fheroes2::Point leftPoint = Maps::GetPoint( left );
+                                                const fheroes2::Point rightPoint = Maps::GetPoint( right );
+
+                                                const int32_t leftDiffX = leftPoint.x - heroPoint.x;
+                                                const int32_t leftDiffY = leftPoint.y - heroPoint.y;
+                                                const int32_t rightDiffX = rightPoint.x - heroPoint.x;
+                                                const int32_t rightDiffY = rightPoint.y - heroPoint.y;
+
+                                                return ( leftDiffX * leftDiffX + leftDiffY * leftDiffY ) < ( rightDiffX * rightDiffX + rightDiffY * rightDiffY );
+                                            } );
+        if ( iter == possibleBoatPositions.end() ) {
             return -1;
         }
 
-        std::sort( possibleBoatPositions.begin(), possibleBoatPositions.end(), [heroPoint = Maps::GetPoint( heroTileIdx )]( const int32_t left, const int32_t right ) {
-            const fheroes2::Point leftPoint = Maps::GetPoint( left );
-            const fheroes2::Point rightPoint = Maps::GetPoint( right );
-
-            const int32_t leftDiffX = leftPoint.x - heroPoint.x;
-            const int32_t leftDiffY = leftPoint.y - heroPoint.y;
-            const int32_t rightDiffX = rightPoint.x - heroPoint.x;
-            const int32_t rightDiffY = rightPoint.y - heroPoint.y;
-
-            return ( leftDiffX * leftDiffX + leftDiffY * leftDiffY ) < ( rightDiffX * rightDiffX + rightDiffY * rightDiffY );
-        } );
-
-        return possibleBoatPositions.front();
+        return *iter;
     }
 
     int32_t getSummonableBoat( const Heroes & hero )

--- a/src/fheroes2/spell/spell_info.h
+++ b/src/fheroes2/spell/spell_info.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/spell/spell_info.h
+++ b/src/fheroes2/spell/spell_info.h
@@ -47,6 +47,8 @@ namespace fheroes2
 
     std::string getSpellDescription( const Spell & spell, const HeroBase * hero );
 
+    // Returns the index of the tile that the boat would have been summoned to when using the Summon Boat spell by the given hero, or -1 if there is no suitable tile
+    // nearby.
     int32_t getPossibleBoatPosition( const Heroes & hero );
 
     int32_t getSummonableBoat( const Heroes & hero );


### PR DESCRIPTION
Related to #8834

This PR just makes sure that `OBJ_EVENT` objects will not be overwritten when summoning a boat. The problem (and the need) to replicate the behavior of the original game in this case is still questionable.