### PR TITLE
Status Window: update army info after the battle, add sand grains to the hourglass animation and code clean

### DIFF
--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -43,7 +43,6 @@
 #include "localevent.h"
 #include "math_base.h"
 #include "players.h"
-#include "resource.h"
 #include "screen.h"
 #include "settings.h"
 #include "tools.h"
@@ -52,28 +51,6 @@
 #include "ui_dialog.h"
 #include "ui_text.h"
 #include "world.h"
-
-namespace
-{
-    const uint32_t resourceWindowExpireTime = 2500;
-}
-
-Interface::StatusWindow::StatusWindow( BaseInterface & interface )
-    : BorderWindow( { 0, 0, 144, 72 } )
-    , _interface( interface )
-    , _state( StatusType::STATUS_UNKNOWN )
-    , lastResource( Resource::UNKNOWN )
-    , countLastResource( 0 )
-    , turn_progress( 0 )
-    , showLastResourceDelay( resourceWindowExpireTime )
-{}
-
-void Interface::StatusWindow::Reset()
-{
-    _state = StatusType::STATUS_DAY;
-    lastResource = Resource::UNKNOWN;
-    countLastResource = 0;
-}
 
 void Interface::StatusWindow::SavePosition()
 {
@@ -88,9 +65,9 @@ void Interface::StatusWindow::SetRedraw() const
     _interface.setRedraw( REDRAW_STATUS );
 }
 
-void Interface::StatusWindow::SetPos( int32_t ox, int32_t oy )
+void Interface::StatusWindow::SetPos( const int32_t ox, const int32_t oy )
 {
-    uint32_t ow = 144;
+    const uint32_t ow = 144;
     uint32_t oh = 72;
 
     if ( !Settings::Get().isHideInterfaceEnabled() ) {
@@ -125,7 +102,7 @@ void Interface::StatusWindow::_redraw() const
         BorderWindow::Redraw();
     }
     else {
-        DrawBackground();
+        _drawBackground();
     }
 
     // Do not draw anything if the game hasn't really started yet
@@ -137,34 +114,36 @@ void Interface::StatusWindow::_redraw() const
     const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( conf.isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
     const int32_t stonHeight = ston.height();
 
-    if ( StatusType::STATUS_AITURN == _state ) {
-        DrawAITurns();
+    if ( _state == StatusType::STATUS_AITURN ) {
+        _drawAITurns();
     }
     else if ( StatusType::STATUS_UNKNOWN != _state && pos.height >= ( stonHeight * 3 + 15 ) ) {
-        DrawDayInfo();
+        _drawDayInfo();
 
         if ( conf.CurrentColor() & Players::HumanColors() ) {
-            DrawKingdomInfo( stonHeight + 5 );
+            _drawKingdomInfo( stonHeight + 5 );
 
-            if ( _state != StatusType::STATUS_RESOURCE )
-                DrawArmyInfo( 2 * stonHeight + 10 );
-            else
-                DrawResourceInfo( 2 * stonHeight + 10 );
+            if ( _state != StatusType::STATUS_RESOURCE ) {
+                _drawArmyInfo( 2 * stonHeight + 10 );
+            }
+            else {
+                _drawResourceInfo( 2 * stonHeight + 10 );
+            }
         }
     }
     else if ( StatusType::STATUS_UNKNOWN != _state && pos.height >= ( stonHeight * 2 + 15 ) ) {
-        DrawDayInfo();
+        _drawDayInfo();
 
         switch ( _state ) {
         case StatusType::STATUS_FUNDS:
-            DrawKingdomInfo( stonHeight + 5 );
+            _drawKingdomInfo( stonHeight + 5 );
             break;
         case StatusType::STATUS_DAY:
         case StatusType::STATUS_ARMY:
-            DrawArmyInfo( stonHeight + 5 );
+            _drawArmyInfo( stonHeight + 5 );
             break;
         case StatusType::STATUS_RESOURCE:
-            DrawResourceInfo( stonHeight + 5 );
+            _drawResourceInfo( stonHeight + 5 );
             break;
         case StatusType::STATUS_UNKNOWN:
         case StatusType::STATUS_AITURN:
@@ -177,16 +156,16 @@ void Interface::StatusWindow::_redraw() const
     else {
         switch ( _state ) {
         case StatusType::STATUS_DAY:
-            DrawDayInfo();
+            _drawDayInfo();
             break;
         case StatusType::STATUS_FUNDS:
-            DrawKingdomInfo();
+            _drawKingdomInfo();
             break;
         case StatusType::STATUS_ARMY:
-            DrawArmyInfo();
+            _drawArmyInfo();
             break;
         case StatusType::STATUS_RESOURCE:
-            DrawResourceInfo();
+            _drawResourceInfo();
             break;
         case StatusType::STATUS_UNKNOWN:
         case StatusType::STATUS_AITURN:
@@ -206,10 +185,12 @@ void Interface::StatusWindow::NextState()
 
     const bool skipDayStatus = areaHeight >= ( stonHeight * 2 + 15 ) && areaHeight < ( stonHeight * 3 + 15 );
 
-    if ( StatusType::STATUS_DAY == _state )
+    if ( StatusType::STATUS_DAY == _state ) {
         _state = StatusType::STATUS_FUNDS;
-    else if ( StatusType::STATUS_FUNDS == _state )
+    }
+    else if ( StatusType::STATUS_FUNDS == _state ) {
         _state = ( GameFocus::UNSEL == GetFocusType() ? StatusType::STATUS_DAY : StatusType::STATUS_ARMY );
+    }
     else if ( StatusType::STATUS_ARMY == _state ) {
         if ( skipDayStatus ) {
             _state = StatusType::STATUS_FUNDS;
@@ -218,57 +199,66 @@ void Interface::StatusWindow::NextState()
             _state = StatusType::STATUS_DAY;
         }
     }
-    else if ( StatusType::STATUS_RESOURCE == _state )
+    else if ( StatusType::STATUS_RESOURCE == _state ) {
         _state = StatusType::STATUS_ARMY;
+    }
 
     if ( _state == StatusType::STATUS_ARMY ) {
         const Castle * castle = GetFocusCastle();
 
         // skip empty army for castle
-        if ( castle && !castle->GetArmy().isValid() )
+        if ( castle && !castle->GetArmy().isValid() ) {
             NextState();
+        }
     }
 }
 
-void Interface::StatusWindow::DrawKingdomInfo( int oh ) const
+void Interface::StatusWindow::_drawKingdomInfo( const int32_t offsetY ) const
 {
-    const fheroes2::Rect & pos = GetArea();
+    fheroes2::Point pos = GetArea().getPosition();
     const Kingdom & myKingdom = world.GetKingdom( Settings::Get().CurrentColor() );
+
+    pos.y += offsetY + 3;
 
     // sprite all resource
     fheroes2::Display & display = fheroes2::Display::instance();
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::RESSMALL, 0 ), display, pos.x + 6, pos.y + 3 + oh );
+    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::RESSMALL, 0 ), display, pos.x + 6, pos.y );
+
+    pos.y += 27;
 
     // count castle
     fheroes2::Text text( std::to_string( myKingdom.GetCountCastle() ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 26 - text.width() / 2, pos.y + 30 + oh, display );
+    text.draw( pos.x + 26 - text.width() / 2, pos.y, display );
     // count town
     text.set( std::to_string( myKingdom.GetCountTown() ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 78 - text.width() / 2, pos.y + 30 + oh, display );
+    text.draw( pos.x + 78 - text.width() / 2, pos.y, display );
     // count gold
     text.set( std::to_string( myKingdom.GetFunds().Get( Resource::GOLD ) ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 122 - text.width() / 2, pos.y + 30 + oh, display );
+    text.draw( pos.x + 122 - text.width() / 2, pos.y, display );
+
+    pos.y += 30;
+
     // count wood
     text.set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::WOOD ) ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 15 - text.width() / 2, pos.y + 60 + oh, display );
+    text.draw( pos.x + 15 - text.width() / 2, pos.y, display );
     // count mercury
     text.set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::MERCURY ) ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 37 - text.width() / 2, pos.y + 60 + oh, display );
+    text.draw( pos.x + 37 - text.width() / 2, pos.y, display );
     // count ore
     text.set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::ORE ) ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 60 - text.width() / 2, pos.y + 60 + oh, display );
+    text.draw( pos.x + 60 - text.width() / 2, pos.y, display );
     // count sulfur
     text.set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::SULFUR ) ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 84 - text.width() / 2, pos.y + 60 + oh, display );
+    text.draw( pos.x + 84 - text.width() / 2, pos.y, display );
     // count crystal
     text.set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::CRYSTAL ) ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 108 - text.width() / 2, pos.y + 60 + oh, display );
+    text.draw( pos.x + 108 - text.width() / 2, pos.y, display );
     // count gems
     text.set( fheroes2::abbreviateNumber( myKingdom.GetFunds().Get( Resource::GEMS ) ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + 130 - text.width() / 2, pos.y + 60 + oh, display );
+    text.draw( pos.x + 130 - text.width() / 2, pos.y, display );
 }
 
-void Interface::StatusWindow::DrawDayInfo( int oh ) const
+void Interface::StatusWindow::_drawDayInfo( const int32_t offsetY ) const
 {
     const fheroes2::Rect & pos = GetArea();
 
@@ -284,119 +274,123 @@ void Interface::StatusWindow::DrawDayInfo( int oh ) const
     }
 
     fheroes2::Display & display = fheroes2::Display::instance();
-    fheroes2::Blit( fheroes2::AGG::GetICN( icnType, icnId ), display, pos.x, pos.y + 1 + oh );
+    fheroes2::Blit( fheroes2::AGG::GetICN( icnType, icnId ), display, pos.x, pos.y + 1 + offsetY );
 
     std::string message = _( "Month: %{month} Week: %{week}" );
     StringReplace( message, "%{month}", month );
     StringReplace( message, "%{week}", weekOfMonth );
     fheroes2::Text text( message, fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + 32 + oh, display );
+    text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + 32 + offsetY, display );
 
     message = _( "Day: %{day}" );
     StringReplace( message, "%{day}", dayOfWeek );
     text.set( message, fheroes2::FontType::normalWhite() );
-    text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + 48 + oh, display );
+    text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + 48 + offsetY, display );
 }
 
-void Interface::StatusWindow::SetResource( int res, uint32_t count )
+void Interface::StatusWindow::SetResource( const int resource, const uint32_t count )
 {
-    lastResource = res;
-    countLastResource = count;
+    _lastResource = resource;
+    _lastResourceCount = count;
     _state = StatusType::STATUS_RESOURCE;
 
-    showLastResourceDelay.reset();
+    _showLastResourceDelay.reset();
 }
 
-void Interface::StatusWindow::DrawResourceInfo( int oh ) const
+void Interface::StatusWindow::_drawResourceInfo( const int32_t offsetY ) const
 {
     const fheroes2::Rect & pos = GetArea();
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
     std::string message = _( "You find a small\nquantity of %{resource}." );
-    StringReplace( message, "%{resource}", Resource::String( lastResource ) );
+    StringReplace( message, "%{resource}", Resource::String( _lastResource ) );
     fheroes2::Text text{ std::move( message ), fheroes2::FontType::smallWhite() };
-    text.draw( pos.x, pos.y + 6 + oh, pos.width, display );
+    text.draw( pos.x, pos.y + 6 + offsetY, pos.width, display );
 
-    const fheroes2::Sprite & spr = fheroes2::AGG::GetICN( ICN::RESOURCE, Resource::getIconIcnIndex( lastResource ) );
-    fheroes2::Blit( spr, display, pos.x + ( pos.width - spr.width() ) / 2, pos.y + 6 + oh + text.height( pos.width ) );
+    const fheroes2::Sprite & spr = fheroes2::AGG::GetICN( ICN::RESOURCE, Resource::getIconIcnIndex( _lastResource ) );
+    fheroes2::Blit( spr, display, pos.x + ( pos.width - spr.width() ) / 2, pos.y + 6 + offsetY + text.height( pos.width ) );
 
-    text.set( std::to_string( countLastResource ), fheroes2::FontType::smallWhite() );
-    text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + oh + text.height() * 2 + spr.height() + 10, display );
+    text.set( std::to_string( _lastResourceCount ), fheroes2::FontType::smallWhite() );
+    text.draw( pos.x + ( pos.width - text.width() ) / 2, pos.y + offsetY + text.height() * 2 + spr.height() + 10, display );
 }
 
-void Interface::StatusWindow::DrawArmyInfo( int oh ) const
+void Interface::StatusWindow::_drawArmyInfo( const int32_t offsetY ) const
 {
     const Army * armies = nullptr;
 
-    if ( GetFocusHeroes() )
+    if ( GetFocusHeroes() ) {
         armies = &GetFocusHeroes()->GetArmy();
-    else if ( GetFocusCastle() )
+    }
+    else if ( GetFocusCastle() ) {
         armies = &GetFocusCastle()->GetArmy();
+    }
 
     if ( armies ) {
         const fheroes2::Rect & pos = GetArea();
-        Army::drawMultipleMonsterLines( *armies, pos.x + 4, pos.y + 1 + oh, 138, true, true );
+        Army::drawMultipleMonsterLines( *armies, pos.x + 4, pos.y + 1 + offsetY, 138, true, true );
     }
 }
 
-void Interface::StatusWindow::DrawAITurns() const
+void Interface::StatusWindow::_drawAITurns() const
 {
     // restore background
-    DrawBackground();
+    _drawBackground();
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
     const fheroes2::Sprite & glass = fheroes2::AGG::GetICN( ICN::HOURGLAS, 0 );
-    const fheroes2::Rect & pos = GetArea();
+    const fheroes2::Rect & statusRoi = GetArea();
 
-    int32_t dst_x = pos.x + ( pos.width - glass.width() ) / 2;
-    int32_t dst_y = pos.y + ( pos.height - glass.height() ) / 2;
+    int32_t posX = statusRoi.x + ( statusRoi.width - glass.width() ) / 2;
+    int32_t posY = statusRoi.y + ( statusRoi.height - glass.height() ) / 2;
 
-    fheroes2::Blit( glass, display, dst_x, dst_y );
+    fheroes2::Blit( glass, display, posX, posY );
 
-    int color_index = 0;
+    uint32_t colorIndex = 0;
 
-    const Settings & conf = Settings::Get();
-    switch ( conf.CurrentColor() ) {
+    switch ( Settings::Get().CurrentColor() ) {
     case Color::BLUE:
-        color_index = 0;
         break;
     case Color::GREEN:
-        color_index = 1;
+        colorIndex = 1;
         break;
     case Color::RED:
-        color_index = 2;
+        colorIndex = 2;
         break;
     case Color::YELLOW:
-        color_index = 3;
+        colorIndex = 3;
         break;
     case Color::ORANGE:
-        color_index = 4;
+        colorIndex = 4;
         break;
     case Color::PURPLE:
-        color_index = 5;
+        colorIndex = 5;
         break;
     default:
+        // Have you added a new player color? Check the logic above!
+        assert( 0 );
         return;
     }
 
-    const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::BRCREST, color_index );
+    const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::BRCREST, colorIndex );
 
-    dst_x += 2;
-    dst_y += 2;
+    posX += 2;
+    posY += 2;
 
-    fheroes2::Blit( crest, display, dst_x, dst_y );
+    fheroes2::Blit( crest, display, posX, posY );
 
-    const fheroes2::Sprite & sand = fheroes2::AGG::GetICN( ICN::HOURGLAS, 1 + ( turn_progress % 10 ) );
+    posX += glass.width() - 3;
 
-    dst_x += ( glass.width() - sand.width() - sand.x() - 3 );
-    dst_y += sand.y();
+    // TODO: Make smooth sand grains animation. Image indices (11-20) are for the start and indices (21-30) in a loop.
+    const fheroes2::Sprite & sandGains = fheroes2::AGG::GetICN( ICN::HOURGLAS, 21 + ( _aiTurnProgress % 10 ) );
+    fheroes2::Blit( sandGains, display, posX - sandGains.width() - sandGains.x(), posY + sandGains.y() );
 
-    fheroes2::Blit( sand, display, dst_x, dst_y );
+    const fheroes2::Sprite & sand = fheroes2::AGG::GetICN( ICN::HOURGLAS, 1 + ( _aiTurnProgress % 10 ) );
+    fheroes2::Blit( sand, display, posX - sand.width() - sand.x(), posY + sand.y() );
 }
 
-void Interface::StatusWindow::DrawBackground() const
+void Interface::StatusWindow::_drawBackground() const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
     const fheroes2::Sprite & icnston = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
@@ -408,23 +402,24 @@ void Interface::StatusWindow::DrawBackground() const
         const int32_t copyHeight = 46;
         fheroes2::Rect srcrt( 0, 0, icnston.width(), startY );
         fheroes2::Point dstpt( pos.x, pos.y );
-        fheroes2::Blit( icnston, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
+        fheroes2::Copy( icnston, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
 
         // middle
-        srcrt = fheroes2::Rect( 0, startY, icnston.width(), copyHeight );
+        srcrt.y = startY;
+        srcrt.height = copyHeight;
         const int32_t count = ( pos.height - ( icnston.height() - copyHeight ) ) / copyHeight;
         for ( int32_t i = 0; i < count; ++i ) {
             dstpt = fheroes2::Point( pos.x, pos.y + copyHeight * i + startY );
-            fheroes2::Blit( icnston, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
+            fheroes2::Copy( icnston, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
         }
 
         // bottom
-        srcrt = fheroes2::Rect( 0, startY, icnston.width(), icnston.height() - startY );
-        dstpt = fheroes2::Point( pos.x, pos.y + pos.height - ( icnston.height() - startY ) );
-        fheroes2::Blit( icnston, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
+        srcrt.height = icnston.height() - startY;
+        dstpt = fheroes2::Point( pos.x, pos.y + pos.height - srcrt.height );
+        fheroes2::Copy( icnston, srcrt.x, srcrt.y, display, dstpt.x, dstpt.y, srcrt.width, srcrt.height );
     }
     else {
-        fheroes2::Blit( icnston, display, pos.x, pos.y );
+        fheroes2::Copy( icnston, 0, 0, display, pos.x, pos.y, icnston.width(), icnston.height() );
     }
 }
 
@@ -462,7 +457,7 @@ void Interface::StatusWindow::QueueEventProcessing()
 
 void Interface::StatusWindow::TimerEventProcessing()
 {
-    if ( _state != StatusType::STATUS_RESOURCE || !showLastResourceDelay.isPassed() ) {
+    if ( _state != StatusType::STATUS_RESOURCE || !_showLastResourceDelay.isPassed() ) {
         return;
     }
 
@@ -486,7 +481,7 @@ void Interface::StatusWindow::DrawAITurnProgress( const uint32_t progressValue )
     // Process events if any before rendering a frame. For instance, updating a mouse cursor position.
     LocalEvent::Get().HandleEvents( false );
 
-    turn_progress = progressValue;
+    _aiTurnProgress = progressValue;
 
     _interface.setRedraw( REDRAW_STATUS );
 

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -27,6 +27,7 @@
 #include <cstdint>
 
 #include "interface_border.h"
+#include "resource.h"
 #include "timing.h"
 
 namespace Interface
@@ -46,23 +47,34 @@ namespace Interface
     class StatusWindow final : public BorderWindow
     {
     public:
-        explicit StatusWindow( BaseInterface & interface );
+        explicit StatusWindow( BaseInterface & interface )
+            : BorderWindow( { 0, 0, 144, 72 } )
+            , _interface( interface )
+        {
+            // Do nothing.
+        }
+
         StatusWindow( const StatusWindow & ) = delete;
 
         ~StatusWindow() override = default;
 
         StatusWindow & operator=( const StatusWindow & ) = delete;
 
-        void SetPos( int32_t ox, int32_t oy ) override;
+        void SetPos( const int32_t ox, const int32_t oy ) override;
         void SavePosition() override;
         void SetRedraw() const;
 
-        void Reset();
+        void Reset()
+        {
+            _state = StatusType::STATUS_DAY;
+            _lastResource = Resource::UNKNOWN;
+            _lastResourceCount = 0;
+        }
 
         void NextState();
 
         void SetState( const StatusType status );
-        void SetResource( int, uint32_t );
+        void SetResource( const int resource, const uint32_t count );
         void DrawAITurnProgress( const uint32_t progressValue );
         void QueueEventProcessing();
         void TimerEventProcessing();
@@ -72,21 +84,21 @@ namespace Interface
         void _redraw() const;
 
     private:
-        void DrawKingdomInfo( int oh = 0 ) const;
-        void DrawDayInfo( int oh = 0 ) const;
-        void DrawArmyInfo( int oh = 0 ) const;
-        void DrawResourceInfo( int oh = 0 ) const;
-        void DrawBackground() const;
-        void DrawAITurns() const;
+        void _drawKingdomInfo( const int32_t offsetY = 0 ) const;
+        void _drawDayInfo( const int32_t offsetY = 0 ) const;
+        void _drawArmyInfo( const int32_t offsetY = 0 ) const;
+        void _drawResourceInfo( const int32_t offsetY = 0 ) const;
+        void _drawBackground() const;
+        void _drawAITurns() const;
 
         BaseInterface & _interface;
 
-        StatusType _state;
-        int lastResource;
-        uint32_t countLastResource;
-        uint32_t turn_progress;
+        StatusType _state{ StatusType::STATUS_UNKNOWN };
+        int _lastResource{ Resource::UNKNOWN };
+        uint32_t _lastResourceCount{ 0 };
+        uint32_t _aiTurnProgress{ 0 };
 
-        fheroes2::TimeDelay showLastResourceDelay;
+        fheroes2::TimeDelay _showLastResourceDelay{ 2500 };
     };
 }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -407,8 +407,8 @@ namespace
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
-            // Hero' spell points could have changed. Update heroes icons.
-            I.renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
+            // Hero' spell points and army could have changed. Update heroes icons and status area.
+            I.renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -528,8 +528,8 @@ namespace
 
             castle->ActionAfterBattle( res.AttackerWins() );
 
-            // Hero' spell points could have changed. Update heroes icons.
-            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_ICONS | Interface::REDRAW_BUTTONS );
+            // Hero' spell points and army could have changed. Update heroes icons and status area.
+            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
             // The defender was defeated
             if ( !res.DefenderWins() && defender ) {
@@ -603,8 +603,8 @@ namespace
 
         const Battle::Result res = Battle::Loader( hero.GetArmy(), otherHero->GetArmy(), dstIndex );
 
-        // Hero' spell points could have changed. Update heroes icons.
-        Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
+        // Hero' spell points and army could have changed. Update heroes icons and status area.
+        Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
         // TODO: make fading animation of both heroes together.
 
@@ -1135,8 +1135,8 @@ namespace
 
                 const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
-                // Hero' spell points could have changed. Update heroes icons.
-                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
+                // Hero' spell points and army could have changed. Update heroes icons and status area.
+                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
                 if ( res.AttackerWins() ) {
                     hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -1698,8 +1698,8 @@ namespace
             if ( battle ) {
                 const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
-                // Hero' spell points could have changed. Update heroes icons.
-                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
+                // Hero' spell points and army could have changed. Update heroes icons and status area.
+                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
                 if ( res.AttackerWins() ) {
                     hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -2094,8 +2094,8 @@ namespace
 
                 const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
-                // Hero' spell points could have changed. Update heroes icons.
-                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
+                // Hero' spell points and army could have changed. Update heroes icons and status area.
+                Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
                 if ( result.AttackerWins() ) {
                     hero.IncreaseExperience( result.GetExperienceAttacker() );
@@ -2147,8 +2147,8 @@ namespace
 
             const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
-            // Hero' spell points could have changed. Update heroes icons.
-            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
+            // Hero' spell points and army could have changed. Update heroes icons and status area.
+            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
             if ( result.AttackerWins() ) {
                 hero.IncreaseExperience( result.GetExperienceAttacker() );
@@ -2431,8 +2431,8 @@ namespace
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
-            // Hero' spell points could have changed. Update heroes icons.
-            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
+            // Hero' spell points and army could have changed. Update heroes icons and status area.
+            Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
             if ( res.AttackerWins() ) {
                 hero.IncreaseExperience( res.GetExperienceAttacker() );
@@ -3067,8 +3067,8 @@ namespace
 
                     const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
-                    // Hero' spell points could have changed. Update heroes icons.
-                    Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
+                    // Hero' spell points and army could have changed. Update heroes icons and status area.
+                    Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
                     if ( res.AttackerWins() ) {
                         hero.IncreaseExperience( res.GetExperienceAttacker() );


### PR DESCRIPTION
Fix #9021

This PR also basely adds sand grains to the hourglass animation during the enemy's turn.
Currently only the "loop" part of this animation is used and updated only with the hourglass (rare and non-smooth):
![изображение](https://github.com/user-attachments/assets/841c01cb-fc5c-437f-ad9c-5496f815f4fc)
 In future this part should be updated along with the turn progress value generation (TODO is left in the code).

Also a small code clean is performed in interface_status.cpp/.h