### PR TITLE
Rework the castle buildings construction logic

### DIFF
--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -44,7 +44,7 @@
 #include "resource.h"
 #include "resource_trading.h"
 
-bool AI::BuildIfPossible( Castle & castle, const building_t building )
+bool AI::BuildIfPossible( Castle & castle, const BuildingType building )
 {
     switch ( castle.CheckBuyBuilding( building ) ) {
     case BuildingStatus::LACK_RESOURCES: {
@@ -68,7 +68,7 @@ bool AI::BuildIfPossible( Castle & castle, const building_t building )
     return result;
 }
 
-bool AI::BuildIfEnoughFunds( Castle & castle, const building_t building, const uint32_t fundsMultiplier )
+bool AI::BuildIfEnoughFunds( Castle & castle, const BuildingType building, const uint32_t fundsMultiplier )
 {
     if ( fundsMultiplier < 1 || fundsMultiplier > 99 ) {
         return false;

--- a/src/fheroes2/ai/ai_common.h
+++ b/src/fheroes2/ai/ai_common.h
@@ -30,20 +30,20 @@ class Kingdom;
 
 struct Funds;
 
-enum building_t : uint32_t;
+enum BuildingType : uint32_t;
 
 namespace AI
 {
     // Builds the given building in the given castle if possible. If possible and necessary, obtains the resources
     // that are missing for construction through trading on the marketplace. Returns true if the construction was
     // successful, otherwise returns false.
-    bool BuildIfPossible( Castle & castle, const building_t building );
+    bool BuildIfPossible( Castle & castle, const BuildingType building );
 
     // Builds the given building in the given castle if possible and if there is a sufficient supply of resources
     // (see the implementation for details). If possible and necessary, obtains the resources that are missing for
     // construction through trading on the marketplace. Returns true if the construction was successful, otherwise
     // returns false.
-    bool BuildIfEnoughFunds( Castle & castle, const building_t building, const uint32_t fundsMultiplier );
+    bool BuildIfEnoughFunds( Castle & castle, const BuildingType building, const uint32_t fundsMultiplier );
 
     // Performs the pre-battle arrangement of the given army, see the implementation for details
     void OptimizeTroopsOrder( Army & army );

--- a/src/fheroes2/ai/ai_planner_castle.cpp
+++ b/src/fheroes2/ai/ai_planner_castle.cpp
@@ -45,11 +45,11 @@ namespace
 {
     struct BuildOrder
     {
-        const building_t building = BUILD_NOTHING;
+        const BuildingType building = BUILD_NOTHING;
         const uint32_t priority = 1;
 
         BuildOrder() = default;
-        BuildOrder( const building_t b, const uint32_t p )
+        BuildOrder( const BuildingType b, const uint32_t p )
             : building( b )
             , priority( p )
         {}

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -225,7 +225,7 @@ Funds BuildingInfo::GetCost( uint32_t build, int race )
     return payment;
 }
 
-BuildingInfo::BuildingInfo( const Castle & c, const building_t b )
+BuildingInfo::BuildingInfo( const Castle & c, const BuildingType b )
     : castle( c )
     , _buildingType( b )
     , area( 0, 0, 135, 70 )
@@ -301,7 +301,7 @@ std::string BuildingInfo::getBuildingDescription( const int race, const uint32_t
         }
     }
     else {
-        description = fheroes2::getBuildingDescription( race, static_cast<building_t>( buildingId ) );
+        description = fheroes2::getBuildingDescription( race, static_cast<BuildingType>( buildingId ) );
 
         switch ( buildingId ) {
         case BUILD_WELL:
@@ -365,7 +365,7 @@ void BuildingInfo::Redraw() const
     }
 
     fheroes2::Display & display = fheroes2::Display::instance();
-    const int index = fheroes2::getIndexBuildingSprite( static_cast<building_t>( _buildingType ) );
+    const int index = fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) );
 
     const fheroes2::Sprite & buildingFrame = fheroes2::AGG::GetICN( ICN::BLDGXTRA, 0 );
     fheroes2::Blit( buildingFrame, display, area.x, area.y );
@@ -466,7 +466,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
     std::string requirement;
 
     if ( _status != BuildingStatus::BUILD_DISABLE ) {
-        requirement = fheroes2::getBuildingRequirementString( castle.GetRace(), static_cast<building_t>( _buildingType ) );
+        requirement = fheroes2::getBuildingRequirementString( castle.GetRace(), static_cast<BuildingType>( _buildingType ) );
     }
 
     const bool requirementsPresent = !requirement.empty();
@@ -510,7 +510,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
     fheroes2::Blit( buildingFrame, display, pos.x, pos.y );
 
     const fheroes2::Sprite & buildingImage
-        = fheroes2::AGG::GetICN( ICN::Get4Building( castle.GetRace() ), fheroes2::getIndexBuildingSprite( static_cast<building_t>( _buildingType ) ) );
+        = fheroes2::AGG::GetICN( ICN::Get4Building( castle.GetRace() ), fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) ) );
     pos.x = dialogRoi.x + ( dialogRoi.width - buildingImage.width() ) / 2;
     pos.y += 1;
     fheroes2::Blit( buildingImage, display, pos.x, pos.y );
@@ -720,7 +720,7 @@ bool DwellingsBar::ActionBarLeftMouseSingleClick( DwellingItem & dwl )
     else if ( !castle.isBuild( BUILD_CASTLE ) )
         fheroes2::showStandardTextMessage( "", GetBuildConditionDescription( BuildingStatus::NEED_CASTLE ), Dialog::OK );
     else {
-        const BuildingInfo dwelling( castle, static_cast<building_t>( dwType ) );
+        const BuildingInfo dwelling( castle, static_cast<BuildingType>( dwType ) );
 
         if ( dwelling.DialogBuyBuilding( true ) ) {
             AudioManager::PlaySound( M82::BUILDTWN );

--- a/src/fheroes2/castle/buildinginfo.h
+++ b/src/fheroes2/castle/buildinginfo.h
@@ -41,13 +41,13 @@ namespace fheroes2
 class Castle;
 class StatusBar;
 
-enum building_t : uint32_t;
+enum BuildingType : uint32_t;
 enum class BuildingStatus : int32_t;
 
 class BuildingInfo
 {
 public:
-    BuildingInfo( const Castle & c, const building_t b );
+    BuildingInfo( const Castle & c, const BuildingType b );
 
     uint32_t getBuilding() const
     {

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1011,7 +1011,7 @@ bool Castle::isFortificationBuilt() const
 
 const char * Castle::GetStringBuilding( uint32_t build, int race )
 {
-    return fheroes2::getBuildingName( race, static_cast<building_t>( build ) );
+    return fheroes2::getBuildingName( race, static_cast<BuildingType>( build ) );
 }
 
 bool Castle::AllowBuyHero( std::string * msg ) const
@@ -1310,7 +1310,7 @@ BuildingStatus Castle::CheckBuyBuilding( const uint32_t build ) const
         break;
     }
 
-    const uint32_t requirement = fheroes2::getBuildingRequirement( race, static_cast<building_t>( build ) );
+    const uint32_t requirement = fheroes2::getBuildingRequirement( race, static_cast<BuildingType>( build ) );
 
     for ( uint32_t itr = 0x00000001; itr; itr <<= 1 ) {
         if ( ( requirement & itr ) && !( _constructedBuildings & itr ) ) {
@@ -2064,7 +2064,7 @@ uint32_t Castle::GetUpgradeBuilding( const uint32_t buildingId ) const
         return fheroes2::getUpgradeForBuilding( race, DWELLING_UPGRADE6 );
     }
 
-    return fheroes2::getUpgradeForBuilding( race, static_cast<building_t>( buildingId ) );
+    return fheroes2::getUpgradeForBuilding( race, static_cast<BuildingType>( buildingId ) );
 }
 
 bool Castle::PredicateIsCastle( const Castle * castle )
@@ -2611,7 +2611,7 @@ std::string Castle::GetStringBuilding( uint32_t build ) const
 
 std::string Castle::GetDescriptionBuilding( uint32_t build ) const
 {
-    std::string res = fheroes2::getBuildingDescription( GetRace(), static_cast<building_t>( build ) );
+    std::string res = fheroes2::getBuildingDescription( GetRace(), static_cast<BuildingType>( build ) );
 
     switch ( build ) {
     case BUILD_WELL:

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -73,9 +73,11 @@ enum building_t : uint32_t
     BUILD_LEFTTURRET = 0x00000020,
     BUILD_RIGHTTURRET = 0x00000040,
     BUILD_MARKETPLACE = 0x00000080,
-    BUILD_WEL2 = 0x00000100, // Farm, Garbage He, Crystal Gar, Waterfall, Orchard, Skull Pile
+    // Farm, Garbage Heap, Crystal Garden, Waterfall, Orchard, Skull Pile
+    BUILD_WEL2 = 0x00000100,
     BUILD_MOAT = 0x00000200,
-    BUILD_SPEC = 0x00000400, // Fortification, Coliseum, Rainbow, Dungeon, Library, Storm
+    // Fortifications, Coliseum, Rainbow, Dungeon, Library, Storm
+    BUILD_SPEC = 0x00000400,
     BUILD_CASTLE = 0x00000800,
     BUILD_CAPTAIN = 0x00001000,
     BUILD_SHRINE = 0x00002000,
@@ -85,7 +87,7 @@ enum building_t : uint32_t
     BUILD_MAGEGUILD4 = 0x00020000,
     BUILD_MAGEGUILD5 = 0x00040000,
     BUILD_MAGEGUILD = BUILD_MAGEGUILD1 | BUILD_MAGEGUILD2 | BUILD_MAGEGUILD3 | BUILD_MAGEGUILD4 | BUILD_MAGEGUILD5,
-    BUILD_TENT = 0x00080000, // deprecated
+    BUILD_TENT = 0x00080000,
     DWELLING_MONSTER1 = 0x00100000,
     DWELLING_MONSTER2 = 0x00200000,
     DWELLING_MONSTER3 = 0x00400000,
@@ -98,7 +100,8 @@ enum building_t : uint32_t
     DWELLING_UPGRADE4 = 0x10000000,
     DWELLING_UPGRADE5 = 0x20000000,
     DWELLING_UPGRADE6 = 0x40000000,
-    DWELLING_UPGRADE7 = 0x80000000, // black dragon
+    // Black Dragons
+    DWELLING_UPGRADE7 = 0x80000000,
     DWELLING_UPGRADES = DWELLING_UPGRADE2 | DWELLING_UPGRADE3 | DWELLING_UPGRADE4 | DWELLING_UPGRADE5 | DWELLING_UPGRADE6 | DWELLING_UPGRADE7
 };
 
@@ -360,35 +363,55 @@ namespace CastleDialog
     class FadeBuilding
     {
     public:
-        FadeBuilding()
-            : _alpha( 255 )
-            , _build( BUILD_NOTHING )
-        {}
+        FadeBuilding() = default;
 
-        void StartFadeBuilding( const uint32_t build );
+        void StartFadeBuilding( const uint32_t building )
+        {
+            _alpha = 0;
+            _building = building;
+            _isOnlyBoat = false;
+        }
 
-        bool UpdateFadeBuilding();
+        void StartFadeBoat()
+        {
+            _alpha = 0;
+            _building = BUILD_SHIPYARD;
+            _isOnlyBoat = true;
+        }
+
+        bool UpdateFade();
 
         bool IsFadeDone() const
         {
             return _alpha == 255;
         }
 
-        void StopFadeBuilding();
+        void StopFade()
+        {
+            _alpha = 255;
+            _building = BUILD_NOTHING;
+            _isOnlyBoat = false;
+        }
 
         uint8_t GetAlpha() const
         {
             return _alpha;
         }
 
-        uint32_t GetBuild() const
+        uint32_t GetBuilding() const
         {
-            return _build;
+            return _building;
+        }
+
+        bool isOnlyBoat() const
+        {
+            return _isOnlyBoat;
         }
 
     private:
-        uint8_t _alpha;
-        uint32_t _build;
+        uint8_t _alpha{ 255 };
+        uint32_t _building{ BUILD_NOTHING };
+        bool _isOnlyBoat{ false };
     };
 
     struct BuildingRenderInfo
@@ -409,14 +432,11 @@ namespace CastleDialog
 
     struct CacheBuildings : std::vector<BuildingRenderInfo>
     {
-        CacheBuildings( const Castle &, const fheroes2::Point & );
+        CacheBuildings( const Castle & castle, const fheroes2::Point & top );
     };
 
     void RedrawAllBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CacheBuildings & orders, const CastleDialog::FadeBuilding & alphaBuilding,
                             const uint32_t animationIndex );
-
-    void CastleRedrawBuilding( const Castle &, const fheroes2::Point &, uint32_t build, uint32_t frame, uint8_t alpha = 255 );
-    void CastleRedrawBuildingExtended( const Castle &, const fheroes2::Point &, uint32_t build, uint32_t frame, uint8_t alpha = 255 );
 }
 
 struct VecCastles : public std::vector<Castle *>

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -62,7 +62,7 @@ class Heroes;
 class StreamBase;
 class Troop;
 
-enum building_t : uint32_t
+enum BuildingType : uint32_t
 {
     BUILD_NOTHING = 0x00000000,
     BUILD_THIEVESGUILD = 0x00000001,
@@ -416,7 +416,7 @@ namespace CastleDialog
 
     struct BuildingRenderInfo
     {
-        BuildingRenderInfo( building_t b, const fheroes2::Rect & r )
+        BuildingRenderInfo( BuildingType b, const fheroes2::Rect & r )
             : id( b )
             , coord( r )
         {}
@@ -426,7 +426,7 @@ namespace CastleDialog
             return b == static_cast<uint32_t>( id );
         }
 
-        building_t id;
+        BuildingType id;
         fheroes2::Rect coord;
     };
 

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -435,8 +435,8 @@ namespace CastleDialog
         CacheBuildings( const Castle & castle, const fheroes2::Point & top );
     };
 
-    void RedrawAllBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CacheBuildings & orders, const CastleDialog::FadeBuilding & alphaBuilding,
-                            const uint32_t animationIndex );
+    void RedrawAllBuildings( const Castle & castle, const fheroes2::Point & dst_pt, const CacheBuildings & orders, const CastleDialog::FadeBuilding & alphaBuilding,
+                             const uint32_t animationIndex );
 }
 
 struct VecCastles : public std::vector<Castle *>

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -141,6 +141,232 @@ namespace
             fheroes2::drawCastleDialogBuilding( ICN::NECROMANCER_CASTLE_CAPTAIN_QUARTERS_BRIDGE, 0, castle, position, roi, alpha );
         }
     }
+
+    void redrawCastleBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const uint32_t building, const uint32_t frame, const uint8_t alpha = 255 )
+    {
+        if ( building == BUILD_TENT ) {
+            // We don't need to draw a tent because it's on the background image.
+            return;
+        }
+
+        const int race = castle.GetRace();
+        uint32_t index = 0;
+
+        switch ( building ) {
+        case BUILD_MAGEGUILD1:
+            if ( castle.GetLevelMageGuild() > 1 ) {
+                return;
+            }
+            break;
+        case BUILD_MAGEGUILD2:
+            if ( castle.GetLevelMageGuild() > 2 ) {
+                return;
+            }
+            index = ( Race::NECR == race ) ? 6 : 1;
+            break;
+        case BUILD_MAGEGUILD3:
+            if ( castle.GetLevelMageGuild() > 3 ) {
+                return;
+            }
+            index = ( Race::NECR == race ) ? 12 : 2;
+            break;
+        case BUILD_MAGEGUILD4:
+            if ( castle.GetLevelMageGuild() > 4 ) {
+                return;
+            }
+            index = ( Race::NECR == race ) ? 18 : 3;
+            break;
+        case BUILD_MAGEGUILD5:
+            index = ( Race::NECR == race ) ? 24 : 4;
+            break;
+        default:
+            break;
+        }
+
+        const int icn = Castle::GetICNBuilding( building, race );
+        if ( icn == ICN::UNKNOWN ) {
+            // Have you added a new building? Add the logic for it!
+            assert( 0 );
+            return;
+        }
+
+        const fheroes2::Rect max = CastleGetMaxArea( castle, dst_pt );
+
+        // Building main sprite.
+        fheroes2::drawCastleDialogBuilding( icn, index, castle, dst_pt, max, alpha );
+
+        // Special case: Knight castle's flags are overlapped by Right Turret so we need to draw flags after drawing the Turret.
+        const bool knightCastleCase = ( race == Race::KNGT && castle.isBuild( BUILD_RIGHTTURRET ) && castle.isBuild( BUILD_CASTLE ) );
+        if ( knightCastleCase && building == BUILD_CASTLE ) {
+            // Do not draw flags.
+            return;
+        }
+
+        // Building animation sprite.
+        if ( const uint32_t index2 = ICN::AnimationFrame( icn, index, frame ) ) {
+            fheroes2::drawCastleDialogBuilding( icn, index2, castle, dst_pt, max, alpha );
+        }
+
+        if ( knightCastleCase && building == BUILD_RIGHTTURRET ) {
+            // Draw Castle's flags after the Turret.
+            const int castleIcn = Castle::GetICNBuilding( BUILD_CASTLE, race );
+            const uint32_t flagAnimFrame = ICN::AnimationFrame( castleIcn, index, frame );
+            if ( flagAnimFrame > 0 ) {
+                fheroes2::drawCastleDialogBuilding( castleIcn, flagAnimFrame, castle, dst_pt, max, alpha );
+            }
+        }
+    }
+
+    void redrawCastleBuildingExtended( const Castle & castle, const fheroes2::Point & dst_pt, const uint32_t building, const uint32_t frame, const uint8_t alpha = 255 )
+    {
+        if ( building == BUILD_TENT ) {
+            // We don't need to draw a tent because it's on the background image.
+            return;
+        }
+
+        const fheroes2::Rect max = CastleGetMaxArea( castle, dst_pt );
+        const int icn = Castle::GetICNBuilding( building, castle.GetRace() );
+
+        if ( building == BUILD_SHIPYARD ) {
+            if ( castle.HasBoatNearby() ) {
+                const int icn2 = Castle::GetICNBoat( castle.GetRace() );
+
+                fheroes2::drawCastleDialogBuilding( icn2, 0, castle, dst_pt, max, alpha );
+
+                if ( const uint32_t index2 = ICN::AnimationFrame( icn2, 0, frame ) ) {
+                    fheroes2::drawCastleDialogBuilding( icn2, index2, castle, dst_pt, max, alpha );
+                }
+            }
+            else {
+                if ( const uint32_t index2 = ICN::AnimationFrame( icn, 0, frame ) ) {
+                    fheroes2::drawCastleDialogBuilding( icn, index2, castle, dst_pt, max, alpha );
+                }
+            }
+        }
+        else if ( building == BUILD_WEL2 && Race::SORC == castle.GetRace() ) {
+            const int icn2 = castle.isBuild( BUILD_STATUE ) ? ICN::TWNSEXT1 : icn;
+
+            fheroes2::drawCastleDialogBuilding( icn2, 0, castle, dst_pt, max, alpha );
+
+            if ( const uint32_t index2 = ICN::AnimationFrame( icn2, 0, frame ) ) {
+                fheroes2::drawCastleDialogBuilding( icn2, index2, castle, dst_pt, max, alpha );
+            }
+        }
+        else if ( building == BUILD_WEL2 && castle.GetRace() == Race::KNGT && !castle.isBuild( BUILD_CASTLE ) ) {
+            const fheroes2::Sprite & rightFarm = fheroes2::AGG::GetICN( ICN::KNIGHT_CASTLE_RIGHT_FARM, 0 );
+            const fheroes2::Sprite & leftFarm = fheroes2::AGG::GetICN( ICN::KNIGHT_CASTLE_LEFT_FARM, 0 );
+            fheroes2::drawCastleDialogBuilding( ICN::KNIGHT_CASTLE_LEFT_FARM, 0, castle, { dst_pt.x + rightFarm.x() - leftFarm.width(), dst_pt.y + rightFarm.y() }, max,
+                                                alpha );
+        }
+        else if ( building == BUILD_CAPTAIN && castle.GetRace() == Race::BARB && !castle.isBuild( BUILD_CASTLE ) ) {
+            const fheroes2::Sprite & rightCaptainQuarters = fheroes2::AGG::GetICN( ICN::TWNBCAPT, 0 );
+            const fheroes2::Sprite & leftCaptainQuarters = fheroes2::AGG::GetICN( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0 );
+            fheroes2::drawCastleDialogBuilding( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0, castle,
+                                                { dst_pt.x + rightCaptainQuarters.x() - leftCaptainQuarters.width(), dst_pt.y + rightCaptainQuarters.y() }, max, alpha );
+        }
+        else if ( building == BUILD_CAPTAIN && castle.GetRace() == Race::SORC && !castle.isBuild( BUILD_CASTLE ) ) {
+            fheroes2::drawCastleDialogBuilding( ICN::SORCERESS_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0, castle, dst_pt, max, alpha );
+        }
+    }
+
+    void redrawCurrentCastleBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CastleDialog::CacheBuildings & orders,
+                                      const CastleDialog::FadeBuilding & fadeBuilding, const uint32_t animationIndex )
+    {
+        fheroes2::Display & display = fheroes2::Display::instance();
+
+        const fheroes2::Sprite & townbkg = fheroes2::AGG::GetICN( getTownIcnId( castle.GetRace() ), 0 );
+        const fheroes2::Rect max( dst_pt.x, dst_pt.y, townbkg.width(), townbkg.height() );
+        fheroes2::Copy( townbkg, 0, 0, display, dst_pt.x, dst_pt.y, max.width, max.height );
+
+        if ( Race::BARB == castle.GetRace() ) {
+            const fheroes2::Sprite & sprite0 = fheroes2::AGG::GetICN( ICN::TWNBEXT1, 1 + animationIndex % 5 );
+            fheroes2::Blit( sprite0, display, dst_pt.x + sprite0.x(), dst_pt.y + sprite0.y() );
+        }
+
+        // Bay animation
+        if ( Race::WZRD == castle.GetRace() || ( !castle.isBuild( BUILD_SHIPYARD ) && castle.HasSeaAccess() ) ) {
+            int bayIcnId = 0;
+            const uint32_t bayExtraIndex = 1 + animationIndex % 5;
+
+            switch ( castle.GetRace() ) {
+            case Race::KNGT:
+                bayIcnId = ICN::TWNKEXT0;
+                break;
+            case Race::BARB:
+                bayIcnId = ICN::TWNBEXT0;
+                break;
+            case Race::SORC:
+                bayIcnId = ICN::TWNSEXT0;
+                break;
+            case Race::NECR:
+                bayIcnId = ICN::TWNNEXT0;
+                break;
+            case Race::WRLK:
+                bayIcnId = ICN::TWNWEXT0;
+                break;
+            case Race::WZRD:
+                bayIcnId = ICN::TWNZEXT0;
+                break;
+            default:
+                // Did you add a new race? Add the logic for it!
+                assert( 0 );
+                break;
+            }
+
+            fheroes2::drawCastleDialogBuilding( bayIcnId, 0, castle, dst_pt, max );
+            fheroes2::drawCastleDialogBuilding( bayIcnId, bayExtraIndex, castle, dst_pt, max );
+        }
+
+        if ( fadeBuilding.GetBuilding() == BUILD_NOTHING ) {
+            for ( const CastleDialog::BuildingRenderInfo & currentBuild : orders ) {
+                if ( !castle.isBuild( currentBuild.id ) ) {
+                    continue;
+                }
+
+                redrawCastleBuilding( castle, dst_pt, currentBuild.id, animationIndex );
+                redrawCastleBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex );
+
+                if ( isBuildingConnectionNeeded( castle, currentBuild.id, false ) ) {
+                    redrawBuildingConnection( castle, dst_pt, currentBuild.id );
+                }
+            }
+
+            return;
+        }
+
+        if ( std::find( orders.cbegin(), orders.cend(), fadeBuilding.GetBuilding() ) == orders.cend() ) {
+            return;
+        }
+
+        for ( const CastleDialog::BuildingRenderInfo & currentBuild : orders ) {
+            if ( currentBuild.id == fadeBuilding.GetBuilding() && !fadeBuilding.isOnlyBoat() ) {
+                redrawCastleBuilding( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
+                redrawCastleBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
+
+                if ( isBuildingConnectionNeeded( castle, currentBuild.id, true ) ) {
+                    redrawBuildingConnection( castle, dst_pt, currentBuild.id, fadeBuilding.GetAlpha() );
+                }
+
+                continue;
+            }
+
+            if ( castle.isBuild( currentBuild.id ) ) {
+                redrawCastleBuilding( castle, dst_pt, currentBuild.id, animationIndex );
+
+                if ( currentBuild.id == BUILD_SHIPYARD && fadeBuilding.GetBuilding() == BUILD_SHIPYARD ) {
+                    redrawCastleBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
+                }
+                else {
+                    redrawCastleBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex );
+                }
+
+                if ( isBuildingConnectionNeeded( castle, currentBuild.id, false ) ) {
+                    redrawBuildingConnection( castle, dst_pt, fadeBuilding.GetBuilding(), fadeBuilding.GetAlpha() );
+                    redrawBuildingConnection( castle, dst_pt, currentBuild.id );
+                }
+            }
+        }
+    }
 }
 
 CastleDialog::CacheBuildings::CacheBuildings( const Castle & castle, const fheroes2::Point & top )
@@ -152,13 +378,7 @@ CastleDialog::CacheBuildings::CacheBuildings( const Castle & castle, const fhero
     }
 }
 
-void CastleDialog::FadeBuilding::StartFadeBuilding( const uint32_t build )
-{
-    _alpha = 0;
-    _build = build;
-}
-
-bool CastleDialog::FadeBuilding::UpdateFadeBuilding()
+bool CastleDialog::FadeBuilding::UpdateFade()
 {
     if ( _alpha < 255 && Game::validateAnimationDelay( Game::CASTLE_BUILD_DELAY ) ) {
         if ( _alpha < 255 - 15 ) {
@@ -167,252 +387,16 @@ bool CastleDialog::FadeBuilding::UpdateFadeBuilding()
         else {
             _alpha = 255;
         }
+
         return true;
     }
+
     return false;
-}
-
-void CastleDialog::FadeBuilding::StopFadeBuilding()
-{
-    if ( _build != BUILD_NOTHING ) {
-        _build = BUILD_NOTHING;
-        _alpha = 255;
-    }
-}
-
-void CastleRedrawCurrentBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CastleDialog::CacheBuildings & orders,
-                                  const CastleDialog::FadeBuilding & fadeBuilding, const uint32_t animationIndex )
-{
-    fheroes2::Display & display = fheroes2::Display::instance();
-
-    const fheroes2::Sprite & townbkg = fheroes2::AGG::GetICN( getTownIcnId( castle.GetRace() ), 0 );
-    const fheroes2::Rect max( dst_pt.x, dst_pt.y, townbkg.width(), townbkg.height() );
-    fheroes2::Copy( townbkg, 0, 0, display, dst_pt.x, dst_pt.y, max.width, max.height );
-
-    if ( Race::BARB == castle.GetRace() ) {
-        const fheroes2::Sprite & sprite0 = fheroes2::AGG::GetICN( ICN::TWNBEXT1, 1 + animationIndex % 5 );
-        fheroes2::Blit( sprite0, display, dst_pt.x + sprite0.x(), dst_pt.y + sprite0.y() );
-    }
-
-    // Bay animation
-    if ( Race::WZRD == castle.GetRace() || ( !castle.isBuild( BUILD_SHIPYARD ) && castle.HasSeaAccess() ) ) {
-        int bayIcnId = 0;
-        const uint32_t bayExtraIndex = 1 + animationIndex % 5;
-
-        switch ( castle.GetRace() ) {
-        case Race::KNGT:
-            bayIcnId = ICN::TWNKEXT0;
-            break;
-        case Race::BARB:
-            bayIcnId = ICN::TWNBEXT0;
-            break;
-        case Race::SORC:
-            bayIcnId = ICN::TWNSEXT0;
-            break;
-        case Race::NECR:
-            bayIcnId = ICN::TWNNEXT0;
-            break;
-        case Race::WRLK:
-            bayIcnId = ICN::TWNWEXT0;
-            break;
-        case Race::WZRD:
-            bayIcnId = ICN::TWNZEXT0;
-            break;
-        default:
-            // Did you add a new race? Add the logic for it!
-            assert( 0 );
-            break;
-        }
-
-        fheroes2::drawCastleDialogBuilding( bayIcnId, 0, castle, dst_pt, max );
-        fheroes2::drawCastleDialogBuilding( bayIcnId, bayExtraIndex, castle, dst_pt, max );
-    }
-
-    // redraw all builds
-    if ( BUILD_NOTHING == fadeBuilding.GetBuild() ) {
-        for ( const CastleDialog::BuildingRenderInfo & currentBuild : orders ) {
-            if ( castle.isBuild( currentBuild.id ) ) {
-                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuild.id, animationIndex );
-                CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex );
-                if ( isBuildingConnectionNeeded( castle, currentBuild.id, false ) ) {
-                    redrawBuildingConnection( castle, dst_pt, currentBuild.id );
-                }
-            }
-        }
-    }
-    // redraw build with alpha
-    else if ( orders.cend() != std::find( orders.cbegin(), orders.cend(), fadeBuilding.GetBuild() ) ) {
-        for ( const CastleDialog::BuildingRenderInfo & currentBuild : orders ) {
-            if ( castle.isBuild( currentBuild.id ) ) {
-                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuild.id, animationIndex );
-                if ( currentBuild.id == BUILD_SHIPYARD && fadeBuilding.GetBuild() == BUILD_SHIPYARD ) {
-                    CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
-                }
-                else {
-                    CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex );
-                }
-                if ( isBuildingConnectionNeeded( castle, currentBuild.id, false ) ) {
-                    redrawBuildingConnection( castle, dst_pt, fadeBuilding.GetBuild(), fadeBuilding.GetAlpha() );
-                    redrawBuildingConnection( castle, dst_pt, currentBuild.id );
-                }
-            }
-            else if ( currentBuild.id == fadeBuilding.GetBuild() ) {
-                CastleDialog::CastleRedrawBuilding( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
-                CastleDialog::CastleRedrawBuildingExtended( castle, dst_pt, currentBuild.id, animationIndex, fadeBuilding.GetAlpha() );
-                if ( isBuildingConnectionNeeded( castle, currentBuild.id, true ) ) {
-                    redrawBuildingConnection( castle, dst_pt, currentBuild.id, fadeBuilding.GetAlpha() );
-                }
-            }
-        }
-    }
 }
 
 void CastleDialog::RedrawAllBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CacheBuildings & orders,
                                       const CastleDialog::FadeBuilding & alphaBuilding, const uint32_t animationIndex )
 {
-    CastleRedrawCurrentBuilding( castle, dst_pt, orders, alphaBuilding, animationIndex );
+    redrawCurrentCastleBuilding( castle, dst_pt, orders, alphaBuilding, animationIndex );
     fheroes2::drawCastleName( castle, fheroes2::Display::instance(), dst_pt );
-}
-
-void CastleDialog::CastleRedrawBuilding( const Castle & castle, const fheroes2::Point & dst_pt, uint32_t build, uint32_t frame, uint8_t alpha )
-{
-    if ( build == BUILD_TENT ) {
-        // We don't need to draw a tent because it's on the background image.
-        return;
-    }
-
-    // correct build
-    switch ( build ) {
-    case DWELLING_MONSTER2:
-    case DWELLING_MONSTER3:
-    case DWELLING_MONSTER4:
-    case DWELLING_MONSTER5:
-    case DWELLING_MONSTER6:
-        build = castle.GetActualDwelling( build );
-        break;
-
-    default:
-        break;
-    }
-
-    const int race = castle.GetRace();
-    uint32_t index = 0;
-
-    // correct index (mage guild)
-    switch ( build ) {
-    case BUILD_MAGEGUILD1:
-        if ( castle.GetLevelMageGuild() > 1 ) {
-            return;
-        }
-        break;
-    case BUILD_MAGEGUILD2:
-        if ( castle.GetLevelMageGuild() > 2 ) {
-            return;
-        }
-        index = ( Race::NECR == race ) ? 6 : 1;
-        break;
-    case BUILD_MAGEGUILD3:
-        if ( castle.GetLevelMageGuild() > 3 ) {
-            return;
-        }
-        index = ( Race::NECR == race ) ? 12 : 2;
-        break;
-    case BUILD_MAGEGUILD4:
-        if ( castle.GetLevelMageGuild() > 4 ) {
-            return;
-        }
-        index = ( Race::NECR == race ) ? 18 : 3;
-        break;
-    case BUILD_MAGEGUILD5:
-        index = ( Race::NECR == race ) ? 24 : 4;
-        break;
-    default:
-        break;
-    }
-
-    const int icn = Castle::GetICNBuilding( build, race );
-    if ( icn == ICN::UNKNOWN ) {
-        // Have you added a new building? Add the logic for it!
-        assert( 0 );
-        return;
-    }
-
-    const fheroes2::Rect max = CastleGetMaxArea( castle, dst_pt );
-
-    // Building main sprite.
-    fheroes2::drawCastleDialogBuilding( icn, index, castle, dst_pt, max, alpha );
-
-    // Special case: Knight castle's flags are overlapped by Right Turret so we need to draw flags after drawing the Turret.
-    const bool knightCastleCase = ( race == Race::KNGT && castle.isBuild( BUILD_RIGHTTURRET ) && castle.isBuild( BUILD_CASTLE ) );
-    if ( knightCastleCase && build == BUILD_CASTLE ) {
-        // Do not draw flags.
-        return;
-    }
-
-    // Building animation sprite.
-    if ( const uint32_t index2 = ICN::AnimationFrame( icn, index, frame ) ) {
-        fheroes2::drawCastleDialogBuilding( icn, index2, castle, dst_pt, max, alpha );
-    }
-
-    if ( knightCastleCase && build == BUILD_RIGHTTURRET ) {
-        // Draw Castle's flags after the Turret.
-        const int castleIcn = Castle::GetICNBuilding( BUILD_CASTLE, race );
-        const uint32_t flagAnimFrame = ICN::AnimationFrame( castleIcn, index, frame );
-        if ( flagAnimFrame > 0 ) {
-            fheroes2::drawCastleDialogBuilding( castleIcn, flagAnimFrame, castle, dst_pt, max, alpha );
-        }
-    }
-}
-
-void CastleDialog::CastleRedrawBuildingExtended( const Castle & castle, const fheroes2::Point & dst_pt, uint32_t build, uint32_t frame, uint8_t alpha )
-{
-    if ( build == BUILD_TENT ) {
-        // We don't need to draw a tent because it's on the background image.
-        return;
-    }
-
-    const fheroes2::Rect max = CastleGetMaxArea( castle, dst_pt );
-    const int icn = Castle::GetICNBuilding( build, castle.GetRace() );
-
-    if ( build == BUILD_SHIPYARD ) {
-        // boat
-        if ( castle.HasBoatNearby() ) {
-            const int icn2 = Castle::GetICNBoat( castle.GetRace() );
-
-            fheroes2::drawCastleDialogBuilding( icn2, 0, castle, dst_pt, max, alpha );
-
-            if ( const uint32_t index2 = ICN::AnimationFrame( icn2, 0, frame ) ) {
-                fheroes2::drawCastleDialogBuilding( icn2, index2, castle, dst_pt, max, alpha );
-            }
-        }
-        else {
-            if ( const uint32_t index2 = ICN::AnimationFrame( icn, 0, frame ) ) {
-                fheroes2::drawCastleDialogBuilding( icn, index2, castle, dst_pt, max, alpha );
-            }
-        }
-    }
-    else if ( build == BUILD_WEL2 && Race::SORC == castle.GetRace() ) { // sorc and anime wel2 or statue
-        const int icn2 = castle.isBuild( BUILD_STATUE ) ? ICN::TWNSEXT1 : icn;
-
-        fheroes2::drawCastleDialogBuilding( icn2, 0, castle, dst_pt, max, alpha );
-
-        if ( const uint32_t index2 = ICN::AnimationFrame( icn2, 0, frame ) ) {
-            fheroes2::drawCastleDialogBuilding( icn2, index2, castle, dst_pt, max, alpha );
-        }
-    }
-    else if ( build == BUILD_WEL2 && castle.GetRace() == Race::KNGT && !castle.isBuild( BUILD_CASTLE ) ) {
-        const fheroes2::Sprite & rightFarm = fheroes2::AGG::GetICN( ICN::KNIGHT_CASTLE_RIGHT_FARM, 0 );
-        const fheroes2::Sprite & leftFarm = fheroes2::AGG::GetICN( ICN::KNIGHT_CASTLE_LEFT_FARM, 0 );
-        fheroes2::drawCastleDialogBuilding( ICN::KNIGHT_CASTLE_LEFT_FARM, 0, castle, { dst_pt.x + rightFarm.x() - leftFarm.width(), dst_pt.y + rightFarm.y() }, max,
-                                            alpha );
-    }
-    else if ( build == BUILD_CAPTAIN && castle.GetRace() == Race::BARB && !castle.isBuild( BUILD_CASTLE ) ) {
-        const fheroes2::Sprite & rightCaptainQuarters = fheroes2::AGG::GetICN( ICN::TWNBCAPT, 0 );
-        const fheroes2::Sprite & leftCaptainQuarters = fheroes2::AGG::GetICN( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0 );
-        fheroes2::drawCastleDialogBuilding( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0, castle,
-                                            { dst_pt.x + rightCaptainQuarters.x() - leftCaptainQuarters.width(), dst_pt.y + rightCaptainQuarters.y() }, max, alpha );
-    }
-    else if ( build == BUILD_CAPTAIN && castle.GetRace() == Race::SORC && !castle.isBuild( BUILD_CASTLE ) ) {
-        fheroes2::drawCastleDialogBuilding( ICN::SORCERESS_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0, castle, dst_pt, max, alpha );
-    }
 }

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -371,9 +371,9 @@ namespace
 
 CastleDialog::CacheBuildings::CacheBuildings( const Castle & castle, const fheroes2::Point & top )
 {
-    const std::vector<building_t> ordersBuildings = fheroes2::getBuildingDrawingPriorities( castle.GetRace(), Settings::Get().getCurrentMapInfo().version );
+    const std::vector<BuildingType> ordersBuildings = fheroes2::getBuildingDrawingPriorities( castle.GetRace(), Settings::Get().getCurrentMapInfo().version );
 
-    for ( const building_t buildingId : ordersBuildings ) {
+    for ( const BuildingType buildingId : ordersBuildings ) {
         emplace_back( buildingId, fheroes2::getCastleBuildingArea( castle.GetRace(), buildingId ) + top );
     }
 }

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -269,8 +269,8 @@ namespace
         }
     }
 
-    void redrawCurrentCastleBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CastleDialog::CacheBuildings & orders,
-                                      const CastleDialog::FadeBuilding & fadeBuilding, const uint32_t animationIndex )
+    void redrawCastleBuildings( const Castle & castle, const fheroes2::Point & dst_pt, const CastleDialog::CacheBuildings & orders,
+                                const CastleDialog::FadeBuilding & fadeBuilding, const uint32_t animationIndex )
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -394,9 +394,9 @@ bool CastleDialog::FadeBuilding::UpdateFade()
     return false;
 }
 
-void CastleDialog::RedrawAllBuilding( const Castle & castle, const fheroes2::Point & dst_pt, const CacheBuildings & orders,
-                                      const CastleDialog::FadeBuilding & alphaBuilding, const uint32_t animationIndex )
+void CastleDialog::RedrawAllBuildings( const Castle & castle, const fheroes2::Point & dst_pt, const CacheBuildings & orders,
+                                       const CastleDialog::FadeBuilding & alphaBuilding, const uint32_t animationIndex )
 {
-    redrawCurrentCastleBuilding( castle, dst_pt, orders, alphaBuilding, animationIndex );
+    redrawCastleBuildings( castle, dst_pt, orders, alphaBuilding, animationIndex );
     fheroes2::drawCastleName( castle, fheroes2::Display::instance(), dst_pt );
 }

--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -30,7 +30,7 @@
 
 namespace
 {
-    fheroes2::Rect getKnightBuildingArea( const building_t buildingId )
+    fheroes2::Rect getKnightBuildingArea( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_THIEVESGUILD:
@@ -98,7 +98,7 @@ namespace
         return {};
     }
 
-    fheroes2::Rect getBarbarianBuildingArea( const building_t buildingId )
+    fheroes2::Rect getBarbarianBuildingArea( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_THIEVESGUILD:
@@ -166,7 +166,7 @@ namespace
         return {};
     }
 
-    fheroes2::Rect getSorceressBuildingArea( const building_t buildingId )
+    fheroes2::Rect getSorceressBuildingArea( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_THIEVESGUILD:
@@ -231,7 +231,7 @@ namespace
         return {};
     }
 
-    fheroes2::Rect getWarlockBuildingArea( const building_t buildingId )
+    fheroes2::Rect getWarlockBuildingArea( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_THIEVESGUILD:
@@ -299,7 +299,7 @@ namespace
         return {};
     }
 
-    fheroes2::Rect getWizardBuildingArea( const building_t buildingId )
+    fheroes2::Rect getWizardBuildingArea( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_THIEVESGUILD:
@@ -367,7 +367,7 @@ namespace
         return {};
     }
 
-    fheroes2::Rect getNecromancerBuildingArea( const building_t buildingId )
+    fheroes2::Rect getNecromancerBuildingArea( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_THIEVESGUILD:
@@ -435,7 +435,7 @@ namespace
         return {};
     }
 
-    const char * getKnightBuildingName( const building_t buildingId )
+    const char * getKnightBuildingName( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -473,7 +473,7 @@ namespace
         return nullptr;
     }
 
-    const char * getBarbarianBuildingName( const building_t buildingId )
+    const char * getBarbarianBuildingName( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -507,7 +507,7 @@ namespace
         return nullptr;
     }
 
-    const char * getSorceressBuildingName( const building_t buildingId )
+    const char * getSorceressBuildingName( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -541,7 +541,7 @@ namespace
         return nullptr;
     }
 
-    const char * getWarlockBuildingName( const building_t buildingId )
+    const char * getWarlockBuildingName( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -575,7 +575,7 @@ namespace
         return nullptr;
     }
 
-    const char * getWizardBuildingName( const building_t buildingId )
+    const char * getWizardBuildingName( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -609,7 +609,7 @@ namespace
         return nullptr;
     }
 
-    const char * getNecromancerBuildingName( const building_t buildingId )
+    const char * getNecromancerBuildingName( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -647,7 +647,7 @@ namespace
         return nullptr;
     }
 
-    const char * getRandomBuildingName( const building_t buildingId )
+    const char * getRandomBuildingName( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -687,7 +687,7 @@ namespace
         return nullptr;
     }
 
-    const char * getKnightBuildingDescription( const building_t buildingId )
+    const char * getKnightBuildingDescription( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -703,7 +703,7 @@ namespace
         return nullptr;
     }
 
-    const char * getBarbarianBuildingDescription( const building_t buildingId )
+    const char * getBarbarianBuildingDescription( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -719,7 +719,7 @@ namespace
         return nullptr;
     }
 
-    const char * getSorceressBuildingDescription( const building_t buildingId )
+    const char * getSorceressBuildingDescription( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -735,7 +735,7 @@ namespace
         return nullptr;
     }
 
-    const char * getWarlockBuildingDescription( const building_t buildingId )
+    const char * getWarlockBuildingDescription( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -751,7 +751,7 @@ namespace
         return nullptr;
     }
 
-    const char * getWizardBuildingDescription( const building_t buildingId )
+    const char * getWizardBuildingDescription( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -767,7 +767,7 @@ namespace
         return nullptr;
     }
 
-    const char * getNecromancerBuildingDescription( const building_t buildingId )
+    const char * getNecromancerBuildingDescription( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -783,7 +783,7 @@ namespace
         return nullptr;
     }
 
-    const char * getRandomBuildingDescription( const building_t buildingId )
+    const char * getRandomBuildingDescription( const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_SPEC:
@@ -802,7 +802,7 @@ namespace
 
 namespace fheroes2
 {
-    Rect getCastleBuildingArea( const int race, const building_t buildingId )
+    Rect getCastleBuildingArea( const int race, const BuildingType buildingId )
     {
         if ( buildingId == BUILD_NOTHING ) {
             // Special case which we should ignore.
@@ -832,7 +832,7 @@ namespace fheroes2
         return {};
     }
 
-    const char * getBuildingName( const int race, const building_t buildingId )
+    const char * getBuildingName( const int race, const BuildingType buildingId )
     {
         if ( buildingId == BUILD_NOTHING ) {
             // Special case which we should ignore.
@@ -904,7 +904,7 @@ namespace fheroes2
         return nullptr;
     }
 
-    const char * getBuildingDescription( const int race, const building_t buildingId )
+    const char * getBuildingDescription( const int race, const BuildingType buildingId )
     {
         if ( buildingId == BUILD_NOTHING ) {
             // Special case which we should ignore.
@@ -974,7 +974,7 @@ namespace fheroes2
         return nullptr;
     }
 
-    building_t getUpgradeForBuilding( const int race, const building_t buildingId )
+    BuildingType getUpgradeForBuilding( const int race, const BuildingType buildingId )
     {
         switch ( buildingId ) {
         case BUILD_TENT:
@@ -1091,7 +1091,7 @@ namespace fheroes2
         return buildingId;
     }
 
-    building_t getBuildingRequirement( const int race, const building_t building )
+    BuildingType getBuildingRequirement( const int race, const BuildingType building )
     {
         uint32_t requirement = 0;
 
@@ -1343,10 +1343,10 @@ namespace fheroes2
             break;
         }
 
-        return static_cast<building_t>( requirement );
+        return static_cast<BuildingType>( requirement );
     }
 
-    std::string getBuildingRequirementString( const int race, const building_t building )
+    std::string getBuildingRequirementString( const int race, const BuildingType building )
     {
         // prepare requirement build string
         std::string requirement;
@@ -1367,7 +1367,7 @@ namespace fheroes2
         return requirement;
     }
 
-    int getIndexBuildingSprite( const building_t build )
+    int getIndexBuildingSprite( const BuildingType build )
     {
         switch ( build ) {
         case DWELLING_MONSTER1:
@@ -1434,9 +1434,9 @@ namespace fheroes2
         return 0;
     }
 
-    std::vector<building_t> getBuildingDrawingPriorities( const int race, const GameVersion version )
+    std::vector<BuildingType> getBuildingDrawingPriorities( const int race, const GameVersion version )
     {
-        std::vector<building_t> priorities;
+        std::vector<BuildingType> priorities;
         priorities.reserve( 32 );
 
         switch ( race ) {

--- a/src/fheroes2/castle/castle_building_info.h
+++ b/src/fheroes2/castle/castle_building_info.h
@@ -30,20 +30,20 @@ enum class GameVersion : int;
 
 namespace fheroes2
 {
-    Rect getCastleBuildingArea( const int race, const building_t buildingId );
+    Rect getCastleBuildingArea( const int race, const BuildingType buildingId );
 
-    const char * getBuildingName( const int race, const building_t buildingId );
+    const char * getBuildingName( const int race, const BuildingType buildingId );
 
-    const char * getBuildingDescription( const int race, const building_t buildingId );
+    const char * getBuildingDescription( const int race, const BuildingType buildingId );
 
     // Returns the upgraded building ID for the given one or the input building if no upgrade is available.
-    building_t getUpgradeForBuilding( const int race, const building_t buildingId );
+    BuildingType getUpgradeForBuilding( const int race, const BuildingType buildingId );
 
-    building_t getBuildingRequirement( const int race, const building_t building );
+    BuildingType getBuildingRequirement( const int race, const BuildingType building );
 
-    std::string getBuildingRequirementString( const int race, const building_t building );
+    std::string getBuildingRequirementString( const int race, const BuildingType building );
 
-    int getIndexBuildingSprite( const building_t build );
+    int getIndexBuildingSprite( const BuildingType build );
 
-    std::vector<building_t> getBuildingDrawingPriorities( const int race, const GameVersion version );
+    std::vector<BuildingType> getBuildingDrawingPriorities( const int race, const GameVersion version );
 }

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -72,7 +72,7 @@ namespace
 {
     uint32_t castleAnimationIndex = 0;
 
-    building_t getPressedBuildingHotkey()
+    BuildingType getPressedBuildingHotkey()
     {
         if ( HotKeyPressEvent( Game::HotKeyEvent::TOWN_DWELLING_LEVEL_1 ) ) {
             return DWELLING_MONSTER1;
@@ -121,7 +121,7 @@ namespace
     {
         // Check if building is a monster dwelling or its upgraded version
         if ( ( buildingId & DWELLING_MONSTERS ) == 0 && ( buildingId & DWELLING_UPGRADES ) == 0 ) {
-            return fheroes2::getBuildingName( race, static_cast<building_t>( buildingId ) );
+            return fheroes2::getBuildingName( race, static_cast<BuildingType>( buildingId ) );
         }
 
         const Monster monster( race, buildingId );
@@ -511,7 +511,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             }
 
             // Get pressed hotkey.
-            const building_t hotKeyBuilding = getPressedBuildingHotkey();
+            const BuildingType hotKeyBuilding = getPressedBuildingHotkey();
 
             // Interaction with buildings.
             // Animation queue starts from the lowest by Z-value buildings which means that they draw first and most likely overlap by the top buildings in the queue.

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -56,8 +56,6 @@
 #include "math_base.h"
 #include "monster.h"
 #include "mus.h"
-#include "payment.h"
-#include "resource.h"
 #include "screen.h"
 #include "statusbar.h"
 #include "tools.h"
@@ -277,9 +275,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             break;
         default:
             if ( build != BUILD_NOTHING ) {
-                Funds remainingFunds = GetKingdom().GetFunds() - PaymentConditions::BuyBuilding( race, build );
-                remainingFunds.Trim();
-                fheroes2::drawResourcePanel( remainingFunds, display, dialogRoi.getPosition() );
                 AudioManager::PlaySound( M82::BUILDTWN );
                 fadeBuilding.StartFadeBuilding( build );
             }
@@ -592,7 +587,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                             const fheroes2::ButtonRestorer exitRestorer( buttonExit );
                             if ( Dialog::OK == Dialog::BuyBoat( AllowBuyBoat( true ) ) ) {
                                 BuyBoat();
-                                fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, dialogRoi.getPosition() );
                                 fadeBuilding.StartFadeBuilding( BUILD_SHIPYARD );
                             }
                             break;
@@ -616,9 +610,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                                 fheroes2::showStandardTextMessage( _( "Town" ), _( "This town may not be upgraded to a castle." ), Dialog::OK );
                             }
                             else if ( Dialog::OK == DialogBuyCastle( true ) ) {
-                                Funds remainingFunds = GetKingdom().GetFunds() - PaymentConditions::BuyBuilding( race, BUILD_CASTLE );
-                                remainingFunds.Trim();
-                                fheroes2::drawResourcePanel( remainingFunds, display, dialogRoi.getPosition() );
                                 AudioManager::PlaySound( M82::BUILDTWN );
                                 fadeBuilding.StartFadeBuilding( BUILD_CASTLE );
                             }
@@ -733,6 +724,9 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                     RedrawIcons( *this, hero, dialogRoi.getPosition() );
                     fheroes2::drawCastleName( *this, fheroes2::Display::instance(), dialogRoi.getPosition() );
                 }
+
+                fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, dialogRoi.getPosition() );
+
                 display.render( dialogRoi );
             }
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -364,7 +364,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     const CastleDialog::CacheBuildings cacheBuildings( *this, dialogRoi.getPosition() );
 
     // Render castle buildings.
-    CastleDialog::RedrawAllBuilding( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
+    CastleDialog::RedrawAllBuildings( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
 
     if ( GetKingdom().GetCastles().size() < 2 ) {
         buttonPrevCastle.disable();
@@ -758,7 +758,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
         // Castle dialog animation.
         if ( Game::validateAnimationDelay( Game::CASTLE_AROUND_DELAY ) || needRedraw ) {
-            CastleDialog::RedrawAllBuilding( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
+            CastleDialog::RedrawAllBuildings( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
 
             display.render( dialogRoi );
 

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -257,7 +257,7 @@ Castle::ConstructionDialogResult Castle::openConstructionDialog( uint32_t & dwel
     dwelling6.Redraw();
 
     // mage guild
-    building_t level = BUILD_NOTHING;
+    BuildingType level = BUILD_NOTHING;
     switch ( GetLevelMageGuild() ) {
     case 0:
         level = BUILD_MAGEGUILD1;

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -97,7 +97,7 @@ namespace
         return count;
     }
 
-    building_t getPressedBuildingHotkey()
+    BuildingType getPressedBuildingHotkey()
     {
         if ( HotKeyPressEvent( Game::HotKeyEvent::TOWN_DWELLING_LEVEL_1 ) ) {
             return DWELLING_MONSTER1;
@@ -249,7 +249,7 @@ void Castle::OpenWell()
         le.isMouseLeftButtonPressedInArea( buttonExit.area() ) ? buttonExit.drawOnPress() : buttonExit.drawOnRelease();
 
         le.isMouseLeftButtonPressedInArea( buttonMax.area() ) ? buttonMax.drawOnPress() : buttonMax.drawOnRelease();
-        const building_t pressedHotkeyBuildingID = getPressedBuildingHotkey();
+        const BuildingType pressedHotkeyBuildingID = getPressedBuildingHotkey();
 
         if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() ) {
             break;

--- a/src/fheroes2/editor/editor_castle_details_window.cpp
+++ b/src/fheroes2/editor/editor_castle_details_window.cpp
@@ -64,7 +64,7 @@ namespace
     class BuildingData
     {
     public:
-        explicit BuildingData( building_t buildingType, const int race, const building_t builtBuildings, const building_t restrictedBuildings )
+        explicit BuildingData( BuildingType buildingType, const int race, const BuildingType builtBuildings, const BuildingType restrictedBuildings )
             : _mainBuildingType( buildingType )
             , _race( race )
         {
@@ -75,7 +75,7 @@ namespace
                 _restrictedId = 0;
             }
 
-            for ( building_t upgradedBuildingType = fheroes2::getUpgradeForBuilding( _race, _mainBuildingType ); upgradedBuildingType != buildingType;
+            for ( BuildingType upgradedBuildingType = fheroes2::getUpgradeForBuilding( _race, _mainBuildingType ); upgradedBuildingType != buildingType;
                   upgradedBuildingType = fheroes2::getUpgradeForBuilding( _race, upgradedBuildingType ) ) {
                 if ( builtBuildings & upgradedBuildingType ) {
                     _builtId = _buildingVariants;
@@ -110,14 +110,14 @@ namespace
             return _area;
         }
 
-        std::vector<building_t> getBuildLevel() const
+        std::vector<BuildingType> getBuildLevel() const
         {
             if ( _builtId < 0 ) {
                 return {};
             }
 
             const int8_t levelsBuilt = _builtId + 1;
-            std::vector<building_t> buildings;
+            std::vector<BuildingType> buildings;
             buildings.reserve( levelsBuilt );
             for ( int8_t i = 0; i < levelsBuilt; ++i ) {
                 buildings.push_back( _getBuildingType( i ) );
@@ -125,7 +125,7 @@ namespace
             return buildings;
         }
 
-        building_t getRestrictLevel() const
+        BuildingType getRestrictLevel() const
         {
             return _getBuildingType( _restrictedId );
         }
@@ -161,7 +161,7 @@ namespace
             }
 
             if ( le.isMouseRightButtonPressed() ) {
-                const building_t building = _getBuildindTypeForRender();
+                const BuildingType building = _getBuildindTypeForRender();
                 std::string description = BuildingInfo::getBuildingDescription( _race, building );
                 const std::string requirement = fheroes2::getBuildingRequirementString( _race, building );
 
@@ -257,7 +257,7 @@ namespace
         }
 
     private:
-        building_t _getBuildindTypeForRender() const
+        BuildingType _getBuildindTypeForRender() const
         {
             if ( _builtId < 1 ) {
                 return _mainBuildingType;
@@ -266,13 +266,13 @@ namespace
             return _getBuildingType( _builtId );
         }
 
-        building_t _getBuildingType( const int8_t level ) const
+        BuildingType _getBuildingType( const int8_t level ) const
         {
             if ( level < 0 ) {
                 return BUILD_NOTHING;
             }
 
-            building_t building = _mainBuildingType;
+            BuildingType building = _mainBuildingType;
             for ( int8_t i = 0; i < level; ++i ) {
                 building = fheroes2::getUpgradeForBuilding( _race, building );
             }
@@ -280,7 +280,7 @@ namespace
             return building;
         }
 
-        building_t _mainBuildingType{ BUILD_NOTHING };
+        BuildingType _mainBuildingType{ BUILD_NOTHING };
         int _race{ Race::NONE };
         int8_t _builtId{ -1 };
         int8_t _restrictedId{ -1 };
@@ -399,8 +399,8 @@ namespace Editor
         armyBar.setRenderingOffset( { dialogRoi.x + rightPartOffsetX + 33, dialogRoi.y + 332 } );
         armyBar.Redraw( display );
 
-        const building_t metadataBuildings = static_cast<building_t>( Maps::getBuildingsFromVector( castleMetadata.builtBuildings ) );
-        const building_t metadataRestrictedBuildings = static_cast<building_t>( Maps::getBuildingsFromVector( castleMetadata.bannedBuildings ) );
+        const BuildingType metadataBuildings = static_cast<BuildingType>( Maps::getBuildingsFromVector( castleMetadata.builtBuildings ) );
+        const BuildingType metadataRestrictedBuildings = static_cast<BuildingType>( Maps::getBuildingsFromVector( castleMetadata.bannedBuildings ) );
 
         assert( ( metadataBuildings & metadataRestrictedBuildings ) == 0 );
 
@@ -648,10 +648,10 @@ namespace Editor
 
         if ( castleMetadata.customBuildings ) {
             for ( const BuildingData & building : buildings ) {
-                std::vector<building_t> buildingLevels = building.getBuildLevel();
+                std::vector<BuildingType> buildingLevels = building.getBuildLevel();
                 std::move( buildingLevels.begin(), buildingLevels.end(), std::back_inserter( castleMetadata.builtBuildings ) );
 
-                if ( const building_t buildId = building.getRestrictLevel(); buildId != BUILD_NOTHING ) {
+                if ( const BuildingType buildId = building.getRestrictLevel(); buildId != BUILD_NOTHING ) {
                     castleMetadata.bannedBuildings.push_back( buildId );
                 }
             }

--- a/src/fheroes2/game/difficulty.cpp
+++ b/src/fheroes2/game/difficulty.cpp
@@ -254,7 +254,7 @@ bool Difficulty::allowAIToDevelopCastlesOnDay( const int difficulty, const bool 
     return true;
 }
 
-bool Difficulty::allowAIToBuildCastleBuilding( const int difficulty, const bool isCampaign, const building_t building )
+bool Difficulty::allowAIToBuildCastleBuilding( const int difficulty, const bool isCampaign, const BuildingType building )
 {
     switch ( difficulty ) {
     case Difficulty::EASY:

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -30,7 +30,7 @@
 
 class Kingdom;
 
-enum building_t : uint32_t;
+enum BuildingType : uint32_t;
 
 namespace Difficulty
 {
@@ -70,7 +70,7 @@ namespace Difficulty
     bool allowAIToSplitWeakStacks( const int difficulty );
 
     bool allowAIToDevelopCastlesOnDay( const int difficulty, const bool isCampaign, const uint32_t day );
-    bool allowAIToBuildCastleBuilding( const int difficulty, const bool isCampaign, const building_t building );
+    bool allowAIToBuildCastleBuilding( const int difficulty, const bool isCampaign, const BuildingType building );
 }
 
 #endif


### PR DESCRIPTION
fix #9020

Currently in the `master` branch, buildings that are "under construction" have not actually been built yet, and the resources for their construction have not yet been written off from the kingdom's balance. #8358 tried to solve this issue "head-on" by pre-calculating the final kingdom balance and drawing it in advance, but this approach did not always work well due to the possibility of further redrawing the "actual" balance on top of the previously drawn "pre-calculated" one in certain cases. I decided not to try to "catch" these redraws because I believe that this approach is too error-prone, so I decided to implement the opposite logic - buy a building first, and only then build it.

With this PR:

https://github.com/user-attachments/assets/005f4d88-0d9d-4fe5-97d5-17ba3a6f49b9

Also renamed the `building_t` to the `BuildingType`, because `_t` suffix is reserved by POSIX for their own identifiers.

Since this PR changes the logic of redrawing the castle buildings, it should be well tested. Maybe it won't go to the next release (depends on the specific date of this release).