### PR TITLE
Add Backslash character to normal and small fonts

### DIFF
--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -136,13 +136,6 @@ namespace
 
         void ActionListPressRight( Maps::FileInfo & info ) override
         {
-            // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
-            // To avoid this we have to replace all '\' symbols with '/' symbols.
-            std::string fullPath = info.filename;
-
-            // TODO: Make '\' symbol in small font to properly show file path in OS familiar style.
-            StringReplace( fullPath, "\\", "/" );
-
             const fheroes2::Text header( System::truncateFileExtensionAndPath( info.filename ), fheroes2::FontType::normalYellow() );
 
             fheroes2::MultiFontText body;
@@ -160,7 +153,7 @@ namespace
             }
 
             body.add( { _( "\n\nLocation: " ), fheroes2::FontType::smallYellow() } );
-            body.add( { fullPath, fheroes2::FontType::smallWhite() } );
+            body.add( { info.filename, fheroes2::FontType::smallWhite() } );
 
             fheroes2::showMessage( header, body, Dialog::ZERO );
         }

--- a/src/fheroes2/dialog/dialog_selectscenario.cpp
+++ b/src/fheroes2/dialog/dialog_selectscenario.cpp
@@ -94,11 +94,6 @@ namespace
 
     void mapInfo( const Maps::FileInfo & info )
     {
-        // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
-        // To avoid this we have to replace all '\' symbols with '/' symbols.
-        std::string fullPath = info.filename;
-        StringReplace( fullPath, "\\", "/" );
-
         fheroes2::Text header( info.name, fheroes2::FontType::normalYellow() );
 
         fheroes2::MultiFontText body;
@@ -121,7 +116,7 @@ namespace
         }
 
         body.add( { _( "\n\nLocation: " ), fheroes2::FontType::smallYellow() } );
-        body.add( { fullPath, fheroes2::FontType::smallWhite() } );
+        body.add( { info.filename, fheroes2::FontType::smallWhite() } );
 
         fheroes2::showMessage( header, body, Dialog::ZERO );
     }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1780,11 +1780,7 @@ namespace Interface
                 assert( 0 );
             }
 
-            // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
-            // To avoid this we have to replace all '\' symbols with '/' symbols.
-            StringReplace( fullPath, "\\", "/" );
-
-            _warningMessage.reset( _( "Map saved to: " ) + fullPath );
+            _warningMessage.reset( _( "Map saved to: " ) + std::move( fullPath ) );
 
             return;
         }

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -96,13 +96,6 @@ namespace
 
         void ActionListPressRight( Maps::FileInfo & info ) override
         {
-            // On some OSes like Windows, the path may contain '\' symbols. This symbol doesn't exist in the resources.
-            // To avoid this we have to replace all '\' symbols with '/' symbols.
-            std::string fullPath = info.filename;
-
-            // TODO: Make '\' symbol in small font to properly show file path in OS familiar style.
-            StringReplace( fullPath, "\\", "/" );
-
             const fheroes2::Text header( System::truncateFileExtensionAndPath( info.filename ), fheroes2::FontType::normalYellow() );
 
             fheroes2::MultiFontText body;
@@ -114,7 +107,7 @@ namespace
             body.add( { _( "\n\nDescription: " ), fheroes2::FontType::normalYellow() } );
             body.add( { info.description, fheroes2::FontType::normalWhite() } );
             body.add( { _( "\n\nLocation: " ), fheroes2::FontType::smallYellow() } );
-            body.add( { fullPath, fheroes2::FontType::smallWhite() } );
+            body.add( { info.filename, fheroes2::FontType::smallWhite() } );
 
             fheroes2::showMessage( header, body, Dialog::ZERO );
         }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -2345,6 +2345,7 @@ namespace
             updateSmallFontLetterShadow( font[255 - 32] );
         }
     }
+
     // CP1252 supports German, Italian, Spanish, Norwegian, Swedish and Danish (and French but OG has custom encoding)
     void generateCP1252Alphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
     {
@@ -2365,7 +2366,7 @@ namespace
             font[161 - 32].reset();
             fheroes2::Copy( font[33 - 32], 1, 0, font[161 - 32], 1, 3, font[33 - 32].width(), font[33 - 32].height() );
             {
-                fheroes2::Sprite temp = fheroes2::Flip( font[161 - 32], false, true );
+                const fheroes2::Image temp = fheroes2::Flip( font[161 - 32], false, true );
                 fheroes2::Copy( temp, 0, 2, font[161 - 32], 1, 2, temp.width(), temp.height() );
             }
             font[161 - 32].setPosition( font[33 - 32].x(), font[33 - 32].y() + 2 );
@@ -2400,7 +2401,7 @@ namespace
             font[191 - 32].reset();
             fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 11 );
             {
-                fheroes2::Sprite temp = fheroes2::Flip( font[191 - 32], true, true );
+                const fheroes2::Image temp = fheroes2::Flip( font[191 - 32], true, true );
                 fheroes2::Copy( temp, 1, 2, font[191 - 32], 0, 0, temp.width(), temp.height() );
             }
             // Remove old shadows
@@ -2925,7 +2926,7 @@ namespace
             font[161 - 32].reset();
             fheroes2::Copy( font[33 - 32], 1, 0, font[161 - 32], 1, 0, font[33 - 32].width(), 7 );
             {
-                fheroes2::Sprite temp = fheroes2::Flip( font[161 - 32], false, true );
+                const fheroes2::Image temp = fheroes2::Flip( font[161 - 32], false, true );
                 fheroes2::Copy( temp, 0, 1, font[161 - 32], 0, 0, temp.width(), temp.height() );
             }
             font[161 - 32].setPosition( font[33 - 32].x(), font[33 - 32].y() + 2 );
@@ -2936,7 +2937,7 @@ namespace
             font[191 - 32].reset();
             fheroes2::Copy( font[63 - 32], 1, 0, font[191 - 32], 0, 0, font[63 - 32].width(), 7 );
             {
-                fheroes2::Sprite temp = fheroes2::Flip( font[191 - 32], true, true );
+                const fheroes2::Image temp = fheroes2::Flip( font[191 - 32], true, true );
                 fheroes2::Copy( temp, 0, 1, font[191 - 32], 0, 0, temp.width(), temp.height() );
             }
             // Remove old shadows
@@ -5973,6 +5974,16 @@ namespace fheroes2
         fheroes2::FillTransform( icnVsSprite[5], 3, 0, 4, 1, 1 );
         fheroes2::FillTransform( icnVsSprite[5], 4, 1, 2, 1, 1 );
         updateNormalFontLetterShadow( icnVsSprite[5] );
+
+        // Add the '\' character.
+        icnVsSprite[60].resize( 5, 9 );
+        icnVsSprite[60].reset();
+        fheroes2::Copy( icnVsSprite[15], 4, 0, icnVsSprite[60], 1, 0, 1, 2 );
+        fheroes2::Copy( icnVsSprite[15], 4, 0, icnVsSprite[60], 2, 2, 1, 2 );
+        fheroes2::Copy( icnVsSprite[15], 4, 0, icnVsSprite[60], 3, 4, 1, 2 );
+        fheroes2::Copy( icnVsSprite[15], 4, 0, icnVsSprite[60], 4, 6, 1, 2 );
+        icnVsSprite[60].setPosition( icnVsSprite[15].x(), icnVsSprite[15].y() );
+        updateSmallFontLetterShadow( icnVsSprite[60] );
 
         // Proper lowercase k.
         icnVsSprite[75].resize( 6, 8 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -5948,6 +5948,13 @@ namespace fheroes2
         icnVsSprite[13].setPosition( icnVsSprite[13].x(), icnVsSprite[13].y() + 1 );
         updateNormalFontLetterShadow( icnVsSprite[13] );
 
+        // Add the '\' character.
+        icnVsSprite[60].resize( 8, 14 );
+        icnVsSprite[60].reset();
+        fheroes2::Blit( icnVsSprite[15], 1, 0, icnVsSprite[60], 1, 0, 7, 12, true );
+        icnVsSprite[60].setPosition( icnVsSprite[15].x(), icnVsSprite[15].y() );
+        updateNormalFontLetterShadow( icnVsSprite[60] );
+
         // Proper lowercase k.
         fheroes2::FillTransform( icnVsSprite[75], 4, 1, 5, 8, 1 );
         fheroes2::Copy( icnVsSprite[43], 6, 5, icnVsSprite[75], 4, 7, 3, 1 );


### PR DESCRIPTION
Close #8709

![small_font](https://github.com/user-attachments/assets/f3fef646-b4c1-476c-8b35-4e5067180baa)

![normal_font](https://github.com/user-attachments/assets/64cfa749-a542-410e-ba46-7f5b009069ab)
