### PR TITLE
Handle the AI hero's patrol mode in the AI pathfinder

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -236,7 +236,7 @@ namespace
 
     void AITownPortal( Heroes & hero, const int32_t targetIndex )
     {
-        assert( !hero.Modes( Heroes::PATROL ) && Maps::isValidAbsIndex( targetIndex ) );
+        assert( Maps::isValidAbsIndex( targetIndex ) );
 #if !defined( NDEBUG ) || defined( WITH_DEBUG )
         const Castle * targetCastle = world.getCastleEntrance( Maps::GetPoint( targetIndex ) );
 #endif

--- a/src/fheroes2/ai/ai_planner.h
+++ b/src/fheroes2/ai/ai_planner.h
@@ -195,7 +195,7 @@ namespace AI
 
         std::vector<AICastle> getSortedCastleList( const VecCastles & castles, const std::set<int> & castlesInDanger );
 
-        int getPriorityTarget( Heroes * hero, double & maxPriority );
+        int getPriorityTarget( Heroes & hero, double & maxPriority );
 
         double getGeneralObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;

--- a/src/fheroes2/ai/ai_planner.h
+++ b/src/fheroes2/ai/ai_planner.h
@@ -115,13 +115,6 @@ namespace AI
         }
     };
 
-    struct HeroToMove
-    {
-        Heroes * hero = nullptr;
-        int patrolCenter = -1;
-        uint32_t patrolDistance = 0;
-    };
-
     struct EnemyArmy
     {
         EnemyArmy() = default;
@@ -202,7 +195,7 @@ namespace AI
 
         std::vector<AICastle> getSortedCastleList( const VecCastles & castles, const std::set<int> & castlesInDanger );
 
-        int getPriorityTarget( const HeroToMove & heroInfo, double & maxPriority );
+        int getPriorityTarget( Heroes * hero, double & maxPriority );
 
         double getGeneralObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;
         double getFighterObjectValue( const Heroes & hero, const int index, const double valueToIgnore, const uint32_t distanceToObject ) const;

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2179,11 +2179,9 @@ int AI::Planner::getCourierMainTarget( const Heroes & hero, const AIWorldPathfin
     return targetIndex;
 }
 
-int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
+int AI::Planner::getPriorityTarget( Heroes & hero, double & maxPriority )
 {
-    assert( hero != nullptr );
-
-    DEBUG_LOG( DBG_AI, DBG_INFO, "Find Adventure Map target for hero " << hero->GetName() << " at current position " << hero->GetIndex() )
+    DEBUG_LOG( DBG_AI, DBG_INFO, "Find Adventure Map target for hero " << hero.GetName() << " at current position " << hero.GetIndex() )
 
     const double lowestPossibleValue = -1.0 * Maps::Ground::slowestMovePenalty * world.getSize();
 
@@ -2210,7 +2208,7 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
 #endif
 
     // Pre-calculate penalties for tiles where there is a threat of enemy attack
-    const std::vector<double> enemyThreatPenalties = [this, hero = static_cast<const Heroes *>( hero )]() {
+    const std::vector<double> enemyThreatPenalties = [this, &hero = std::as_const( hero )]() {
         std::vector<double> result( world.getSize(), 0.0 );
 
         const AIWorldPathfinderStateRestorer pathfinderStateRestorer( _pathfinder );
@@ -2219,7 +2217,7 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
         _pathfinder.setMinimalArmyStrengthAdvantage( ARMY_ADVANTAGE_DESPERATE );
         _pathfinder.setSpellPointsReserveRatio( 0.0 );
 
-        const double heroStrength = hero->GetArmy().GetStrength();
+        const double heroStrength = hero.GetArmy().GetStrength();
 
         for ( const auto & [dummy, enemyArmy] : _enemyArmies ) {
             // Only enemy heroes are taken into account
@@ -2242,8 +2240,8 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
             const uint32_t enemyArmyMovePointsThreshold = enemyArmy.movePoints + Maps::Ground::slowestMovePenalty * 2;
             // If the enemy hero can't cross paths with our hero anywhere, then it makes sense to use a rough but quick estimate. Otherwise, an accurate but
             // relatively slow estimate will be used.
-            const bool useRoughEstimate = ( Maps::GetApproximateDistance( hero->GetIndex(), enemyArmy.index ) * Maps::Ground::fastestMovePenalty
-                                            > hero->GetMovePoints() + enemyArmyMovePointsThreshold );
+            const bool useRoughEstimate = ( Maps::GetApproximateDistance( hero.GetIndex(), enemyArmy.index ) * Maps::Ground::fastestMovePenalty
+                                            > hero.GetMovePoints() + enemyArmyMovePointsThreshold );
 
             if ( !useRoughEstimate ) {
                 // Pre-cache the pathfinder database for the enemy hero
@@ -2291,12 +2289,12 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
     }();
 
     // Pre-cache the pathfinder database for our hero
-    _pathfinder.reEvaluateIfNeeded( *hero );
+    _pathfinder.reEvaluateIfNeeded( hero );
 
-    ObjectValidator objectValidator( *hero, _pathfinder, *this );
-    ObjectValueStorage valueStorage( *hero, *this, lowestPossibleValue );
+    ObjectValidator objectValidator( hero, _pathfinder, *this );
+    ObjectValueStorage valueStorage( hero, *this, lowestPossibleValue );
 
-    const auto getObjectValue = [this, hero = static_cast<const Heroes *>( hero ), &enemyThreatPenalties, &objectValidator,
+    const auto getObjectValue = [this, &hero = std::as_const( hero ), &enemyThreatPenalties, &objectValidator,
                                  &valueStorage]( const int destination, uint32_t & distance, double & value, const MP2::MapObjectType type, const bool isDimensionDoor ) {
         // Dimension door path does not include any objects on the way.
         if ( !isDimensionDoor ) {
@@ -2311,16 +2309,16 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
             }
         }
 
-        const uint32_t heroMovePoints = hero->GetMovePoints();
+        const uint32_t heroMovePoints = hero.GetMovePoints();
 
-        const double enemyThreatPenalty = [hero, &enemyThreatPenalties, destination, distance, type, heroMovePoints]() {
+        const double enemyThreatPenalty = [&hero, &enemyThreatPenalties, destination, distance, type, heroMovePoints]() {
             if ( type == MP2::OBJ_CASTLE ) {
                 const Castle * castle = world.getCastleEntrance( Maps::GetPoint( destination ) );
                 assert( castle != nullptr );
 
                 // We should strive to defend our castles even if our hero is relatively weak (he can get reinforcements in the castle), so enemy threat
                 // penalties should not apply if our hero is able to reach the castle within one turn.
-                if ( castle->GetColor() == hero->GetColor() && distance <= heroMovePoints ) {
+                if ( castle->GetColor() == hero.GetColor() && distance <= heroMovePoints ) {
                     return 0.0;
                 }
             }
@@ -2341,8 +2339,8 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
     };
 
     // Set baseline target if it's a special role
-    if ( hero->getAIRole() == Heroes::Role::COURIER ) {
-        const int courierTarget = getCourierMainTarget( *hero, _pathfinder, lowestPossibleValue );
+    if ( hero.getAIRole() == Heroes::Role::COURIER ) {
+        const int courierTarget = getCourierMainTarget( hero, _pathfinder, lowestPossibleValue );
         if ( courierTarget != -1 ) {
             // Anything with positive value can override the courier's main task (i.e. castle or mine capture on the way)
             maxPriority = 0;
@@ -2351,11 +2349,11 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
             objectType = world.GetTiles( courierTarget ).GetObject();
 #endif
 
-            DEBUG_LOG( DBG_AI, DBG_INFO, hero->GetName() << " is a courier with a main target tile at " << courierTarget )
+            DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " is a courier with a main target tile at " << courierTarget )
         }
         else {
             // If there's nothing to do as a Courier reset the role
-            hero->setAIRole( Heroes::Role::HUNTER );
+            hero.setAIRole( Heroes::Role::HUNTER );
         }
     }
 
@@ -2367,7 +2365,7 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
         uint32_t dist = _pathfinder.getDistance( node.first );
 
         bool useDimensionDoor = false;
-        const uint32_t dimensionDoorDist = Route::calculatePathPenalty( _pathfinder.getDimensionDoorPath( *hero, node.first ) );
+        const uint32_t dimensionDoorDist = Route::calculatePathPenalty( _pathfinder.getDimensionDoorPath( hero, node.first ) );
         if ( dimensionDoorDist > 0 && ( dist == 0 || dimensionDoorDist < dist / 2 ) ) {
             dist = dimensionDoorDist;
             useDimensionDoor = true;
@@ -2388,19 +2386,19 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
 #endif
 
             DEBUG_LOG( DBG_AI, DBG_TRACE,
-                       hero->GetName() << ": valid object at " << node.first << " value is " << value << " ("
-                                       << MP2::StringObject( static_cast<MP2::MapObjectType>( node.second ) ) << ")" )
+                       hero.GetName() << ": valid object at " << node.first << " value is " << value << " ("
+                                      << MP2::StringObject( static_cast<MP2::MapObjectType>( node.second ) ) << ")" )
         }
     }
 
-    double fogDiscoveryValue = getFogDiscoveryValue( *hero );
-    const auto [fogDiscoveryTarget, isTerritoryExpansion] = _pathfinder.getFogDiscoveryTile( *hero );
+    double fogDiscoveryValue = getFogDiscoveryValue( hero );
+    const auto [fogDiscoveryTarget, isTerritoryExpansion] = _pathfinder.getFogDiscoveryTile( hero );
     if ( fogDiscoveryTarget >= 0 ) {
         uint32_t distanceToFogDiscovery = _pathfinder.getDistance( fogDiscoveryTarget );
 
         // TODO: add logic to check fog discovery based on Dimension Door distance, not the nearest tile.
         bool useDimensionDoor = false;
-        const uint32_t dimensionDoorDist = Route::calculatePathPenalty( _pathfinder.getDimensionDoorPath( *hero, fogDiscoveryTarget ) );
+        const uint32_t dimensionDoorDist = Route::calculatePathPenalty( _pathfinder.getDimensionDoorPath( hero, fogDiscoveryTarget ) );
         if ( dimensionDoorDist > 0 && ( distanceToFogDiscovery == 0 || dimensionDoorDist < distanceToFogDiscovery / 2 ) ) {
             distanceToFogDiscovery = dimensionDoorDist;
             useDimensionDoor = true;
@@ -2408,7 +2406,7 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
 
         if ( isTerritoryExpansion ) {
             // Over time the AI should focus more on territory expansion.
-            const uint32_t period = getTimeoutBeforeFogDiscoveryIntensification( *hero );
+            const uint32_t period = getTimeoutBeforeFogDiscoveryIntensification( hero );
             assert( period > 0 );
 
             if ( fogDiscoveryValue < 0 ) {
@@ -2436,16 +2434,16 @@ int AI::Planner::getPriorityTarget( Heroes * hero, double & maxPriority )
         if ( fogDiscoveryTarget >= 0 && fogDiscoveryValue > maxPriority ) {
             priorityTarget = fogDiscoveryTarget;
             maxPriority = fogDiscoveryValue;
-            DEBUG_LOG( DBG_AI, DBG_INFO, hero->GetName() << ": selected target: " << priorityTarget << " value is " << maxPriority << " (fog discovery)" )
+            DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << ": selected target: " << priorityTarget << " value is " << maxPriority << " (fog discovery)" )
         }
         else {
             DEBUG_LOG( DBG_AI, DBG_INFO,
-                       hero->GetName() << ": selected target: " << priorityTarget << " value is " << maxPriority << " (" << MP2::StringObject( objectType ) << ")" )
+                       hero.GetName() << ": selected target: " << priorityTarget << " value is " << maxPriority << " (" << MP2::StringObject( objectType ) << ")" )
         }
     }
     else {
         priorityTarget = fogDiscoveryTarget;
-        DEBUG_LOG( DBG_AI, DBG_INFO, hero->GetName() << " can't find an object. Scouting the fog of war at " << priorityTarget )
+        DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " can't find an object. Scouting the fog of war at " << priorityTarget )
     }
 
     return priorityTarget;
@@ -2751,7 +2749,7 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressVa
 
                 for ( Heroes * hero : availableHeroes ) {
                     double priority = -1;
-                    const int targetIndex = getPriorityTarget( hero, priority );
+                    const int targetIndex = getPriorityTarget( *hero, priority );
 
                     if ( targetIndex != -1 && ( priority > maxPriority || bestTargetIndex == -1 ) ) {
                         maxPriority = priority;

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2769,8 +2769,8 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressVa
             Rand::Shuffle( availableHeroes );
 
             for ( Heroes * hero : availableHeroes ) {
-                // Skip heroes who are in castles or on patrol.
-                if ( hero->Modes( Heroes::PATROL ) || hero->inCastle() != nullptr ) {
+                // Skip heroes located in castles.
+                if ( hero->inCastle() != nullptr ) {
                     continue;
                 }
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -686,7 +686,7 @@ namespace
     void addHeroToMove( Heroes * hero, std::vector<Heroes *> & availableHeroes )
     {
         if ( hero->Modes( Heroes::PATROL ) && ( hero->GetPatrolDistance() == 0 ) ) {
-            DEBUG_LOG( DBG_AI, DBG_TRACE, hero->GetName() << " standing still. Skip turn." )
+            DEBUG_LOG( DBG_AI, DBG_TRACE, hero->GetName() << " stands still due to the patrol settings" )
             return;
         }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -1296,24 +1296,30 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
     uint32_t spellsUsed = 0;
     while ( maxCasts > spellsUsed ) {
         const int32_t currentNodeIdx = Maps::GetIndexFromAbsPoint( current );
+
         fheroes2::Point another = current;
         another.x += ( difference.x > 0 ) ? std::min( difference.x, distanceLimit ) : std::max( difference.x, -distanceLimit );
         another.y += ( difference.y > 0 ) ? std::min( difference.y, distanceLimit ) : std::max( difference.y, -distanceLimit );
 
         const int32_t anotherNodeIdx = Maps::GetIndexFromAbsPoint( another );
-        bool found = Maps::isValidForDimensionDoor( anotherNodeIdx, water );
 
-        if ( !found ) {
+        if ( Maps::isValidForDimensionDoor( anotherNodeIdx, water ) ) {
+            path.emplace_back( anotherNodeIdx, currentNodeIdx, Direction::CENTER, movementCost );
+            current = another;
+        }
+        else {
             fheroes2::Point bestDirectionDiff;
             int bestNextIdx = -1;
 
             for ( size_t i = 0; i < directions.size(); ++i ) {
-                if ( !Maps::isValidDirection( anotherNodeIdx, directions[i] ) )
+                if ( !Maps::isValidDirection( anotherNodeIdx, directions[i] ) ) {
                     continue;
+                }
 
                 const int newIndex = anotherNodeIdx + _mapOffset[i];
-                if ( !Maps::isValidForDimensionDoor( newIndex, water ) )
+                if ( !Maps::isValidForDimensionDoor( newIndex, water ) ) {
                     continue;
+                }
 
                 // If we are near the destination and we cannot reach the cell, skip it.
                 if ( anotherNodeIdx == targetIndex && !isMovementAllowed( newIndex, Direction::Reflect( directions[i] ) ) ) {
@@ -1339,10 +1345,6 @@ std::list<Route::Step> AIWorldPathfinder::getDimensionDoorPath( const Heroes & h
 
             path.emplace_back( bestNextIdx, currentNodeIdx, Direction::CENTER, movementCost );
             current = Maps::GetPoint( bestNextIdx );
-        }
-        else {
-            path.emplace_back( anotherNodeIdx, currentNodeIdx, Direction::CENTER, movementCost );
-            current = another;
         }
 
         ++spellsUsed;

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -102,9 +102,9 @@ protected:
     std::vector<WorldNode> _cache;
     std::vector<int> _mapOffset;
 
-    // Hero properties should be cached here because they can change even if the hero's position does not change,
-    // so it should be possible to compare the old values with the new ones to detect the need to recalculate the
-    // pathfinder's cache
+    // The hero properties used by the pathfinder are cached here not just for optimization, but also because some
+    // of them may change even if the position of the hero does not change, so it should be possible to compare the
+    // old values with the new ones to determine whether the pathfinder cache needs to be recalculated.
     int _pathStart{ -1 };
     int _color{ Color::NONE };
     uint32_t _remainingMovePoints{ 0 };
@@ -138,9 +138,9 @@ private:
     // surface on which the hero is currently located is used.
     uint32_t getMaxMovePoints( const bool onWater ) const override;
 
-    // Hero properties should be cached here because they can change even if the hero's position does not change,
-    // so it should be possible to compare the old values with the new ones to detect the need to recalculate the
-    // pathfinder's cache
+    // The hero properties used by the pathfinder are cached here not just for optimization, but also because some
+    // of them may change even if the position of the hero does not change, so it should be possible to compare the
+    // old values with the new ones to determine whether the pathfinder cache needs to be recalculated.
     uint32_t _maxMovePoints{ 0 };
 };
 
@@ -225,9 +225,9 @@ private:
     // this hero and it should also have a valid information about the hero's remaining movement points.
     uint32_t getMovementPenalty( const int from, const int to, const int direction ) const override;
 
-    // Hero properties should be cached here because they can change even if the hero's position does not change,
-    // so it should be possible to compare the old values with the new ones to detect the need to recalculate the
-    // pathfinder's cache
+    // The hero properties used by the pathfinder are cached here not just for optimization, but also because some
+    // of them may change even if the position of the hero does not change, so it should be possible to compare the
+    // old values with the new ones to determine whether the pathfinder cache needs to be recalculated.
     int32_t _patrolCenter{ -1 };
     uint32_t _patrolDistance{ 0 };
     uint32_t _maxMovePointsOnLand{ 0 };

--- a/src/fheroes2/world/world_pathfinding.h
+++ b/src/fheroes2/world/world_pathfinding.h
@@ -228,9 +228,12 @@ private:
     // Hero properties should be cached here because they can change even if the hero's position does not change,
     // so it should be possible to compare the old values with the new ones to detect the need to recalculate the
     // pathfinder's cache
+    int32_t _patrolCenter{ -1 };
+    uint32_t _patrolDistance{ 0 };
     uint32_t _maxMovePointsOnLand{ 0 };
     uint32_t _maxMovePointsOnWater{ 0 };
     double _armyStrength{ -1 };
+    bool _isOnPatrol{ false };
     bool _isArtifactsBagFull{ false };
     bool _isEquippedWithSpellBook{ false };
     bool _isSummonBoatSpellAvailable{ false };


### PR DESCRIPTION
fix #9015

Currently in the `master` branch, the "patrol mode" is implemented as follows: objects outside the patrol radius are simply not considered as targets for the hero in "patrol mode". This leads to the possibility of behavior like this:

https://github.com/user-attachments/assets/2b42c8c9-7bde-4f67-89eb-566df29c11f2

This hero has the patrol mode enabled and a patrol radius of 4 tiles, thus, the artifact is "sort of" in this radius, so he does not hesitate to simply run through the already-explored territory to this object, even along a trajectory that is outside the patrol zone. I believe something similar could have happened in #9015, just on a larger scale.

With this PR:

https://github.com/user-attachments/assets/6715af88-4a08-41a1-bc3e-7f8e4372fc0e

Also, this PR removes any restrictions on the use of any adventure spells by heroes in patrol mode to pave the way. For instance, now such heroes can use Town Portal to teleport to any town or castle within their patrol radius.