### PR TITLE
Fix multiple issues with action creation in the Editor

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1164,11 +1164,12 @@ namespace Interface
                     const int color = Color::IndexToColor( Maps::getTownColorIndex( _mapFormat, tileIndex, object.id ) );
 
                     auto & castleMetadata = _mapFormat.castleMetadata[object.id];
-                    const auto castleMetadataBackup = castleMetadata;
+                    auto castleMetadataBackup = castleMetadata;
 
-                    fheroes2::ActionCreator action( _historyManager, _mapFormat );
-                    Editor::castleDetailsDialog( castleMetadata, race, color );
+                    Editor::castleDetailsDialog( castleMetadataBackup, race, color );
                     if ( castleMetadata != castleMetadataBackup ) {
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        castleMetadata = std::move( castleMetadataBackup );
                         action.commit();
                     }
                 }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1162,7 +1162,15 @@ namespace Interface
 
                     const int race = Race::IndexToRace( static_cast<int>( objectInfo.metadata[0] ) );
                     const int color = Color::IndexToColor( Maps::getTownColorIndex( _mapFormat, tileIndex, object.id ) );
-                    Editor::castleDetailsDialog( _mapFormat.castleMetadata[object.id], race, color );
+
+                    auto & castleMetadata = _mapFormat.castleMetadata[object.id];
+                    const auto castleMetadataBackup = castleMetadata;
+
+                    fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                    Editor::castleDetailsDialog( castleMetadata, race, color );
+                    if ( castleMetadata != castleMetadataBackup ) {
+                        action.commit();
+                    }
                 }
                 else if ( objectType == MP2::OBJ_SIGN || objectType == MP2::OBJ_BOTTLE ) {
                     fheroes2::ActionCreator action( _historyManager, _mapFormat );

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1124,6 +1124,9 @@ namespace Interface
         Maps::Tiles & tile = world.GetTiles( tileIndex );
 
         if ( _editorPanel.isDetailEdit() ) {
+            // Trigger an action only when metadata has been changed to avoid expensive computations and bloated list of actions.
+            // Comparing a metadata structure is much faster than restoring the whole map.
+
             for ( const auto & object : _mapFormat.tiles[tileIndex].objects ) {
                 const auto & objectGroupInfo = Maps::getObjectsByGroup( object.group );
                 assert( object.index <= objectGroupInfo.size() );
@@ -1149,10 +1152,10 @@ namespace Interface
                     hero.SetColor( color );
                     hero.applyHeroMetadata( _mapFormat.heroMetadata[object.id], objectType == MP2::OBJ_JAIL, true );
 
-                    fheroes2::ActionCreator action( _historyManager, _mapFormat );
                     hero.OpenDialog( false, false, true, true, true, true );
                     Maps::Map_Format::HeroMetadata heroNewMetadata = hero.getHeroMetadata();
                     if ( heroNewMetadata != _mapFormat.heroMetadata[object.id] ) {
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
                         _mapFormat.heroMetadata[object.id] = std::move( heroNewMetadata );
                         action.commit();
                     }
@@ -1164,32 +1167,37 @@ namespace Interface
                     const int color = Color::IndexToColor( Maps::getTownColorIndex( _mapFormat, tileIndex, object.id ) );
 
                     auto & castleMetadata = _mapFormat.castleMetadata[object.id];
-                    auto castleMetadataBackup = castleMetadata;
+                    Maps::Map_Format::CastleMetadata newCastleMetadata = castleMetadata;
 
-                    Editor::castleDetailsDialog( castleMetadataBackup, race, color );
-                    if ( castleMetadata != castleMetadataBackup ) {
+                    Editor::castleDetailsDialog( newCastleMetadata, race, color );
+                    if ( castleMetadata != newCastleMetadata ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
-                        castleMetadata = std::move( castleMetadataBackup );
+                        castleMetadata = std::move( newCastleMetadata );
                         action.commit();
                     }
                 }
                 else if ( objectType == MP2::OBJ_SIGN || objectType == MP2::OBJ_BOTTLE ) {
-                    fheroes2::ActionCreator action( _historyManager, _mapFormat );
-
                     std::string header = _( "Input %{object} text" );
                     StringReplace( header, "%{object}", MP2::StringObject( objectType ) );
 
-                    std::string signText = _mapFormat.signMetadata[object.id].message;
-                    if ( Dialog::inputString( std::move( header ), signText, {}, 0, true, true ) ) {
-                        _mapFormat.signMetadata[object.id].message = std::move( signText );
+                    auto & originalMessage = _mapFormat.signMetadata[object.id].message;
+                    std::string signText = originalMessage;
+
+                    if ( Dialog::inputString( std::move( header ), signText, {}, 0, true, true ) && originalMessage != signText ) {
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        originalMessage = std::move( signText );
                         action.commit();
                     }
                 }
                 else if ( objectType == MP2::OBJ_EVENT ) {
                     assert( _mapFormat.adventureMapEventMetadata.find( object.id ) != _mapFormat.adventureMapEventMetadata.end() );
 
-                    fheroes2::ActionCreator action( _historyManager, _mapFormat );
-                    if ( Editor::eventDetailsDialog( _mapFormat.adventureMapEventMetadata[object.id], _mapFormat.humanPlayerColors, _mapFormat.computerPlayerColors ) ) {
+                    auto & eventMetadata = _mapFormat.adventureMapEventMetadata[object.id];
+                    Maps::Map_Format::AdventureMapEventMetadata newEventData = eventMetadata;
+
+                    if ( Editor::eventDetailsDialog( newEventData, _mapFormat.humanPlayerColors, _mapFormat.computerPlayerColors ) && newEventData != eventMetadata ) {
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        eventMetadata = std::move( newEventData );
                         action.commit();
                     }
                 }
@@ -1200,20 +1208,24 @@ namespace Interface
                     if ( monsterMetadata != _mapFormat.standardMetadata.end() ) {
                         monsterCount = monsterMetadata->second.metadata[0];
                     }
+                    else {
+                        // This could be a corrupted map. Add missing metadata into it. This action should be outside action manager scope.
+                        _mapFormat.standardMetadata[object.id] = { 0, 0, Monster::JOIN_CONDITION_UNSET };
+                    }
 
                     const Monster tempMonster( static_cast<int>( object.index ) + 1 );
 
                     std::string str = _( "Set %{monster} Count" );
                     StringReplace( str, "%{monster}", tempMonster.GetName() );
 
-                    fheroes2::ActionCreator action( _historyManager, _mapFormat );
                     std::unique_ptr<const fheroes2::MonsterDialogElement> monsterUi = nullptr;
 
                     if ( tempMonster.isValid() ) {
                         monsterUi = std::make_unique<const fheroes2::MonsterDialogElement>( tempMonster );
                     }
 
-                    if ( Dialog::SelectCount( str, 0, 500000, monsterCount, 1, monsterUi.get() ) ) {
+                    if ( Dialog::SelectCount( str, 0, 500000, monsterCount, 1, monsterUi.get() ) && _mapFormat.standardMetadata[object.id].metadata[0] != monsterCount ) {
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
                         _mapFormat.standardMetadata[object.id] = { monsterCount, 0, Monster::JOIN_CONDITION_UNSET };
                         action.commit();
                     }
@@ -1222,30 +1234,34 @@ namespace Interface
                     if ( objectInfo.objectType == MP2::OBJ_RANDOM_ULTIMATE_ARTIFACT ) {
                         assert( _mapFormat.standardMetadata.find( object.id ) != _mapFormat.standardMetadata.end() );
 
-                        int32_t radius = _mapFormat.standardMetadata[object.id].metadata[0];
+                        auto & originalRadius = _mapFormat.standardMetadata[object.id].metadata[0];
+                        int32_t radius = originalRadius;
 
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
-                        if ( Dialog::SelectCount( _( "Set Random Ultimate Artifact Radius" ), 0, 100, radius ) ) {
-                            _mapFormat.standardMetadata[object.id].metadata[0] = radius;
+                        if ( Dialog::SelectCount( _( "Set Random Ultimate Artifact Radius" ), 0, 100, radius ) && radius != originalRadius ) {
+                            fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                            originalRadius = radius;
                             action.commit();
                         }
                     }
                     else if ( objectInfo.objectType == MP2::OBJ_ARTIFACT && objectInfo.metadata[0] == Artifact::SPELL_SCROLL ) {
-                        // Find Spell Scroll object.
+                        // Find Artifact object.
                         assert( _mapFormat.standardMetadata.find( object.id ) != _mapFormat.standardMetadata.end() );
 
-                        const int spellId = Dialog::selectSpell( _mapFormat.standardMetadata[object.id].metadata[0], true ).GetID();
+                        auto & artifactSpellId = _mapFormat.standardMetadata[object.id].metadata[0];
 
-                        if ( spellId == Spell::NONE ) {
-                            // We do not place the Spell Scroll artifact if the spell for it was not selected.
+                        const int newSpellId = Dialog::selectSpell( artifactSpellId, true ).GetID();
+
+                        if ( newSpellId == Spell::NONE || artifactSpellId == newSpellId ) {
+                            // We do not place the Spell Scroll artifact if the spell for it was not selected
+                            // or when the same spell was chosen.
                             return;
                         }
 
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
-                        _mapFormat.standardMetadata[object.id].metadata[0] = spellId;
+                        artifactSpellId = newSpellId;
 
-                        Maps::setSpellOnTile( tile, spellId );
+                        Maps::setSpellOnTile( tile, newSpellId );
 
                         action.commit();
                     }
@@ -1258,8 +1274,12 @@ namespace Interface
                 else if ( objectType == MP2::OBJ_SPHINX ) {
                     assert( _mapFormat.sphinxMetadata.find( object.id ) != _mapFormat.sphinxMetadata.end() );
 
-                    fheroes2::ActionCreator action( _historyManager, _mapFormat );
-                    if ( Editor::openSphinxWindow( _mapFormat.sphinxMetadata[object.id] ) ) {
+                    auto & originalMetadata = _mapFormat.sphinxMetadata[object.id];
+                    Maps::Map_Format::SphinxMetadata newMetadata = originalMetadata;
+
+                    if ( Editor::openSphinxWindow( newMetadata ) && newMetadata != originalMetadata ) {
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        originalMetadata = std::move( newMetadata );
                         action.commit();
                     }
                 }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1819,6 +1819,7 @@ namespace Interface
 
     void EditorInterface::openMapSpecificationsDialog()
     {
+        // TODO: avoid creation of an action for cases when no changes are being done in the map format.
         fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
         if ( Editor::mapSpecificationsDialog( _mapFormat ) ) {

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -85,6 +85,20 @@ namespace Maps::Map_Format
 
         // The number of monsters available to hire in dwellings. A negative value means that no change will be applied.
         std::array<int32_t, 6> availableToHireMonsterCount{ -1 };
+
+        bool operator==( const CastleMetadata & anotherCastleMetadata ) const
+        {
+            return customName == anotherCastleMetadata.customName && defenderMonsterType == anotherCastleMetadata.defenderMonsterType
+                   && defenderMonsterCount == anotherCastleMetadata.defenderMonsterCount && customBuildings == anotherCastleMetadata.customBuildings
+                   && builtBuildings == anotherCastleMetadata.builtBuildings && bannedBuildings == anotherCastleMetadata.bannedBuildings
+                   && mustHaveSpells == anotherCastleMetadata.mustHaveSpells && bannedSpells == anotherCastleMetadata.bannedSpells
+                   && availableToHireMonsterCount == anotherCastleMetadata.availableToHireMonsterCount;
+        }
+
+        bool operator!=( const CastleMetadata & anotherCastleMetadata ) const
+        {
+            return !( *this == anotherCastleMetadata );
+        }
     };
 
     struct HeroMetadata

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -181,6 +181,17 @@ namespace Maps::Map_Format
 
         // Resources to be given as a reward.
         Funds resources;
+
+        bool operator==( const SphinxMetadata & anotherMetadata ) const
+        {
+            return riddle == anotherMetadata.riddle && answers == anotherMetadata.answers && artifact == anotherMetadata.artifact
+                   && artifactMetadata == anotherMetadata.artifactMetadata && resources == anotherMetadata.resources;
+        }
+
+        bool operator!=( const SphinxMetadata & anotherMetadata ) const
+        {
+            return !( *this == anotherMetadata );
+        }
     };
 
     struct SignMetadata
@@ -219,6 +230,22 @@ namespace Maps::Map_Format
 
         int32_t monsterType{ 0 };
         int32_t monsterCount{ 0 };
+
+        bool operator==( const AdventureMapEventMetadata & anotherMetadata ) const
+        {
+            return message == anotherMetadata.message && humanPlayerColors == anotherMetadata.humanPlayerColors
+                   &&  computerPlayerColors == anotherMetadata.computerPlayerColors && isRecurringEvent == anotherMetadata.isRecurringEvent
+                   && artifact == anotherMetadata.artifact && artifactMetadata == anotherMetadata.artifactMetadata && resources == anotherMetadata.resources
+                   && attack == anotherMetadata.attack && defense == anotherMetadata.defense && knowledge == anotherMetadata.knowledge
+                   && spellPower == anotherMetadata.spellPower && experience == anotherMetadata.experience && secondarySkill == anotherMetadata.secondarySkill
+                   && secondarySkillLevel == anotherMetadata.secondarySkillLevel && monsterType == anotherMetadata.monsterType
+                   && monsterCount == anotherMetadata.monsterCount;
+        }
+
+        bool operator!=( const AdventureMapEventMetadata & anotherMetadata ) const
+        {
+            return !( *this == anotherMetadata );
+        }
     };
 
     struct ShrineMetadata

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -234,7 +234,7 @@ namespace Maps::Map_Format
         bool operator==( const AdventureMapEventMetadata & anotherMetadata ) const
         {
             return message == anotherMetadata.message && humanPlayerColors == anotherMetadata.humanPlayerColors
-                   &&  computerPlayerColors == anotherMetadata.computerPlayerColors && isRecurringEvent == anotherMetadata.isRecurringEvent
+                   && computerPlayerColors == anotherMetadata.computerPlayerColors && isRecurringEvent == anotherMetadata.isRecurringEvent
                    && artifact == anotherMetadata.artifact && artifactMetadata == anotherMetadata.artifactMetadata && resources == anotherMetadata.resources
                    && attack == anotherMetadata.attack && defense == anotherMetadata.defense && knowledge == anotherMetadata.knowledge
                    && spellPower == anotherMetadata.spellPower && experience == anotherMetadata.experience && secondarySkill == anotherMetadata.secondarySkill


### PR DESCRIPTION
This pull request solves 3 major problems with the Editor:
- before the changes any modification of **castle properties** couldn't be undone by clicking Undo button or using a hotkey. The only way to undo changes was to go to the castle and revert them manually
- we were committing actions even if no changes were being done for the map. For example, you can open a monster count dialog and just press OKAY leading to creation of a new action which does nothing.
- we were creating actions and undoing them when no changes were done. This causes the Editor to hang for few seconds (at least on my setup) as it reloads the whole map. Of course it is almost not noticeable in release mode but we were wasting heavy resources for doing nothing.