### PR TITLE
Implement special victory and loss conditions for heroes and towns

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2958,6 +2958,21 @@ namespace fheroes2
                         out = Crop( out, 0, 0, out.width() - 1, out.height() );
                     }
                 }
+
+                if ( _icnVsSprite[id].size() == 25 ) {
+                    // Add random town and castle icons for Editor.
+                    // A temporary solution: blurred Wizard castle/town in purple palette.
+                    _icnVsSprite[id].resize( 27 );
+                    _icnVsSprite[id][25] = CreateHolyShoutEffect( _icnVsSprite[id][13], 1, 0 );
+                    _icnVsSprite[id][26] = CreateHolyShoutEffect( _icnVsSprite[id][19], 1, 0 );
+                    ApplyPalette( _icnVsSprite[id][25], PAL::GetPalette( PAL::PaletteType::PURPLE ) );
+                    ApplyPalette( _icnVsSprite[id][26], PAL::GetPalette( PAL::PaletteType::PURPLE ) );
+
+                    // Add the '?' mark above the image.
+                    const Text text( "? ? ?", FontType::normalWhite() );
+                    text.draw( ( _icnVsSprite[id][25].width() - text.width() ) / 2, 6, _icnVsSprite[id][25] );
+                    text.draw( ( _icnVsSprite[id][26].width() - text.width() ) / 2, 6, _icnVsSprite[id][26] );
+                }
                 return true;
             case ICN::TOWNBKG2:
                 LoadOriginalICN( id );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -774,36 +774,14 @@ namespace
 
         // color flags, except for neutral heroes
         if ( !isNeutralHero ) {
-            uint32_t index = 0;
+            // Use castle flags to show hero's color flags.
+            const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( hero.GetColor() );
 
-            switch ( hero.GetColor() ) {
-            case Color::BLUE:
-                index = 0;
-                break;
-            case Color::GREEN:
-                index = 2;
-                break;
-            case Color::RED:
-                index = 4;
-                break;
-            case Color::YELLOW:
-                index = 6;
-                break;
-            case Color::ORANGE:
-                index = 8;
-                break;
-            case Color::PURPLE:
-                index = 10;
-                break;
-            default:
-                break;
-            }
-
-            const fheroes2::Sprite & l_flag = fheroes2::AGG::GetICN( ICN::FLAG32, index );
+            const fheroes2::Sprite & l_flag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex );
             dst_pt.x = cur_rt.x + ( cur_rt.width - 40 ) / 2 - l_flag.width();
             fheroes2::Blit( l_flag, display, dst_pt.x, dst_pt.y );
 
-            const fheroes2::Sprite & r_flag = fheroes2::AGG::GetICN( ICN::FLAG32, index + 1 );
+            const fheroes2::Sprite & r_flag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex + 1 );
             dst_pt.x = cur_rt.x + ( cur_rt.width + 40 ) / 2;
             fheroes2::Blit( r_flag, display, dst_pt.x, dst_pt.y );
         }

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -614,39 +614,14 @@ namespace
         fheroes2::drawCastleIcon( castle, display, fheroes2::Point( dst_pt.x + 4, dst_pt.y + 4 ) );
 
         // color flags
-        uint32_t index = 0;
-        switch ( castle.GetColor() ) {
-        case Color::BLUE:
-            index = 0;
-            break;
-        case Color::GREEN:
-            index = 2;
-            break;
-        case Color::RED:
-            index = 4;
-            break;
-        case Color::YELLOW:
-            index = 6;
-            break;
-        case Color::ORANGE:
-            index = 8;
-            break;
-        case Color::PURPLE:
-            index = 10;
-            break;
-        case Color::NONE:
-            index = 12;
-            break;
-        default:
-            break;
-        }
+        const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( castle.GetColor() );
 
         const fheroes2::Point flagOffset( 5, 4 );
 
-        const fheroes2::Sprite & l_flag = fheroes2::AGG::GetICN( ICN::FLAG32, index );
+        const fheroes2::Sprite & l_flag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex );
         fheroes2::Blit( l_flag, display, dst_pt.x - flagOffset.x - l_flag.width(), dst_pt.y + flagOffset.y );
 
-        const fheroes2::Sprite & r_flag = fheroes2::AGG::GetICN( ICN::FLAG32, index + 1 );
+        const fheroes2::Sprite & r_flag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex + 1 );
         fheroes2::Blit( r_flag, display, dst_pt.x + flagOffset.x + castleIcon.width(), dst_pt.y + flagOffset.y );
 
         const int currentColor = conf.CurrentColor();

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -741,9 +741,8 @@ namespace Dialog
     {
         const int32_t scrollBarWidth = _scrollbar.width();
 
-        setScrollBarImage(
-            fheroes2::generateScrollbarSlider( _scrollbar, false, _scrollbar.getArea().height, VisibleItemCount(), _size(), { 0, 0, scrollBarWidth, 8 },
-                                               { 0, 7, scrollBarWidth, 8 } ) );
+        setScrollBarImage( fheroes2::generateScrollbarSlider( _scrollbar, false, _scrollbar.getArea().height, VisibleItemCount(), _size(), { 0, 0, scrollBarWidth, 8 },
+                                                              { 0, 7, scrollBarWidth, 8 } ) );
         _scrollbar.moveToIndex( _topId );
     }
 

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -48,7 +48,6 @@
 #include "map_object_info.h"
 #include "maps.h"
 #include "maps_fileinfo.h"
-#include "math_base.h"
 #include "mp2.h"
 #include "pal.h"
 #include "race.h"
@@ -810,6 +809,12 @@ namespace Dialog
         }
 
         return Dialog::ZERO;
+    }
+
+    fheroes2::Rect ItemSelectionWindow::getBackgroundArea() const
+    {
+        assert( _window );
+        return _window->totalArea();
     }
 }
 

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -234,6 +234,7 @@ class SelectKingdomCastle final : public Dialog::ItemSelectionWindow
 public:
     explicit SelectKingdomCastle( const fheroes2::Size & rt, std::string title, std::string description )
         : Dialog::ItemSelectionWindow( rt, std::move( title ), std::move( description ) )
+        , _townFrameIcnId( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS )
     {
         SetAreaMaxItems( rtAreaItems.height / itemsOffsetY );
     }
@@ -260,7 +261,7 @@ public:
     static const int32_t itemsOffsetY{ 35 };
 
 private:
-    const int _townFrameIcnId{ Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS };
+    const int _townFrameIcnId{ ICN::UNKNOWN };
 };
 
 namespace

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -74,16 +74,16 @@ namespace
     }
 }
 
-class SelectEnumMonster final : public Dialog::ItemSelectionWindow<int>
+class SelectEnumMonster final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectEnumMonster( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -108,16 +108,16 @@ private:
     static const int32_t _offsetY{ 43 };
 };
 
-class SelectEnumHeroes final : public Dialog::ItemSelectionWindow<int>
+class SelectEnumHeroes final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectEnumHeroes( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -135,16 +135,16 @@ private:
     static const int32_t _offsetY{ 35 };
 };
 
-class SelectEnumArtifact final : public Dialog::ItemSelectionWindow<int>
+class SelectEnumArtifact final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectEnumArtifact( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -163,16 +163,16 @@ private:
     static const int32_t _offsetY{ 42 };
 };
 
-class SelectEnumSpell final : public Dialog::ItemSelectionWindow<int>
+class SelectEnumSpell final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectEnumSpell( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -191,7 +191,7 @@ private:
     static const int32_t _offsetY{ 55 };
 };
 
-class SelectEnumSecSkill final : public Dialog::ItemSelectionWindow<int>
+class SelectEnumSecSkill final : public Dialog::ItemSelectionWindow
 {
 public:
     static int getSkillFromListIndex( int index )
@@ -205,12 +205,12 @@ public:
     }
 
     explicit SelectEnumSecSkill( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -229,16 +229,16 @@ private:
     static const int32_t _offsetY{ 42 };
 };
 
-class SelectKingdomCastle final : public Dialog::ItemSelectionWindow<int>
+class SelectKingdomCastle final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectKingdomCastle( const fheroes2::Size & rt, std::string title, std::string description )
-        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ), std::move( description ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ), std::move( description ) )
     {
         SetAreaMaxItems( rtAreaItems.height / itemsOffsetY );
     }
 
-    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -266,12 +266,12 @@ private:
 namespace
 {
     // This is a base class for items used in the Editor and they rely on Maps::ObjectInfo structures.
-    class ObjectTypeSelection : public Dialog::ItemSelectionWindow<int>
+    class ObjectTypeSelection : public Dialog::ItemSelectionWindow
     {
     public:
         ObjectTypeSelection( const std::vector<Maps::ObjectInfo> & objectInfo, const fheroes2::Size & size, std::string title, const int32_t imageOffsetX,
                              const int32_t textOffsetX, const int32_t offsetY )
-            : Dialog::ItemSelectionWindow<int>( size, std::move( title ) )
+            : Dialog::ItemSelectionWindow( size, std::move( title ) )
             , _objectInfo( objectInfo )
             , _imageOffsetX( imageOffsetX )
             , _textOffsetX( textOffsetX )
@@ -280,7 +280,7 @@ namespace
             SetAreaMaxItems( rtAreaItems.height / _offsetY );
         }
 
-        using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
+        using Dialog::ItemSelectionWindow::ActionListPressRight;
 
         void RedrawItem( const int & objectId, int32_t posX, int32_t posY, bool isSelected ) override
         {
@@ -691,8 +691,7 @@ int32_t Dialog::selectKingdomCastle( const Kingdom & kingdom, const bool notOccu
 
 namespace Dialog
 {
-    template <class Item>
-    ItemSelectionWindow<Item>::ItemSelectionWindow( const fheroes2::Size & dialogSize, std::string title, std::string description )
+    ItemSelectionWindow::ItemSelectionWindow( const fheroes2::Size & dialogSize, std::string title, std::string description )
     {
         assert( !title.empty() );
 
@@ -719,7 +718,7 @@ namespace Dialog
 
         _backgroundRestorer = std::make_unique<fheroes2::ImageRestorer>( display, listRoi.x, listRoi.y, listRoi.width, listRoi.height );
 
-        ItemSelectionWindow<Item>::SetAreaItems( { listRoi.x + 5, listRoi.y + 5, listRoi.width - 10, listRoi.height - 10 } );
+        SetAreaItems( { listRoi.x + 5, listRoi.y + 5, listRoi.width - 10, listRoi.height - 10 } );
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
         const int32_t scrollbarOffsetX = area.x + area.width - 25;
@@ -729,31 +728,28 @@ namespace Dialog
         const int32_t topPartHeight = 19;
         const int listIcnId = isEvilInterface ? ICN::SCROLLE : ICN::SCROLL;
 
-        ItemSelectionWindow<Item>::SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX + 1, listRoi.y + 1 } );
-        ItemSelectionWindow<Item>::SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX + 1, listRoi.y + listRoi.height - 15 } );
-        ItemSelectionWindow<Item>::setScrollBarArea( { scrollbarOffsetX + 3, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        ItemSelectionWindow<Item>::setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX + 1, listRoi.y + 1 } );
+        SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX + 1, listRoi.y + listRoi.height - 15 } );
+        setScrollBarArea( { scrollbarOffsetX + 3, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
+        setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
 
         // Render dialog buttons.
         _window->renderOkayCancelButtons( _buttonOk, _buttonCancel, isEvilInterface );
     }
 
-    template <class Item>
-    void ItemSelectionWindow<Item>::updateScrollBarImage()
+    void ItemSelectionWindow::updateScrollBarImage()
     {
-        const int32_t scrollBarWidth = ItemSelectionWindow<Item>::_scrollbar.width();
+        const int32_t scrollBarWidth = _scrollbar.width();
 
-        ItemSelectionWindow<Item>::setScrollBarImage(
-            fheroes2::generateScrollbarSlider( ItemSelectionWindow<Item>::_scrollbar, false, ItemSelectionWindow<Item>::_scrollbar.getArea().height,
-                                               ItemSelectionWindow<Item>::VisibleItemCount(), ItemSelectionWindow<Item>::_size(), { 0, 0, scrollBarWidth, 8 },
+        setScrollBarImage(
+            fheroes2::generateScrollbarSlider( _scrollbar, false, _scrollbar.getArea().height, VisibleItemCount(), _size(), { 0, 0, scrollBarWidth, 8 },
                                                { 0, 7, scrollBarWidth, 8 } ) );
-        ItemSelectionWindow<Item>::_scrollbar.moveToIndex( ItemSelectionWindow<Item>::_topId );
+        _scrollbar.moveToIndex( _topId );
     }
 
     // An image with text should have offset of 10 pixels from all left and right edges.
-    template <class Item>
-    void ItemSelectionWindow<Item>::renderItem( const fheroes2::Sprite & itemSprite, std::string itemText, const fheroes2::Point & destination,
-                                                const int32_t middleImageOffsetX, const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const
+    void ItemSelectionWindow::renderItem( const fheroes2::Sprite & itemSprite, std::string itemText, const fheroes2::Point & destination,
+                                          const int32_t middleImageOffsetX, const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -764,8 +760,7 @@ namespace Dialog
         text.draw( destination.x + textOffsetX, destination.y + itemOffsetY - ( text.height() / 2 ) + 2, display );
     }
 
-    template <class Item>
-    int32_t ItemSelectionWindow<Item>::selectItemsEventProcessing()
+    int32_t ItemSelectionWindow::selectItemsEventProcessing()
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -776,7 +771,7 @@ namespace Dialog
 
         updateScrollBarImage();
 
-        ItemSelectionWindow<Item>::Redraw();
+        Redraw();
         display.render( _window->totalArea() );
 
         LocalEvent & le = LocalEvent::Get();
@@ -799,13 +794,13 @@ namespace Dialog
                 fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
             }
 
-            ItemSelectionWindow<Item>::QueueEventProcessing();
+            QueueEventProcessing();
 
-            if ( !ItemSelectionWindow<Item>::IsNeedRedraw() ) {
+            if ( !IsNeedRedraw() ) {
                 continue;
             }
 
-            ItemSelectionWindow<Item>::Redraw();
+            Redraw();
             display.render( roi );
         }
 
@@ -816,8 +811,7 @@ namespace Dialog
         return Dialog::ZERO;
     }
 
-    template <class Item>
-    fheroes2::Rect ItemSelectionWindow<Item>::getBackgroundArea() const
+    fheroes2::Rect ItemSelectionWindow::getBackgroundArea() const
     {
         assert( _window );
         return _window->totalArea();

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -74,16 +74,16 @@ namespace
     }
 }
 
-class SelectEnumMonster final : public Dialog::ItemSelectionWindow
+class SelectEnumMonster final : public Dialog::ItemSelectionWindow<int>
 {
 public:
     explicit SelectEnumMonster( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow::ActionListPressRight;
+    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -108,16 +108,16 @@ private:
     static const int32_t _offsetY{ 43 };
 };
 
-class SelectEnumHeroes final : public Dialog::ItemSelectionWindow
+class SelectEnumHeroes final : public Dialog::ItemSelectionWindow<int>
 {
 public:
     explicit SelectEnumHeroes( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow::ActionListPressRight;
+    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -135,16 +135,16 @@ private:
     static const int32_t _offsetY{ 35 };
 };
 
-class SelectEnumArtifact final : public Dialog::ItemSelectionWindow
+class SelectEnumArtifact final : public Dialog::ItemSelectionWindow<int>
 {
 public:
     explicit SelectEnumArtifact( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow::ActionListPressRight;
+    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -163,16 +163,16 @@ private:
     static const int32_t _offsetY{ 42 };
 };
 
-class SelectEnumSpell final : public Dialog::ItemSelectionWindow
+class SelectEnumSpell final : public Dialog::ItemSelectionWindow<int>
 {
 public:
     explicit SelectEnumSpell( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow::ActionListPressRight;
+    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -191,7 +191,7 @@ private:
     static const int32_t _offsetY{ 55 };
 };
 
-class SelectEnumSecSkill final : public Dialog::ItemSelectionWindow
+class SelectEnumSecSkill final : public Dialog::ItemSelectionWindow<int>
 {
 public:
     static int getSkillFromListIndex( int index )
@@ -205,12 +205,12 @@ public:
     }
 
     explicit SelectEnumSecSkill( const fheroes2::Size & rt, std::string title )
-        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using Dialog::ItemSelectionWindow::ActionListPressRight;
+    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -229,17 +229,16 @@ private:
     static const int32_t _offsetY{ 42 };
 };
 
-class SelectKingdomCastle final : public Dialog::ItemSelectionWindow
+class SelectKingdomCastle final : public Dialog::ItemSelectionWindow<int>
 {
 public:
     explicit SelectKingdomCastle( const fheroes2::Size & rt, std::string title, std::string description )
-        : Dialog::ItemSelectionWindow( rt, std::move( title ), std::move( description ) )
-        , _townFrameIcnId( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS )
+        : Dialog::ItemSelectionWindow<int>( rt, std::move( title ), std::move( description ) )
     {
         SetAreaMaxItems( rtAreaItems.height / itemsOffsetY );
     }
 
-    using Dialog::ItemSelectionWindow::ActionListPressRight;
+    using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -261,18 +260,18 @@ public:
     static const int32_t itemsOffsetY{ 35 };
 
 private:
-    const int _townFrameIcnId;
+    const int _townFrameIcnId{ Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS };
 };
 
 namespace
 {
     // This is a base class for items used in the Editor and they rely on Maps::ObjectInfo structures.
-    class ObjectTypeSelection : public Dialog::ItemSelectionWindow
+    class ObjectTypeSelection : public Dialog::ItemSelectionWindow<int>
     {
     public:
         ObjectTypeSelection( const std::vector<Maps::ObjectInfo> & objectInfo, const fheroes2::Size & size, std::string title, const int32_t imageOffsetX,
                              const int32_t textOffsetX, const int32_t offsetY )
-            : Dialog::ItemSelectionWindow( size, std::move( title ) )
+            : Dialog::ItemSelectionWindow<int>( size, std::move( title ) )
             , _objectInfo( objectInfo )
             , _imageOffsetX( imageOffsetX )
             , _textOffsetX( textOffsetX )
@@ -281,7 +280,7 @@ namespace
             SetAreaMaxItems( rtAreaItems.height / _offsetY );
         }
 
-        using Dialog::ItemSelectionWindow::ActionListPressRight;
+        using Dialog::ItemSelectionWindow<int>::ActionListPressRight;
 
         void RedrawItem( const int & objectId, int32_t posX, int32_t posY, bool isSelected ) override
         {
@@ -692,7 +691,8 @@ int32_t Dialog::selectKingdomCastle( const Kingdom & kingdom, const bool notOccu
 
 namespace Dialog
 {
-    ItemSelectionWindow::ItemSelectionWindow( const fheroes2::Size & dialogSize, std::string title, std::string description )
+    template <class Item>
+    ItemSelectionWindow<Item>::ItemSelectionWindow( const fheroes2::Size & dialogSize, std::string title, std::string description )
     {
         assert( !title.empty() );
 
@@ -719,7 +719,7 @@ namespace Dialog
 
         _backgroundRestorer = std::make_unique<fheroes2::ImageRestorer>( display, listRoi.x, listRoi.y, listRoi.width, listRoi.height );
 
-        SetAreaItems( { listRoi.x + 5, listRoi.y + 5, listRoi.width - 10, listRoi.height - 10 } );
+        ItemSelectionWindow<Item>::SetAreaItems( { listRoi.x + 5, listRoi.y + 5, listRoi.width - 10, listRoi.height - 10 } );
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
         const int32_t scrollbarOffsetX = area.x + area.width - 25;
@@ -729,38 +729,43 @@ namespace Dialog
         const int32_t topPartHeight = 19;
         const int listIcnId = isEvilInterface ? ICN::SCROLLE : ICN::SCROLL;
 
-        SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX + 1, listRoi.y + 1 } );
-        SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX + 1, listRoi.y + listRoi.height - 15 } );
-        setScrollBarArea( { scrollbarOffsetX + 3, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        ItemSelectionWindow<Item>::SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX + 1, listRoi.y + 1 } );
+        ItemSelectionWindow<Item>::SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX + 1, listRoi.y + listRoi.height - 15 } );
+        ItemSelectionWindow<Item>::setScrollBarArea( { scrollbarOffsetX + 3, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
+        ItemSelectionWindow<Item>::setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
 
         // Render dialog buttons.
         _window->renderOkayCancelButtons( _buttonOk, _buttonCancel, isEvilInterface );
     }
 
-    void ItemSelectionWindow::updateScrollBarImage()
+    template <class Item>
+    void ItemSelectionWindow<Item>::updateScrollBarImage()
     {
-        const int32_t scrollBarWidth = _scrollbar.width();
+        const int32_t scrollBarWidth = ItemSelectionWindow<Item>::_scrollbar.width();
 
-        setScrollBarImage( fheroes2::generateScrollbarSlider( _scrollbar, false, _scrollbar.getArea().height, VisibleItemCount(), _size(), { 0, 0, scrollBarWidth, 8 },
-                                                              { 0, 7, scrollBarWidth, 8 } ) );
-        _scrollbar.moveToIndex( _topId );
+        ItemSelectionWindow<Item>::setScrollBarImage(
+            fheroes2::generateScrollbarSlider( ItemSelectionWindow<Item>::_scrollbar, false, ItemSelectionWindow<Item>::_scrollbar.getArea().height,
+                                               ItemSelectionWindow<Item>::VisibleItemCount(), ItemSelectionWindow<Item>::_size(), { 0, 0, scrollBarWidth, 8 },
+                                               { 0, 7, scrollBarWidth, 8 } ) );
+        ItemSelectionWindow<Item>::_scrollbar.moveToIndex( ItemSelectionWindow<Item>::_topId );
     }
 
     // An image with text should have offset of 10 pixels from all left and right edges.
-    void ItemSelectionWindow::renderItem( const fheroes2::Sprite & itemSprite, const std::string & itemText, const fheroes2::Point & destination,
-                                          const int32_t middleImageOffsetX, const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const
+    template <class Item>
+    void ItemSelectionWindow<Item>::renderItem( const fheroes2::Sprite & itemSprite, std::string itemText, const fheroes2::Point & destination,
+                                                const int32_t middleImageOffsetX, const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
         fheroes2::Blit( itemSprite, display, destination.x + middleImageOffsetX - ( itemSprite.width() / 2 ), destination.y + itemOffsetY - ( itemSprite.height() / 2 ) );
 
-        fheroes2::Text text( itemText, current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );
+        fheroes2::Text text( std::move( itemText ), current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );
         text.fitToOneRow( _window->activeArea().width - textOffsetX - 55 );
         text.draw( destination.x + textOffsetX, destination.y + itemOffsetY - ( text.height() / 2 ) + 2, display );
     }
 
-    int32_t ItemSelectionWindow::selectItemsEventProcessing()
+    template <class Item>
+    int32_t ItemSelectionWindow<Item>::selectItemsEventProcessing()
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -771,7 +776,7 @@ namespace Dialog
 
         updateScrollBarImage();
 
-        Redraw();
+        ItemSelectionWindow<Item>::Redraw();
         display.render( _window->totalArea() );
 
         LocalEvent & le = LocalEvent::Get();
@@ -794,13 +799,13 @@ namespace Dialog
                 fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
             }
 
-            QueueEventProcessing();
+            ItemSelectionWindow<Item>::QueueEventProcessing();
 
-            if ( !IsNeedRedraw() ) {
+            if ( !ItemSelectionWindow<Item>::IsNeedRedraw() ) {
                 continue;
             }
 
-            Redraw();
+            ItemSelectionWindow<Item>::Redraw();
             display.render( roi );
         }
 
@@ -811,7 +816,8 @@ namespace Dialog
         return Dialog::ZERO;
     }
 
-    fheroes2::Rect ItemSelectionWindow::getBackgroundArea() const
+    template <class Item>
+    fheroes2::Rect ItemSelectionWindow<Item>::getBackgroundArea() const
     {
         assert( _window );
         return _window->totalArea();

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -261,7 +261,7 @@ public:
     static const int32_t itemsOffsetY{ 35 };
 
 private:
-    const int _townFrameIcnId{ ICN::UNKNOWN };
+    const int _townFrameIcnId;
 };
 
 namespace

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -28,7 +28,6 @@
 #include <cassert>
 #include <cstddef>
 #include <iterator>
-#include <memory>
 #include <numeric>
 #include <utility>
 #include <vector>
@@ -44,8 +43,6 @@
 #include "ground.h"
 #include "heroes_base.h"
 #include "icn.h"
-#include "image.h"
-#include "interface_list.h"
 #include "kingdom.h"
 #include "localevent.h"
 #include "map_object_info.h"
@@ -60,14 +57,12 @@
 #include "settings.h"
 #include "tools.h"
 #include "translations.h"
-#include "ui_button.h"
 #include "ui_castle.h"
 #include "ui_dialog.h"
 #include "ui_map_object.h"
 #include "ui_scrollbar.h"
 #include "ui_text.h"
 #include "ui_tool.h"
-#include "ui_window.h"
 #include "world.h"
 
 namespace
@@ -80,182 +75,16 @@ namespace
     }
 }
 
-class SelectEnum : public Interface::ListBox<int>
-{
-public:
-    using Interface::ListBox<int>::ActionListDoubleClick;
-    using Interface::ListBox<int>::ActionListSingleClick;
-    using Interface::ListBox<int>::ActionListPressRight;
-
-    SelectEnum() = delete;
-
-    explicit SelectEnum( const fheroes2::Size & dialogSize, std::string title, std::string description = {} )
-    {
-        assert( !title.empty() );
-
-        fheroes2::Display & display = fheroes2::Display::instance();
-        background = std::make_unique<fheroes2::StandardWindow>( dialogSize.width, dialogSize.height, true, display );
-
-        const fheroes2::Rect & area = background->activeArea();
-
-        int32_t listOffsetY = 0;
-
-        fheroes2::Text text( std::move( title ), fheroes2::FontType::normalYellow() );
-        text.draw( area.x + ( area.width - text.width() ) / 2, area.y + 10, display );
-
-        // The additional text under the title.
-        if ( !description.empty() ) {
-            text.set( std::move( description ), fheroes2::FontType::normalWhite() );
-            text.draw( area.x + ( area.width - text.width() ) / 2, area.y + 30, display );
-            listOffsetY = text.height() + 3;
-        }
-
-        const fheroes2::Rect listRoi( area.x + 10, area.y + 30 + listOffsetY, area.width - 40, area.height - 70 - listOffsetY );
-
-        background->applyTextBackgroundShading( listRoi );
-
-        listBackground = std::make_unique<fheroes2::ImageRestorer>( display, listRoi.x, listRoi.y, listRoi.width, listRoi.height );
-
-        SetAreaItems( { listRoi.x + 5, listRoi.y + 5, listRoi.width - 10, listRoi.height - 10 } );
-
-        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-        const int32_t scrollbarOffsetX = area.x + area.width - 25;
-
-        background->renderScrollbarBackground( { scrollbarOffsetX, listRoi.y, listRoi.width, listRoi.height }, isEvilInterface );
-
-        const int32_t topPartHeight = 19;
-        const int listIcnId = isEvilInterface ? ICN::SCROLLE : ICN::SCROLL;
-
-        SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX + 1, listRoi.y + 1 } );
-        SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX + 1, listRoi.y + listRoi.height - 15 } );
-        setScrollBarArea( { scrollbarOffsetX + 3, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
-
-        // Render dialog buttons.
-        background->renderOkayCancelButtons( buttonOk, buttonCancel, isEvilInterface );
-    }
-
-    void RedrawBackground( const fheroes2::Point & /* unused */ ) override
-    {
-        listBackground->restore();
-    }
-
-    void ActionListDoubleClick( int & /* unused */ ) override
-    {
-        ok = true;
-    }
-
-    void RedrawItem( const int & /* unused */, int32_t /* ox */, int32_t /* oy */, bool /* current */ ) override
-    {
-        // Do nothing.
-    }
-
-    void ActionCurrentUp() override
-    {
-        // Do nothing.
-    }
-
-    void ActionCurrentDn() override
-    {
-        // Do nothing.
-    }
-
-    void ActionListSingleClick( int & /* unused */ ) override
-    {
-        // Do nothing.
-    }
-
-    void ActionListPressRight( int & /* unused */ ) override
-    {
-        // Do nothing.
-    }
-
-    void updateScrollBarImage()
-    {
-        const int32_t scrollBarWidth = _scrollbar.width();
-
-        setScrollBarImage( fheroes2::generateScrollbarSlider( _scrollbar, false, _scrollbar.getArea().height, VisibleItemCount(), _size(), { 0, 0, scrollBarWidth, 8 },
-                                                              { 0, 7, scrollBarWidth, 8 } ) );
-        _scrollbar.moveToIndex( _topId );
-    }
-
-    // An image with text should have offset of 10 pixels from all left and right edges.
-    void renderItem( const fheroes2::Sprite & itemSprite, const std::string & itemText, const fheroes2::Point & destination, const int32_t middleImageOffsetX,
-                     const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const
-    {
-        fheroes2::Display & display = fheroes2::Display::instance();
-
-        fheroes2::Blit( itemSprite, display, destination.x + middleImageOffsetX - ( itemSprite.width() / 2 ), destination.y + itemOffsetY - ( itemSprite.height() / 2 ) );
-
-        fheroes2::Text text( itemText, current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );
-        text.fitToOneRow( background->activeArea().width - textOffsetX - 55 );
-        text.draw( destination.x + textOffsetX, destination.y + itemOffsetY - ( text.height() / 2 ) + 2, display );
-    }
-
-    int32_t selectItemsEventProcessing()
-    {
-        fheroes2::Display & display = fheroes2::Display::instance();
-
-        // setup cursor
-        const CursorRestorer cursorRestorer( true, Cursor::POINTER );
-
-        const fheroes2::Rect & roi = background->activeArea();
-
-        updateScrollBarImage();
-
-        Redraw();
-        display.render( background->totalArea() );
-
-        LocalEvent & le = LocalEvent::Get();
-
-        while ( !ok && le.HandleEvents() ) {
-            le.isMouseLeftButtonPressedInArea( buttonOk.area() ) ? buttonOk.drawOnPress() : buttonOk.drawOnRelease();
-            le.isMouseLeftButtonPressedInArea( buttonCancel.area() ) ? buttonCancel.drawOnPress() : buttonCancel.drawOnRelease();
-
-            if ( le.MouseClickLeft( buttonOk.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) ) {
-                return Dialog::OK;
-            }
-            if ( le.MouseClickLeft( buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-                return Dialog::CANCEL;
-            }
-
-            if ( le.isMouseRightButtonPressedInArea( buttonOk.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Accept the choice made." ), Dialog::ZERO );
-            }
-            else if ( le.isMouseRightButtonPressedInArea( buttonCancel.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
-            }
-
-            QueueEventProcessing();
-
-            if ( !IsNeedRedraw() ) {
-                continue;
-            }
-
-            Redraw();
-            display.render( roi );
-        }
-
-        return Dialog::ZERO;
-    }
-
-    bool ok{ false };
-    std::unique_ptr<fheroes2::StandardWindow> background;
-    std::unique_ptr<fheroes2::ImageRestorer> listBackground;
-    fheroes2::Button buttonOk;
-    fheroes2::Button buttonCancel;
-};
-
-class SelectEnumMonster final : public SelectEnum
+class SelectEnumMonster final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectEnumMonster( const fheroes2::Size & rt, std::string title )
-        : SelectEnum( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using SelectEnum::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -280,16 +109,16 @@ private:
     static const int32_t _offsetY{ 43 };
 };
 
-class SelectEnumHeroes final : public SelectEnum
+class SelectEnumHeroes final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectEnumHeroes( const fheroes2::Size & rt, std::string title )
-        : SelectEnum( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using SelectEnum::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -307,16 +136,16 @@ private:
     static const int32_t _offsetY{ 35 };
 };
 
-class SelectEnumArtifact final : public SelectEnum
+class SelectEnumArtifact final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectEnumArtifact( const fheroes2::Size & rt, std::string title )
-        : SelectEnum( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using SelectEnum::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -335,16 +164,16 @@ private:
     static const int32_t _offsetY{ 42 };
 };
 
-class SelectEnumSpell final : public SelectEnum
+class SelectEnumSpell final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectEnumSpell( const fheroes2::Size & rt, std::string title )
-        : SelectEnum( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using SelectEnum::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -363,7 +192,7 @@ private:
     static const int32_t _offsetY{ 55 };
 };
 
-class SelectEnumSecSkill final : public SelectEnum
+class SelectEnumSecSkill final : public Dialog::ItemSelectionWindow
 {
 public:
     static int getSkillFromListIndex( int index )
@@ -377,12 +206,12 @@ public:
     }
 
     explicit SelectEnumSecSkill( const fheroes2::Size & rt, std::string title )
-        : SelectEnum( rt, std::move( title ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ) )
     {
         SetAreaMaxItems( rtAreaItems.height / _offsetY );
     }
 
-    using SelectEnum::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -401,17 +230,17 @@ private:
     static const int32_t _offsetY{ 42 };
 };
 
-class SelectKingdomCastle final : public SelectEnum
+class SelectKingdomCastle final : public Dialog::ItemSelectionWindow
 {
 public:
     explicit SelectKingdomCastle( const fheroes2::Size & rt, std::string title, std::string description )
-        : SelectEnum( rt, std::move( title ), std::move( description ) )
+        : Dialog::ItemSelectionWindow( rt, std::move( title ), std::move( description ) )
         , _townFrameIcnId( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS )
     {
         SetAreaMaxItems( rtAreaItems.height / itemsOffsetY );
     }
 
-    using SelectEnum::ActionListPressRight;
+    using Dialog::ItemSelectionWindow::ActionListPressRight;
 
     void RedrawItem( const int & index, int32_t dstx, int32_t dsty, bool current ) override
     {
@@ -427,7 +256,7 @@ public:
 
     void ActionListPressRight( int & index ) override
     {
-        Dialog::QuickInfoWithIndicationOnRadar( *world.getCastleEntrance( Maps::GetPoint( index ) ), background->totalArea() );
+        Dialog::QuickInfoWithIndicationOnRadar( *world.getCastleEntrance( Maps::GetPoint( index ) ), getBackgroundArea() );
     }
 
     static const int32_t itemsOffsetY{ 35 };
@@ -439,12 +268,12 @@ private:
 namespace
 {
     // This is a base class for items used in the Editor and they rely on Maps::ObjectInfo structures.
-    class ObjectTypeSelection : public SelectEnum
+    class ObjectTypeSelection : public Dialog::ItemSelectionWindow
     {
     public:
         ObjectTypeSelection( const std::vector<Maps::ObjectInfo> & objectInfo, const fheroes2::Size & size, std::string title, const int32_t imageOffsetX,
                              const int32_t textOffsetX, const int32_t offsetY )
-            : SelectEnum( size, std::move( title ) )
+            : Dialog::ItemSelectionWindow( size, std::move( title ) )
             , _objectInfo( objectInfo )
             , _imageOffsetX( imageOffsetX )
             , _textOffsetX( textOffsetX )
@@ -453,7 +282,7 @@ namespace
             SetAreaMaxItems( rtAreaItems.height / _offsetY );
         }
 
-        using SelectEnum::ActionListPressRight;
+        using Dialog::ItemSelectionWindow::ActionListPressRight;
 
         void RedrawItem( const int & objectId, int32_t posX, int32_t posY, bool isSelected ) override
         {
@@ -719,7 +548,7 @@ namespace
         objectSelection.SetCurrent( std::max( objectType, 0 ) );
 
         const int32_t result = objectSelection.selectItemsEventProcessing();
-        return result == Dialog::OK || objectSelection.ok ? objectSelection.GetCurrent() : -1;
+        return result == Dialog::OK ? objectSelection.GetCurrent() : -1;
     }
 
     class MineTypeList final : public Interface::ListBox<Maps::ObjectInfo>
@@ -859,7 +688,129 @@ int32_t Dialog::selectKingdomCastle( const Kingdom & kingdom, const bool notOccu
 
     const int32_t result = listbox.selectItemsEventProcessing();
 
-    return ( result == Dialog::OK || listbox.ok ) ? listbox.GetCurrent() : -1;
+    return ( result == Dialog::OK ) ? listbox.GetCurrent() : -1;
+}
+
+namespace Dialog
+{
+    ItemSelectionWindow::ItemSelectionWindow( const fheroes2::Size & dialogSize, std::string title, std::string description )
+    {
+        assert( !title.empty() );
+
+        fheroes2::Display & display = fheroes2::Display::instance();
+        _window = std::make_unique<fheroes2::StandardWindow>( dialogSize.width, dialogSize.height, true, display );
+
+        const fheroes2::Rect & area = _window->activeArea();
+
+        int32_t listOffsetY = 0;
+
+        fheroes2::Text text( std::move( title ), fheroes2::FontType::normalYellow() );
+        text.draw( area.x + ( area.width - text.width() ) / 2, area.y + 10, display );
+
+        // The additional text under the title.
+        if ( !description.empty() ) {
+            text.set( std::move( description ), fheroes2::FontType::normalWhite() );
+            text.draw( area.x + ( area.width - text.width() ) / 2, area.y + 30, display );
+            listOffsetY = text.height() + 3;
+        }
+
+        const fheroes2::Rect listRoi( area.x + 10, area.y + 30 + listOffsetY, area.width - 40, area.height - 70 - listOffsetY );
+
+        _window->applyTextBackgroundShading( listRoi );
+
+        _backgroundRestorer = std::make_unique<fheroes2::ImageRestorer>( display, listRoi.x, listRoi.y, listRoi.width, listRoi.height );
+
+        SetAreaItems( { listRoi.x + 5, listRoi.y + 5, listRoi.width - 10, listRoi.height - 10 } );
+
+        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
+        const int32_t scrollbarOffsetX = area.x + area.width - 25;
+
+        _window->renderScrollbarBackground( { scrollbarOffsetX, listRoi.y, listRoi.width, listRoi.height }, isEvilInterface );
+
+        const int32_t topPartHeight = 19;
+        const int listIcnId = isEvilInterface ? ICN::SCROLLE : ICN::SCROLL;
+
+        SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX + 1, listRoi.y + 1 } );
+        SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX + 1, listRoi.y + listRoi.height - 15 } );
+        setScrollBarArea( { scrollbarOffsetX + 3, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
+        setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+
+        // Render dialog buttons.
+        _window->renderOkayCancelButtons( _buttonOk, _buttonCancel, isEvilInterface );
+    }
+
+    void ItemSelectionWindow::updateScrollBarImage()
+    {
+        const int32_t scrollBarWidth = _scrollbar.width();
+
+        setScrollBarImage( fheroes2::generateScrollbarSlider( _scrollbar, false, _scrollbar.getArea().height, VisibleItemCount(), _size(), { 0, 0, scrollBarWidth, 8 },
+                                                              { 0, 7, scrollBarWidth, 8 } ) );
+        _scrollbar.moveToIndex( _topId );
+    }
+
+    // An image with text should have offset of 10 pixels from all left and right edges.
+    void ItemSelectionWindow::renderItem( const fheroes2::Sprite & itemSprite, const std::string & itemText, const fheroes2::Point & destination,
+                                          const int32_t middleImageOffsetX, const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const
+    {
+        fheroes2::Display & display = fheroes2::Display::instance();
+
+        fheroes2::Blit( itemSprite, display, destination.x + middleImageOffsetX - ( itemSprite.width() / 2 ), destination.y + itemOffsetY - ( itemSprite.height() / 2 ) );
+
+        fheroes2::Text text( itemText, current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );
+        text.fitToOneRow( _window->activeArea().width - textOffsetX - 55 );
+        text.draw( destination.x + textOffsetX, destination.y + itemOffsetY - ( text.height() / 2 ) + 2, display );
+    }
+
+    int32_t ItemSelectionWindow::selectItemsEventProcessing()
+    {
+        fheroes2::Display & display = fheroes2::Display::instance();
+
+        // setup cursor
+        const CursorRestorer cursorRestorer( true, Cursor::POINTER );
+
+        const fheroes2::Rect & roi = _window->activeArea();
+
+        updateScrollBarImage();
+
+        Redraw();
+        display.render( _window->totalArea() );
+
+        LocalEvent & le = LocalEvent::Get();
+
+        while ( !_isDoubleClicked && le.HandleEvents() ) {
+            _buttonOk.drawOnState( le.isMouseLeftButtonPressedInArea( _buttonOk.area() ) );
+            _buttonCancel.drawOnState( le.isMouseLeftButtonPressedInArea( _buttonCancel.area() ) );
+
+            if ( le.MouseClickLeft( _buttonOk.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) ) {
+                return Dialog::OK;
+            }
+            if ( le.MouseClickLeft( _buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
+                return Dialog::CANCEL;
+            }
+
+            if ( le.isMouseRightButtonPressedInArea( _buttonOk.area() ) ) {
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Accept the choice made." ), Dialog::ZERO );
+            }
+            else if ( le.isMouseRightButtonPressedInArea( _buttonCancel.area() ) ) {
+                fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
+            }
+
+            QueueEventProcessing();
+
+            if ( !IsNeedRedraw() ) {
+                continue;
+            }
+
+            Redraw();
+            display.render( roi );
+        }
+
+        if ( _isDoubleClicked ) {
+            return Dialog::OK;
+        }
+
+        return Dialog::ZERO;
+    }
 }
 
 Skill::Secondary Dialog::selectSecondarySkill( const Heroes & hero, const int skillId /* = Skill::Secondary::UNKNOWN */ )
@@ -882,7 +833,7 @@ Skill::Secondary Dialog::selectSecondarySkill( const Heroes & hero, const int sk
 
     const int32_t result = listbox.selectItemsEventProcessing();
 
-    if ( result == Dialog::OK || listbox.ok ) {
+    if ( result == Dialog::OK ) {
         const int skillIndex = listbox.GetCurrent();
         return { SelectEnumSecSkill::getSkillFromListIndex( skillIndex ), SelectEnumSecSkill::getLevelFromListIndex( skillIndex ) };
     }
@@ -910,7 +861,7 @@ Spell Dialog::selectSpell( const int spellId, const bool includeRandomSpells )
 
     const int32_t result = listbox.selectItemsEventProcessing();
 
-    return result == Dialog::OK || listbox.ok ? Spell( listbox.GetCurrent() ) : Spell( Spell::NONE );
+    return ( result == Dialog::OK ) ? Spell( listbox.GetCurrent() ) : Spell( Spell::NONE );
 }
 
 Artifact Dialog::selectArtifact( const int artifactId, const bool isForVictoryConditions )
@@ -959,7 +910,7 @@ Artifact Dialog::selectArtifact( const int artifactId, const bool isForVictoryCo
 
     const int32_t result = listbox.selectItemsEventProcessing();
 
-    return ( result == Dialog::OK || listbox.ok ) ? Artifact( listbox.GetCurrent() ) : Artifact( Artifact::UNKNOWN );
+    return ( result == Dialog::OK ) ? Artifact( listbox.GetCurrent() ) : Artifact( Artifact::UNKNOWN );
 }
 
 Monster Dialog::selectMonster( const int monsterId )
@@ -979,7 +930,7 @@ Monster Dialog::selectMonster( const int monsterId )
 
     const int32_t result = listbox.selectItemsEventProcessing();
 
-    return result == Dialog::OK || listbox.ok ? Monster( listbox.GetCurrent() ) : Monster( Monster::UNKNOWN );
+    return ( result == Dialog::OK ) ? Monster( listbox.GetCurrent() ) : Monster( Monster::UNKNOWN );
 }
 
 int Dialog::selectHeroes( const int heroId /* = Heroes::UNKNOWN */ )
@@ -1000,7 +951,7 @@ int Dialog::selectHeroes( const int heroId /* = Heroes::UNKNOWN */ )
 
     const int32_t result = listbox.selectItemsEventProcessing();
 
-    return result == Dialog::OK || listbox.ok ? listbox.GetCurrent() : Heroes::UNKNOWN;
+    return ( result == Dialog::OK ) ? listbox.GetCurrent() : Heroes::UNKNOWN;
 }
 
 int Dialog::selectHeroType( const int heroType )

--- a/src/fheroes2/dialog/dialog_selectitems.h
+++ b/src/fheroes2/dialog/dialog_selectitems.h
@@ -32,6 +32,7 @@
 #include "heroes.h"
 #include "image.h"
 #include "interface_list.h"
+#include "math_base.h"
 #include "monster.h"
 #include "skill.h"
 #include "spell.h"
@@ -96,11 +97,7 @@ namespace Dialog
 
         int32_t selectItemsEventProcessing();
 
-        fheroes2::Rect getBackgroundArea() const
-        {
-            assert( _window );
-            return _window->totalArea();
-        }
+        fheroes2::Rect getBackgroundArea() const;
 
     private:
         bool _isDoubleClicked{ false };

--- a/src/fheroes2/dialog/dialog_selectitems.h
+++ b/src/fheroes2/dialog/dialog_selectitems.h
@@ -25,18 +25,91 @@
 #define H2EDITOR_DIALOGS_H
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include "artifact.h"
 #include "heroes.h"
+#include "image.h"
+#include "interface_list.h"
 #include "monster.h"
 #include "skill.h"
 #include "spell.h"
+#include "ui_button.h"
+#include "ui_window.h"
 
 class Kingdom;
 
 namespace Dialog
 {
+    class ItemSelectionWindow : public Interface::ListBox<int>
+    {
+    public:
+        using Interface::ListBox<int>::ActionListDoubleClick;
+        using Interface::ListBox<int>::ActionListSingleClick;
+        using Interface::ListBox<int>::ActionListPressRight;
+
+        ItemSelectionWindow() = delete;
+
+        explicit ItemSelectionWindow( const fheroes2::Size & dialogSize, std::string title, std::string description = {} );
+
+        void RedrawBackground( const fheroes2::Point & /* unused */ ) override
+        {
+            _backgroundRestorer->restore();
+        }
+
+        void ActionListDoubleClick( int & /* unused */ ) override
+        {
+            _isDoubleClicked = true;
+        }
+
+        void RedrawItem( const int & /* unused */, int32_t /* ox */, int32_t /* oy */, bool /* current */ ) override
+        {
+            // Do nothing.
+        }
+
+        void ActionCurrentUp() override
+        {
+            // Do nothing.
+        }
+
+        void ActionCurrentDn() override
+        {
+            // Do nothing.
+        }
+
+        void ActionListSingleClick( int & /* unused */ ) override
+        {
+            // Do nothing.
+        }
+
+        void ActionListPressRight( int & /* unused */ ) override
+        {
+            // Do nothing.
+        }
+
+        void updateScrollBarImage();
+
+        // An image with text should have offset of 10 pixels from all left and right edges.
+        void renderItem( const fheroes2::Sprite & itemSprite, const std::string & itemText, const fheroes2::Point & destination, const int32_t middleImageOffsetX,
+                         const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const;
+
+        int32_t selectItemsEventProcessing();
+
+        fheroes2::Rect getBackgroundArea() const
+        {
+            assert( _window );
+            return _window->totalArea();
+        }
+
+    private:
+        bool _isDoubleClicked{ false };
+        std::unique_ptr<fheroes2::StandardWindow> _window;
+        std::unique_ptr<fheroes2::ImageRestorer> _backgroundRestorer;
+        fheroes2::Button _buttonOk;
+        fheroes2::Button _buttonCancel;
+    };
+
     Monster selectMonster( const int monsterId );
 
     int selectHeroes( const int heroId = Heroes::UNKNOWN );

--- a/src/fheroes2/dialog/dialog_selectitems.h
+++ b/src/fheroes2/dialog/dialog_selectitems.h
@@ -43,12 +43,13 @@ class Kingdom;
 
 namespace Dialog
 {
-    class ItemSelectionWindow : public Interface::ListBox<int>
+    template <class Item>
+    class ItemSelectionWindow : public Interface::ListBox<Item>
     {
     public:
-        using Interface::ListBox<int>::ActionListDoubleClick;
-        using Interface::ListBox<int>::ActionListSingleClick;
-        using Interface::ListBox<int>::ActionListPressRight;
+        using Interface::ListBox<Item>::ActionListDoubleClick;
+        using Interface::ListBox<Item>::ActionListSingleClick;
+        using Interface::ListBox<Item>::ActionListPressRight;
 
         ItemSelectionWindow() = delete;
 
@@ -59,12 +60,12 @@ namespace Dialog
             _backgroundRestorer->restore();
         }
 
-        void ActionListDoubleClick( int & /* unused */ ) override
+        void ActionListDoubleClick( Item & /* unused */ ) override
         {
             _isDoubleClicked = true;
         }
 
-        void RedrawItem( const int & /* unused */, int32_t /* ox */, int32_t /* oy */, bool /* current */ ) override
+        void RedrawItem( const Item & /* unused */, int32_t /* ox */, int32_t /* oy */, bool /* current */ ) override
         {
             // Do nothing.
         }
@@ -79,12 +80,12 @@ namespace Dialog
             // Do nothing.
         }
 
-        void ActionListSingleClick( int & /* unused */ ) override
+        void ActionListSingleClick( Item & /* unused */ ) override
         {
             // Do nothing.
         }
 
-        void ActionListPressRight( int & /* unused */ ) override
+        void ActionListPressRight( Item & /* unused */ ) override
         {
             // Do nothing.
         }
@@ -92,7 +93,7 @@ namespace Dialog
         void updateScrollBarImage();
 
         // An image with text should have offset of 10 pixels from all left and right edges.
-        void renderItem( const fheroes2::Sprite & itemSprite, const std::string & itemText, const fheroes2::Point & destination, const int32_t middleImageOffsetX,
+        void renderItem( const fheroes2::Sprite & itemSprite, std::string itemText, const fheroes2::Point & destination, const int32_t middleImageOffsetX,
                          const int32_t textOffsetX, const int32_t itemOffsetY, const bool current ) const;
 
         int32_t selectItemsEventProcessing();

--- a/src/fheroes2/dialog/dialog_selectitems.h
+++ b/src/fheroes2/dialog/dialog_selectitems.h
@@ -43,13 +43,12 @@ class Kingdom;
 
 namespace Dialog
 {
-    template <class Item>
-    class ItemSelectionWindow : public Interface::ListBox<Item>
+    class ItemSelectionWindow : public Interface::ListBox<int>
     {
     public:
-        using Interface::ListBox<Item>::ActionListDoubleClick;
-        using Interface::ListBox<Item>::ActionListSingleClick;
-        using Interface::ListBox<Item>::ActionListPressRight;
+        using Interface::ListBox<int>::ActionListDoubleClick;
+        using Interface::ListBox<int>::ActionListSingleClick;
+        using Interface::ListBox<int>::ActionListPressRight;
 
         ItemSelectionWindow() = delete;
 
@@ -60,12 +59,12 @@ namespace Dialog
             _backgroundRestorer->restore();
         }
 
-        void ActionListDoubleClick( Item & /* unused */ ) override
+        void ActionListDoubleClick( int & /* unused */ ) override
         {
             _isDoubleClicked = true;
         }
 
-        void RedrawItem( const Item & /* unused */, int32_t /* ox */, int32_t /* oy */, bool /* current */ ) override
+        void RedrawItem( const int & /* unused */, int32_t /* ox */, int32_t /* oy */, bool /* current */ ) override
         {
             // Do nothing.
         }
@@ -80,12 +79,12 @@ namespace Dialog
             // Do nothing.
         }
 
-        void ActionListSingleClick( Item & /* unused */ ) override
+        void ActionListSingleClick( int & /* unused */ ) override
         {
             // Do nothing.
         }
 
-        void ActionListPressRight( Item & /* unused */ ) override
+        void ActionListPressRight( int & /* unused */ ) override
         {
             // Do nothing.
         }

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -187,7 +187,7 @@ namespace
             const auto & heroMetadata = _heroInfos[index].heroMetadata;
 
             renderItem( drawHeroIcon( heroMetadata->customPortrait, heroMetadata->race, _heroInfos[index].color, _townIcnId ),
-                        getObjectNameAndPositionText( heroMetadata->customName, _heroInfos[index].tileIndex, _mapWidth ), { dstx, dsty }, 45, 95, itemsOffsetY / 2,
+                        getObjectNameAndPositionText( heroMetadata->customName, _heroInfos[index].tileIndex, _mapWidth ), { dstx, dsty }, 40, 85, itemsOffsetY / 2,
                         current );
         }
 

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -248,8 +248,10 @@ namespace
     class SelectMapHero final : public Dialog::ItemSelectionWindow
     {
     public:
-        explicit SelectMapHero( const fheroes2::Size & rt, std::string title, std::string description, const int32_t mapWidth, const std::vector<HeroInfo> & heroInfos )
-            : Dialog::ItemSelectionWindow( rt, std::move( title ), std::move( description ) )
+        explicit SelectMapHero( const fheroes2::Size & dialogSize, std::string title, std::string description, const int32_t mapWidth,
+                                const std::vector<HeroInfo> & heroInfos, const bool isEvilInterface )
+            : Dialog::ItemSelectionWindow( dialogSize, std::move( title ), std::move( description ) )
+            , _townIcnId( isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS )
             , _mapWidth( mapWidth )
             , _heroInfos( heroInfos )
         {
@@ -282,7 +284,7 @@ namespace
         static const int32_t itemsOffsetY{ 35 };
 
     private:
-        const int _townIcnId{ Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS };
+        const int _townIcnId{ ICN::UNKNOWN };
         const int32_t _mapWidth{ 0 };
         const std::vector<HeroInfo> & _heroInfos;
     };
@@ -290,8 +292,10 @@ namespace
     class SelectMapCastle final : public Dialog::ItemSelectionWindow
     {
     public:
-        explicit SelectMapCastle( const fheroes2::Size & rt, std::string title, std::string description, const int32_t mapWidth, const std::vector<TownInfo> & townInfos )
-            : Dialog::ItemSelectionWindow( rt, std::move( title ), std::move( description ) )
+        explicit SelectMapCastle( const fheroes2::Size & dialogSize, std::string title, std::string description, const int32_t mapWidth,
+                                  const std::vector<TownInfo> & townInfos, const bool isEvilInterface )
+            : Dialog::ItemSelectionWindow( dialogSize, std::move( title ), std::move( description ) )
+            , _townIcnId( isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS )
             , _mapWidth( mapWidth )
             , _townInfos( townInfos )
         {
@@ -331,7 +335,7 @@ namespace
         static const int32_t itemsOffsetY{ 35 };
 
     private:
-        const int _townIcnId{ Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS };
+        const int _townIcnId{ ICN::UNKNOWN };
         const int32_t _mapWidth{ 0 };
         const std::vector<TownInfo> & _townInfos;
     };
@@ -1116,7 +1120,7 @@ namespace
                         = std::max( 100 + SelectMapCastle::itemsOffsetY * static_cast<int32_t>( _mapTownInfos.size() ), 100 + SelectMapCastle::itemsOffsetY * 5 );
                     const int32_t totalHeight = std::min( itemsHeight, maxHeight );
 
-                    SelectMapCastle listbox( { 450, totalHeight }, _( "Select a Town to capture for victory" ), {}, _mapWidth, _mapTownInfos );
+                    SelectMapCastle listbox( { 450, totalHeight }, _( "Select a Town to capture for victory" ), {}, _mapWidth, _mapTownInfos, _isEvilInterface );
 
                     std::vector<int> townIndicies( _mapTownInfos.size() );
                     std::iota( townIndicies.begin(), townIndicies.end(), 0 );
@@ -1179,7 +1183,7 @@ namespace
                         = std::max( 100 + SelectMapCastle::itemsOffsetY * static_cast<int32_t>( _mapHeroInfos.size() ), 100 + SelectMapCastle::itemsOffsetY * 5 );
                     const int32_t totalHeight = std::min( itemsHeight, maxHeight );
 
-                    SelectMapHero listbox( { 450, totalHeight }, _( "Select a Hero to kill for victory" ), {}, _mapWidth, _mapHeroInfos );
+                    SelectMapHero listbox( { 450, totalHeight }, _( "Select a Hero to kill for victory" ), {}, _mapWidth, _mapHeroInfos, _isEvilInterface );
 
                     std::vector<int> heroIndicies( _mapHeroInfos.size() );
                     std::iota( heroIndicies.begin(), heroIndicies.end(), 0 );
@@ -1648,7 +1652,7 @@ namespace
                         = std::max( 100 + SelectMapCastle::itemsOffsetY * static_cast<int32_t>( _mapTownInfos.size() ), 100 + SelectMapCastle::itemsOffsetY * 5 );
                     const int32_t totalHeight = std::min( itemsHeight, maxHeight );
 
-                    SelectMapCastle listbox( { 450, totalHeight }, _( "Select a Town to lose for defeat" ), {}, _mapWidth, _mapTownInfos );
+                    SelectMapCastle listbox( { 450, totalHeight }, _( "Select a Town to lose for defeat" ), {}, _mapWidth, _mapTownInfos, _isEvilInterface );
 
                     std::vector<int> townIndicies( _mapTownInfos.size() );
                     std::iota( townIndicies.begin(), townIndicies.end(), 0 );
@@ -1697,7 +1701,7 @@ namespace
                         = std::max( 100 + SelectMapCastle::itemsOffsetY * static_cast<int32_t>( _mapHeroInfos.size() ), 100 + SelectMapCastle::itemsOffsetY * 5 );
                     const int32_t totalHeight = std::min( itemsHeight, maxHeight );
 
-                    SelectMapHero listbox( { 450, totalHeight }, _( "Select a Hero to lose for defeat" ), {}, _mapWidth, _mapHeroInfos );
+                    SelectMapHero listbox( { 450, totalHeight }, _( "Select a Hero to lose for defeat" ), {}, _mapWidth, _mapHeroInfos, _isEvilInterface );
 
                     std::vector<int> heroIndicies( _mapHeroInfos.size() );
                     std::iota( heroIndicies.begin(), heroIndicies.end(), 0 );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -475,7 +475,6 @@ namespace
                     if ( !heroFound ) {
                         _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     }
-
                 }
                 else {
                     // Since the metadata in invalid we have 2 options:

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -574,7 +574,7 @@ namespace
 
                 if ( !heroFound ) {
                     // The hero doesn't exist in the list.
-                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
+                    _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     mapFormat.victoryConditionType = _conditionType;
                 }
 
@@ -1028,7 +1028,7 @@ namespace
 
                 if ( !heroFound ) {
                     // The hero doesn't exist in the list.
-                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
+                    _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     mapFormat.victoryConditionType = _conditionType;
                 }
 

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -1288,7 +1288,7 @@ namespace
         const bool _isEvilInterface{ false };
         uint32_t _victoryArtifactId{ ultimateArtifactId };
         const int32_t _mapWidth{ 0 };
-        // Town or hero loss metadata include: X position, Y position, color.
+        // Town or hero loss metadata include tile ID and color.
         std::array<uint32_t, 2> _heroToKill{ 0 };
         std::array<uint32_t, 2> _townToCapture{ 0 };
         std::vector<TownInfo> _mapTownInfos;

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -88,6 +88,21 @@ namespace
     const std::vector<uint8_t> supportedLossConditions{ Maps::FileInfo::LOSS_EVERYTHING, Maps::FileInfo::LOSS_TOWN, Maps::FileInfo::LOSS_HERO,
                                                         Maps::FileInfo::LOSS_OUT_OF_TIME };
 
+    struct HeroInfo
+    {
+        int32_t tileIndex{ -1 };
+        int32_t color{ Color::NONE };
+        const Maps::Map_Format::HeroMetadata * heroMetadata{ nullptr };
+    };
+
+    struct TownInfo
+    {
+        int32_t tileIndex{ -1 };
+        int32_t color{ Color::NONE };
+        int32_t race{ Race::NONE };
+        const Maps::Map_Format::CastleMetadata * castleMetadata{ nullptr };
+    };
+
     fheroes2::Sprite drawCastleIcon( const std::vector<uint32_t> & bannedBuildings, const int32_t race, const int townIcnId )
     {
         fheroes2::Sprite castleIcon( fheroes2::AGG::GetICN( townIcnId, 23 ) );
@@ -105,7 +120,7 @@ namespace
     class SelectMapCastle final : public Dialog::ItemSelectionWindow
     {
     public:
-        explicit SelectMapCastle( const fheroes2::Size & rt, std::string title, std::string description, const std::vector<Maps::Map_Format::TownInfo> & townInfos )
+        explicit SelectMapCastle( const fheroes2::Size & rt, std::string title, std::string description, const std::vector<TownInfo> & townInfos )
             : Dialog::ItemSelectionWindow( rt, std::move( title ), std::move( description ) )
             , _townInfos( townInfos )
         {
@@ -136,10 +151,10 @@ namespace
 
     private:
         const int _townIcnId{ Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS };
-        const std::vector<Maps::Map_Format::TownInfo> & _townInfos;
+        const std::vector<TownInfo> & _townInfos;
     };
 
-    std::vector<Maps::Map_Format::HeroInfo> getMapHeroes( const Maps::Map_Format::MapFormat & map, const int32_t allowedColors )
+    std::vector<HeroInfo> getMapHeroes( const Maps::Map_Format::MapFormat & map, const int32_t allowedColors )
     {
         if ( allowedColors == Color::NONE ) {
             // Nothing to do.
@@ -148,7 +163,7 @@ namespace
 
         const auto & heroObjects = Maps::getObjectsByGroup( Maps::ObjectGroup::KINGDOM_HEROES );
 
-        std::vector<Maps::Map_Format::HeroInfo> heroInfos;
+        std::vector<HeroInfo> heroInfos;
 
         // TODO: cache all heroes once this dialog is open. No need to run through all objects every time.
         for ( size_t tileIndex = 0; tileIndex < map.tiles.size(); ++tileIndex ) {
@@ -171,7 +186,7 @@ namespace
                 }
 
                 heroInfos.emplace_back();
-                Maps::Map_Format::HeroInfo & heroInfo = heroInfos.back();
+                HeroInfo & heroInfo = heroInfos.back();
 
                 heroInfo.tileIndex = static_cast<int32_t>( tileIndex );
                 heroInfo.color = color;
@@ -186,7 +201,7 @@ namespace
         return heroInfos;
     }
 
-    std::vector<Maps::Map_Format::TownInfo> getMapTowns( const Maps::Map_Format::MapFormat & map, const int32_t allowedColors )
+    std::vector<TownInfo> getMapTowns( const Maps::Map_Format::MapFormat & map, const int32_t allowedColors )
     {
         if ( allowedColors == Color::NONE ) {
             // Nothing to do.
@@ -195,7 +210,7 @@ namespace
 
         const auto & townObjects = Maps::getObjectsByGroup( Maps::ObjectGroup::KINGDOM_TOWNS );
 
-        std::vector<Maps::Map_Format::TownInfo> townInfos;
+        std::vector<TownInfo> townInfos;
 
         // TODO: cache all towns once this dialog is open. No need to run through all objects every time.
         for ( size_t tileIndex = 0; tileIndex < map.tiles.size(); ++tileIndex ) {
@@ -216,7 +231,7 @@ namespace
                 }
 
                 townInfos.emplace_back();
-                Maps::Map_Format::TownInfo & townInfo = townInfos.back();
+                TownInfo & townInfo = townInfos.back();
 
                 townInfo.tileIndex = static_cast<int32_t>( tileIndex );
                 townInfo.color = color;
@@ -942,7 +957,7 @@ namespace
         // Town or hero loss metadata include: X position, Y position, color.
         std::array<uint32_t, 2> _heroToKill{ 0 };
         std::array<uint32_t, 2> _townToCapture{ 0 };
-        std::vector<Maps::Map_Format::TownInfo> _mapTownInfos;
+        std::vector<TownInfo> _mapTownInfos;
 
         fheroes2::ImageRestorer _restorer;
 

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -275,7 +275,7 @@ namespace
 
             const auto & heroInfo = _heroInfos[index];
 
-            fheroes2::showStandardTextMessage( {}, getHeroTitle( heroInfo.heroMetadata->customName,  heroInfo.heroMetadata->race, heroInfo.tileIndex, _mapWidth ),
+            fheroes2::showStandardTextMessage( {}, getHeroTitle( heroInfo.heroMetadata->customName, heroInfo.heroMetadata->race, heroInfo.tileIndex, _mapWidth ),
                                                Dialog::ZERO );
         }
 
@@ -304,27 +304,27 @@ namespace
         {
             assert( index >= 0 && static_cast<size_t>( index ) < _townInfos.size() );
 
-            const auto & castleInfo = _townInfos[index];
-            const auto & castleMetadata = castleInfo.castleMetadata;
+            const auto & townInfo = _townInfos[index];
+            const auto & castleMetadata = townInfo.castleMetadata;
 
             const bool isTown
                 = std::find( castleMetadata->builtBuildings.begin(), castleMetadata->builtBuildings.end(), BUILD_CASTLE ) == castleMetadata->builtBuildings.end();
 
-            renderItem( getCastleIcon( isTown, castleInfo.race, castleInfo.color, _townIcnId ),
-                        getTownTitle( castleMetadata->customName, castleInfo.race, isTown, castleInfo.tileIndex, _mapWidth ), { dstx, dsty }, 45, 95, itemsOffsetY / 2,
+            renderItem( getCastleIcon( isTown, townInfo.race, townInfo.color, _townIcnId ),
+                        getTownTitle( castleMetadata->customName, townInfo.race, isTown, townInfo.tileIndex, _mapWidth ), { dstx, dsty }, 45, 95, itemsOffsetY / 2,
                         current );
         }
 
         void ActionListPressRight( int & index ) override
         {
             assert( index >= 0 && static_cast<size_t>( index ) < _townInfos.size() );
-            const auto & castleInfo = _townInfos[index];
-            const auto & castleMetadata = castleInfo.castleMetadata;
+            const auto & townInfo = _townInfos[index];
+            const auto & castleMetadata = townInfo.castleMetadata;
 
             const bool isTown
                 = std::find( castleMetadata->builtBuildings.begin(), castleMetadata->builtBuildings.end(), BUILD_CASTLE ) == castleMetadata->builtBuildings.end();
 
-            fheroes2::showStandardTextMessage( {}, getTownTitle( castleInfo.castleMetadata->customName, castleInfo.race, isTown, castleInfo.tileIndex, _mapWidth ),
+            fheroes2::showStandardTextMessage( {}, getTownTitle( townInfo.castleMetadata->customName, townInfo.race, isTown, townInfo.tileIndex, _mapWidth ),
                                                Dialog::ZERO );
         }
 
@@ -932,19 +932,19 @@ namespace
                     }
                 }
 
-                const auto & castleInfo = _mapTownInfos[selectedTownIndex];
-                const auto & castleMetadata = castleInfo.castleMetadata;
+                const auto & townInfo = _mapTownInfos[selectedTownIndex];
+                const auto & castleMetadata = townInfo.castleMetadata;
                 const int townIcnId = _isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS;
 
                 const bool isTown
                     = std::find( castleMetadata->builtBuildings.begin(), castleMetadata->builtBuildings.end(), BUILD_CASTLE ) == castleMetadata->builtBuildings.end();
 
-                const fheroes2::Sprite castleIcon( getCastleIcon( isTown, castleInfo.race, castleInfo.color, townIcnId ) );
+                const fheroes2::Sprite castleIcon( getCastleIcon( isTown, townInfo.race, townInfo.color, townIcnId ) );
 
                 const fheroes2::Rect roi{ _restorer.rect() };
                 fheroes2::Blit( castleIcon, output, roi.x, roi.y + 4 );
 
-                fheroes2::Text text( getTownTitle( castleMetadata->customName, castleInfo.race, isTown, castleInfo.tileIndex, _mapWidth ),
+                fheroes2::Text text( getTownTitle( castleMetadata->customName, townInfo.race, isTown, townInfo.tileIndex, _mapWidth ),
                                      fheroes2::FontType::normalWhite() );
                 text.fitToOneRow( roi.width - castleIcon.width() - 5 );
                 text.drawInRoi( roi.x + castleIcon.width() + 5, roi.y + 12, output, roi );
@@ -1528,19 +1528,19 @@ namespace
                     }
                 }
 
-                const auto & castleInfo = _mapTownInfos[selectedTownIndex];
-                const auto & castleMetadata = castleInfo.castleMetadata;
+                const auto & townInfo = _mapTownInfos[selectedTownIndex];
+                const auto & castleMetadata = townInfo.castleMetadata;
                 const int townIcnId = _isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS;
 
                 const bool isTown
                     = std::find( castleMetadata->builtBuildings.begin(), castleMetadata->builtBuildings.end(), BUILD_CASTLE ) == castleMetadata->builtBuildings.end();
 
-                const fheroes2::Sprite castleIcon( getCastleIcon( isTown, castleInfo.race, castleInfo.color, townIcnId ) );
+                const fheroes2::Sprite castleIcon( getCastleIcon( isTown, townInfo.race, townInfo.color, townIcnId ) );
 
                 const fheroes2::Rect roi{ _restorer.rect() };
                 fheroes2::Blit( castleIcon, output, roi.x, roi.y + 4 );
 
-                fheroes2::Text text( getTownTitle( castleMetadata->customName, castleInfo.race, isTown, castleInfo.tileIndex, _mapWidth ),
+                fheroes2::Text text( getTownTitle( castleMetadata->customName, townInfo.race, isTown, townInfo.tileIndex, _mapWidth ),
                                      fheroes2::FontType::normalWhite() );
                 text.fitToOneRow( roi.width - castleIcon.width() - 5 );
                 text.draw( roi.x + castleIcon.width() + 5, roi.y + 12, output );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -947,26 +947,28 @@ namespace
 
                 _selectConditionRoi = { roi.x, roi.y + 4, townIcon.width() + 5 + text.width(), townIcon.height() };
 
+                if ( !_isNormalVictoryAllowed ) {
+                    _allowNormalVictory.hide();
+                }
+
                 _allowNormalVictoryRoi = Editor::drawCheckboxWithText( _allowNormalVictory, _( "Allow standard victory conditions" ), output, roi.x + 5,
                                                                        roi.y + _selectConditionRoi.height + 35, _isEvilInterface );
 
                 if ( _isNormalVictoryAllowed ) {
                     _allowNormalVictory.show();
                 }
-                else {
-                    _allowNormalVictory.hide();
-                }
 
                 // Allow "Allow this condition also for AI" setting only for neutral towns.
                 if ( _townToCapture[1] == Color::NONE ) {
+                    if ( !_isVictoryConditionApplicableForAI ) {
+                        _allowVictoryConditionForAI.hide();
+                    }
+
                     _allowVictoryConditionForAIRoi = Editor::drawCheckboxWithText( _allowVictoryConditionForAI, _( "Allow this condition also for AI" ), output,
                                                                                    roi.x + 5, roi.y + _selectConditionRoi.height + 10, _isEvilInterface );
 
                     if ( _isVictoryConditionApplicableForAI ) {
                         _allowVictoryConditionForAI.show();
-                    }
-                    else {
-                        _allowVictoryConditionForAI.hide();
                     }
                 }
 
@@ -1036,6 +1038,10 @@ namespace
 
                     fheroes2::Blit( artifactFrame, output, _selectConditionRoi.x, _selectConditionRoi.y );
 
+                    if ( !_isNormalVictoryAllowed ) {
+                        _allowNormalVictory.hide();
+                    }
+
                     _allowNormalVictoryRoi = Editor::drawCheckboxWithText( _allowNormalVictory, _( "Allow standard victory conditions" ), output, roi.x + 5,
                                                                            roi.y + _selectConditionRoi.height + 10, _isEvilInterface );
                 }
@@ -1064,6 +1070,13 @@ namespace
 
                     const fheroes2::Text text( _( "Gold:" ), fheroes2::FontType::normalWhite() );
                     text.draw( uiOffset.x - text.width() - 5, roi.y + ( valueSectionUiSize.height - text.height() ) / 2 + 2, output );
+
+                    if ( !_isVictoryConditionApplicableForAI ) {
+                        _allowVictoryConditionForAI.hide();
+                    }
+                    if ( !_isNormalVictoryAllowed ) {
+                        _allowNormalVictory.hide();
+                    }
 
                     _allowVictoryConditionForAIRoi = Editor::drawCheckboxWithText( _allowVictoryConditionForAI, _( "Allow this condition also for AI" ), output,
                                                                                    roi.x + 5, roi.y + valueSectionUiSize.height + 10, _isEvilInterface );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -1029,6 +1029,7 @@ namespace
             }
         }
 
+        // Returns true if rendering is required.
         bool processEvents()
         {
             switch ( _conditionType ) {
@@ -1073,12 +1074,10 @@ namespace
                         if ( townIndex != initiallySelectedTownIndex ) {
                             _townToCapture[0] = static_cast<uint32_t>( _mapTownInfos[townIndex].tileIndex );
                             _townToCapture[1] = static_cast<uint32_t>( _mapTownInfos[townIndex].color );
-
-                            return true;
                         }
                     }
 
-                    return false;
+                    return true;
                 }
 
                 if ( le.isMouseRightButtonPressedInArea( _selectConditionRoi ) ) {
@@ -1137,12 +1136,10 @@ namespace
                         if ( heroIndex != initiallySelectedHeroIndex ) {
                             _heroToKill[0] = static_cast<uint32_t>( _mapHeroInfos[heroIndex].tileIndex );
                             _heroToKill[1] = static_cast<uint32_t>( _mapHeroInfos[heroIndex].color );
-
-                            return true;
                         }
                     }
 
-                    return false;
+                    return true;
                 }
 
                 if ( le.isMouseRightButtonPressedInArea( _selectConditionRoi ) ) {
@@ -1561,6 +1558,7 @@ namespace
             }
         }
 
+        // Returns true if rendering is required.
         bool processEvents()
         {
             switch ( _conditionType ) {
@@ -1604,12 +1602,10 @@ namespace
                         if ( townIndex != initiallySelectedTownIndex ) {
                             _townToLose[0] = static_cast<uint32_t>( _mapTownInfos[townIndex].tileIndex );
                             _townToLose[1] = static_cast<uint32_t>( _mapTownInfos[townIndex].color );
-
-                            return true;
                         }
                     }
 
-                    return false;
+                    return true;
                 }
 
                 if ( le.isMouseRightButtonPressedInArea( _selectConditionRoi ) ) {
@@ -1655,12 +1651,10 @@ namespace
                         if ( heroIndex != initiallySelectedHeroIndex ) {
                             _heroToLose[0] = static_cast<uint32_t>( _mapHeroInfos[heroIndex].tileIndex );
                             _heroToLose[1] = static_cast<uint32_t>( _mapHeroInfos[heroIndex].color );
-
-                            return true;
                         }
                     }
 
-                    return false;
+                    return true;
                 }
 
                 if ( le.isMouseRightButtonPressedInArea( _selectConditionRoi ) ) {

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -673,10 +673,11 @@ namespace
     class VictoryConditionUI final
     {
     public:
-        VictoryConditionUI( fheroes2::Image & output, const fheroes2::Rect & roi, const Maps::Map_Format::MapFormat & mapFormat )
+        VictoryConditionUI( fheroes2::Image & output, const fheroes2::Rect & roi, const Maps::Map_Format::MapFormat & mapFormat, const bool isEvilInterface )
             : _conditionType( mapFormat.victoryConditionType )
             , _isNormalVictoryAllowed( mapFormat.allowNormalVictory )
             , _isVictoryConditionApplicableForAI( mapFormat.isVictoryConditionApplicableForAI )
+            , _isEvilInterface( isEvilInterface )
             , _mapWidth( mapFormat.size )
             , _restorer( output, roi.x, roi.y, roi.width, roi.height )
         {
@@ -1284,7 +1285,7 @@ namespace
         uint8_t _conditionType{ Maps::FileInfo::VICTORY_DEFEAT_EVERYONE };
         bool _isNormalVictoryAllowed{ false };
         bool _isVictoryConditionApplicableForAI{ false };
-        const bool _isEvilInterface{ Settings::Get().isEvilInterfaceEnabled() };
+        const bool _isEvilInterface{ false };
         uint32_t _victoryArtifactId{ ultimateArtifactId };
         const int32_t _mapWidth{ 0 };
         // Town or hero loss metadata include: X position, Y position, color.
@@ -1307,8 +1308,9 @@ namespace
     class LossConditionUI final
     {
     public:
-        LossConditionUI( fheroes2::Image & output, const fheroes2::Rect & roi, const Maps::Map_Format::MapFormat & mapFormat )
+        LossConditionUI( fheroes2::Image & output, const fheroes2::Rect & roi, const Maps::Map_Format::MapFormat & mapFormat, const bool isEvilInterface )
             : _conditionType( mapFormat.lossConditionType )
+            , _isEvilInterface( isEvilInterface )
             , _mapWidth( mapFormat.size )
             , _restorer( output, roi.x, roi.y, roi.width, roi.height )
         {
@@ -1753,7 +1755,7 @@ namespace
 
     private:
         uint8_t _conditionType{ Maps::FileInfo::LOSS_EVERYTHING };
-        const bool _isEvilInterface{ Settings::Get().isEvilInterfaceEnabled() };
+        const bool _isEvilInterface{ false };
         const int32_t _mapWidth{ 0 };
         std::array<uint32_t, 2> _heroToLose{ 0 };
         std::array<uint32_t, 2> _townToLose{ 0 };
@@ -2059,7 +2061,7 @@ namespace Editor
         offsetY += 30;
 
         const fheroes2::Rect victoryConditionUIRoi{ offsetX, offsetY, victoryDroplistButtonRoi.width, 150 };
-        VictoryConditionUI victoryConditionUI( display, victoryConditionUIRoi, mapFormat );
+        VictoryConditionUI victoryConditionUI( display, victoryConditionUIRoi, mapFormat, isEvilInterface );
 
         victoryConditionUI.render( display, true );
 
@@ -2083,7 +2085,7 @@ namespace Editor
         offsetY += 30;
 
         const fheroes2::Rect lossConditionUIRoi{ offsetX, offsetY, lossDroplistButtonRoi.width, 150 };
-        LossConditionUI lossConditionUI( display, lossConditionUIRoi, mapFormat );
+        LossConditionUI lossConditionUI( display, lossConditionUIRoi, mapFormat, isEvilInterface );
 
         lossConditionUI.render( display, true );
 

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -59,7 +59,6 @@
 #include "ui_text.h"
 #include "ui_tool.h"
 #include "ui_window.h"
-#include "world.h"
 
 namespace
 {
@@ -435,7 +434,7 @@ namespace
 
                     // Verify that this is a valid town.
                     const auto & towns = getMapTowns( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors );
-                    const int32_t townTileIndex = _townToCapture[0] + _townToCapture[1] * world.w();
+                    const int32_t townTileIndex = static_cast<int32_t>( _townToCapture[0] + _townToCapture[1] * static_cast<uint32_t>( mapFormat.size ) );
 
                     bool townFound = false;
                     for ( const auto & town : towns ) {
@@ -464,7 +463,7 @@ namespace
 
                     // Verify that this is a valid hero.
                     const auto & heroes = getMapHeroes( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors );
-                    const int32_t heroTileIndex = _heroToKill[0] + _heroToKill[1] * world.w();
+                    const int32_t heroTileIndex = static_cast<int32_t>( _heroToKill[0] + _heroToKill[1] * static_cast<uint32_t>( mapFormat.size ) );
                     bool heroFound = false;
                     for ( const auto & hero : heroes ) {
                         if ( heroTileIndex == hero.tileIndex && static_cast<int32_t>( _heroToKill[2] ) == hero.color ) {

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -116,7 +116,7 @@ namespace
                 }
 
                 const auto & metadata = heroObjects[object.index].metadata;
-                const int32_t color = Color::IndexToColor( 1 << metadata[0] );
+                const int32_t color = 1 << metadata[0];
 
                 if ( !( color & allowedColors ) ) {
                     // Current hero color is not allowed.

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -566,10 +566,9 @@ namespace
                     mapFormat.victoryConditionMetadata.resize( 1 );
                 }
 
-                mapFormat.isVictoryConditionApplicableForAI = false;
-
                 mapFormat.victoryConditionMetadata[0] = static_cast<uint32_t>( _goldAccumulationValue.getValue() );
                 mapFormat.allowNormalVictory = _isNormalVictoryAllowed;
+                mapFormat.isVictoryConditionApplicableForAI = _isVictoryConditionApplicableForAI;
 
                 return;
             default:
@@ -632,14 +631,14 @@ namespace
             case Maps::FileInfo::VICTORY_KILL_HERO: {
                 const fheroes2::Rect roi{ _restorer.rect() };
 
-                const fheroes2::Sprite & heroFrame = fheroes2::AGG::GetICN( ICN::HEROBKG, 0 );
+                const fheroes2::Sprite & heroFrame = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
 
-                const int32_t heroFrameWidth = 107;
-                const int32_t heroFrameHeight = 99;
+                const int32_t heroFrameWidth = 111;
+                const int32_t heroFrameHeight = 105;
 
                 _selectConditionRoi = { roi.x + ( roi.width - heroFrameWidth ) / 2, roi.y + 4, heroFrameWidth, heroFrameHeight };
 
-                fheroes2::Blit( heroFrame, 46, 28, output, _selectConditionRoi.x, _selectConditionRoi.y, heroFrameWidth, heroFrameHeight );
+                fheroes2::Blit( heroFrame, 88, 66, output, _selectConditionRoi.x, _selectConditionRoi.y, heroFrameWidth, heroFrameHeight );
 
                 break;
             }
@@ -681,8 +680,10 @@ namespace
                     const fheroes2::Text text( _( "Gold:" ), fheroes2::FontType::normalWhite() );
                     text.draw( uiOffset.x - text.width() - 5, roi.y + ( valueSectionUiSize.height - text.height() ) / 2 + 2, output );
 
+                    _allowVictoryConditionForAIRoi = Editor::drawCheckboxWithText( _allowVictoryConditionForAI, _( "Allow this condition also for AI" ), output,
+                                                                                   roi.x + 5, roi.y + valueSectionUiSize.height + 10, isEvilInterface );
                     _allowNormalVictoryRoi = Editor::drawCheckboxWithText( _allowNormalVictory, _( "Allow standard victory conditions" ), output, roi.x + 5,
-                                                                           roi.y + valueSectionUiSize.height + 10, isEvilInterface );
+                                                                           roi.y + valueSectionUiSize.height + 35, isEvilInterface );
                 }
 
                 _goldAccumulationValue.draw( output );
@@ -692,6 +693,13 @@ namespace
                 }
                 else {
                     _allowNormalVictory.hide();
+                }
+
+                if ( _isVictoryConditionApplicableForAI ) {
+                    _allowVictoryConditionForAI.show();
+                }
+                else {
+                    _allowVictoryConditionForAI.hide();
                 }
 
                 break;
@@ -757,18 +765,27 @@ namespace
 
                 break;
             }
-            case Maps::FileInfo::VICTORY_COLLECT_ENOUGH_GOLD:
+            case Maps::FileInfo::VICTORY_COLLECT_ENOUGH_GOLD: {
                 if ( _goldAccumulationValue.processEvents() ) {
                     return true;
                 }
 
-                if ( LocalEvent::Get().MouseClickLeft( _allowNormalVictoryRoi ) ) {
+                LocalEvent & le = LocalEvent::Get();
+
+                if ( le.MouseClickLeft( _allowNormalVictoryRoi ) ) {
                     _isNormalVictoryAllowed = !_isNormalVictoryAllowed;
 
                     return true;
                 }
 
+                if ( le.MouseClickLeft( _allowVictoryConditionForAIRoi ) ) {
+                    _isVictoryConditionApplicableForAI = !_isVictoryConditionApplicableForAI;
+
+                    return true;
+                }
+
                 break;
+            }
             default:
                 // Did you add more conditions? Add the logic for them!
                 assert( 0 );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -764,7 +764,7 @@ namespace
                 }
 
                 const auto & castleMetadata = _mapTownInfos[selectedTownIndex].castleMetadata;
-                const uint32_t townIcnId = _isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS;
+                const int townIcnId = _isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS;
 
                 fheroes2::Sprite castleIcon(
                     drawCastleIcon( castleMetadata->bannedBuildings, _mapTownInfos[selectedTownIndex].race, _mapTownInfos[selectedTownIndex].color, townIcnId ) );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -528,20 +528,58 @@ namespace
         bool updateCondition( Maps::Map_Format::MapFormat & mapFormat )
         {
             switch ( _conditionType ) {
-            case Maps::FileInfo::VICTORY_CAPTURE_TOWN:
-                if ( getMapTowns( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) ).empty() ) {
+            case Maps::FileInfo::VICTORY_CAPTURE_TOWN: {
+                const auto towns = getMapTowns( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) );
+                if ( towns.empty() ) {
                     // No towns exist for computer-only players.
                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     mapFormat.victoryConditionType = _conditionType;
                 }
-                return true;
-            case Maps::FileInfo::VICTORY_KILL_HERO:
-                if ( getMapHeroes( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) ).empty() ) {
+
+                const int32_t townTileIndex = static_cast<int32_t>( _townToCapture[0] );
+
+                bool townFound = false;
+                for ( const auto & town : towns ) {
+                    if ( townTileIndex == town.tileIndex && static_cast<int32_t>( _townToCapture[1] ) == town.color ) {
+                        townFound = true;
+                        break;
+                    }
+                }
+
+                if ( !townFound ) {
+                    // The town doesn't exist in the list.
+                    _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
+                    mapFormat.lossConditionType = _conditionType;
+                    return true;
+                }
+
+                return false;
+            }
+            case Maps::FileInfo::VICTORY_KILL_HERO: {
+                const auto heroes = getMapHeroes( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) );
+                if ( heroes.empty() ) {
                     // No heroes exist for computer-only players.
                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     mapFormat.victoryConditionType = _conditionType;
                 }
-                return true;
+
+                const int32_t heroTileIndex = static_cast<int32_t>( _heroToKill[0] );
+                bool heroFound = false;
+                for ( const auto & hero : heroes ) {
+                    if ( heroTileIndex == hero.tileIndex && static_cast<int32_t>( _heroToKill[1] ) == hero.color ) {
+                        heroFound = true;
+                        break;
+                    }
+                }
+
+                if ( !heroFound ) {
+                    // The hero doesn't exist in the list.
+                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
+                    mapFormat.victoryConditionType = _conditionType;
+                }
+
+                return false;
+            }
             default:
                 // No changes for other victory conditions.
                 break;
@@ -943,20 +981,59 @@ namespace
         bool updateCondition( Maps::Map_Format::MapFormat & mapFormat )
         {
             switch ( _conditionType ) {
-            case Maps::FileInfo::LOSS_TOWN:
-                if ( getMapTowns( mapFormat, mapFormat.humanPlayerColors ).empty() ) {
+            case Maps::FileInfo::LOSS_TOWN: {
+                const auto towns = getMapTowns( mapFormat, mapFormat.humanPlayerColors );
+                if ( towns.empty() ) {
                     // No towns exist for human-only players.
                     _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
                     mapFormat.lossConditionType = _conditionType;
+                    return true;
                 }
-                return true;
-            case Maps::FileInfo::LOSS_HERO:
-                if ( getMapHeroes( mapFormat, mapFormat.humanPlayerColors ).empty() ) {
+
+                const int32_t townTileIndex = static_cast<int32_t>( _townToLose[0] );
+
+                bool townFound = false;
+                for ( const auto & town : towns ) {
+                    if ( townTileIndex == town.tileIndex && static_cast<int32_t>( _townToLose[1] ) == town.color ) {
+                        townFound = true;
+                        break;
+                    }
+                }
+
+                if ( !townFound ) {
+                    // The town doesn't exist in the list.
+                    _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
+                    mapFormat.lossConditionType = _conditionType;
+                    return true;
+                }
+
+                break;
+            }
+            case Maps::FileInfo::LOSS_HERO: {
+                const auto heroes = getMapHeroes( mapFormat, mapFormat.humanPlayerColors );
+                if ( heroes.empty() ) {
                     // No heroes exist for human-only players.
                     _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
                     mapFormat.lossConditionType = _conditionType;
                 }
-                return true;
+
+                const int32_t heroTileIndex = static_cast<int32_t>( _heroToLose[0] );
+                bool heroFound = false;
+                for ( const auto & hero : heroes ) {
+                    if ( heroTileIndex == hero.tileIndex && static_cast<int32_t>( _heroToLose[1] ) == hero.color ) {
+                        heroFound = true;
+                        break;
+                    }
+                }
+
+                if ( !heroFound ) {
+                    // The hero doesn't exist in the list.
+                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
+                    mapFormat.victoryConditionType = _conditionType;
+                }
+
+                return false;
+            }
             default:
                 // No changes for other loss conditions.
                 break;

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -52,11 +52,13 @@
 #include "map_object_info.h"
 #include "maps_fileinfo.h"
 #include "math_base.h"
+#include "race.h"
 #include "screen.h"
 #include "settings.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_button.h"
+#include "ui_castle.h"
 #include "ui_dialog.h"
 #include "ui_text.h"
 #include "ui_tool.h"
@@ -95,8 +97,23 @@ namespace
     {
         int32_t tileIndex{ -1 };
         int32_t color{ Color::NONE };
+        int32_t race{ Race::NONE };
         const Maps::Map_Format::CastleMetadata * castleMetadata{ nullptr };
     };
+
+    fheroes2::Sprite drawCastleIcon( const std::vector<uint32_t> & bannedBuildings, const int32_t race, const int townIcnId )
+    {
+        fheroes2::Sprite castleIcon( fheroes2::AGG::GetICN( townIcnId, 23 ) );
+
+        const bool isCastle = std::find( bannedBuildings.begin(), bannedBuildings.end(), BUILD_CASTLE ) == bannedBuildings.end();
+
+        const uint32_t icnIndex = fheroes2::getCastleIcnIndex( race, isCastle );
+
+        const fheroes2::Sprite & castleImage = fheroes2::AGG::GetICN( townIcnId, icnIndex );
+        Copy( castleImage, 0, 0, castleIcon, 4, 4, castleImage.width(), castleImage.height() );
+
+        return castleIcon;
+    }
 
     std::vector<HeroInfo> getMapHeroes( const Maps::Map_Format::MapFormat & map, const int32_t allowedColors )
     {
@@ -179,6 +196,7 @@ namespace
 
                 townInfo.tileIndex = static_cast<int32_t>( tileIndex );
                 townInfo.color = color;
+                townInfo.race = Race::IndexToRace( static_cast<int>( townObjects[object.index].metadata[0] ) );
 
                 const auto castleMetadataIter = map.castleMetadata.find( object.id );
                 assert( castleMetadataIter != map.castleMetadata.end() );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -34,6 +34,7 @@
 
 #include "agg_image.h"
 #include "artifact.h"
+#include "castle.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -972,7 +972,7 @@ namespace
                 }
 
                 break;
-            case Maps::FileInfo::VICTORY_KILL_HERO: {
+            case Maps::FileInfo::LOSS_HERO: {
                 const fheroes2::Rect roi{ _restorer.rect() };
 
                 const fheroes2::Sprite & heroFrame = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
@@ -1027,9 +1027,9 @@ namespace
                 // No events to process.
 
                 return false;
-            case Maps::FileInfo::VICTORY_CAPTURE_TOWN:
+            case Maps::FileInfo::LOSS_TOWN:
                 break;
-            case Maps::FileInfo::VICTORY_KILL_HERO:
+            case Maps::FileInfo::LOSS_HERO:
                 break;
             case Maps::FileInfo::LOSS_OUT_OF_TIME:
                 return _outOfTimeValue.processEvents();

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -242,7 +242,7 @@ namespace
             break;
         }
 
-        return {};
+        return nullptr;
     }
 
     uint32_t getLossIcnIndex( const uint8_t lossConditionType )

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -1129,7 +1129,7 @@ namespace
                         = std::max( 100 + SelectMapCastle::itemsOffsetY * static_cast<int32_t>( _mapTownInfos.size() ), 100 + SelectMapCastle::itemsOffsetY * 5 );
                     const int32_t totalHeight = std::min( itemsHeight, maxHeight );
 
-                    SelectMapCastle listbox( { 450, totalHeight }, _( "Select a Town to capture for victory" ), {}, _mapWidth, _mapTownInfos, _isEvilInterface );
+                    SelectMapCastle listbox( { 450, totalHeight }, _( "Select a Town to capture to achieve victory" ), {}, _mapWidth, _mapTownInfos, _isEvilInterface );
 
                     std::vector<int> townIndicies( _mapTownInfos.size() );
                     std::iota( townIndicies.begin(), townIndicies.end(), 0 );
@@ -1162,7 +1162,7 @@ namespace
                 }
 
                 if ( le.isMouseRightButtonPressedInArea( _selectConditionRoi ) ) {
-                    fheroes2::showStandardTextMessage( _( "Special Victory Condition" ), _( "Click here to change the town needed to capture for the victory." ),
+                    fheroes2::showStandardTextMessage( _( "Special Victory Condition" ), _( "Click here to change the town needed to capture to achieve victory." ),
                                                        Dialog::ZERO );
                     return false;
                 }
@@ -1192,7 +1192,7 @@ namespace
                         = std::max( 100 + SelectMapCastle::itemsOffsetY * static_cast<int32_t>( _mapHeroInfos.size() ), 100 + SelectMapCastle::itemsOffsetY * 5 );
                     const int32_t totalHeight = std::min( itemsHeight, maxHeight );
 
-                    SelectMapHero listbox( { 450, totalHeight }, _( "Select a Hero to kill for victory" ), {}, _mapWidth, _mapHeroInfos, _isEvilInterface );
+                    SelectMapHero listbox( { 450, totalHeight }, _( "Select a Hero to defeat to achieve victory" ), {}, _mapWidth, _mapHeroInfos, _isEvilInterface );
 
                     std::vector<int> heroIndicies( _mapHeroInfos.size() );
                     std::iota( heroIndicies.begin(), heroIndicies.end(), 0 );
@@ -1224,7 +1224,7 @@ namespace
                 }
 
                 if ( le.isMouseRightButtonPressedInArea( _selectConditionRoi ) ) {
-                    fheroes2::showStandardTextMessage( _( "Special Victory Condition" ), _( "Click here to change the hero needed to kill for the victory." ),
+                    fheroes2::showStandardTextMessage( _( "Special Victory Condition" ), _( "Click here to change the hero needed to defeat to achieve victory." ),
                                                        Dialog::ZERO );
                     return false;
                 }
@@ -1662,7 +1662,7 @@ namespace
                         = std::max( 100 + SelectMapCastle::itemsOffsetY * static_cast<int32_t>( _mapTownInfos.size() ), 100 + SelectMapCastle::itemsOffsetY * 5 );
                     const int32_t totalHeight = std::min( itemsHeight, maxHeight );
 
-                    SelectMapCastle listbox( { 450, totalHeight }, _( "Select a Town to lose for defeat" ), {}, _mapWidth, _mapTownInfos, _isEvilInterface );
+                    SelectMapCastle listbox( { 450, totalHeight }, _( "Select a Town to lose to suffer defeat" ), {}, _mapWidth, _mapTownInfos, _isEvilInterface );
 
                     std::vector<int> townIndicies( _mapTownInfos.size() );
                     std::iota( townIndicies.begin(), townIndicies.end(), 0 );
@@ -1711,7 +1711,7 @@ namespace
                         = std::max( 100 + SelectMapCastle::itemsOffsetY * static_cast<int32_t>( _mapHeroInfos.size() ), 100 + SelectMapCastle::itemsOffsetY * 5 );
                     const int32_t totalHeight = std::min( itemsHeight, maxHeight );
 
-                    SelectMapHero listbox( { 450, totalHeight }, _( "Select a Hero to lose for defeat" ), {}, _mapWidth, _mapHeroInfos, _isEvilInterface );
+                    SelectMapHero listbox( { 450, totalHeight }, _( "Select a Hero to lose to suffer defeat" ), {}, _mapWidth, _mapHeroInfos, _isEvilInterface );
 
                     std::vector<int> heroIndicies( _mapHeroInfos.size() );
                     std::iota( heroIndicies.begin(), heroIndicies.end(), 0 );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -445,7 +445,7 @@ namespace
                 if ( mapFormat.victoryConditionMetadata.size() == 2 ) {
                     std::copy( mapFormat.victoryConditionMetadata.begin(), mapFormat.victoryConditionMetadata.end(), _townToCapture.begin() );
 
-                    // Verify that this is a valid town.
+                    // Verify that this is a valid computer-only town.
                     const auto & towns = getMapTowns( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) );
                     const int32_t townTileIndex = static_cast<int32_t>( _townToCapture[0] );
 
@@ -474,7 +474,7 @@ namespace
                 if ( mapFormat.victoryConditionMetadata.size() == 2 ) {
                     std::copy( mapFormat.victoryConditionMetadata.begin(), mapFormat.victoryConditionMetadata.end(), _heroToKill.begin() );
 
-                    // Verify that this is a valid hero.
+                    // Verify that this is a valid computer-only hero.
                     const auto & heroes = getMapHeroes( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) );
                     const int32_t heroTileIndex = static_cast<int32_t>( _heroToKill[0] );
                     bool heroFound = false;
@@ -530,14 +530,14 @@ namespace
             switch ( _conditionType ) {
             case Maps::FileInfo::VICTORY_CAPTURE_TOWN:
                 if ( getMapTowns( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) ).empty() ) {
-                    // No towns exist for only-computer players.
+                    // No towns exist for computer-only players.
                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     mapFormat.victoryConditionType = _conditionType;
                 }
                 return true;
             case Maps::FileInfo::VICTORY_KILL_HERO:
                 if ( getMapHeroes( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) ).empty() ) {
-                    // No heroes exist for only-computer players.
+                    // No heroes exist for computer-only players.
                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     mapFormat.victoryConditionType = _conditionType;
                 }
@@ -868,7 +868,7 @@ namespace
                 if ( mapFormat.victoryConditionMetadata.size() == 2 ) {
                     std::copy( mapFormat.victoryConditionMetadata.begin(), mapFormat.victoryConditionMetadata.end(), _townToLose.begin() );
 
-                    // Verify that this is a valid town.
+                    // Verify that this is a valid human-only town.
                     const auto & towns = getMapTowns( mapFormat, mapFormat.humanPlayerColors );
                     const int32_t townTileIndex = static_cast<int32_t>( _townToLose[0] );
 
@@ -897,7 +897,7 @@ namespace
                 if ( mapFormat.victoryConditionMetadata.size() == 2 ) {
                     std::copy( mapFormat.victoryConditionMetadata.begin(), mapFormat.victoryConditionMetadata.end(), _heroToLose.begin() );
 
-                    // Verify that this is a valid hero.
+                    // Verify that this is a valid human-only hero.
                     const auto & heroes = getMapHeroes( mapFormat, mapFormat.humanPlayerColors );
                     const int32_t heroTileIndex = static_cast<int32_t>( _heroToLose[0] );
                     bool heroFound = false;
@@ -945,20 +945,20 @@ namespace
             switch ( _conditionType ) {
             case Maps::FileInfo::LOSS_TOWN:
                 if ( getMapTowns( mapFormat, mapFormat.humanPlayerColors ).empty() ) {
-                    // No towns exist for only-human players.
+                    // No towns exist for human-only players.
                     _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
                     mapFormat.lossConditionType = _conditionType;
                 }
                 return true;
             case Maps::FileInfo::LOSS_HERO:
                 if ( getMapHeroes( mapFormat, mapFormat.humanPlayerColors ).empty() ) {
-                    // No heroes exist for only-human players.
+                    // No heroes exist for human-only players.
                     _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
                     mapFormat.lossConditionType = _conditionType;
                 }
                 return true;
             default:
-                // No changes for other victory conditions.
+                // No changes for other loss conditions.
                 break;
             }
 

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -939,12 +939,14 @@ namespace
         if ( !isLossList ) {
             if ( getMapHeroes( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors ).empty() ) {
                 conditions.erase( std::remove_if( conditions.begin(), conditions.end(),
-                                                  []( const uint8_t condition ) { return condition == Maps::FileInfo::VICTORY_KILL_HERO; } ), conditions.end() );
+                                                  []( const uint8_t condition ) { return condition == Maps::FileInfo::VICTORY_KILL_HERO; } ),
+                                  conditions.end() );
             }
 
             if ( getMapTowns( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors ).empty() ) {
                 conditions.erase( std::remove_if( conditions.begin(), conditions.end(),
-                                                  []( const uint8_t condition ) { return condition == Maps::FileInfo::VICTORY_CAPTURE_TOWN; } ), conditions.end() );
+                                                  []( const uint8_t condition ) { return condition == Maps::FileInfo::VICTORY_CAPTURE_TOWN; } ),
+                                  conditions.end() );
             }
         }
 

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -1225,7 +1225,7 @@ namespace
                     std::copy( mapFormat.lossConditionMetadata.begin(), mapFormat.lossConditionMetadata.end(), _townToLose.begin() );
 
                     // Verify that this is a valid human-only town.
-                    _mapTownInfos = getMapTowns( mapFormat, mapFormat.humanPlayerColors, true );
+                    _mapTownInfos = getMapTowns( mapFormat, mapFormat.humanPlayerColors & ( ~mapFormat.computerPlayerColors ), true );
                     const int32_t townTileIndex = static_cast<int32_t>( _townToLose[0] );
 
                     bool townFound = false;
@@ -1254,7 +1254,7 @@ namespace
                     std::copy( mapFormat.lossConditionMetadata.begin(), mapFormat.lossConditionMetadata.end(), _heroToLose.begin() );
 
                     // Verify that this is a valid human-only hero.
-                    _mapHeroInfos = getMapHeroes( mapFormat, mapFormat.humanPlayerColors );
+                    _mapHeroInfos = getMapHeroes( mapFormat, mapFormat.humanPlayerColors & ( ~mapFormat.computerPlayerColors ) );
                     const int32_t heroTileIndex = static_cast<int32_t>( _heroToLose[0] );
                     bool heroFound = false;
                     for ( const auto & hero : _mapHeroInfos ) {
@@ -1300,7 +1300,7 @@ namespace
         {
             switch ( _conditionType ) {
             case Maps::FileInfo::LOSS_TOWN: {
-                _mapTownInfos = getMapTowns( mapFormat, mapFormat.humanPlayerColors, true );
+                _mapTownInfos = getMapTowns( mapFormat, mapFormat.humanPlayerColors & ( ~mapFormat.computerPlayerColors ), true );
                 if ( _mapTownInfos.empty() ) {
                     // No towns exist for human-only players.
                     _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
@@ -1329,7 +1329,7 @@ namespace
                 break;
             }
             case Maps::FileInfo::LOSS_HERO: {
-                _mapHeroInfos = getMapHeroes( mapFormat, mapFormat.humanPlayerColors );
+                _mapHeroInfos = getMapHeroes( mapFormat, mapFormat.humanPlayerColors & ( ~mapFormat.computerPlayerColors ) );
                 if ( _mapHeroInfos.empty() ) {
                     // No heroes exist for human-only players.
                     _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
@@ -1678,13 +1678,13 @@ namespace
 
         if ( isLossList ) {
             // Remove the conditions that have no selection among objects.
-            if ( getMapHeroes( mapFormat, mapFormat.humanPlayerColors ).empty() ) {
+            if ( getMapHeroes( mapFormat, mapFormat.humanPlayerColors & ( ~mapFormat.computerPlayerColors ) ).empty() ) {
                 conditions.erase( std::remove_if( conditions.begin(), conditions.end(),
                                                   []( const uint8_t condition ) { return condition == Maps::FileInfo::LOSS_HERO; } ),
                                   conditions.end() );
             }
 
-            if ( getMapTowns( mapFormat, mapFormat.humanPlayerColors, true ).empty() ) {
+            if ( getMapTowns( mapFormat, mapFormat.humanPlayerColors & ( ~mapFormat.computerPlayerColors ), true ).empty() ) {
                 conditions.erase( std::remove_if( conditions.begin(), conditions.end(),
                                                   []( const uint8_t condition ) { return condition == Maps::FileInfo::LOSS_TOWN; } ),
                                   conditions.end() );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -937,6 +937,7 @@ namespace
         assert( std::find( conditions.begin(), conditions.end(), selectedCondition ) != conditions.end() );
 
         if ( !isLossList ) {
+            // Remove the conditions that have no selection among objects.
             if ( getMapHeroes( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors ).empty() ) {
                 conditions.erase( std::remove_if( conditions.begin(), conditions.end(),
                                                   []( const uint8_t condition ) { return condition == Maps::FileInfo::VICTORY_KILL_HERO; } ),

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -189,13 +189,10 @@ namespace
         std::string title;
 
         if ( name.empty() ) {
-            title = _( "[%{pos}]: Random %{race} hero" );
-        }
-        else if ( race == Race::RAND ) {
-            title = _( "[%{pos}]: Random hero" );
+            title = _( "[%{pos}]: %{race} hero" );
         }
         else {
-            title = _( "[%{pos}]: %{name} the %{race}" );
+            title = _( "[%{pos}]: %{name}, %{race} hero" );
 
             StringReplace( title, "%{name}", name );
         }
@@ -213,18 +210,10 @@ namespace
 
         if ( name.empty() ) {
             if ( isTown ) {
-                title = _( "[%{pos}]: Random %{race} town" );
+                title = _( "[%{pos}]: %{race} town" );
             }
             else {
-                title = _( "[%{pos}]: Random %{race} castle" );
-            }
-        }
-        else if ( race == Race::RAND ) {
-            if ( isTown ) {
-                title = _( "[%{pos}]: Random town" );
-            }
-            else {
-                title = _( "[%{pos}]: Random castle" );
+                title = _( "[%{pos}]: %{race} castle" );
             }
         }
         else {

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -846,7 +846,9 @@ namespace
                 std::copy( _townToCapture.begin(), _townToCapture.end(), mapFormat.victoryConditionMetadata.begin() );
 
                 mapFormat.allowNormalVictory = _isNormalVictoryAllowed;
-                mapFormat.isVictoryConditionApplicableForAI = _isVictoryConditionApplicableForAI;
+
+                // For all non-neutral towns disable the "Allow this condition also for AI" setting.
+                mapFormat.isVictoryConditionApplicableForAI = ( _townToCapture[1] == Color::NONE ) ? _isVictoryConditionApplicableForAI : false;
 
                 return;
             case Maps::FileInfo::VICTORY_KILL_HERO:
@@ -945,8 +947,6 @@ namespace
 
                 _selectConditionRoi = { roi.x, roi.y + 4, townIcon.width() + 5 + text.width(), townIcon.height() };
 
-                _allowVictoryConditionForAIRoi = Editor::drawCheckboxWithText( _allowVictoryConditionForAI, _( "Allow this condition also for AI" ), output, roi.x + 5,
-                                                                               roi.y + _selectConditionRoi.height + 10, _isEvilInterface );
                 _allowNormalVictoryRoi = Editor::drawCheckboxWithText( _allowNormalVictory, _( "Allow standard victory conditions" ), output, roi.x + 5,
                                                                        roi.y + _selectConditionRoi.height + 35, _isEvilInterface );
 
@@ -957,11 +957,17 @@ namespace
                     _allowNormalVictory.hide();
                 }
 
-                if ( _isVictoryConditionApplicableForAI ) {
-                    _allowVictoryConditionForAI.show();
-                }
-                else {
-                    _allowVictoryConditionForAI.hide();
+                // Allow "Allow this condition also for AI" setting only for neutral towns.
+                if ( _townToCapture[1] == Color::NONE ) {
+                    _allowVictoryConditionForAIRoi = Editor::drawCheckboxWithText( _allowVictoryConditionForAI, _( "Allow this condition also for AI" ), output,
+                                                                                   roi.x + 5, roi.y + _selectConditionRoi.height + 10, _isEvilInterface );
+
+                    if ( _isVictoryConditionApplicableForAI ) {
+                        _allowVictoryConditionForAI.show();
+                    }
+                    else {
+                        _allowVictoryConditionForAI.hide();
+                    }
                 }
 
                 break;

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -842,7 +842,7 @@ namespace
                 const auto & castleMetadata = _mapTownInfos[selectedTownIndex].castleMetadata;
                 const int townIcnId = _isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS;
 
-                fheroes2::Sprite castleIcon(
+                const fheroes2::Sprite castleIcon(
                     drawCastleIcon( castleMetadata->bannedBuildings, _mapTownInfos[selectedTownIndex].race, _mapTownInfos[selectedTownIndex].color, townIcnId ) );
 
                 const fheroes2::Rect roi{ _restorer.rect() };
@@ -905,7 +905,7 @@ namespace
                 }
 
                 // To render hero icons we use castle flags and frame.
-                const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( _heroToKill[1] );
+                const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( static_cast<int>( _heroToKill[1] ) );
                 const fheroes2::Sprite & castleLeftFlag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex );
                 const fheroes2::Sprite & castleRightFlag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex + 1 );
                 Blit( castleLeftFlag, 0, 0, output, _selectConditionRoi.x - 21, _selectConditionRoi.y + 45, castleLeftFlag.width(), castleLeftFlag.height() );
@@ -924,7 +924,8 @@ namespace
                     fheroes2::renderHeroRacePortrait( heroMetadata->race, { _selectConditionRoi.x + 5, _selectConditionRoi.y + 6, 101, 93 }, output );
                 }
 
-                fheroes2::Text extraText( getObjectNameAndPositionText( heroMetadata->customName, _heroToKill[0], _mapWidth ), fheroes2::FontType::normalWhite() );
+                fheroes2::Text extraText( getObjectNameAndPositionText( heroMetadata->customName, static_cast<int32_t>( _heroToKill[0] ), _mapWidth ),
+                                          fheroes2::FontType::normalWhite() );
                 extraText.fitToOneRow( roi.width );
                 extraText.drawInRoi( roi.x, _selectConditionRoi.y + _selectConditionRoi.height + 5, roi.width, output, roi );
 
@@ -1437,7 +1438,7 @@ namespace
                 const auto & castleMetadata = _mapTownInfos[selectedTownIndex].castleMetadata;
                 const int townIcnId = _isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS;
 
-                fheroes2::Sprite castleIcon(
+                const fheroes2::Sprite castleIcon(
                     drawCastleIcon( castleMetadata->bannedBuildings, _mapTownInfos[selectedTownIndex].race, _mapTownInfos[selectedTownIndex].color, townIcnId ) );
 
                 const fheroes2::Rect roi{ _restorer.rect() };

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -161,7 +161,7 @@ namespace
         return castleIcon;
     }
 
-    fheroes2::Sprite getCastleIcon( const bool isTown, const int32_t race, const int32_t color, const int townIcnId )
+    fheroes2::Sprite getTownIcon( const bool isTown, const int32_t race, const int32_t color, const int townIcnId )
     {
         const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( color );
 
@@ -314,7 +314,7 @@ namespace
             const bool isTown
                 = std::find( castleMetadata->builtBuildings.begin(), castleMetadata->builtBuildings.end(), BUILD_CASTLE ) == castleMetadata->builtBuildings.end();
 
-            renderItem( getCastleIcon( isTown, townInfo.race, townInfo.color, _townIcnId ),
+            renderItem( getTownIcon( isTown, townInfo.race, townInfo.color, _townIcnId ),
                         getTownTitle( castleMetadata->customName, townInfo.race, isTown, townInfo.tileIndex, _mapWidth ), { dstx, dsty }, 45, 95, itemsOffsetY / 2,
                         current );
         }
@@ -944,17 +944,17 @@ namespace
                 const bool isTown
                     = std::find( castleMetadata->builtBuildings.begin(), castleMetadata->builtBuildings.end(), BUILD_CASTLE ) == castleMetadata->builtBuildings.end();
 
-                const fheroes2::Sprite castleIcon( getCastleIcon( isTown, townInfo.race, townInfo.color, townIcnId ) );
+                const fheroes2::Sprite townIcon( getTownIcon( isTown, townInfo.race, townInfo.color, townIcnId ) );
 
                 const fheroes2::Rect roi{ _restorer.rect() };
-                fheroes2::Blit( castleIcon, output, roi.x, roi.y + 4 );
+                fheroes2::Blit( townIcon, output, roi.x, roi.y + 4 );
 
                 fheroes2::Text text( getTownTitle( castleMetadata->customName, townInfo.race, isTown, townInfo.tileIndex, _mapWidth ),
                                      fheroes2::FontType::normalWhite() );
-                text.fitToOneRow( roi.width - castleIcon.width() - 5 );
-                text.drawInRoi( roi.x + castleIcon.width() + 5, roi.y + 12, output, roi );
+                text.fitToOneRow( roi.width - townIcon.width() - 5 );
+                text.drawInRoi( roi.x + townIcon.width() + 5, roi.y + 12, output, roi );
 
-                _selectConditionRoi = { roi.x, roi.y + 4, castleIcon.width() + 5 + text.width(), castleIcon.height() };
+                _selectConditionRoi = { roi.x, roi.y + 4, townIcon.width() + 5 + text.width(), townIcon.height() };
 
                 _allowVictoryConditionForAIRoi = Editor::drawCheckboxWithText( _allowVictoryConditionForAI, _( "Allow this condition also for AI" ), output, roi.x + 5,
                                                                                roi.y + _selectConditionRoi.height + 10, _isEvilInterface );
@@ -1541,17 +1541,17 @@ namespace
                 const bool isTown
                     = std::find( castleMetadata->builtBuildings.begin(), castleMetadata->builtBuildings.end(), BUILD_CASTLE ) == castleMetadata->builtBuildings.end();
 
-                const fheroes2::Sprite castleIcon( getCastleIcon( isTown, townInfo.race, townInfo.color, townIcnId ) );
+                const fheroes2::Sprite townIcon( getTownIcon( isTown, townInfo.race, townInfo.color, townIcnId ) );
 
                 const fheroes2::Rect roi{ _restorer.rect() };
-                fheroes2::Blit( castleIcon, output, roi.x, roi.y + 4 );
+                fheroes2::Blit( townIcon, output, roi.x, roi.y + 4 );
 
                 fheroes2::Text text( getTownTitle( castleMetadata->customName, townInfo.race, isTown, townInfo.tileIndex, _mapWidth ),
                                      fheroes2::FontType::normalWhite() );
-                text.fitToOneRow( roi.width - castleIcon.width() - 5 );
-                text.draw( roi.x + castleIcon.width() + 5, roi.y + 12, output );
+                text.fitToOneRow( roi.width - townIcon.width() - 5 );
+                text.draw( roi.x + townIcon.width() + 5, roi.y + 12, output );
 
-                _selectConditionRoi = { roi.x, roi.y + 4, castleIcon.width() + 5 + text.width(), castleIcon.height() };
+                _selectConditionRoi = { roi.x, roi.y + 4, townIcon.width() + 5 + text.width(), townIcon.height() };
 
                 break;
             }

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -125,9 +125,37 @@ namespace
         }
         else {
             // This is a hero with a random race dependent portrait. Render the default race portrait.
-            fheroes2::Image heroPortrait( 101, 93 );
-            fheroes2::renderHeroRacePortrait( race, { 0, 0, 101, 93 }, heroPortrait );
-            fheroes2::SubpixelResize( heroPortrait, 0, 0, 101, 93, castleIcon, castleLeftFlag.width() + 6, 4, 30, 22 );
+
+            uint32_t portraitIndex = 0;
+            switch ( race ) {
+            case Race::KNGT:
+                portraitIndex = 51;
+                break;
+            case Race::BARB:
+                portraitIndex = 52;
+                break;
+            case Race::SORC:
+                portraitIndex = 53;
+                break;
+            case Race::WRLK:
+                portraitIndex = 54;
+                break;
+            case Race::WZRD:
+                portraitIndex = 55;
+                break;
+            case Race::NECR:
+                portraitIndex = 56;
+                break;
+            case Race::RAND:
+                portraitIndex = 58;
+                break;
+            default:
+                // Have you added a new race? Correct the logic above!
+                assert( 0 );
+                break;
+            }
+
+            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::NGEXTRA, portraitIndex ), 17, 10, castleIcon, castleLeftFlag.width() + 6, 4, 30, 22 );
         }
 
         return castleIcon;

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -100,6 +100,11 @@ namespace
 
     std::vector<HeroInfo> getMapHeroes( const Maps::Map_Format::MapFormat & map, const int32_t allowedColors )
     {
+        if ( allowedColors == 0 ) {
+            // Nothing to do.
+            return {};
+        }
+
         const auto & heroObjects = Maps::getObjectsByGroup( Maps::ObjectGroup::KINGDOM_HEROES );
 
         std::vector<HeroInfo> heroInfos;
@@ -141,6 +146,11 @@ namespace
 
     std::vector<TownInfo> getMapTowns( const Maps::Map_Format::MapFormat & map, const int32_t allowedColors )
     {
+        if ( allowedColors == 0 ) {
+            // Nothing to do.
+            return {};
+        }
+
         const auto & townObjects = Maps::getObjectsByGroup( Maps::ObjectGroup::KINGDOM_TOWNS );
 
         std::vector<TownInfo> townInfos;
@@ -436,7 +446,7 @@ namespace
                     std::copy( mapFormat.victoryConditionMetadata.begin(), mapFormat.victoryConditionMetadata.end(), _townToCapture.begin() );
 
                     // Verify that this is a valid town.
-                    const auto & towns = getMapTowns( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors );
+                    const auto & towns = getMapTowns( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) );
                     const int32_t townTileIndex = static_cast<int32_t>( _townToCapture[0] );
 
                     bool townFound = false;
@@ -465,7 +475,7 @@ namespace
                     std::copy( mapFormat.victoryConditionMetadata.begin(), mapFormat.victoryConditionMetadata.end(), _heroToKill.begin() );
 
                     // Verify that this is a valid hero.
-                    const auto & heroes = getMapHeroes( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors );
+                    const auto & heroes = getMapHeroes( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) );
                     const int32_t heroTileIndex = static_cast<int32_t>( _heroToKill[0] );
                     bool heroFound = false;
                     for ( const auto & hero : heroes ) {
@@ -519,14 +529,14 @@ namespace
         {
             switch ( _conditionType ) {
             case Maps::FileInfo::VICTORY_CAPTURE_TOWN:
-                if ( getMapTowns( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors ).empty() ) {
+                if ( getMapTowns( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) ).empty() ) {
                     // No towns exist for only-computer players.
                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     mapFormat.victoryConditionType = _conditionType;
                 }
                 return true;
             case Maps::FileInfo::VICTORY_KILL_HERO:
-                if ( getMapHeroes( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors ).empty() ) {
+                if ( getMapHeroes( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) ).empty() ) {
                     // No heroes exist for only-computer players.
                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                     mapFormat.victoryConditionType = _conditionType;
@@ -1127,13 +1137,13 @@ namespace
         }
         else {
             // Remove the conditions that have no selection among objects.
-            if ( getMapHeroes( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors ).empty() ) {
+            if ( getMapHeroes( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) ).empty() ) {
                 conditions.erase( std::remove_if( conditions.begin(), conditions.end(),
                                                   []( const uint8_t condition ) { return condition == Maps::FileInfo::VICTORY_KILL_HERO; } ),
                                   conditions.end() );
             }
 
-            if ( getMapTowns( mapFormat, mapFormat.computerPlayerColors ^ mapFormat.humanPlayerColors ).empty() ) {
+            if ( getMapTowns( mapFormat, mapFormat.computerPlayerColors & ( ~mapFormat.humanPlayerColors ) ).empty() ) {
                 conditions.erase( std::remove_if( conditions.begin(), conditions.end(),
                                                   []( const uint8_t condition ) { return condition == Maps::FileInfo::VICTORY_CAPTURE_TOWN; } ),
                                   conditions.end() );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -198,7 +198,7 @@ namespace
             break;
         }
 
-        return {};
+        return nullptr;
     }
 
     uint32_t getVictoryIcnIndex( const uint8_t victoryConditionType )

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -858,11 +858,11 @@ namespace
 
                 assert( !_mapTownInfos.empty() );
 
-                int selectedTownIndex = 0;
+                size_t selectedTownIndex = 0;
                 for ( size_t i = 0; i < _mapTownInfos.size(); ++i ) {
                     if ( static_cast<int32_t>( _townToCapture[0] ) == _mapTownInfos[i].tileIndex
                          && static_cast<int32_t>( _townToCapture[1] ) == _mapTownInfos[i].color ) {
-                        selectedTownIndex = static_cast<int>( i );
+                        selectedTownIndex = i;
                         break;
                     }
                 }
@@ -924,10 +924,10 @@ namespace
 
                 assert( !_mapHeroInfos.empty() );
 
-                int selectedHeroIndex = 0;
+                size_t selectedHeroIndex = 0;
                 for ( size_t i = 0; i < _mapHeroInfos.size(); ++i ) {
                     if ( static_cast<int32_t>( _heroToKill[0] ) == _mapHeroInfos[i].tileIndex && static_cast<int32_t>( _heroToKill[1] ) == _mapHeroInfos[i].color ) {
-                        selectedHeroIndex = static_cast<int>( i );
+                        selectedHeroIndex = i;
                         break;
                     }
                 }
@@ -1455,10 +1455,10 @@ namespace
 
                 assert( !_mapTownInfos.empty() );
 
-                int selectedTownIndex = 0;
+                size_t selectedTownIndex = 0;
                 for ( size_t i = 0; i < _mapTownInfos.size(); ++i ) {
                     if ( static_cast<int32_t>( _townToLose[0] ) == _mapTownInfos[i].tileIndex && static_cast<int32_t>( _townToLose[1] ) == _mapTownInfos[i].color ) {
-                        selectedTownIndex = static_cast<int>( i );
+                        selectedTownIndex = i;
                         break;
                     }
                 }
@@ -1501,10 +1501,10 @@ namespace
 
                 assert( !_mapHeroInfos.empty() );
 
-                int selectedHeroIndex = 0;
+                size_t selectedHeroIndex = 0;
                 for ( size_t i = 0; i < _mapHeroInfos.size(); ++i ) {
                     if ( static_cast<int32_t>( _heroToLose[0] ) == _mapHeroInfos[i].tileIndex && static_cast<int32_t>( _heroToLose[1] ) == _mapHeroInfos[i].color ) {
-                        selectedHeroIndex = static_cast<int>( i );
+                        selectedHeroIndex = i;
                         break;
                     }
                 }

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -109,6 +109,7 @@ namespace
 
         std::vector<HeroInfo> heroInfos;
 
+        // TODO: cache all heroes once this dialog is open. No need to run through all objects every time.
         for ( size_t tileIndex = 0; tileIndex < map.tiles.size(); ++tileIndex ) {
             for ( const auto & object : map.tiles[tileIndex].objects ) {
                 if ( object.group != Maps::ObjectGroup::KINGDOM_HEROES ) {
@@ -155,6 +156,7 @@ namespace
 
         std::vector<TownInfo> townInfos;
 
+        // TODO: cache all towns once this dialog is open. No need to run through all objects every time.
         for ( size_t tileIndex = 0; tileIndex < map.tiles.size(); ++tileIndex ) {
             for ( const auto & object : map.tiles[tileIndex].objects ) {
                 if ( object.group != Maps::ObjectGroup::KINGDOM_TOWNS ) {

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -638,10 +638,10 @@ namespace
                     }
                 }
                 else {
-                    // Since the metadata in invalid we have 2 options:
+                    // Since the metadata is invalid we have 2 options:
                     // - fall back to normal victory condition as no town was set
-                    // - generate a list of towns and pick the one
-                    // For the simplicity we are choosing the first option for now.
+                    // - generate a list of towns and pick one
+                    // For simplicity we are choosing the first option for now.
                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                 }
 
@@ -666,10 +666,10 @@ namespace
                     }
                 }
                 else {
-                    // Since the metadata in invalid we have 2 options:
+                    // Since the metadata is invalid we have 2 options:
                     // - fall back to normal victory condition as no hero was set
-                    // - generate a list of heroes and pick the one
-                    // For the simplicity we are choosing the first option for now.
+                    // - generate a list of heroes and pick one
+                    // For simplicity we are choosing the first option for now.
                     _conditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
                 }
 
@@ -1269,10 +1269,10 @@ namespace
                     }
                 }
                 else {
-                    // Since the metadata in invalid we have 2 options:
+                    // Since the metadata is invalid we have 2 options:
                     // - fall back to normal loss condition as no town was set
-                    // - generate a list of towns and pick the one
-                    // For the simplicity we are choosing the first option for now.
+                    // - generate a list of towns and pick one
+                    // For simplicity we are choosing the first option for now.
                     _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
                 }
 
@@ -1297,10 +1297,10 @@ namespace
                     }
                 }
                 else {
-                    // Since the metadata in invalid we have 2 options:
+                    // Since the metadata is invalid we have 2 options:
                     // - fall back to normal loss condition as no hero was set
-                    // - generate a list of heroes and pick the one
-                    // For the simplicity we are choosing the first option for now.
+                    // - generate a list of heroes and pick one
+                    // For simplicity we are choosing the first option for now.
                     _conditionType = Maps::FileInfo::LOSS_EVERYTHING;
                 }
 

--- a/src/fheroes2/editor/editor_map_specs_window.h
+++ b/src/fheroes2/editor/editor_map_specs_window.h
@@ -20,9 +20,32 @@
 
 #pragma once
 
+#include <cstdint>
+
+#include "color.h"
+#include "race.h"
+
 namespace Maps::Map_Format
 {
     struct MapFormat;
+    struct HeroMetadata;
+    struct CastleMetadata;
+
+    struct HeroInfo
+    {
+        int32_t tileIndex{ -1 };
+        int32_t color{ Color::NONE };
+        const HeroMetadata * heroMetadata{ nullptr };
+    };
+
+    struct TownInfo
+    {
+        int32_t tileIndex{ -1 };
+        int32_t color{ Color::NONE };
+        int32_t race{ Race::NONE };
+        const CastleMetadata * castleMetadata{ nullptr };
+    };
+
 }
 
 namespace Editor

--- a/src/fheroes2/editor/editor_map_specs_window.h
+++ b/src/fheroes2/editor/editor_map_specs_window.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include <cstdint>
-
 namespace Maps::Map_Format
 {
     struct MapFormat;

--- a/src/fheroes2/editor/editor_map_specs_window.h
+++ b/src/fheroes2/editor/editor_map_specs_window.h
@@ -22,29 +22,9 @@
 
 #include <cstdint>
 
-#include "color.h"
-#include "race.h"
-
 namespace Maps::Map_Format
 {
     struct MapFormat;
-    struct HeroMetadata;
-    struct CastleMetadata;
-
-    struct HeroInfo
-    {
-        int32_t tileIndex{ -1 };
-        int32_t color{ Color::NONE };
-        const HeroMetadata * heroMetadata{ nullptr };
-    };
-
-    struct TownInfo
-    {
-        int32_t tileIndex{ -1 };
-        int32_t color{ Color::NONE };
-        int32_t race{ Race::NONE };
-        const CastleMetadata * castleMetadata{ nullptr };
-    };
 }
 
 namespace Editor

--- a/src/fheroes2/editor/editor_map_specs_window.h
+++ b/src/fheroes2/editor/editor_map_specs_window.h
@@ -45,7 +45,6 @@ namespace Maps::Map_Format
         int32_t race{ Race::NONE };
         const CastleMetadata * castleMetadata{ nullptr };
     };
-
 }
 
 namespace Editor

--- a/src/fheroes2/gui/ui_castle.cpp
+++ b/src/fheroes2/gui/ui_castle.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "ui_castle.h"
+
 #include <array>
 #include <cassert>
 #include <string>
@@ -33,7 +35,6 @@
 #include "resource.h"
 #include "screen.h"
 #include "settings.h"
-#include "ui_castle.h"
 #include "ui_text.h"
 
 namespace
@@ -166,44 +167,43 @@ namespace
 
 namespace fheroes2
 {
-    void drawCastleIcon( const Castle & castle, Image & output, const Point & offset )
+    uint32_t getCastleIcnIndex( const int race, const bool isCastle )
     {
-        uint32_t icnIndex = 1;
-
-        switch ( castle.GetRace() ) {
+        switch ( race ) {
         case Race::KNGT:
-            icnIndex = castle.isCastle() ? 9 : 15;
-            break;
+            return isCastle ? 9 : 15;
         case Race::BARB:
-            icnIndex = castle.isCastle() ? 10 : 16;
-            break;
+            return isCastle ? 10 : 16;
         case Race::SORC:
-            icnIndex = castle.isCastle() ? 11 : 17;
-            break;
+            return isCastle ? 11 : 17;
         case Race::WRLK:
-            icnIndex = castle.isCastle() ? 12 : 18;
-            break;
+            return isCastle ? 12 : 18;
         case Race::WZRD:
-            icnIndex = castle.isCastle() ? 13 : 19;
-            break;
+            return isCastle ? 13 : 19;
         case Race::NECR:
-            icnIndex = castle.isCastle() ? 14 : 20;
-            break;
+            return isCastle ? 14 : 20;
         default:
             assert( 0 );
             DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown race" )
         }
 
-        const Sprite & castleImage = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, icnIndex );
-        fheroes2::Blit( castleImage, output, offset.x, offset.y );
+        return 1;
+    }
+
+    void drawCastleIcon( const Castle & castle, Image & output, const Point & offset )
+    {
+        const uint32_t icnIndex = getCastleIcnIndex( castle.GetRace(), castle.isCastle() );
+
+        const Sprite & castleImage = AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, icnIndex );
+        Copy( castleImage, 0, 0, output, offset.x, offset.y, castleImage.width(), castleImage.height() );
 
         // Draw castle's marker.
         switch ( Castle::GetAllBuildingStatus( castle ) ) {
         case NOT_TODAY:
-            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CSLMARKER, 0 ), output, offset.x + 40, offset.y );
+            Blit( AGG::GetICN( ICN::CSLMARKER, 0 ), output, offset.x + 40, offset.y );
             break;
         case REQUIRES_BUILD:
-            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CSLMARKER, 1 ), output, offset.x + 40, offset.y );
+            Blit( AGG::GetICN( ICN::CSLMARKER, 1 ), output, offset.x + 40, offset.y );
             break;
         default:
             break;

--- a/src/fheroes2/gui/ui_castle.cpp
+++ b/src/fheroes2/gui/ui_castle.cpp
@@ -182,12 +182,42 @@ namespace fheroes2
             return isCastle ? 13 : 19;
         case Race::NECR:
             return isCastle ? 14 : 20;
+        case Race::RAND:
+            // It is used in Editor to select random castle as a victory/loss special condition.
+            return isCastle ? 25 : 26;
         default:
             assert( 0 );
             DEBUG_LOG( DBG_GAME, DBG_WARN, "unknown race" )
         }
 
         return 1;
+    }
+
+    uint32_t getCastleLeftFlagIcnIndex( const int color )
+    {
+        switch ( color ) {
+        case Color::BLUE:
+            return 0;
+        case Color::GREEN:
+            return 2;
+        case Color::RED:
+            return 4;
+            break;
+        case Color::YELLOW:
+            return 6;
+        case Color::ORANGE:
+            return 8;
+        case Color::PURPLE:
+            return 10;
+        case Color::NONE:
+            return 12;
+        default:
+            // Have you added a new player color? Update the logic above.
+            assert( 0 );
+            break;
+        }
+
+        return 0;
     }
 
     void drawCastleIcon( const Castle & castle, Image & output, const Point & offset )

--- a/src/fheroes2/gui/ui_castle.h
+++ b/src/fheroes2/gui/ui_castle.h
@@ -30,6 +30,8 @@ namespace fheroes2
 {
     class Image;
 
+    uint32_t getCastleIcnIndex( const int race, const bool isCastle );
+
     void drawCastleIcon( const Castle & castle, Image & output, const Point & offset );
 
     Rect drawResourcePanel( const Funds & kingdomTreasures, Image & output, const Point & offset );

--- a/src/fheroes2/gui/ui_castle.h
+++ b/src/fheroes2/gui/ui_castle.h
@@ -32,6 +32,8 @@ namespace fheroes2
 
     uint32_t getCastleIcnIndex( const int race, const bool isCastle );
 
+    uint32_t getCastleLeftFlagIcnIndex( const int color );
+
     void drawCastleIcon( const Castle & castle, Image & output, const Point & offset );
 
     Rect drawResourcePanel( const Funds & kingdomTreasures, Image & output, const Point & offset );

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -29,10 +29,14 @@
 #include <ctime>
 #include <utility>
 
+#include "agg_image.h"
 #include "cursor.h"
 #include "game_delays.h"
+#include "icn.h"
 #include "image_palette.h"
 #include "localevent.h"
+#include "pal.h"
+#include "race.h"
 #include "render_processor.h"
 #include "screen.h"
 #include "settings.h"
@@ -761,4 +765,54 @@ namespace fheroes2
 
         return true;
     }
+
+    void renderHeroRacePortrait( const int race, const fheroes2::Rect & portPos, fheroes2::Image & output )
+    {
+        fheroes2::Image racePortrait( portPos.width, portPos.height );
+
+        auto preparePortrait = [&racePortrait, &portPos]( const int icnId, const int bkgIndex, const bool applyRandomPalette ) {
+            fheroes2::SubpixelResize( fheroes2::AGG::GetICN( ICN::STRIP, bkgIndex ), racePortrait );
+            const fheroes2::Sprite & heroSprite = fheroes2::AGG::GetICN( icnId, 1 );
+            if ( applyRandomPalette ) {
+                fheroes2::Sprite tmp = heroSprite;
+                fheroes2::ApplyPalette( tmp, PAL::GetPalette( PAL::PaletteType::PURPLE ) );
+                fheroes2::Blit( tmp, 0, std::max( 0, tmp.height() - portPos.height ), racePortrait, ( portPos.width - tmp.width() ) / 2,
+                                std::max( 0, portPos.height - tmp.height() ), tmp.width(), portPos.height );
+            }
+            else {
+                fheroes2::Blit( heroSprite, 0, std::max( 0, heroSprite.height() - portPos.height ), racePortrait, ( portPos.width - heroSprite.width() ) / 2,
+                                std::max( 0, portPos.height - heroSprite.height() ), heroSprite.width(), portPos.height );
+            }
+        };
+
+        switch ( race ) {
+        case Race::KNGT:
+            preparePortrait( ICN::CMBTHROK, 4, false );
+            break;
+        case Race::BARB:
+            preparePortrait( ICN::CMBTHROB, 5, false );
+            break;
+        case Race::SORC:
+            preparePortrait( ICN::CMBTHROS, 6, false );
+            break;
+        case Race::WRLK:
+            preparePortrait( ICN::CMBTHROW, 7, false );
+            break;
+        case Race::WZRD:
+            preparePortrait( ICN::CMBTHROZ, 8, false );
+            break;
+        case Race::NECR:
+            preparePortrait( ICN::CMBTHRON, 9, false );
+            break;
+        case Race::RAND:
+            preparePortrait( ICN::CMBTHROW, 10, true );
+            break;
+        default:
+            // Have you added a new race? Correct the logic above!
+            assert( 0 );
+            break;
+        }
+        fheroes2::Copy( racePortrait, 0, 0, output, portPos );
+    }
+
 }

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -814,5 +814,4 @@ namespace fheroes2
         }
         fheroes2::Copy( racePortrait, 0, 0, output, portPos );
     }
-
 }

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -220,4 +220,7 @@ namespace fheroes2
     void InvertedShadow( Image & image, const Rect & roi, const Rect & excludedRoi, const uint8_t paletteId, const int32_t paletteCount );
 
     bool processIntegerValueTyping( const int32_t minimum, const int32_t maximum, int32_t & value );
+
+    // Render "hero on a horse" portrait dependent from hero race. Used in Editor.
+    void renderHeroRacePortrait( const int race, const fheroes2::Rect & portPos, fheroes2::Image & output );
 }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -21,7 +21,6 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include <algorithm>
 #include <cassert>
 #include <cstdint>
 #include <functional>

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -69,55 +69,6 @@ namespace
     const fheroes2::Size primarySkillIconSize{ 82, 93 };
     const uint32_t experienceMaxValue{ 2990600 };
     const uint32_t spellPointsMaxValue{ 999 };
-
-    void renderRacePortrait( const int race, const fheroes2::Rect & portPos, fheroes2::Image & output )
-    {
-        fheroes2::Image racePortrait( portPos.width, portPos.height );
-
-        auto preparePortrait = [&racePortrait, &portPos]( const int icnId, const int bkgIndex, const bool applyRandomPalette ) {
-            fheroes2::SubpixelResize( fheroes2::AGG::GetICN( ICN::STRIP, bkgIndex ), racePortrait );
-            const fheroes2::Sprite & heroSprite = fheroes2::AGG::GetICN( icnId, 1 );
-            if ( applyRandomPalette ) {
-                fheroes2::Sprite tmp = heroSprite;
-                fheroes2::ApplyPalette( tmp, PAL::GetPalette( PAL::PaletteType::PURPLE ) );
-                fheroes2::Blit( tmp, 0, std::max( 0, tmp.height() - portPos.height ), racePortrait, ( portPos.width - tmp.width() ) / 2,
-                                std::max( 0, portPos.height - tmp.height() ), tmp.width(), portPos.height );
-            }
-            else {
-                fheroes2::Blit( heroSprite, 0, std::max( 0, heroSprite.height() - portPos.height ), racePortrait, ( portPos.width - heroSprite.width() ) / 2,
-                                std::max( 0, portPos.height - heroSprite.height() ), heroSprite.width(), portPos.height );
-            }
-        };
-
-        switch ( race ) {
-        case Race::KNGT:
-            preparePortrait( ICN::CMBTHROK, 4, false );
-            break;
-        case Race::BARB:
-            preparePortrait( ICN::CMBTHROB, 5, false );
-            break;
-        case Race::SORC:
-            preparePortrait( ICN::CMBTHROS, 6, false );
-            break;
-        case Race::WRLK:
-            preparePortrait( ICN::CMBTHROW, 7, false );
-            break;
-        case Race::WZRD:
-            preparePortrait( ICN::CMBTHROZ, 8, false );
-            break;
-        case Race::NECR:
-            preparePortrait( ICN::CMBTHRON, 9, false );
-            break;
-        case Race::RAND:
-            preparePortrait( ICN::CMBTHROW, 10, true );
-            break;
-        default:
-            // Have you added a new race? Correct the logic above!
-            assert( 0 );
-            break;
-        }
-        fheroes2::Copy( racePortrait, 0, 0, output, portPos );
-    }
 }
 
 int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disableDismiss, const bool disableSwitch, const bool renderBackgroundDialog,
@@ -159,7 +110,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     // Hero portrait.
     const fheroes2::Rect portPos( dialogRoi.x + 49, dialogRoi.y + 31, 101, 93 );
     if ( isEditor && !isValidId( portrait ) ) {
-        renderRacePortrait( _race, portPos, display );
+        fheroes2::renderHeroRacePortrait( _race, portPos, display );
     }
     else {
         PortraitRedraw( portPos.x, portPos.y, PORT_BIG, display );
@@ -643,7 +594,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         else if ( le.isMouseRightButtonPressedInArea( portPos ) ) {
             if ( isEditor ) {
                 portrait = 0;
-                renderRacePortrait( _race, portPos, display );
+                fheroes2::renderHeroRacePortrait( _race, portPos, display );
                 needRedraw = true;
             }
             else {
@@ -701,7 +652,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
                     redrawRace( _race );
 
                     if ( portrait == 0 ) {
-                        renderRacePortrait( _race, portPos, display );
+                        fheroes2::renderHeroRacePortrait( _race, portPos, display );
                     }
 
                     if ( primarySkillsBar.isDefaultValues() ) {

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -472,20 +472,10 @@ namespace Maps
         // Update map format settings based on the gathered information.
         map.availablePlayerColors = 0;
         for ( size_t i = 0; i < mainColors; ++i ) {
-            if ( heroColorsPresent[i] || townColorsPresent[i] ) {
-                assert( heroRacesPresent[i] != 0 || townRacesPresent[i] != 0 );
+            map.playerRace[i] = ( heroRacesPresent[i] | townRacesPresent[i] );
 
+            if ( map.playerRace[i] != 0 ) {
                 map.availablePlayerColors += static_cast<uint8_t>( 1 << i );
-                map.playerRace[i] &= ( heroRacesPresent[i] | townRacesPresent[i] );
-
-                if ( map.playerRace[i] == 0 ) {
-                    map.playerRace[i] = ( heroRacesPresent[i] | townRacesPresent[i] );
-                }
-            }
-            else {
-                assert( heroRacesPresent[i] == 0 && townRacesPresent[i] == 0 );
-
-                map.playerRace[i] = 0;
             }
 
             // Only one race can be present.

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -625,7 +625,7 @@ namespace Maps
                         }
 
                         const uint32_t color = 1 << heroObjects[object.index].metadata[0];
-                        if ( color != map.victoryConditionMetadata[1] ) {
+                        if ( color != conditionMetadata[1] ) {
                             // Current hero color is incorrect.
                             continue;
                         }
@@ -650,14 +650,14 @@ namespace Maps
 
         switch ( map.victoryConditionType ) {
         case Maps::FileInfo::VICTORY_CAPTURE_TOWN:
-            if ( !checkSpecialCondition( map.victoryConditionMetadata, Maps::ObjectGroup::KINGDOM_TOWNS ) ) {
+            if ( ( map.victoryConditionMetadata.size() != 2 ) || !checkSpecialCondition( map.victoryConditionMetadata, Maps::ObjectGroup::KINGDOM_TOWNS ) ) {
                 map.victoryConditionMetadata.clear();
                 map.victoryConditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
             }
 
             break;
         case Maps::FileInfo::VICTORY_KILL_HERO:
-            if ( !checkSpecialCondition( map.victoryConditionMetadata, Maps::ObjectGroup::KINGDOM_HEROES ) ) {
+            if ( ( map.victoryConditionMetadata.size() != 2 ) || !checkSpecialCondition( map.victoryConditionMetadata, Maps::ObjectGroup::KINGDOM_HEROES ) ) {
                 map.victoryConditionMetadata.clear();
                 map.victoryConditionType = Maps::FileInfo::VICTORY_DEFEAT_EVERYONE;
             }
@@ -669,14 +669,14 @@ namespace Maps
 
         switch ( map.lossConditionType ) {
         case Maps::FileInfo::LOSS_TOWN:
-            if ( !checkSpecialCondition( map.lossConditionMetadata, Maps::ObjectGroup::KINGDOM_TOWNS ) ) {
+            if ( ( map.lossConditionMetadata.size() != 2 ) || !checkSpecialCondition( map.lossConditionMetadata, Maps::ObjectGroup::KINGDOM_TOWNS ) ) {
                 map.lossConditionMetadata.clear();
                 map.lossConditionType = Maps::FileInfo::LOSS_EVERYTHING;
             }
 
             break;
         case Maps::FileInfo::LOSS_HERO:
-            if ( !checkSpecialCondition( map.lossConditionMetadata, Maps::ObjectGroup::KINGDOM_HEROES ) ) {
+            if ( ( map.lossConditionMetadata.size() != 2 ) || !checkSpecialCondition( map.lossConditionMetadata, Maps::ObjectGroup::KINGDOM_HEROES ) ) {
                 map.lossConditionMetadata.clear();
                 map.lossConditionType = Maps::FileInfo::LOSS_EVERYTHING;
             }

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -600,7 +600,7 @@ namespace Maps
         auto checkSpecialCondition = [&map, &heroObjects]( const std::vector<uint32_t> & conditionMetadata, const ObjectGroup objectGroup ) {
             if ( conditionMetadata.size() == 2 ) {
                 // Verify that this is a valid town.
-                const int32_t tileIndex = conditionMetadata[0];
+                const uint32_t tileIndex = conditionMetadata[0];
 
                 bool objectFound = false;
                 for ( const auto & object : map.tiles[tileIndex].objects ) {

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -594,7 +594,7 @@ namespace Maps
             eventMetadata.computerPlayerColors = eventMetadata.computerPlayerColors & map.computerPlayerColors;
         }
 
-        // Check and update the special victory and loss conditions that depends on player objects.
+        // Check and update the special victory and loss conditions that depend on player objects.
 
         // Returns true if all is OK.
         auto checkSpecialCondition = [&map, &heroObjects]( const std::vector<uint32_t> & conditionMetadata, const ObjectGroup objectGroup ) {

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -668,14 +668,14 @@ namespace Maps
         }
 
         switch ( map.lossConditionType ) {
-        case Maps::FileInfo::VICTORY_CAPTURE_TOWN:
+        case Maps::FileInfo::LOSS_TOWN:
             if ( !checkSpecialCondition( map.lossConditionMetadata, Maps::ObjectGroup::KINGDOM_TOWNS ) ) {
                 map.lossConditionMetadata.clear();
                 map.lossConditionType = Maps::FileInfo::LOSS_EVERYTHING;
             }
 
             break;
-        case Maps::FileInfo::VICTORY_KILL_HERO:
+        case Maps::FileInfo::LOSS_HERO:
             if ( !checkSpecialCondition( map.lossConditionMetadata, Maps::ObjectGroup::KINGDOM_HEROES ) ) {
                 map.lossConditionMetadata.clear();
                 map.lossConditionType = Maps::FileInfo::LOSS_EVERYTHING;

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -607,7 +607,6 @@ namespace Maps
 
             assert( tileIndex < map.tiles.size() );
 
-            bool objectFound = false;
             for ( const auto & object : map.tiles[tileIndex].objects ) {
                 if ( object.group != objectGroup ) {
                     continue;
@@ -621,9 +620,7 @@ namespace Maps
                         continue;
                     }
 
-                    objectFound = true;
-
-                    break;
+                    return true;
                 }
                 case Maps::ObjectGroup::KINGDOM_HEROES: {
                     if ( object.index >= heroObjects.size() ) {
@@ -637,20 +634,16 @@ namespace Maps
                         continue;
                     }
 
-                    objectFound = true;
-
-                    break;
+                    return true;
                 }
                 default:
                     // Have you added a new object type for victory or loss conditions? Update the logic!
                     assert( 0 );
                     break;
                 }
-
-                break;
             }
 
-            return objectFound;
+            return false;
         };
 
         switch ( map.victoryConditionType ) {

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -597,7 +597,7 @@ namespace Maps
         // Check and update the special victory and loss conditions that depend on player objects.
 
         // Returns true if all is OK.
-        auto checkSpecialCondition = [&map, &heroObjects]( const std::vector<uint32_t> & conditionMetadata, const ObjectGroup objectGroup ) {
+        auto checkSpecialCondition = [&map, &heroObjects, &townObjects]( const std::vector<uint32_t> & conditionMetadata, const ObjectGroup objectGroup ) {
             if ( conditionMetadata.size() != 2 ) {
                 return false;
             }
@@ -614,6 +614,11 @@ namespace Maps
 
                 switch ( objectGroup ) {
                 case Maps::ObjectGroup::KINGDOM_TOWNS: {
+                    if ( object.index >= townObjects.size() ) {
+                        assert( 0 );
+                        continue;
+                    }
+
                     const uint32_t color = Color::IndexToColor( Maps::getTownColorIndex( map, tileIndex, object.id ) );
                     if ( color != conditionMetadata[1] ) {
                         // Current town color is incorrect.

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -254,6 +254,7 @@ namespace Maps::Map_Format
         uint8_t lossConditionType{ 0 };
         std::vector<uint32_t> lossConditionMetadata;
 
+        // The world width in tiles.
         int32_t size{ 0 };
 
         fheroes2::SupportedLanguage language{ fheroes2::SupportedLanguage::English };

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -254,7 +254,7 @@ namespace Maps::Map_Format
         uint8_t lossConditionType{ 0 };
         std::vector<uint32_t> lossConditionMetadata;
 
-        // The world width in tiles.
+        // The world width in tiles. It is equal to the world height since currently all maps are square maps.
         int32_t size{ 0 };
 
         fheroes2::SupportedLanguage language{ fheroes2::SupportedLanguage::English };

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -477,13 +477,12 @@ bool Maps::FileInfo::loadResurrectionMap( const Map_Format::BaseMapFormat & map,
     case VICTORY_CAPTURE_TOWN:
     case VICTORY_KILL_HERO:
         // Town or hero capture metadata must include the following:
-        // - X position of the object
-        // - Y position of the object
-        // - color of the object (the color is needed to modify the game for multi-player)
-        assert( map.victoryConditionMetadata.size() == 3 );
-        victoryConditionParams[0] = static_cast<uint16_t>( map.victoryConditionMetadata[0] );
-        victoryConditionParams[1] = static_cast<uint16_t>( map.victoryConditionMetadata[1] );
-        assert( ( map.victoryConditionMetadata[2] & map.availablePlayerColors ) == map.victoryConditionMetadata[2] );
+        // - tile index of the object
+        // - color of the object (the color is needed to modify the game for multi-player mode)
+        assert( map.victoryConditionMetadata.size() == 2 );
+        victoryConditionParams[0] = static_cast<uint16_t>( map.victoryConditionMetadata[0] / map.size );
+        victoryConditionParams[1] = static_cast<uint16_t>( map.victoryConditionMetadata[0] % map.size );
+        assert( ( map.victoryConditionMetadata[1] & map.availablePlayerColors ) == map.victoryConditionMetadata[1] );
         break;
     case VICTORY_OBTAIN_ARTIFACT:
         assert( map.victoryConditionMetadata.size() == 1 );

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -480,8 +480,8 @@ bool Maps::FileInfo::loadResurrectionMap( const Map_Format::BaseMapFormat & map,
         // - tile index of the object
         // - color of the object (the color is needed to modify the game for multi-player mode)
         assert( map.victoryConditionMetadata.size() == 2 );
-        victoryConditionParams[0] = static_cast<uint16_t>( map.victoryConditionMetadata[0] / map.size );
-        victoryConditionParams[1] = static_cast<uint16_t>( map.victoryConditionMetadata[0] % map.size );
+        victoryConditionParams[0] = static_cast<uint16_t>( map.victoryConditionMetadata[0] % map.size );
+        victoryConditionParams[1] = static_cast<uint16_t>( map.victoryConditionMetadata[0] / map.size );
         assert( ( map.victoryConditionMetadata[1] & map.availablePlayerColors ) == map.victoryConditionMetadata[1] );
         break;
     case VICTORY_OBTAIN_ARTIFACT:

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -446,13 +446,12 @@ bool Maps::FileInfo::loadResurrectionMap( const Map_Format::BaseMapFormat & map,
     case LOSS_TOWN:
     case LOSS_HERO:
         // Town or hero loss metadata must include the following:
-        // - X position of the object
-        // - Y position of the object
+        // - tile index of the object
         // - color of the object (the color is needed to modify the game for multi-player)
-        assert( map.lossConditionMetadata.size() == 3 );
-        lossConditionParams[0] = static_cast<uint16_t>( map.lossConditionMetadata[0] );
-        lossConditionParams[1] = static_cast<uint16_t>( map.lossConditionMetadata[1] );
-        assert( ( map.lossConditionMetadata[2] & map.humanPlayerColors ) == map.lossConditionMetadata[2] );
+        assert( map.lossConditionMetadata.size() == 2 );
+        lossConditionParams[0] = static_cast<uint16_t>( map.lossConditionMetadata[0] % map.size );
+        lossConditionParams[1] = static_cast<uint16_t>( map.lossConditionMetadata[0] / map.size );
+        assert( ( map.lossConditionMetadata[1] & map.humanPlayerColors ) == map.lossConditionMetadata[1] );
         break;
     case LOSS_OUT_OF_TIME:
         assert( map.lossConditionMetadata.size() == 1 );

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -720,7 +720,7 @@ bool World::loadResurrectionMap( const std::string & filename )
     std::set<uint32_t> adventureMapEventMetadataUIDs;
 #endif
 
-    std::set<fheroes2::Point> hiredHeroPos;
+    std::set<size_t> hiredHeroTileId;
 
     for ( size_t tileId = 0; tileId < map.tiles.size(); ++tileId ) {
         const auto & tile = map.tiles[tileId];
@@ -806,7 +806,7 @@ bool World::loadResurrectionMap( const std::string & filename )
 
                         hero->applyHeroMetadata( heroInfo, false, false );
 
-                        hiredHeroPos.emplace( static_cast<int32_t>( tileId ) % width, static_cast<int32_t>( tileId ) / width );
+                        hiredHeroTileId.emplace( tileId );
                     }
                     else {
                         VERBOSE_LOG( "A hero at position " << tileId << " with UID " << object.id << " failed to be hired." )
@@ -1078,31 +1078,33 @@ bool World::loadResurrectionMap( const std::string & filename )
 
     // Verify that a capture or loss object exists.
     if ( map.lossConditionType == Maps::FileInfo::LOSS_HERO ) {
-        auto iter = hiredHeroPos.find( { static_cast<int32_t>( map.lossConditionMetadata[0] ), static_cast<int32_t>( map.lossConditionMetadata[1] ) } );
-        if ( iter == hiredHeroPos.end() ) {
-            VERBOSE_LOG( "A hero at position [" << map.lossConditionMetadata[0] << ", " << map.lossConditionMetadata[1] << "] does not exist." )
+        auto iter = hiredHeroTileId.find( map.lossConditionMetadata[0] );
+        if ( iter == hiredHeroTileId.end() ) {
+            VERBOSE_LOG( "A hero at tile " << map.lossConditionMetadata[0] << " does not exist." )
             return false;
         }
     }
     else if ( map.lossConditionType == Maps::FileInfo::LOSS_TOWN ) {
-        const Castle * castle = vec_castles.Get( { static_cast<int32_t>( map.lossConditionMetadata[0] ), static_cast<int32_t>( map.lossConditionMetadata[1] ) } );
+        const Castle * castle = vec_castles.Get(
+            { static_cast<int32_t>( map.lossConditionMetadata[0] % map.size ), static_cast<int32_t>( map.lossConditionMetadata[0] / map.size ) } );
         if ( castle == nullptr ) {
-            VERBOSE_LOG( "A castle at position [" << map.lossConditionMetadata[0] << ", " << map.lossConditionMetadata[1] << "] does not exist." )
+            VERBOSE_LOG( "A castle at tile " << map.lossConditionMetadata[0] << " does not exist." )
             return false;
         }
     }
 
     if ( map.victoryConditionType == Maps::FileInfo::VICTORY_KILL_HERO ) {
-        auto iter = hiredHeroPos.find( { static_cast<int32_t>( map.victoryConditionMetadata[0] ), static_cast<int32_t>( map.victoryConditionMetadata[1] ) } );
-        if ( iter == hiredHeroPos.end() ) {
-            VERBOSE_LOG( "A hero at position [" << map.victoryConditionMetadata[0] << ", " << map.victoryConditionMetadata[1] << "] does not exist." )
+        auto iter = hiredHeroTileId.find( map.victoryConditionMetadata[0] );
+        if ( iter == hiredHeroTileId.end() ) {
+            VERBOSE_LOG( "A hero at tile " << map.victoryConditionMetadata[0] << " does not exist." )
             return false;
         }
     }
     else if ( map.victoryConditionType == Maps::FileInfo::VICTORY_CAPTURE_TOWN ) {
-        const Castle * castle = vec_castles.Get( { static_cast<int32_t>( map.victoryConditionMetadata[0] ), static_cast<int32_t>( map.victoryConditionMetadata[1] ) } );
+        const Castle * castle = vec_castles.Get(
+            { static_cast<int32_t>( map.victoryConditionMetadata[0] % map.size ), static_cast<int32_t>( map.victoryConditionMetadata[0] / map.size ) } );
         if ( castle == nullptr ) {
-            VERBOSE_LOG( "A castle at position [" << map.victoryConditionMetadata[0] << ", " << map.victoryConditionMetadata[1] << "] does not exist." )
+            VERBOSE_LOG( "A castle at tile " << map.victoryConditionMetadata[0] << " does not exist." )
             return false;
         }
     }

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -1085,8 +1085,8 @@ bool World::loadResurrectionMap( const std::string & filename )
         }
     }
     else if ( map.lossConditionType == Maps::FileInfo::LOSS_TOWN ) {
-        const Castle * castle = vec_castles.Get(
-            { static_cast<int32_t>( map.lossConditionMetadata[0] % map.size ), static_cast<int32_t>( map.lossConditionMetadata[0] / map.size ) } );
+        const Castle * castle
+            = vec_castles.Get( { static_cast<int32_t>( map.lossConditionMetadata[0] % map.size ), static_cast<int32_t>( map.lossConditionMetadata[0] / map.size ) } );
         if ( castle == nullptr ) {
             VERBOSE_LOG( "A castle at tile " << map.lossConditionMetadata[0] << " does not exist." )
             return false;


### PR DESCRIPTION
close https://github.com/ihhub/fheroes2/issues/8717

This PR adds ability to set in Editor the next special conditions:
- Capture a specific town.
- Defeat a specific hero.
- Lose a specific town.
- Lose a specific hero.

It adds functions to get a list of heroes or towns present on the map.
![изображение](https://github.com/ihhub/fheroes2/assets/113276641/4f48ce11-d07a-4628-a8b1-054b2ca77dd7)

![изображение](https://github.com/ihhub/fheroes2/assets/113276641/f18ad46f-1453-4a95-978e-4e00bd8ba119)

![изображение](https://github.com/ihhub/fheroes2/assets/113276641/5cf6e186-97a6-478d-b748-a717b57b8cea)
