### PR TITLE
Prevent redistribution of hero's last unit

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -62,23 +62,28 @@ namespace
         assert( overallCount > 0 );
 
         if ( overallCount == 1 ) {
-            // prevent cross-army split if we lose the last unit in the hero army
+            // Prevent units from moving between armies if this would result in no units remaining in the hero's army
             if ( saveLastTroop ) {
                 return;
             }
 
-            // it seems that we are just moving a single unit to a free cell
+            // It seems that we are just moving a single unit to a free cell
             assert( !troopTarget.isValid() );
 
             Army::SwapTroops( troopFrom, troopTarget );
         }
         else if ( !troopTarget.isValid() && troopFrom.GetCount() == 2 ) {
-            // a player splits a slot with two monsters into an empty slot; move one monster into the source slot to the target slot.
+            // Player splits a slot with two monsters into an empty slot; move one monster from the source slot to the target slot
             troopFrom.SetCount( 1 );
             troopTarget.Set( troopFrom.GetMonster(), 1 );
         }
         else if ( isSameTroopType && troopFrom.isValid() && troopFrom.GetCount() == 1 && troopTarget.isValid() && troopTarget.GetCount() == 1 ) {
-            // a player splits the same troop type and both count one; move a monster from the source slot to the target slot.
+            // Prevent units from moving between armies if this would result in no units remaining in the hero's army
+            if ( saveLastTroop ) {
+                return;
+            }
+
+            // Player splits a slot with just one monster into a slot with just one monster of the same type; add a monster from the source slot to the target slot
             troopFrom.Reset();
             troopTarget.SetCount( 2 );
         }
@@ -89,7 +94,7 @@ namespace
             }
 
             const int32_t maxCount = static_cast<int32_t>( saveLastTroop ? troopFrom.GetCount() - 1 : troopFrom.GetCount() );
-            int32_t redistributeCount = isSameTroopType ? 1 : static_cast<int32_t>( troopFrom.GetCount() ) / 2;
+            int32_t redistributeCount = isSameTroopType ? std::min( 1, maxCount ) : static_cast<int32_t>( troopFrom.GetCount() ) / 2;
 
             bool useFastSplit = !isSameTroopType;
             const int32_t slots = Dialog::ArmySplitTroop( ( freeSlots > static_cast<int32_t>( overallCount ) ? static_cast<int32_t>( overallCount ) : freeSlots ),
@@ -102,25 +107,29 @@ namespace
             uint32_t totalSplitTroopCount = troopFrom.GetCount();
 
             if ( !useFastSplit && slots == 2 ) {
-                // this logic is used when splitting to a stack with the same unit
-                if ( isSameTroopType )
+                // This logic is used when splitting to a stack with the same unit
+                if ( isSameTroopType ) {
                     troopTarget.SetCount( troopTarget.GetCount() + static_cast<uint32_t>( redistributeCount ) );
-                else
+                }
+                else {
                     troopTarget.Set( troopFrom, static_cast<uint32_t>( redistributeCount ) );
+                }
 
                 troopFrom.SetCount( totalSplitTroopCount - static_cast<uint32_t>( redistributeCount ) );
             }
             else {
-                if ( isSameTroopType )
+                if ( isSameTroopType ) {
                     totalSplitTroopCount += troopTarget.GetCount();
+                }
 
                 const uint32_t troopFromSplitCount = ( totalSplitTroopCount + slots - 1 ) / slots;
                 troopFrom.SetCount( troopFromSplitCount );
 
                 const uint32_t troopTargetSplitCount = ( totalSplitTroopCount + slots - 2 ) / slots;
 
-                if ( !isSameTroopType )
+                if ( !isSameTroopType ) {
                     troopTarget.SetMonster( troopFrom.GetID() );
+                }
 
                 troopTarget.SetCount( troopTargetSplitCount );
 

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -67,7 +67,7 @@ namespace
                 return;
             }
 
-            // It seems that we are just moving a single unit to a free cell
+            // It seems that we are just moving a single unit to an empty slot
             assert( !troopTarget.isValid() );
 
             Army::SwapTroops( troopFrom, troopTarget );

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -61,10 +61,6 @@ namespace
 
         assert( overallCount > 0 );
 
-        if ( saveLastTroop && troopFrom.GetCount() <= 1 ) {
-            return;
-        }
-
         if ( overallCount == 1 ) {
             // prevent cross-army split if we lose the last unit in the hero army
             if ( saveLastTroop ) {

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -61,6 +61,10 @@ namespace
 
         assert( overallCount > 0 );
 
+        if ( saveLastTroop && troopFrom.GetCount() <= 1 ) {
+            return;
+        }
+
         if ( overallCount == 1 ) {
             // prevent cross-army split if we lose the last unit in the hero army
             if ( saveLastTroop ) {


### PR DESCRIPTION
Moving a hero's last unit by dragging and dropping caused the game to crash.
![dialog-error](https://github.com/user-attachments/assets/a0c27f17-1683-43b5-87b2-6fcc2def6c09)
This PR adds a check that returns early if the last unit should be saved.