### PR TITLE
Update hero spell points indicator after the battle and before performing defeated opponent fade animation

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -382,10 +382,10 @@ namespace
                 assert( 0 );
 
                 if ( isDefenderHuman ) {
-                    DEBUG_LOG( DBG_AI, DBG_INFO, defender->GetName() << " the AI hero is protecting the human castle " << castle->GetName() )
+                    DEBUG_LOG( DBG_AI, DBG_WARN, defender->GetName() << " the AI hero is protecting the human castle " << castle->GetName() )
                 }
                 else {
-                    DEBUG_LOG( DBG_AI, DBG_INFO, defender->GetName() << " the human hero is protecting the AI castle " << castle->GetName() )
+                    DEBUG_LOG( DBG_AI, DBG_WARN, defender->GetName() << " the human hero is protecting the AI castle " << castle->GetName() )
                 }
             }
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -328,6 +328,20 @@ namespace
         taker.GetBagArtifacts().exchangeArtifacts( giver.GetBagArtifacts(), taker, giver );
     }
 
+    // Call this function after the battle with human controlled hero or castle to update icons on the interface.
+    // This function also runs fade-in after the battle if it is planned.
+    void redrawPlayerIcons()
+    {
+        if ( Game::validateDisplayFadeIn() ) {
+            Interface::AdventureMap::Get().redraw( Interface::REDRAW_ICONS );
+
+            fheroes2::fadeInDisplay();
+        }
+        else {
+            Interface::AdventureMap::Get().setRedraw( Interface::REDRAW_ICONS );
+        }
+    }
+
     void AIToCastle( Heroes & hero, const int32_t dstIndex )
     {
         Castle * castle = world.getCastleEntrance( Maps::GetPoint( dstIndex ) );
@@ -376,22 +390,49 @@ namespace
             DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " attacks the enemy castle " << castle->GetName() )
 
             Heroes * defender = castle->GetHero();
-            const bool playVanishingHeroSound = defender != nullptr && defender->isControlHuman();
+            const bool isDefenderHuman = castle->isControlHuman();
+
+            if ( defender && ( defender->isControlHuman() != isDefenderHuman ) ) {
+                assert( 0 );
+
+                if ( isDefenderHuman ) {
+                    DEBUG_LOG( DBG_AI, DBG_INFO, defender->GetName() << " the AI hero is protecting the human castle " << castle->GetName() )
+                }
+                else {
+                    DEBUG_LOG( DBG_AI, DBG_INFO, defender->GetName() << " the human hero is protecting the AI castle " << castle->GetName() )
+                }
+            }
+
+            if ( isDefenderHuman ) {
+                // Sometimes the battle action is performed without attacker movement if the defender is standing close to him.
+                // Update the game area before the battle to show the dueling heroes.
+                Interface::AdventureMap::Get().redraw( Interface::REDRAW_GAMEAREA );
+            }
 
             castle->ActionPreBattle();
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dstIndex );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dstIndex );
+
+            // Human controlled castle or hero in this castle was in the battle. Update icons.
+            redrawPlayerIcons();
 
             castle->ActionAfterBattle( res.AttackerWins() );
 
             // The defender was defeated
-            if ( !res.DefenderWins() && defender ) {
-                AIBattleLose( *defender, res, false, nullptr, playVanishingHeroSound );
+            if ( !res.DefenderWins() ) {
+                if ( defender ) {
+                    AIBattleLose( *defender, res, false, nullptr, isDefenderHuman );
+                }
+
+                if ( isDefenderHuman ) {
+                    // Update interface heroes and castles icons after the defeat.
+                    Interface::AdventureMap::Get().setRedraw( Interface::REDRAW_ICONS );
+                }
             }
 
             // The attacker was defeated
             if ( !res.AttackerWins() ) {
-                AIBattleLose( hero, res, true, &( castle->GetCenter() ), playVanishingHeroSound );
+                AIBattleLose( hero, res, true, &( castle->GetCenter() ), isDefenderHuman );
             }
 
             // The attacker won
@@ -454,18 +495,32 @@ namespace
 
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " attacks " << otherHero->GetName() )
 
-        const bool playVanishingHeroSound = otherHero->isControlHuman();
+        const bool isDefenderHuman = otherHero->isControlHuman();
 
-        Battle::Result res = Battle::Loader( hero.GetArmy(), otherHero->GetArmy(), dstIndex );
+        if ( isDefenderHuman ) {
+            // Sometimes the battle action is performed without attacker movement if the defender is standing close to him.
+            // Update the game area before the battle to show the dueling heroes.
+            Interface::AdventureMap::Get().redraw( Interface::REDRAW_GAMEAREA );
+        }
+
+        const Battle::Result res = Battle::Loader( hero.GetArmy(), otherHero->GetArmy(), dstIndex );
+
+        // Human controlled hero could be in the battle. Update icons.
+        redrawPlayerIcons();
 
         // The defender was defeated
         if ( !res.DefenderWins() ) {
-            AIBattleLose( *otherHero, res, false, nullptr, playVanishingHeroSound );
+            AIBattleLose( *otherHero, res, false, nullptr, isDefenderHuman );
+
+            if ( isDefenderHuman ) {
+                // Update interface heroes and castles icons after the defeat.
+                Interface::AdventureMap::Get().setRedraw( Interface::REDRAW_ICONS );
+            }
         }
 
         // The attacker was defeated
         if ( !res.AttackerWins() ) {
-            AIBattleLose( hero, res, true, ( otherHero->isActive() ? &( otherHero->GetCenter() ) : nullptr ), playVanishingHeroSound );
+            AIBattleLose( hero, res, true, ( otherHero->isActive() ? &( otherHero->GetCenter() ) : nullptr ), isDefenderHuman );
         }
 
         // The attacker won
@@ -482,7 +537,7 @@ namespace
     {
         bool destroy = false;
         Maps::Tiles & tile = world.GetTiles( dst_index );
-        Troop troop = getTroopFromTile( tile );
+        const Troop troop = getTroopFromTile( tile );
 
         const NeutralMonsterJoiningCondition join = Army::GetJoinSolution( hero, tile, troop );
 
@@ -537,7 +592,7 @@ namespace
 
             Army army( tile );
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -699,7 +754,7 @@ namespace
             if ( isCaptureObjectProtected( tile ) ) {
                 Army army( tile );
 
-                Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
+                const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
                 if ( result.AttackerWins() ) {
                     hero.IncreaseExperience( result.GetExperienceAttacker() );
@@ -757,7 +812,7 @@ namespace
             const Artifact & art = getArtifactFromTile( tile );
 
             if ( !hero.PickupArtifact( art ) ) {
-                uint32_t gold = GoldInsteadArtifact( objectType );
+                const uint32_t gold = GoldInsteadArtifact( objectType );
                 hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, gold ) );
             }
 
@@ -1142,24 +1197,32 @@ namespace
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) )
 
         switch ( objectType ) {
-        case MP2::OBJ_HILL_FORT:
-            if ( hero.GetArmy().HasMonster( Monster::DWARF ) )
-                hero.GetArmy().UpgradeMonsters( Monster::DWARF );
-            if ( hero.GetArmy().HasMonster( Monster::ORC ) )
-                hero.GetArmy().UpgradeMonsters( Monster::ORC );
-            if ( hero.GetArmy().HasMonster( Monster::OGRE ) )
-                hero.GetArmy().UpgradeMonsters( Monster::OGRE );
+        case MP2::OBJ_HILL_FORT: {
+            Army & army = hero.GetArmy();
+            if ( army.HasMonster( Monster::DWARF ) ) {
+                army.UpgradeMonsters( Monster::DWARF );
+            }
+            if ( army.HasMonster( Monster::ORC ) ) {
+                army.UpgradeMonsters( Monster::ORC );
+            }
+            if ( army.HasMonster( Monster::OGRE ) ) {
+                army.UpgradeMonsters( Monster::OGRE );
+            }
             break;
-
-        case MP2::OBJ_FREEMANS_FOUNDRY:
-            if ( hero.GetArmy().HasMonster( Monster::PIKEMAN ) )
-                hero.GetArmy().UpgradeMonsters( Monster::PIKEMAN );
-            if ( hero.GetArmy().HasMonster( Monster::SWORDSMAN ) )
-                hero.GetArmy().UpgradeMonsters( Monster::SWORDSMAN );
-            if ( hero.GetArmy().HasMonster( Monster::IRON_GOLEM ) )
-                hero.GetArmy().UpgradeMonsters( Monster::IRON_GOLEM );
+        }
+        case MP2::OBJ_FREEMANS_FOUNDRY: {
+            Army & army = hero.GetArmy();
+            if ( army.HasMonster( Monster::PIKEMAN ) ) {
+                army.UpgradeMonsters( Monster::PIKEMAN );
+            }
+            if ( army.HasMonster( Monster::SWORDSMAN ) ) {
+                army.UpgradeMonsters( Monster::SWORDSMAN );
+            }
+            if ( army.HasMonster( Monster::IRON_GOLEM ) ) {
+                army.UpgradeMonsters( Monster::IRON_GOLEM );
+            }
             break;
-
+        }
         default:
             break;
         }
@@ -1196,7 +1259,7 @@ namespace
         if ( gold ) {
             Army army( tile );
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
                 complete = true;
@@ -1246,7 +1309,7 @@ namespace
             // battle
             Army army( tile );
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -1323,7 +1386,7 @@ namespace
         if ( doesTileContainValuableItems( tile ) ) {
             Army army( tile );
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
                 // Daemon Cave always gives 2500 Gold after a battle
@@ -1480,7 +1543,7 @@ namespace
 
         Army army( tile );
 
-        Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
+        const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
         if ( result.AttackerWins() ) {
             hero.IncreaseExperience( result.GetExperienceAttacker() );
@@ -1567,7 +1630,7 @@ namespace
         else if ( condition >= Maps::ArtifactCaptureCondition::FIGHT_50_ROGUES && condition <= Maps::ArtifactCaptureCondition::FIGHT_1_BONE_DRAGON ) {
             Army army( tile );
 
-            Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
+            const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
                 result = true;
@@ -1596,14 +1659,13 @@ namespace
 
         hero.setLastGroundRegion( world.GetTiles( hero.GetIndex() ).GetRegion() );
 
-        const fheroes2::Point offset( Maps::GetPoint( dst_index ) - hero.GetCenter() );
-
         // Get the direction of the boat so that the direction of the hero can be set to it after boarding
-        const int boatDirection = world.GetTiles( dst_index ).getBoatDirection();
+        Maps::Tiles & destinationTile = world.GetTiles( dst_index );
+        const int boatDirection = destinationTile.getBoatDirection();
 
         if ( AIIsShowAnimationForHero( hero, AIGetAllianceColors() ) ) {
             Interface::AdventureMap::Get().getGameArea().SetCenter( hero.GetCenter() );
-            hero.FadeOut( Game::AIHeroAnimSpeedMultiplier(), offset );
+            hero.FadeOut( Game::AIHeroAnimSpeedMultiplier(), Maps::GetPoint( dst_index ) - hero.GetCenter() );
         }
 
         hero.Scout( dst_index );
@@ -1614,11 +1676,11 @@ namespace
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
         hero.setDirection( boatDirection );
         hero.setObjectTypeUnderHero( MP2::OBJ_NONE );
-        world.GetTiles( dst_index ).resetObjectSprite();
+        destinationTile.resetObjectSprite();
         hero.SetShipMaster( true );
 
         // Boat is no longer empty so we reset color to default
-        world.GetTiles( dst_index ).resetBoatOwnerColor();
+        destinationTile.resetBoatOwnerColor();
     }
 
     void AIToCoast( Heroes & hero, const int32_t dst_index )
@@ -1634,7 +1696,6 @@ namespace
 
         // Calculate the offset before making the action.
         const fheroes2::Point prevPos = hero.GetCenter();
-        const fheroes2::Point offset( Maps::GetPoint( dst_index ) - prevPos );
 
         hero.Scout( dst_index );
         hero.Move2Dest( dst_index );
@@ -1646,7 +1707,7 @@ namespace
 
         if ( AIIsShowAnimationForHero( hero, AIGetAllianceColors() ) ) {
             Interface::AdventureMap::Get().getGameArea().SetCenter( prevPos );
-            hero.FadeIn( Game::AIHeroAnimSpeedMultiplier(), offset );
+            hero.FadeIn( Game::AIHeroAnimSpeedMultiplier(), Maps::GetPoint( dst_index ) - prevPos );
         }
 
         hero.ActionNewPosition( true );
@@ -1848,6 +1909,7 @@ void AI::HeroesAction( Heroes & hero, const int32_t dst_index )
     case MP2::OBJ_MERCENARY_CAMP:
     case MP2::OBJ_WITCH_DOCTORS_HUT:
     case MP2::OBJ_STANDING_STONES:
+    case MP2::OBJ_ARENA:
         AIToPrimarySkillObject( hero, objectType, dst_index );
         break;
 
@@ -1941,6 +2003,7 @@ void AI::HeroesAction( Heroes & hero, const int32_t dst_index )
     case MP2::OBJ_TREE_CITY:
     case MP2::OBJ_WAGON_CAMP:
     case MP2::OBJ_DESERT_TENT:
+    case MP2::OBJ_GENIE_LAMP:
     // loyalty version objects
     case MP2::OBJ_WATER_ALTAR:
     case MP2::OBJ_AIR_ALTAR:
@@ -1957,16 +2020,8 @@ void AI::HeroesAction( Heroes & hero, const int32_t dst_index )
         AIToDwellingBattleMonster( hero, objectType, dst_index );
         break;
 
-    // recruit genie
-    case MP2::OBJ_GENIE_LAMP:
-        AIToDwellingRecruitMonster( hero, objectType, dst_index );
-        break;
-
     case MP2::OBJ_STABLES:
         AIToStables( hero, objectType, dst_index );
-        break;
-    case MP2::OBJ_ARENA:
-        AIToPrimarySkillObject( hero, objectType, dst_index );
         break;
 
     case MP2::OBJ_BARRIER:

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -71,7 +71,6 @@
 #include "skill.h"
 #include "spell.h"
 #include "spell_info.h"
-#include "ui_tool.h"
 #include "visit.h"
 #include "world.h"
 
@@ -329,20 +328,6 @@ namespace
         taker.GetBagArtifacts().exchangeArtifacts( giver.GetBagArtifacts(), taker, giver );
     }
 
-    // Call this function after the battle with human controlled hero or castle to update icons on the interface.
-    // This function also runs fade-in after the battle if it is planned.
-    void redrawPlayerIcons()
-    {
-        if ( Game::validateDisplayFadeIn() ) {
-            Interface::AdventureMap::Get().redraw( Interface::REDRAW_ICONS );
-
-            fheroes2::fadeInDisplay();
-        }
-        else {
-            Interface::AdventureMap::Get().setRedraw( Interface::REDRAW_ICONS );
-        }
-    }
-
     void AIToCastle( Heroes & hero, const int32_t dstIndex )
     {
         Castle * castle = world.getCastleEntrance( Maps::GetPoint( dstIndex ) );
@@ -415,7 +400,7 @@ namespace
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
             // Human controlled castle or hero in this castle was in the battle. Update icons.
-            redrawPlayerIcons();
+            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_ICONS );
 
             castle->ActionAfterBattle( res.AttackerWins() );
 
@@ -507,7 +492,7 @@ namespace
         const Battle::Result res = Battle::Loader( hero.GetArmy(), otherHero->GetArmy(), dstIndex );
 
         // Human controlled hero could be in the battle. Update icons.
-        redrawPlayerIcons();
+        Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES );
 
         // The defender was defeated
         if ( !res.DefenderWins() ) {
@@ -515,7 +500,7 @@ namespace
 
             if ( isDefenderHuman ) {
                 // Update interface heroes and castles icons after the defeat.
-                Interface::AdventureMap::Get().setRedraw( Interface::REDRAW_ICONS );
+                Interface::AdventureMap::Get().setRedraw( Interface::REDRAW_HEROES );
             }
         }
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -71,6 +71,7 @@
 #include "skill.h"
 #include "spell.h"
 #include "spell_info.h"
+#include "ui_tool.h"
 #include "visit.h"
 #include "world.h"
 

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -647,7 +647,12 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
         = allowToRestart ? fheroes2::StandardWindow::Padding::BOTTOM_LEFT : fheroes2::StandardWindow::Padding::BOTTOM_CENTER;
     background.renderButton( buttonOk, buttonOkICN, 0, 1, { buttonHorizontalMargin, buttonVerticalMargin }, buttonOkPadding );
 
-    display.render( background.totalArea() );
+    if ( Game::validateDisplayFadeIn() ) {
+        fheroes2::fadeInDisplay();
+    }
+    else {
+        display.render( background.totalArea() );
+    }
 
     LocalEvent & le = LocalEvent::Get();
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -52,6 +52,7 @@
 #include "bin_info.h"
 #include "castle.h"
 #include "color.h"
+#include "game.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "gamedefs.h"
@@ -1305,7 +1306,7 @@ Battle::Interface::~Interface()
         // the battle results screen (if the battle was quick ended).
         _background.reset();
 
-        fheroes2::fadeInDisplay();
+        Game::setDisplayFadeIn();
     }
 }
 

--- a/src/fheroes2/gui/interface_base.cpp
+++ b/src/fheroes2/gui/interface_base.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/interface_base.cpp
+++ b/src/fheroes2/gui/interface_base.cpp
@@ -25,6 +25,18 @@
 
 namespace Interface
 {
+    void BaseInterface::renderWithFadeInOrPlanRender( const uint32_t redrawMask )
+    {
+        if ( Game::validateDisplayFadeIn() ) {
+            redraw( redrawMask );
+
+            fheroes2::fadeInDisplay();
+        }
+        else {
+            setRedraw( redrawMask );
+        }
+    }
+
     void Interface::BaseInterface::validateFadeInAndRender()
     {
         if ( Game::validateDisplayFadeIn() ) {
@@ -36,5 +48,4 @@ namespace Interface
             fheroes2::Display::instance().render();
         }
     }
-
 }

--- a/src/fheroes2/gui/interface_base.h
+++ b/src/fheroes2/gui/interface_base.h
@@ -144,6 +144,10 @@ namespace Interface
             return _isEditor;
         }
 
+        // Call this function to plan (set) redraw if fade in is not set
+        // or redraw the given interface items and do fade in with them rendered.
+        void renderWithFadeInOrPlanRender( const uint32_t redrawMask );
+
     protected:
         // If display fade-in state is set reset it to false and fade-in the full display image. Otherwise render full display image without fade-in.
         void validateFadeInAndRender();

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2364,7 +2364,7 @@ namespace
             return;
         }
 
-        enum class Outcome : uint8_t
+        enum class Outcome
         {
             Invalid,
             Empty,
@@ -2925,7 +2925,7 @@ namespace
 
         const std::string title = MP2::StringObject( objectType );
 
-        enum class Outcome : uint8_t
+        enum class Outcome
         {
             Invalid,
             Ignore,
@@ -3403,7 +3403,7 @@ namespace
     {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
-        enum class Outcome : uint8_t
+        enum class Outcome
         {
             Invalid,
             Empty,

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -85,6 +85,7 @@
 #include "ui_dialog.h"
 #include "ui_monster.h"
 #include "ui_text.h"
+#include "ui_tool.h"
 #include "visit.h"
 #include "world.h"
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -85,7 +85,6 @@
 #include "ui_dialog.h"
 #include "ui_monster.h"
 #include "ui_text.h"
-#include "ui_tool.h"
 #include "visit.h"
 #include "world.h"
 
@@ -244,20 +243,6 @@ namespace
         // Update radar in the place of the removed object.
         I.getRadar().SetRenderArea( { Maps::GetPoint( tile.GetIndex() ), { 1, 1 } } );
         I.setRedraw( Interface::REDRAW_RADAR );
-    }
-
-    // Call this function after the battle or other dialog than can update hero icon (movement points and/or spell points)
-    // and there is some animation (enemy fade-out) to perform before returning to the standard game area rendering.
-    void redrawHeroIcons()
-    {
-        if ( Game::validateDisplayFadeIn() ) {
-            Interface::AdventureMap::Get().redraw( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
-
-            fheroes2::fadeInDisplay();
-        }
-        else {
-            Interface::AdventureMap::Get().setRedraw( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
-        }
     }
 
     void RecruitMonsterFromTile( Heroes & hero, Maps::Tiles & tile, std::string msg, const Troop & troop, const bool remove )
@@ -422,7 +407,7 @@ namespace
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
             // Hero' spell points could have changed. Update heroes icons.
-            redrawHeroIcons();
+            I.renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -543,7 +528,7 @@ namespace
             castle->ActionAfterBattle( res.AttackerWins() );
 
             // Hero' spell points could have changed. Update heroes icons.
-            redrawHeroIcons();
+            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_ICONS | Interface::REDRAW_BUTTONS );
 
             // The defender was defeated
             if ( !res.DefenderWins() && defender ) {
@@ -618,7 +603,7 @@ namespace
         const Battle::Result res = Battle::Loader( hero.GetArmy(), otherHero->GetArmy(), dstIndex );
 
         // Hero' spell points could have changed. Update heroes icons.
-        redrawHeroIcons();
+        Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
         // TODO: make fading animation of both heroes together.
 
@@ -1150,7 +1135,7 @@ namespace
                 const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
                 // Hero' spell points could have changed. Update heroes icons.
-                redrawHeroIcons();
+                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
                 if ( res.AttackerWins() ) {
                     hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -1369,7 +1354,7 @@ namespace
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
             // Hero' spell points could have changed. Update heroes icons.
-            redrawHeroIcons();
+            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -1713,7 +1698,7 @@ namespace
                 const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
                 // Hero' spell points could have changed. Update heroes icons.
-                redrawHeroIcons();
+                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
                 if ( res.AttackerWins() ) {
                     hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -2109,7 +2094,7 @@ namespace
                 const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
                 // Hero' spell points could have changed. Update heroes icons.
-                redrawHeroIcons();
+                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
                 if ( result.AttackerWins() ) {
                     hero.IncreaseExperience( result.GetExperienceAttacker() );
@@ -2162,7 +2147,7 @@ namespace
             const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
             // Hero' spell points could have changed. Update heroes icons.
-            redrawHeroIcons();
+            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
             if ( result.AttackerWins() ) {
                 hero.IncreaseExperience( result.GetExperienceAttacker() );
@@ -2446,7 +2431,7 @@ namespace
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
             // Hero' spell points could have changed. Update heroes icons.
-            redrawHeroIcons();
+            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -3082,7 +3067,7 @@ namespace
                     const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
                     // Hero' spell points could have changed. Update heroes icons.
-                    redrawHeroIcons();
+                    Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
                     if ( res.AttackerWins() ) {
                         hero.IncreaseExperience( res.GetExperienceAttacker() );


### PR DESCRIPTION
Fix #7518

This PR:
- forces the heroes icons update after any battle during player actions;
- forces heroes and castles update during AI actions after the battle with the human player;
- also makes some minor code improvements to heroes action code including AI actions.

Master build (AI actions):

https://github.com/user-attachments/assets/e20f597f-f0d1-4128-bd04-a972e5c3be6d


This PR (AI actions): 

https://github.com/user-attachments/assets/74d0a483-6f66-4e4f-a903-90fa54d75d62


This PR (player actions):

https://github.com/user-attachments/assets/76df81b6-ab0c-4d71-ab55-42d67d1c4308

