### PR TITLE
Use showStandardTextMessage() instead of showMessage() where possible and reduce string copying by using std::move()

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3021,8 +3021,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
                 listlog->SetOpenLog( !listlog->isOpenLog() );
             }
             else if ( le.isMouseRightButtonPressedInArea( status ) ) {
-                fheroes2::showMessage( fheroes2::Text( _( "Message Bar" ), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( "Shows the results of individual monster's actions." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Message Bar" ), _( "Shows the results of individual monster's actions." ), Dialog::ZERO );
             }
         }
 
@@ -3175,9 +3174,7 @@ void Battle::Interface::EventStartAutoBattle( const Unit & unit, Actions & actio
     assert( arena.CanToggleAutoBattle() );
     assert( !arena.AutoBattleInProgress() );
 
-    int startAutoBattle
-        = fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "Are you sure you want to enable auto combat?" ), fheroes2::FontType::normalWhite() ),
-                                 Dialog::YES | Dialog::NO );
+    int startAutoBattle = fheroes2::showStandardTextMessage( {}, _( "Are you sure you want to enable auto combat?" ), Dialog::YES | Dialog::NO );
     if ( startAutoBattle != Dialog::YES ) {
         return;
     }
@@ -3190,10 +3187,7 @@ void Battle::Interface::EventStartAutoBattle( const Unit & unit, Actions & actio
 
 void Battle::Interface::EventAutoFinish( Actions & actions )
 {
-    if ( fheroes2::showMessage( fheroes2::Text( "", {} ),
-                                fheroes2::Text( _( "Are you sure you want to finish the battle in auto mode?" ), fheroes2::FontType::normalWhite() ),
-                                Dialog::YES | Dialog::NO )
-         != Dialog::YES ) {
+    if ( fheroes2::showStandardTextMessage( {}, _( "Are you sure you want to finish the battle in auto mode?" ), Dialog::YES | Dialog::NO ) != Dialog::YES ) {
         return;
     }
 
@@ -6412,9 +6406,7 @@ void Battle::Interface::InterruptAutoBattleIfRequested( LocalEvent & le )
     // Right now there should be no pending auto battle interruptions.
     assert( _interruptAutoBattleForColor == 0 );
 
-    const int interrupt = fheroes2::showMessage( fheroes2::Text( "", {} ),
-                                                 fheroes2::Text( _( "Are you sure you want to interrupt the auto combat?" ), fheroes2::FontType::normalWhite() ),
-                                                 Dialog::YES | Dialog::NO );
+    const int interrupt = fheroes2::showStandardTextMessage( {}, _( "Are you sure you want to interrupt the auto combat?" ), Dialog::YES | Dialog::NO );
     if ( interrupt == Dialog::YES ) {
         _interruptAutoBattleForColor = color;
     }

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -213,7 +213,7 @@ namespace
                 Game::PlayPickupSound();
 
                 const fheroes2::SpellDialogElement spellUI( sp, &hero );
-                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK, { &spellUI } );
+                fheroes2::showStandardTextMessage( {}, std::move( msg ), Dialog::OK, { &spellUI } );
             }
         }
 

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -29,6 +29,7 @@
 #include <ostream>
 #include <set>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "ai.h"
@@ -57,7 +58,6 @@
 #include "tools.h"
 #include "translations.h"
 #include "ui_dialog.h"
-#include "ui_text.h"
 #include "world.h"
 
 namespace

--- a/src/fheroes2/castle/castle_mageguild.cpp
+++ b/src/fheroes2/castle/castle_mageguild.cpp
@@ -258,10 +258,7 @@ void Castle::OpenMageGuild( const Heroes * hero ) const
             || spells5.QueueEventProcessing();
 
         if ( le.isMouseRightButtonPressedInArea( buttonExit.area() ) ) {
-            fheroes2::Text header( _( "Exit" ), fheroes2::FontType::normalYellow() );
-            fheroes2::Text body( _( "Exit this menu." ), fheroes2::FontType::normalWhite() );
-
-            fheroes2::showMessage( header, body, 0 );
+            fheroes2::showStandardTextMessage( _( "Exit" ), _( "Exit this menu." ), Dialog::ZERO );
         }
     }
 }

--- a/src/fheroes2/castle/castle_tavern.cpp
+++ b/src/fheroes2/castle/castle_tavern.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -44,6 +44,5 @@ void Castle::OpenTavern() const
     const fheroes2::AnimationDialogElement imageUI( ICN::TAVWIN, { 0, 1 }, 0, Game::getAnimationDelayValue( Game::CASTLE_TAVERN_DELAY ) );
     const fheroes2::TextDialogElement textBodyUI( std::make_shared<fheroes2::Text>( std::move( body ), fheroes2::FontType::normalWhite() ) );
 
-    fheroes2::showMessage( fheroes2::Text( GetStringBuilding( BUILD_TAVERN ), fheroes2::FontType::normalYellow() ), fheroes2::Text( "", {} ), Dialog::OK,
-                           { &imageUI, &textBodyUI } );
+    fheroes2::showStandardTextMessage( GetStringBuilding( BUILD_TAVERN ), {}, Dialog::OK, { &imageUI, &textBodyUI } );
 }

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -177,15 +177,14 @@ bool Castle::_recruitCastleMax( const Troops & currentCastleArmy )
         }
         if ( isCreaturePresent ) {
             if ( !canAffordOneCreature ) {
-                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "Not enough resources to recruit creatures." ), normalWhite ), Dialog::OK );
+                fheroes2::showStandardTextMessage( {}, _( "Not enough resources to recruit creatures." ), Dialog::OK );
             }
             else {
-                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "You are unable to recruit at this time, your ranks are full." ), normalWhite ),
-                                       Dialog::OK );
+                fheroes2::showStandardTextMessage( {}, _( "You are unable to recruit at this time, your ranks are full." ), Dialog::OK );
             }
         }
         else {
-            fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "No creatures available for purchase." ), normalWhite ), Dialog::OK );
+            fheroes2::showStandardTextMessage( {}, _( "No creatures available for purchase." ), Dialog::OK );
         }
     }
     else if ( fheroes2::showResourceMessage( fheroes2::Text( _( "Recruit Creatures" ), fheroes2::FontType::normalYellow() ),
@@ -297,13 +296,11 @@ void Castle::OpenWell()
         }
 
         if ( le.isMouseRightButtonPressedInArea( buttonExit.area() ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "Exit" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Exit this menu." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Exit" ), _( "Exit this menu." ), Dialog::ZERO );
         }
 
         if ( le.isMouseRightButtonPressedInArea( buttonMax.area() ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "Max" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Hire all creatures in the town." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Max" ), _( "Hire all creatures in the town." ), Dialog::ZERO );
         }
     }
 }

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -659,8 +659,7 @@ int Dialog::ArmyJoinFree( const Troop & troop )
     std::string message = _( "A group of %{monster} with a desire for greater glory wish to join you.\nDo you accept?" );
     StringReplaceWithLowercase( message, "%{monster}", troop.GetMultiName() );
 
-    return fheroes2::showMessage( fheroes2::Text( _( "Followers" ), fheroes2::FontType::normalYellow() ),
-                                  fheroes2::Text( std::move( message ), fheroes2::FontType::normalWhite() ), Dialog::YES | Dialog::NO );
+    return fheroes2::showStandardTextMessage( _( "Followers" ), std::move( message ), Dialog::YES | Dialog::NO );
 }
 
 int Dialog::ArmyJoinWithCost( const Troop & troop, const uint32_t join, const uint32_t gold )

--- a/src/fheroes2/dialog/dialog_artifact.cpp
+++ b/src/fheroes2/dialog/dialog_artifact.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2023                                             *
+ *   Copyright (C) 2022 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -35,6 +35,5 @@ void Dialog::ArtifactSetAssembled( const ArtifactSetData & artifactSetData )
 
     AudioManager::PlaySound( M82::TREASURE );
 
-    fheroes2::showMessage( fheroes2::Text( artifact.GetName(), fheroes2::FontType::normalYellow() ),
-                           fheroes2::Text( _( artifactSetData._assembleMessage ), fheroes2::FontType::normalWhite() ), Dialog::OK, { &artifactUI } );
+    fheroes2::showStandardTextMessage( artifact.GetName(), _( artifactSetData._assembleMessage ), Dialog::OK, { &artifactUI } );
 }

--- a/src/fheroes2/dialog/dialog_artifact.cpp
+++ b/src/fheroes2/dialog/dialog_artifact.cpp
@@ -26,7 +26,6 @@
 #include "m82.h"
 #include "translations.h"
 #include "ui_dialog.h"
-#include "ui_text.h"
 
 void Dialog::ArtifactSetAssembled( const ArtifactSetData & artifactSetData )
 {

--- a/src/fheroes2/dialog/dialog_file.cpp
+++ b/src/fheroes2/dialog/dialog_file.cpp
@@ -104,8 +104,7 @@ namespace
             }
             else if ( le.MouseClickLeft( buttonLoad.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_LOAD_GAME ) ) {
                 if ( ListFiles::IsEmpty( Game::GetSaveDir(), Game::GetSaveFileExtension(), false ) ) {
-                    fheroes2::showMessage( fheroes2::Text( _( "Load Game" ), fheroes2::FontType::normalYellow() ),
-                                           fheroes2::Text( _( "No save files to load." ), fheroes2::FontType::normalWhite() ), Dialog::OK );
+                    fheroes2::showStandardTextMessage( _( "Load Game" ), _( "No save files to load." ), Dialog::OK );
                 }
                 else if ( Interface::AdventureMap::Get().EventLoadGame() == fheroes2::GameMode::LOAD_GAME ) {
                     result = fheroes2::GameMode::LOAD_GAME;
@@ -129,24 +128,19 @@ namespace
                 break;
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonNew.area() ) ) {
-                fheroes2::showMessage( fheroes2::Text( _( "New Game" ), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( "Start a single or multi-player game." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "New Game" ), _( "Start a single or multi-player game." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonLoad.area() ) ) {
-                fheroes2::showMessage( fheroes2::Text( _( "Load Game" ), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( "Load a previously saved game." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Load Game" ), _( "Load a previously saved game." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonSave.area() ) ) {
-                fheroes2::showMessage( fheroes2::Text( _( "Save Game" ), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( "Save the current game." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Save Game" ), _( "Save the current game." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonQuit.area() ) ) {
-                fheroes2::showMessage( fheroes2::Text( _( "Quit" ), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( "Quit out of Heroes of Might and Magic II." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Quit" ), _( "Quit out of Heroes of Might and Magic II." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonCancel.area() ) ) {
-                fheroes2::showMessage( fheroes2::Text( _( "Cancel" ), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( "Exit this menu without doing anything." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
             }
         }
 

--- a/src/fheroes2/dialog/dialog_file.cpp
+++ b/src/fheroes2/dialog/dialog_file.cpp
@@ -39,7 +39,6 @@
 #include "translations.h"
 #include "ui_button.h"
 #include "ui_dialog.h"
-#include "ui_text.h"
 #include "ui_window.h"
 
 namespace

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -194,18 +194,18 @@ struct ResourceBar
             int32_t sel = cur;
             uint32_t max = mul > 1 ? ( funds.Get( rs ) + resource.Get( rs ) ) / mul : funds.Get( rs ) + resource.Get( rs );
             if ( 0 == mul ) {
-                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( _( "First select recipients!" ), fheroes2::FontType::normalWhite() ), Dialog::OK );
+                fheroes2::showStandardTextMessage( {}, _( "First select recipients!" ), Dialog::OK );
             }
             else if ( 0 == max ) {
                 std::string msg = _( "You cannot select %{resource}!" );
                 StringReplace( msg, "%{resource}", Resource::String( rs ) );
-                fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK );
+                fheroes2::showStandardTextMessage( {}, std::move( msg ), Dialog::OK );
             }
             else {
                 std::string msg = _( "Select count %{resource}:" );
                 StringReplace( msg, "%{resource}", Resource::String( rs ) );
 
-                if ( Dialog::SelectCount( msg, 0, max, sel, step ) && cur != sel ) {
+                if ( Dialog::SelectCount( std::move( msg ), 0, max, sel, step ) && cur != sel ) {
                     int32_t * from = funds.GetPtr( rs );
                     int32_t * to = resource.GetPtr( rs );
 

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -27,6 +27,7 @@
 #include <iterator>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "agg_image.h"
@@ -188,11 +189,11 @@ struct ResourceBar
 
         if ( index >= 0 ) {
             int rs = Resource::getResourceTypeFromIconIndex( index );
-            uint32_t step = rs == Resource::GOLD ? 100 : 1;
+            const int32_t step = ( rs == Resource::GOLD ) ? 100 : 1;
 
             int32_t cur = resource.Get( rs );
             int32_t sel = cur;
-            uint32_t max = mul > 1 ? ( funds.Get( rs ) + resource.Get( rs ) ) / mul : funds.Get( rs ) + resource.Get( rs );
+            const int32_t max = mul > 1 ? ( funds.Get( rs ) + resource.Get( rs ) ) / static_cast<int32_t>( mul ) : funds.Get( rs ) + resource.Get( rs );
             if ( 0 == mul ) {
                 fheroes2::showStandardTextMessage( {}, _( "First select recipients!" ), Dialog::OK );
             }
@@ -212,7 +213,7 @@ struct ResourceBar
                     if ( from && to ) {
                         int32_t count = sel - cur;
 
-                        *from -= mul > 1 ? count * mul : count;
+                        *from -= mul > 1 ? count * static_cast<int32_t>( mul ) : count;
                         *to += count;
 
                         return true;

--- a/src/fheroes2/dialog/dialog_hotkeys.cpp
+++ b/src/fheroes2/dialog/dialog_hotkeys.cpp
@@ -307,9 +307,7 @@ namespace fheroes2
             }
 
             if ( le.isMouseRightButtonPressedInArea( buttonOk.area() ) ) {
-                const fheroes2::Text header( _( "Okay" ), fheroes2::FontType::normalYellow() );
-                const fheroes2::Text body( _( "Exit this menu." ), fheroes2::FontType::normalWhite() );
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Exit this menu." ), Dialog::ZERO );
 
                 continue;
             }

--- a/src/fheroes2/dialog/dialog_language_selection.cpp
+++ b/src/fheroes2/dialog/dialog_language_selection.cpp
@@ -29,6 +29,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
+#include "dialog.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -246,14 +247,10 @@ namespace
             }
 
             if ( le.isMouseRightButtonPressedInArea( buttonCancel.area() ) ) {
-                fheroes2::Text header( _( "Cancel" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Exit this menu without doing anything." ), fheroes2::FontType::normalWhite() );
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonOk.area() ) ) {
-                fheroes2::Text header( _( "Okay" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Click to choose the selected language." ), fheroes2::FontType::normalWhite() );
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Click to choose the selected language." ), Dialog::ZERO );
             }
 
             if ( !listBox.IsNeedRedraw() ) {

--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -53,7 +53,7 @@ void DialogPrimaryOnly( const std::string & name, const int primarySkillType )
 
     const fheroes2::PrimarySkillDialogElement primarySkillUI( primarySkillType, "+1" );
 
-    fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ), Dialog::OK, { &primarySkillUI } );
+    fheroes2::showStandardTextMessage( {}, std::move( message ), Dialog::OK, { &primarySkillUI } );
 }
 
 int DialogOneSecondary( const Heroes & hero, const std::string & name, const int primarySkillType, const Skill::Secondary & sec )
@@ -70,7 +70,7 @@ int DialogOneSecondary( const Heroes & hero, const std::string & name, const int
 
     const fheroes2::SecondarySkillDialogElement secondarySkillUI( sec, hero );
 
-    fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ), Dialog::OK, { &secondarySkillUI } );
+    fheroes2::showStandardTextMessage( {}, std::move( message ), Dialog::OK, { &secondarySkillUI } );
 
     return sec.Skill();
 }

--- a/src/fheroes2/dialog/dialog_resolution.cpp
+++ b/src/fheroes2/dialog/dialog_resolution.cpp
@@ -30,6 +30,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
+#include "dialog.h"
 #include "embedded_image.h"
 #include "game_hotkeys.h"
 #include "icn.h"
@@ -280,14 +281,10 @@ namespace
                 break;
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonCancel.area() ) ) {
-                fheroes2::Text header( _( "Cancel" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Exit this menu without doing anything." ), fheroes2::FontType::normalWhite() );
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonOk.area() ) ) {
-                fheroes2::Text header( _( "Okay" ), fheroes2::FontType::normalYellow() );
-                fheroes2::Text body( _( "Click to apply the selected resolution." ), fheroes2::FontType::normalWhite() );
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Click to apply the selected resolution." ), Dialog::ZERO );
             }
 
             if ( !listBox.IsNeedRedraw() ) {

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -366,12 +366,11 @@ namespace Editor
                 const Artifact artifact( eventMetadata.artifact );
 
                 if ( artifact.isValid() ) {
-                    const fheroes2::Text header( artifact.GetName(), fheroes2::FontType::normalYellow() );
-                    const fheroes2::Text description( fheroes2::getArtifactData( eventMetadata.artifact ).getDescription( eventMetadata.artifactMetadata ),
-                                                      fheroes2::FontType::normalWhite() );
-
                     fheroes2::ArtifactDialogElement artifactUI( artifact );
-                    fheroes2::showMessage( header, description, Dialog::ZERO, { &artifactUI } );
+
+                    fheroes2::showStandardTextMessage( artifact.GetName(),
+                                                       fheroes2::getArtifactData( eventMetadata.artifact ).getDescription( eventMetadata.artifactMetadata ), Dialog::ZERO,
+                                                       { &artifactUI } );
                 }
                 else {
                     fheroes2::showStandardTextMessage( _( "Artifact" ), _( "No artifact will be given as a reward." ), Dialog::ZERO );

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -430,12 +430,10 @@ namespace Editor
                 const Artifact artifact( metadata.artifact );
 
                 if ( artifact.isValid() ) {
-                    const fheroes2::Text header( artifact.GetName(), fheroes2::FontType::normalYellow() );
-                    const fheroes2::Text description( fheroes2::getArtifactData( metadata.artifact ).getDescription( metadata.artifactMetadata ),
-                                                      fheroes2::FontType::normalWhite() );
-
                     fheroes2::ArtifactDialogElement artifactUI( artifact );
-                    fheroes2::showMessage( header, description, Dialog::ZERO, { &artifactUI } );
+
+                    fheroes2::showStandardTextMessage( artifact.GetName(), fheroes2::getArtifactData( metadata.artifact ).getDescription( metadata.artifactMetadata ),
+                                                       Dialog::ZERO, { &artifactUI } );
                 }
                 else {
                     fheroes2::showStandardTextMessage( _( "Artifact" ), _( "No artifact will be given as a reward." ), Dialog::ZERO );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1039,31 +1039,19 @@ namespace
             bool updateInfo = false;
 
             if ( le.isMouseRightButtonPressedInArea( buttonOk.area() ) ) {
-                const fheroes2::Text header( _( "Okay" ), fheroes2::FontType::normalYellow() );
-                const fheroes2::Text body( _( "Exit this menu." ), fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( _( "Okay" ), _( "Exit this menu." ), Dialog::ZERO );
                 updateInfo = true;
             }
             else if ( le.isMouseRightButtonPressedInArea( difficultyArea[0] ) ) {
-                const fheroes2::Text header( getCampaignDifficultyText( Campaign::CampaignDifficulty::Easy ), fheroes2::FontType::normalYellow() );
-                const fheroes2::Text body( easyDescription, fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Easy ), easyDescription, Dialog::ZERO );
                 updateInfo = true;
             }
             else if ( le.isMouseRightButtonPressedInArea( difficultyArea[1] ) ) {
-                const fheroes2::Text header( getCampaignDifficultyText( Campaign::CampaignDifficulty::Normal ), fheroes2::FontType::normalYellow() );
-                const fheroes2::Text body( normalDescription, fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Normal ), normalDescription, Dialog::ZERO );
                 updateInfo = true;
             }
             else if ( le.isMouseRightButtonPressedInArea( difficultyArea[2] ) ) {
-                const fheroes2::Text header( getCampaignDifficultyText( Campaign::CampaignDifficulty::Hard ), fheroes2::FontType::normalYellow() );
-                const fheroes2::Text body( hardDescription, fheroes2::FontType::normalWhite() );
-
-                fheroes2::showMessage( header, body, 0 );
+                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Hard ), hardDescription, Dialog::ZERO );
                 updateInfo = true;
             }
 
@@ -1565,31 +1553,24 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             = ( buttonRestart.isEnabled() && ( le.MouseClickLeft( buttonRestart.area() ) || HotKeyPressEvent( HotKeyEvent::CAMPAIGN_RESTART_SCENARIO ) ) );
 
         if ( le.isMouseRightButtonPressedInArea( buttonCancel.area() ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "Cancel" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Exit this menu without doing anything." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
             updateDisplay = true;
         }
         else if ( buttonOk.isVisible() && le.isMouseRightButtonPressedInArea( buttonOk.area() ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "Okay" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Start the selected scenario." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Okay" ), _( "Start the selected scenario." ), Dialog::ZERO );
             updateDisplay = true;
         }
         else if ( le.isMouseRightButtonPressedInArea( buttonViewIntro.area() ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "View Intro" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "View the intro video for the current state of the campaign." ), fheroes2::FontType::normalWhite() ),
-                                   Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "View Intro" ), _( "View the intro video for the current state of the campaign." ), Dialog::ZERO );
             updateDisplay = true;
         }
         else if ( le.isMouseRightButtonPressedInArea( buttonDifficulty.area() ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "Campaign Difficulty" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Select the campaign difficulty. This can be lowered at any point during the campaign." ),
-                                                   fheroes2::FontType::normalWhite() ),
-                                   Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Campaign Difficulty" ), _( "Select the campaign difficulty. This can be lowered at any point during the campaign." ),
+                                               Dialog::ZERO );
             updateDisplay = true;
         }
         else if ( buttonRestart.isVisible() && le.isMouseRightButtonPressedInArea( buttonRestart.area() ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "Restart" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Restart the current scenario." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Restart" ), _( "Restart the current scenario." ), Dialog::ZERO );
             updateDisplay = true;
         }
         else if ( ( buttonOk.isEnabled() && ( le.MouseClickLeft( buttonOk.area() ) || HotKeyPressEvent( HotKeyEvent::DEFAULT_OKAY ) ) ) || restartButtonClicked ) {
@@ -1687,8 +1668,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             fheroes2::fadeInDisplay( restorer.rect(), false );
         }
         else if ( le.isMouseRightButtonPressedInArea( areaDaysSpent ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "Days spent" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "The number of days spent on this campaign." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Days spent" ), _( "The number of days spent on this campaign." ), Dialog::ZERO );
             updateDisplay = true;
         }
         else if ( le.MouseClickLeft( buttonDifficulty.area() ) || HotKeyPressEvent( HotKeyEvent::CAMPAIGN_SELECT_DIFFICULTY ) ) {

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -241,8 +241,7 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
             msg += std::to_string( GetRating() * getGameOverScoreFactor() / 100 );
         }
 
-        fheroes2::showMessage( fheroes2::Text( "High Scores", fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                               Dialog::OK );
+        fheroes2::showStandardTextMessage( _( "High Scores" ), std::move( msg ), Dialog::OK );
 
         gameResult.ResetResult();
 
@@ -392,17 +391,14 @@ fheroes2::GameMode Game::DisplayHighScores( const bool isCampaign )
         }
 
         if ( le.isMouseRightButtonPressedInArea( buttonExit.area() ) ) {
-            fheroes2::showMessage( fheroes2::Text( _( "Exit" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Exit this menu." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Exit" ), _( "Exit this menu." ), Dialog::ZERO );
         }
         else if ( le.isMouseRightButtonPressedInArea( buttonOtherHighScore.area() ) ) {
             if ( isCampaign ) {
-                fheroes2::showMessage( fheroes2::Text( _( "Standard" ), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( "View High Scores for Standard Maps." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Standard" ), _( "View High Scores for Standard Maps." ), Dialog::ZERO );
             }
             else {
-                fheroes2::showMessage( fheroes2::Text( _( "Campaign" ), fheroes2::FontType::normalYellow() ),
-                                       fheroes2::Text( _( "View High Scores for Campaigns." ), fheroes2::FontType::normalWhite() ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Campaign" ), _( "View High Scores for Campaigns." ), Dialog::ZERO );
             }
         }
 

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -130,11 +130,10 @@ namespace
 
     void showMissingVideoFilesWindow()
     {
-        fheroes2::showMessage( fheroes2::Text{ _( "Warning!" ), fheroes2::FontType::normalYellow() },
-                               fheroes2::Text{ _( "The required video files for the campaign selection window are missing. "
-                                                  "Please make sure that all necessary files are present in the system." ),
-                                               fheroes2::FontType::normalWhite() },
-                               Dialog::OK );
+        fheroes2::showStandardTextMessage( _( "Warning!" ),
+                                           _( "The required video files for the campaign selection window are missing. "
+                                              "Please make sure that all necessary files are present in the system." ),
+                                           Dialog::OK );
     }
 }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -205,8 +205,7 @@ void Game::DialogPlayers( int color, std::string title, std::string message )
     }
 
     const fheroes2::CustomImageDialogElement imageUI( std::move( sign ) );
-    fheroes2::showMessage( fheroes2::Text( std::move( title ), fheroes2::FontType::normalYellow() ),
-                           fheroes2::Text( std::move( message ), fheroes2::FontType::normalWhite() ), Dialog::OK, { &imageUI } );
+    fheroes2::showStandardTextMessage( std::move( title ), std::move( message ), Dialog::OK, { &imageUI } );
 }
 
 void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */, const bool renderBackgroundDialog /* = true */ )

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -26,6 +26,7 @@
 #include <cstdint>
 #include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "artifact.h"
@@ -68,7 +69,6 @@
 #include "tools.h"
 #include "translations.h"
 #include "ui_dialog.h"
-#include "ui_text.h"
 #include "ui_tool.h"
 #include "view_world.h"
 #include "world.h"

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -464,8 +464,7 @@ fheroes2::GameMode Interface::AdventureMap::EventDigArtifact()
             StringReplace( msg, "%{artifact}", ultimate.GetName() );
 
             const fheroes2::ArtifactDialogElement artifactUI( ultimate.GetID() );
-            fheroes2::showMessage( fheroes2::Text( _( "Congratulations!" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK, { &artifactUI } );
+            fheroes2::showStandardTextMessage( _( "Congratulations!" ), std::move( msg ), Dialog::OK, { &artifactUI } );
         }
         else {
             fheroes2::showStandardTextMessage( "", _( "Nothing here. Where could it be?" ), Dialog::OK );

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -312,13 +312,11 @@ bool Interface::PlayersInfo::QueueEventProcessing()
 
         player = getPlayerFromHandicapRoi( le.getMouseCursorPos() );
         if ( player != nullptr ) {
-            fheroes2::
-                showMessage( fheroes2::Text( _( "Handicap" ), fheroes2::FontType::normalYellow() ),
-                             fheroes2::Text( _( "This lets you change the handicap of a particular player. Only human players may have a handicap. Handicapped players "
-                                                "start with fewer resources and earn 15 or 30% fewer resources per turn for mild and severe handicaps, "
-                                                "respectively." ),
-                                             fheroes2::FontType::normalWhite() ),
-                             Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Handicap" ),
+                                               _( "This lets you change the handicap of a particular player. Only human players may have a handicap. Handicapped players "
+                                                  "start with fewer resources and earn 15 or 30% fewer resources per turn for mild and severe handicaps, "
+                                                  "respectively." ),
+                                               Dialog::ZERO );
             return true;
         }
 
@@ -442,22 +440,15 @@ bool Interface::PlayersInfo::readOnlyEventProcessing()
     if ( player != nullptr ) {
         switch ( player->getHandicapStatus() ) {
         case Player::HandicapStatus::NONE:
-            fheroes2::showMessage( fheroes2::Text( _( "No Handicap" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "No special restrictions on starting resources and resource income per turn." ),
-                                                   fheroes2::FontType::normalWhite() ),
-                                   Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "No Handicap" ), _( "No special restrictions on starting resources and resource income per turn." ), Dialog::ZERO );
             break;
         case Player::HandicapStatus::MILD:
-            fheroes2::showMessage( fheroes2::Text( _( "Mild Handicap" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Players with mild handicap start with fewer resources and earn 15% fewer resources per turn." ),
-                                                   fheroes2::FontType::normalWhite() ),
-                                   Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Mild Handicap" ), _( "Players with mild handicap start with fewer resources and earn 15% fewer resources per turn." ),
+                                               Dialog::ZERO );
             break;
         case Player::HandicapStatus::SEVERE:
-            fheroes2::showMessage( fheroes2::Text( _( "Severe Handicap" ), fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "Players with severe handicap start with fewer resources and earn 30% fewer resources per turn." ),
-                                                   fheroes2::FontType::normalWhite() ),
-                                   Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Severe Handicap" ),
+                                               _( "Players with severe handicap start with fewer resources and earn 30% fewer resources per turn." ), Dialog::ZERO );
             break;
         default:
             // Did you add a new handicap status? Add the logic above!

--- a/src/fheroes2/gui/ui_campaign.cpp
+++ b/src/fheroes2/gui/ui_campaign.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2023                                             *
+ *   Copyright (C) 2022 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -82,24 +82,21 @@ namespace fheroes2
             const ArtifactDialogElement artifactUI( artifact );
             const TextDialogElement artifactDescriptionUI( std::make_shared<Text>( artifact.GetDescription(), FontType::normalWhite() ) );
 
-            showMessage( Text( bonusData.getName(), FontType::normalYellow() ), Text( bonusData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &artifactUI, &artifactDescriptionUI } );
+            showStandardTextMessage( bonusData.getName(), bonusData.getDescription(), Dialog::ZERO, { &artifactUI, &artifactDescriptionUI } );
             break;
         }
         case Campaign::ScenarioBonusData::RESOURCES: {
             const std::string resourceAmount = std::to_string( bonusData._amount );
             const ResourceDialogElement resourceUI( bonusData._subType, ( bonusData._amount > 0 ? "+" + resourceAmount : resourceAmount ) );
 
-            showMessage( Text( bonusData.getName(), FontType::normalYellow() ), Text( bonusData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &resourceUI } );
+            showStandardTextMessage( bonusData.getName(), bonusData.getDescription(), Dialog::ZERO, { &resourceUI } );
             break;
         }
         case Campaign::ScenarioBonusData::TROOP: {
             const Monster monster( bonusData._subType );
             const CustomImageDialogElement monsterUI( getMonsterFrame( monster, bonusData._amount ) );
 
-            showMessage( Text( bonusData.getName(), FontType::normalYellow() ), Text( bonusData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &monsterUI } );
+            showStandardTextMessage( bonusData.getName(), bonusData.getDescription(), Dialog::ZERO, { &monsterUI } );
             break;
         }
         case Campaign::ScenarioBonusData::SPELL: {
@@ -107,15 +104,14 @@ namespace fheroes2
             const SpellDialogElement spellUI( spell, nullptr );
             const TextDialogElement spellDescriptionUI( std::make_shared<Text>( getSpellDescription( spell, nullptr ), FontType::normalWhite() ) );
 
-            showMessage( Text( bonusData.getName(), FontType::normalYellow() ), Text( bonusData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &spellUI, &spellDescriptionUI } );
+            showStandardTextMessage( bonusData.getName(), bonusData.getDescription(), Dialog::ZERO, { &spellUI, &spellDescriptionUI } );
             break;
         }
         case Campaign::ScenarioBonusData::STARTING_RACE:
         case Campaign::ScenarioBonusData::STARTING_RACE_AND_ARMY: {
             const CustomImageDialogElement raceUI( AGG::GetICN( ICN::Get4Captain( bonusData._subType ), 1 ) );
 
-            showMessage( Text( bonusData.getName(), FontType::normalYellow() ), Text( bonusData.getDescription(), FontType::normalWhite() ), Dialog::ZERO, { &raceUI } );
+            showStandardTextMessage( bonusData.getName(), bonusData.getDescription(), Dialog::ZERO, { &raceUI } );
             break;
         }
         case Campaign::ScenarioBonusData::SKILL_PRIMARY: {
@@ -123,8 +119,7 @@ namespace fheroes2
             const TextDialogElement skillDescriptionUI(
                 std::make_shared<Text>( Skill::Primary::StringDescription( bonusData._subType, nullptr ), FontType::normalWhite() ) );
 
-            showMessage( Text( bonusData.getName(), FontType::normalYellow() ), Text( bonusData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &primarySkillUI, &skillDescriptionUI } );
+            showStandardTextMessage( bonusData.getName(), bonusData.getDescription(), Dialog::ZERO, { &primarySkillUI, &skillDescriptionUI } );
             break;
         }
         case Campaign::ScenarioBonusData::SKILL_SECONDARY: {
@@ -133,8 +128,7 @@ namespace fheroes2
             const SecondarySkillDialogElement secondarySkillUI( skill, fakeHero );
             const TextDialogElement skillDescriptionUI( std::make_shared<Text>( skill.GetDescription( fakeHero ), FontType::normalWhite() ) );
 
-            showMessage( Text( bonusData.getName(), FontType::normalYellow() ), Text( bonusData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &secondarySkillUI, &skillDescriptionUI } );
+            showStandardTextMessage( bonusData.getName(), bonusData.getDescription(), Dialog::ZERO, { &secondarySkillUI, &skillDescriptionUI } );
             break;
         }
         default:
@@ -162,7 +156,7 @@ namespace fheroes2
                 uiElements.emplace_back( monsterUI.back().get() );
             }
 
-            showMessage( Text( awardData.getName(), FontType::normalYellow() ), Text( awardData.getDescription(), FontType::normalWhite() ), Dialog::ZERO, uiElements );
+            showStandardTextMessage( awardData.getName(), awardData.getDescription(), Dialog::ZERO, uiElements );
             break;
         }
         case Campaign::CampaignAwardData::TYPE_GET_ARTIFACT: {
@@ -170,8 +164,7 @@ namespace fheroes2
             const ArtifactDialogElement artifactUI( artifact );
             const TextDialogElement artifactDescriptionUI( std::make_shared<Text>( artifact.GetDescription(), FontType::normalWhite() ) );
 
-            showMessage( Text( awardData.getName(), FontType::normalYellow() ), Text( awardData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &artifactUI, &artifactDescriptionUI } );
+            showStandardTextMessage( awardData.getName(), awardData.getDescription(), Dialog::ZERO, { &artifactUI, &artifactDescriptionUI } );
             break;
         }
         case Campaign::CampaignAwardData::TYPE_CARRY_OVER_FORCES: {
@@ -187,7 +180,7 @@ namespace fheroes2
                 uiElements.emplace_back( monsterUI.back().get() );
             }
 
-            showMessage( Text( awardData.getName(), FontType::normalYellow() ), Text( awardData.getDescription(), FontType::normalWhite() ), Dialog::ZERO, uiElements );
+            showStandardTextMessage( awardData.getName(), awardData.getDescription(), Dialog::ZERO, uiElements );
             break;
         }
         case Campaign::CampaignAwardData::TYPE_RESOURCE_BONUS: {
@@ -195,8 +188,7 @@ namespace fheroes2
             const std::string resourceAmount = std::to_string( awardData._amount );
             const ResourceDialogElement resourceUI( resourceType, ( awardData._amount > 0 ? "+" + resourceAmount : resourceAmount ) );
 
-            showMessage( Text( awardData.getName(), FontType::normalYellow() ), Text( awardData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &resourceUI } );
+            showStandardTextMessage( awardData.getName(), awardData.getDescription(), Dialog::ZERO, { &resourceUI } );
             break;
         }
         case Campaign::CampaignAwardData::TYPE_GET_SPELL: {
@@ -204,8 +196,7 @@ namespace fheroes2
             const SpellDialogElement spellUI( spell, nullptr );
             const TextDialogElement spellDescriptionUI( std::make_shared<Text>( getSpellDescription( spell, nullptr ), FontType::normalWhite() ) );
 
-            showMessage( Text( awardData.getName(), FontType::normalYellow() ), Text( awardData.getDescription(), FontType::normalWhite() ), Dialog::ZERO,
-                         { &spellUI, &spellDescriptionUI } );
+            showStandardTextMessage( awardData.getName(), awardData.getDescription(), Dialog::ZERO, { &spellUI, &spellDescriptionUI } );
             break;
         }
         case Campaign::CampaignAwardData::TYPE_HIREABLE_HERO:
@@ -216,7 +207,7 @@ namespace fheroes2
 
             const CustomImageDialogElement heroUI( std::move( output ) );
 
-            showMessage( Text( awardData.getName(), FontType::normalYellow() ), Text( awardData.getDescription(), FontType::normalWhite() ), Dialog::ZERO, { &heroUI } );
+            showStandardTextMessage( awardData.getName(), awardData.getDescription(), Dialog::ZERO, { &heroUI } );
             break;
         }
         default:

--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -84,7 +84,7 @@ namespace
 
 namespace fheroes2
 {
-    int showMessage( const TextBase & header, const TextBase & body, const int buttons, const std::vector<const DialogElement *> & elements )
+    int showMessage( const TextBase & header, const TextBase & body, const int buttons, const std::vector<const DialogElement *> & elements /* = {} */ )
     {
         outputInTextSupportMode( header, body, buttons );
 
@@ -159,7 +159,7 @@ namespace fheroes2
             elementHeight += rowHeight.back();
         }
 
-        Dialog::FrameBox box( overallTextHeight + elementHeight, isProperDialog );
+        const Dialog::FrameBox box( overallTextHeight + elementHeight, isProperDialog );
         const Rect & pos = box.GetArea();
 
         Display & display = Display::instance();
@@ -244,11 +244,11 @@ namespace fheroes2
         return result;
     }
 
-    int showStandardTextMessage( std::string headerText, std::string messageBody, const int buttons )
+    int showStandardTextMessage( std::string headerText, std::string messageBody, const int buttons, const std::vector<const DialogElement *> & elements /* = {} */ )
     {
-        Text header( std::move( headerText ), FontType::normalYellow() );
-        Text body( std::move( messageBody ), FontType::normalWhite() );
-        return showMessage( header, body, buttons );
+        const Text header( std::move( headerText ), FontType::normalYellow() );
+        const Text body( std::move( messageBody ), FontType::normalWhite() );
+        return showMessage( header, body, buttons, elements );
     }
 
     TextDialogElement::TextDialogElement( const std::shared_ptr<TextBase> & text )
@@ -328,10 +328,7 @@ namespace fheroes2
 
     void ArtifactDialogElement::showPopup( const int buttons ) const
     {
-        const Text header( _artifact.GetName(), FontType::normalYellow() );
-        const Text description( _artifact.GetDescription(), FontType::normalWhite() );
-
-        showMessage( header, description, buttons, { this } );
+        showStandardTextMessage( _artifact.GetName(), _artifact.GetDescription(), buttons, { this } );
     }
 
     ResourceDialogElement::ResourceDialogElement( const int32_t resourceType, std::string text )
@@ -367,10 +364,7 @@ namespace fheroes2
 
     void ResourceDialogElement::showPopup( const int buttons ) const
     {
-        const Text header( Resource::String( _resourceType ), FontType::normalYellow() );
-        const Text description( Resource::getDescription(), FontType::normalWhite() );
-
-        showMessage( header, description, buttons );
+        showStandardTextMessage( Resource::String( _resourceType ), Resource::getDescription(), buttons );
     }
 
     std::vector<ResourceDialogElement> getResourceDialogElements( const Funds & funds )
@@ -461,10 +455,7 @@ namespace fheroes2
 
     void SpellDialogElement::showPopup( const int buttons ) const
     {
-        const Text header( _spell.GetName(), FontType::normalYellow() );
-        const Text description( getSpellDescription( _spell, _hero ), FontType::normalWhite() );
-
-        showMessage( header, description, buttons, { this } );
+        showStandardTextMessage( _spell.GetName(), getSpellDescription( _spell, _hero ), buttons, { this } );
     }
 
     LuckDialogElement::LuckDialogElement( const bool goodLuck )
@@ -492,10 +483,7 @@ namespace fheroes2
     {
         const int luckType = _goodLuck ? Luck::GOOD : Luck::BAD;
 
-        const Text header( LuckString( luckType ), FontType::normalYellow() );
-        const Text description( Luck::Description( luckType ), FontType::normalWhite() );
-
-        showMessage( header, description, buttons, { this } );
+        showStandardTextMessage( LuckString( luckType ), Luck::Description( luckType ), buttons, { this } );
     }
 
     MoraleDialogElement::MoraleDialogElement( const bool goodMorale )
@@ -523,10 +511,7 @@ namespace fheroes2
     {
         const int moraleType = _goodMorale ? Morale::GOOD : Morale::POOR;
 
-        const Text header( MoraleString( moraleType ), FontType::normalYellow() );
-        const Text description( Morale::Description( moraleType ), FontType::normalWhite() );
-
-        showMessage( header, description, buttons, { this } );
+        showStandardTextMessage( MoraleString( moraleType ), Morale::Description( moraleType ), buttons, { this } );
     }
 
     ExperienceDialogElement::ExperienceDialogElement( const int32_t experience )
@@ -569,12 +554,9 @@ namespace fheroes2
 
     void ExperienceDialogElement::showPopup( const int buttons ) const
     {
-        const Text header( getExperienceName(), FontType::normalYellow() );
-        const Text description( getExperienceDescription(), FontType::normalWhite() );
-
         const ExperienceDialogElement experienceUI( 0 );
 
-        showMessage( header, description, buttons, { &experienceUI } );
+        showStandardTextMessage( getExperienceName(), getExperienceDescription(), buttons, { &experienceUI } );
     }
 
     PrimarySkillDialogElement::PrimarySkillDialogElement( const int32_t skillType, std::string text )
@@ -635,12 +617,9 @@ namespace fheroes2
 
     void PrimarySkillDialogElement::showPopup( const int buttons ) const
     {
-        const Text header( Skill::Primary::String( _skillType ), FontType::normalYellow() );
-        const Text description( Skill::Primary::StringDescription( _skillType, nullptr ), FontType::normalWhite() );
-
         const PrimarySkillDialogElement elementUI( _skillType, std::string() );
 
-        showMessage( header, description, buttons, { &elementUI } );
+        showStandardTextMessage( Skill::Primary::String( _skillType ), Skill::Primary::StringDescription( _skillType, nullptr ), buttons, { &elementUI } );
     }
 
     SmallPrimarySkillDialogElement::SmallPrimarySkillDialogElement( const int32_t skillType, std::string text )
@@ -718,10 +697,7 @@ namespace fheroes2
 
     void SecondarySkillDialogElement::showPopup( const int buttons ) const
     {
-        const Text header( _skill.GetNameWithBonus( _hero ), FontType::normalYellow() );
-        const Text description( _skill.GetDescription( _hero ), FontType::normalWhite() );
-
-        showMessage( header, description, buttons, { this } );
+        showStandardTextMessage( _skill.GetNameWithBonus( _hero ), _skill.GetDescription( _hero ), buttons, { this } );
     }
 
     AnimationDialogElement::AnimationDialogElement( const int icnId, std::vector<uint32_t> backgroundIndices, const uint32_t animationIndexOffset, const uint64_t delay )

--- a/src/fheroes2/gui/ui_dialog.h
+++ b/src/fheroes2/gui/ui_dialog.h
@@ -47,7 +47,7 @@ namespace fheroes2
 
     // This is a simplified version of UI window which is used to display a window with a text.
     // Header text has yellow normal font style and body text - white normal font style.
-    int showStandardTextMessage( std::string headerText, std::string messageBody, const int buttons );
+    int showStandardTextMessage( std::string headerText, std::string messageBody, const int buttons, const std::vector<const DialogElement *> & elements = {} );
 
     // An interactive UI element within a dialog.
     class DialogElement

--- a/src/fheroes2/gui/ui_kingdom.cpp
+++ b/src/fheroes2/gui/ui_kingdom.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2023                                             *
+ *   Copyright (C) 2022 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -50,7 +50,6 @@ namespace fheroes2
     void showLighthouseInfo( const Kingdom & kingdom, const int buttons )
     {
         const uint32_t lighthouseCount = world.CountCapturedObject( MP2::OBJ_LIGHTHOUSE, kingdom.GetColor() );
-        const std::string body( _( "For every lighthouse controlled, your ships will move further each day." ) );
 
         const Sprite & shadowTop = AGG::GetICN( ICN::OBJNMUL2, 60 );
         const Sprite & shadowMiddle = AGG::GetICN( ICN::OBJNMUL2, 71 );
@@ -81,7 +80,7 @@ namespace fheroes2
                                                                                 getAnimationDelayValue( Game::MAPS_DELAY ) );
 
         // StringObject on OBJ_LIGHTHOUSE with count 2 for the plural of lighthouse
-        showMessage( Text( StringObject( MP2::OBJ_LIGHTHOUSE, 2 ), FontType::normalYellow() ), Text( body, FontType::normalWhite() ), buttons,
-                     { &lighthouseCustomDynamicImageElement, &lighthouseControlledElement } );
+        showStandardTextMessage( StringObject( MP2::OBJ_LIGHTHOUSE, 2 ), _( "For every lighthouse controlled, your ships will move further each day." ), buttons,
+                                 { &lighthouseCustomDynamicImageElement, &lighthouseControlledElement } );
     }
 }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1602,8 +1602,7 @@ bool Heroes::BuySpellBook( const Castle * castle )
             header.append( _( "Unfortunately, you seem to be a little short of cash at the moment." ) );
 
             const fheroes2::ArtifactDialogElement artifactUI( Artifact::MAGIC_BOOK );
-            fheroes2::showMessage( fheroes2::Text( GetName(), fheroes2::FontType::normalYellow() ), fheroes2::Text( header, fheroes2::FontType::normalWhite() ),
-                                   Dialog::OK, { &artifactUI } );
+            fheroes2::showStandardTextMessage( GetName(), std::move( header ), Dialog::OK, { &artifactUI } );
         }
         return false;
     }
@@ -1613,9 +1612,7 @@ bool Heroes::BuySpellBook( const Castle * castle )
         header.append( _( "Do you wish to buy one?" ) );
 
         const fheroes2::ArtifactDialogElement artifactUI( Artifact::MAGIC_BOOK );
-        if ( fheroes2::showMessage( fheroes2::Text( GetName(), fheroes2::FontType::normalYellow() ), fheroes2::Text( header, fheroes2::FontType::normalWhite() ),
-                                    Dialog::YES | Dialog::NO, { &artifactUI } )
-             == Dialog::NO ) {
+        if ( fheroes2::showStandardTextMessage( GetName(), std::move( header ), Dialog::YES | Dialog::NO, { &artifactUI } ) == Dialog::NO ) {
             return false;
         }
     }

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -77,7 +77,6 @@
 #include "tools.h"
 #include "translations.h"
 #include "ui_dialog.h"
-#include "ui_text.h"
 #include "world.h"
 
 namespace

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -143,7 +143,7 @@ namespace
         const AudioManager::MusicRestorer _musicRestorer;
     };
 
-    void DialogCaptureResourceObject( const std::string & hdr, const std::string & str, const int32_t resourceType )
+    void DialogCaptureResourceObject( std::string hdr, std::string msg, const int32_t resourceType )
     {
         const Funds info = ProfitConditions::FromMine( resourceType );
         int32_t resourceCount = 0;
@@ -179,7 +179,6 @@ namespace
         std::string perday = _( "%{count} / day" );
         StringReplace( perday, "%{count}", resourceCount );
 
-        std::string msg = str;
         switch ( resourceCount ) {
         case 1:
             StringReplace( msg, "%{count}", _( "one" ) );
@@ -194,8 +193,7 @@ namespace
 
         fheroes2::ResourceDialogElement resourceUI( resourceType, std::move( perday ) );
 
-        fheroes2::showMessage( fheroes2::Text( hdr, fheroes2::FontType::normalYellow() ), fheroes2::Text( std::move( msg ), fheroes2::FontType::normalWhite() ),
-                               Dialog::OK, { &resourceUI } );
+        fheroes2::showStandardTextMessage( std::move( hdr ), std::move( msg ), Dialog::OK, { &resourceUI } );
     }
 
     void BattleLose( Heroes & hero, const Battle::Result & res, bool attacker )
@@ -218,10 +216,10 @@ namespace
         I.setRedraw( Interface::REDRAW_RADAR );
     }
 
-    void RecruitMonsterFromTile( Heroes & hero, Maps::Tiles & tile, const std::string & msg, const Troop & troop, bool remove )
+    void RecruitMonsterFromTile( Heroes & hero, Maps::Tiles & tile, std::string msg, const Troop & troop, bool remove )
     {
         if ( !hero.GetArmy().CanJoinTroop( troop ) )
-            fheroes2::showStandardTextMessage( msg, _( "You are unable to recruit at this time, your ranks are full." ), Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( msg ), _( "You are unable to recruit at this time, your ranks are full." ), Dialog::OK );
         else {
             const uint32_t recruit = Dialog::RecruitMonster( troop.GetMonster(), troop.GetCount(), false, 0 ).GetCount();
 
@@ -289,7 +287,7 @@ namespace
     void ActionToMonster( Heroes & hero, int32_t dst_index )
     {
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        Troop troop = getTroopFromTile( tile );
+        const Troop troop = getTroopFromTile( tile );
 
         Interface::AdventureMap & I = Interface::AdventureMap::Get();
 
@@ -362,7 +360,7 @@ namespace
             std::string message = _( "The %{monster}, awed by the power of your forces, begin to scatter.\nDo you wish to pursue and engage them?" );
             StringReplaceWithLowercase( message, "%{monster}", troop.GetMultiName() );
 
-            if ( fheroes2::showStandardTextMessage( "", message, Dialog::YES | Dialog::NO ) == Dialog::NO ) {
+            if ( fheroes2::showStandardTextMessage( "", std::move( message ), Dialog::YES | Dialog::NO ) == Dialog::NO ) {
                 destroy = true;
             }
         }
@@ -378,7 +376,7 @@ namespace
 
             Army army( tile );
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -718,10 +716,10 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) )
 
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        Funds funds = getFundsFromTile( tile );
+        const Funds funds = getFundsFromTile( tile );
 
         std::string msg;
-        const std::string & caption = MP2::StringObject( objectType );
+        std::string caption = MP2::StringObject( objectType );
 
         switch ( objectType ) {
         case MP2::OBJ_WINDMILL:
@@ -770,14 +768,14 @@ namespace
                     AudioManager::PlaySound( M82::TREASURE );
                 }
 
-                fheroes2::showResourceMessage( fheroes2::Text( caption, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                               Dialog::OK, funds );
+                fheroes2::showResourceMessage( fheroes2::Text( std::move( caption ), fheroes2::FontType::normalYellow() ),
+                                               fheroes2::Text( std::move( msg ), fheroes2::FontType::normalWhite() ), Dialog::OK, funds );
             }
 
             hero.GetKingdom().AddFundsResource( funds );
         }
         else {
-            fheroes2::showStandardTextMessage( caption, msg, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( caption ), std::move( msg ), Dialog::OK );
         }
 
         resetObjectInfoOnTile( tile );
@@ -790,16 +788,16 @@ namespace
 
         Maps::Tiles & tile = world.GetTiles( dst_index );
         std::string message( _( "You come upon the remains of an unfortunate adventurer." ) );
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         // artifact
         if ( doesTileContainValuableItems( tile ) ) {
             if ( hero.IsFullBagArtifacts() ) {
-                uint32_t gold = GoldInsteadArtifact( objectType );
+                const uint32_t gold = GoldInsteadArtifact( objectType );
                 const Funds funds( Resource::GOLD, gold );
                 AudioManager::PlaySound( M82::EXPERNCE );
 
-                fheroes2::showResourceMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ),
+                fheroes2::showResourceMessage( fheroes2::Text( std::move( title ), fheroes2::FontType::normalYellow() ),
                                                fheroes2::Text( _( "Treasure" ), fheroes2::FontType::normalWhite() ), Dialog::OK, funds );
 
                 hero.GetKingdom().AddFundsResource( funds );
@@ -813,8 +811,7 @@ namespace
 
                 const fheroes2::ArtifactDialogElement artifactUI( art );
 
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ),
-                                       Dialog::OK, { &artifactUI } );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( message ), Dialog::OK, { &artifactUI } );
 
                 hero.PickupArtifact( art );
             }
@@ -824,7 +821,7 @@ namespace
         else {
             message += '\n';
             message.append( _( "Searching through the tattered clothing, you find nothing." ) );
-            fheroes2::showStandardTextMessage( title, message, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( message ), Dialog::OK );
         }
 
         hero.SetVisitedWideTile( dst_index, objectType, Visit::GLOBAL );
@@ -836,7 +833,7 @@ namespace
 
         Maps::Tiles & tile = world.GetTiles( dst_index );
         std::string message( _( "You come across an old wagon left by a trader who didn't quite make it to safe terrain." ) );
-        const std::string title( MP2::StringObject( MP2::OBJ_WAGON ) );
+        std::string title( MP2::StringObject( MP2::OBJ_WAGON ) );
 
         if ( doesTileContainValuableItems( tile ) ) {
             const Artifact & art = getArtifactFromTile( tile );
@@ -845,7 +842,7 @@ namespace
                 if ( hero.IsFullBagArtifacts() ) {
                     message += '\n';
                     message.append( _( "Unfortunately, others have found it first, and the wagon is empty." ) );
-                    fheroes2::showStandardTextMessage( title, message, Dialog::OK );
+                    fheroes2::showStandardTextMessage( std::move( title ), std::move( message ), Dialog::OK );
                 }
                 else {
                     message += '\n';
@@ -855,8 +852,7 @@ namespace
 
                     const fheroes2::ArtifactDialogElement artifactUI( art );
 
-                    fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ),
-                                           Dialog::OK, { &artifactUI } );
+                    fheroes2::showStandardTextMessage( std::move( title ), std::move( message ), Dialog::OK, { &artifactUI } );
 
                     hero.PickupArtifact( art );
                 }
@@ -867,8 +863,8 @@ namespace
                 message += '\n';
                 message.append( _( "Inside, you find some of the wagon's cargo still intact." ) );
 
-                fheroes2::showResourceMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( message, fheroes2::FontType::normalWhite() ),
-                                               Dialog::OK, funds );
+                fheroes2::showResourceMessage( fheroes2::Text( std::move( title ), fheroes2::FontType::normalYellow() ),
+                                               fheroes2::Text( std::move( message ), fheroes2::FontType::normalWhite() ), Dialog::OK, funds );
 
                 hero.GetKingdom().AddFundsResource( funds );
             }
@@ -890,7 +886,7 @@ namespace
 
         Maps::Tiles & tile = world.GetTiles( dst_index );
         std::string msg;
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         const Funds & funds = getFundsFromTile( tile );
 
@@ -898,14 +894,14 @@ namespace
             msg = funds.wood && funds.gold ? _( "You search through the flotsam, and find some wood and some gold." )
                                            : _( "You search through the flotsam, and find some wood." );
 
-            fheroes2::showResourceMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                           Dialog::OK, funds );
+            fheroes2::showResourceMessage( fheroes2::Text( std::move( title ), fheroes2::FontType::normalYellow() ),
+                                           fheroes2::Text( std::move( msg ), fheroes2::FontType::normalWhite() ), Dialog::OK, funds );
 
             hero.GetKingdom().AddFundsResource( funds );
         }
         else {
             msg = _( "You search through the flotsam, but find nothing." );
-            fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
         }
 
         Game::PlayPickupSound();
@@ -956,25 +952,24 @@ namespace
             // check valid level spell and wisdom skill
             if ( 3 == spellLevel && Skill::Level::NONE == hero.GetLevelSkill( Skill::Secondary::WISDOM ) ) {
                 body += _( "\nUnfortunately, you do not have the wisdom to understand the spell, and you are unable to learn it." );
-                fheroes2::showStandardTextMessage( head, body, Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( head ), std::move( body ), Dialog::OK );
             }
             // already know (skip bag artifacts)
             else if ( hero.HaveSpell( spell.GetID(), true ) ) {
                 body += _( "\nUnfortunately, you already have knowledge of this spell, so there is nothing more for them to teach you." );
-                fheroes2::showStandardTextMessage( head, body, Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( head ), std::move( body ), Dialog::OK );
             }
             else {
                 AudioManager::PlaySound( M82::TREASURE );
                 hero.AppendSpellToBook( spell.GetID() );
 
                 const fheroes2::SpellDialogElement spellUI( spell, &hero );
-                fheroes2::showMessage( fheroes2::Text( head, fheroes2::FontType::normalYellow() ), fheroes2::Text( body, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &spellUI } );
+                fheroes2::showStandardTextMessage( std::move( head ), std::move( body ), Dialog::OK, { &spellUI } );
             }
         }
         else {
             body += _( "\nUnfortunately, you have no Magic Book to record the spell with." );
-            fheroes2::showStandardTextMessage( head, body, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( head ), std::move( body ), Dialog::OK );
         }
 
         hero.SetVisited( dst_index, Visit::GLOBAL );
@@ -990,18 +985,18 @@ namespace
             const std::string & skill_name = Skill::Secondary::String( skill.Skill() );
             StringReplace( msg, "%{skill}", skill_name );
 
-            const std::string title( MP2::StringObject( objectType ) );
+            std::string title( MP2::StringObject( objectType ) );
 
             // No room for a new skill
             if ( hero.HasMaxSecondarySkill() ) {
                 msg.append( _(
                     "As you approach, she turns and focuses her one glass eye on you.\n\"You already know everything you deserve to learn!\" the witch screeches. \"NOW GET OUT OF MY HOUSE!\"" ) );
-                fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
             }
             // Skill has already been learned
             else if ( hero.HasSecondarySkill( skill.Skill() ) ) {
                 msg.append( _( "As you approach, she turns and speaks.\n\"You already know that which I would teach you. I can help you no further.\"" ) );
-                fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
             }
             else {
                 hero.LearnSkill( skill );
@@ -1019,8 +1014,7 @@ namespace
                     const MusicalEffectPlayer musicalEffectPlayer( MUS::EXPERIENCE );
 
                     const fheroes2::SecondarySkillDialogElement secondarySkillUI( skill, hero );
-                    fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                           Dialog::OK, { &secondarySkillUI } );
+                    fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &secondarySkillUI } );
                 }
             }
         }
@@ -1036,7 +1030,7 @@ namespace
     {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) )
 
-        bool visited = hero.isObjectTypeVisited( objectType );
+        const bool visited = hero.isObjectTypeVisited( objectType );
         std::string msg;
 
         switch ( objectType ) {
@@ -1066,11 +1060,11 @@ namespace
             break;
         }
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         // check already visited
         if ( visited ) {
-            fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
         }
         else {
             // modify luck
@@ -1078,8 +1072,7 @@ namespace
             AudioManager::PlaySound( M82::GOODLUCK );
 
             const fheroes2::LuckDialogElement luckUI( true );
-            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                   { &luckUI } );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &luckUI } );
         }
     }
 
@@ -1090,17 +1083,17 @@ namespace
         Maps::Tiles & tile = world.GetTiles( dst_index );
         const Spell & spell = getSpellFromTile( tile );
 
-        const std::string ask = _(
+        std::string ask = _(
             "You come upon the pyramid of a great and ancient king.\nYou are tempted to search it for treasure, but all the old stories warn of fearful curses and undead "
             "guardians.\nWill you search?" );
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         bool enter = false;
 
         {
             const MusicalEffectPlayer musicalEffectPlayer( MUS::DUNGEON );
 
-            enter = ( fheroes2::showStandardTextMessage( title, ask, Dialog::YES | Dialog::NO ) == Dialog::YES );
+            enter = ( fheroes2::showStandardTextMessage( title, std::move( ask ), Dialog::YES | Dialog::NO ) == Dialog::YES );
         }
 
         if ( enter ) {
@@ -1133,13 +1126,12 @@ namespace
 
                     if ( valid ) {
                         const fheroes2::SpellDialogElement spellUI( spell, &hero );
-                        fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                               Dialog::OK, { &spellUI } );
+                        fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &spellUI } );
 
                         hero.AppendSpellToBook( spell );
                     }
                     else {
-                        fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+                        fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
                     }
 
                     resetObjectInfoOnTile( tile );
@@ -1153,11 +1145,10 @@ namespace
                 // Modify luck
                 AudioManager::PlaySound( M82::BADLUCK );
 
-                const std::string msg = _( "You come upon the pyramid of a great and ancient king.\nRoutine exploration reveals that the pyramid is completely empty." );
+                std::string msg = _( "You come upon the pyramid of a great and ancient king.\nRoutine exploration reveals that the pyramid is completely empty." );
 
                 const fheroes2::LuckDialogElement luckUI( false );
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &luckUI, &luckUI } );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &luckUI, &luckUI } );
 
                 hero.SetVisited( dst_index, Visit::LOCAL );
                 hero.SetVisited( dst_index, Visit::GLOBAL );
@@ -1181,16 +1172,17 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
         const uint32_t max = hero.GetMaxSpellPoints();
-        const std::string title( MP2::StringObject( MP2::OBJ_MAGIC_WELL ) );
+        std::string title( MP2::StringObject( MP2::OBJ_MAGIC_WELL ) );
 
         if ( hero.GetSpellPoints() >= max ) {
-            fheroes2::showStandardTextMessage( title, _( "A drink at the well is supposed to restore your spell points, but you are already at maximum." ), Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), _( "A drink at the well is supposed to restore your spell points, but you are already at maximum." ),
+                                               Dialog::OK );
         }
         else {
             if ( hero.isObjectTypeVisited( MP2::OBJ_MAGIC_WELL ) ) {
                 const MusicalEffectPlayer musicalEffectPlayer( MUS::WATERSPRING );
 
-                fheroes2::showStandardTextMessage( title, _( "A second drink at the well in one day will not help you." ), Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( title ), _( "A second drink at the well in one day will not help you." ), Dialog::OK );
             }
             else {
                 hero.SetSpellPoints( max );
@@ -1198,7 +1190,7 @@ namespace
                 {
                     const MusicalEffectPlayer musicalEffectPlayer( MUS::WATERSPRING );
 
-                    fheroes2::showStandardTextMessage( title, _( "A drink from the well has restored your spell points to maximum." ), Dialog::OK );
+                    fheroes2::showStandardTextMessage( std::move( title ), _( "A drink from the well has restored your spell points to maximum." ), Dialog::OK );
                 }
 
                 hero.SetVisited( dst_index );
@@ -1221,7 +1213,7 @@ namespace
 
         std::string msg;
         int skill = Skill::Primary::ATTACK;
-        bool visited = hero.isVisited( tile );
+        const bool visited = hero.isVisited( tile );
 
         switch ( objectType ) {
         case MP2::OBJ_FORT:
@@ -1257,10 +1249,10 @@ namespace
             return;
         }
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( visited ) {
-            fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
         }
         else {
             hero.IncreasePrimarySkill( skill );
@@ -1269,8 +1261,7 @@ namespace
                 const MusicalEffectPlayer musicalEffectPlayer( MUS::SKILL );
 
                 const fheroes2::PrimarySkillDialogElement primarySkillUI( skill, "+1" );
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &primarySkillUI } );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &primarySkillUI } );
             }
 
             hero.SetVisited( dst_index );
@@ -1315,7 +1306,7 @@ namespace
         {
             const MusicalEffectPlayer musicalEffectPlayer( MUS::WATCHTOWER );
 
-            if ( fheroes2::showStandardTextMessage( title, ask, Dialog::YES | Dialog::NO ) != Dialog::YES ) {
+            if ( fheroes2::showStandardTextMessage( title, std::move( ask ), Dialog::YES | Dialog::NO ) != Dialog::YES ) {
                 return;
             }
         }
@@ -1325,7 +1316,7 @@ namespace
         if ( gold ) {
             Army army( tile );
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
 
@@ -1343,15 +1334,13 @@ namespace
 
                         const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
 
-                        fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( win, fheroes2::FontType::normalWhite() ),
-                                               Dialog::OK, { &goldUI } );
+                        fheroes2::showStandardTextMessage( title, std::move( win ), Dialog::OK, { &goldUI } );
                     }
                     else {
                         const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
                         const fheroes2::ArtifactDialogElement artifactUI( art );
 
-                        fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( win, fheroes2::FontType::normalWhite() ),
-                                               Dialog::OK, { &artifactUI, &goldUI } );
+                        fheroes2::showStandardTextMessage( title, std::move( win ), Dialog::OK, { &artifactUI, &goldUI } );
 
                         hero.PickupArtifact( art );
                     }
@@ -1359,8 +1348,7 @@ namespace
                 else {
                     const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
 
-                    fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( win, fheroes2::FontType::normalWhite() ),
-                                           Dialog::OK, { &goldUI } );
+                    fheroes2::showStandardTextMessage( title, std::move( win ), Dialog::OK, { &goldUI } );
                 }
 
                 hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, gold ) );
@@ -1382,8 +1370,7 @@ namespace
             AudioManager::PlaySound( M82::BADMRLE );
 
             const fheroes2::MoraleDialogElement moraleUI( false );
-            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                   { &moraleUI } );
+            fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::OK, { &moraleUI } );
         }
     }
 
@@ -1393,7 +1380,7 @@ namespace
 
         std::string msg;
         uint32_t move = 0;
-        bool visited = hero.isObjectTypeVisited( objectType );
+        const bool visited = hero.isObjectTypeVisited( objectType );
 
         switch ( objectType ) {
         case MP2::OBJ_BUOY:
@@ -1423,10 +1410,10 @@ namespace
             return;
         }
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
         // check already visited
         if ( visited ) {
-            fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
         }
         else {
             // modify morale
@@ -1439,8 +1426,7 @@ namespace
                 elementUI.emplace_back( &moraleUI );
             }
 
-            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                   elementUI );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, elementUI );
 
             hero.IncreaseMovePoints( move );
 
@@ -1455,7 +1441,7 @@ namespace
 
         const Maps::Tiles & tile = world.GetTiles( dst_index );
 
-        bool visited = hero.isVisited( tile );
+        const bool visited = hero.isVisited( tile );
         std::string msg;
 
         int32_t exp = 0;
@@ -1473,10 +1459,10 @@ namespace
             return;
         }
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( visited ) {
-            fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
         }
         else {
             {
@@ -1490,8 +1476,7 @@ namespace
                 }
 
                 const fheroes2::ExperienceDialogElement experienceUI( exp );
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &experienceUI } );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &experienceUI } );
             }
 
             hero.IncreaseExperience( exp );
@@ -1505,18 +1490,17 @@ namespace
 
         Maps::Tiles & tile = world.GetTiles( dst_index );
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( hero.IsFullBagArtifacts() ) {
             const uint32_t gold = GoldInsteadArtifact( objectType );
 
             const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
 
-            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ),
-                                   fheroes2::Text( _( "You've pulled a shipwreck survivor from certain death in an unforgiving ocean. Grateful, he says, "
-                                                      "\"I would give you an artifact as a reward, but you're all full.\"" ),
-                                                   fheroes2::FontType::normalWhite() ),
-                                   Dialog::OK, { &goldUI } );
+            fheroes2::showStandardTextMessage( std::move( title ),
+                                               _( "You've pulled a shipwreck survivor from certain death in an unforgiving ocean. Grateful, he says, "
+                                                  "\"I would give you an artifact as a reward, but you're all full.\"" ),
+                                               Dialog::OK, { &goldUI } );
 
             hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, gold ) );
         }
@@ -1529,8 +1513,7 @@ namespace
 
             const fheroes2::ArtifactDialogElement artifactUI( art );
 
-            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( str, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                   { &artifactUI } );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( str ), Dialog::OK, { &artifactUI } );
 
             hero.PickupArtifact( art );
         }
@@ -1548,17 +1531,17 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        const std::string title( MP2::StringObject( MP2::OBJ_ARTIFACT ) );
+        std::string title( MP2::StringObject( MP2::OBJ_ARTIFACT ) );
 
         const Artifact art = getArtifactFromTile( tile );
         if ( art.GetID() == Artifact::MAGIC_BOOK && hero.HaveSpellBook() ) {
-            fheroes2::showStandardTextMessage( title, _( "You cannot have multiple spell books." ), Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), _( "You cannot have multiple spell books." ), Dialog::OK );
 
             return;
         }
 
         if ( hero.IsFullBagArtifacts() ) {
-            fheroes2::showStandardTextMessage( title, _( "You cannot pick up this artifact, you already have a full load!" ), Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), _( "You cannot pick up this artifact, you already have a full load!" ), Dialog::OK );
 
             return;
         }
@@ -1597,22 +1580,21 @@ namespace
             AudioManager::PlaySound( M82::EXPERNCE );
 
             const fheroes2::ArtifactDialogElement artifactUI( art );
-            const fheroes2::Text titleText( title, fheroes2::FontType::normalYellow() );
-            const fheroes2::Text bodyText( msg, fheroes2::FontType::normalWhite() );
 
-            if ( Dialog::YES == fheroes2::showMessage( titleText, bodyText, Dialog::YES | Dialog::NO, { &artifactUI } ) ) {
+            if ( Dialog::YES == fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::YES | Dialog::NO, { &artifactUI } ) ) {
                 if ( hero.GetKingdom().AllowPayment( payment ) ) {
                     result = true;
                     hero.GetKingdom().OddFundsResource( payment );
                 }
                 else {
                     fheroes2::showStandardTextMessage(
-                        title, _( "You try to pay the leprechaun, but realize that you can't afford it. The leprechaun stamps his foot and ignores you." ), Dialog::OK );
+                        std::move( title ), _( "You try to pay the leprechaun, but realize that you can't afford it. The leprechaun stamps his foot and ignores you." ),
+                        Dialog::OK );
                 }
             }
             else {
-                fheroes2::showStandardTextMessage( title, _( "Insulted by your refusal of his generous offer, the leprechaun stamps his foot and ignores you." ),
-                                                   Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( title ),
+                                                   _( "Insulted by your refusal of his generous offer, the leprechaun stamps his foot and ignores you." ), Dialog::OK );
             }
         }
         else if ( condition == Maps::ArtifactCaptureCondition::HAVE_WISDOM_SKILL || condition == Maps::ArtifactCaptureCondition::HAVE_LEADERSHIP_SKILL ) {
@@ -1632,8 +1614,7 @@ namespace
 
                 const fheroes2::ArtifactDialogElement artifactUI( art );
 
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &artifactUI } );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &artifactUI } );
 
                 result = true;
             }
@@ -1654,7 +1635,7 @@ namespace
                 }
 
                 StringReplace( msg, "%{art}", art.GetName() );
-                fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
             }
         }
         else if ( condition >= Maps::ArtifactCaptureCondition::FIGHT_50_ROGUES && condition <= Maps::ArtifactCaptureCondition::FIGHT_1_BONE_DRAGON ) {
@@ -1671,12 +1652,12 @@ namespace
                     msg = _(
                         "Through a clearing you observe an ancient artifact. Unfortunately, it's guarded by a nearby %{monster}. Do you want to fight the %{monster} for the artifact?" );
                     StringReplaceWithLowercase( msg, "%{monster}", troop->GetName() );
-                    battle = ( Dialog::YES == fheroes2::showStandardTextMessage( title, msg, Dialog::YES | Dialog::NO ) );
+                    battle = ( Dialog::YES == fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::YES | Dialog::NO ) );
                 }
             }
 
             if ( battle ) {
-                Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+                const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
                 if ( res.AttackerWins() ) {
                     hero.IncreaseExperience( res.GetExperienceAttacker() );
                     result = true;
@@ -1686,15 +1667,15 @@ namespace
 
                     const fheroes2::ArtifactDialogElement artifactUI( art );
 
-                    fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                           Dialog::OK, { &artifactUI } );
+                    fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &artifactUI } );
                 }
                 else {
                     BattleLose( hero, res, true );
                 }
             }
             else {
-                fheroes2::showStandardTextMessage( title, _( "Discretion is the better part of valor, and you decide to avoid this fight for today." ), Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( title ), _( "Discretion is the better part of valor, and you decide to avoid this fight for today." ),
+                                                   Dialog::OK );
             }
         }
         else {
@@ -1710,8 +1691,7 @@ namespace
             AudioManager::PlaySound( M82::TREASURE );
 
             const fheroes2::ArtifactDialogElement artifactUI( art );
-            fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                   { &artifactUI } );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK, { &artifactUI } );
             result = true;
         }
 
@@ -1737,7 +1717,7 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        const std::string & hdr = MP2::StringObject( objectType );
+        std::string hdr = MP2::StringObject( objectType );
 
         std::string msg;
         const Funds funds = getFundsFromTile( tile );
@@ -1758,8 +1738,7 @@ namespace
 
                         const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
 
-                        fheroes2::showMessage( fheroes2::Text( hdr, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                               Dialog::OK, { &goldUI } );
+                        fheroes2::showStandardTextMessage( std::move( hdr ), std::move( msg ), Dialog::OK, { &goldUI } );
                     }
                     else {
                         msg = _( "After spending hours trying to fish the chest out of the sea, you open it and find %{gold} gold and the %{art}." );
@@ -1769,8 +1748,7 @@ namespace
                         const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
                         const fheroes2::ArtifactDialogElement artifactUI( art );
 
-                        fheroes2::showMessage( fheroes2::Text( hdr, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                               Dialog::OK, { &artifactUI, &goldUI } );
+                        fheroes2::showStandardTextMessage( std::move( hdr ), std::move( msg ), Dialog::OK, { &artifactUI, &goldUI } );
 
                         hero.PickupArtifact( art );
                     }
@@ -1781,13 +1759,12 @@ namespace
 
                     const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
 
-                    fheroes2::showMessage( fheroes2::Text( hdr, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                           Dialog::OK, { &goldUI } );
+                    fheroes2::showStandardTextMessage( std::move( hdr ), std::move( msg ), Dialog::OK, { &goldUI } );
                 }
             }
             else {
-                fheroes2::showStandardTextMessage( hdr, _( "After spending hours trying to fish the chest out of the sea, you open it, only to find it empty." ),
-                                                   Dialog::OK );
+                fheroes2::showStandardTextMessage( std::move( hdr ),
+                                                   _( "After spending hours trying to fish the chest out of the sea, you open it, only to find it empty." ), Dialog::OK );
             }
         }
         else {
@@ -1811,8 +1788,7 @@ namespace
 
                     const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
 
-                    fheroes2::showMessage( fheroes2::Text( hdr, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                           Dialog::OK, { &goldUI } );
+                    fheroes2::showStandardTextMessage( std::move( hdr ), std::move( msg ), Dialog::OK, { &goldUI } );
                 }
                 else {
                     msg = _( "After scouring the area, you fall upon a hidden chest, containing the ancient artifact %{art}." );
@@ -1821,8 +1797,7 @@ namespace
 
                     const fheroes2::ArtifactDialogElement artifactUI( art );
 
-                    fheroes2::showMessage( fheroes2::Text( hdr, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                           Dialog::OK, { &artifactUI } );
+                    fheroes2::showStandardTextMessage( std::move( hdr ), std::move( msg ), Dialog::OK, { &artifactUI } );
 
                     hero.PickupArtifact( art );
                 }
@@ -2070,10 +2045,10 @@ namespace
                     }
 
                     if ( resource == Resource::UNKNOWN ) {
-                        fheroes2::showStandardTextMessage( header, body, Dialog::OK );
+                        fheroes2::showStandardTextMessage( std::move( header ), std::move( body ), Dialog::OK );
                     }
                     else {
-                        DialogCaptureResourceObject( header, body, resource );
+                        DialogCaptureResourceObject( std::move( header ), std::move( body ), resource );
                     }
                 }
             };
@@ -2081,7 +2056,7 @@ namespace
             if ( isCaptureObjectProtected( tile ) ) {
                 Army army( tile );
 
-                Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
+                const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
                 if ( result.AttackerWins() ) {
                     hero.IncreaseExperience( result.GetExperienceAttacker() );
@@ -2131,7 +2106,7 @@ namespace
 
             Army army( tile );
 
-            Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
+            const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
             if ( result.AttackerWins() ) {
                 hero.IncreaseExperience( result.GetExperienceAttacker() );
@@ -2167,7 +2142,7 @@ namespace
         Maps::Tiles & tile = world.GetTiles( dst_index );
         const Troop & troop = getTroopFromTile( tile );
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( troop.isValid() ) {
             std::string message = _( "A group of %{monster} with a desire for greater glory wish to join you. Do you accept?" );
@@ -2186,7 +2161,7 @@ namespace
                     AudioManager::PlaySound( M82::EXPERNCE );
                 }
 
-                recruit = ( fheroes2::showStandardTextMessage( title, message, Dialog::YES | Dialog::NO ) == Dialog::YES );
+                recruit = ( fheroes2::showStandardTextMessage( std::move( title ), std::move( message ), Dialog::YES | Dialog::NO ) == Dialog::YES );
             }
 
             if ( recruit ) {
@@ -2202,7 +2177,7 @@ namespace
             }
         }
         else {
-            fheroes2::showStandardTextMessage( title, _( "As you approach the dwelling, you notice that there is no one here." ), Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), _( "As you approach the dwelling, you notice that there is no one here." ), Dialog::OK );
         }
 
         hero.SetVisited( dst_index, Visit::GLOBAL );
@@ -2277,7 +2252,7 @@ namespace
         const std::string title( MP2::StringObject( objectType ) );
 
         if ( !troop.isValid() ) {
-            fheroes2::showStandardTextMessage( title, msg_void, Dialog::OK );
+            fheroes2::showStandardTextMessage( title, std::move( msg_void ), Dialog::OK );
         }
         else {
             bool recruit = false;
@@ -2297,7 +2272,7 @@ namespace
                     AudioManager::PlaySound( M82::EXPERNCE );
                 }
 
-                recruit = ( fheroes2::showStandardTextMessage( title, msg_full, Dialog::YES | Dialog::NO ) == Dialog::YES );
+                recruit = ( fheroes2::showStandardTextMessage( title, std::move( msg_full ), Dialog::YES | Dialog::NO ) == Dialog::YES );
             }
 
             if ( recruit ) {
@@ -2465,10 +2440,10 @@ namespace
     {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
-        const std::string title( MP2::StringObject( MP2::OBJ_ARTESIAN_SPRING ) );
+        std::string title( MP2::StringObject( MP2::OBJ_ARTESIAN_SPRING ) );
 
         if ( world.isAnyKingdomVisited( objectType, dst_index ) ) {
-            fheroes2::showStandardTextMessage( title, _( "The spring only refills once a week, and someone's already been here this week." ), Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), _( "The spring only refills once a week, and someone's already been here this week." ), Dialog::OK );
         }
         else {
             const uint32_t max = hero.GetMaxSpellPoints();
@@ -2477,7 +2452,7 @@ namespace
                 const MusicalEffectPlayer musicalEffectPlayer( MUS::WATERSPRING );
 
                 fheroes2::
-                    showStandardTextMessage( title,
+                    showStandardTextMessage( std::move( title ),
                                              _( "A drink at the spring is supposed to give you twice your normal spell points, but you are already at that level." ),
                                              Dialog::OK );
             }
@@ -2487,7 +2462,7 @@ namespace
                 {
                     const MusicalEffectPlayer musicalEffectPlayer( MUS::WATERSPRING );
 
-                    fheroes2::showStandardTextMessage( title,
+                    fheroes2::showStandardTextMessage( std::move( title ),
                                                        _( "A drink from the spring fills your blood with magic! You have twice your normal spell points in reserve." ),
                                                        Dialog::OK );
                 }
@@ -2502,10 +2477,10 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
         const Maps::Tiles & tile = world.GetTiles( dst_index );
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( hero.isVisited( tile ) ) {
-            fheroes2::showStandardTextMessage( title,
+            fheroes2::showStandardTextMessage( std::move( title ),
                                                _( "Recognizing you, the butler refuses to admit you. \"The master,\" he says, \"will not see the same student twice.\"" ),
                                                Dialog::OK );
         }
@@ -2519,11 +2494,9 @@ namespace
                     const fheroes2::SmallPrimarySkillDialogElement powerUI( Skill::Primary::POWER, "+1" );
                     const fheroes2::SmallPrimarySkillDialogElement knowledgeUI( Skill::Primary::KNOWLEDGE, "+1" );
 
-                    fheroes2::
-                        showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ),
-                                     fheroes2::Text( _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ),
-                                                     fheroes2::FontType::normalWhite() ),
-                                     Dialog::OK, { &attackUI, &defenseUI, &powerUI, &knowledgeUI } );
+                    fheroes2::showStandardTextMessage( std::move( title ),
+                                                       _( "The butler admits you to see the master of the house. He trains you in the four skills a hero should know." ),
+                                                       Dialog::OK, { &attackUI, &defenseUI, &powerUI, &knowledgeUI } );
                 }
 
                 hero.IncreasePrimarySkill( Skill::Primary::ATTACK );
@@ -2534,7 +2507,7 @@ namespace
             }
             else {
                 fheroes2::showStandardTextMessage(
-                    title,
+                    std::move( title ),
                     _( "The butler opens the door and looks you up and down. \"You are neither famous nor diplomatic enough to be admitted to see my master,\" he sniffs. \"Come back when you think yourself worthy.\"" ),
                     Dialog::OK );
             }
@@ -2622,7 +2595,7 @@ namespace
                 mons.emplace_back( &monsToUpgrade[i] );
         }
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( !mons.empty() ) {
             // composite sprite
@@ -2668,12 +2641,11 @@ namespace
                 }
 
                 const fheroes2::CustomImageDialogElement imageUI( std::move( surface ) );
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg1, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &imageUI } );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( msg1 ), Dialog::OK, { &imageUI } );
             }
         }
         else {
-            fheroes2::showStandardTextMessage( title, msg2, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( msg2 ), Dialog::OK );
         }
     }
 
@@ -2684,11 +2656,12 @@ namespace
         const Funds payment = PaymentConditions::getMagellansMapsPurchasePrice();
         Kingdom & kingdom = hero.GetKingdom();
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
             fheroes2::showStandardTextMessage(
-                title, _( "The captain looks at you with surprise and says:\n\"You already have all the maps I know about. Let me fish in peace now.\"" ), Dialog::OK );
+                std::move( title ), _( "The captain looks at you with surprise and says:\n\"You already have all the maps I know about. Let me fish in peace now.\"" ),
+                Dialog::OK );
         }
         else {
             if ( kingdom.AllowPayment( payment ) ) {
@@ -2698,7 +2671,7 @@ namespace
                     const MusicalEffectPlayer musicalEffectPlayer( MUS::WATCHTOWER );
 
                     buy = ( fheroes2::showStandardTextMessage(
-                                title,
+                                std::move( title ),
                                 _( "A retired captain living on this refurbished fishing platform offers to sell you maps of the sea he made in his younger days for 1,000 gold. Do you wish to buy the maps?" ),
                                 Dialog::YES | Dialog::NO )
                             == Dialog::YES );
@@ -2721,7 +2694,7 @@ namespace
             else {
                 const MusicalEffectPlayer musicalEffectPlayer( MUS::WATCHTOWER );
 
-                fheroes2::showStandardTextMessage( title,
+                fheroes2::showStandardTextMessage( std::move( title ),
                                                    _( "The captain sighs. \"You don't have enough money, eh? You can't expect me to give my maps away for free!\"" ),
                                                    Dialog::OK );
             }
@@ -2763,7 +2736,7 @@ namespace
                 elementUI.emplace_back( artifactUI.get() );
             }
 
-            fheroes2::showMessage( fheroes2::Text( "", {} ), fheroes2::Text( event_maps->message, fheroes2::FontType::normalWhite() ), Dialog::OK, elementUI );
+            fheroes2::showStandardTextMessage( {}, event_maps->message, Dialog::OK, elementUI );
 
             // PickupArtifact() has a built-in check for Artifact correctness, the presence of a magic book
             // and the fullness of the bag. Is also displays appropriate text when an artifact cannot be picked up.
@@ -2783,20 +2756,20 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
         Kingdom & kingdom = hero.GetKingdom();
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( !hero.isVisited( world.GetTiles( dst_index ), Visit::GLOBAL ) ) {
             hero.SetVisited( dst_index, Visit::GLOBAL );
             kingdom.PuzzleMaps().Update( kingdom.CountVisitedObjects( MP2::OBJ_OBELISK ), world.CountObeliskOnMaps() );
             AudioManager::PlaySound( M82::EXPERNCE );
             fheroes2::showStandardTextMessage(
-                title,
+                std::move( title ),
                 _( "You come upon an obelisk made from a type of stone you have never seen before. Staring at it intensely, the smooth surface suddenly changes to an inscription. The inscription is a piece of a lost ancient map. Quickly you copy down the piece and the inscription vanishes as abruptly as it appeared." ),
                 Dialog::OK );
             kingdom.PuzzleMaps().ShowMapsDialog();
         }
         else {
-            fheroes2::showStandardTextMessage( title, _( "You have already been to this obelisk." ), Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), _( "You have already been to this obelisk." ), Dialog::OK );
         }
     }
 
@@ -2805,12 +2778,12 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
         const Maps::Tiles & tile = world.GetTiles( dst_index );
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( hero.isVisited( tile ) ) {
             fheroes2::showStandardTextMessage(
-                title, _( "Upon your approach, the tree opens its eyes in delight. \"It is good to see you, my student. I hope my teachings have helped you.\"" ),
-                Dialog::OK );
+                std::move( title ),
+                _( "Upon your approach, the tree opens its eyes in delight. \"It is good to see you, my student. I hope my teachings have helped you.\"" ), Dialog::OK );
         }
         else {
             const Funds & payment = getTreeOfKnowledgeRequirement( tile );
@@ -2825,15 +2798,15 @@ namespace
 
                 // Free training
                 if ( increaseExperience ) {
-                    const std::string msg = _(
-                        "Upon your approach, the tree opens its eyes in delight. \"Ahh, an adventurer! Allow me to teach you a little of what I have learned over the ages.\"" );
-
                     const fheroes2::ExperienceDialogElement experienceUI( static_cast<int32_t>( possibleExperience ) );
-                    const fheroes2::Text titleUI( title, fheroes2::FontType::normalYellow() );
-                    const fheroes2::Text messageUI( msg, fheroes2::FontType::normalWhite() );
 
                     // In the original game, there was no way to refuse to level up for free, this is an improvement specific to fheroes2
-                    increaseExperience = ( fheroes2::showMessage( titleUI, messageUI, Dialog::YES | Dialog::NO, { &experienceUI } ) == Dialog::YES );
+                    increaseExperience
+                        = ( fheroes2::showStandardTextMessage(
+                                std::move( title ),
+                                _( "Upon your approach, the tree opens its eyes in delight. \"Ahh, an adventurer! Allow me to teach you a little of what I have learned over the ages.\"" ),
+                                Dialog::YES | Dialog::NO, { &experienceUI } )
+                            == Dialog::YES );
                 }
                 else {
                     const auto rc = payment.getFirstValidResource();
@@ -2850,10 +2823,9 @@ namespace
                         StringReplace( msg, "%{count}", std::to_string( rc.second ) );
 
                         const fheroes2::ExperienceDialogElement experienceUI( static_cast<int32_t>( possibleExperience ) );
-                        const fheroes2::Text titleUI( title, fheroes2::FontType::normalYellow() );
-                        const fheroes2::Text messageUI( msg, fheroes2::FontType::normalWhite() );
 
-                        increaseExperience = ( fheroes2::showMessage( titleUI, messageUI, Dialog::YES | Dialog::NO, { &experienceUI } ) == Dialog::YES );
+                        increaseExperience
+                            = ( fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::YES | Dialog::NO, { &experienceUI } ) == Dialog::YES );
                     }
                     else {
                         std::string msg = _( "Tears brim in the eyes of the tree." );
@@ -2864,7 +2836,7 @@ namespace
                         StringReplace( msg, "%{res}", Resource::String( rc.first ) );
                         StringReplace( msg, "%{count}", std::to_string( rc.second ) );
 
-                        fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+                        fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
                     }
                 }
                 hero.SetVisited( dst_index, Visit::GLOBAL );
@@ -2960,8 +2932,7 @@ namespace
                 StringReplace( msg, "%{exp}", std::to_string( demonSlayingExperience ) );
 
                 const fheroes2::ExperienceDialogElement experienceUI( demonSlayingExperience );
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &experienceUI } );
+                fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::OK, { &experienceUI } );
 
                 return Outcome::Experience;
             }
@@ -2978,8 +2949,7 @@ namespace
 
                 const fheroes2::ExperienceDialogElement experienceUI( demonSlayingExperience );
                 const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &experienceUI, &goldUI } );
+                fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::OK, { &experienceUI, &goldUI } );
 
                 return Outcome::ExperienceAndGold;
             }
@@ -2995,8 +2965,7 @@ namespace
 
                 const fheroes2::ExperienceDialogElement experienceUI( demonSlayingExperience );
                 const fheroes2::ArtifactDialogElement artifactUI( art );
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &experienceUI, &artifactUI } );
+                fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::OK, { &experienceUI, &artifactUI } );
 
                 return Outcome::ExperienceAndArtifact;
             }
@@ -3008,7 +2977,7 @@ namespace
                     std::string msg = _( "Seeing that you do not have %{count} gold, the demon slashes you with its claws, and the last thing you see is a red haze." );
                     StringReplace( msg, "%{count}", std::to_string( payment.gold ) );
 
-                    fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+                    fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::OK );
 
                     return Outcome::Death;
                 }
@@ -3017,7 +2986,7 @@ namespace
                     "The Demon leaps upon you and has its claws at your throat before you can even draw your sword. \"Your life is mine,\" it says. \"I will sell it back to you for %{count} gold.\"" );
                 StringReplace( msg, "%{count}", std::to_string( payment.gold ) );
 
-                if ( fheroes2::showStandardTextMessage( title, msg, Dialog::YES | Dialog::NO ) == Dialog::YES ) {
+                if ( fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::YES | Dialog::NO ) == Dialog::YES ) {
                     return Outcome::PayOff;
                 }
 
@@ -3045,7 +3014,7 @@ namespace
                 case Outcome::BattleWithServants: {
                     Army army( tile );
 
-                    Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+                    const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
                     if ( res.AttackerWins() ) {
                         hero.IncreaseExperience( res.GetExperienceAttacker() );
 
@@ -3057,8 +3026,7 @@ namespace
 
                         const fheroes2::ResourceDialogElement goldUI( Resource::GOLD, std::to_string( gold ) );
 
-                        fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ),
-                                               Dialog::OK, { &goldUI } );
+                        fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::OK, { &goldUI } );
 
                         kingdom.AddFundsResource( Funds( Resource::GOLD, gold ) );
                     }
@@ -3120,7 +3088,7 @@ namespace
         BagArtifacts & bag = hero.GetBagArtifacts();
         const uint32_t cursed = static_cast<uint32_t>( std::count_if( bag.begin(), bag.end(), []( const Artifact & art ) { return art.containsCurses(); } ) );
 
-        const char * title = MP2::StringObject( MP2::OBJ_ALCHEMIST_TOWER );
+        std::string title = MP2::StringObject( MP2::OBJ_ALCHEMIST_TOWER );
 
         if ( cursed ) {
             const Funds payment = PaymentConditions::ForAlchemist();
@@ -3137,7 +3105,7 @@ namespace
 
             AudioManager::PlaySound( M82::EXPERNCE );
 
-            if ( Dialog::YES == fheroes2::showStandardTextMessage( title, msg, Dialog::YES | Dialog::NO ) ) {
+            if ( Dialog::YES == fheroes2::showStandardTextMessage( title, std::move( msg ), Dialog::YES | Dialog::NO ) ) {
                 if ( hero.GetKingdom().AllowPayment( payment ) ) {
                     hero.GetKingdom().OddFundsResource( payment );
 
@@ -3154,16 +3122,17 @@ namespace
 
                     AudioManager::PlaySound( M82::GOODLUCK );
 
-                    fheroes2::showStandardTextMessage( title, msg, Dialog::OK );
+                    fheroes2::showStandardTextMessage( std::move( title ), std::move( msg ), Dialog::OK );
                 }
                 else {
-                    fheroes2::showStandardTextMessage( title, _( "You hear a voice from behind the locked door, \"You don't have enough gold to pay for my services.\"" ),
+                    fheroes2::showStandardTextMessage( std::move( title ),
+                                                       _( "You hear a voice from behind the locked door, \"You don't have enough gold to pay for my services.\"" ),
                                                        Dialog::OK );
                 }
             }
         }
         else {
-            fheroes2::showStandardTextMessage( title, _( "You hear a voice from high above in the tower, \"Go away! I can't help you!\"" ), Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), _( "You hear a voice from high above in the tower, \"Go away! I can't help you!\"" ), Dialog::OK );
         }
     }
 
@@ -3202,7 +3171,7 @@ namespace
             ActionToUpgradeArmyObject( hero, objectType, body );
         }
         else {
-            fheroes2::showStandardTextMessage( MP2::StringObject( objectType ), body, Dialog::OK );
+            fheroes2::showStandardTextMessage( MP2::StringObject( objectType ), std::move( body ), Dialog::OK );
         }
     }
 
@@ -3224,18 +3193,19 @@ namespace
     {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( hero.isObjectTypeVisited( objectType ) ) {
             fheroes2::showStandardTextMessage(
-                title, _( "You have your crew stop up their ears with wax before the sirens' eerie song has any chance of luring them to a watery grave." ), Dialog::OK );
+                std::move( title ), _( "You have your crew stop up their ears with wax before the sirens' eerie song has any chance of luring them to a watery grave." ),
+                Dialog::OK );
         }
         else {
             const uint32_t experience = hero.GetArmy().ActionToSirens();
             if ( experience == 0 ) {
                 fheroes2::showStandardTextMessage(
-                    title, _( "As the sirens sing their eerie song, your small, determined army manages to overcome the urge to dive headlong into the sea." ),
-                    Dialog::OK );
+                    std::move( title ),
+                    _( "As the sirens sing their eerie song, your small, determined army manages to overcome the urge to dive headlong into the sea." ), Dialog::OK );
             }
             else {
                 const fheroes2::ExperienceDialogElement experienceUI( static_cast<int32_t>( experience ) );
@@ -3246,8 +3216,7 @@ namespace
 
                 AudioManager::PlaySound( M82::EXPERNCE );
 
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( str, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       { &experienceUI } );
+                fheroes2::showStandardTextMessage( std::move( title ), std::move( str ), Dialog::OK, { &experienceUI } );
 
                 hero.IncreaseExperience( experience );
             }
@@ -3261,13 +3230,13 @@ namespace
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
         const Kingdom & kingdom = hero.GetKingdom();
-        const std::string title( MP2::StringObject( objectType ) );
+        std::string title( MP2::StringObject( objectType ) );
 
         if ( kingdom.AllowRecruitHero( false ) ) {
             const Maps::Tiles & tile = world.GetTiles( dst_index );
             AudioManager::PlaySound( M82::EXPERNCE );
             fheroes2::showStandardTextMessage(
-                title,
+                std::move( title ),
                 _( "In a dazzling display of daring, you break into the local jail and free the hero imprisoned there, who, in return, pledges loyalty to your cause." ),
                 Dialog::OK );
 
@@ -3289,7 +3258,7 @@ namespace
         else {
             std::string str = _( "You already have %{count} heroes, and regretfully must leave the prisoner in this jail to languish in agony for untold days." );
             StringReplace( str, "%{count}", Kingdom::GetMaxHeroes() );
-            fheroes2::showStandardTextMessage( title, str, Dialog::OK );
+            fheroes2::showStandardTextMessage( std::move( title ), std::move( str ), Dialog::OK );
         }
     }
 
@@ -3432,8 +3401,6 @@ namespace
             const Artifact & art = riddle->artifact;
             const uint32_t count = res.GetValidItemsCount();
 
-            const std::string msg = _( "Looking somewhat disappointed, the Sphinx sighs. \"You've answered my riddle so here's your reward. Now begone.\"" );
-
             if ( count || art.isValid() ) {
                 const std::vector<fheroes2::ResourceDialogElement> resourceUiElements = fheroes2::getResourceDialogElements( res );
 
@@ -3452,8 +3419,10 @@ namespace
                     uiElements.emplace_back( artifactUI.get() );
                 }
 
-                fheroes2::showMessage( fheroes2::Text( title, fheroes2::FontType::normalYellow() ), fheroes2::Text( msg, fheroes2::FontType::normalWhite() ), Dialog::OK,
-                                       uiElements );
+                fheroes2::
+                    showStandardTextMessage( title,
+                                             _( "Looking somewhat disappointed, the Sphinx sighs. \"You've answered my riddle so here's your reward. Now begone.\"" ),
+                                             Dialog::OK, uiElements );
 
                 return Outcome::CorrectAnswer;
             }
@@ -3513,13 +3482,13 @@ namespace
         const Maps::Tiles & tile = world.GetTiles( dst_index );
         const Kingdom & kingdom = hero.GetKingdom();
 
-        const std::string title = MP2::StringObject( objectType );
+        std::string title = MP2::StringObject( objectType );
 
         if ( kingdom.IsVisitTravelersTent( getColorFromTile( tile ) ) ) {
             AudioManager::PlaySound( M82::EXPERNCE );
 
             fheroes2::showStandardTextMessage(
-                title,
+                std::move( title ),
                 _( "A magical barrier stands tall before you, blocking your way. Runes on the arch read,\n\"Speak the key and you may pass.\"\nAs you speak the magic word, the glowing barrier dissolves into nothingness." ),
                 Dialog::OK );
 
@@ -3530,7 +3499,7 @@ namespace
         }
         else {
             fheroes2::showStandardTextMessage(
-                title,
+                std::move( title ),
                 _( "A magical barrier stands tall before you, blocking your way. Runes on the arch read,\n\"Speak the key and you may pass.\"\nYou speak, and nothing happens." ),
                 Dialog::OK );
         }


### PR DESCRIPTION
This PR replaces the usage of `showMessage()` by `showStandardTextMessage()` where `fheroes2::Text` is used.
Also in such updated places `std::move()` is now mostly used to prevent sting copying.

This PR affects most pop-up messages. The most changes are done to the hero's actions dialogs.