### PR TITLE
Do not take into account top layer when selecting objects to erase.

### DIFF
--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -3296,12 +3296,9 @@ namespace Maps
                     }
                 }
 
-                for ( const auto & addon : currentTile.getTopLayerAddons() ) {
-                    // Top layer addons don't have layer type.
-                    if ( addon._uid != 0 ) {
-                        objectsUids.insert( addon._uid );
-                    }
-                }
+                // The top layer objects are not taken into account to correspond the original editor
+                // and because they can be small or even zero-sized parts of the Main or Bottom layer
+                // objects which can be selected by their non-top parts.
             }
         }
 

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -179,5 +179,6 @@ namespace Maps
     bool setObjectOnTile( Tiles & tile, const ObjectInfo & info, const bool updateMapPassabilities );
 
     // Returns UIDs in given area for all objects in the OBJECT and TERRAIN layers.
+    // This function does not take into account object parts in the top layer.
     std::set<uint32_t> getObjectUidsInArea( const int32_t startTileId, const int32_t endTileId );
 }


### PR DESCRIPTION
Fix #9132

In original Editor the Eraser does not erase objects by selecting only their top layer parts.
In the game there could be very small or even empty top layer parts like the upper tiles of Towns.
So not to confuse map maker and to correspond the original Editor behavior this PR skips checking the Top layer when getting objects to remove in the highlighted area.