### PR TITLE
Fix the recently introduced code smell

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -13,6 +13,7 @@ Checks: >-
   -cppcoreguidelines-pro-bounds-pointer-arithmetic,
   -cppcoreguidelines-pro-type-reinterpret-cast,
   -cppcoreguidelines-pro-type-union-access,
+  google-explicit-constructor,
   misc-*,
   -misc-include-cleaner,
   -misc-non-private-member-variables-in-classes,

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -381,7 +381,7 @@ namespace
         {
             SoundTask() = default;
 
-            SoundTask( const int m82 )
+            explicit SoundTask( const int m82 )
                 : m82Sound( m82 )
             {
                 // Do nothing.


### PR DESCRIPTION
Also added the `google-explicit-constructor` check for Clang-Tidy. Unfortunately, there is no non-vendor-specific check for this.