### PR TITLE
Properly handle radar dragging in Editor when area select brush is used

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -860,7 +860,7 @@ namespace Interface
             isCursorOverGamearea = false;
 
             // cursor is over the radar
-            if ( le.isMouseCursorPosInArea( _radar.GetRect() ) ) {
+            if ( le.isMouseCursorPosInArea( _radar.GetArea() ) ) {
                 cursor.SetThemes( Cursor::POINTER );
 
                 // TODO: Add checks for object placing/moving, and other Editor functions that uses mouse dragging.
@@ -892,7 +892,7 @@ namespace Interface
                 if ( !_radar.isDragRadar() ) {
                     _gameArea.QueueEventProcessing( isCursorOverGamearea );
                 }
-                else if ( !le.isMouseLeftButtonPressed() ) {
+                else if ( le.isMouseLeftButtonReleased() ) {
                     _radar.QueueEventProcessing();
                 }
             }
@@ -928,7 +928,7 @@ namespace Interface
                     }
                 }
 
-                if ( _areaSelectionStartTileId == -1 && isValidTile && isBrushEmpty && le.isMouseLeftButtonPressed() ) {
+                if ( _areaSelectionStartTileId == -1 && isValidTile && isBrushEmpty && !_radar.isDragRadar() && le.isMouseLeftButtonPressed() ) {
                     _areaSelectionStartTileId = tilePos.y * world.w() + tilePos.x;
                     _redraw |= REDRAW_GAMEAREA;
                 }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1199,8 +1199,9 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isload )
         else if ( ( !isHiddenInterface || conf.ShowRadar() ) && le.isMouseCursorPosInArea( _radar.GetRect() ) ) {
             cursor.SetThemes( Cursor::POINTER );
 
-            if ( !_gameArea.isDragScroll() )
+            if ( !_gameArea.isDragScroll() ) {
                 _radar.QueueEventProcessing();
+            }
         }
         // cursor is over the control panel
         else if ( isHiddenInterface && conf.ShowControlPanel() && le.isMouseCursorPosInArea( controlPanel.GetArea() ) ) {
@@ -1221,10 +1222,12 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isload )
 
         // gamearea
         if ( !_gameArea.NeedScroll() && !isMovingHero ) {
-            if ( !_radar.isDragRadar() )
+            if ( !_radar.isDragRadar() ) {
                 _gameArea.QueueEventProcessing( isCursorOverGamearea );
-            else if ( !le.isMouseLeftButtonPressed() )
+            }
+            else if ( le.isMouseLeftButtonReleased() ) {
                 _radar.QueueEventProcessing();
+            }
         }
 
         if ( prevIsCursorOverButtons && !isCursorOverButtons ) {


### PR DESCRIPTION
This PR fixes the next issue:
>https://github.com/user-attachments/assets/192b3708-d730-4cd9-90d6-716f7db17cb0
>
>How to reproduce:
>
>* Select the "fill mode";
>* Move the mouse cursor to the radar area and press the left mouse button;
>* Scroll the editor area a bit using the radar;
>* Without releasing the left mouse button, move the cursor to the editor area and back to the radar;
>* Release the left mouse button while mouse cursor is on radar;
>* Radar does not respond to new left-click and mouse cursor movement, scrolling does not work;
>* After releasing the left mouse button again, everything starts working again.

_Originally posted by @oleg-derevenetz in https://github.com/ihhub/fheroes2/issues/9133#issuecomment-2369319940_

This PR also max a change from `!le.isMouseLeftButtonPressed()` to `le.isMouseLeftButtonReleased()` in both Editor and the **game**. This change relates to the case when you start dragging on radar, moved the cursor over the game area and released the left mouse button - to properly return from radar dragging to game are interaction.