### PR TITLE
Enable a few more compiler warnings, add more RAII for C-style "alloc()/free(), open()/close()"-like function pairs

### DIFF
--- a/android/app/jni/Android.mk
+++ b/android/app/jni/Android.mk
@@ -27,10 +27,12 @@ FHEROES2_C_WARN_OPTIONS := \
     -Wextra \
     -Wcast-align \
     -Wcast-qual \
+    -Wdouble-promotion \
     -Wfloat-conversion \
     -Wfloat-equal \
     -Wredundant-decls \
     -Wshadow \
+    -Wswitch-default \
     -Wundef \
     -Wunused
 
@@ -39,6 +41,7 @@ FHEROES2_CPP_WARN_OPTIONS := \
     -Wctor-dtor-privacy \
     -Wextra-semi \
     -Wmissing-declarations \
+    -Wold-style-cast \
     -Woverloaded-virtual \
     -Wsuggest-override
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,13 +20,13 @@
 
 set(
 	GNU_CC_WARN_OPTS
-	-pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wfloat-conversion -Wfloat-equal -Wredundant-decls
-	-Wshadow -Wundef -Wunused
+	-pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdouble-promotion -Wfloat-conversion -Wfloat-equal
+	-Wredundant-decls -Wshadow -Wswitch-default -Wundef -Wunused
 	)
 set(
 	GNU_CXX_WARN_OPTS
-	${GNU_CC_WARN_OPTS} -Wctor-dtor-privacy -Wextra-semi -Wmissing-declarations -Woverloaded-virtual
-	-Wsuggest-override
+	${GNU_CC_WARN_OPTS} -Wctor-dtor-privacy -Wextra-semi -Wmissing-declarations -Wold-style-cast
+	-Woverloaded-virtual -Wsuggest-override
 	)
 set(
 	MSVC_CC_WARN_OPTS

--- a/src/Makefile
+++ b/src/Makefile
@@ -117,12 +117,11 @@ CCFLAGS := $(CCFLAGS) -DFHEROES2_DATA="$(FHEROES2_DATA)"
 endif
 
 # TODO: Add -Wconversion -Wsign-conversion flags once we fix all the corresponding code smells
-# TODO: Add -Wdouble-promotion -Wold-style-cast -Wswitch-default flags once SDL headers can be compiled with them
-CCWARNOPTS := -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wfloat-conversion -Wfloat-equal -Wredundant-decls \
-              -Wshadow -Wundef -Wunused
+CCWARNOPTS := -pedantic -Wall -Wextra -Wcast-align -Wcast-qual -Wdouble-promotion -Wfloat-conversion -Wfloat-equal \
+              -Wredundant-decls -Wshadow -Wswitch-default -Wundef -Wunused
 CFLAGS := $(CFLAGS) $(CCWARNOPTS)
-CXXFLAGS := $(CXXFLAGS) $(CCWARNOPTS) -Wctor-dtor-privacy -Wextra-semi -Wmissing-declarations -Woverloaded-virtual \
-                                      -Wsuggest-override
+CXXFLAGS := $(CXXFLAGS) $(CCWARNOPTS) -Wctor-dtor-privacy -Wextra-semi -Wmissing-declarations -Wold-style-cast \
+                                      -Woverloaded-virtual -Wsuggest-override
 
 ifdef FHEROES2_STRICT_COMPILATION
 CCFLAGS := $(CCFLAGS) -Werror

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -236,12 +236,10 @@ namespace
                     ERROR_LOG( "Failed to create a music track from memory. The error: " << SDL_GetError() )
                 }
                 else {
-                    result = Mix_LoadMUS_RW( rwops, 0 );
+                    result = Mix_LoadMUS_RW( rwops, 1 );
                     if ( result == nullptr ) {
                         ERROR_LOG( "Failed to create a music track from memory. The error: " << Mix_GetError() )
                     }
-
-                    SDL_FreeRW( rwops );
                 }
             }
             else if ( std::holds_alternative<std::string>( _source ) ) {

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -36,11 +36,25 @@
 #include <utility>
 #include <variant>
 
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
 #include <SDL_audio.h>
 #include <SDL_error.h>
 #include <SDL_mixer.h>
 #include <SDL_rwops.h>
 #include <SDL_stdinc.h>
+
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
 
 #include "core.h"
 #include "dir.h"

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -27,7 +27,6 @@
 #include <atomic>
 #include <cassert>
 #include <cmath>
-#include <functional>
 #include <list>
 #include <map>
 #include <memory>

--- a/src/engine/core.cpp
+++ b/src/engine/core.cpp
@@ -24,8 +24,22 @@
 #include <cstdint>
 #include <stdexcept>
 
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
 #include <SDL.h>
 #include <SDL_error.h>
+
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
 
 #include "audio.h"
 #include "localevent.h"

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -89,8 +89,8 @@ namespace
         const int32_t width = image.width();
         const int32_t height = image.height();
 
-        SDL_Surface * surface = SDL_CreateRGBSurface( 0, width, height, 8, 0, 0, 0, 0 );
-        if ( surface == nullptr ) {
+        const std::unique_ptr<SDL_Surface, std::function<void( SDL_Surface * )>> surface( SDL_CreateRGBSurface( 0, width, height, 8, 0, 0, 0, 0 ), SDL_FreeSurface );
+        if ( !surface ) {
             ERROR_LOG( "Error while creating a SDL surface for an image to be saved under " << path << ". Error " << SDL_GetError() )
             return false;
         }
@@ -125,20 +125,18 @@ namespace
 #if defined( ENABLE_PNG )
         int res = 0;
         if ( isPNGFilePath( path ) ) {
-            res = IMG_SavePNG( surface, path.c_str() );
+            res = IMG_SavePNG( surface.get(), path.c_str() );
         }
         else {
-            res = SDL_SaveBMP( surface, path.c_str() );
+            res = SDL_SaveBMP( surface.get(), path.c_str() );
         }
 #else
         if ( isPNGFilePath( path ) ) {
             memcpy( path.data() + path.size() - 3, "bmp", 3 );
         }
 
-        const int res = SDL_SaveBMP( surface, path.c_str() );
+        const int res = SDL_SaveBMP( surface.get(), path.c_str() );
 #endif
-
-        SDL_FreeSurface( surface );
 
         return res == 0;
     }

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -28,6 +28,15 @@
 #include <string_view>
 #include <vector>
 
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
 #include <SDL_error.h>
 #include <SDL_pixels.h>
 #include <SDL_stdinc.h>
@@ -37,6 +46,11 @@
 #if defined( WITH_IMAGE )
 #define ENABLE_PNG
 #include <SDL_image.h>
+#endif
+
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
 #endif
 
 #include "image_palette.h"

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -88,7 +88,7 @@ namespace
         const int32_t width = image.width();
         const int32_t height = image.height();
 
-        const std::unique_ptr<SDL_Surface, std::function<void( SDL_Surface * )>> surface( SDL_CreateRGBSurface( 0, width, height, 8, 0, 0, 0, 0 ), SDL_FreeSurface );
+        const std::unique_ptr<SDL_Surface, void ( * )( SDL_Surface * )> surface( SDL_CreateRGBSurface( 0, width, height, 8, 0, 0, 0, 0 ), SDL_FreeSurface );
         if ( !surface ) {
             ERROR_LOG( "Error while creating a SDL surface for an image to be saved under " << path << ". Error " << SDL_GetError() )
             return false;
@@ -173,8 +173,8 @@ namespace fheroes2
             return false;
         }
 
-        std::unique_ptr<SDL_Surface, std::function<void( SDL_Surface * )>> surface( nullptr, SDL_FreeSurface );
-        std::unique_ptr<SDL_Surface, std::function<void( SDL_Surface * )>> loadedSurface( nullptr, SDL_FreeSurface );
+        std::unique_ptr<SDL_Surface, void ( * )( SDL_Surface * )> surface( nullptr, SDL_FreeSurface );
+        std::unique_ptr<SDL_Surface, void ( * )( SDL_Surface * )> loadedSurface( nullptr, SDL_FreeSurface );
 
 #if defined( WITH_IMAGE )
         loadedSurface.reset( IMG_Load( path.c_str() ) );
@@ -192,7 +192,7 @@ namespace fheroes2
 
         // Image loading functions can theoretically return SDL_Surface in any supported color format, so we will convert it to a specific format for subsequent
         // processing
-        const std::unique_ptr<SDL_PixelFormat, std::function<void( SDL_PixelFormat * )>> pixelFormat( SDL_AllocFormat( SDL_PIXELFORMAT_BGRA32 ), SDL_FreeFormat );
+        const std::unique_ptr<SDL_PixelFormat, void ( * )( SDL_PixelFormat * )> pixelFormat( SDL_AllocFormat( SDL_PIXELFORMAT_BGRA32 ), SDL_FreeFormat );
         if ( !pixelFormat ) {
             return false;
         }

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -44,7 +44,6 @@
 #include <SDL_version.h>
 
 #if defined( WITH_IMAGE )
-#define ENABLE_PNG
 #include <SDL_image.h>
 #endif
 
@@ -77,7 +76,7 @@ namespace
         return palette;
     }
 
-#if defined( ENABLE_PNG )
+#if defined( WITH_IMAGE )
     bool SaveImage( const fheroes2::Image & image, const std::string & path )
 #else
     bool SaveImage( const fheroes2::Image & image, std::string path )
@@ -122,8 +121,9 @@ namespace
             memcpy( surface->pixels, image.image(), static_cast<size_t>( width * height ) );
         }
 
-#if defined( ENABLE_PNG )
+#if defined( WITH_IMAGE )
         int res = 0;
+
         if ( isPNGFilePath( path ) ) {
             res = IMG_SavePNG( surface.get(), path.c_str() );
         }
@@ -176,7 +176,7 @@ namespace fheroes2
         std::unique_ptr<SDL_Surface, std::function<void( SDL_Surface * )>> surface( nullptr, SDL_FreeSurface );
         std::unique_ptr<SDL_Surface, std::function<void( SDL_Surface * )>> loadedSurface( nullptr, SDL_FreeSurface );
 
-#if defined( ENABLE_PNG )
+#if defined( WITH_IMAGE )
         loadedSurface.reset( IMG_Load( path.c_str() ) );
 #else
         loadedSurface.reset( SDL_LoadBMP( path.c_str() ) );
@@ -368,7 +368,7 @@ namespace fheroes2
 
     bool isPNGFormatSupported()
     {
-#if defined( ENABLE_PNG )
+#if defined( WITH_IMAGE )
         return true;
 #else
         return false;

--- a/src/engine/image_tool.cpp
+++ b/src/engine/image_tool.cpp
@@ -22,7 +22,6 @@
 #include <cassert>
 #include <cstdint>
 #include <cstring>
-#include <functional>
 #include <memory>
 #include <ostream>
 #include <string_view>

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -31,6 +31,15 @@
 #include <set>
 #include <utility>
 
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
 #include <SDL_error.h>
 #include <SDL_events.h>
 #include <SDL_gamecontroller.h>
@@ -44,6 +53,11 @@
 #include <SDL_touch.h>
 #include <SDL_version.h>
 #include <SDL_video.h>
+
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
 
 #include "audio.h"
 #include "image.h"

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -28,6 +28,15 @@
 #include <set>
 #include <utility>
 
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
 #include <SDL_error.h>
 #include <SDL_events.h>
 #include <SDL_hints.h>
@@ -38,6 +47,11 @@
 #include <SDL_stdinc.h>
 #include <SDL_surface.h>
 #include <SDL_video.h>
+
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
 
 #if defined( TARGET_PS_VITA )
 #include <vita2d.h>

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -29,7 +29,6 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
-#include <functional>
 #include <iterator>
 #include <list>
 #include <map>

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -428,7 +428,7 @@ private:
         }
     }
 
-    std::unique_ptr<std::FILE, std::function<int( std::FILE * )>> _file{ nullptr, std::fclose };
+    std::unique_ptr<std::FILE, int ( * )( std::FILE * )> _file{ nullptr, std::fclose };
 };
 
 namespace fheroes2

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -25,7 +25,6 @@
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
-#include <functional>
 #include <memory>
 
 #include "exception.h"

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -46,7 +46,7 @@ namespace
         }
 
         // Verify that the file is valid. We use C-code on purpose since libsmacker library does the same.
-        std::unique_ptr<std::FILE, int ( * )( std::FILE * )> file( std::fopen( filePath.c_str(), "rb" ), std::fclose );
+        const std::unique_ptr<std::FILE, int ( * )( std::FILE * )> file( std::fopen( filePath.c_str(), "rb" ), std::fclose );
         if ( file == nullptr ) {
             return;
         }

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -46,7 +46,7 @@ namespace
 
         // Verify that the file is valid. We use C-code on purpose since libsmacker library does the same.
         const std::unique_ptr<std::FILE, int ( * )( std::FILE * )> file( std::fopen( filePath.c_str(), "rb" ), std::fclose );
-        if ( file == nullptr ) {
+        if ( !file ) {
             return;
         }
 

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -46,7 +46,7 @@ namespace
         }
 
         // Verify that the file is valid. We use C-code on purpose since libsmacker library does the same.
-        std::unique_ptr<std::FILE, std::function<int( std::FILE * )>> file( std::fopen( filePath.c_str(), "rb" ), std::fclose );
+        std::unique_ptr<std::FILE, int ( * )( std::FILE * )> file( std::fopen( filePath.c_str(), "rb" ), std::fclose );
         if ( file == nullptr ) {
             return;
         }

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -74,6 +74,9 @@
 #endif
 
 #if SDL_VERSION_ATLEAST( 2, 0, 1 ) && ( !defined( __linux__ ) || defined( ANDROID ) )
+#include <functional>
+#include <memory>
+
 #include <SDL_filesystem.h>
 #include <SDL_stdinc.h>
 #endif
@@ -131,13 +134,9 @@ namespace
         }
 
 #if SDL_VERSION_ATLEAST( 2, 0, 1 )
-        char * path = SDL_GetPrefPath( "", prog.c_str() );
+        const std::unique_ptr<char, std::function<void( void * )>> path( SDL_GetPrefPath( "", prog.c_str() ), SDL_free );
         if ( path ) {
-            const std::string result{ path };
-
-            SDL_free( path );
-
-            return result;
+            return path.get();
         }
 #endif
 

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -57,6 +57,15 @@
 #include <strings.h>
 #endif
 
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
 #include <SDL_version.h>
 
 #if defined( ANDROID )
@@ -67,6 +76,11 @@
 #if SDL_VERSION_ATLEAST( 2, 0, 1 ) && ( !defined( __linux__ ) || defined( ANDROID ) )
 #include <SDL_filesystem.h>
 #include <SDL_stdinc.h>
+#endif
+
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
 #endif
 
 #if defined( _WIN32 )

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -134,7 +134,7 @@ namespace
         }
 
 #if SDL_VERSION_ATLEAST( 2, 0, 1 )
-        const std::unique_ptr<char, std::function<void( void * )>> path( SDL_GetPrefPath( "", prog.c_str() ), SDL_free );
+        const std::unique_ptr<char, void ( * )( void * )> path( SDL_GetPrefPath( "", prog.c_str() ), SDL_free );
         if ( path ) {
             return path.get();
         }

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -74,7 +74,6 @@
 #endif
 
 #if SDL_VERSION_ATLEAST( 2, 0, 1 ) && ( !defined( __linux__ ) || defined( ANDROID ) )
-#include <functional>
 #include <memory>
 
 #include <SDL_filesystem.h>

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -23,7 +23,6 @@
 
 #include "zzlib.h"
 
-#include <algorithm>
 #include <cstring>
 #include <ostream>
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -32,9 +32,23 @@
 #include <string>
 #include <vector>
 
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Wdouble-promotion"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
 #include <SDL_events.h>
 #include <SDL_main.h> // IWYU pragma: keep
 #include <SDL_mouse.h>
+
+// Managing compiler warnings for SDL headers
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
 
 #if defined( _WIN32 )
 #include <cassert>


### PR DESCRIPTION
Close the long-standing TODO by enabling a few more useful compiler warnings. Unfortunately, SDL headers still cannot be compiled with them, and they are not treated as system headers since `sdl2-config --cflags` uses `-I` flag and not `-isystem` (gcc and clang do not issue warnings for system headers), so I had to disable new warnings for them using pragmas. Fortunately, we have relatively few files that use SDL headers.

Also this PR migrates a few places in the code to RAII.

Also this PR replaces custom `std::function`-based deleters in `std::unique_ptr`s by pointer-to-function-based. The reasons are as follows:

1. `std::unique_ptr`'s destructor as well as various methods like `reset()` require that deleter should not throw. However, with `std::function`, deleter may throw if we accidentally pass an empty deleter, while with function pointer it's just impossible to accidentally forget to specify the deleter. See [this example](https://godbolt.org/z/j34dPnar9) for details;
2. `std::function` may allocate heap memory and needs the appropriate header file.