### PR TITLE
Fix original maps bottom layer (hacky) placed resources and artifacts

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1568,22 +1568,20 @@ void Maps::Tiles::updateObjectType()
 
     // And sometimes even in the bottom layer addons.
     // Take a note that we iterate object parts from back to front as the latest object part has higher priority.
-    if ( objectType == MP2::OBJ_NONE ) {
-        for ( auto iter = _addonBottomLayer.rbegin(); iter != _addonBottomLayer.rend(); ++iter ) {
-            const MP2::MapObjectType type = Maps::getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex );
-            if ( type == MP2::OBJ_NONE ) {
-                continue;
-            }
+    for ( auto iter = _addonBottomLayer.rbegin(); iter != _addonBottomLayer.rend(); ++iter ) {
+        const MP2::MapObjectType type = Maps::getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex );
+        if ( type == MP2::OBJ_NONE ) {
+            continue;
+        }
 
-            if ( MP2::isOffGameActionObject( type ) ) {
-                // Set object type only when this is an interactive object type to make sure that interaction can be done.
-                SetObject( type );
-                return;
-            }
+        if ( MP2::isOffGameActionObject( type ) ) {
+            // Set object type only when this is an interactive object type to make sure that interaction can be done.
+            SetObject( type );
+            return;
+        }
 
-            if ( objectType == MP2::OBJ_NONE ) {
-                objectType = type;
-            }
+        if ( objectType == MP2::OBJ_NONE ) {
+            objectType = type;
         }
     }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2159,7 +2159,21 @@ namespace Maps
         case MP2::OBJ_ARTIFACT: {
             assert( isFirstLoad );
 
-            const int art = Artifact::getArtifactFromMapSpriteIndex( tile.GetObjectSpriteIndex() ).GetID();
+            uint8_t artifactSpriteIndex = Artifact::UNKNOWN;
+            if ( tile.getObjectIcnType() == MP2::OBJ_ICN_TYPE_OBJNARTI ) {
+                artifactSpriteIndex = tile.GetObjectSpriteIndex();
+            }
+            else {
+                // On some hacked original maps artifact can be placed to the bottom layer addons.
+                for ( const auto & addon : tile.getBottomLayerAddons() ) {
+                    if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNARTI ) {
+                        artifactSpriteIndex = addon._imageIndex;
+                        break;
+                    }
+                }
+            }
+
+            const int art = Artifact::getArtifactFromMapSpriteIndex( artifactSpriteIndex ).GetID();
             if ( Artifact::UNKNOWN == art ) {
                 // This is an unknown artifact. Did you add a new one?
                 assert( 0 );
@@ -2208,7 +2222,7 @@ namespace Maps
                 resourceType = Resource::FromIndexSprite( tile.GetObjectSpriteIndex() );
             }
             else {
-                for ( TilesAddon & addon : tile.getBottomLayerAddons() ) {
+                for ( const TilesAddon & addon : tile.getBottomLayerAddons() ) {
                     if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
                         resourceType = Resource::FromIndexSprite( addon._imageIndex );
                         // If this happens we are in trouble. It looks like that map maker put the resource under an object which is impossible to do.

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2212,8 +2212,8 @@ namespace Maps
                     if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
                         resourceType = Resource::FromIndexSprite( addon._imageIndex );
                         // If this happens we are in trouble. It looks like that map maker put the resource under an object which is impossible to do.
-                        // Let's swap the addon and main tile objects
-                        tile.swap( addon );
+                        // Let's update the tile's object type to properly show the action object.
+                        tile.updateObjectType();
 
                         break;
                     }


### PR DESCRIPTION
Fix #8852

This PR fixes some issues for the original maps made by hack or some original editor bug when an action object is placed to the bottom player addons instead of the main main tile object.

It:
- reverts the implemented in https://github.com/ihhub/fheroes2/pull/6395 bottom layer to main object swap;
- fixes object type update for the case when an action object is placed to the bottom layer and the main tile object is not empty;
- fixes artifact type setting to correspond the shown artifact sprite when artifact is placed to the bottom layer.

Important! This PR fixes only the new games, not the saved games

Such map "hacks" can be observed on the map **LOSTRELI.MP2** ("Lost Relic").
Master build (the picked up artifact is not the same as shown on the map):

https://github.com/user-attachments/assets/05173434-780f-4c17-b246-4933b67d5a7a

This PR:

https://github.com/user-attachments/assets/1f513a08-b158-491f-92e6-c02df64c6ee4

The resource "hack" is noticeable of the map 4 of the Roland campaign.

https://github.com/user-attachments/assets/eded2889-988f-4b02-8408-b113eefa1af9

