### PR TITLE
Fix swap of the main tile addon if a top object already exists in that tile

### DIFF
--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -221,23 +221,24 @@ namespace Maps
 
     void writeTile( const Tiles & tile, Map_Format::TileInfo & info )
     {
-        std::deque<std::pair<uint32_t, uint8_t>> roadParts;
-        std::deque<std::pair<uint32_t, uint8_t>> streamParts;
+        // A tile cannot contain an exactly the same road or stream parts.
+        std::set<std::pair<uint32_t, uint8_t>> roadParts;
+        std::set<std::pair<uint32_t, uint8_t>> streamParts;
 
         const MP2::ObjectIcnType mainObjectIcnType = tile.getObjectIcnType();
         if ( mainObjectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
-            roadParts.emplace_back( tile.GetObjectUID(), tile.GetObjectSpriteIndex() );
+            roadParts.emplace( tile.GetObjectUID(), tile.GetObjectSpriteIndex() );
         }
         else if ( mainObjectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
-            streamParts.emplace_back( tile.GetObjectUID(), tile.GetObjectSpriteIndex() );
+            streamParts.emplace( tile.GetObjectUID(), tile.GetObjectSpriteIndex() );
         }
 
         for ( const auto & addon : tile.getBottomLayerAddons() ) {
             if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
-                roadParts.emplace_back( addon._uid, addon._imageIndex );
+                roadParts.emplace( addon._uid, addon._imageIndex );
             }
             else if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
-                streamParts.emplace_back( addon._uid, addon._imageIndex );
+                streamParts.emplace( addon._uid, addon._imageIndex );
             }
         }
 
@@ -251,9 +252,9 @@ namespace Maps
                     continue;
                 }
 
-                object.id = roadParts.front().first;
-                object.index = roadParts.front().second;
-                roadParts.pop_front();
+                object.id = roadParts.begin()->first;
+                object.index = roadParts.begin()->second;
+                roadParts.erase( roadParts.begin() );
             }
             else if ( object.group == ObjectGroup::STREAMS ) {
                 if ( streamParts.empty() ) {
@@ -262,9 +263,9 @@ namespace Maps
                     continue;
                 }
 
-                object.id = streamParts.front().first;
-                object.index = streamParts.front().second;
-                streamParts.pop_front();
+                object.id = streamParts.begin()->first;
+                object.index = streamParts.begin()->second;
+                streamParts.erase( streamParts.begin() );
             }
 
             ++objectIndex;

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -25,7 +25,6 @@
 #include <cassert>
 #include <cstddef>
 #include <cstdint>
-#include <deque>
 #include <list>
 #include <map>
 #include <memory>

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -270,11 +270,11 @@ namespace Maps
             ++objectIndex;
         }
 
-        for ( const auto [uid, index] : roadParts ) {
+        for ( const auto & [uid, index] : roadParts ) {
             addObjectToTile( info, ObjectGroup::ROADS, index, uid );
         }
 
-        for ( const auto [uid, index] : streamParts ) {
+        for ( const auto & [uid, index] : streamParts ) {
             addObjectToTile( info, ObjectGroup::STREAMS, index, uid );
         }
 

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -270,12 +270,12 @@ namespace Maps
             ++objectIndex;
         }
 
-        for ( const auto & part : roadParts ) {
-            addObjectToTile( info, ObjectGroup::ROADS, part.second, part.first );
+        for ( const auto [uid, index] : roadParts ) {
+            addObjectToTile( info, ObjectGroup::ROADS, index, uid );
         }
 
-        for ( const auto & part : streamParts ) {
-            addObjectToTile( info, ObjectGroup::STREAMS, part.second, part.first );
+        for ( const auto [uid, index] : streamParts ) {
+            addObjectToTile( info, ObjectGroup::STREAMS, index, uid );
         }
 
         info.terrainIndex = tile.getTerrainImageIndex();

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -225,27 +225,19 @@ namespace Maps
         std::deque<std::pair<uint32_t, uint8_t>> streamParts;
 
         const MP2::ObjectIcnType mainObjectIcnType = tile.getObjectIcnType();
-        if ( mainObjectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
-            if ( mainObjectIcnType == MP2::OBJ_ICN_TYPE_ROAD || mainObjectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
-                const bool isRoad = ( mainObjectIcnType == MP2::OBJ_ICN_TYPE_ROAD );
-                if ( isRoad ) {
-                    roadParts.emplace_back( tile.GetObjectUID(), tile.GetObjectSpriteIndex() );
-                }
-                else {
-                    streamParts.emplace_back( tile.GetObjectUID(), tile.GetObjectSpriteIndex() );
-                }
-            }
+        if ( mainObjectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
+            roadParts.emplace_back( tile.GetObjectUID(), tile.GetObjectSpriteIndex() );
+        }
+        else if ( mainObjectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
+            streamParts.emplace_back( tile.GetObjectUID(), tile.GetObjectSpriteIndex() );
         }
 
         for ( const auto & addon : tile.getBottomLayerAddons() ) {
-            if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD || addon._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
-                const bool isRoad = ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD );
-                if ( isRoad ) {
-                    roadParts.emplace_back( addon._uid, addon._imageIndex );
-                }
-                else {
-                    streamParts.emplace_back( addon._uid, addon._imageIndex );
-                }
+            if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
+                roadParts.emplace_back( addon._uid, addon._imageIndex );
+            }
+            else if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
+                streamParts.emplace_back( addon._uid, addon._imageIndex );
             }
         }
 

--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -4891,6 +4891,7 @@ namespace Maps
             }
         }
 
+        // TODO: check whether we need to add an assertion as we are hitting this code.
         return MP2::OBJ_NONE;
     }
 

--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -4876,10 +4876,17 @@ namespace Maps
         for ( const auto & group : objectData ) {
             for ( const auto & object : group ) {
                 assert( !object.groundLevelParts.empty() );
-                const auto & info = object.groundLevelParts.front();
 
-                if ( info.icnType == icnType && info.icnIndex == icnIndex ) {
-                    return info.objectType;
+                for ( const auto & info : object.groundLevelParts ) {
+                    if ( info.icnType == icnType && info.icnIndex == icnIndex ) {
+                        return info.objectType;
+                    }
+                }
+
+                for ( const auto & info : object.topLevelParts ) {
+                    if ( info.icnType == icnType && info.icnIndex == icnIndex ) {
+                        return info.objectType;
+                    }
                 }
             }
         }

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -295,6 +295,7 @@ namespace Maps
         {
             if ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
                 _addonBottomLayer.emplace_back( _mainAddon );
+                _mainAddon = {};
             }
         }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1250,6 +1250,9 @@ namespace
             // The first case if the existing tile has no object type being set.
             const MP2::MapObjectType tileObjectType = currentTile.GetObject();
 
+            // Always move the current object part to the back of the bottom layer list to make proper sorting later.
+            currentTile.moveMainAddonToBottomLayer();
+
             if ( tileObjectType == MP2::OBJ_NONE ) {
                 setObjectType = ( partInfo.objectType != MP2::OBJ_NONE );
             }
@@ -1286,9 +1289,6 @@ namespace
                     setObjectType = !higherObjectFound;
                 }
             }
-
-            // Always move the current object part to the back of the bottom layer list to make proper sorting later.
-            currentTile.moveMainAddonToBottomLayer();
 
             // Push the object to the ground (bottom) object parts.
             currentTile.pushBottomLayerAddon( Maps::TilesAddon( partInfo.layerType, uid, partInfo.icnType, static_cast<uint8_t>( partInfo.icnIndex ) ) );

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1272,8 +1272,13 @@ namespace
 
                     if ( !higherObjectFound ) {
                         for ( const auto & groundPart : currentTile.getBottomLayerAddons() ) {
+                            if ( groundPart._layerType >= partInfo.layerType ) {
+                                // A ground object part is has "lower" or equal layer type. Skip it.
+                                continue;
+                            }
+
                             const MP2::MapObjectType type = Maps::getObjectTypeByIcn( groundPart._objectIcnType, groundPart._imageIndex );
-                            if ( type != MP2::OBJ_NONE && groundPart._layerType < partInfo.layerType ) {
+                            if ( type != MP2::OBJ_NONE ) {
                                 // A ground object part is present and it has "higher" layer type.
                                 higherObjectFound = true;
                                 break;

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1298,6 +1298,14 @@ namespace
                 }
             }
 
+#if defined( WITH_DEBUG )
+            // Check that we don't put the same object part.
+            for ( const auto & groundPart : currentTile.getBottomLayerAddons() ) {
+                assert( groundPart._uid != uid || groundPart._imageIndex != static_cast<uint8_t>( partInfo.icnIndex ) || groundPart._objectIcnType != partInfo.icnType ||
+                        groundPart._layerType != partInfo.layerType );
+            }
+#endif
+
             // Push the object to the ground (bottom) object parts.
             currentTile.pushBottomLayerAddon( Maps::TilesAddon( partInfo.layerType, uid, partInfo.icnType, static_cast<uint8_t>( partInfo.icnIndex ) ) );
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1234,7 +1234,8 @@ namespace
 
             Maps::Tiles & currentTile = world.GetTiles( pos.x, pos.y );
 
-            if ( !isMainObject ) {
+            // Also do not move the main addon if a background layer object is placing over an object with ID.
+            if ( !isMainObject || ( partInfo.layerType == Maps::BACKGROUND_LAYER && currentTile.GetObjectUID() != 0 ) ) {
                 // Shadows and terrain object do not change main tile information.
                 currentTile.pushBottomLayerAddon( Maps::TilesAddon( partInfo.layerType, uid, partInfo.icnType, static_cast<uint8_t>( partInfo.icnIndex ) ) );
                 continue;

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1301,8 +1301,8 @@ namespace
 #if defined( WITH_DEBUG )
             // Check that we don't put the same object part.
             for ( const auto & groundPart : currentTile.getBottomLayerAddons() ) {
-                assert( groundPart._uid != uid || groundPart._imageIndex != static_cast<uint8_t>( partInfo.icnIndex ) || groundPart._objectIcnType != partInfo.icnType ||
-                        groundPart._layerType != partInfo.layerType );
+                assert( groundPart._uid != uid || groundPart._imageIndex != static_cast<uint8_t>( partInfo.icnIndex ) || groundPart._objectIcnType != partInfo.icnType
+                        || groundPart._layerType != partInfo.layerType );
             }
 #endif
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1228,11 +1228,6 @@ namespace
         const uint32_t uid = Maps::getNewObjectUID();
 
         for ( const auto & partInfo : info.groundLevelParts ) {
-            if ( partInfo.icnType == MP2::OBJ_ICN_TYPE_UNKNOWN ) {
-                // Ignore this object part as useless.
-                continue;
-            }
-
             const fheroes2::Point pos = mainTilePos + partInfo.tileOffset;
             if ( !Maps::isValidAbsPoint( pos.x, pos.y ) ) {
                 // Make sure that the above condition about object placement is correct.

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1234,8 +1234,10 @@ namespace
 
             Maps::Tiles & currentTile = world.GetTiles( pos.x, pos.y );
 
-            // Also do not move the main addon if a background layer object is placing over an object with ID.
-            if ( !isMainObject || ( partInfo.layerType == Maps::BACKGROUND_LAYER && currentTile.GetObjectUID() != 0 ) ) {
+            // Also do not move the main addon if a BACKGROUND_LAYER object is being placed over an OBJECT_LAYER object.
+            const bool keepMainAddon = ( partInfo.layerType == Maps::BACKGROUND_LAYER ) && ( currentTile.getLayerType() == Maps::OBJECT_LAYER );
+
+            if ( !isMainObject || keepMainAddon ) {
                 // Shadows and terrain object do not change main tile information.
                 currentTile.pushBottomLayerAddon( Maps::TilesAddon( partInfo.layerType, uid, partInfo.icnType, static_cast<uint8_t>( partInfo.icnIndex ) ) );
                 continue;
@@ -1245,10 +1247,14 @@ namespace
             assert( partInfo.objectType != MP2::OBJ_NONE );
 
             bool setObjectType = true;
+            // Action objects should be always placed to the main addon.
             if ( !MP2::isOffGameActionObject( partInfo.objectType ) ) {
+                const MP2::MapObjectType mainType = currentTile.GetObject();
+
+                // If any of top layer addons have the same type as the main addon then keep the main addon object type.
                 for ( const auto & addon : currentTile.getTopLayerAddons() ) {
                     const MP2::MapObjectType type = Maps::getObjectTypeByIcn( addon._objectIcnType, addon._imageIndex );
-                    if ( type != MP2::OBJ_NONE ) {
+                    if ( type == mainType ) {
                         setObjectType = false;
                         break;
                     }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -860,11 +860,19 @@ namespace
     {
         // To place some roads we need to check not only the road directions around this tile, but also the road ICN index at the nearby tile.
         auto checkRoadIcnIndex = []( const int32_t tileIndex, const std::vector<uint8_t> & roadIcnIndexes ) {
-            for ( const Maps::TilesAddon & addon : world.GetTiles( tileIndex ).getBottomLayerAddons() ) {
+            const Maps::Tiles & currentTile = world.GetTiles( tileIndex );
+
+            if ( currentTile.getObjectIcnType() == MP2::OBJ_ICN_TYPE_ROAD ) {
+                return std::any_of( roadIcnIndexes.begin(), roadIcnIndexes.end(),
+                                    [&currentTile]( const uint8_t index ) { return currentTile.GetObjectSpriteIndex() == index; } );
+            }
+
+            for ( const Maps::TilesAddon & addon : currentTile.getBottomLayerAddons() ) {
                 if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
                     return std::any_of( roadIcnIndexes.begin(), roadIcnIndexes.end(), [&addon]( const uint8_t index ) { return addon._imageIndex == index; } );
                 }
             }
+
             return false;
         };
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1258,7 +1258,8 @@ namespace
                     // Since this is an action object we must enforce setting its type.
                     setObjectType = true;
                 }
-                else {
+                else if ( !MP2::isOffGameActionObject( tileObjectType ) ) {
+                    // The current tile does not have an action object.
                     // We need to run through each object part present at the tile and see if it has "higher" layer object.
                     bool higherObjectFound = false;
 


### PR DESCRIPTION
The objects order on the same tile is determined by the current main addon object type (checked by `getObjectTypeByIcn()` function) and the layer type of the new tile being placed.

This PR fixes the `getObjectTypeByIcn()` function that was giving object type only for the main tile and giving `OBJ_NONE` for all other tiles. Now the function checks all object tiles.

It also forbids main addon swap if a new tile is the background layer one and the current tile already has an object with ID.

Master build:

https://github.com/ihhub/fheroes2/assets/113276641/140d8fac-6d5b-491a-af13-e3186577a294

This PR:

https://github.com/ihhub/fheroes2/assets/113276641/d3e15a10-bc20-41ca-b2ec-d9c4db49130f

