### PR TITLE
Migrate the build from macOS 12 to macOS 13

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -102,7 +102,7 @@ jobs:
             CXX: aarch64-linux-gnu-g++
             AR: aarch64-linux-gnu-ar
         - name: macOS SDL2
-          os: macos-12
+          os: macos-13
           dependencies: sdl2 sdl2_mixer sdl2_image
           env:
             FHEROES2_STRICT_COMPILATION: ON


### PR DESCRIPTION
macOS 12 is now [deprecated](https://github.com/actions/runner-images/issues/10721) with all the usual consequences - less runners, intermittent failures and so on.