### PR TITLE
Implement a type-safe and const-correct version of StreamBuf class

### DIFF
--- a/src/engine/agg_file.cpp
+++ b/src/engine/agg_file.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2022                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/agg_file.cpp
+++ b/src/engine/agg_file.cpp
@@ -103,14 +103,14 @@ namespace fheroes2
     }
 }
 
-StreamBase & operator>>( StreamBase & st, fheroes2::ICNHeader & icn )
+IStreamBase & operator>>( IStreamBase & stream, fheroes2::ICNHeader & icn )
 {
-    icn.offsetX = static_cast<int16_t>( st.getLE16() );
-    icn.offsetY = static_cast<int16_t>( st.getLE16() );
-    icn.width = st.getLE16();
-    icn.height = st.getLE16();
-    icn.animationFrames = st.get();
-    icn.offsetData = st.getLE32();
+    icn.offsetX = static_cast<int16_t>( stream.getLE16() );
+    icn.offsetY = static_cast<int16_t>( stream.getLE16() );
+    icn.width = stream.getLE16();
+    icn.height = stream.getLE16();
+    icn.animationFrames = stream.get();
+    icn.offsetData = stream.getLE32();
 
-    return st;
+    return stream;
 }

--- a/src/engine/agg_file.cpp
+++ b/src/engine/agg_file.cpp
@@ -37,10 +37,10 @@ namespace fheroes2
         if ( count * ( fileRecordSize + _maxFilenameSize ) >= size )
             return false;
 
-        StreamBuf fileEntries = _stream.toStreamBuf( count * fileRecordSize );
+        RWStreamBuf fileEntries = _stream.toStreamBuf( count * fileRecordSize );
         const size_t nameEntriesSize = _maxFilenameSize * count;
         _stream.seek( size - nameEntriesSize );
-        StreamBuf nameEntries = _stream.toStreamBuf( nameEntriesSize );
+        RWStreamBuf nameEntries = _stream.toStreamBuf( nameEntriesSize );
 
         for ( size_t i = 0; i < count; ++i ) {
             std::string name = nameEntries.toString( _maxFilenameSize );

--- a/src/engine/agg_file.h
+++ b/src/engine/agg_file.h
@@ -74,6 +74,6 @@ namespace fheroes2
     uint32_t calculateAggFilenameHash( const std::string_view str );
 }
 
-StreamBase & operator>>( StreamBase & st, fheroes2::ICNHeader & icn );
+IStreamBase & operator>>( IStreamBase & stream, fheroes2::ICNHeader & icn );
 
 #endif

--- a/src/engine/audio_xmi2mid.cpp
+++ b/src/engine/audio_xmi2mid.cpp
@@ -221,18 +221,20 @@ namespace
         {}
     };
 
-    StreamBuf & operator>>( StreamBuf & sb, IFFChunkHeader & st )
+    StreamBuf & operator>>( StreamBuf & stream, IFFChunkHeader & st )
     {
-        st.ID = sb.getBE32();
-        st.length = sb.getBE32();
-        return sb;
+        st.ID = stream.getBE32();
+        st.length = stream.getBE32();
+
+        return stream;
     }
 
-    RWStreamBuf & operator<<( RWStreamBuf & sb, const IFFChunkHeader & st )
+    RWStreamBuf & operator<<( RWStreamBuf & stream, const IFFChunkHeader & st )
     {
-        sb.putBE32( st.ID );
-        sb.putBE32( st.length );
-        return sb;
+        stream.putBE32( st.ID );
+        stream.putBE32( st.length );
+
+        return stream;
     }
 
     struct GroupChunkHeader
@@ -242,12 +244,13 @@ namespace
         uint32_t type{ 0 }; // 4 byte ASCII string
     };
 
-    StreamBuf & operator>>( StreamBuf & sb, GroupChunkHeader & st )
+    StreamBuf & operator>>( StreamBuf & stream, GroupChunkHeader & st )
     {
-        st.ID = sb.getBE32();
-        st.length = sb.getBE32();
-        st.type = sb.getBE32();
-        return sb;
+        st.ID = stream.getBE32();
+        st.length = stream.getBE32();
+        st.type = stream.getBE32();
+
+        return stream;
     }
 
     struct XMITrack
@@ -398,19 +401,19 @@ namespace
         return left._time < right._time;
     }
 
-    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidiChunk & event )
+    RWStreamBuf & operator<<( RWStreamBuf & stream, const MidiChunk & event )
     {
         for ( const uint8_t binaryTimeByte : event._binaryTime ) {
-            sb << binaryTimeByte;
+            stream << binaryTimeByte;
         }
 
-        sb << event._type;
+        stream << event._type;
 
         for ( const uint8_t dataByte : event._data ) {
-            sb << dataByte;
+            stream << dataByte;
         }
 
-        return sb;
+        return stream;
     }
 
     struct MidiEvents : public std::vector<MidiChunk>
@@ -589,13 +592,13 @@ namespace
         }
     };
 
-    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidiEvents & st )
+    RWStreamBuf & operator<<( RWStreamBuf & stream, const MidiEvents & st )
     {
         for ( const MidiChunk & chunk : st ) {
-            sb << chunk;
+            stream << chunk;
         }
 
-        return sb;
+        return stream;
     }
 
     struct MidTrack
@@ -611,11 +614,12 @@ namespace
         }
     };
 
-    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidTrack & st )
+    RWStreamBuf & operator<<( RWStreamBuf & stream, const MidTrack & st )
     {
-        sb << st.mtrk;
-        sb << st.events;
-        return sb;
+        stream << st.mtrk;
+        stream << st.events;
+
+        return stream;
     }
 
     struct MidTracks : std::list<MidTrack>
@@ -635,13 +639,13 @@ namespace
         }
     };
 
-    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidTracks & st )
+    RWStreamBuf & operator<<( RWStreamBuf & stream, const MidTracks & st )
     {
         for ( const MidTrack & track : st ) {
-            sb << track;
+            stream << track;
         }
 
-        return sb;
+        return stream;
     }
 
     struct MidData
@@ -665,15 +669,15 @@ namespace
         }
     };
 
-    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidData & st )
+    RWStreamBuf & operator<<( RWStreamBuf & stream, const MidData & st )
     {
-        sb << st.mthd;
-        sb.putBE16( static_cast<uint16_t>( st.format ) );
-        sb.putBE16( static_cast<uint16_t>( st.tracks.count() ) );
-        sb.putBE16( static_cast<uint16_t>( st.ppqn ) );
-        sb << st.tracks;
+        stream << st.mthd;
+        stream.putBE16( static_cast<uint16_t>( st.format ) );
+        stream.putBE16( static_cast<uint16_t>( st.tracks.count() ) );
+        stream.putBE16( static_cast<uint16_t>( st.ppqn ) );
+        stream << st.tracks;
 
-        return sb;
+        return stream;
     }
 }
 

--- a/src/engine/audio_xmi2mid.cpp
+++ b/src/engine/audio_xmi2mid.cpp
@@ -265,7 +265,7 @@ namespace
         explicit XMIData( const std::vector<uint8_t> & buf )
         {
             // Please refer to https://moddingwiki.shikadi.net/wiki/XMI_Format#File_format
-            StreamBuf sb( buf );
+            ROStreamBuf sb( buf );
 
             GroupChunkHeader group;
             sb >> group;
@@ -684,7 +684,7 @@ std::vector<uint8_t> Music::Xmi2Mid( const std::vector<uint8_t> & buf )
         return {};
     }
 
-    StreamBuf sb( 16 * 4096 );
+    RWStreamBuf sb( 16 * 4096 );
 
     const MidData mid( xmi.tracks );
     sb << mid;

--- a/src/engine/audio_xmi2mid.cpp
+++ b/src/engine/audio_xmi2mid.cpp
@@ -228,7 +228,7 @@ namespace
         return sb;
     }
 
-    StreamBuf & operator<<( StreamBuf & sb, const IFFChunkHeader & st )
+    RWStreamBuf & operator<<( RWStreamBuf & sb, const IFFChunkHeader & st )
     {
         sb.putBE32( st.ID );
         sb.putBE32( st.length );
@@ -398,7 +398,7 @@ namespace
         return left._time < right._time;
     }
 
-    StreamBuf & operator<<( StreamBuf & sb, const MidiChunk & event )
+    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidiChunk & event )
     {
         for ( const uint8_t binaryTimeByte : event._binaryTime ) {
             sb << binaryTimeByte;
@@ -589,7 +589,7 @@ namespace
         }
     };
 
-    StreamBuf & operator<<( StreamBuf & sb, const MidiEvents & st )
+    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidiEvents & st )
     {
         for ( const MidiChunk & chunk : st ) {
             sb << chunk;
@@ -611,7 +611,7 @@ namespace
         }
     };
 
-    StreamBuf & operator<<( StreamBuf & sb, const MidTrack & st )
+    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidTrack & st )
     {
         sb << st.mtrk;
         sb << st.events;
@@ -635,7 +635,7 @@ namespace
         }
     };
 
-    StreamBuf & operator<<( StreamBuf & sb, const MidTracks & st )
+    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidTracks & st )
     {
         for ( const MidTrack & track : st ) {
             sb << track;
@@ -665,7 +665,7 @@ namespace
         }
     };
 
-    StreamBuf & operator<<( StreamBuf & sb, const MidData & st )
+    RWStreamBuf & operator<<( RWStreamBuf & sb, const MidData & st )
     {
         sb << st.mthd;
         sb.putBE16( static_cast<uint16_t>( st.format ) );

--- a/src/engine/audio_xmi2mid.cpp
+++ b/src/engine/audio_xmi2mid.cpp
@@ -221,7 +221,7 @@ namespace
         {}
     };
 
-    StreamBuf & operator>>( StreamBuf & stream, IFFChunkHeader & st )
+    IStreamBuf & operator>>( IStreamBuf & stream, IFFChunkHeader & st )
     {
         st.ID = stream.getBE32();
         st.length = stream.getBE32();
@@ -244,7 +244,7 @@ namespace
         uint32_t type{ 0 }; // 4 byte ASCII string
     };
 
-    StreamBuf & operator>>( StreamBuf & stream, GroupChunkHeader & st )
+    IStreamBuf & operator>>( IStreamBuf & stream, GroupChunkHeader & st )
     {
         st.ID = stream.getBE32();
         st.length = stream.getBE32();

--- a/src/engine/h2d_file.cpp
+++ b/src/engine/h2d_file.cpp
@@ -182,7 +182,7 @@ namespace fheroes2
             return false;
         }
 
-        StreamBuf stream( data );
+        ROStreamBuf stream( data );
         const int32_t width = static_cast<int32_t>( stream.getLE32() );
         const int32_t height = static_cast<int32_t>( stream.getLE32() );
         const int32_t x = static_cast<int32_t>( stream.getLE32() );
@@ -206,7 +206,7 @@ namespace fheroes2
         // TODO: Store in h2d images the 'isSingleLayer' state to disable and skip transform layer for such images.
         assert( !image.empty() && !image.singleLayer() );
 
-        StreamBuf stream;
+        RWStreamBuf stream;
         stream.putLE32( static_cast<uint32_t>( image.width() ) );
         stream.putLE32( static_cast<uint32_t>( image.height() ) );
         stream.putLE32( static_cast<uint32_t>( image.x() ) );

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -37,7 +37,7 @@ namespace
     const size_t minBufferCapacity = 1024;
 }
 
-void StreamBase::setbigendian( bool f )
+void StreamBase::setBigendian( bool f )
 {
     if ( f ) {
         _flags |= BIGENDIAN;
@@ -47,7 +47,7 @@ void StreamBase::setbigendian( bool f )
     }
 }
 
-void StreamBase::setfail( bool f )
+void StreamBase::setFail( bool f )
 {
     if ( f ) {
         _flags |= FAILURE;
@@ -209,7 +209,7 @@ RWStreamBuf::RWStreamBuf( const size_t sz )
         reallocBuf( sz );
     }
 
-    setbigendian( IS_BIGENDIAN );
+    setBigendian( IS_BIGENDIAN );
 }
 
 void RWStreamBuf::putBE16( uint16_t v )
@@ -334,7 +334,7 @@ ROStreamBuf::ROStreamBuf( const std::vector<uint8_t> & buf )
     _itget = _itbeg;
     _itput = _itend;
 
-    setbigendian( IS_BIGENDIAN );
+    setBigendian( IS_BIGENDIAN );
 }
 
 bool StreamFile::open( const std::string & fn, const std::string & mode )
@@ -344,7 +344,7 @@ bool StreamFile::open( const std::string & fn, const std::string & mode )
         ERROR_LOG( "Error opening file " << fn )
     }
 
-    setfail( !_file );
+    setFail( !_file );
 
     return !fail();
 }
@@ -362,26 +362,26 @@ size_t StreamFile::size()
 
     const long pos = std::ftell( _file.get() );
     if ( pos < 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
 
     if ( std::fseek( _file.get(), 0, SEEK_END ) != 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
 
     const long len = std::ftell( _file.get() );
     if ( len < 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
 
     if ( std::fseek( _file.get(), pos, SEEK_SET ) != 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
@@ -401,7 +401,7 @@ void StreamFile::seek( size_t pos )
     }
 
     if ( std::fseek( _file.get(), static_cast<long>( pos ), SEEK_SET ) != 0 ) {
-        setfail( true );
+        setFail( true );
     }
 }
 
@@ -413,33 +413,33 @@ size_t StreamFile::sizeg()
 
     const long pos = std::ftell( _file.get() );
     if ( pos < 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
 
     if ( std::fseek( _file.get(), 0, SEEK_END ) != 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
 
     const long len = std::ftell( _file.get() );
     if ( len < 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
 
     if ( std::fseek( _file.get(), pos, SEEK_SET ) != 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
 
     // Something weird has happened
     if ( len < pos ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
@@ -455,7 +455,7 @@ size_t StreamFile::tellg()
 
     const long pos = std::ftell( _file.get() );
     if ( pos < 0 ) {
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
@@ -480,7 +480,7 @@ void StreamFile::skip( size_t pos )
     }
 
     if ( std::fseek( _file.get(), static_cast<long int>( pos ), SEEK_CUR ) != 0 ) {
-        setfail( true );
+        setFail( true );
     }
 }
 
@@ -544,7 +544,7 @@ std::vector<uint8_t> StreamFile::getRaw( const size_t size )
     std::vector<uint8_t> v( chunkSize );
 
     if ( std::fread( v.data(), chunkSize, 1, _file.get() ) != 1 ) {
-        setfail( true );
+        setFail( true );
 
         return {};
     }
@@ -564,7 +564,7 @@ void StreamFile::putRaw( const void * ptr, size_t sz )
     }
 
     if ( std::fwrite( ptr, sz, 1, _file.get() ) != 1 ) {
-        setfail( true );
+        setFail( true );
     }
 }
 
@@ -578,7 +578,7 @@ RWStreamBuf StreamFile::toStreamBuf( const size_t size /* = 0 */ )
     RWStreamBuf buffer( chunkSize );
 
     if ( std::fread( buffer.rwData(), chunkSize, 1, _file.get() ) != 1 ) {
-        setfail( true );
+        setFail( true );
 
         return {};
     }

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -283,7 +283,7 @@ void RWStreamBuf::put8( const uint8_t v )
 void RWStreamBuf::reallocBuf( size_t size )
 {
     if ( !_buf ) {
-        assert( _itbeg == nullptr && _itget == nullptr && _itput == nullptr && _itend == nullptr );
+        assert( ( []( const auto... args ) { return ( ( args == nullptr ) && ... ); }( _itbeg, _itget, _itput, _itend ) ) );
 
         size = std::max( size, minBufferCapacity );
 
@@ -298,7 +298,7 @@ void RWStreamBuf::reallocBuf( size_t size )
         return;
     }
 
-    assert( _itbeg != nullptr && _itget != nullptr && _itput != nullptr && _itend != nullptr );
+    assert( ( []( const auto... args ) { return ( ( args != nullptr ) && ... ); }( _itbeg, _itget, _itput, _itend ) ) );
 
     if ( sizep() < size ) {
         size = std::max( size, minBufferCapacity );

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -144,11 +144,9 @@ IStreamBase & IStreamBase::operator>>( uint32_t & v )
 
 IStreamBase & IStreamBase::operator>>( std::string & v )
 {
-    uint32_t size = get32();
-    v.resize( size );
+    v.resize( get32() );
 
-    for ( std::string::iterator it = v.begin(); it != v.end(); ++it )
-        *it = get8();
+    std::for_each( v.begin(), v.end(), [this]( char & item ) { item = get8(); } );
 
     return *this;
 }
@@ -227,6 +225,7 @@ OStreamBase & OStreamBase::operator<<( const uint32_t v )
 OStreamBase & OStreamBase::operator<<( const std::string & v )
 {
     put32( static_cast<uint32_t>( v.size() ) );
+
     // A string is a container of bytes so it doesn't matter which endianess is being used.
     putRaw( v.data(), v.size() );
 

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -57,65 +57,65 @@ void StreamBase::setfail( bool f )
     }
 }
 
-uint16_t StreamBase::get16()
+uint16_t IStreamBase::get16()
 {
     return bigendian() ? getBE16() : getLE16();
 }
 
-uint32_t StreamBase::get32()
+uint32_t IStreamBase::get32()
 {
     return bigendian() ? getBE32() : getLE32();
 }
 
-StreamBase & StreamBase::operator>>( bool & v )
+IStreamBase & IStreamBase::operator>>( bool & v )
 {
     v = ( get8() != 0 );
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( char & v )
+IStreamBase & IStreamBase::operator>>( char & v )
 {
     v = get8();
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( int8_t & v )
+IStreamBase & IStreamBase::operator>>( int8_t & v )
 {
     v = static_cast<int8_t>( get8() );
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( uint8_t & v )
+IStreamBase & IStreamBase::operator>>( uint8_t & v )
 {
     v = get8();
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( uint16_t & v )
+IStreamBase & IStreamBase::operator>>( int16_t & v )
 {
     v = get16();
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( int16_t & v )
+IStreamBase & IStreamBase::operator>>( uint16_t & v )
 {
     v = get16();
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( uint32_t & v )
+IStreamBase & IStreamBase::operator>>( int32_t & v )
 {
     v = get32();
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( int32_t & v )
+IStreamBase & IStreamBase::operator>>( uint32_t & v )
 {
     v = get32();
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( std::string & v )
+IStreamBase & IStreamBase::operator>>( std::string & v )
 {
     uint32_t size = get32();
     v.resize( size );
@@ -126,70 +126,70 @@ StreamBase & StreamBase::operator>>( std::string & v )
     return *this;
 }
 
-StreamBase & StreamBase::operator>>( fheroes2::Point & point_ )
+IStreamBase & IStreamBase::operator>>( fheroes2::Point & v )
 {
-    return *this >> point_.x >> point_.y;
+    return *this >> v.x >> v.y;
 }
 
-void StreamBase::put16( uint16_t v )
+void OStreamBase::put16( uint16_t v )
 {
     bigendian() ? putBE16( v ) : putLE16( v );
 }
 
-void StreamBase::put32( uint32_t v )
+void OStreamBase::put32( uint32_t v )
 {
     bigendian() ? putBE32( v ) : putLE32( v );
 }
 
-StreamBase & StreamBase::operator<<( const bool v )
+OStreamBase & OStreamBase::operator<<( const bool v )
 {
     put8( v );
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const char v )
+OStreamBase & OStreamBase::operator<<( const char v )
 {
     put8( v );
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const int8_t v )
+OStreamBase & OStreamBase::operator<<( const int8_t v )
 {
     put8( static_cast<uint8_t>( v ) );
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const uint8_t v )
+OStreamBase & OStreamBase::operator<<( const uint8_t v )
 {
     put8( v );
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const uint16_t v )
+OStreamBase & OStreamBase::operator<<( const int16_t v )
 {
     put16( v );
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const int16_t v )
+OStreamBase & OStreamBase::operator<<( const uint16_t v )
 {
     put16( v );
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const int32_t v )
+OStreamBase & OStreamBase::operator<<( const int32_t v )
 {
     put32( v );
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const uint32_t v )
+OStreamBase & OStreamBase::operator<<( const uint32_t v )
 {
     put32( v );
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const std::string & v )
+OStreamBase & OStreamBase::operator<<( const std::string & v )
 {
     put32( static_cast<uint32_t>( v.size() ) );
     // A string is a container of bytes so it doesn't matter which endianess is being used.
@@ -198,9 +198,9 @@ StreamBase & StreamBase::operator<<( const std::string & v )
     return *this;
 }
 
-StreamBase & StreamBase::operator<<( const fheroes2::Point & point_ )
+OStreamBase & OStreamBase::operator<<( const fheroes2::Point & v )
 {
-    return *this << point_.x << point_.y;
+    return *this << v.x << v.y;
 }
 
 RWStreamBuf::RWStreamBuf( const size_t sz )
@@ -280,6 +280,16 @@ void RWStreamBuf::put8( const uint8_t v )
     ++_itput;
 }
 
+size_t RWStreamBuf::tellp()
+{
+    return _itput - _itbeg;
+}
+
+size_t RWStreamBuf::sizep()
+{
+    return _itend - _itput;
+}
+
 void RWStreamBuf::reallocBuf( size_t size )
 {
     if ( !_buf ) {
@@ -325,36 +335,6 @@ ROStreamBuf::ROStreamBuf( const std::vector<uint8_t> & buf )
     _itput = _itend;
 
     setbigendian( IS_BIGENDIAN );
-}
-
-void ROStreamBuf::putBE16( uint16_t /* v */ )
-{
-    assert( 0 );
-}
-
-void ROStreamBuf::putLE16( uint16_t /* v */ )
-{
-    assert( 0 );
-}
-
-void ROStreamBuf::putBE32( uint32_t /* v */ )
-{
-    assert( 0 );
-}
-
-void ROStreamBuf::putLE32( uint32_t /* v */ )
-{
-    assert( 0 );
-}
-
-void ROStreamBuf::putRaw( const void * /* ptr */, size_t /* sz */ )
-{
-    assert( 0 );
-}
-
-void ROStreamBuf::put8( const uint8_t /* v */ )
-{
-    assert( 0 );
 }
 
 bool StreamFile::open( const std::string & fn, const std::string & mode )

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -287,7 +287,7 @@ void RWStreamBuf::reallocBuf( size_t size )
 
         size = std::max( size, minBufferCapacity );
 
-        _buf.reset( new uint8_t[size]{} );
+        _buf = std::make_unique<uint8_t[]>( size );
 
         _itbeg = _buf.get();
         _itend = _itbeg + size;
@@ -303,7 +303,7 @@ void RWStreamBuf::reallocBuf( size_t size )
     if ( sizep() < size ) {
         size = std::max( size, minBufferCapacity );
 
-        std::unique_ptr<uint8_t[]> newBuf( new uint8_t[size]{} );
+        std::unique_ptr<uint8_t[]> newBuf = std::make_unique<uint8_t[]>( size );
 
         std::copy( _itbeg, _itput, newBuf.get() );
 

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -164,14 +164,6 @@ IStreamBase & IStreamBase::operator>>( fheroes2::Point & v )
     return *this >> v.x >> v.y;
 }
 
-OStreamBase & OStreamBase::operator=( OStreamBase && /* stream */ ) noexcept
-{
-    // Should never be called
-    assert( 0 );
-
-    return *this;
-}
-
 void OStreamBase::put16( uint16_t v )
 {
     bigendian() ? putBE16( v ) : putLE16( v );

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -592,7 +592,7 @@ RWStreamBuf StreamFile::toStreamBuf( const size_t size /* = 0 */ )
 {
     const size_t chunkSize = size > 0 ? size : sizeg();
     if ( chunkSize == 0 || !_file ) {
-        return RWStreamBuf{};
+        return {};
     }
 
     RWStreamBuf buffer( chunkSize );
@@ -600,7 +600,7 @@ RWStreamBuf StreamFile::toStreamBuf( const size_t size /* = 0 */ )
     if ( std::fread( buffer.rwData(), chunkSize, 1, _file.get() ) != 1 ) {
         setfail( true );
 
-        return RWStreamBuf{};
+        return {};
     }
 
     buffer.advance( chunkSize );

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -97,48 +97,56 @@ uint32_t IStreamBase::get32()
 IStreamBase & IStreamBase::operator>>( bool & v )
 {
     v = ( get8() != 0 );
+
     return *this;
 }
 
 IStreamBase & IStreamBase::operator>>( char & v )
 {
     v = get8();
+
     return *this;
 }
 
 IStreamBase & IStreamBase::operator>>( int8_t & v )
 {
     v = static_cast<int8_t>( get8() );
+
     return *this;
 }
 
 IStreamBase & IStreamBase::operator>>( uint8_t & v )
 {
     v = get8();
+
     return *this;
 }
 
 IStreamBase & IStreamBase::operator>>( int16_t & v )
 {
     v = get16();
+
     return *this;
 }
 
 IStreamBase & IStreamBase::operator>>( uint16_t & v )
 {
     v = get16();
+
     return *this;
 }
 
 IStreamBase & IStreamBase::operator>>( int32_t & v )
 {
     v = get32();
+
     return *this;
 }
 
 IStreamBase & IStreamBase::operator>>( uint32_t & v )
 {
     v = get32();
+
     return *this;
 }
 
@@ -177,48 +185,56 @@ void OStreamBase::put32( uint32_t v )
 OStreamBase & OStreamBase::operator<<( const bool v )
 {
     put8( v );
+
     return *this;
 }
 
 OStreamBase & OStreamBase::operator<<( const char v )
 {
     put8( v );
+
     return *this;
 }
 
 OStreamBase & OStreamBase::operator<<( const int8_t v )
 {
     put8( static_cast<uint8_t>( v ) );
+
     return *this;
 }
 
 OStreamBase & OStreamBase::operator<<( const uint8_t v )
 {
     put8( v );
+
     return *this;
 }
 
 OStreamBase & OStreamBase::operator<<( const int16_t v )
 {
     put16( v );
+
     return *this;
 }
 
 OStreamBase & OStreamBase::operator<<( const uint16_t v )
 {
     put16( v );
+
     return *this;
 }
 
 OStreamBase & OStreamBase::operator<<( const int32_t v )
 {
     put32( v );
+
     return *this;
 }
 
 OStreamBase & OStreamBase::operator<<( const uint32_t v )
 {
     put32( v );
+
     return *this;
 }
 

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -599,7 +599,7 @@ RWStreamBuf StreamFile::toStreamBuf( const size_t size /* = 0 */ )
 
     RWStreamBuf buffer( chunkSize );
 
-    if ( std::fread( buffer.dataForWriting(), chunkSize, 1, _file.get() ) != 1 ) {
+    if ( std::fread( buffer.rwData(), chunkSize, 1, _file.get() ) != 1 ) {
         setfail( true );
 
         return RWStreamBuf{};

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -80,7 +80,7 @@ private:
     uint32_t _flags{ 0 };
 };
 
-class IStreamBase : public virtual StreamBase
+class IStreamBase : virtual public StreamBase
 {
 public:
     IStreamBase( const IStreamBase & ) = delete;
@@ -193,7 +193,7 @@ protected:
     virtual size_t tellg() = 0;
 };
 
-class OStreamBase : public virtual StreamBase
+class OStreamBase : virtual public StreamBase
 {
 public:
     OStreamBase( const OStreamBase & ) = delete;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -26,7 +26,6 @@
 
 #include <algorithm>
 #include <array>
-#include <cassert>
 #include <cstdint>
 #include <cstdio>
 #include <iterator>

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -458,7 +458,7 @@ private:
     void reallocBuf( size_t size );
 
     // After using this method to write data, update the cursor by calling the advance() method.
-    uint8_t * dataForWriting()
+    uint8_t * rwData()
     {
         return itput;
     }

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -280,8 +280,6 @@ protected:
 
     OStreamBase( OStreamBase && ) = default;
 
-    OStreamBase & operator=( OStreamBase && stream ) noexcept;
-
     virtual void put8( const uint8_t ) = 0;
 
     virtual size_t sizep() = 0;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -44,29 +44,11 @@
 class StreamBase
 {
 public:
-    StreamBase() = default;
-
     StreamBase( const StreamBase & ) = delete;
-
-    StreamBase( StreamBase && stream ) noexcept
-    {
-        std::swap( _flags, stream._flags );
-    }
 
     virtual ~StreamBase() = default;
 
     StreamBase & operator=( const StreamBase & ) = delete;
-
-    StreamBase & operator=( StreamBase && stream ) noexcept
-    {
-        if ( this == &stream ) {
-            return *this;
-        }
-
-        std::swap( _flags, stream._flags );
-
-        return *this;
-    }
 
     void setBigendian( bool f );
 
@@ -81,6 +63,12 @@ public:
     }
 
 protected:
+    StreamBase() = default;
+
+    StreamBase( StreamBase && stream ) noexcept;
+
+    StreamBase & operator=( StreamBase && stream ) noexcept;
+
     void setFail( bool f );
 
 private:
@@ -96,6 +84,12 @@ private:
 class IStreamBase : public virtual StreamBase
 {
 public:
+    IStreamBase( const IStreamBase & ) = delete;
+
+    ~IStreamBase() override = default;
+
+    IStreamBase & operator=( const IStreamBase & ) = delete;
+
     virtual void skip( size_t ) = 0;
 
     virtual uint16_t getBE16() = 0;
@@ -188,6 +182,12 @@ public:
     }
 
 protected:
+    IStreamBase() = default;
+
+    IStreamBase( IStreamBase && ) = default;
+
+    IStreamBase & operator=( IStreamBase && stream ) noexcept;
+
     virtual uint8_t get8() = 0;
 
     virtual size_t sizeg() = 0;
@@ -197,6 +197,12 @@ protected:
 class OStreamBase : public virtual StreamBase
 {
 public:
+    OStreamBase( const OStreamBase & ) = delete;
+
+    ~OStreamBase() override = default;
+
+    OStreamBase & operator=( const OStreamBase & ) = delete;
+
     virtual void putBE16( uint16_t ) = 0;
     virtual void putLE16( uint16_t ) = 0;
     virtual void putBE32( uint32_t ) = 0;
@@ -271,6 +277,12 @@ public:
     }
 
 protected:
+    OStreamBase() = default;
+
+    OStreamBase( OStreamBase && ) = default;
+
+    OStreamBase & operator=( OStreamBase && stream ) noexcept;
+
     virtual void put8( const uint8_t ) = 0;
 
     virtual size_t sizep() = 0;
@@ -454,12 +466,12 @@ public:
     explicit RWStreamBuf( const size_t sz );
 
     RWStreamBuf( const RWStreamBuf & ) = delete;
-    RWStreamBuf( RWStreamBuf && stream ) = default;
+    RWStreamBuf( RWStreamBuf && ) = default;
 
     ~RWStreamBuf() override = default;
 
     RWStreamBuf & operator=( const RWStreamBuf & ) = delete;
-    RWStreamBuf & operator=( RWStreamBuf && stream ) = default;
+    RWStreamBuf & operator=( RWStreamBuf && stream ) noexcept;
 
     void putBE32( uint32_t v ) override;
     void putLE32( uint32_t v ) override;
@@ -499,12 +511,12 @@ public:
     explicit ROStreamBuf( const std::vector<uint8_t> & buf );
 
     ROStreamBuf( const ROStreamBuf & ) = delete;
-    ROStreamBuf( ROStreamBuf && stream ) = default;
+    ROStreamBuf( ROStreamBuf && ) = default;
 
     ~ROStreamBuf() override = default;
 
     ROStreamBuf & operator=( const ROStreamBuf & ) = delete;
-    ROStreamBuf & operator=( ROStreamBuf && stream ) = default;
+    ROStreamBuf & operator=( ROStreamBuf && ) = default;
 };
 
 class StreamFile final : public IStreamBase, public OStreamBase

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -93,7 +93,8 @@ public:
     virtual void putBE16( uint16_t ) = 0;
     virtual void putLE16( uint16_t ) = 0;
 
-    virtual std::vector<uint8_t> getRaw( size_t = 0 /* all data */ ) = 0;
+    // 0 stands for all data.
+    virtual std::vector<uint8_t> getRaw( size_t = 0 ) = 0;
     virtual void putRaw( const void *, size_t ) = 0;
 
     uint16_t get16();
@@ -343,7 +344,8 @@ public:
         return result;
     }
 
-    std::vector<uint8_t> getRaw( size_t sz = 0 /* all data */ ) override
+    // 0 stands for all data.
+    std::vector<uint8_t> getRaw( size_t sz = 0 ) override
     {
         const size_t actualSize = sizeg();
         const size_t resultSize = sz > 0 ? sz : actualSize;
@@ -357,6 +359,7 @@ public:
         return result;
     }
 
+    // 0 stands for all data.
     std::string toString( const size_t sz = 0 )
     {
         const size_t length = ( sz > 0 && sz < sizeg() ) ? sz : sizeg();
@@ -511,7 +514,7 @@ public:
     bool open( const std::string & fn, const std::string & mode );
     void close();
 
-    // 0 stands for full data.
+    // 0 stands for all data.
     RWStreamBuf toStreamBuf( const size_t size = 0 );
 
     void seek( size_t );
@@ -527,11 +530,12 @@ public:
     void putBE32( uint32_t ) override;
     void putLE32( uint32_t ) override;
 
-    // 0 stands for full data.
+    // 0 stands for all data.
     std::vector<uint8_t> getRaw( const size_t size = 0 ) override;
 
     void putRaw( const void * ptr, size_t sz ) override;
 
+    // 0 stands for all data.
     std::string toString( const size_t size = 0 );
 
 private:

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
+#include <cstring>
 #include <iterator>
 #include <list>
 #include <map>

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -68,7 +68,7 @@ public:
         return *this;
     }
 
-    void setbigendian( bool f );
+    void setBigendian( bool f );
 
     bool fail() const
     {
@@ -81,7 +81,7 @@ public:
     }
 
 protected:
-    void setfail( bool f );
+    void setFail( bool f );
 
 private:
     enum : uint32_t
@@ -175,7 +175,7 @@ public:
     {
         const uint32_t size = get32();
         if ( size != v.size() ) {
-            setfail( true );
+            setFail( true );
 
             v = {};
 
@@ -433,7 +433,7 @@ protected:
             return *( _itget++ );
         }
 
-        setfail( true );
+        setFail( true );
 
         return 0;
     }
@@ -567,7 +567,7 @@ private:
         T val;
 
         if ( std::fread( &val, sizeof( T ), 1, _file.get() ) != 1 ) {
-            setfail( true );
+            setFail( true );
 
             return 0;
         }
@@ -583,7 +583,7 @@ private:
         }
 
         if ( std::fwrite( &val, sizeof( T ), 1, _file.get() ) != 1 ) {
-            setfail( true );
+            setFail( true );
         }
     }
 

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -492,8 +492,6 @@ public:
 
 private:
     void put8( const uint8_t v ) override;
-
-    void reallocBuf( size_t size );
 };
 
 class StreamFile final : public StreamBase

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -281,7 +281,7 @@ public:
 
     const uint8_t * data() const override
     {
-        return itget;
+        return _itget;
     }
 
     size_t size() override
@@ -291,17 +291,17 @@ public:
 
     size_t capacity() const
     {
-        return itend - itbeg;
+        return _itend - _itbeg;
     }
 
     void seek( size_t sz )
     {
-        itget = ( itbeg + sz < itend ? itbeg + sz : itend );
+        _itget = ( _itbeg + sz < _itend ? _itbeg + sz : _itend );
     }
 
     void skip( size_t sz ) override
     {
-        itget += ( sz <= sizeg() ? sz : sizeg() );
+        _itget += ( sz <= sizeg() ? sz : sizeg() );
     }
 
     uint16_t getBE16() override
@@ -352,9 +352,9 @@ public:
         const size_t sizeToCopy = std::min( resultSize, actualSize );
 
         std::vector<uint8_t> result( resultSize, 0 );
-        memcpy( result.data(), itget, sizeToCopy );
+        memcpy( result.data(), _itget, sizeToCopy );
 
-        itget += sizeToCopy;
+        _itget += sizeToCopy;
 
         return result;
     }
@@ -364,10 +364,10 @@ public:
     {
         const size_t length = ( sz > 0 && sz < sizeg() ) ? sz : sizeg();
 
-        T * strBeg = itget;
-        itget += length;
+        T * strBeg = _itget;
+        _itget += length;
 
-        return { strBeg, std::find( strBeg, itget, 0 ) };
+        return { strBeg, std::find( strBeg, _itget, 0 ) };
     }
 
 protected:
@@ -376,10 +376,10 @@ protected:
     StreamBufTmpl( StreamBufTmpl && stream ) noexcept
         : StreamBuf( std::move( stream ) )
     {
-        std::swap( itbeg, stream.itbeg );
-        std::swap( itget, stream.itget );
-        std::swap( itput, stream.itput );
-        std::swap( itend, stream.itend );
+        std::swap( _itbeg, stream._itbeg );
+        std::swap( _itget, stream._itget );
+        std::swap( _itput, stream._itput );
+        std::swap( _itend, stream._itend );
     }
 
     StreamBufTmpl & operator=( StreamBufTmpl && stream ) noexcept
@@ -390,47 +390,47 @@ protected:
 
         StreamBase::operator=( std::move( stream ) );
 
-        std::swap( itbeg, stream.itbeg );
-        std::swap( itget, stream.itget );
-        std::swap( itput, stream.itput );
-        std::swap( itend, stream.itend );
+        std::swap( _itbeg, stream._itbeg );
+        std::swap( _itget, stream._itget );
+        std::swap( _itput, stream._itput );
+        std::swap( _itend, stream._itend );
 
         return *this;
     }
 
     size_t tellg() override
     {
-        return itget - itbeg;
+        return _itget - _itbeg;
     }
 
     size_t tellp() override
     {
-        return itput - itbeg;
+        return _itput - _itbeg;
     }
 
     size_t sizeg() override
     {
-        return itput - itget;
+        return _itput - _itget;
     }
 
     size_t sizep() override
     {
-        return itend - itput;
+        return _itend - _itput;
     }
 
     uint8_t get8() override
     {
         if ( sizeg() > 0 ) {
-            return *( itget++ );
+            return *( _itget++ );
         }
 
         return 0;
     }
 
-    T * itbeg{ nullptr };
-    T * itget{ nullptr };
-    T * itput{ nullptr };
-    T * itend{ nullptr };
+    T * _itbeg{ nullptr };
+    T * _itget{ nullptr };
+    T * _itput{ nullptr };
+    T * _itend{ nullptr };
 };
 
 class RWStreamBuf final : public StreamBufTmpl<uint8_t>
@@ -441,7 +441,7 @@ public:
     RWStreamBuf( const RWStreamBuf & ) = delete;
     RWStreamBuf( RWStreamBuf && stream ) = default;
 
-    ~RWStreamBuf() override;
+    ~RWStreamBuf() override = default;
 
     RWStreamBuf & operator=( const RWStreamBuf & ) = delete;
     RWStreamBuf & operator=( RWStreamBuf && stream ) = default;
@@ -463,14 +463,16 @@ private:
     // After using this method to write data, update the cursor by calling the advance() method.
     uint8_t * rwData()
     {
-        return itput;
+        return _itput;
     }
 
     // Advances the cursor intended for writing data forward by a specified number of bytes.
     void advance( const size_t size )
     {
-        itput += size;
+        _itput += size;
     }
+
+    std::unique_ptr<uint8_t[]> _buf;
 };
 
 class ROStreamBuf final : public StreamBufTmpl<const uint8_t>

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -436,7 +436,11 @@ protected:
 class RWStreamBuf final : public StreamBufTmpl<uint8_t>
 {
 public:
-    explicit RWStreamBuf( const size_t sz = 0 );
+    RWStreamBuf()
+        : RWStreamBuf( 0 )
+    {}
+
+    explicit RWStreamBuf( const size_t sz );
 
     RWStreamBuf( const RWStreamBuf & ) = delete;
     RWStreamBuf( RWStreamBuf && stream ) = default;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -29,7 +29,6 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdio>
-#include <cstring>
 #include <iterator>
 #include <list>
 #include <map>
@@ -352,7 +351,8 @@ public:
         const size_t sizeToCopy = std::min( resultSize, actualSize );
 
         std::vector<uint8_t> result( resultSize, 0 );
-        memcpy( result.data(), _itget, sizeToCopy );
+
+        std::copy( _itget, _itget + sizeToCopy, result.data() );
 
         _itget += sizeToCopy;
 

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -120,9 +120,9 @@ public:
     IStreamBase & operator>>( fheroes2::Point & v );
 
     template <class Type1, class Type2>
-    IStreamBase & operator>>( std::pair<Type1, Type2> & p )
+    IStreamBase & operator>>( std::pair<Type1, Type2> & v )
     {
-        return *this >> p.first >> p.second;
+        return *this >> v.first >> v.second;
     }
 
     template <class Type>
@@ -230,9 +230,9 @@ public:
     OStreamBase & operator<<( const fheroes2::Point & v );
 
     template <class Type1, class Type2>
-    OStreamBase & operator<<( const std::pair<Type1, Type2> & p )
+    OStreamBase & operator<<( const std::pair<Type1, Type2> & v )
     {
-        return *this << p.first << p.second;
+        return *this << v.first << v.second;
     }
 
     template <class Type>

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -288,18 +288,18 @@ protected:
     virtual size_t tellp() = 0;
 };
 
-class StreamBuf : public IStreamBase
+class IStreamBuf : public IStreamBase
 {
 public:
     virtual const uint8_t * data() const = 0;
     virtual size_t size() = 0;
 
 protected:
-    StreamBuf() = default;
+    IStreamBuf() = default;
 };
 
 template <typename T, typename = typename std::enable_if_t<std::is_same_v<T, uint8_t> || std::is_same_v<T, const uint8_t>>>
-class StreamBufTmpl : public StreamBuf
+class StreamBufTmpl : public IStreamBuf
 {
 public:
     StreamBufTmpl( const StreamBufTmpl & ) = delete;
@@ -404,7 +404,7 @@ protected:
     StreamBufTmpl() = default;
 
     StreamBufTmpl( StreamBufTmpl && stream ) noexcept
-        : StreamBuf( std::move( stream ) )
+        : IStreamBuf( std::move( stream ) )
     {
         std::swap( _itbeg, stream._itbeg );
         std::swap( _itget, stream._itget );
@@ -418,7 +418,7 @@ protected:
             return *this;
         }
 
-        StreamBuf::operator=( std::move( stream ) );
+        IStreamBuf::operator=( std::move( stream ) );
 
         std::swap( _itbeg, stream._itbeg );
         std::swap( _itget, stream._itget );

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -187,6 +187,11 @@ protected:
 
     IStreamBase( IStreamBase && ) = default;
 
+    // All this operator does is call the corresponding base class operator. It is not recommended to
+    // declare these operators as default in the case of a virtual base, even if they are trivial, to
+    // catch a situation where, in the case of the diamond inheritance, the corresponding operator of
+    // the base class will be called multiple times. GCC has a special warning for this case (see the
+    // description of the -Wno-virtual-move-assign switch).
     IStreamBase & operator=( IStreamBase && stream ) noexcept;
 
     virtual uint8_t get8() = 0;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -520,12 +520,10 @@ public:
     explicit ROStreamBuf( const std::vector<uint8_t> & buf );
 
     ROStreamBuf( const ROStreamBuf & ) = delete;
-    ROStreamBuf( ROStreamBuf && ) = default;
 
     ~ROStreamBuf() override = default;
 
     ROStreamBuf & operator=( const ROStreamBuf & ) = delete;
-    ROStreamBuf & operator=( ROStreamBuf && ) = default;
 };
 
 // Stream with a file storage backend that supports both reading and writing

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -81,7 +81,7 @@ private:
     uint32_t _flags{ 0 };
 };
 
-// Interface that describes the methods needed to read from a stream
+// Interface that declares the methods needed to read from a stream
 class IStreamBase : virtual public StreamBase
 {
 public:
@@ -200,7 +200,7 @@ protected:
     virtual size_t tellg() = 0;
 };
 
-// Interface that describes the methods needed to write to a stream
+// Interface that declares the methods needed to write to a stream
 class OStreamBase : virtual public StreamBase
 {
 public:
@@ -294,7 +294,7 @@ protected:
     virtual size_t tellp() = 0;
 };
 
-// Interface that describes a stream with an in-memory storage backend that can be read from
+// Interface that declares a stream with an in-memory storage backend that can be read from
 class IStreamBuf : public IStreamBase
 {
 public:

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -388,7 +388,7 @@ protected:
             return *this;
         }
 
-        StreamBase::operator=( std::move( stream ) );
+        StreamBuf::operator=( std::move( stream ) );
 
         std::swap( _itbeg, stream._itbeg );
         std::swap( _itget, stream._itget );

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -274,6 +274,8 @@ class StreamBufTmpl : public StreamBuf
 public:
     StreamBufTmpl( const StreamBufTmpl & ) = delete;
 
+    ~StreamBufTmpl() override = default;
+
     StreamBufTmpl & operator=( const StreamBufTmpl & ) = delete;
 
     const uint8_t * data() const override
@@ -475,6 +477,8 @@ public:
 
     ROStreamBuf( const ROStreamBuf & ) = delete;
     ROStreamBuf( ROStreamBuf && stream ) = default;
+
+    ~ROStreamBuf() override = default;
 
     ROStreamBuf & operator=( const ROStreamBuf & ) = delete;
     ROStreamBuf & operator=( ROStreamBuf && stream ) = default;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -40,6 +40,7 @@
 #include "endian_h2.h"
 #include "math_base.h"
 
+// Base class for all I/O facilities
 class StreamBase
 {
 public:
@@ -80,6 +81,7 @@ private:
     uint32_t _flags{ 0 };
 };
 
+// Interface that describes the methods needed to read from a stream
 class IStreamBase : virtual public StreamBase
 {
 public:
@@ -193,6 +195,7 @@ protected:
     virtual size_t tellg() = 0;
 };
 
+// Interface that describes the methods needed to write to a stream
 class OStreamBase : virtual public StreamBase
 {
 public:
@@ -286,6 +289,7 @@ protected:
     virtual size_t tellp() = 0;
 };
 
+// Interface that describes a stream with an in-memory storage backend that can be read from
 class IStreamBuf : public IStreamBase
 {
 public:
@@ -296,6 +300,7 @@ protected:
     IStreamBuf() = default;
 };
 
+// Class template for a stream with an in-memory storage backend that can store either const or non-const data as desired
 template <typename T, typename = typename std::enable_if_t<std::is_same_v<T, uint8_t> || std::is_same_v<T, const uint8_t>>>
 class StreamBufTmpl : public IStreamBuf
 {
@@ -453,6 +458,7 @@ protected:
     T * _itend{ nullptr };
 };
 
+// Stream with a dynamically-sized in-memory storage backend that supports both reading and writing
 class RWStreamBuf final : public StreamBufTmpl<uint8_t>, public OStreamBase
 {
 public:
@@ -502,6 +508,7 @@ private:
     std::unique_ptr<uint8_t[]> _buf;
 };
 
+// Stream with read-only in-memory storage backed by a const vector instance
 class ROStreamBuf final : public StreamBufTmpl<const uint8_t>
 {
 public:
@@ -516,6 +523,7 @@ public:
     ROStreamBuf & operator=( ROStreamBuf && ) = default;
 };
 
+// Stream with a file storage backend that supports both reading and writing
 class StreamFile final : public IStreamBase, public OStreamBase
 {
 public:

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -180,7 +180,7 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
 
             ++channelCount;
 
-            StreamBuf wavHeader( audioHeaderSize );
+            RWStreamBuf wavHeader( audioHeaderSize );
             wavHeader.putLE32( 0x46464952 ); // RIFF marker ("RIFF")
             wavHeader.putLE32( originalSize + 0x24 ); // Total size minus the size of this and previous fields
             wavHeader.putLE32( 0x45564157 ); // File type header ("WAVE")

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -205,7 +205,7 @@ namespace
     {
         // TODO: plural forms are not in use: Plural-Forms.
         LocaleType locale{ LocaleType::LOCALE_EN };
-        StreamBuf buf;
+        RWStreamBuf buf;
         std::map<uint32_t, Chunk> hash_offsets;
         std::string domain;
         std::string encoding;

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -160,7 +160,7 @@ namespace Compression
         return !output.fail();
     }
 
-    bool writeIntoFileStream( StreamFile & fileStream, StreamBuf & data )
+    bool writeIntoFileStream( StreamFile & fileStream, IStreamBuf & data )
     {
         const std::vector<uint8_t> zip = compressData( data.data(), data.size() );
         if ( zip.empty() ) {

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -134,7 +134,7 @@ namespace Compression
         return res;
     }
 
-    bool readFromFileStream( StreamFile & fileStream, StreamBuf & output )
+    bool readFromFileStream( StreamFile & fileStream, RWStreamBuf & output )
     {
         const uint32_t rawSize = fileStream.get32();
         const uint32_t zipSize = fileStream.get32();

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -30,7 +30,7 @@
 
 #include "image.h"
 
-class StreamBuf;
+class IStreamBuf;
 class RWStreamBuf;
 class StreamFile;
 
@@ -52,7 +52,7 @@ namespace Compression
     // Zips the contents of the buffer from the current read position to the end of the buffer and writes
     // it to the specified file stream. The current read position of the buffer does not change. Returns
     // true on success and false on error.
-    bool writeIntoFileStream( StreamFile & fileStream, StreamBuf & data );
+    bool writeIntoFileStream( StreamFile & fileStream, IStreamBuf & data );
 
     fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );
 }

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -31,6 +31,7 @@
 #include "image.h"
 
 class StreamBuf;
+class RWStreamBuf;
 class StreamFile;
 
 namespace Compression
@@ -46,7 +47,7 @@ namespace Compression
 
     // Reads & unzips the zipped chunk from the specified file stream and appends
     // it to the end of the buffer. Returns true on success or false on error.
-    bool readFromFileStream( StreamFile & fileStream, StreamBuf & output );
+    bool readFromFileStream( StreamFile & fileStream, RWStreamBuf & output );
 
     // Zips the contents of the buffer from the current read position to the end of the buffer and writes
     // it to the specified file stream. The current read position of the buffer does not change. Returns

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -272,7 +272,7 @@ namespace
             return {};
         }
 
-        StreamBuf imageStream( data );
+        ROStreamBuf imageStream( data );
 
         const uint8_t blackColor = imageStream.get();
         const uint8_t whiteColor = 11;
@@ -591,7 +591,7 @@ namespace
             return;
         }
 
-        StreamBuf imageStream( body );
+        ROStreamBuf imageStream( body );
 
         const uint32_t count = imageStream.getLE16();
         const uint32_t blockSize = imageStream.getLE32();
@@ -5025,7 +5025,7 @@ namespace
                 return 0;
             }
 
-            StreamBuf buffer( data );
+            ROStreamBuf buffer( data );
 
             const size_t count = buffer.getLE16();
             const int32_t width = buffer.getLE16();

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1904,26 +1904,26 @@ void Army::ArrangeForBattle( const Monster & monster, const uint32_t monstersCou
     }
 }
 
-StreamBase & operator<<( StreamBase & msg, const Army & army )
+OStreamBase & operator<<( OStreamBase & stream, const Army & army )
 {
-    msg << static_cast<uint32_t>( army.size() );
+    stream << static_cast<uint32_t>( army.size() );
 
     // Army: fixed size
     for ( Army::const_iterator it = army.begin(); it != army.end(); ++it )
-        msg << **it;
+        stream << **it;
 
-    return msg << army._isSpreadCombatFormation << army.color;
+    return stream << army._isSpreadCombatFormation << army.color;
 }
 
-StreamBase & operator>>( StreamBase & msg, Army & army )
+IStreamBase & operator>>( IStreamBase & stream, Army & army )
 {
     uint32_t armysz;
-    msg >> armysz;
+    stream >> armysz;
 
     for ( Army::iterator it = army.begin(); it != army.end(); ++it )
-        msg >> **it;
+        stream >> **it;
 
-    msg >> army._isSpreadCombatFormation >> army.color;
+    stream >> army._isSpreadCombatFormation >> army.color;
 
     // set army
     for ( Army::iterator it = army.begin(); it != army.end(); ++it ) {
@@ -1935,5 +1935,5 @@ StreamBase & operator>>( StreamBase & msg, Army & army )
     // set later from owner (castle, heroes)
     army.commander = nullptr;
 
-    return msg;
+    return stream;
 }

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -33,7 +33,8 @@
 #include "monster.h"
 #include "players.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class Castle;
 class HeroBase;
@@ -256,8 +257,8 @@ public:
     void ArrangeForWhirlpool();
 
 private:
-    friend StreamBase & operator<<( StreamBase &, const Army & );
-    friend StreamBase & operator>>( StreamBase &, Army & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Army & army );
+    friend IStreamBase & operator>>( IStreamBase & stream, Army & army );
 
     // Performs the pre-battle arrangement of given monsters in a given number, dividing them into a given number of stacks if possible
     void ArrangeForBattle( const Monster & monster, const uint32_t monstersCount, const uint32_t stacksCount );
@@ -269,8 +270,5 @@ private:
     bool _isSpreadCombatFormation;
     int color;
 };
-
-StreamBase & operator<<( StreamBase &, const Army & );
-StreamBase & operator>>( StreamBase &, Army & );
 
 #endif

--- a/src/fheroes2/army/army_troop.cpp
+++ b/src/fheroes2/army/army_troop.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/army/army_troop.cpp
+++ b/src/fheroes2/army/army_troop.cpp
@@ -262,12 +262,12 @@ std::string ArmyTroop::GetDefenseString() const
     return output;
 }
 
-StreamBase & operator<<( StreamBase & msg, const Troop & troop )
+OStreamBase & operator<<( OStreamBase & stream, const Troop & troop )
 {
-    return msg << troop.id << troop.count;
+    return stream << troop.id << troop.count;
 }
 
-StreamBase & operator>>( StreamBase & msg, Troop & troop )
+IStreamBase & operator>>( IStreamBase & stream, Troop & troop )
 {
-    return msg >> troop.id >> troop.count;
+    return stream >> troop.id >> troop.count;
 }

--- a/src/fheroes2/army/army_troop.h
+++ b/src/fheroes2/army/army_troop.h
@@ -30,7 +30,8 @@
 #include "monster.h"
 #include "resource.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class Army;
 
@@ -80,16 +81,13 @@ public:
     double GetStrengthWithBonus( int bonusAttack, int bonusDefense ) const;
 
 protected:
-    friend StreamBase & operator<<( StreamBase &, const Troop & );
-    friend StreamBase & operator>>( StreamBase &, Troop & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Troop & troop );
+    friend IStreamBase & operator>>( IStreamBase & stream, Troop & troop );
 
     static std::string GetSpeedString( uint32_t speed );
 
     uint32_t count;
 };
-
-StreamBase & operator<<( StreamBase &, const Troop & );
-StreamBase & operator>>( StreamBase &, Troop & );
 
 class ArmyTroop : public Troop
 {

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -197,7 +197,7 @@ namespace
         const std::vector<uint8_t> & body = getDataFromAggFile( M82::GetString( m82 ), false );
 
         if ( !body.empty() ) {
-            StreamBuf wavHeader( 44 );
+            RWStreamBuf wavHeader( 44 );
             wavHeader.putLE32( 0x46464952 ); // RIFF marker ("RIFF")
             wavHeader.putLE32( static_cast<uint32_t>( body.size() ) + 0x24 ); // Total size minus the size of this and previous fields
             wavHeader.putLE32( 0x45564157 ); // File type header ("WAVE")

--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -158,21 +158,21 @@ namespace Campaign
         return obtainedAwards;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const CampaignSaveData & data )
+    OStreamBase & operator<<( OStreamBase & stream, const CampaignSaveData & data )
     {
-        return msg << data._currentScenarioInfoId.campaignId << data._currentScenarioInfoId.scenarioId << data._currentScenarioBonusId << data._finishedMaps
-                   << data._bonusesForFinishedMaps << data._daysPassed << data._obtainedCampaignAwards << data._carryOverTroops << data._difficulty;
+        return stream << data._currentScenarioInfoId.campaignId << data._currentScenarioInfoId.scenarioId << data._currentScenarioBonusId << data._finishedMaps
+                      << data._bonusesForFinishedMaps << data._daysPassed << data._obtainedCampaignAwards << data._carryOverTroops << data._difficulty;
     }
 
-    StreamBase & operator>>( StreamBase & msg, CampaignSaveData & data )
+    IStreamBase & operator>>( IStreamBase & stream, CampaignSaveData & data )
     {
-        msg >> data._currentScenarioInfoId.campaignId >> data._currentScenarioInfoId.scenarioId >> data._currentScenarioBonusId >> data._finishedMaps
+        stream >> data._currentScenarioInfoId.campaignId >> data._currentScenarioInfoId.scenarioId >> data._currentScenarioBonusId >> data._finishedMaps
             >> data._bonusesForFinishedMaps;
 
         // Make sure that the number of elements in the vector of map bonuses matches the number of elements in the vector of finished maps
         data._bonusesForFinishedMaps.resize( data._finishedMaps.size(), -1 );
 
-        return msg >> data._daysPassed >> data._obtainedCampaignAwards >> data._carryOverTroops >> data._difficulty;
+        return stream >> data._daysPassed >> data._obtainedCampaignAwards >> data._carryOverTroops >> data._difficulty;
     }
 
     ScenarioVictoryCondition getCurrentScenarioVictoryCondition()

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -28,7 +28,8 @@
 #include "army_troop.h"
 #include "campaign_scenariodata.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class Troops;
 
@@ -122,8 +123,8 @@ namespace Campaign
         static CampaignSaveData & Get();
 
     private:
-        friend StreamBase & operator<<( StreamBase & msg, const CampaignSaveData & data );
-        friend StreamBase & operator>>( StreamBase & msg, CampaignSaveData & data );
+        friend OStreamBase & operator<<( OStreamBase & stream, const CampaignSaveData & data );
+        friend IStreamBase & operator>>( IStreamBase & stream, CampaignSaveData & data );
 
         CampaignSaveData() = default;
 

--- a/src/fheroes2/campaign/campaign_scenariodata.cpp
+++ b/src/fheroes2/campaign/campaign_scenariodata.cpp
@@ -642,14 +642,14 @@ namespace
 
 namespace Campaign
 {
-    StreamBase & operator<<( StreamBase & msg, const ScenarioInfoId & data )
+    OStreamBase & operator<<( OStreamBase & stream, const ScenarioInfoId & data )
     {
-        return msg << data.campaignId << data.scenarioId;
+        return stream << data.campaignId << data.scenarioId;
     }
 
-    StreamBase & operator>>( StreamBase & msg, ScenarioInfoId & data )
+    IStreamBase & operator>>( IStreamBase & stream, ScenarioInfoId & data )
     {
-        return msg >> data.campaignId >> data.scenarioId;
+        return stream >> data.campaignId >> data.scenarioId;
     }
 
     ScenarioBonusData::ScenarioBonusData()

--- a/src/fheroes2/campaign/campaign_scenariodata.h
+++ b/src/fheroes2/campaign/campaign_scenariodata.h
@@ -27,7 +27,8 @@
 
 #include "maps_fileinfo.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 namespace Video
 {
@@ -81,8 +82,8 @@ namespace Campaign
             return !operator==( info );
         }
 
-        friend StreamBase & operator<<( StreamBase & msg, const ScenarioInfoId & data );
-        friend StreamBase & operator>>( StreamBase & msg, ScenarioInfoId & data );
+        friend OStreamBase & operator<<( OStreamBase & stream, const ScenarioInfoId & data );
+        friend IStreamBase & operator>>( IStreamBase & stream, ScenarioInfoId & data );
 
         int campaignId{ -1 };
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -233,7 +233,7 @@ void Castle::LoadFromMP2( const std::vector<uint8_t> & data )
     // - unused 29 bytes
     //    Always zeros.
 
-    StreamBuf dataStream( data );
+    ROStreamBuf dataStream( data );
 
     const uint8_t ownerColor = dataStream.get();
     switch ( ownerColor ) {

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2499,23 +2499,23 @@ void AllCastles::Scout( int colors ) const
             ( *it )->Scout();
 }
 
-StreamBase & operator<<( StreamBase & msg, const Castle & castle )
+OStreamBase & operator<<( OStreamBase & stream, const Castle & castle )
 {
     const ColorBase & color = castle;
 
-    msg << static_cast<const MapPosition &>( castle ) << castle.modes << castle.race << castle._constructedBuildings << castle._disabledBuildings << castle.captain
-        << color << castle.name << castle.mageguild << static_cast<uint32_t>( castle.dwelling.size() );
+    stream << static_cast<const MapPosition &>( castle ) << castle.modes << castle.race << castle._constructedBuildings << castle._disabledBuildings << castle.captain
+           << color << castle.name << castle.mageguild << static_cast<uint32_t>( castle.dwelling.size() );
 
     for ( const uint32_t dwelling : castle.dwelling ) {
-        msg << dwelling;
+        stream << dwelling;
     }
 
-    return msg << castle.army;
+    return stream << castle.army;
 }
 
-StreamBase & operator>>( StreamBase & msg, Castle & castle )
+IStreamBase & operator>>( IStreamBase & stream, Castle & castle )
 {
-    msg >> static_cast<MapPosition &>( castle ) >> castle.modes >> castle.race >> castle._constructedBuildings;
+    stream >> static_cast<MapPosition &>( castle ) >> castle.modes >> castle.race >> castle._constructedBuildings;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1101_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1101_RELEASE ) {
@@ -2524,14 +2524,14 @@ StreamBase & operator>>( StreamBase & msg, Castle & castle )
         }
     }
     else {
-        msg >> castle._disabledBuildings;
+        stream >> castle._disabledBuildings;
     }
 
     ColorBase & color = castle;
-    msg >> castle.captain >> color >> castle.name >> castle.mageguild;
+    stream >> castle.captain >> color >> castle.name >> castle.mageguild;
 
     uint32_t dwellingcount;
-    msg >> dwellingcount;
+    stream >> dwellingcount;
 
     if ( dwellingcount != castle.dwelling.size() ) {
         // Is it a corrupted save?
@@ -2541,67 +2541,67 @@ StreamBase & operator>>( StreamBase & msg, Castle & castle )
     }
     else {
         for ( uint32_t & dwelling : castle.dwelling ) {
-            msg >> dwelling;
+            stream >> dwelling;
         }
     }
 
-    msg >> castle.army;
+    stream >> castle.army;
     castle.army.SetCommander( &castle.captain );
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator<<( StreamBase & msg, const VecCastles & castles )
+OStreamBase & operator<<( OStreamBase & stream, const VecCastles & castles )
 {
-    msg << static_cast<uint32_t>( castles.size() );
+    stream << static_cast<uint32_t>( castles.size() );
 
     for ( auto it = castles.begin(); it != castles.end(); ++it )
-        msg << ( *it ? ( *it )->GetIndex() : static_cast<int32_t>( -1 ) );
+        stream << ( *it ? ( *it )->GetIndex() : static_cast<int32_t>( -1 ) );
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, VecCastles & castles )
+IStreamBase & operator>>( IStreamBase & stream, VecCastles & castles )
 {
     int32_t index;
     uint32_t size;
-    msg >> size;
+    stream >> size;
 
     castles.resize( size, nullptr );
 
     for ( auto it = castles.begin(); it != castles.end(); ++it ) {
-        msg >> index;
+        stream >> index;
         *it = ( index < 0 ? nullptr : world.getCastleEntrance( Maps::GetPoint( index ) ) );
         assert( *it != nullptr );
     }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator<<( StreamBase & msg, const AllCastles & castles )
+OStreamBase & operator<<( OStreamBase & stream, const AllCastles & castles )
 {
-    msg << static_cast<uint32_t>( castles.Size() );
+    stream << static_cast<uint32_t>( castles.Size() );
 
     for ( const Castle * castle : castles )
-        msg << *castle;
+        stream << *castle;
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, AllCastles & castles )
+IStreamBase & operator>>( IStreamBase & stream, AllCastles & castles )
 {
     uint32_t size;
-    msg >> size;
+    stream >> size;
 
     castles.Clear();
 
     for ( uint32_t i = 0; i < size; ++i ) {
         Castle * castle = new Castle();
-        msg >> *castle;
+        stream >> *castle;
         castles.AddCastle( castle );
     }
 
-    return msg;
+    return stream;
 }
 
 std::string Castle::GetStringBuilding( uint32_t build ) const

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -45,6 +45,15 @@
 #include "players.h"
 #include "position.h"
 
+class IStreamBase;
+class OStreamBase;
+
+class HeroBase;
+class Heroes;
+class Troop;
+
+struct Funds;
+
 namespace fheroes2
 {
     class RandomMonsterAnimation;
@@ -55,12 +64,6 @@ namespace Maps::Map_Format
 {
     struct CastleMetadata;
 }
-
-struct Funds;
-class HeroBase;
-class Heroes;
-class StreamBase;
-class Troop;
 
 enum BuildingType : uint32_t
 {
@@ -341,8 +344,8 @@ private:
     bool _recruitCastleMax( const Troops & currentCastleArmy );
     bool RecruitMonsterFromDwelling( uint32_t dw, uint32_t count, bool force = false );
 
-    friend StreamBase & operator<<( StreamBase &, const Castle & );
-    friend StreamBase & operator>>( StreamBase &, Castle & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Castle & castle );
+    friend IStreamBase & operator>>( IStreamBase & stream, Castle & castle );
 
     int race;
     uint32_t _constructedBuildings;
@@ -513,13 +516,10 @@ private:
     std::map<fheroes2::Point, size_t> _castleTiles;
 };
 
-StreamBase & operator<<( StreamBase &, const VecCastles & );
-StreamBase & operator>>( StreamBase &, VecCastles & );
+OStreamBase & operator<<( OStreamBase & stream, const VecCastles & castles );
+IStreamBase & operator>>( IStreamBase & stream, VecCastles & castles );
 
-StreamBase & operator<<( StreamBase &, const AllCastles & );
-StreamBase & operator>>( StreamBase &, AllCastles & );
-
-StreamBase & operator<<( StreamBase &, const Castle & );
-StreamBase & operator>>( StreamBase &, Castle & );
+OStreamBase & operator<<( OStreamBase & stream, const AllCastles & castles );
+IStreamBase & operator>>( IStreamBase & stream, AllCastles & castles );
 
 #endif

--- a/src/fheroes2/castle/mageguild.cpp
+++ b/src/fheroes2/castle/mageguild.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/castle/mageguild.cpp
+++ b/src/fheroes2/castle/mageguild.cpp
@@ -198,12 +198,12 @@ void MageGuild::educateHero( HeroBase & hero, int guildLevel, bool hasLibrary ) 
     }
 }
 
-StreamBase & operator<<( StreamBase & msg, const MageGuild & guild )
+OStreamBase & operator<<( OStreamBase & stream, const MageGuild & guild )
 {
-    return msg << guild.general << guild.library;
+    return stream << guild.general << guild.library;
 }
 
-StreamBase & operator>>( StreamBase & msg, MageGuild & guild )
+IStreamBase & operator>>( IStreamBase & stream, MageGuild & guild )
 {
-    return msg >> guild.general >> guild.library;
+    return stream >> guild.general >> guild.library;
 }

--- a/src/fheroes2/castle/mageguild.h
+++ b/src/fheroes2/castle/mageguild.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/castle/mageguild.h
+++ b/src/fheroes2/castle/mageguild.h
@@ -26,7 +26,8 @@
 
 #include "spell_storage.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class HeroBase;
 
@@ -43,14 +44,11 @@ public:
     SpellStorage GetSpells( int guildLevel, bool hasLibrary, int spellLevel = -1 ) const;
 
 private:
-    friend StreamBase & operator<<( StreamBase &, const MageGuild & );
-    friend StreamBase & operator>>( StreamBase &, MageGuild & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const MageGuild & guild );
+    friend IStreamBase & operator>>( IStreamBase & stream, MageGuild & guild );
 
     SpellStorage general;
     SpellStorage library;
 };
-
-StreamBase & operator<<( StreamBase &, const MageGuild & );
-StreamBase & operator>>( StreamBase &, MageGuild & );
 
 #endif

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -92,14 +92,14 @@ namespace
         int gameType;
     };
 
-    StreamBase & operator<<( StreamBase & msg, const HeaderSAV & hdr )
+    OStreamBase & operator<<( OStreamBase & stream, const HeaderSAV & hdr )
     {
-        return msg << hdr.status << hdr.info << hdr.gameType;
+        return stream << hdr.status << hdr.info << hdr.gameType;
     }
 
-    StreamBase & operator>>( StreamBase & msg, HeaderSAV & hdr )
+    IStreamBase & operator>>( IStreamBase & stream, HeaderSAV & hdr )
     {
-        return msg >> hdr.status >> hdr.info >> hdr.gameType;
+        return stream >> hdr.status >> hdr.info >> hdr.gameType;
     }
 }
 

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -133,7 +133,7 @@ bool Game::Save( const std::string & filePath, const bool autoSave /* = false */
         return false;
     }
 
-    StreamBuf dataStream;
+    RWStreamBuf dataStream;
     dataStream.setbigendian( true );
 
     dataStream << World::Get() << Settings::Get() << GameOver::Result::Get();
@@ -225,7 +225,7 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
         return fheroes2::GameMode::CANCEL;
     }
 
-    StreamBuf dataStream;
+    RWStreamBuf dataStream;
     dataStream.setbigendian( true );
 
     if ( !Compression::readFromFileStream( fileStream, dataStream ) ) {

--- a/src/fheroes2/game/game_io.cpp
+++ b/src/fheroes2/game/game_io.cpp
@@ -115,7 +115,7 @@ bool Game::Save( const std::string & filePath, const bool autoSave /* = false */
     const Settings & conf = Settings::Get();
 
     StreamFile fileStream;
-    fileStream.setbigendian( true );
+    fileStream.setBigendian( true );
 
     if ( !fileStream.open( filePath, "wb" ) ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Error opening the file " << filePath )
@@ -134,7 +134,7 @@ bool Game::Save( const std::string & filePath, const bool autoSave /* = false */
     }
 
     RWStreamBuf dataStream;
-    dataStream.setbigendian( true );
+    dataStream.setBigendian( true );
 
     dataStream << World::Get() << Settings::Get() << GameOver::Result::Get();
     if ( dataStream.fail() ) {
@@ -165,7 +165,7 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
     const auto showGenericErrorMessage = []() { fheroes2::showStandardTextMessage( _( "Error" ), _( "The save file is corrupted." ), Dialog::OK ); };
 
     StreamFile fileStream;
-    fileStream.setbigendian( true );
+    fileStream.setBigendian( true );
 
     if ( !fileStream.open( filePath, "rb" ) ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Error opening the file " << filePath )
@@ -226,7 +226,7 @@ fheroes2::GameMode Game::Load( const std::string & filePath )
     }
 
     RWStreamBuf dataStream;
-    dataStream.setbigendian( true );
+    dataStream.setBigendian( true );
 
     if ( !Compression::readFromFileStream( fileStream, dataStream ) ) {
         showGenericErrorMessage();
@@ -290,7 +290,7 @@ bool Game::LoadSAV2FileInfo( std::string filePath, Maps::FileInfo & fileInfo )
     DEBUG_LOG( DBG_GAME, DBG_INFO, filePath )
 
     StreamFile fs;
-    fs.setbigendian( true );
+    fs.setBigendian( true );
 
     if ( !fs.open( filePath, "rb" ) ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Error opening the file " << filePath )

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/game_over.cpp
+++ b/src/fheroes2/game/game_over.cpp
@@ -604,12 +604,12 @@ fheroes2::GameMode GameOver::Result::checkGameOver()
     return res;
 }
 
-StreamBase & GameOver::operator<<( StreamBase & msg, const Result & res )
+OStreamBase & GameOver::operator<<( OStreamBase & stream, const Result & res )
 {
-    return msg << res.colors << res.result;
+    return stream << res.colors << res.result;
 }
 
-StreamBase & GameOver::operator>>( StreamBase & msg, Result & res )
+IStreamBase & GameOver::operator>>( IStreamBase & stream, Result & res )
 {
-    return msg >> res.colors >> res.result;
+    return stream >> res.colors >> res.result;
 }

--- a/src/fheroes2/game/game_over.h
+++ b/src/fheroes2/game/game_over.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/game_over.h
+++ b/src/fheroes2/game/game_over.h
@@ -29,7 +29,8 @@
 
 #include "game_mode.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 namespace GameOver
 {
@@ -82,8 +83,8 @@ namespace GameOver
         fheroes2::GameMode checkGameOver();
 
     private:
-        friend StreamBase & operator<<( StreamBase &, const Result & );
-        friend StreamBase & operator>>( StreamBase &, Result & );
+        friend OStreamBase & operator<<( OStreamBase & stream, const Result & res );
+        friend IStreamBase & operator>>( IStreamBase & stream, Result & res );
 
         Result();
 
@@ -91,8 +92,8 @@ namespace GameOver
         uint32_t result;
     };
 
-    StreamBase & operator<<( StreamBase &, const Result & );
-    StreamBase & operator>>( StreamBase &, Result & );
+    OStreamBase & operator<<( OStreamBase & stream, const Result & res );
+    IStreamBase & operator>>( IStreamBase & stream, Result & res );
 }
 
 #endif

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -109,21 +109,21 @@ namespace fheroes2
         return static_cast<uint32_t>( std::time( nullptr ) );
     }
 
-    void HighscoreData::loadV1( StreamBase & msg )
+    void HighscoreData::loadV1( IStreamBase & stream )
     {
         languageAbbreviation = fheroes2::getLanguageAbbreviation( fheroes2::SupportedLanguage::English );
 
-        msg >> playerName >> scenarioName >> completionTime >> dayCount >> rating >> mapSeed;
+        stream >> playerName >> scenarioName >> completionTime >> dayCount >> rating >> mapSeed;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const HighscoreData & data )
+    OStreamBase & operator<<( OStreamBase & stream, const HighscoreData & data )
     {
-        return msg << data.languageAbbreviation << data.playerName << data.scenarioName << data.completionTime << data.dayCount << data.rating << data.mapSeed;
+        return stream << data.languageAbbreviation << data.playerName << data.scenarioName << data.completionTime << data.dayCount << data.rating << data.mapSeed;
     }
 
-    StreamBase & operator>>( StreamBase & msg, HighscoreData & data )
+    IStreamBase & operator>>( IStreamBase & stream, HighscoreData & data )
     {
-        return msg >> data.languageAbbreviation >> data.playerName >> data.scenarioName >> data.completionTime >> data.dayCount >> data.rating >> data.mapSeed;
+        return stream >> data.languageAbbreviation >> data.playerName >> data.scenarioName >> data.completionTime >> data.dayCount >> data.rating >> data.mapSeed;
     }
 
     bool HighScoreDataContainer::load( const std::string & fileName )

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -129,13 +129,13 @@ namespace fheroes2
     bool HighScoreDataContainer::load( const std::string & fileName )
     {
         StreamFile fileStream;
-        fileStream.setbigendian( true );
+        fileStream.setBigendian( true );
         if ( !fileStream.open( fileName, "rb" ) ) {
             return false;
         }
 
         RWStreamBuf hdata;
-        hdata.setbigendian( true );
+        hdata.setBigendian( true );
 
         if ( !Compression::readFromFileStream( fileStream, hdata ) ) {
             return false;
@@ -201,14 +201,14 @@ namespace fheroes2
     bool HighScoreDataContainer::save( const std::string & fileName ) const
     {
         StreamFile fileStream;
-        fileStream.setbigendian( true );
+        fileStream.setBigendian( true );
 
         if ( !fileStream.open( fileName, "wb" ) ) {
             return false;
         }
 
         RWStreamBuf hdata;
-        hdata.setbigendian( true );
+        hdata.setBigendian( true );
         hdata << highscoreFileMagicValueV2 << _highScoresStandard << _highScoresCampaign;
 
         return !hdata.fail() && Compression::writeIntoFileStream( fileStream, hdata );

--- a/src/fheroes2/game/highscores.cpp
+++ b/src/fheroes2/game/highscores.cpp
@@ -134,7 +134,7 @@ namespace fheroes2
             return false;
         }
 
-        StreamBuf hdata;
+        RWStreamBuf hdata;
         hdata.setbigendian( true );
 
         if ( !Compression::readFromFileStream( fileStream, hdata ) ) {
@@ -207,7 +207,7 @@ namespace fheroes2
             return false;
         }
 
-        StreamBuf hdata;
+        RWStreamBuf hdata;
         hdata.setbigendian( true );
         hdata << highscoreFileMagicValueV2 << _highScoresStandard << _highScoresCampaign;
 

--- a/src/fheroes2/game/highscores.h
+++ b/src/fheroes2/game/highscores.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2023                                             *
+ *   Copyright (C) 2022 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/highscores.h
+++ b/src/fheroes2/game/highscores.h
@@ -29,7 +29,8 @@
 
 #include "monster.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 namespace fheroes2
 {
@@ -78,11 +79,11 @@ namespace fheroes2
 
         static uint32_t generateCompletionTime();
 
-        void loadV1( StreamBase & msg );
+        void loadV1( IStreamBase & stream );
 
     private:
-        friend StreamBase & operator<<( StreamBase &, const HighscoreData & );
-        friend StreamBase & operator>>( StreamBase &, HighscoreData & );
+        friend OStreamBase & operator<<( OStreamBase & stream, const HighscoreData & data );
+        friend IStreamBase & operator>>( IStreamBase & stream, HighscoreData & data );
     };
 
     class HighScoreDataContainer
@@ -122,8 +123,8 @@ namespace fheroes2
         std::vector<HighscoreData> _highScoresCampaign;
     };
 
-    StreamBase & operator<<( StreamBase & msg, const HighscoreData & data );
-    StreamBase & operator>>( StreamBase & msg, HighscoreData & data );
+    OStreamBase & operator<<( OStreamBase & stream, const HighscoreData & data );
+    IStreamBase & operator>>( IStreamBase & stream, HighscoreData & data );
 }
 
 #endif

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -456,7 +456,7 @@ void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int
     // Reset the army to default
     army.Reset( true );
 
-    StreamBuf dataStream( data );
+    ROStreamBuf dataStream( data );
 
     // Skip first unused byte.
     dataStream.skip( 1 );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2428,28 +2428,28 @@ Heroes * AllHeroes::FromJail( int32_t index ) const
     return nullptr;
 }
 
-StreamBase & operator<<( StreamBase & msg, const VecHeroes & heroes )
+OStreamBase & operator<<( OStreamBase & stream, const VecHeroes & heroes )
 {
-    msg << static_cast<uint32_t>( heroes.size() );
+    stream << static_cast<uint32_t>( heroes.size() );
 
     for ( const Heroes * hero : heroes ) {
         assert( hero != nullptr );
-        msg << hero->GetID();
+        stream << hero->GetID();
     }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, VecHeroes & heroes )
+IStreamBase & operator>>( IStreamBase & stream, VecHeroes & heroes )
 {
     uint32_t size;
-    msg >> size;
+    stream >> size;
 
     heroes.clear();
 
     for ( uint32_t i = 0; i < size; ++i ) {
         int32_t hid;
-        msg >> hid;
+        stream >> hid;
 
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
         if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
@@ -2481,35 +2481,35 @@ StreamBase & operator>>( StreamBase & msg, VecHeroes & heroes )
         }
     }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator<<( StreamBase & msg, const Heroes & hero )
+OStreamBase & operator<<( OStreamBase & stream, const Heroes & hero )
 {
     const HeroBase & base = hero;
     const ColorBase & col = hero;
 
     // HeroBase
-    msg << base;
+    stream << base;
 
     // Heroes
     using ObjectTypeUnderHeroType = std::underlying_type_t<decltype( hero._objectTypeUnderHero )>;
 
-    return msg << hero.name << col << hero.experience << hero.secondary_skills << hero.army << hero._id << hero.portrait << hero._race
-               << static_cast<ObjectTypeUnderHeroType>( hero._objectTypeUnderHero ) << hero.path << hero.direction << hero.sprite_index << hero._patrolCenter
-               << hero._patrolDistance << hero.visit_object << hero._lastGroundRegion;
+    return stream << hero.name << col << hero.experience << hero.secondary_skills << hero.army << hero._id << hero.portrait << hero._race
+                  << static_cast<ObjectTypeUnderHeroType>( hero._objectTypeUnderHero ) << hero.path << hero.direction << hero.sprite_index << hero._patrolCenter
+                  << hero._patrolDistance << hero.visit_object << hero._lastGroundRegion;
 }
 
-StreamBase & operator>>( StreamBase & msg, Heroes & hero )
+IStreamBase & operator>>( IStreamBase & stream, Heroes & hero )
 {
     HeroBase & base = hero;
     ColorBase & col = hero;
 
     // HeroBase
-    msg >> base;
+    stream >> base;
 
     // Heroes
-    msg >> hero.name >> col >> hero.experience >> hero.secondary_skills >> hero.army >> hero._id >> hero.portrait >> hero._race;
+    stream >> hero.name >> col >> hero.experience >> hero.secondary_skills >> hero.army >> hero._id >> hero.portrait >> hero._race;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1100_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1100_RELEASE ) {
@@ -2541,14 +2541,14 @@ StreamBase & operator>>( StreamBase & msg, Heroes & hero )
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1009_RELEASE, "Remove the logic below." );
         if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1009_RELEASE ) {
             int temp = 0;
-            msg >> temp;
+            stream >> temp;
 
             hero._objectTypeUnderHero = static_cast<MP2::MapObjectType>( temp );
         }
         else {
             uint8_t temp = 0;
 
-            msg >> temp;
+            stream >> temp;
 
             hero._objectTypeUnderHero = static_cast<MP2::MapObjectType>( temp );
         }
@@ -2556,46 +2556,46 @@ StreamBase & operator>>( StreamBase & msg, Heroes & hero )
     else {
         ObjectTypeUnderHeroType temp = 0;
 
-        msg >> temp;
+        stream >> temp;
 
         hero._objectTypeUnderHero = static_cast<MP2::MapObjectType>( temp );
     }
 
-    msg >> hero.path >> hero.direction >> hero.sprite_index;
+    stream >> hero.path >> hero.direction >> hero.sprite_index;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
         int16_t patrolX = 0;
         int16_t patrolY = 0;
 
-        msg >> patrolX >> patrolY;
+        stream >> patrolX >> patrolY;
         hero._patrolCenter = fheroes2::Point( patrolX, patrolY );
     }
     else {
-        msg >> hero._patrolCenter;
+        stream >> hero._patrolCenter;
     }
 
-    msg >> hero._patrolDistance >> hero.visit_object >> hero._lastGroundRegion;
+    stream >> hero._patrolDistance >> hero.visit_object >> hero._lastGroundRegion;
 
     hero.army.SetCommander( &hero );
-    return msg;
+    return stream;
 }
 
-StreamBase & operator<<( StreamBase & msg, const AllHeroes & heroes )
+OStreamBase & operator<<( OStreamBase & stream, const AllHeroes & heroes )
 {
-    msg << static_cast<uint32_t>( heroes.size() );
+    stream << static_cast<uint32_t>( heroes.size() );
 
     for ( Heroes * const & hero : heroes ) {
-        msg << *hero;
+        stream << *hero;
     }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, AllHeroes & heroes )
+IStreamBase & operator>>( IStreamBase & stream, AllHeroes & heroes )
 {
     uint32_t size;
-    msg >> size;
+    stream >> size;
 
     heroes.clear();
     heroes.resize( size, nullptr );
@@ -2606,18 +2606,18 @@ StreamBase & operator>>( StreamBase & msg, AllHeroes & heroes )
         // In order to preserve the original order of heroes we have to do the below trick.
         for ( size_t i = 1; i < heroes.size(); ++i ) {
             heroes[i] = new Heroes();
-            msg >> *heroes[i];
+            stream >> *heroes[i];
         }
 
         heroes[0] = new Heroes();
-        msg >> *heroes[0];
+        stream >> *heroes[0];
     }
     else {
         for ( Heroes *& hero : heroes ) {
             hero = new Heroes();
-            msg >> *hero;
+            stream >> *hero;
         }
     }
 
-    return msg;
+    return stream;
 }

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -46,8 +46,10 @@
 #include "spell.h"
 #include "visit.h"
 
+class IStreamBase;
+class OStreamBase;
+
 class Castle;
-class StreamBase;
 
 namespace Battle
 {
@@ -692,8 +694,8 @@ public:
     void resetHeroSprite();
 
 private:
-    friend StreamBase & operator<<( StreamBase &, const Heroes & );
-    friend StreamBase & operator>>( StreamBase &, Heroes & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Heroes & hero );
+    friend IStreamBase & operator>>( IStreamBase & stream, Heroes & hero );
 
     enum
     {
@@ -810,13 +812,10 @@ struct AllHeroes : public VecHeroes
     Heroes * FromJail( int32_t index ) const;
 };
 
-StreamBase & operator<<( StreamBase &, const VecHeroes & );
-StreamBase & operator>>( StreamBase &, VecHeroes & );
+OStreamBase & operator<<( OStreamBase & stream, const VecHeroes & heroes );
+IStreamBase & operator>>( IStreamBase & stream, VecHeroes & heroes );
 
-StreamBase & operator<<( StreamBase &, const Heroes & );
-StreamBase & operator>>( StreamBase &, Heroes & );
-
-StreamBase & operator<<( StreamBase &, const AllHeroes & );
-StreamBase & operator>>( StreamBase &, AllHeroes & );
+OStreamBase & operator<<( OStreamBase & stream, const AllHeroes & heroes );
+IStreamBase & operator>>( IStreamBase & stream, AllHeroes & heroes );
 
 #endif

--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -586,16 +586,16 @@ bool HeroBase::CanLearnSpell( const Spell & spell ) const
              || ( 3 == spell.Level() && Skill::Level::BASIC <= wisdom ) || 3 > spell.Level() );
 }
 
-StreamBase & operator<<( StreamBase & msg, const HeroBase & hero )
+OStreamBase & operator<<( OStreamBase & stream, const HeroBase & hero )
 {
-    return msg << static_cast<const Skill::Primary &>( hero ) << static_cast<const MapPosition &>( hero ) << hero.modes << hero.magic_point << hero.move_point
-               << hero.spell_book << hero.bag_artifacts;
+    return stream << static_cast<const Skill::Primary &>( hero ) << static_cast<const MapPosition &>( hero ) << hero.modes << hero.magic_point << hero.move_point
+                  << hero.spell_book << hero.bag_artifacts;
 }
 
-StreamBase & operator>>( StreamBase & msg, HeroBase & hero )
+IStreamBase & operator>>( IStreamBase & stream, HeroBase & hero )
 {
-    msg >> static_cast<Skill::Primary &>( hero ) >> static_cast<MapPosition &>( hero ) >> hero.modes >> hero.magic_point >> hero.move_point >> hero.spell_book
+    stream >> static_cast<Skill::Primary &>( hero ) >> static_cast<MapPosition &>( hero ) >> hero.modes >> hero.magic_point >> hero.move_point >> hero.spell_book
         >> hero.bag_artifacts;
 
-    return msg;
+    return stream;
 }

--- a/src/fheroes2/heroes/heroes_base.h
+++ b/src/fheroes2/heroes/heroes_base.h
@@ -38,7 +38,8 @@
 #include "spell_book.h"
 #include "spell_storage.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 namespace fheroes2
 {
@@ -171,8 +172,8 @@ public:
     void LoadDefaults( const int type, const int race );
 
 protected:
-    friend StreamBase & operator<<( StreamBase & msg, const HeroBase & hero );
-    friend StreamBase & operator>>( StreamBase & msg, HeroBase & hero );
+    friend OStreamBase & operator<<( OStreamBase & stream, const HeroBase & hero );
+    friend IStreamBase & operator>>( IStreamBase & stream, HeroBase & hero );
 
     uint32_t magic_point;
     uint32_t move_point;
@@ -181,7 +182,7 @@ protected:
     BagArtifacts bag_artifacts;
 };
 
-StreamBase & operator<<( StreamBase & msg, const HeroBase & hero );
-StreamBase & operator>>( StreamBase & msg, HeroBase & hero );
+OStreamBase & operator<<( OStreamBase & stream, const HeroBase & hero );
+IStreamBase & operator>>( IStreamBase & stream, HeroBase & hero );
 
 #endif

--- a/src/fheroes2/heroes/heroes_recruits.cpp
+++ b/src/fheroes2/heroes/heroes_recruits.cpp
@@ -121,19 +121,19 @@ void Recruits::appendSurrenderedHero( Heroes & hero, const uint32_t heroSurrende
     recruit = Recruit( hero, heroSurrenderDay );
 }
 
-StreamBase & operator<<( StreamBase & msg, const Recruit & recruit )
+OStreamBase & operator<<( OStreamBase & stream, const Recruit & recruit )
 {
-    return msg << recruit._id << recruit._surrenderDay;
+    return stream << recruit._id << recruit._surrenderDay;
 }
 
-StreamBase & operator>>( StreamBase & msg, Recruit & recruit )
+IStreamBase & operator>>( IStreamBase & stream, Recruit & recruit )
 {
-    msg >> recruit._id >> recruit._surrenderDay;
+    stream >> recruit._id >> recruit._surrenderDay;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
         ++recruit._id;
     }
 
-    return msg;
+    return stream;
 }

--- a/src/fheroes2/heroes/heroes_recruits.h
+++ b/src/fheroes2/heroes/heroes_recruits.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_recruits.h
+++ b/src/fheroes2/heroes/heroes_recruits.h
@@ -27,8 +27,10 @@
 #include <cstdint>
 #include <utility>
 
+class IStreamBase;
+class OStreamBase;
+
 class Heroes;
-class StreamBase;
 
 class Recruit
 {
@@ -57,8 +59,8 @@ private:
     int _id;
     uint32_t _surrenderDay;
 
-    friend StreamBase & operator<<( StreamBase & msg, const Recruit & recruit );
-    friend StreamBase & operator>>( StreamBase & msg, Recruit & recruit );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Recruit & recruit );
+    friend IStreamBase & operator>>( IStreamBase & stream, Recruit & recruit );
 };
 
 class Recruits : public std::pair<Recruit, Recruit>
@@ -83,7 +85,7 @@ public:
     void appendSurrenderedHero( Heroes & hero, const uint32_t heroSurrenderDay );
 };
 
-StreamBase & operator<<( StreamBase & msg, const Recruit & recruit );
-StreamBase & operator>>( StreamBase & msg, Recruit & recruit );
+OStreamBase & operator<<( OStreamBase & stream, const Recruit & recruit );
+IStreamBase & operator>>( IStreamBase & stream, Recruit & recruit );
 
 #endif

--- a/src/fheroes2/heroes/route.cpp
+++ b/src/fheroes2/heroes/route.cpp
@@ -377,24 +377,24 @@ std::string Route::Path::String() const
     return output;
 }
 
-StreamBase & Route::operator<<( StreamBase & msg, const Step & step )
+OStreamBase & Route::operator<<( OStreamBase & stream, const Step & step )
 {
-    return msg << step.from << step.direction << step.penalty;
+    return stream << step.from << step.direction << step.penalty;
 }
 
-StreamBase & Route::operator<<( StreamBase & msg, const Path & path )
+OStreamBase & Route::operator<<( OStreamBase & stream, const Path & path )
 {
-    return msg << path._hide << static_cast<const std::list<Step> &>( path );
+    return stream << path._hide << static_cast<const std::list<Step> &>( path );
 }
 
-StreamBase & Route::operator>>( StreamBase & msg, Step & step )
+IStreamBase & Route::operator>>( IStreamBase & stream, Step & step )
 {
-    msg >> step.from >> step.direction >> step.penalty;
+    stream >> step.from >> step.direction >> step.penalty;
     step.currentIndex = Maps::GetDirectionIndex( step.from, step.direction );
-    return msg;
+    return stream;
 }
 
-StreamBase & Route::operator>>( StreamBase & msg, Path & path )
+IStreamBase & Route::operator>>( IStreamBase & stream, Path & path )
 {
     std::list<Step> & base = path;
 
@@ -402,10 +402,10 @@ StreamBase & Route::operator>>( StreamBase & msg, Path & path )
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1007_RELEASE ) {
         int32_t dummy;
 
-        msg >> dummy;
+        stream >> dummy;
     }
 
-    return msg >> path._hide >> base;
+    return stream >> path._hide >> base;
 }
 
 uint32_t Route::calculatePathPenalty( const std::list<Step> & path )

--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -29,8 +29,10 @@
 
 #include "direction.h"
 
+class IStreamBase;
+class OStreamBase;
+
 class Heroes;
-class StreamBase;
 
 namespace Route
 {
@@ -66,8 +68,8 @@ namespace Route
         }
 
     protected:
-        friend StreamBase & operator<<( StreamBase &, const Step & );
-        friend StreamBase & operator>>( StreamBase &, Step & );
+        friend OStreamBase & operator<<( OStreamBase & stream, const Step & step );
+        friend IStreamBase & operator>>( IStreamBase & stream, Step & step );
 
         int32_t currentIndex = -1;
         int32_t from = -1;
@@ -189,17 +191,18 @@ namespace Route
         static int GetIndexSprite( const int from, const int to, const int cost );
 
     private:
-        friend StreamBase & operator<<( StreamBase &, const Path & );
-        friend StreamBase & operator>>( StreamBase &, Path & );
+        friend OStreamBase & operator<<( OStreamBase & stream, const Path & path );
+        friend IStreamBase & operator>>( IStreamBase & stream, Path & path );
 
         const Heroes * _hero;
         bool _hide;
     };
 
-    StreamBase & operator<<( StreamBase &, const Step & );
-    StreamBase & operator<<( StreamBase &, const Path & );
-    StreamBase & operator>>( StreamBase &, Step & );
-    StreamBase & operator>>( StreamBase &, Path & );
+    OStreamBase & operator<<( OStreamBase & stream, const Step & step );
+    IStreamBase & operator>>( IStreamBase & stream, Step & step );
+
+    OStreamBase & operator<<( OStreamBase & stream, const Path & path );
+    IStreamBase & operator>>( IStreamBase & stream, Path & path );
 
     uint32_t calculatePathPenalty( const std::list<Step> & path );
 }

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -901,33 +901,28 @@ uint32_t Skill::GetDiplomacySurrenderCostDiscount( const int level )
     }
 }
 
-StreamBase & Skill::operator<<( StreamBase & msg, const Primary & skill )
+OStreamBase & Skill::operator<<( OStreamBase & stream, const Primary & skill )
 {
-    return msg << skill.attack << skill.defense << skill.knowledge << skill.power;
+    return stream << skill.attack << skill.defense << skill.knowledge << skill.power;
 }
 
-StreamBase & Skill::operator>>( StreamBase & msg, Primary & skill )
+IStreamBase & Skill::operator>>( IStreamBase & stream, Primary & skill )
 {
-    return msg >> skill.attack >> skill.defense >> skill.knowledge >> skill.power;
+    return stream >> skill.attack >> skill.defense >> skill.knowledge >> skill.power;
 }
 
-StreamBase & Skill::operator>>( StreamBase & sb, Secondary & st )
-{
-    return sb >> st.first >> st.second;
-}
-
-StreamBase & Skill::operator<<( StreamBase & sb, const SecSkills & ss )
+OStreamBase & Skill::operator<<( OStreamBase & stream, const SecSkills & ss )
 {
     const std::vector<Secondary> & v = ss;
-    return sb << v;
+    return stream << v;
 }
 
-StreamBase & Skill::operator>>( StreamBase & sb, SecSkills & ss )
+IStreamBase & Skill::operator>>( IStreamBase & stream, SecSkills & ss )
 {
     std::vector<Secondary> & v = ss;
-    sb >> v;
+    stream >> v;
 
     if ( v.size() > HEROESMAXSKILL )
         v.resize( HEROESMAXSKILL );
-    return sb;
+    return stream;
 }

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -922,7 +922,9 @@ IStreamBase & Skill::operator>>( IStreamBase & stream, SecSkills & ss )
     std::vector<Secondary> & v = ss;
     stream >> v;
 
-    if ( v.size() > HEROESMAXSKILL )
+    if ( v.size() > HEROESMAXSKILL ) {
         v.resize( HEROESMAXSKILL );
+    }
+
     return stream;
 }

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -29,11 +29,13 @@
 #include <utility>
 #include <vector>
 
-void StringAppendModifiers( std::string &, int );
+class IStreamBase;
+class OStreamBase;
 
 class Heroes;
 class HeroBase;
-class StreamBase;
+
+void StringAppendModifiers( std::string &, int );
 
 namespace Skill
 {
@@ -122,8 +124,6 @@ namespace Skill
         static const char * String( int );
     };
 
-    StreamBase & operator>>( StreamBase &, Secondary & );
-
     class SecSkills final : protected std::vector<Secondary>
     {
     public:
@@ -154,12 +154,9 @@ namespace Skill
         const std::vector<Secondary> & ToVector() const;
 
     protected:
-        friend StreamBase & operator<<( StreamBase &, const SecSkills & );
-        friend StreamBase & operator>>( StreamBase &, SecSkills & );
+        friend OStreamBase & operator<<( OStreamBase & stream, const SecSkills & ss );
+        friend IStreamBase & operator>>( IStreamBase & stream, SecSkills & ss );
     };
-
-    StreamBase & operator<<( StreamBase &, const SecSkills & );
-    StreamBase & operator>>( StreamBase &, SecSkills & );
 
     class Primary
     {
@@ -200,8 +197,8 @@ namespace Skill
     protected:
         void LoadDefaults( int type, int race );
 
-        friend StreamBase & operator<<( StreamBase &, const Primary & );
-        friend StreamBase & operator>>( StreamBase &, Primary & );
+        friend OStreamBase & operator<<( OStreamBase & stream, const Primary & skill );
+        friend IStreamBase & operator>>( IStreamBase & stream, Primary & skill );
 
         int attack;
         int defense;
@@ -209,7 +206,7 @@ namespace Skill
         int knowledge;
     };
 
-    StreamBase & operator<<( StreamBase &, const Primary & );
-    StreamBase & operator>>( StreamBase &, Primary & );
+    OStreamBase & operator<<( OStreamBase & stream, const Primary & skill );
+    IStreamBase & operator>>( IStreamBase & stream, Primary & skill );
 }
 #endif

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -206,6 +206,9 @@ namespace Skill
         int knowledge;
     };
 
+    OStreamBase & operator<<( OStreamBase & stream, const SecSkills & ss );
+    IStreamBase & operator>>( IStreamBase & stream, SecSkills & ss );
+
     OStreamBase & operator<<( OStreamBase & stream, const Primary & skill );
     IStreamBase & operator>>( IStreamBase & stream, Primary & skill );
 }

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -153,7 +153,7 @@ namespace Skill
         std::vector<Secondary> & ToVector();
         const std::vector<Secondary> & ToVector() const;
 
-    protected:
+    private:
         friend OStreamBase & operator<<( OStreamBase & stream, const SecSkills & ss );
         friend IStreamBase & operator>>( IStreamBase & stream, SecSkills & ss );
     };

--- a/src/fheroes2/kingdom/color.cpp
+++ b/src/fheroes2/kingdom/color.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/kingdom/color.cpp
+++ b/src/fheroes2/kingdom/color.cpp
@@ -239,12 +239,12 @@ Kingdom & ColorBase::GetKingdom() const
     return world.GetKingdom( color );
 }
 
-StreamBase & operator<<( StreamBase & msg, const ColorBase & col )
+OStreamBase & operator<<( OStreamBase & stream, const ColorBase & col )
 {
-    return msg << col.color;
+    return stream << col.color;
 }
 
-StreamBase & operator>>( StreamBase & msg, ColorBase & col )
+IStreamBase & operator>>( IStreamBase & stream, ColorBase & col )
 {
-    return msg >> col.color;
+    return stream >> col.color;
 }

--- a/src/fheroes2/kingdom/color.h
+++ b/src/fheroes2/kingdom/color.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/kingdom/color.h
+++ b/src/fheroes2/kingdom/color.h
@@ -27,7 +27,8 @@
 #include <string>
 #include <vector>
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 namespace fheroes2
 {
@@ -73,8 +74,8 @@ class ColorBase
 {
     int color;
 
-    friend StreamBase & operator<<( StreamBase &, const ColorBase & );
-    friend StreamBase & operator>>( StreamBase &, ColorBase & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const ColorBase & col );
+    friend IStreamBase & operator>>( IStreamBase & stream, ColorBase & col );
 
 public:
     explicit ColorBase( int col = Color::NONE )
@@ -91,8 +92,5 @@ public:
         return color;
     }
 };
-
-StreamBase & operator<<( StreamBase &, const ColorBase & );
-StreamBase & operator>>( StreamBase &, ColorBase & );
 
 #endif

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -998,45 +998,45 @@ Cost Kingdom::_getKingdomStartingResources( const int difficulty ) const
     return { 7500, 20, 5, 20, 5, 5, 5 };
 }
 
-StreamBase & operator<<( StreamBase & msg, const Kingdom & kingdom )
+OStreamBase & operator<<( OStreamBase & stream, const Kingdom & kingdom )
 {
-    return msg << kingdom.modes << kingdom.color << kingdom.resource << kingdom.lost_town_days << kingdom.castles << kingdom.heroes << kingdom.recruits
-               << kingdom.visit_object << kingdom.puzzle_maps << kingdom.visited_tents_colors << kingdom._topCastleInKingdomView << kingdom._topHeroInKingdomView;
+    return stream << kingdom.modes << kingdom.color << kingdom.resource << kingdom.lost_town_days << kingdom.castles << kingdom.heroes << kingdom.recruits
+                  << kingdom.visit_object << kingdom.puzzle_maps << kingdom.visited_tents_colors << kingdom._topCastleInKingdomView << kingdom._topHeroInKingdomView;
 }
 
-StreamBase & operator>>( StreamBase & msg, Kingdom & kingdom )
+IStreamBase & operator>>( IStreamBase & stream, Kingdom & kingdom )
 {
-    msg >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits >> kingdom.visit_object
-        >> kingdom.puzzle_maps >> kingdom.visited_tents_colors;
+    stream >> kingdom.modes >> kingdom.color >> kingdom.resource >> kingdom.lost_town_days >> kingdom.castles >> kingdom.heroes >> kingdom.recruits
+        >> kingdom.visit_object >> kingdom.puzzle_maps >> kingdom.visited_tents_colors;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1100_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1100_RELEASE ) {
         int dummy;
 
-        msg >> dummy;
+        stream >> dummy;
     }
 
-    return msg >> kingdom._topCastleInKingdomView >> kingdom._topHeroInKingdomView;
+    return stream >> kingdom._topCastleInKingdomView >> kingdom._topHeroInKingdomView;
 }
 
-StreamBase & operator<<( StreamBase & msg, const Kingdoms & obj )
+OStreamBase & operator<<( OStreamBase & stream, const Kingdoms & obj )
 {
-    msg << Kingdoms::_size;
+    stream << Kingdoms::_size;
     for ( const Kingdom & kingdom : obj.kingdoms )
-        msg << kingdom;
+        stream << kingdom;
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, Kingdoms & obj )
+IStreamBase & operator>>( IStreamBase & stream, Kingdoms & obj )
 {
     uint32_t kingdomscount = 0;
-    msg >> kingdomscount;
+    stream >> kingdomscount;
 
     if ( kingdomscount <= Kingdoms::_size ) {
         for ( uint32_t i = 0; i < kingdomscount; ++i )
-            msg >> obj.kingdoms[i];
+            stream >> obj.kingdoms[i];
     }
 
-    return msg;
+    return stream;
 }

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -40,7 +40,8 @@
 #include "puzzle.h"
 #include "resource.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 struct EventDate;
 
@@ -206,8 +207,8 @@ public:
 private:
     Cost _getKingdomStartingResources( const int difficulty ) const;
 
-    friend StreamBase & operator<<( StreamBase &, const Kingdom & );
-    friend StreamBase & operator>>( StreamBase &, Kingdom & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Kingdom & kingdom );
+    friend IStreamBase & operator>>( IStreamBase & stream, Kingdom & kingdom );
 
     int color;
     Funds resource;
@@ -257,17 +258,11 @@ public:
     std::set<Heroes *> resetRecruits();
 
 private:
-    friend StreamBase & operator<<( StreamBase &, const Kingdoms & );
-    friend StreamBase & operator>>( StreamBase &, Kingdoms & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Kingdoms & obj );
+    friend IStreamBase & operator>>( IStreamBase & stream, Kingdoms & obj );
 
     static constexpr uint32_t _size = KINGDOMMAX + 1;
     Kingdom kingdoms[_size];
 };
-
-StreamBase & operator<<( StreamBase &, const Kingdom & );
-StreamBase & operator>>( StreamBase &, Kingdom & );
-
-StreamBase & operator<<( StreamBase &, const Kingdoms & );
-StreamBase & operator>>( StreamBase &, Kingdoms & );
 
 #endif

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -342,58 +342,58 @@ void Puzzle::ShowMapsDialog() const
     }
 }
 
-StreamBase & operator<<( StreamBase & msg, const Puzzle & pzl )
+OStreamBase & operator<<( OStreamBase & stream, const Puzzle & pzl )
 {
-    msg << pzl.to_string<char, std::char_traits<char>, std::allocator<char>>();
+    stream << pzl.to_string<char, std::char_traits<char>, std::allocator<char>>();
 
     // orders
-    msg << static_cast<uint8_t>( pzl.zone1_order.size() );
+    stream << static_cast<uint8_t>( pzl.zone1_order.size() );
     for ( const uint8_t tile : pzl.zone1_order )
-        msg << tile;
+        stream << tile;
 
-    msg << static_cast<uint8_t>( pzl.zone2_order.size() );
+    stream << static_cast<uint8_t>( pzl.zone2_order.size() );
     for ( const uint8_t tile : pzl.zone2_order )
-        msg << tile;
+        stream << tile;
 
-    msg << static_cast<uint8_t>( pzl.zone3_order.size() );
+    stream << static_cast<uint8_t>( pzl.zone3_order.size() );
     for ( const uint8_t tile : pzl.zone3_order )
-        msg << tile;
+        stream << tile;
 
-    msg << static_cast<uint8_t>( pzl.zone4_order.size() );
+    stream << static_cast<uint8_t>( pzl.zone4_order.size() );
     for ( const uint8_t tile : pzl.zone4_order )
-        msg << tile;
+        stream << tile;
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, Puzzle & pzl )
+IStreamBase & operator>>( IStreamBase & stream, Puzzle & pzl )
 {
     std::string str;
 
-    msg >> str;
+    stream >> str;
     pzl = str.c_str();
 
     uint8_t size;
 
-    msg >> size;
+    stream >> size;
     pzl.zone1_order.resize( size );
     for ( uint8_t ii = 0; ii < size; ++ii )
-        msg >> pzl.zone1_order[ii];
+        stream >> pzl.zone1_order[ii];
 
-    msg >> size;
+    stream >> size;
     pzl.zone2_order.resize( size );
     for ( uint8_t ii = 0; ii < size; ++ii )
-        msg >> pzl.zone2_order[ii];
+        stream >> pzl.zone2_order[ii];
 
-    msg >> size;
+    stream >> size;
     pzl.zone3_order.resize( size );
     for ( uint8_t ii = 0; ii < size; ++ii )
-        msg >> pzl.zone3_order[ii];
+        stream >> pzl.zone3_order[ii];
 
-    msg >> size;
+    stream >> size;
     pzl.zone4_order.resize( size );
     for ( uint8_t ii = 0; ii < size; ++ii )
-        msg >> pzl.zone4_order[ii];
+        stream >> pzl.zone4_order[ii];
 
-    return msg;
+    return stream;
 }

--- a/src/fheroes2/kingdom/puzzle.h
+++ b/src/fheroes2/kingdom/puzzle.h
@@ -30,7 +30,8 @@
 
 #define PUZZLETILES 48
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class Puzzle : public std::bitset<PUZZLETILES>
 {
@@ -48,7 +49,7 @@ public:
     std::vector<uint8_t> zone4_order{ 20, 21, 26, 27 };
 };
 
-StreamBase & operator<<( StreamBase &, const Puzzle & );
-StreamBase & operator>>( StreamBase &, Puzzle & );
+OStreamBase & operator<<( OStreamBase & stream, const Puzzle & pzl );
+IStreamBase & operator>>( IStreamBase & stream, Puzzle & pzl );
 
 #endif

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -210,7 +210,7 @@ namespace
         }
 
         RWStreamBuf compressed;
-        compressed.setbigendian( true );
+        compressed.setBigendian( true );
 
         compressed << map.additionalInfo << map.tiles << map.dailyEvents << map.rumors << map.standardMetadata << map.castleMetadata << map.heroMetadata
                    << map.sphinxMetadata << map.signMetadata << map.adventureMapEventMetadata << map.shrineMetadata;
@@ -231,7 +231,7 @@ namespace
         }
 
         RWStreamBuf decompressed;
-        decompressed.setbigendian( true );
+        decompressed.setBigendian( true );
 
         {
             std::vector<uint8_t> temp = stream.getRaw();
@@ -406,7 +406,7 @@ namespace Maps::Map_Format
         }
 
         StreamFile fileStream;
-        fileStream.setbigendian( true );
+        fileStream.setBigendian( true );
 
         if ( !fileStream.open( path, "rb" ) ) {
             return false;
@@ -433,7 +433,7 @@ namespace Maps::Map_Format
         }
 
         StreamFile fileStream;
-        fileStream.setbigendian( true );
+        fileStream.setBigendian( true );
 
         if ( !fileStream.open( path, "rb" ) ) {
             return false;
@@ -460,7 +460,7 @@ namespace Maps::Map_Format
         }
 
         StreamFile fileStream;
-        fileStream.setbigendian( true );
+        fileStream.setBigendian( true );
 
         if ( !fileStream.open( path, "wb" ) ) {
             return false;

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -31,35 +31,35 @@ namespace Maps::Map_Format
 {
     // The following operators are used only inside this module, but they cannot be declared in an anonymous namespace due to the way ADL works
 
-    StreamBase & operator<<( StreamBase & msg, const TileObjectInfo & object );
-    StreamBase & operator>>( StreamBase & msg, TileObjectInfo & object );
+    OStreamBase & operator<<( OStreamBase & stream, const TileObjectInfo & object );
+    IStreamBase & operator>>( IStreamBase & stream, TileObjectInfo & object );
 
-    StreamBase & operator<<( StreamBase & msg, const TileInfo & tile );
-    StreamBase & operator>>( StreamBase & msg, TileInfo & tile );
+    OStreamBase & operator<<( OStreamBase & stream, const TileInfo & tile );
+    IStreamBase & operator>>( IStreamBase & stream, TileInfo & tile );
 
-    StreamBase & operator<<( StreamBase & msg, const DailyEvent & eventInfo );
-    StreamBase & operator>>( StreamBase & msg, DailyEvent & eventInfo );
+    OStreamBase & operator<<( OStreamBase & stream, const DailyEvent & eventInfo );
+    IStreamBase & operator>>( IStreamBase & stream, DailyEvent & eventInfo );
 
-    StreamBase & operator<<( StreamBase & msg, const StandardObjectMetadata & metadata );
-    StreamBase & operator>>( StreamBase & msg, StandardObjectMetadata & metadata );
+    OStreamBase & operator<<( OStreamBase & stream, const StandardObjectMetadata & metadata );
+    IStreamBase & operator>>( IStreamBase & stream, StandardObjectMetadata & metadata );
 
-    StreamBase & operator<<( StreamBase & msg, const CastleMetadata & metadata );
-    StreamBase & operator>>( StreamBase & msg, CastleMetadata & metadata );
+    OStreamBase & operator<<( OStreamBase & stream, const CastleMetadata & metadata );
+    IStreamBase & operator>>( IStreamBase & stream, CastleMetadata & metadata );
 
-    StreamBase & operator<<( StreamBase & msg, const HeroMetadata & metadata );
-    StreamBase & operator>>( StreamBase & msg, HeroMetadata & metadata );
+    OStreamBase & operator<<( OStreamBase & stream, const HeroMetadata & metadata );
+    IStreamBase & operator>>( IStreamBase & stream, HeroMetadata & metadata );
 
-    StreamBase & operator<<( StreamBase & msg, const SphinxMetadata & metadata );
-    StreamBase & operator>>( StreamBase & msg, SphinxMetadata & metadata );
+    OStreamBase & operator<<( OStreamBase & stream, const SphinxMetadata & metadata );
+    IStreamBase & operator>>( IStreamBase & stream, SphinxMetadata & metadata );
 
-    StreamBase & operator<<( StreamBase & msg, const SignMetadata & metadata );
-    StreamBase & operator>>( StreamBase & msg, SignMetadata & metadata );
+    OStreamBase & operator<<( OStreamBase & stream, const SignMetadata & metadata );
+    IStreamBase & operator>>( IStreamBase & stream, SignMetadata & metadata );
 
-    StreamBase & operator<<( StreamBase & msg, const AdventureMapEventMetadata & metadata );
-    StreamBase & operator>>( StreamBase & msg, AdventureMapEventMetadata & metadata );
+    OStreamBase & operator<<( OStreamBase & stream, const AdventureMapEventMetadata & metadata );
+    IStreamBase & operator>>( IStreamBase & stream, AdventureMapEventMetadata & metadata );
 
-    StreamBase & operator<<( StreamBase & msg, const ShrineMetadata & metadata );
-    StreamBase & operator>>( StreamBase & msg, ShrineMetadata & metadata );
+    OStreamBase & operator<<( OStreamBase & stream, const ShrineMetadata & metadata );
+    IStreamBase & operator>>( IStreamBase & stream, ShrineMetadata & metadata );
 }
 
 namespace
@@ -161,26 +161,26 @@ namespace
         }
     }
 
-    bool saveToStream( StreamBase & msg, const Maps::Map_Format::BaseMapFormat & map )
+    bool saveToStream( OStreamBase & stream, const Maps::Map_Format::BaseMapFormat & map )
     {
         using LanguageUnderlyingType = std::underlying_type_t<decltype( map.language )>;
 
-        msg << currentSupportedVersion << map.isCampaign << map.difficulty << map.availablePlayerColors << map.humanPlayerColors << map.computerPlayerColors
-            << map.alliances << map.playerRace << map.victoryConditionType << map.isVictoryConditionApplicableForAI << map.allowNormalVictory
-            << map.victoryConditionMetadata << map.lossConditionType << map.lossConditionMetadata << map.size << static_cast<LanguageUnderlyingType>( map.language )
-            << map.name << map.description;
+        stream << currentSupportedVersion << map.isCampaign << map.difficulty << map.availablePlayerColors << map.humanPlayerColors << map.computerPlayerColors
+               << map.alliances << map.playerRace << map.victoryConditionType << map.isVictoryConditionApplicableForAI << map.allowNormalVictory
+               << map.victoryConditionMetadata << map.lossConditionType << map.lossConditionMetadata << map.size << static_cast<LanguageUnderlyingType>( map.language )
+               << map.name << map.description;
 
-        return !msg.fail();
+        return !stream.fail();
     }
 
-    bool loadFromStream( StreamBase & msg, Maps::Map_Format::BaseMapFormat & map )
+    bool loadFromStream( IStreamBase & stream, Maps::Map_Format::BaseMapFormat & map )
     {
-        msg >> map.version;
+        stream >> map.version;
         if ( map.version < minimumSupportedVersion || map.version > currentSupportedVersion ) {
             return false;
         }
 
-        msg >> map.isCampaign >> map.difficulty >> map.availablePlayerColors >> map.humanPlayerColors >> map.computerPlayerColors >> map.alliances >> map.playerRace
+        stream >> map.isCampaign >> map.difficulty >> map.availablePlayerColors >> map.humanPlayerColors >> map.computerPlayerColors >> map.alliances >> map.playerRace
             >> map.victoryConditionType >> map.isVictoryConditionApplicableForAI >> map.allowNormalVictory >> map.victoryConditionMetadata >> map.lossConditionType
             >> map.lossConditionMetadata >> map.size;
 
@@ -193,19 +193,19 @@ namespace
         static_assert( std::is_same_v<LanguageUnderlyingType, uint8_t>, "Type of language has been changed, check the logic below" );
         LanguageUnderlyingType language;
 
-        msg >> language;
+        stream >> language;
         map.language = static_cast<fheroes2::SupportedLanguage>( language );
 
-        msg >> map.name >> map.description;
+        stream >> map.name >> map.description;
 
-        return !msg.fail();
+        return !stream.fail();
     }
 
-    bool saveToStream( StreamBase & msg, const Maps::Map_Format::MapFormat & map )
+    bool saveToStream( OStreamBase & stream, const Maps::Map_Format::MapFormat & map )
     {
         // Only the base map information is not encoded.
         // The rest of data must be compressed to prevent manual corruption of the file.
-        if ( !saveToStream( msg, static_cast<const Maps::Map_Format::BaseMapFormat &>( map ) ) ) {
+        if ( !saveToStream( stream, static_cast<const Maps::Map_Format::BaseMapFormat &>( map ) ) ) {
             return false;
         }
 
@@ -217,15 +217,15 @@ namespace
 
         const std::vector<uint8_t> temp = Compression::compressData( compressed.data(), compressed.size() );
 
-        msg.putRaw( temp.data(), temp.size() );
+        stream.putRaw( temp.data(), temp.size() );
 
-        return !msg.fail();
+        return !stream.fail();
     }
 
-    bool loadFromStream( StreamBase & msg, Maps::Map_Format::MapFormat & map )
+    bool loadFromStream( IStreamBase & stream, Maps::Map_Format::MapFormat & map )
     {
         // TODO: verify the correctness of metadata.
-        if ( !loadFromStream( msg, static_cast<Maps::Map_Format::BaseMapFormat &>( map ) ) ) {
+        if ( !loadFromStream( stream, static_cast<Maps::Map_Format::BaseMapFormat &>( map ) ) ) {
             map = {};
             return false;
         }
@@ -234,7 +234,7 @@ namespace
         decompressed.setbigendian( true );
 
         {
-            std::vector<uint8_t> temp = msg.getRaw();
+            std::vector<uint8_t> temp = stream.getRaw();
             if ( temp.empty() ) {
                 // This is a corrupted file.
                 map = {};
@@ -269,134 +269,134 @@ namespace
         convertFromV3ToV4( map );
         convertFromV4ToV5( map );
 
-        return !msg.fail();
+        return !stream.fail();
     }
 }
 
 namespace Maps::Map_Format
 {
-    StreamBase & operator<<( StreamBase & msg, const TileObjectInfo & object )
+    OStreamBase & operator<<( OStreamBase & stream, const TileObjectInfo & object )
     {
         using GroupUnderlyingType = std::underlying_type_t<decltype( object.group )>;
 
-        return msg << object.id << static_cast<GroupUnderlyingType>( object.group ) << object.index;
+        return stream << object.id << static_cast<GroupUnderlyingType>( object.group ) << object.index;
     }
 
-    StreamBase & operator>>( StreamBase & msg, TileObjectInfo & object )
+    IStreamBase & operator>>( IStreamBase & stream, TileObjectInfo & object )
     {
-        msg >> object.id;
+        stream >> object.id;
 
         using GroupUnderlyingType = std::underlying_type_t<decltype( object.group )>;
         GroupUnderlyingType group;
-        msg >> group;
+        stream >> group;
 
         object.group = static_cast<ObjectGroup>( group );
 
-        return msg >> object.index;
+        return stream >> object.index;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const TileInfo & tile )
+    OStreamBase & operator<<( OStreamBase & stream, const TileInfo & tile )
     {
-        return msg << tile.terrainIndex << tile.terrainFlag << tile.objects;
+        return stream << tile.terrainIndex << tile.terrainFlag << tile.objects;
     }
 
-    StreamBase & operator>>( StreamBase & msg, TileInfo & tile )
+    IStreamBase & operator>>( IStreamBase & stream, TileInfo & tile )
     {
-        return msg >> tile.terrainIndex >> tile.terrainFlag >> tile.objects;
+        return stream >> tile.terrainIndex >> tile.terrainFlag >> tile.objects;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const DailyEvent & eventInfo )
+    OStreamBase & operator<<( OStreamBase & stream, const DailyEvent & eventInfo )
     {
-        return msg << eventInfo.message << eventInfo.humanPlayerColors << eventInfo.computerPlayerColors << eventInfo.firstOccurrenceDay << eventInfo.repeatPeriodInDays
-                   << eventInfo.resources;
+        return stream << eventInfo.message << eventInfo.humanPlayerColors << eventInfo.computerPlayerColors << eventInfo.firstOccurrenceDay
+                      << eventInfo.repeatPeriodInDays << eventInfo.resources;
     }
 
-    StreamBase & operator>>( StreamBase & msg, DailyEvent & eventInfo )
+    IStreamBase & operator>>( IStreamBase & stream, DailyEvent & eventInfo )
     {
-        return msg >> eventInfo.message >> eventInfo.humanPlayerColors >> eventInfo.computerPlayerColors >> eventInfo.firstOccurrenceDay >> eventInfo.repeatPeriodInDays
-               >> eventInfo.resources;
+        return stream >> eventInfo.message >> eventInfo.humanPlayerColors >> eventInfo.computerPlayerColors >> eventInfo.firstOccurrenceDay
+               >> eventInfo.repeatPeriodInDays >> eventInfo.resources;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const StandardObjectMetadata & metadata )
+    OStreamBase & operator<<( OStreamBase & stream, const StandardObjectMetadata & metadata )
     {
-        return msg << metadata.metadata;
+        return stream << metadata.metadata;
     }
 
-    StreamBase & operator>>( StreamBase & msg, StandardObjectMetadata & metadata )
+    IStreamBase & operator>>( IStreamBase & stream, StandardObjectMetadata & metadata )
     {
-        return msg >> metadata.metadata;
+        return stream >> metadata.metadata;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const CastleMetadata & metadata )
+    OStreamBase & operator<<( OStreamBase & stream, const CastleMetadata & metadata )
     {
-        return msg << metadata.customName << metadata.defenderMonsterType << metadata.defenderMonsterCount << metadata.customBuildings << metadata.builtBuildings
-                   << metadata.bannedBuildings << metadata.mustHaveSpells << metadata.bannedSpells << metadata.availableToHireMonsterCount;
+        return stream << metadata.customName << metadata.defenderMonsterType << metadata.defenderMonsterCount << metadata.customBuildings << metadata.builtBuildings
+                      << metadata.bannedBuildings << metadata.mustHaveSpells << metadata.bannedSpells << metadata.availableToHireMonsterCount;
     }
 
-    StreamBase & operator>>( StreamBase & msg, CastleMetadata & metadata )
+    IStreamBase & operator>>( IStreamBase & stream, CastleMetadata & metadata )
     {
-        return msg >> metadata.customName >> metadata.defenderMonsterType >> metadata.defenderMonsterCount >> metadata.customBuildings >> metadata.builtBuildings
+        return stream >> metadata.customName >> metadata.defenderMonsterType >> metadata.defenderMonsterCount >> metadata.customBuildings >> metadata.builtBuildings
                >> metadata.bannedBuildings >> metadata.mustHaveSpells >> metadata.bannedSpells >> metadata.availableToHireMonsterCount;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const HeroMetadata & metadata )
+    OStreamBase & operator<<( OStreamBase & stream, const HeroMetadata & metadata )
     {
-        return msg << metadata.customName << metadata.customPortrait << metadata.armyMonsterType << metadata.armyMonsterCount << metadata.artifact
-                   << metadata.artifactMetadata << metadata.availableSpells << metadata.isOnPatrol << metadata.patrolRadius << metadata.secondarySkill
-                   << metadata.secondarySkillLevel << metadata.customLevel << metadata.customExperience << metadata.customAttack << metadata.customDefense
-                   << metadata.customKnowledge << metadata.customSpellPower << metadata.magicPoints << metadata.race;
+        return stream << metadata.customName << metadata.customPortrait << metadata.armyMonsterType << metadata.armyMonsterCount << metadata.artifact
+                      << metadata.artifactMetadata << metadata.availableSpells << metadata.isOnPatrol << metadata.patrolRadius << metadata.secondarySkill
+                      << metadata.secondarySkillLevel << metadata.customLevel << metadata.customExperience << metadata.customAttack << metadata.customDefense
+                      << metadata.customKnowledge << metadata.customSpellPower << metadata.magicPoints << metadata.race;
     }
 
-    StreamBase & operator>>( StreamBase & msg, HeroMetadata & metadata )
+    IStreamBase & operator>>( IStreamBase & stream, HeroMetadata & metadata )
     {
-        return msg >> metadata.customName >> metadata.customPortrait >> metadata.armyMonsterType >> metadata.armyMonsterCount >> metadata.artifact
+        return stream >> metadata.customName >> metadata.customPortrait >> metadata.armyMonsterType >> metadata.armyMonsterCount >> metadata.artifact
                >> metadata.artifactMetadata >> metadata.availableSpells >> metadata.isOnPatrol >> metadata.patrolRadius >> metadata.secondarySkill
                >> metadata.secondarySkillLevel >> metadata.customLevel >> metadata.customExperience >> metadata.customAttack >> metadata.customDefense
                >> metadata.customKnowledge >> metadata.customSpellPower >> metadata.magicPoints >> metadata.race;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const SphinxMetadata & metadata )
+    OStreamBase & operator<<( OStreamBase & stream, const SphinxMetadata & metadata )
     {
-        return msg << metadata.riddle << metadata.answers << metadata.artifact << metadata.artifactMetadata << metadata.resources;
+        return stream << metadata.riddle << metadata.answers << metadata.artifact << metadata.artifactMetadata << metadata.resources;
     }
 
-    StreamBase & operator>>( StreamBase & msg, SphinxMetadata & metadata )
+    IStreamBase & operator>>( IStreamBase & stream, SphinxMetadata & metadata )
     {
-        return msg >> metadata.riddle >> metadata.answers >> metadata.artifact >> metadata.artifactMetadata >> metadata.resources;
+        return stream >> metadata.riddle >> metadata.answers >> metadata.artifact >> metadata.artifactMetadata >> metadata.resources;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const SignMetadata & metadata )
+    OStreamBase & operator<<( OStreamBase & stream, const SignMetadata & metadata )
     {
-        return msg << metadata.message;
+        return stream << metadata.message;
     }
 
-    StreamBase & operator>>( StreamBase & msg, SignMetadata & metadata )
+    IStreamBase & operator>>( IStreamBase & stream, SignMetadata & metadata )
     {
-        return msg >> metadata.message;
+        return stream >> metadata.message;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const AdventureMapEventMetadata & metadata )
+    OStreamBase & operator<<( OStreamBase & stream, const AdventureMapEventMetadata & metadata )
     {
-        return msg << metadata.message << metadata.humanPlayerColors << metadata.computerPlayerColors << metadata.isRecurringEvent << metadata.artifact
-                   << metadata.artifactMetadata << metadata.resources << metadata.attack << metadata.defense << metadata.knowledge << metadata.spellPower
-                   << metadata.experience << metadata.secondarySkill << metadata.secondarySkillLevel << metadata.monsterType << metadata.monsterCount;
+        return stream << metadata.message << metadata.humanPlayerColors << metadata.computerPlayerColors << metadata.isRecurringEvent << metadata.artifact
+                      << metadata.artifactMetadata << metadata.resources << metadata.attack << metadata.defense << metadata.knowledge << metadata.spellPower
+                      << metadata.experience << metadata.secondarySkill << metadata.secondarySkillLevel << metadata.monsterType << metadata.monsterCount;
     }
 
-    StreamBase & operator>>( StreamBase & msg, AdventureMapEventMetadata & metadata )
+    IStreamBase & operator>>( IStreamBase & stream, AdventureMapEventMetadata & metadata )
     {
-        return msg >> metadata.message >> metadata.humanPlayerColors >> metadata.computerPlayerColors >> metadata.isRecurringEvent >> metadata.artifact
+        return stream >> metadata.message >> metadata.humanPlayerColors >> metadata.computerPlayerColors >> metadata.isRecurringEvent >> metadata.artifact
                >> metadata.artifactMetadata >> metadata.resources >> metadata.attack >> metadata.defense >> metadata.knowledge >> metadata.spellPower
                >> metadata.experience >> metadata.secondarySkill >> metadata.secondarySkillLevel >> metadata.monsterType >> metadata.monsterCount;
     }
 
-    StreamBase & operator<<( StreamBase & msg, const ShrineMetadata & metadata )
+    OStreamBase & operator<<( OStreamBase & stream, const ShrineMetadata & metadata )
     {
-        return msg << metadata.allowedSpells;
+        return stream << metadata.allowedSpells;
     }
 
-    StreamBase & operator>>( StreamBase & msg, ShrineMetadata & metadata )
+    IStreamBase & operator>>( IStreamBase & stream, ShrineMetadata & metadata )
     {
-        return msg >> metadata.allowedSpells;
+        return stream >> metadata.allowedSpells;
     }
 
     bool loadBaseMap( const std::string & path, BaseMapFormat & map )

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -209,7 +209,7 @@ namespace
             return false;
         }
 
-        StreamBuf compressed;
+        RWStreamBuf compressed;
         compressed.setbigendian( true );
 
         compressed << map.additionalInfo << map.tiles << map.dailyEvents << map.rumors << map.standardMetadata << map.castleMetadata << map.heroMetadata
@@ -230,7 +230,7 @@ namespace
             return false;
         }
 
-        StreamBuf decompressed;
+        RWStreamBuf decompressed;
         decompressed.setbigendian( true );
 
         {

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -627,32 +627,32 @@ bool Maps::FileInfo::WinsCompAlsoWins() const
     return compAlsoWins && ( ( GameOver::WINS_TOWN | GameOver::WINS_GOLD ) & ConditionWins() );
 }
 
-StreamBase & Maps::operator<<( StreamBase & msg, const FileInfo & fi )
+OStreamBase & Maps::operator<<( OStreamBase & stream, const FileInfo & fi )
 {
     using VersionUnderlyingType = std::underlying_type_t<decltype( fi.version )>;
 
     // Only the basename of map filename (fi.file) is saved
-    msg << System::GetBasename( fi.filename ) << fi.name << fi.description << fi.width << fi.height << fi.difficulty << static_cast<uint8_t>( KINGDOMMAX );
+    stream << System::GetBasename( fi.filename ) << fi.name << fi.description << fi.width << fi.height << fi.difficulty << static_cast<uint8_t>( KINGDOMMAX );
 
     static_assert( std::is_same_v<decltype( fi.races ), std::array<uint8_t, KINGDOMMAX>>, "Type of races has been changed, check the logic below" );
     static_assert( std::is_same_v<decltype( fi.unions ), std::array<uint8_t, KINGDOMMAX>>, "Type of unions has been changed, check the logic below" );
 
     for ( size_t i = 0; i < KINGDOMMAX; ++i ) {
-        msg << fi.races[i] << fi.unions[i];
+        stream << fi.races[i] << fi.unions[i];
     }
 
-    return msg << fi.kingdomColors << fi.colorsAvailableForHumans << fi.colorsAvailableForComp << fi.colorsOfRandomRaces << fi.victoryConditionType << fi.compAlsoWins
-               << fi.allowNormalVictory << fi.victoryConditionParams[0] << fi.victoryConditionParams[1] << fi.lossConditionType << fi.lossConditionParams[0]
-               << fi.lossConditionParams[1] << fi.timestamp << fi.startWithHeroInFirstCastle << static_cast<VersionUnderlyingType>( fi.version ) << fi.worldDay
-               << fi.worldWeek << fi.worldMonth;
+    return stream << fi.kingdomColors << fi.colorsAvailableForHumans << fi.colorsAvailableForComp << fi.colorsOfRandomRaces << fi.victoryConditionType << fi.compAlsoWins
+                  << fi.allowNormalVictory << fi.victoryConditionParams[0] << fi.victoryConditionParams[1] << fi.lossConditionType << fi.lossConditionParams[0]
+                  << fi.lossConditionParams[1] << fi.timestamp << fi.startWithHeroInFirstCastle << static_cast<VersionUnderlyingType>( fi.version ) << fi.worldDay
+                  << fi.worldWeek << fi.worldMonth;
 }
 
-StreamBase & Maps::operator>>( StreamBase & msg, FileInfo & fi )
+IStreamBase & Maps::operator>>( IStreamBase & stream, FileInfo & fi )
 {
     uint8_t kingdommax = 0;
 
     // Only the basename of map filename (fi.file) is loaded
-    msg >> fi.filename >> fi.name >> fi.description >> fi.width >> fi.height >> fi.difficulty >> kingdommax;
+    stream >> fi.filename >> fi.name >> fi.description >> fi.width >> fi.height >> fi.difficulty >> kingdommax;
 
     static_assert( std::is_same_v<decltype( fi.races ), std::array<uint8_t, KINGDOMMAX>>, "Type of races has been changed, check the logic below" );
     static_assert( std::is_same_v<decltype( fi.unions ), std::array<uint8_t, KINGDOMMAX>>, "Type of unions has been changed, check the logic below" );
@@ -664,7 +664,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, FileInfo & fi )
         RacesItemType racesItem = 0;
         UnionsItemType unionsItem = 0;
 
-        msg >> racesItem >> unionsItem;
+        stream >> racesItem >> unionsItem;
 
         if ( i < KINGDOMMAX ) {
             fi.races[i] = racesItem;
@@ -672,7 +672,7 @@ StreamBase & Maps::operator>>( StreamBase & msg, FileInfo & fi )
         }
     }
 
-    msg >> fi.kingdomColors >> fi.colorsAvailableForHumans >> fi.colorsAvailableForComp >> fi.colorsOfRandomRaces >> fi.victoryConditionType >> fi.compAlsoWins
+    stream >> fi.kingdomColors >> fi.colorsAvailableForHumans >> fi.colorsAvailableForComp >> fi.colorsOfRandomRaces >> fi.victoryConditionType >> fi.compAlsoWins
         >> fi.allowNormalVictory >> fi.victoryConditionParams[0] >> fi.victoryConditionParams[1] >> fi.lossConditionType >> fi.lossConditionParams[0]
         >> fi.lossConditionParams[1] >> fi.timestamp >> fi.startWithHeroInFirstCastle;
 
@@ -680,11 +680,11 @@ StreamBase & Maps::operator>>( StreamBase & msg, FileInfo & fi )
     static_assert( std::is_same_v<VersionUnderlyingType, int>, "Type of version has been changed, check the logic below" );
 
     VersionUnderlyingType version = 0;
-    msg >> version;
+    stream >> version;
 
     fi.version = static_cast<GameVersion>( version );
 
-    return msg >> fi.worldDay >> fi.worldWeek >> fi.worldMonth;
+    return stream >> fi.worldDay >> fi.worldWeek >> fi.worldMonth;
 }
 
 MapsFileInfoList Maps::getAllMapFileInfos( const bool isForEditor, const uint8_t humanPlayerCount )

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -32,7 +32,8 @@
 #include "gamedefs.h"
 #include "math_base.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 enum class GameVersion : int
 {
@@ -204,8 +205,8 @@ namespace Maps
         void FillUnions( const int side1Colors, const int side2Colors );
     };
 
-    StreamBase & operator<<( StreamBase &, const FileInfo & );
-    StreamBase & operator>>( StreamBase &, FileInfo & );
+    OStreamBase & operator<<( OStreamBase & stream, const FileInfo & fi );
+    IStreamBase & operator>>( IStreamBase & stream, FileInfo & fi );
 }
 
 using MapsFileInfoList = std::vector<Maps::FileInfo>;

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -102,7 +102,7 @@ void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & da
     // - string
     //    Null terminated string containing the event text.
 
-    StreamBuf dataStream( data );
+    ROStreamBuf dataStream( data );
 
     dataStream.skip( 1 );
 
@@ -222,7 +222,7 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
     // - string
     //    Question itself.
 
-    StreamBuf dataStream( data );
+    ROStreamBuf dataStream( data );
     const uint8_t magicNumber = dataStream.get();
     if ( magicNumber != 0 ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Sphinx data magic number " << static_cast<int>( magicNumber ) << " is incorrect." )
@@ -295,7 +295,7 @@ void MapSign::LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & 
     // - string
     //    Null terminated string.
 
-    StreamBuf dataStream( data );
+    ROStreamBuf dataStream( data );
     dataStream.skip( 9 );
     message = dataStream.toString();
 

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -314,52 +314,52 @@ void MapSign::setDefaultMessage()
     message = Rand::Get( randomMessage );
 }
 
-StreamBase & operator<<( StreamBase & msg, const MapObjectSimple & obj )
+OStreamBase & operator<<( OStreamBase & stream, const MapObjectSimple & obj )
 {
-    return msg << obj.type << obj.uid << static_cast<const MapPosition &>( obj );
+    return stream << obj.type << obj.uid << static_cast<const MapPosition &>( obj );
 }
 
-StreamBase & operator>>( StreamBase & msg, MapObjectSimple & obj )
+IStreamBase & operator>>( IStreamBase & stream, MapObjectSimple & obj )
 {
-    return msg >> obj.type >> obj.uid >> static_cast<MapPosition &>( obj );
+    return stream >> obj.type >> obj.uid >> static_cast<MapPosition &>( obj );
 }
 
-StreamBase & operator<<( StreamBase & msg, const MapEvent & obj )
+OStreamBase & operator<<( OStreamBase & stream, const MapEvent & obj )
 {
-    return msg << static_cast<const MapObjectSimple &>( obj ) << obj.resources << obj.artifact << obj.computer << obj.isSingleTimeEvent << obj.colors << obj.message;
+    return stream << static_cast<const MapObjectSimple &>( obj ) << obj.resources << obj.artifact << obj.computer << obj.isSingleTimeEvent << obj.colors << obj.message;
 }
 
-StreamBase & operator>>( StreamBase & msg, MapEvent & obj )
+IStreamBase & operator>>( IStreamBase & stream, MapEvent & obj )
 {
-    return msg >> static_cast<MapObjectSimple &>( obj ) >> obj.resources >> obj.artifact >> obj.computer >> obj.isSingleTimeEvent >> obj.colors >> obj.message;
+    return stream >> static_cast<MapObjectSimple &>( obj ) >> obj.resources >> obj.artifact >> obj.computer >> obj.isSingleTimeEvent >> obj.colors >> obj.message;
 }
 
-StreamBase & operator<<( StreamBase & msg, const MapSphinx & obj )
+OStreamBase & operator<<( OStreamBase & stream, const MapSphinx & obj )
 {
-    return msg << static_cast<const MapObjectSimple &>( obj ) << obj.resources << obj.artifact << obj.answers << obj.riddle << obj.valid << obj.isTruncatedAnswer;
+    return stream << static_cast<const MapObjectSimple &>( obj ) << obj.resources << obj.artifact << obj.answers << obj.riddle << obj.valid << obj.isTruncatedAnswer;
 }
 
-StreamBase & operator>>( StreamBase & msg, MapSphinx & obj )
+IStreamBase & operator>>( IStreamBase & stream, MapSphinx & obj )
 {
-    msg >> static_cast<MapObjectSimple &>( obj ) >> obj.resources >> obj.artifact >> obj.answers >> obj.riddle >> obj.valid;
+    stream >> static_cast<MapObjectSimple &>( obj ) >> obj.resources >> obj.artifact >> obj.answers >> obj.riddle >> obj.valid;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1100_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1100_RELEASE ) {
         obj.isTruncatedAnswer = true;
     }
     else {
-        msg >> obj.isTruncatedAnswer;
+        stream >> obj.isTruncatedAnswer;
     }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator<<( StreamBase & msg, const MapSign & obj )
+OStreamBase & operator<<( OStreamBase & stream, const MapSign & obj )
 {
-    return msg << static_cast<const MapObjectSimple &>( obj ) << obj.message;
+    return stream << static_cast<const MapObjectSimple &>( obj ) << obj.message;
 }
 
-StreamBase & operator>>( StreamBase & msg, MapSign & obj )
+IStreamBase & operator>>( IStreamBase & stream, MapSign & obj )
 {
-    return msg >> static_cast<MapObjectSimple &>( obj ) >> obj.message;
+    return stream >> static_cast<MapObjectSimple &>( obj ) >> obj.message;
 }

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -34,7 +34,8 @@
 #include "position.h"
 #include "resource.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class MapObjectSimple : public MapPosition
 {
@@ -70,8 +71,8 @@ public:
     }
 
 protected:
-    friend StreamBase & operator<<( StreamBase & msg, const MapObjectSimple & obj );
-    friend StreamBase & operator>>( StreamBase & msg, MapObjectSimple & obj );
+    friend OStreamBase & operator<<( OStreamBase & stream, const MapObjectSimple & obj );
+    friend IStreamBase & operator>>( IStreamBase & stream, MapObjectSimple & obj );
 
     uint32_t uid;
     int type;
@@ -172,16 +173,16 @@ struct MapSign : public MapObjectSimple
     std::string message;
 };
 
-StreamBase & operator<<( StreamBase & msg, const MapObjectSimple & obj );
-StreamBase & operator>>( StreamBase & msg, MapObjectSimple & obj );
+OStreamBase & operator<<( OStreamBase & stream, const MapObjectSimple & obj );
+IStreamBase & operator>>( IStreamBase & stream, MapObjectSimple & obj );
 
-StreamBase & operator<<( StreamBase & msg, const MapEvent & obj );
-StreamBase & operator>>( StreamBase & msg, MapEvent & obj );
+OStreamBase & operator<<( OStreamBase & stream, const MapEvent & obj );
+IStreamBase & operator>>( IStreamBase & stream, MapEvent & obj );
 
-StreamBase & operator<<( StreamBase & msg, const MapSphinx & obj );
-StreamBase & operator>>( StreamBase & msg, MapSphinx & obj );
+OStreamBase & operator<<( OStreamBase & stream, const MapSphinx & obj );
+IStreamBase & operator>>( IStreamBase & stream, MapSphinx & obj );
 
-StreamBase & operator<<( StreamBase & msg, const MapSign & obj );
-StreamBase & operator>>( StreamBase & msg, MapSign & obj );
+OStreamBase & operator<<( OStreamBase & stream, const MapSign & obj );
+IStreamBase & operator>>( IStreamBase & stream, MapSign & obj );
 
 #endif

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1822,74 +1822,74 @@ bool Maps::Tiles::isDetachedObject() const
     return false;
 }
 
-StreamBase & Maps::operator<<( StreamBase & msg, const TilesAddon & ta )
+OStreamBase & Maps::operator<<( OStreamBase & stream, const TilesAddon & ta )
 {
     using ObjectIcnTypeUnderlyingType = std::underlying_type_t<decltype( ta._objectIcnType )>;
 
-    return msg << ta._layerType << ta._uid << static_cast<ObjectIcnTypeUnderlyingType>( ta._objectIcnType ) << ta._imageIndex;
+    return stream << ta._layerType << ta._uid << static_cast<ObjectIcnTypeUnderlyingType>( ta._objectIcnType ) << ta._imageIndex;
 }
 
-StreamBase & Maps::operator>>( StreamBase & msg, TilesAddon & ta )
+IStreamBase & Maps::operator>>( IStreamBase & stream, TilesAddon & ta )
 {
-    msg >> ta._layerType;
+    stream >> ta._layerType;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1009_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1009_RELEASE ) {
         ta._layerType = ( ta._layerType & 0x03 );
     }
 
-    msg >> ta._uid;
+    stream >> ta._uid;
 
     using ObjectIcnTypeUnderlyingType = std::underlying_type_t<decltype( ta._objectIcnType )>;
     static_assert( std::is_same_v<ObjectIcnTypeUnderlyingType, uint8_t>, "Type of _objectIcnType has been changed, check the logic below" );
 
     ObjectIcnTypeUnderlyingType objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
-    msg >> objectIcnType;
+    stream >> objectIcnType;
 
     ta._objectIcnType = static_cast<MP2::ObjectIcnType>( objectIcnType );
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1009_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1009_RELEASE ) {
         bool temp;
-        msg >> temp >> temp;
+        stream >> temp >> temp;
     }
 
-    msg >> ta._imageIndex;
+    stream >> ta._imageIndex;
 
-    return msg;
+    return stream;
 }
 
-StreamBase & Maps::operator<<( StreamBase & msg, const Tiles & tile )
+OStreamBase & Maps::operator<<( OStreamBase & stream, const Tiles & tile )
 {
     using ObjectIcnTypeUnderlyingType = std::underlying_type_t<decltype( tile._mainAddon._objectIcnType )>;
     using MainObjectTypeUnderlyingType = std::underlying_type_t<decltype( tile._mainObjectType )>;
 
     // TODO: use operator<<() for _mainAddon.
-    return msg << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile._tilePassabilityDirections << tile._mainAddon._uid
-               << static_cast<ObjectIcnTypeUnderlyingType>( tile._mainAddon._objectIcnType ) << tile._mainAddon._imageIndex
-               << static_cast<MainObjectTypeUnderlyingType>( tile._mainObjectType ) << tile._fogColors << tile._metadata << tile._occupantHeroId
-               << tile._isTileMarkedAsRoad << tile._addonBottomLayer << tile._addonTopLayer << tile._mainAddon._layerType << tile._boatOwnerColor;
+    return stream << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile._tilePassabilityDirections << tile._mainAddon._uid
+                  << static_cast<ObjectIcnTypeUnderlyingType>( tile._mainAddon._objectIcnType ) << tile._mainAddon._imageIndex
+                  << static_cast<MainObjectTypeUnderlyingType>( tile._mainObjectType ) << tile._fogColors << tile._metadata << tile._occupantHeroId
+                  << tile._isTileMarkedAsRoad << tile._addonBottomLayer << tile._addonTopLayer << tile._mainAddon._layerType << tile._boatOwnerColor;
 }
 
-StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
+IStreamBase & Maps::operator>>( IStreamBase & stream, Tiles & tile )
 {
-    msg >> tile._index >> tile._terrainImageIndex >> tile._terrainFlags >> tile._tilePassabilityDirections >> tile._mainAddon._uid;
+    stream >> tile._index >> tile._terrainImageIndex >> tile._terrainFlags >> tile._tilePassabilityDirections >> tile._mainAddon._uid;
 
     using ObjectIcnTypeUnderlyingType = std::underlying_type_t<decltype( tile._mainAddon._objectIcnType )>;
     static_assert( std::is_same_v<ObjectIcnTypeUnderlyingType, uint8_t>, "Type of _objectIcnType has been changed, check the logic below" );
 
     ObjectIcnTypeUnderlyingType objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
-    msg >> objectIcnType;
+    stream >> objectIcnType;
 
     tile._mainAddon._objectIcnType = static_cast<MP2::ObjectIcnType>( objectIcnType );
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1009_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1009_RELEASE ) {
         bool temp;
-        msg >> temp >> temp;
+        stream >> temp >> temp;
     }
 
-    msg >> tile._mainAddon._imageIndex;
+    stream >> tile._mainAddon._imageIndex;
 
     using MainObjectTypeUnderlyingType = std::underlying_type_t<decltype( tile._mainObjectType )>;
     static_assert( std::is_same_v<MainObjectTypeUnderlyingType, uint16_t>, "Type of _mainObjectType has been changed, check the logic below" );
@@ -1897,17 +1897,17 @@ StreamBase & Maps::operator>>( StreamBase & msg, Tiles & tile )
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE3_1100_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE3_1100_RELEASE ) {
         uint8_t mainObjectType = static_cast<uint8_t>( MP2::OBJ_NONE );
-        msg >> mainObjectType;
+        stream >> mainObjectType;
 
         tile._mainObjectType = static_cast<MP2::MapObjectType>( mainObjectType );
     }
     else {
         MainObjectTypeUnderlyingType mainObjectType = MP2::OBJ_NONE;
-        msg >> mainObjectType;
+        stream >> mainObjectType;
 
         tile._mainObjectType = static_cast<MP2::MapObjectType>( mainObjectType );
     }
 
-    return msg >> tile._fogColors >> tile._metadata >> tile._occupantHeroId >> tile._isTileMarkedAsRoad >> tile._addonBottomLayer >> tile._addonTopLayer
+    return stream >> tile._fogColors >> tile._metadata >> tile._occupantHeroId >> tile._isTileMarkedAsRoad >> tile._addonBottomLayer >> tile._addonTopLayer
            >> tile._mainAddon._layerType >> tile._boatOwnerColor;
 }

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -37,7 +37,8 @@
 #include "mp2.h"
 #include "world_regions.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 namespace Maps
 {
@@ -381,8 +382,8 @@ namespace Maps
 
         std::vector<MP2::ObjectIcnType> getValidObjectIcnTypes() const;
 
-        friend StreamBase & operator<<( StreamBase &, const Tiles & );
-        friend StreamBase & operator>>( StreamBase &, Tiles & );
+        friend OStreamBase & operator<<( OStreamBase & stream, const Tiles & tile );
+        friend IStreamBase & operator>>( IStreamBase & stream, Tiles & tile );
 
         // The following members are used in the Editor and in the game.
 
@@ -422,10 +423,10 @@ namespace Maps
         uint32_t _region{ REGION_NODE_BLOCKED };
     };
 
-    StreamBase & operator<<( StreamBase & msg, const TilesAddon & ta );
-    StreamBase & operator<<( StreamBase & msg, const Tiles & tile );
-    StreamBase & operator>>( StreamBase & msg, TilesAddon & ta );
-    StreamBase & operator>>( StreamBase & msg, Tiles & tile );
+    OStreamBase & operator<<( OStreamBase & stream, const TilesAddon & ta );
+    OStreamBase & operator<<( OStreamBase & stream, const Tiles & tile );
+    IStreamBase & operator>>( IStreamBase & stream, TilesAddon & ta );
+    IStreamBase & operator>>( IStreamBase & stream, Tiles & tile );
 }
 
 #endif

--- a/src/fheroes2/maps/mp2_helper.cpp
+++ b/src/fheroes2/maps/mp2_helper.cpp
@@ -19,12 +19,13 @@
  ***************************************************************************/
 
 #include "mp2_helper.h"
+
 #include "mp2.h"
 #include "serialize.h"
 
 namespace MP2
 {
-    void loadTile( StreamBase & stream, MP2TileInfo & tile )
+    void loadTile( IStreamBase & stream, MP2TileInfo & tile )
     {
         tile.terrainImageIndex = stream.getLE16();
         tile.objectName1 = stream.get();
@@ -40,7 +41,7 @@ namespace MP2
         tile.level2ObjectUID = stream.getLE32();
     }
 
-    void loadAddon( StreamBase & stream, MP2AddonInfo & addon )
+    void loadAddon( IStreamBase & stream, MP2AddonInfo & addon )
     {
         addon.nextAddonIndex = stream.getLE16();
         addon.objectNameN1 = stream.get() * 2; // TODO: why we multiply by 2 here?

--- a/src/fheroes2/maps/mp2_helper.h
+++ b/src/fheroes2/maps/mp2_helper.h
@@ -19,14 +19,14 @@
  ***************************************************************************/
 #pragma once
 
-class StreamBase;
+class IStreamBase;
 
 namespace MP2
 {
     struct MP2TileInfo;
     struct MP2AddonInfo;
 
-    void loadTile( StreamBase & stream, MP2TileInfo & tile );
+    void loadTile( IStreamBase & stream, MP2TileInfo & tile );
 
-    void loadAddon( StreamBase & stream, MP2AddonInfo & addon );
+    void loadAddon( IStreamBase & stream, MP2AddonInfo & addon );
 }

--- a/src/fheroes2/maps/position.cpp
+++ b/src/fheroes2/maps/position.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/position.cpp
+++ b/src/fheroes2/maps/position.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "position.h"
+
 #include "maps.h"
 #include "serialize.h"
 
@@ -44,25 +45,25 @@ void MapPosition::SetIndex( const int32_t index )
     center = Maps::isValidAbsIndex( index ) ? Maps::GetPoint( index ) : fheroes2::Point( -1, -1 );
 }
 
-StreamBase & operator<<( StreamBase & sb, const MapPosition & st )
+OStreamBase & operator<<( OStreamBase & stream, const MapPosition & st )
 {
     // TODO: before 0.9.4 Point was int16_t type
     const int16_t x = static_cast<int16_t>( st.center.x );
     const int16_t y = static_cast<int16_t>( st.center.y );
 
-    return sb << x << y;
+    return stream << x << y;
 }
 
-StreamBase & operator>>( StreamBase & sb, MapPosition & st )
+IStreamBase & operator>>( IStreamBase & stream, MapPosition & st )
 {
     // TODO: before 0.9.4 Point was int16_t type
     int16_t x = 0;
     int16_t y = 0;
 
-    sb >> x >> y;
+    stream >> x >> y;
 
     st.center.x = x;
     st.center.y = y;
 
-    return sb;
+    return stream;
 }

--- a/src/fheroes2/maps/position.h
+++ b/src/fheroes2/maps/position.h
@@ -28,7 +28,8 @@
 
 #include "math_base.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class MapPosition
 {
@@ -56,13 +57,10 @@ public:
     }
 
 protected:
-    friend StreamBase & operator<<( StreamBase &, const MapPosition & );
-    friend StreamBase & operator>>( StreamBase &, MapPosition & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const MapPosition & st );
+    friend IStreamBase & operator>>( IStreamBase & stream, MapPosition & st );
 
     fheroes2::Point center;
 };
-
-StreamBase & operator<<( StreamBase &, const MapPosition & );
-StreamBase & operator>>( StreamBase &, MapPosition & );
 
 #endif

--- a/src/fheroes2/maps/position.h
+++ b/src/fheroes2/maps/position.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -506,14 +506,14 @@ const char * Artifact::getDiscoveryDescription( const Artifact & art )
     return _( fheroes2::getArtifactData( art.GetID() ).discoveryEventDescription );
 }
 
-StreamBase & operator<<( StreamBase & msg, const Artifact & art )
+OStreamBase & operator<<( OStreamBase & stream, const Artifact & art )
 {
-    return msg << art.id << art.ext;
+    return stream << art.id << art.ext;
 }
 
-StreamBase & operator>>( StreamBase & msg, Artifact & art )
+IStreamBase & operator>>( IStreamBase & stream, Artifact & art )
 {
-    return msg >> art.id >> art.ext;
+    return stream >> art.id >> art.ext;
 }
 
 BagArtifacts::BagArtifacts()

--- a/src/fheroes2/resource/artifact.h
+++ b/src/fheroes2/resource/artifact.h
@@ -35,9 +35,11 @@
 #include "math_base.h"
 #include "ui_tool.h"
 
+class IStreamBase;
+class OStreamBase;
+
 class Heroes;
 class StatusBar;
-class StreamBase;
 
 namespace MP2
 {
@@ -261,15 +263,12 @@ public:
     static const char * getDiscoveryDescription( const Artifact & );
 
 private:
-    friend StreamBase & operator<<( StreamBase &, const Artifact & );
-    friend StreamBase & operator>>( StreamBase &, Artifact & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Artifact & art );
+    friend IStreamBase & operator>>( IStreamBase & stream, Artifact & art );
 
     int id;
     int ext;
 };
-
-StreamBase & operator<<( StreamBase &, const Artifact & );
-StreamBase & operator>>( StreamBase &, Artifact & );
 
 uint32_t GoldInsteadArtifact( const MP2::MapObjectType objectType );
 

--- a/src/fheroes2/resource/artifact_ultimate.cpp
+++ b/src/fheroes2/resource/artifact_ultimate.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/resource/artifact_ultimate.cpp
+++ b/src/fheroes2/resource/artifact_ultimate.cpp
@@ -22,6 +22,7 @@
  ***************************************************************************/
 
 #include "artifact_ultimate.h"
+
 #include "interface_gamearea.h"
 #include "rand.h"
 #include "serialize.h"
@@ -68,13 +69,13 @@ void UltimateArtifact::Reset()
     _isFound = false;
 }
 
-StreamBase & operator<<( StreamBase & msg, const UltimateArtifact & ultimate )
+OStreamBase & operator<<( OStreamBase & stream, const UltimateArtifact & ultimate )
 {
-    return msg << static_cast<const Artifact &>( ultimate ) << ultimate._index << ultimate._isFound << ultimate._offset;
+    return stream << static_cast<const Artifact &>( ultimate ) << ultimate._index << ultimate._isFound << ultimate._offset;
 }
 
-StreamBase & operator>>( StreamBase & msg, UltimateArtifact & ultimate )
+IStreamBase & operator>>( IStreamBase & stream, UltimateArtifact & ultimate )
 {
     Artifact & artifact = ultimate;
-    return msg >> artifact >> ultimate._index >> ultimate._isFound >> ultimate._offset;
+    return stream >> artifact >> ultimate._index >> ultimate._isFound >> ultimate._offset;
 }

--- a/src/fheroes2/resource/artifact_ultimate.h
+++ b/src/fheroes2/resource/artifact_ultimate.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/resource/artifact_ultimate.h
+++ b/src/fheroes2/resource/artifact_ultimate.h
@@ -30,7 +30,8 @@
 #include "image.h"
 #include "math_base.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class UltimateArtifact : public Artifact
 {
@@ -61,15 +62,12 @@ public:
     const Artifact & GetArtifact() const;
 
 private:
-    friend StreamBase & operator<<( StreamBase &, const UltimateArtifact & );
-    friend StreamBase & operator>>( StreamBase &, UltimateArtifact & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const UltimateArtifact & ultimate );
+    friend IStreamBase & operator>>( IStreamBase & stream, UltimateArtifact & ultimate );
 
     fheroes2::Point _offset;
     int32_t _index;
     bool _isFound;
 };
-
-StreamBase & operator<<( StreamBase &, const UltimateArtifact & );
-StreamBase & operator>>( StreamBase &, UltimateArtifact & );
 
 #endif

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -684,12 +684,12 @@ void Resource::BoxSprite::Redraw() const
     }
 }
 
-StreamBase & operator<<( StreamBase & msg, const Funds & res )
+OStreamBase & operator<<( OStreamBase & stream, const Funds & res )
 {
-    return msg << res.wood << res.mercury << res.ore << res.sulfur << res.crystal << res.gems << res.gold;
+    return stream << res.wood << res.mercury << res.ore << res.sulfur << res.crystal << res.gems << res.gold;
 }
 
-StreamBase & operator>>( StreamBase & msg, Funds & res )
+IStreamBase & operator>>( IStreamBase & stream, Funds & res )
 {
-    return msg >> res.wood >> res.mercury >> res.ore >> res.sulfur >> res.crystal >> res.gems >> res.gold;
+    return stream >> res.wood >> res.mercury >> res.ore >> res.sulfur >> res.crystal >> res.gems >> res.gold;
 }

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -31,7 +31,8 @@
 
 #include "math_base.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 struct Cost
 {
@@ -134,8 +135,8 @@ struct Funds
     int32_t gold{ 0 };
 };
 
-StreamBase & operator<<( StreamBase &, const Funds & res );
-StreamBase & operator>>( StreamBase &, Funds & res );
+OStreamBase & operator<<( OStreamBase & stream, const Funds & res );
+IStreamBase & operator>>( IStreamBase & stream, Funds & res );
 
 namespace Resource
 {

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -793,12 +793,12 @@ int32_t Spell::CalculateDimensionDoorDistance()
     return 14;
 }
 
-StreamBase & operator<<( StreamBase & msg, const Spell & spell )
+OStreamBase & operator<<( OStreamBase & stream, const Spell & spell )
 {
-    return msg << spell.id;
+    return stream << spell.id;
 }
 
-StreamBase & operator>>( StreamBase & msg, Spell & spell )
+IStreamBase & operator>>( IStreamBase & stream, Spell & spell )
 {
-    return msg >> spell.id;
+    return stream >> spell.id;
 }

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -28,8 +28,10 @@
 
 #define DEFAULT_SPELL_DURATION 3
 
+class IStreamBase;
+class OStreamBase;
+
 class HeroBase;
-class StreamBase;
 
 class Spell
 {
@@ -246,13 +248,10 @@ public:
     static int32_t CalculateDimensionDoorDistance();
 
 private:
-    friend StreamBase & operator<<( StreamBase &, const Spell & );
-    friend StreamBase & operator>>( StreamBase &, Spell & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Spell & spell );
+    friend IStreamBase & operator>>( IStreamBase & stream, Spell & spell );
 
     int id;
 };
-
-StreamBase & operator<<( StreamBase &, const Spell & );
-StreamBase & operator>>( StreamBase &, Spell & );
 
 #endif

--- a/src/fheroes2/system/bitmodes.cpp
+++ b/src/fheroes2/system/bitmodes.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/system/bitmodes.cpp
+++ b/src/fheroes2/system/bitmodes.cpp
@@ -22,14 +22,15 @@
  ***************************************************************************/
 
 #include "bitmodes.h"
+
 #include "serialize.h"
 
-StreamBase & operator<<( StreamBase & msg, const BitModes & b )
+OStreamBase & operator<<( OStreamBase & stream, const BitModes & b )
 {
-    return msg << b.modes;
+    return stream << b.modes;
 }
 
-StreamBase & operator>>( StreamBase & msg, BitModes & b )
+IStreamBase & operator>>( IStreamBase & stream, BitModes & b )
 {
-    return msg >> b.modes;
+    return stream >> b.modes;
 }

--- a/src/fheroes2/system/bitmodes.h
+++ b/src/fheroes2/system/bitmodes.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/system/bitmodes.h
+++ b/src/fheroes2/system/bitmodes.h
@@ -26,7 +26,8 @@
 
 #include <cstdint>
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 class BitModes
 {
@@ -58,13 +59,10 @@ public:
     }
 
 protected:
-    friend StreamBase & operator<<( StreamBase &, const BitModes & );
-    friend StreamBase & operator>>( StreamBase &, BitModes & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const BitModes & b );
+    friend IStreamBase & operator>>( IStreamBase & stream, BitModes & b );
 
     uint32_t modes;
 };
-
-StreamBase & operator<<( StreamBase &, const BitModes & );
-StreamBase & operator>>( StreamBase &, BitModes & );
 
 #endif

--- a/src/fheroes2/system/players.cpp
+++ b/src/fheroes2/system/players.cpp
@@ -229,29 +229,29 @@ void Player::commitAIAutoControlMode()
 }
 #endif
 
-StreamBase & operator<<( StreamBase & msg, const Focus & focus )
+OStreamBase & operator<<( OStreamBase & stream, const Focus & focus )
 {
-    msg << focus.first;
+    stream << focus.first;
 
     switch ( focus.first ) {
     case FOCUS_HEROES:
-        msg << static_cast<Heroes *>( focus.second )->GetIndex();
+        stream << static_cast<Heroes *>( focus.second )->GetIndex();
         break;
     case FOCUS_CASTLE:
-        msg << static_cast<Castle *>( focus.second )->GetIndex();
+        stream << static_cast<Castle *>( focus.second )->GetIndex();
         break;
     default:
-        msg << static_cast<int32_t>( -1 );
+        stream << static_cast<int32_t>( -1 );
         break;
     }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, Focus & focus )
+IStreamBase & operator>>( IStreamBase & stream, Focus & focus )
 {
     int32_t index;
-    msg >> focus.first >> index;
+    stream >> focus.first >> index;
 
     switch ( focus.first ) {
     case FOCUS_HEROES:
@@ -265,48 +265,48 @@ StreamBase & operator>>( StreamBase & msg, Focus & focus )
         break;
     }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator<<( StreamBase & msg, const Player & player )
+OStreamBase & operator<<( OStreamBase & stream, const Player & player )
 {
     using AIPersonalityUnderlyingType = std::underlying_type_t<decltype( player._aiPersonality )>;
 
     const BitModes & modes = player;
 
-    msg << modes << player.control << player.color << player.race << player.friends << player.name << player.focus
-        << static_cast<AIPersonalityUnderlyingType>( player._aiPersonality ) << static_cast<uint8_t>( player._handicapStatus );
-    return msg;
+    stream << modes << player.control << player.color << player.race << player.friends << player.name << player.focus
+           << static_cast<AIPersonalityUnderlyingType>( player._aiPersonality ) << static_cast<uint8_t>( player._handicapStatus );
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, Player & player )
+IStreamBase & operator>>( IStreamBase & stream, Player & player )
 {
     BitModes & modes = player;
 
-    msg >> modes;
+    stream >> modes;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1009_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1009_RELEASE ) {
         uint32_t temp;
-        msg >> temp;
+        stream >> temp;
     }
 
-    msg >> player.control >> player.color >> player.race >> player.friends >> player.name >> player.focus;
+    stream >> player.control >> player.color >> player.race >> player.friends >> player.name >> player.focus;
 
     using AIPersonalityUnderlyingType = std::underlying_type_t<decltype( player._aiPersonality )>;
     static_assert( std::is_same_v<AIPersonalityUnderlyingType, int>, "Type of _aiPersonality has been changed, check the logic below" );
 
     AIPersonalityUnderlyingType aiPersonality;
-    msg >> aiPersonality;
+    stream >> aiPersonality;
 
     player._aiPersonality = static_cast<AI::Personality>( aiPersonality );
 
     uint8_t handicapStatusInt;
-    msg >> handicapStatusInt;
+    stream >> handicapStatusInt;
 
     player._handicapStatus = static_cast<Player::HandicapStatus>( handicapStatusInt );
 
-    return msg;
+    return stream;
 }
 
 Players::Players()
@@ -585,21 +585,21 @@ std::string Players::String() const
     return os.str();
 }
 
-StreamBase & operator<<( StreamBase & msg, const Players & players )
+OStreamBase & operator<<( OStreamBase & stream, const Players & players )
 {
-    msg << players.GetColors() << players.getCurrentColor();
+    stream << players.GetColors() << players.getCurrentColor();
 
     for ( Players::const_iterator it = players.begin(); it != players.end(); ++it )
-        msg << ( **it );
+        stream << ( **it );
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, Players & players )
+IStreamBase & operator>>( IStreamBase & stream, Players & players )
 {
     int colors;
     int current;
-    msg >> colors >> current;
+    stream >> colors >> current;
 
     players.clear();
     players.setCurrentColor( current );
@@ -607,10 +607,10 @@ StreamBase & operator>>( StreamBase & msg, Players & players )
 
     for ( uint32_t ii = 0; ii < vcolors.size(); ++ii ) {
         Player * player = new Player();
-        msg >> *player;
+        stream >> *player;
         Players::Set( Color::GetIndex( player->GetColor() ), player );
         players.push_back( player );
     }
 
-    return msg;
+    return stream;
 }

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -33,7 +33,8 @@
 #include "bitmodes.h"
 #include "color.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 namespace Maps
 {
@@ -91,8 +92,8 @@ struct Focus : std::pair<int, void *>
     }
 };
 
-StreamBase & operator<<( StreamBase &, const Focus & );
-StreamBase & operator>>( StreamBase &, Focus & );
+OStreamBase & operator<<( OStreamBase & stream, const Focus & focus );
+IStreamBase & operator>>( IStreamBase & stream, Focus & focus );
 
 struct Control
 {
@@ -197,8 +198,8 @@ public:
 #endif
 
 protected:
-    friend StreamBase & operator<<( StreamBase &, const Player & );
-    friend StreamBase & operator>>( StreamBase &, Player & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Player & player );
+    friend IStreamBase & operator>>( IStreamBase & stream, Player & player );
 
     int control;
     int color;
@@ -218,9 +219,6 @@ protected:
     bool _isAIAutoControlModePlanned;
 #endif
 };
-
-StreamBase & operator<<( StreamBase &, const Player & );
-StreamBase & operator>>( StreamBase &, Player & );
 
 class Players : public std::vector<Player *>
 {
@@ -273,7 +271,7 @@ private:
     int _currentColor{ Color::NONE };
 };
 
-StreamBase & operator<<( StreamBase &, const Players & );
-StreamBase & operator>>( StreamBase &, Players & );
+OStreamBase & operator<<( OStreamBase & stream, const Players & players );
+IStreamBase & operator>>( IStreamBase & stream, Players & players );
 
 #endif

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -1086,20 +1086,20 @@ void Settings::resetFirstGameRun()
     _gameOptions.ResetModes( GAME_FIRST_RUN );
 }
 
-StreamBase & operator<<( StreamBase & msg, const Settings & conf )
+OStreamBase & operator<<( OStreamBase & stream, const Settings & conf )
 {
-    return msg << conf._gameLanguage << conf._currentMapInfo << conf._gameDifficulty << conf.game_type << conf.players;
+    return stream << conf._gameLanguage << conf._currentMapInfo << conf._gameDifficulty << conf.game_type << conf.players;
 }
 
-StreamBase & operator>>( StreamBase & msg, Settings & conf )
+IStreamBase & operator>>( IStreamBase & stream, Settings & conf )
 {
-    msg >> conf._loadedFileLanguage >> conf._currentMapInfo >> conf._gameDifficulty >> conf.game_type;
+    stream >> conf._loadedFileLanguage >> conf._currentMapInfo >> conf._gameDifficulty >> conf.game_type;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1101_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1101_RELEASE ) {
         int temp;
-        msg >> temp;
+        stream >> temp;
     }
 
-    return msg >> conf.players;
+    return stream >> conf.players;
 }

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -36,7 +36,8 @@
 #include "players.h"
 #include "screen.h"
 
-class StreamBase;
+class IStreamBase;
+class OStreamBase;
 
 enum AdventureMapScrollSpeed : int
 {
@@ -345,8 +346,8 @@ public:
     static std::string GetLastFile( const std::string & prefix, const std::string & name );
 
 private:
-    friend StreamBase & operator<<( StreamBase &, const Settings & );
-    friend StreamBase & operator>>( StreamBase &, Settings & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const Settings & conf );
+    friend IStreamBase & operator>>( IStreamBase & stream, Settings & conf );
 
     Settings();
 
@@ -389,7 +390,7 @@ private:
     Players players;
 };
 
-StreamBase & operator<<( StreamBase & msg, const Settings & conf );
-StreamBase & operator>>( StreamBase & msg, Settings & conf );
+OStreamBase & operator<<( OStreamBase & stream, const Settings & conf );
+IStreamBase & operator>>( IStreamBase & stream, Settings & conf );
 
 #endif

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1375,15 +1375,15 @@ OStreamBase & operator<<( OStreamBase & stream, const MapObjects & objs )
 
             switch ( obj.GetType() ) {
             case MP2::OBJ_EVENT:
-                stream << static_cast<const MapEvent &>( obj );
+                stream << dynamic_cast<const MapEvent &>( obj );
                 break;
 
             case MP2::OBJ_SPHINX:
-                stream << static_cast<const MapSphinx &>( obj );
+                stream << dynamic_cast<const MapSphinx &>( obj );
                 break;
 
             case MP2::OBJ_SIGN:
-                stream << static_cast<const MapSign &>( obj );
+                stream << dynamic_cast<const MapSign &>( obj );
                 break;
 
             default:

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1551,7 +1551,7 @@ void EventDate::LoadFromMP2( const std::vector<uint8_t> & data )
     // - string
     //    Null terminated string containing the event text.
 
-    StreamBuf dataStream( data );
+    ROStreamBuf dataStream( data );
 
     dataStream.skip( 1 );
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1355,114 +1355,114 @@ bool World::isAnyKingdomVisited( const MP2::MapObjectType objectType, const int3
     return false;
 }
 
-StreamBase & operator<<( StreamBase & msg, const CapturedObject & obj )
+OStreamBase & operator<<( OStreamBase & stream, const CapturedObject & obj )
 {
-    return msg << obj.objcol << obj.guardians;
+    return stream << obj.objcol << obj.guardians;
 }
 
-StreamBase & operator>>( StreamBase & msg, CapturedObject & obj )
+IStreamBase & operator>>( IStreamBase & stream, CapturedObject & obj )
 {
-    return msg >> obj.objcol >> obj.guardians;
+    return stream >> obj.objcol >> obj.guardians;
 }
 
-StreamBase & operator<<( StreamBase & msg, const MapObjects & objs )
+OStreamBase & operator<<( OStreamBase & stream, const MapObjects & objs )
 {
-    msg << static_cast<uint32_t>( objs.size() );
+    stream << static_cast<uint32_t>( objs.size() );
     for ( MapObjects::const_iterator it = objs.begin(); it != objs.end(); ++it )
         if ( ( *it ).second ) {
             const MapObjectSimple & obj = *( *it ).second;
-            msg << ( *it ).first << obj.GetType();
+            stream << ( *it ).first << obj.GetType();
 
             switch ( obj.GetType() ) {
             case MP2::OBJ_EVENT:
-                msg << static_cast<const MapEvent &>( obj );
+                stream << static_cast<const MapEvent &>( obj );
                 break;
 
             case MP2::OBJ_SPHINX:
-                msg << static_cast<const MapSphinx &>( obj );
+                stream << static_cast<const MapSphinx &>( obj );
                 break;
 
             case MP2::OBJ_SIGN:
-                msg << static_cast<const MapSign &>( obj );
+                stream << static_cast<const MapSign &>( obj );
                 break;
 
             default:
-                msg << obj;
+                stream << obj;
                 break;
             }
         }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator>>( StreamBase & msg, MapObjects & objs )
+IStreamBase & operator>>( IStreamBase & stream, MapObjects & objs )
 {
     uint32_t size = 0;
-    msg >> size;
+    stream >> size;
 
     objs.clear();
 
     for ( uint32_t ii = 0; ii < size; ++ii ) {
         int32_t index;
         int type;
-        msg >> index >> type;
+        stream >> index >> type;
 
         switch ( type ) {
         case MP2::OBJ_EVENT: {
             MapEvent * ptr = new MapEvent();
-            msg >> *ptr;
+            stream >> *ptr;
             objs[index] = ptr;
             break;
         }
 
         case MP2::OBJ_SPHINX: {
             MapSphinx * ptr = new MapSphinx();
-            msg >> *ptr;
+            stream >> *ptr;
             objs[index] = ptr;
             break;
         }
 
         case MP2::OBJ_SIGN: {
             MapSign * ptr = new MapSign();
-            msg >> *ptr;
+            stream >> *ptr;
             objs[index] = ptr;
             break;
         }
 
         default: {
             MapObjectSimple * ptr = new MapObjectSimple();
-            msg >> *ptr;
+            stream >> *ptr;
             objs[index] = ptr;
             break;
         }
         }
     }
 
-    return msg;
+    return stream;
 }
 
-StreamBase & operator<<( StreamBase & msg, const World & w )
+OStreamBase & operator<<( OStreamBase & stream, const World & w )
 {
-    return msg << w.width << w.height << w.vec_tiles << w.vec_heroes << w.vec_castles << w.vec_kingdoms << w._customRumors << w.vec_eventsday << w.map_captureobj
-               << w.ultimate_artifact << w.day << w.week << w.month << w.heroIdAsWinCondition << w.heroIdAsLossCondition << w.map_objects << w._seed;
+    return stream << w.width << w.height << w.vec_tiles << w.vec_heroes << w.vec_castles << w.vec_kingdoms << w._customRumors << w.vec_eventsday << w.map_captureobj
+                  << w.ultimate_artifact << w.day << w.week << w.month << w.heroIdAsWinCondition << w.heroIdAsLossCondition << w.map_objects << w._seed;
 }
 
-StreamBase & operator>>( StreamBase & msg, World & w )
+IStreamBase & operator>>( IStreamBase & stream, World & w )
 {
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1010_RELEASE ) {
         uint16_t width = 0;
         uint16_t height = 0;
 
-        msg >> width >> height;
+        stream >> width >> height;
         w.width = width;
         w.height = height;
     }
     else {
-        msg >> w.width >> w.height;
+        stream >> w.width >> w.height;
     }
 
-    msg >> w.vec_tiles >> w.vec_heroes >> w.vec_castles >> w.vec_kingdoms >> w._customRumors >> w.vec_eventsday >> w.map_captureobj >> w.ultimate_artifact >> w.day
+    stream >> w.vec_tiles >> w.vec_heroes >> w.vec_castles >> w.vec_kingdoms >> w._customRumors >> w.vec_eventsday >> w.map_captureobj >> w.ultimate_artifact >> w.day
         >> w.week >> w.month >> w.heroIdAsWinCondition >> w.heroIdAsLossCondition;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1010_RELEASE, "Remove the logic below." );
@@ -1471,11 +1471,11 @@ StreamBase & operator>>( StreamBase & msg, World & w )
         ++w.heroIdAsLossCondition;
     }
 
-    msg >> w.map_objects >> w._seed;
+    stream >> w.map_objects >> w._seed;
 
     w.PostLoad( false );
 
-    return msg;
+    return stream;
 }
 
 void EventDate::LoadFromMP2( const std::vector<uint8_t> & data )
@@ -1632,12 +1632,12 @@ bool EventDate::isAllow( const int col, const uint32_t date ) const
     return ( ( date - firstOccurrenceDay ) % repeatPeriodInDays ) == 0;
 }
 
-StreamBase & operator<<( StreamBase & msg, const EventDate & obj )
+OStreamBase & operator<<( OStreamBase & stream, const EventDate & obj )
 {
-    return msg << obj.resource << obj.isApplicableForAIPlayers << obj.firstOccurrenceDay << obj.repeatPeriodInDays << obj.colors << obj.message << obj.title;
+    return stream << obj.resource << obj.isApplicableForAIPlayers << obj.firstOccurrenceDay << obj.repeatPeriodInDays << obj.colors << obj.message << obj.title;
 }
 
-StreamBase & operator>>( StreamBase & msg, EventDate & obj )
+IStreamBase & operator>>( IStreamBase & stream, EventDate & obj )
 {
-    return msg >> obj.resource >> obj.isApplicableForAIPlayers >> obj.firstOccurrenceDay >> obj.repeatPeriodInDays >> obj.colors >> obj.message >> obj.title;
+    return stream >> obj.resource >> obj.isApplicableForAIPlayers >> obj.firstOccurrenceDay >> obj.repeatPeriodInDays >> obj.colors >> obj.message >> obj.title;
 }

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -44,8 +44,10 @@
 #include "world_pathfinding.h"
 #include "world_regions.h"
 
+class IStreamBase;
+class OStreamBase;
+
 class MapObjectSimple;
-class StreamBase;
 
 struct MapEvent;
 struct Week;
@@ -139,8 +141,8 @@ struct EventDate
     std::string title;
 };
 
-StreamBase & operator<<( StreamBase &, const EventDate & );
-StreamBase & operator>>( StreamBase &, EventDate & );
+OStreamBase & operator<<( OStreamBase & stream, const EventDate & obj );
+IStreamBase & operator>>( IStreamBase & stream, EventDate & obj );
 
 using EventsDate = std::list<EventDate>;
 
@@ -396,8 +398,8 @@ private:
     void setHeroIdsForMapConditions();
 
     friend class Radar;
-    friend StreamBase & operator<<( StreamBase &, const World & );
-    friend StreamBase & operator>>( StreamBase &, World & );
+    friend OStreamBase & operator<<( OStreamBase & stream, const World & w );
+    friend IStreamBase & operator>>( IStreamBase & stream, World & w );
 
     std::vector<Maps::Tiles> vec_tiles;
     AllHeroes vec_heroes;
@@ -433,14 +435,11 @@ private:
     PlayerWorldPathfinder _pathfinder;
 };
 
-StreamBase & operator<<( StreamBase &, const CapturedObject & );
-StreamBase & operator>>( StreamBase &, CapturedObject & );
+OStreamBase & operator<<( OStreamBase & stream, const CapturedObject & obj );
+IStreamBase & operator>>( IStreamBase & stream, CapturedObject & obj );
 
-StreamBase & operator<<( StreamBase &, const World & );
-StreamBase & operator>>( StreamBase &, World & );
-
-StreamBase & operator<<( StreamBase &, const MapObjects & );
-StreamBase & operator>>( StreamBase &, MapObjects & );
+OStreamBase & operator<<( OStreamBase & stream, const MapObjects & objs );
+IStreamBase & operator>>( IStreamBase & stream, MapObjects & objs );
 
 extern World & world;
 

--- a/src/tools/82m2wav.cpp
+++ b/src/tools/82m2wav.cpp
@@ -131,7 +131,7 @@ int main( int argc, char ** argv )
 
         static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
 
-        StreamBuf wavHeader( wavHeaderLen );
+        RWStreamBuf wavHeader( wavHeaderLen );
         wavHeader.putLE32( 0x46464952 ); // RIFF marker ("RIFF")
         wavHeader.putLE32( static_cast<uint32_t>( size.value() ) + ( wavHeaderLen - 8 ) ); // Total size minus the size of this and previous fields
         wavHeader.putLE32( 0x45564157 ); // File type header ("WAVE")

--- a/src/tools/extractor.cpp
+++ b/src/tools/extractor.cpp
@@ -121,9 +121,9 @@ int main( int argc, char ** argv )
         const size_t inputStreamSize = inputStream.size();
         const uint16_t itemsCount = inputStream.getLE16();
 
-        StreamBuf itemsStream = inputStream.toStreamBuf( static_cast<size_t>( itemsCount ) * 4 * 3 /* hash, offset, size */ );
+        RWStreamBuf itemsStream = inputStream.toStreamBuf( static_cast<size_t>( itemsCount ) * 4 * 3 /* hash, offset, size */ );
         inputStream.seek( inputStreamSize - AGGItemNameLen * itemsCount );
-        StreamBuf namesStream = inputStream.toStreamBuf( AGGItemNameLen * itemsCount );
+        RWStreamBuf namesStream = inputStream.toStreamBuf( AGGItemNameLen * itemsCount );
 
         std::map<std::string, AGGItemInfo, std::less<>> aggItemsMap;
 


### PR DESCRIPTION
Currently in the `master` branch, the `StreamBuf` class has a major flaw: if it is created to get access to the existing `std::vector<uint8_t>::data()` backend, it uses the `const_cast` to cast away the `const`'ness from the vector's data. This is very close to undefined behavior and is very dangerous if methods are accidentally called that will write to this buffer (like `put8()`/`putRaw()`/etc).

This PR turns `StreamBuf` into an abstract class, so various functions, methods, and operators can still use it by reference. But, if you need to create a `StreamBuf` instance, you cannot do this anymore. Instead, you now have two separate classes at your disposal:

* `RWStreamBuf` (with writable `uint8_t *` backend managed by the `RWStreamBuf` itself);
* `ROStreamBuf` (with read-only `const uint8_t *` backend which points to the `data()` of the underlying `std::vector<uint8_t>`).

Both of these classes have an intermediate ancestor in the form of the `StreamBufTmpl` class template, which removes code duplication while providing type safety and const-correctness in a natural way via C++ type system.

~~It would be even more correct to make separate interfaces for reading and writing (just like `std::istream` and `std::ostream`) instead of single `StreamBase`, but this will require a very large number of changes in many places, because the current I/O code (all these `operator>>()` and `operator<<()`, etc, etc) is not designed for this right now. Maybe later in a separate PR.~~

UPDATE: implemented separate interfaces for reading and writing (`IStreamBase` and `OStreamBase` respectively), `StreamBuf` has been renamed to `IStreamBuf`.