### PR TITLE
Set UID counter to the maximum object's UID value after loading a saved game

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -613,8 +613,8 @@ void Maps::Tiles::setBoat( const int direction, const int color )
     const uint32_t newUid = getNewObjectUID();
 
     // Check that this ID is not used for some other object.
-    for ( int32_t idx = 0; idx < world.getSize(); ++idx ) {
-        assert( !world.GetTiles( idx ).doesObjectExist( newUid ) );
+    for ( uint32_t tileIndex = 0; tileIndex < world.getSize(); ++tileIndex ) {
+        assert( !world.GetTiles( tileIndex ).doesObjectExist( newUid ) );
     }
     _mainAddon._uid = newUid;
 #else

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -609,7 +609,17 @@ void Maps::Tiles::setBoat( const int direction, const int color )
         break;
     }
 
+#ifdef WITH_DEBUG
+    const uint32_t newUid = getNewObjectUID();
+
+    // Check that this ID is not used for some other object.
+    for ( int32_t idx = 0; idx < world.getSize(); ++idx ) {
+        assert( !world.GetTiles( idx ).doesObjectExist( newUid ) );
+    }
+    _mainAddon._uid = newUid;
+#else
     _mainAddon._uid = getNewObjectUID();
+#endif // WITH_DEBUG
 
     using BoatOwnerColorType = decltype( _boatOwnerColor );
     static_assert( std::is_same_v<BoatOwnerColorType, uint8_t>, "Type of _boatOwnerColor has been changed, check the logic below" );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1304,7 +1304,7 @@ void World::updatePassabilities()
     }
 }
 
-void World::PostLoad( const bool setTilePassabilities )
+void World::PostLoad( const bool setTilePassabilities, const bool updateUidCounterToMaximum )
 {
     if ( setTilePassabilities ) {
         updatePassabilities();
@@ -1326,6 +1326,26 @@ void World::PostLoad( const bool setTilePassabilities )
 
     resetPathfinder();
     ComputeStaticAnalysis();
+
+    if ( updateUidCounterToMaximum ) {
+        // Find the maximum UID value.
+        uint32_t maxUid = 0;
+
+        for ( const Maps::Tiles & tile : vec_tiles ) {
+            maxUid = std::max( tile.getMainObjectPart()._uid, maxUid );
+
+            for ( const auto & addon : tile.getBottomLayerAddons() ) {
+                maxUid = std::max( addon._uid, maxUid );
+            }
+
+            for ( const auto & addon : tile.getTopLayerAddons() ) {
+                maxUid = std::max( addon._uid, maxUid );
+            }
+        }
+
+        // And set the UID counter value with the found maximum.
+        Maps::setLastObjectUID( maxUid );
+    }
 }
 
 uint32_t World::GetMapSeed() const
@@ -1472,7 +1492,7 @@ IStreamBase & operator>>( IStreamBase & stream, World & w )
 
     stream >> w.map_objects >> w._seed;
 
-    w.PostLoad( false );
+    w.PostLoad( false, true );
 
     return stream;
 }

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1327,24 +1327,28 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
     resetPathfinder();
     ComputeStaticAnalysis();
 
-    if ( updateUidCounterToMaximum ) {
-        // Find the maximum UID value.
-        uint32_t maxUid = 0;
+    // Find the maximum UID value.
+    uint32_t maxUid = 0;
 
-        for ( const Maps::Tiles & tile : vec_tiles ) {
-            maxUid = std::max( tile.getMainObjectPart()._uid, maxUid );
+    for ( const Maps::Tiles & tile : vec_tiles ) {
+        maxUid = std::max( tile.getMainObjectPart()._uid, maxUid );
 
-            for ( const auto & addon : tile.getBottomLayerAddons() ) {
-                maxUid = std::max( addon._uid, maxUid );
-            }
-
-            for ( const auto & addon : tile.getTopLayerAddons() ) {
-                maxUid = std::max( addon._uid, maxUid );
-            }
+        for ( const auto & addon : tile.getBottomLayerAddons() ) {
+            maxUid = std::max( addon._uid, maxUid );
         }
 
+        for ( const auto & addon : tile.getTopLayerAddons() ) {
+            maxUid = std::max( addon._uid, maxUid );
+        }
+    }
+
+    if ( updateUidCounterToMaximum ) {
         // And set the UID counter value with the found maximum.
         Maps::setLastObjectUID( maxUid );
+    }
+    else {
+        // Check that 'getNewObjectUID()' will return values that will not match the existing ones on the started map.
+        assert( Maps::getLastObjectUID() >= maxUid );
     }
 }
 

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -390,7 +390,7 @@ private:
     void Reset();
     void MonthOfMonstersAction( const Monster & );
     bool ProcessNewMP2Map( const std::string & filename, const bool checkPoLObjects );
-    void PostLoad( const bool setTilePassabilities );
+    void PostLoad( const bool setTilePassabilities, const bool updateUidCounterToMaximum );
 
     bool updateTileMetadata( Maps::Tiles & tile, const MP2::MapObjectType objectType, const bool checkPoLObjects );
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -1156,7 +1156,7 @@ bool World::ProcessNewMP2Map( const std::string & filename, const bool checkPoLO
 
     setUltimateArtifact( ultimateArtifactTileId, ultimateArtifactRadius );
 
-    PostLoad( true );
+    PostLoad( true, false );
 
     vec_kingdoms.ApplyPlayWithStartingHero();
 


### PR DESCRIPTION
Fix #9123

When loading a saved game the `objectCounter` is left as it was before the game load. Oh fheroes2 start it is set to 0. So after loading a saved game from the main menu the `objectCounter` starts from 0 and it leads to duplication of map objects' UIDs.

This PR adds a loop though all loaded tiles to get the maximum UID value and set `objectCounter` equal to the found value.

**This PR fixes the cause of the #9123 issue but not the result of setting the incorrect UID that is present in the attached save file.** The attached save file will contain the explained bug which happens when `removeObjectFromMapByUID()` is called. In that save two boats with the same ID are positioned in the nearby tiles and are considered as one 2-tile object by this function.