### PR TITLE
Fix visited info when hero has visited a tree under another player's control

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -291,12 +291,7 @@ namespace
             if ( hero ) {
                 str.append( "\n\n(" );
                 // In case another player visited this tree with this hero.
-                if ( hero->isVisited( tile ) ) {
-                    str.append( _( "already claimed" ) );
-                }
-                else {
-                    str.append( _( "not claimed" ) );
-                }
+                str.append( hero->isVisited( tile ) ? _( "already claimed" ) : _( "not claimed" ) );
                 str += ')';
             }
         }

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -290,7 +290,13 @@ namespace
         else {
             if ( hero ) {
                 str.append( "\n\n(" );
-                str.append( _( "not claimed" ) );
+                // In case another player visited this tree with this hero.
+                if ( hero->isVisited( tile ) ) {
+                    str.append( _( "already claimed" ) );
+                }
+                else {
+                    str.append( _( "not claimed" ) );
+                }
                 str += ')';
             }
         }


### PR DESCRIPTION
In current `master` if you right click a tree which was visited and claimed by a hero who is now under your command the quick info would say `"not claimed"`, which is wrong. Visiting the tree will not give you the chance to level up this hero.

This PR also restores the behavior observed in the original game, although originally the info would say "visited" or "not visited".

Bug introduced in: https://github.com/ihhub/fheroes2/pull/8147
