### PR TITLE
Add an additional assertion

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1064,8 +1064,9 @@ bool Maps::Tiles::isPassableFrom( const int direction, const bool fromWater, con
     // Tiles on which the entrances to the allied castles are located are inaccessible
     if ( _mainObjectType == MP2::OBJ_CASTLE ) {
         const Castle * castle = world.getCastleEntrance( GetCenter() );
+        assert( castle != nullptr );
 
-        if ( castle && castle->GetColor() != heroColor && castle->isFriends( heroColor ) ) {
+        if ( castle->GetColor() != heroColor && castle->isFriends( heroColor ) ) {
             return false;
         }
     }


### PR DESCRIPTION
There should be no valid reason for `World::getCastleEntrance()` to return `nullptr` for a tile with `OBJ_CASTLE`.