### PR TITLE
Fix multiple file-related bugs

### DIFF
--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -366,13 +366,13 @@ std::string System::GetBasename( std::string_view path )
     return std::string{ path.substr( pos + 1 ) };
 }
 
-std::string System::truncateFileExtensionAndPath( std::string_view path )
+std::string System::GetStem( std::string_view path )
 {
     std::string res = GetBasename( path );
 
     const size_t pos = res.rfind( '.' );
 
-    if ( pos != std::string::npos ) {
+    if ( pos != 0 && pos != std::string::npos ) {
         res.resize( pos );
     }
 

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -48,7 +48,7 @@ namespace System
 
     std::string GetDirname( std::string_view path );
     std::string GetBasename( std::string_view path );
-    std::string truncateFileExtensionAndPath( std::string_view path );
+    std::string GetStem( std::string_view path );
 
     bool IsFile( const std::string & path, bool writable = false );
     bool IsDirectory( const std::string & path, bool writable = false );

--- a/src/fheroes2/dialog/dialog_file.cpp
+++ b/src/fheroes2/dialog/dialog_file.cpp
@@ -22,14 +22,11 @@
  ***************************************************************************/
 
 #include <cstdint>
-#include <string>
 
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
-#include "dir.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
-#include "game_io.h"
 #include "game_mode.h"
 #include "gamedefs.h"
 #include "icn.h"
@@ -103,10 +100,7 @@ namespace
                 }
             }
             else if ( le.MouseClickLeft( buttonLoad.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_LOAD_GAME ) ) {
-                if ( ListFiles::IsEmpty( Game::GetSaveDir(), Game::GetSaveFileExtension(), false ) ) {
-                    fheroes2::showStandardTextMessage( _( "Load Game" ), _( "No save files to load." ), Dialog::OK );
-                }
-                else if ( Interface::AdventureMap::Get().EventLoadGame() == fheroes2::GameMode::LOAD_GAME ) {
+                if ( Interface::AdventureMap::Get().EventLoadGame() == fheroes2::GameMode::LOAD_GAME ) {
                     result = fheroes2::GameMode::LOAD_GAME;
                     break;
                 }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -190,10 +190,7 @@ namespace
     void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, int32_t dstx, int32_t dsty, bool current )
     {
         std::string savname( System::GetStem( info.filename ) );
-
-        if ( savname.empty() ) {
-            return;
-        }
+        assert( !savname.empty() );
 
         const fheroes2::FontType font = current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
         fheroes2::Display & display = fheroes2::Display::instance();

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -427,14 +427,9 @@ namespace
                 if ( Dialog::YES == fheroes2::showStandardTextMessage( _( "Warning!" ), msg, Dialog::YES | Dialog::NO ) ) {
                     System::Unlink( listbox.GetCurrent().filename );
                     listbox.RemoveSelected();
+
                     if ( lists.empty() ) {
                         listbox.Redraw();
-
-                        if ( !isEditing ) {
-                            textInputAndDateBackground.restore();
-                            fheroes2::showStandardTextMessage( _( "Load Game" ), _( "No save files to load." ), Dialog::OK );
-                            return {};
-                        }
 
                         isListboxSelected = false;
                         charInsertPos = 0;
@@ -542,7 +537,7 @@ namespace
                     isTextLimit = redrawTextInputField( insertCharToString( filename, charInsertPos, isCursorVisible ? '_' : '\x7F' ), textInputRoi, true );
                     redrawDateTime( display, std::time( nullptr ), dateTimeoffsetX, textInputRoi.y + 4, fheroes2::FontType::normalWhite() );
                 }
-                else {
+                else if ( isListboxSelected ) {
                     redrawTextInputField( filename, textInputRoi, false );
                     redrawDateTime( display, listbox.GetCurrent().timestamp, dateTimeoffsetX, textInputRoi.y + 4, fheroes2::FontType::normalYellow() );
                 }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -422,6 +422,7 @@ namespace
                 std::string msg( _( "Are you sure you want to delete file:" ) );
                 msg.append( "\n\n" );
                 msg.append( System::GetBasename( listbox.GetCurrent().filename ) );
+
                 if ( Dialog::YES == fheroes2::showStandardTextMessage( _( "Warning!" ), msg, Dialog::YES | Dialog::NO ) ) {
                     System::Unlink( listbox.GetCurrent().filename );
                     listbox.RemoveSelected();

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <ctime>
 #include <iomanip>

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -136,7 +136,7 @@ namespace
 
         void ActionListPressRight( Maps::FileInfo & info ) override
         {
-            const fheroes2::Text header( System::truncateFileExtensionAndPath( info.filename ), fheroes2::FontType::normalYellow() );
+            const fheroes2::Text header( System::GetStem( info.filename ), fheroes2::FontType::normalYellow() );
 
             fheroes2::MultiFontText body;
 
@@ -189,17 +189,10 @@ namespace
 
     void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, int32_t dstx, int32_t dsty, bool current )
     {
-        std::string savname( System::GetBasename( info.filename ) );
+        std::string savname( System::GetStem( info.filename ) );
 
         if ( savname.empty() ) {
             return;
-        }
-
-        const std::string saveExtension = Game::GetSaveFileExtension();
-        const size_t dotPos = savname.size() - saveExtension.size();
-
-        if ( StringLower( savname.substr( dotPos ) ) == saveExtension ) {
-            savname.erase( dotPos );
         }
 
         const fheroes2::FontType font = current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
@@ -337,7 +330,7 @@ namespace
         size_t charInsertPos = 0;
 
         if ( !lastfile.empty() ) {
-            filename = System::truncateFileExtensionAndPath( lastfile );
+            filename = System::GetStem( lastfile );
             charInsertPos = filename.size();
 
             MapsFileInfoList::iterator it = lists.begin();
@@ -360,7 +353,7 @@ namespace
         }
 
         if ( filename.empty() && listbox.isSelected() ) {
-            filename = System::truncateFileExtensionAndPath( listbox.GetCurrent().filename );
+            filename = System::GetStem( listbox.GetCurrent().filename );
             charInsertPos = filename.size();
         }
 
@@ -459,11 +452,11 @@ namespace
             }
             else if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY )
                       || listbox.isDoubleClicked() ) {
-                if ( !filename.empty() ) {
-                    result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
-                }
-                else if ( isListboxSelected ) {
+                if ( isListboxSelected ) {
                     result = listbox.GetCurrent().filename;
+                }
+                else if ( !filename.empty() ) {
+                    result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
                 }
             }
             else if ( isEditing ) {
@@ -529,7 +522,7 @@ namespace
             }
 
             if ( needRedraw ) {
-                const std::string selectedFileName = isListboxSelected ? System::truncateFileExtensionAndPath( listbox.GetCurrent().filename ) : "";
+                const std::string selectedFileName = isListboxSelected ? System::GetStem( listbox.GetCurrent().filename ) : "";
                 if ( isListboxSelected && lastSelectedSaveFileName != selectedFileName ) {
                     lastSelectedSaveFileName = selectedFileName;
                     filename = selectedFileName;

--- a/src/fheroes2/dialog/dialog_selectscenario.cpp
+++ b/src/fheroes2/dialog/dialog_selectscenario.cpp
@@ -196,12 +196,12 @@ namespace
 
     size_t GetInitialMapId( const MapsFileInfoList & lists )
     {
-        const Maps::FileInfo & mapInfo = Settings::Get().getCurrentMapInfo();
+        const Maps::FileInfo & currentMapinfo = Settings::Get().getCurrentMapInfo();
 
-        const std::string & mapFileName = System::GetBasename( mapInfo.filename );
         size_t mapId = 0;
+
         for ( MapsFileInfoList::const_iterator mapIter = lists.begin(); mapIter != lists.end(); ++mapIter, ++mapId ) {
-            if ( ( mapIter->name == mapInfo.name ) && ( System::GetBasename( mapIter->filename ) == mapFileName ) ) {
+            if ( mapIter->name == currentMapinfo.name && mapIter->filename == currentMapinfo.filename ) {
                 return mapId;
             }
         }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1704,7 +1704,7 @@ namespace Interface
             return false;
         }
 
-        _loadedFileName = System::truncateFileExtensionAndPath( filePath );
+        _loadedFileName = System::GetStem( filePath );
 
         // Set the loaded map as a default map for the new Standard Game.
         Maps::FileInfo fi;

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1709,7 +1709,7 @@ namespace Interface
         // Set the loaded map as a default map for the new Standard Game.
         Maps::FileInfo fi;
         if ( fi.loadResurrectionMap( _mapFormat, filePath ) ) {
-            Settings::Get().SetCurrentFileInfo( std::move( fi ) );
+            Settings::Get().setCurrentMapInfo( std::move( fi ) );
         }
         else {
             assert( 0 );
@@ -1774,7 +1774,7 @@ namespace Interface
             // Set the saved map as a default map for the new Standard Game.
             Maps::FileInfo fi;
             if ( fi.loadResurrectionMap( _mapFormat, fullPath ) ) {
-                Settings::Get().SetCurrentFileInfo( std::move( fi ) );
+                Settings::Get().setCurrentMapInfo( std::move( fi ) );
             }
             else {
                 assert( 0 );

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -19,6 +19,7 @@
  ***************************************************************************/
 
 #include <algorithm>
+#include <cassert>
 #include <cstdint>
 #include <ctime>
 #include <iterator>

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -96,7 +96,7 @@ namespace
 
         void ActionListPressRight( Maps::FileInfo & info ) override
         {
-            const fheroes2::Text header( System::truncateFileExtensionAndPath( info.filename ), fheroes2::FontType::normalYellow() );
+            const fheroes2::Text header( System::GetStem( info.filename ), fheroes2::FontType::normalYellow() );
 
             fheroes2::MultiFontText body;
 
@@ -283,7 +283,7 @@ namespace Editor
 
         MapsFileInfoList::iterator it = lists.begin();
         for ( ; it != lists.end(); ++it ) {
-            if ( System::truncateFileExtensionAndPath( ( *it ).filename ) == fileName ) {
+            if ( System::GetStem( ( *it ).filename ) == fileName ) {
                 break;
             }
         }
@@ -454,7 +454,7 @@ namespace Editor
             }
 
             if ( needFileNameRedraw ) {
-                const std::string selectedFileName = isListboxSelected ? System::truncateFileExtensionAndPath( listbox.GetCurrent().filename ) : "";
+                const std::string selectedFileName = isListboxSelected ? System::GetStem( listbox.GetCurrent().filename ) : "";
                 if ( isListboxSelected && lastSelectedSaveFileName != selectedFileName ) {
                     lastSelectedSaveFileName = selectedFileName;
                     fileName = selectedFileName;

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -144,10 +144,7 @@ namespace
     void FileInfoListBox::RedrawItem( const Maps::FileInfo & info, int32_t posX, int32_t posY, bool current )
     {
         std::string mapFileName( System::GetBasename( info.filename ) );
-
-        if ( mapFileName.empty() ) {
-            return;
-        }
+        assert( !mapFileName.empty() );
 
         const fheroes2::FontType font = current ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite();
 
@@ -400,13 +397,15 @@ namespace Editor
                 std::string msg( _( "Are you sure you want to delete file:" ) );
                 msg.append( "\n\n" );
                 msg.append( System::GetBasename( listbox.GetCurrent().filename ) );
+
                 if ( Dialog::YES == fheroes2::showStandardTextMessage( _( "Warning!" ), msg, Dialog::YES | Dialog::NO ) ) {
                     System::Unlink( listbox.GetCurrent().filename );
                     listbox.RemoveSelected();
+
                     if ( lists.empty() ) {
                         isListboxSelected = false;
-                        fileName.clear();
                         charInsertPos = 0;
+                        fileName.clear();
 
                         buttonOk.disable();
                         buttonOk.draw();

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1591,7 +1591,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             Maps::FileInfo mapInfo = scenario.loadMap();
             Campaign::CampaignData::updateScenarioGameplayConditions( currentScenarioInfoId, mapInfo );
 
-            conf.SetCurrentFileInfo( mapInfo );
+            conf.setCurrentMapInfo( mapInfo );
 
             assert( !scenarioBonusId || ( scenarioBonusId >= 0 && static_cast<size_t>( *scenarioBonusId ) < bonusChoices.size() ) );
 
@@ -1633,7 +1633,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
                                                    Dialog::OK );
 
                 // TODO: find a way to restore world for the current game after a failure.
-                conf.SetCurrentFileInfo( {} );
+                conf.setCurrentMapInfo( {} );
                 continue;
             }
 

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -142,7 +142,7 @@ fheroes2::GameMode Game::NewStandard()
 {
     Settings & conf = Settings::Get();
     if ( conf.isCampaignGameType() )
-        conf.SetCurrentFileInfo( {} );
+        conf.setCurrentMapInfo( {} );
     conf.SetGameType( Game::TYPE_STANDARD );
     return fheroes2::GameMode::SELECT_SCENARIO_ONE_HUMAN_PLAYER;
 }
@@ -159,7 +159,7 @@ fheroes2::GameMode Game::NewHotSeat()
 {
     Settings & conf = Settings::Get();
     if ( conf.isCampaignGameType() )
-        conf.SetCurrentFileInfo( {} );
+        conf.setCurrentMapInfo( {} );
 
     if ( conf.IsGameType( Game::TYPE_BATTLEONLY ) ) {
         // Redraw the main menu screen without multiplayer sub-menu to show it after the battle using screen restorer.

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -215,7 +215,7 @@ namespace
             for ( const Maps::FileInfo & mapInfo : lists ) {
                 if ( ( mapInfo.name == mapName ) && ( System::GetBasename( mapInfo.filename ) == mapFileName ) ) {
                     if ( mapInfo.filename == conf.getCurrentMapInfo().filename ) {
-                        conf.SetCurrentFileInfo( mapInfo );
+                        conf.setCurrentMapInfo( mapInfo );
                         updatePlayers( players, humanPlayerCount );
                         Game::LoadPlayers( mapInfo.filename, players );
                         resetStartingSettings = false;
@@ -227,7 +227,7 @@ namespace
 
         // set first map's settings
         if ( resetStartingSettings ) {
-            conf.SetCurrentFileInfo( lists.front() );
+            conf.setCurrentMapInfo( lists.front() );
             updatePlayers( players, humanPlayerCount );
             Game::LoadPlayers( lists.front().filename, players );
         }
@@ -316,7 +316,7 @@ namespace
 
                 if ( fi && fi->filename != currentMapName ) {
                     Game::SavePlayers( currentMapName, conf.GetPlayers() );
-                    conf.SetCurrentFileInfo( *fi );
+                    conf.setCurrentMapInfo( *fi );
 
                     mapTitleArea.restore();
                     RedrawMapTitle( scenarioBoxRoi );

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -27,6 +27,7 @@
 #include <cstdint>
 #include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "agg_image.h"
@@ -53,7 +54,6 @@
 #include "players.h"
 #include "screen.h"
 #include "settings.h"
-#include "system.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_button.h"

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -147,6 +147,8 @@ namespace
 
     fheroes2::GameMode ChooseNewMap( const MapsFileInfoList & lists, const int humanPlayerCount )
     {
+        assert( !lists.empty() );
+
         // setup cursor
         const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
@@ -204,34 +206,30 @@ namespace
         const int buttonCancelIcn = isEvilInterface ? ICN::BUTTON_SMALL_CANCEL_EVIL : ICN::BUTTON_SMALL_CANCEL_GOOD;
         background.renderButton( buttonCancel, buttonCancelIcn, 0, 1, buttonOffset, fheroes2::StandardWindow::Padding::BOTTOM_RIGHT );
 
-        bool resetStartingSettings = conf.getCurrentMapInfo().filename.empty();
-        Players & players = conf.GetPlayers();
-        Interface::PlayersInfo playersInfo;
-
-        if ( !resetStartingSettings ) { // verify that current map really exists in map's list
-            resetStartingSettings = true;
-            const std::string & mapName = conf.getCurrentMapInfo().name;
-            const std::string & mapFileName = System::GetBasename( conf.getCurrentMapInfo().filename );
-            for ( const Maps::FileInfo & mapInfo : lists ) {
-                if ( ( mapInfo.name == mapName ) && ( System::GetBasename( mapInfo.filename ) == mapFileName ) ) {
-                    if ( mapInfo.filename == conf.getCurrentMapInfo().filename ) {
-                        conf.setCurrentMapInfo( mapInfo );
-                        updatePlayers( players, humanPlayerCount );
-                        Game::LoadPlayers( mapInfo.filename, players );
-                        resetStartingSettings = false;
-                        break;
-                    }
-                }
+        const Maps::FileInfo & mapInfo = [&lists, &conf = std::as_const( conf )]() {
+            const Maps::FileInfo & currentMapinfo = conf.getCurrentMapInfo();
+            if ( currentMapinfo.filename.empty() ) {
+                return lists.front();
             }
-        }
 
-        // set first map's settings
-        if ( resetStartingSettings ) {
-            conf.setCurrentMapInfo( lists.front() );
-            updatePlayers( players, humanPlayerCount );
-            Game::LoadPlayers( lists.front().filename, players );
-        }
+            // Make sure that the current map actually exists in the map's list
+            const auto iter = std::find_if( lists.begin(), lists.end(), [&currentMapinfo]( const Maps::FileInfo & info ) {
+                return info.name == currentMapinfo.name && info.filename == currentMapinfo.filename;
+            } );
+            if ( iter == lists.end() ) {
+                return lists.front();
+            }
 
+            return *iter;
+        }();
+
+        Players & players = conf.GetPlayers();
+
+        conf.setCurrentMapInfo( mapInfo );
+        updatePlayers( players, humanPlayerCount );
+        Game::LoadPlayers( mapInfo.filename, players );
+
+        Interface::PlayersInfo playersInfo;
         playersInfo.UpdateInfo( players, pointOpponentInfo, pointClassInfo );
 
         DrawScenarioStaticInfo( roi );

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -496,11 +496,11 @@ std::string Settings::String() const
     return os.str();
 }
 
-void Settings::SetCurrentFileInfo( Maps::FileInfo fi )
+void Settings::setCurrentMapInfo( Maps::FileInfo fi )
 {
-    current_maps_file = std::move( fi );
+    _currentMapInfo = std::move( fi );
 
-    players.Init( current_maps_file );
+    players.Init( _currentMapInfo );
 }
 
 bool Settings::setGameLanguage( const std::string & language )
@@ -1088,12 +1088,12 @@ void Settings::resetFirstGameRun()
 
 StreamBase & operator<<( StreamBase & msg, const Settings & conf )
 {
-    return msg << conf._gameLanguage << conf.current_maps_file << conf._gameDifficulty << conf.game_type << conf.players;
+    return msg << conf._gameLanguage << conf._currentMapInfo << conf._gameDifficulty << conf.game_type << conf.players;
 }
 
 StreamBase & operator>>( StreamBase & msg, Settings & conf )
 {
-    msg >> conf._loadedFileLanguage >> conf.current_maps_file >> conf._gameDifficulty >> conf.game_type;
+    msg >> conf._loadedFileLanguage >> conf._currentMapInfo >> conf._gameDifficulty >> conf.game_type;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1101_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1101_RELEASE ) {

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -79,16 +79,17 @@ public:
     bool Save( const std::string_view fileName ) const;
 
     std::string String() const;
-    void SetCurrentFileInfo( Maps::FileInfo fi );
+
+    void setCurrentMapInfo( Maps::FileInfo fi );
 
     const Maps::FileInfo & getCurrentMapInfo() const
     {
-        return current_maps_file;
+        return _currentMapInfo;
     }
 
     Maps::FileInfo & getCurrentMapInfo()
     {
-        return current_maps_file;
+        return _currentMapInfo;
     }
 
     int HeroesMoveSpeed() const
@@ -366,7 +367,7 @@ private:
     // Not saved in the config file or savefile
     std::string _loadedFileLanguage;
 
-    Maps::FileInfo current_maps_file;
+    Maps::FileInfo _currentMapInfo;
 
     int sound_volume;
     int music_volume;

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -372,7 +372,7 @@ void World::generateBattleOnlyMap()
         fi.version = GameVersion::PRICE_OF_LOYALTY;
     }
 
-    conf.SetCurrentFileInfo( std::move( fi ) );
+    conf.setCurrentMapInfo( std::move( fi ) );
 
     Defaults();
 
@@ -407,7 +407,7 @@ void World::generateForEditor( const int32_t size )
 
     fi.version = GameVersion::PRICE_OF_LOYALTY;
 
-    conf.SetCurrentFileInfo( std::move( fi ) );
+    conf.setCurrentMapInfo( std::move( fi ) );
 
     Defaults();
 


### PR DESCRIPTION
`std::filesystem`'s `stem()` doesn't return the empty string if filename begins with dot and has no other dots (`/foo/.bar` -> `.bar`), so I preferred to replicate this behavior in our home-grown support library.

Also this PR fixes the following issues:

* Issues with files whose names consist only of an extension (`.sav`, `.fh2m` and so on) . Currently in the `master` branch, when trying to display a list of save files, among which there is at least one file with a name consisting only of an extension (e.g. `.sav`), we will get the assertion failure inside the `getLineWidth()`. Since such filenames are absolutely legal, I decided to fix this. Savefiles with this PR:

  https://github.com/user-attachments/assets/121a4561-71fa-47ae-b9cd-6ba9e43ca64f

  Please note that users are able to load and overwrite the savefile with the name `.sav` if they choose this file from the list, but if they enter the name `.sav` to the input control, the final filename becomes `.sav.sav` (because of the extension that is automatically added to this name), what I consider acceptable.

  Maps with this PR:

  https://github.com/user-attachments/assets/bc125761-a0b2-48f8-8410-e1b53470b084

  Please note that users are able to to start the map with filename `.fh2m` and load it to the Editor, but are not able to overwrite it, because of the extension that is always added to this name, what I also consider acceptable.

* Currently in the `master` branch, users are not able to load a savefile from the Adventure map GUI (well, almost - see below), if there are no savefiles of the type of game that is currently being played:

  https://github.com/user-attachments/assets/edd760d0-82b6-48b0-96a5-cb609fb2835c

  In other words, user is able to load a campaign savefile using hotkey, but is not able to do it via GUI. With this PR:

  https://github.com/user-attachments/assets/197cc9f1-5c6a-4282-8dcd-4e239fd9c7cf

* Currently in the `master` branch, in the "load game" dialog, when the last savefile has been deleted using the corresponding hotkey, the following happens:

  https://github.com/user-attachments/assets/7cbaed52-de5d-47a4-95f8-408414cb3987

  This is due to a crash that previously occurred when the dialog box was redrawn with an empty file list. I find this behavior problematic because the list of savefiles may be empty here for natural reasons - for example, if all available savefiles of the appropriate type have an outdated version (no longer supported) or corrupted - because the logic of the main menu only checks for files with the appropriate extension, but does not check that they are really suitable for loading. It is better to fix the crash in another way, which I did (at least I hope so). With this PR:

  https://github.com/user-attachments/assets/458e9439-6ca8-48c8-aa67-983be27924bb
