### PR TITLE
Allow normal victory for "Accumulate gold" condition

### DIFF
--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -322,8 +322,6 @@ namespace
         {
             _conditionType = mapFormat.victoryConditionType;
 
-            _isNormalVictoryAllowed = false;
-
             switch ( _conditionType ) {
             case Maps::FileInfo::VICTORY_DEFEAT_EVERYONE:
                 // This condition has no metadata.

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -389,7 +389,7 @@ namespace
             case Maps::FileInfo::VICTORY_COLLECT_ENOUGH_GOLD: {
                 const fheroes2::Size valueSectionUiSize = fheroes2::ValueSelectionDialogElement::getArea();
                 const fheroes2::Rect roi{ _restorer.x(), _restorer.y(), _restorer.width(), _restorer.height() };
-                const fheroes2::Point uiOffset{ roi.x + ( roi.width - fheroes2::ValueSelectionDialogElement::getArea().width ) / 2, roi.y };
+                const fheroes2::Point uiOffset{ roi.x + ( roi.width - valueSectionUiSize.width ) / 2, roi.y };
 
                 _goldAccumulationValue.setOffset( uiOffset );
                 _goldAccumulationValue.draw( output );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -397,8 +397,6 @@ namespace
                 const fheroes2::Text text( _( "Gold:" ), fheroes2::FontType::normalWhite() );
                 text.draw( uiOffset.x - text.width() - 5, roi.y + ( valueSectionUiSize.height - text.height() ) / 2 + 2, output );
 
-
-
                 _allowNormalVictoryRoi = Editor::drawCheckboxWithText( _allowNormalVictory, _( "Also allow normal victory" ), output, roi.x + 5,
                                                                        roi.y + valueSectionUiSize.height + 10, isEvilInterface );
 

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -248,7 +248,7 @@ namespace Maps::Map_Format
 
         uint8_t victoryConditionType{ 0 };
         bool isVictoryConditionApplicableForAI{ false };
-        bool allowNormalVictory{ true };
+        bool allowNormalVictory{ false };
         std::vector<uint32_t> victoryConditionMetadata;
 
         uint8_t lossConditionType{ 0 };

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -490,6 +490,10 @@ bool Maps::FileInfo::loadResurrectionMap( const Map_Format::BaseMapFormat & map,
         assert( ( map.victoryConditionMetadata[2] & map.availablePlayerColors ) == map.victoryConditionMetadata[2] );
         break;
     case VICTORY_OBTAIN_ARTIFACT:
+        assert( map.victoryConditionMetadata.size() == 1 );
+
+        victoryConditionParams[0] = static_cast<uint16_t>( map.victoryConditionMetadata[0] );
+        break;
     case VICTORY_COLLECT_ENOUGH_GOLD:
         assert( map.victoryConditionMetadata.size() == 1 );
         // 10,000 gold is the minimum value can be set since Easy difficulty gives a player this amount of gold.


### PR DESCRIPTION
relates to #8717

- fix rendering while changing victory or loss condition
- fix obtain artifact incorrect metadata handling
- add an option to allow normal victory for "Accumulate Gold" victory condition

![image](https://github.com/ihhub/fheroes2/assets/19829520/1c1ef7cf-b6d6-408c-be1f-5b2fb591175d)
