### PR TITLE
Tune the set of C/C++ compiler warnings

### DIFF
--- a/android/app/jni/Android.mk
+++ b/android/app/jni/Android.mk
@@ -1,6 +1,6 @@
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2022                                                    #
+#   Copyright (C) 2022 - 2024                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -26,19 +26,19 @@ FHEROES2_C_WARN_OPTIONS := \
     -Wall \
     -Wextra \
     -Wcast-align \
-    -Wextra-semi \
+    -Wcast-qual \
     -Wfloat-conversion \
     -Wfloat-equal \
-    -Winit-self \
     -Wredundant-decls \
     -Wshadow \
     -Wundef \
-    -Wuninitialized \
     -Wunused
 
 # C++ only
 FHEROES2_CPP_WARN_OPTIONS := \
     -Wctor-dtor-privacy \
-    -Woverloaded-virtual
+    -Wextra-semi \
+    -Woverloaded-virtual \
+    -Wsuggest-override
 
 include $(call all-subdir-makefiles)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2022 - 2023                                             #
+#   Copyright (C) 2022 - 2024                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #
@@ -20,12 +20,12 @@
 
 set(
 	GNU_CC_WARN_OPTS
-	-pedantic -Wall -Wextra -Wcast-align -Wextra-semi -Wfloat-conversion -Wfloat-equal
-	-Winit-self -Wredundant-decls -Wshadow -Wundef -Wuninitialized -Wunused
+	-pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wfloat-conversion -Wfloat-equal -Wredundant-decls
+	-Wshadow -Wundef -Wunused
 	)
 set(
 	GNU_CXX_WARN_OPTS
-	${GNU_CC_WARN_OPTS} -Wctor-dtor-privacy -Woverloaded-virtual
+	${GNU_CC_WARN_OPTS} -Wctor-dtor-privacy -Wextra-semi -Woverloaded-virtual -Wsuggest-override
 	)
 set(
 	MSVC_CC_WARN_OPTS

--- a/src/Makefile
+++ b/src/Makefile
@@ -117,11 +117,13 @@ CCFLAGS := $(CCFLAGS) -DFHEROES2_DATA="$(FHEROES2_DATA)"
 endif
 
 # TODO: Add -Wconversion -Wsign-conversion flags once we fix all the corresponding code smells
+# TODO: Add -Wmissing-declarations once there will be no more functions that are used only within a single module,
+# TODO:                            but are not declared static (and are not placed in an anonymous namespace)
 # TODO: Add -Wdouble-promotion -Wold-style-cast -Wswitch-default flags once SDL headers can be compiled with them
-CCWARNOPTS := -pedantic -Wall -Wextra -Wcast-align -Wextra-semi -Wfloat-conversion -Wfloat-equal \
-              -Winit-self -Wredundant-decls -Wshadow -Wundef -Wuninitialized -Wunused
+CCWARNOPTS := -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wfloat-conversion -Wfloat-equal -Wredundant-decls \
+              -Wshadow -Wundef -Wunused
 CFLAGS := $(CFLAGS) $(CCWARNOPTS)
-CXXFLAGS := $(CXXFLAGS) $(CCWARNOPTS) -Wctor-dtor-privacy -Woverloaded-virtual
+CXXFLAGS := $(CXXFLAGS) $(CCWARNOPTS) -Wctor-dtor-privacy -Wextra-semi -Woverloaded-virtual -Wsuggest-override
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror


### PR DESCRIPTION
* `-Winit-self` and `-Wuninitialized` are part of the `-Wall`;
* `-Wextra-semi` is C++ only;
* New warnings: `-Wcast-qual` and `-Wsuggest-override`, which are supported both by GCC and Clang.
