### PR TITLE
Editor and fh2m maps: set OBJECT_LAYER when placing a monster on the map

### DIFF
--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2735,27 +2735,27 @@ namespace Maps
     {
         tile.SetObject( MP2::OBJ_MONSTER );
 
-        if ( tile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_UNKNOWN ) {
-            // No object exists on this tile. Add one.
-            tile.getMainObjectPart()._uid = getNewObjectUID();
-            tile.getMainObjectPart()._objectIcnType = MP2::OBJ_ICN_TYPE_MONS32;
-        }
-        else if ( tile.getMainObjectPart()._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 ) {
-            // If there is another object sprite here (shadow for example) push it down to add-ons.
-            tile.pushBottomLayerAddon( tile.getMainObjectPart() );
+        Maps::TilesAddon & mainAddon = tile.getMainObjectPart();
+
+        if ( mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 ) {
+            if ( mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+                // If there is another object sprite here (shadow for example) push it down to add-ons.
+                tile.pushBottomLayerAddon( mainAddon );
+            }
 
             // Set unique UID for placed monster.
-            tile.getMainObjectPart()._uid = getNewObjectUID();
-            tile.getMainObjectPart()._objectIcnType = MP2::OBJ_ICN_TYPE_MONS32;
+            mainAddon._uid = getNewObjectUID();
+            mainAddon._objectIcnType = MP2::OBJ_ICN_TYPE_MONS32;
+            mainAddon._layerType = OBJECT_LAYER;
         }
 
-        using TileImageIndexType = decltype( tile.getMainObjectPart()._imageIndex );
+        using TileImageIndexType = decltype( mainAddon._imageIndex );
         static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of _imageIndex has been changed, check the logic below" );
 
         const uint32_t monsSpriteIndex = mons.GetSpriteIndex();
         assert( monsSpriteIndex >= std::numeric_limits<TileImageIndexType>::min() && monsSpriteIndex <= std::numeric_limits<TileImageIndexType>::max() );
 
-        tile.getMainObjectPart()._imageIndex = static_cast<TileImageIndexType>( monsSpriteIndex );
+        mainAddon._imageIndex = static_cast<TileImageIndexType>( monsSpriteIndex );
 
         const bool setDefinedCount = ( count > 0 );
 


### PR DESCRIPTION
Fix #9131

This PR also fixes a possible monster change when placing an object with a shadow to the right of the monster issue found by **Borasdk** on Discord.