### PR TITLE
Mark the appropriate headers with IWYU pragma: associated

### DIFF
--- a/src/fheroes2/ai/ai_battle_spell.cpp
+++ b/src/fheroes2/ai/ai_battle_spell.cpp
@@ -25,7 +25,7 @@
 #include <ostream>
 #include <vector>
 
-#include "ai_battle.h"
+#include "ai_battle.h" // IWYU pragma: associated
 #include "army_troop.h"
 #include "artifact.h"
 #include "artifact_info.h"

--- a/src/fheroes2/ai/ai_planner_castle.cpp
+++ b/src/fheroes2/ai/ai_planner_castle.cpp
@@ -26,7 +26,7 @@
 #include <vector>
 
 #include "ai_common.h"
-#include "ai_planner.h"
+#include "ai_planner.h" // IWYU pragma: associated
 #include "army.h"
 #include "castle.h"
 #include "difficulty.h"

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -35,7 +35,7 @@
 
 #include "ai_common.h"
 #include "ai_hero_action.h"
-#include "ai_planner.h"
+#include "ai_planner.h" // IWYU pragma: associated
 #include "ai_planner_internals.h"
 #include "army.h"
 #include "army_troop.h"

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -34,7 +34,7 @@
 
 #include "ai_common.h"
 #include "ai_hero_action.h"
-#include "ai_planner.h"
+#include "ai_planner.h" // IWYU pragma: associated
 #include "ai_planner_internals.h"
 #include "army.h"
 #include "army_troop.h"

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -24,12 +24,10 @@
 #ifndef H2BATTLE_H
 #define H2BATTLE_H
 
-#include <utility>
+#include <cstdint>
 #include <vector>
 
-#include "army.h"
-#include "gamedefs.h"
-#include "m82.h"
+class Army;
 
 namespace Battle
 {

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -35,7 +35,7 @@
 #include <vector>
 
 #include "battle.h"
-#include "battle_arena.h"
+#include "battle_arena.h" // IWYU pragma: associated
 #include "battle_army.h"
 #include "battle_board.h"
 #include "battle_bridge.h"

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -23,6 +23,7 @@
 
 #include "battle_catapult.h"
 
+#include <algorithm>
 #include <cassert>
 #include <ostream>
 #include <utility>

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -35,9 +35,9 @@
 #include "audio.h"
 #include "audio_manager.h"
 #include "battle.h"
-#include "battle_arena.h"
+#include "battle_arena.h" // IWYU pragma: associated
 #include "battle_army.h"
-#include "battle_interface.h"
+#include "battle_interface.h" // IWYU pragma: associated
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -39,7 +39,7 @@
 #include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
-#include "battle.h"
+#include "battle.h" // IWYU pragma: associated
 #include "battle_arena.h"
 #include "battle_army.h"
 #include "battle_bridge.h"

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -35,7 +35,7 @@
 #include "army.h"
 #include "army_troop.h"
 #include "artifact.h"
-#include "battle.h"
+#include "battle.h" // IWYU pragma: associated
 #include "battle_arena.h"
 #include "battle_army.h"
 #include "campaign_savedata.h"

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -27,7 +27,7 @@
 #include <vector>
 
 #include "agg_image.h"
-#include "castle.h"
+#include "castle.h" // IWYU pragma: associated
 #include "castle_building_info.h"
 #include "game_delays.h"
 #include "icn.h"

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -35,7 +35,7 @@
 #include "audio.h"
 #include "audio_manager.h"
 #include "captain.h"
-#include "castle.h"
+#include "castle.h" // IWYU pragma: associated
 #include "castle_building_info.h"
 #include "color.h"
 #include "cursor.h"

--- a/src/fheroes2/castle/castle_mageguild.cpp
+++ b/src/fheroes2/castle/castle_mageguild.cpp
@@ -28,7 +28,7 @@
 #include <vector>
 
 #include "agg_image.h"
-#include "castle.h"
+#include "castle.h" // IWYU pragma: associated
 #include "cursor.h"
 #include "dialog.h"
 #include "game_hotkeys.h"

--- a/src/fheroes2/castle/castle_tavern.cpp
+++ b/src/fheroes2/castle/castle_tavern.cpp
@@ -26,7 +26,7 @@
 #include <utility>
 #include <vector>
 
-#include "castle.h"
+#include "castle.h" // IWYU pragma: associated
 #include "dialog.h"
 #include "game_delays.h"
 #include "icn.h"

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -32,7 +32,7 @@
 #include "artifact.h"
 #include "buildinginfo.h"
 #include "captain.h"
-#include "castle.h"
+#include "castle.h" // IWYU pragma: associated
 #include "cursor.h"
 #include "dialog.h"
 #include "game_hotkeys.h"

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -33,7 +33,7 @@
 #include "army.h"
 #include "army_troop.h"
 #include "battle_cell.h"
-#include "castle.h"
+#include "castle.h" // IWYU pragma: associated
 #include "cursor.h"
 #include "dialog.h"
 #include "game_delays.h"

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -23,16 +23,16 @@
 #ifndef H2DIALOG_H
 #define H2DIALOG_H
 
+#include <cstddef>
 #include <cstdint>
-#include <list>
 #include <memory>
 #include <optional>
 #include <string>
-#include <vector>
 
 #include "game_mode.h"
 #include "gamedefs.h"
 #include "image.h"
+#include "math_base.h"
 
 #define SHADOWWIDTH 16
 #define BOXAREA_WIDTH 244
@@ -45,7 +45,6 @@ class Monster;
 class Troop;
 
 struct ArtifactSetData;
-struct CapturedObject;
 
 namespace fheroes2
 {

--- a/src/fheroes2/dialog/dialog_adventure.cpp
+++ b/src/fheroes2/dialog/dialog_adventure.cpp
@@ -24,7 +24,7 @@
 #include <cstdint>
 
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "localevent.h"

--- a/src/fheroes2/dialog/dialog_arena.cpp
+++ b/src/fheroes2/dialog/dialog_arena.cpp
@@ -26,7 +26,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -35,7 +35,7 @@
 #include "battle.h"
 #include "battle_cell.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "icn.h"

--- a/src/fheroes2/dialog/dialog_artifact.cpp
+++ b/src/fheroes2/dialog/dialog_artifact.cpp
@@ -23,7 +23,7 @@
 
 #include "artifact.h"
 #include "audio_manager.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "m82.h"
 #include "translations.h"
 #include "ui_dialog.h"

--- a/src/fheroes2/dialog/dialog_box.cpp
+++ b/src/fheroes2/dialog/dialog_box.cpp
@@ -26,7 +26,7 @@
 #include <memory>
 
 #include "agg_image.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "icn.h"
 #include "image.h"
 #include "screen.h"

--- a/src/fheroes2/dialog/dialog_buyboat.cpp
+++ b/src/fheroes2/dialog/dialog_buyboat.cpp
@@ -23,7 +23,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"

--- a/src/fheroes2/dialog/dialog_chest.cpp
+++ b/src/fheroes2/dialog/dialog_chest.cpp
@@ -26,7 +26,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "icn.h"

--- a/src/fheroes2/dialog/dialog_file.cpp
+++ b/src/fheroes2/dialog/dialog_file.cpp
@@ -25,7 +25,7 @@
 #include <string>
 
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "dir.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"

--- a/src/fheroes2/dialog/dialog_frameborder.cpp
+++ b/src/fheroes2/dialog/dialog_frameborder.cpp
@@ -24,7 +24,7 @@
 #include <cstdint>
 
 #include "agg_image.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "icn.h"
 #include "image.h"
 #include "math_base.h"

--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -25,7 +25,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "difficulty.h"
 #include "game.h"
 #include "game_hotkeys.h"

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -32,7 +32,7 @@
 #include "agg_image.h"
 #include "color.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "icn.h"
 #include "image.h"
 #include "kingdom.h"

--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -27,7 +27,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_hotkeys.h"
 #include "gamedefs.h"
 #include "heroes.h"

--- a/src/fheroes2/dialog/dialog_marketplace.cpp
+++ b/src/fheroes2/dialog/dialog_marketplace.cpp
@@ -31,7 +31,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -37,7 +37,7 @@
 #include "castle.h"
 #include "color.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game.h"
 #include "game_interface.h"
 #include "ground.h"

--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -34,7 +34,7 @@
 #include "army_troop.h"
 #include "bin_info.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_hotkeys.h"
 #include "gamedefs.h"
 #include "icn.h"

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -31,7 +31,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game_delays.h"
 #include "game_language.h"
 #include "icn.h"

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -35,7 +35,7 @@
 
 #include "agg_image.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "dir.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"

--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -35,7 +35,7 @@
 #include "castle.h"
 #include "color.h"
 #include "cursor.h"
-#include "dialog.h"
+#include "dialog.h" // IWYU pragma: associated
 #include "game.h"
 #include "game_hotkeys.h"
 #include "heroes.h"

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -43,7 +43,7 @@
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
-#include "game.h"
+#include "game.h" // IWYU pragma: associated
 #include "game_credits.h"
 #include "game_hotkeys.h"
 #include "game_io.h"

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -35,7 +35,7 @@
 #include "campaign_scenariodata.h"
 #include "cursor.h"
 #include "dialog.h"
-#include "game.h"
+#include "game.h" // IWYU pragma: associated
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "game_io.h"

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -21,7 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "game.h"  // IWYU pragma: associated
+#include "game.h" // IWYU pragma: associated
 
 #include <array>
 #include <cstddef>

--- a/src/fheroes2/game/game_loadgame.cpp
+++ b/src/fheroes2/game/game_loadgame.cpp
@@ -21,7 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "game.h"
+#include "game.h"  // IWYU pragma: associated
 
 #include <array>
 #include <cstddef>

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -39,7 +39,7 @@
 #include "dialog_language_selection.h"
 #include "dialog_resolution.h"
 #include "editor_mainmenu.h"
-#include "game.h"
+#include "game.h" // IWYU pragma: associated
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -21,7 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "game.h"
+#include "game.h" // IWYU pragma: associated
 
 #include <array>
 #include <cassert>

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -36,7 +36,7 @@
 #include "dialog.h"
 #include "dialog_selectscenario.h"
 #include "difficulty.h"
-#include "game.h"
+#include "game.h" // IWYU pragma: associated
 #include "game_hotkeys.h"
 #include "game_interface.h"
 #include "game_mainmenu_ui.h"

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -21,7 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "game.h"
+#include "game.h" // IWYU pragma: associated
 
 #include <algorithm>
 #include <cassert>
@@ -46,7 +46,7 @@
 #include "direction.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
-#include "game_interface.h"
+#include "game_interface.h" // IWYU pragma: associated
 #include "game_io.h"
 #include "game_mode.h"
 #include "game_over.h"

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -40,7 +40,7 @@
 #include "direction.h"
 #include "game.h"
 #include "game_delays.h"
-#include "game_interface.h"
+#include "game_interface.h" // IWYU pragma: associated
 #include "game_io.h"
 #include "game_mode.h"
 #include "game_over.h"

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -29,7 +29,7 @@
 #include "audio_manager.h"
 #include "castle.h"
 #include "game.h"
-#include "game_interface.h"
+#include "game_interface.h" // IWYU pragma: associated
 #include "heroes.h"
 #include "interface_base.h"
 #include "interface_gamearea.h"

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -25,7 +25,7 @@
 #define H2HEROES_H
 
 #include <algorithm>
-#include <cassert>
+#include <cassert> // IWYU pragma: keep
 #include <cmath>
 #include <cstdint>
 #include <exception>

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -48,7 +48,7 @@
 #include "game_delays.h"
 #include "game_interface.h"
 #include "game_static.h"
-#include "heroes.h"
+#include "heroes.h" // IWYU pragma: associated
 #include "icn.h"
 #include "image.h"
 #include "interface_base.h"

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -40,7 +40,7 @@
 #include "game_hotkeys.h"
 #include "game_interface.h"
 #include "gamedefs.h"
-#include "heroes.h"
+#include "heroes.h" // IWYU pragma: associated
 #include "heroes_base.h"
 #include "heroes_indicator.h"
 #include "icn.h"

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -40,7 +40,7 @@
 #include "game.h"
 #include "game_hotkeys.h"
 #include "gamedefs.h"
-#include "heroes.h"
+#include "heroes.h" // IWYU pragma: associated
 #include "heroes_base.h"
 #include "heroes_indicator.h"
 #include "icn.h"

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -33,7 +33,7 @@
 #include "game_delays.h"
 #include "game_interface.h"
 #include "ground.h"
-#include "heroes.h"
+#include "heroes.h" // IWYU pragma: associated
 #include "interface_base.h"
 #include "interface_gamearea.h"
 #include "kingdom.h"

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -37,7 +37,7 @@
 #include "dialog_selectitems.h"
 #include "direction.h"
 #include "game_interface.h"
-#include "heroes.h"
+#include "heroes.h" // IWYU pragma: associated
 #include "interface_base.h"
 #include "interface_gamearea.h"
 #include "interface_radar.h"

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -48,7 +48,7 @@
 #include "interface_gamearea.h"
 #include "interface_icons.h"
 #include "interface_list.h"
-#include "kingdom.h"
+#include "kingdom.h" // IWYU pragma: associated
 #include "localevent.h"
 #include "math_base.h"
 #include "mp2.h"

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -62,7 +62,7 @@
 #include "resource.h"
 #include "serialize.h"
 #include "settings.h"
-#include "world.h"
+#include "world.h" // IWYU pragma: associated
 #include "world_object_uid.h"
 
 namespace

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -18,6 +18,8 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#include "world_regions.h"
+
 #include <algorithm>
 #include <cstddef>
 #include <cstdint>
@@ -31,7 +33,6 @@
 #include "math_base.h"
 #include "mp2.h"
 #include "world.h" // IWYU pragma: associated
-#include "world_regions.h"
 
 namespace
 {

--- a/src/fheroes2/world/world_regions.cpp
+++ b/src/fheroes2/world/world_regions.cpp
@@ -30,7 +30,7 @@
 #include "maps_tiles.h"
 #include "math_base.h"
 #include "mp2.h"
-#include "world.h"
+#include "world.h" // IWYU pragma: associated
 #include "world_regions.h"
 
 namespace


### PR DESCRIPTION
In fheroes2, a scheme is sometimes practiced (especially in old code) when, for one header file with declarations, there are multiple CPP files with implementations of functions or classes declared in that header file (or even vice versa, when one CPP file contains implementations for declarations from multiple header files). Relatively recent versions of IWYU have the [pragma "associated"](https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/IWYUPragmas.md#iwyu-pragma-associated) for better tracking of such dependencies.