### PR TITLE
Remove the misleading TODO comment

### DIFF
--- a/src/fheroes2/agg/m82.cpp
+++ b/src/fheroes2/agg/m82.cpp
@@ -202,10 +202,6 @@ int M82::FromSpell( const int spellID )
     return UNKNOWN;
 }
 
-// TODO: This function works fine for most of objects as they have only one "main" tile. However,
-// TODO: some objects like Oracle or Volcano can be bigger than 1 tile leading to multiple sounds
-// TODO: coming from the same object and these sounds might not be synchronized. This is mostly
-// TODO: noticeable with 3D Audio mode on.
 M82::SoundType M82::getAdventureMapTileSound( const Maps::Tiles & tile )
 {
     if ( tile.isStream() ) {


### PR DESCRIPTION
Looking through the TODO comments, I found this one. After some thought about possible solutions and further testing, I found it a soft of misleading, since this issue (if there is one) applies not only (and not so much) to multi-tile objects, as to chains of single-tile objects, such as coasts or streams, which this function just cannot (and shouldn't) handle. In other words, this (potential) issue is not related to this function itself, but to playback of environment sounds in general.

Speaking of the playback, I have to say that I've done quite a few tests and found that the current mechanics of playing environment sounds work quite well in 3D audio mode. Yes, it would be possible to "combine" sounds in neighboring directions even more to better avoid unsynchronized sounds of the same type (and I tried to do that), but the result, to my taste, is a deterioration of the 3D effect. A certain "desynchronization" of environment sounds from different directions (again, for my taste) even enhances the impression of the 3D effect.