### PR TITLE
Allow skipping docs installation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -135,12 +135,14 @@ if(NOT MACOS_APP_BUNDLE)
 		FILES_MATCHING
 		PATTERN *.h2d
 		)
-if(INSTALL_DOCS)
-	install(
-		FILES docs/README.txt LICENSE changelog.txt
-		DESTINATION ${CMAKE_INSTALL_DOCDIR}
-		)
-endif(INSTALL_DOCS)
+
+	if(INSTALL_DOCS)
+		install(
+			FILES docs/README.txt LICENSE changelog.txt
+			DESTINATION ${CMAKE_INSTALL_DOCDIR}
+			)
+	endif(INSTALL_DOCS)
+
 	if(GET_HOMM2_DEMO)
 		include(FetchContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 option(ENABLE_STRICT_COMPILATION "Enable strict compilation mode (turns warnings into errors)" OFF)
 option(ENABLE_IMAGE "Enable the use of SDL_image (requires libpng)" OFF)
 option(ENABLE_TOOLS "Enable the build of additional tools" OFF)
+option(INSTALL_DOCS "Install docs to the standard docdir" ON)
 
 # Available only on macOS
 cmake_dependent_option(MACOS_APP_BUNDLE "Create a Mac app bundle" OFF "APPLE" OFF)
@@ -134,11 +135,12 @@ if(NOT MACOS_APP_BUNDLE)
 		FILES_MATCHING
 		PATTERN *.h2d
 		)
+if(INSTALL_DOCS)
 	install(
 		FILES docs/README.txt LICENSE changelog.txt
 		DESTINATION ${CMAKE_INSTALL_DOCDIR}
 		)
-
+endif(INSTALL_DOCS)
 	if(GET_HOMM2_DEMO)
 		include(FetchContent)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2022 - 2023                                             #
+#   Copyright (C) 2022 - 2024                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #


### PR DESCRIPTION
Application packaging sometimes requires to list docs explicitly in a packaging' setup file and sometimes even package some of them (namely license file) separately. In this case an extra installation step becomes unnecessary. This patch allows packager to skip it.