### PR TITLE
Make hourglass animation during AI turn more smooth

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -2119,7 +2119,7 @@ void AI::HeroesMove( Heroes & hero )
                 // Update Adventure Map objects' animation.
                 Game::updateAdventureMapAnimationIndex();
 
-                adventureMapInterface.redraw( Interface::REDRAW_GAMEAREA );
+                adventureMapInterface.redraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_STATUS );
 
                 // If this assertion blows up it means that we are holding a RedrawLocker lock for rendering which should not happen.
                 assert( adventureMapInterface.getRedrawMask() == 0 );
@@ -2186,6 +2186,8 @@ void AI::HeroesMove( Heroes & hero )
             if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
                 // Update Adventure Map objects' animation.
                 Game::updateAdventureMapAnimationIndex();
+
+                adventureMapInterface.setRedraw( Interface::REDRAW_STATUS );
             }
 
             adventureMapInterface.redraw( Interface::REDRAW_GAMEAREA );

--- a/src/fheroes2/ai/ai_planner.h
+++ b/src/fheroes2/ai/ai_planner.h
@@ -190,7 +190,7 @@ namespace AI
         void CastleTurn( Castle & castle, const bool defensiveStrategy );
 
         // Returns true if heroes can still do tasks but they have no move points.
-        bool HeroesTurn( VecHeroes & heroes, const uint32_t startProgressValue, const uint32_t endProgressValue );
+        bool HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue );
 
         bool recruitHero( Castle & castle, bool buyArmy );
         void reinforceHeroInCastle( Heroes & hero, Castle & castle, const Funds & budget );

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2722,7 +2722,7 @@ void AI::Planner::HeroesPreBattle( HeroBase & hero, bool isAttacking )
     }
 }
 
-bool AI::Planner::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressValue, const uint32_t endProgressValue )
+bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue )
 {
     if ( heroes.empty() ) {
         // No heroes so we indicate that all heroes moved.
@@ -2730,6 +2730,7 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressVa
     }
 
     std::vector<Heroes *> availableHeroes;
+    availableHeroes.reserve( heroes.size() );
 
     for ( Heroes * hero : heroes ) {
         assert( hero != nullptr );
@@ -2739,7 +2740,17 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressVa
 
     Interface::StatusWindow & status = Interface::AdventureMap::Get().getStatusWindow();
 
-    uint32_t currentProgressValue = startProgressValue;
+    uint32_t heroesToMoveTotalCount = static_cast<uint32_t>( availableHeroes.size() );
+    uint32_t startProgressValue = currentProgressValue;
+
+    if ( endProgressValue - currentProgressValue >= heroesToMoveTotalCount * 2 ) {
+        // An extra case when there is only one hero and we have more than 2 points to display the turn progress.
+        // We increase the start value to display this progress after the pathfinder ends his work
+        // and the next progress increase will be aster the hero makes his move.
+        ++startProgressValue;
+    }
+
+    uint32_t turnProgressScale = 4 * ( endProgressValue - startProgressValue );
 
     while ( !availableHeroes.empty() ) {
         const AIWorldPathfinderStateRestorer pathfinderStateRestorer( _pathfinder );
@@ -2770,12 +2781,25 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressVa
                         bestTargetIndex = targetIndex;
                         bestHero = hero;
                     }
+
+                    // This loop may take many time for computations so update hourglass grains animation.
+                    status.drawAITurnProgress( currentProgressValue );
                 }
 
                 if ( bestTargetIndex != -1 ) {
                     break;
                 }
             }
+        }
+
+        // Calculate turn progress taking into account that the current 'betsHero' most likely will end his turn
+        // and will be removed from 'availableHeroes' vector: we add 3/4 (not 1/2) to help rounding the result.
+        uint32_t progressValue = ( turnProgressScale * ( heroesToMoveTotalCount - static_cast<uint32_t>( availableHeroes.size() ) ) + 3 * heroesToMoveTotalCount )
+                                     / ( 4 * heroesToMoveTotalCount )
+                                 + startProgressValue;
+        if ( currentProgressValue < progressValue ) {
+            currentProgressValue = progressValue;
+            status.drawAITurnProgress( currentProgressValue );
         }
 
         if ( bestTargetIndex == -1 ) {
@@ -2805,7 +2829,7 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressVa
         }
 
         if ( bestTargetIndex == -1 ) {
-            // Nothing to do. Stop everything
+            // Nothing to do. Stop everything.
             break;
         }
 
@@ -2865,28 +2889,36 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, const uint32_t startProgressVa
             }
         }
 
+        // The size of heroes can be increased if a new hero is released from Jail.
         if ( heroes.size() > heroesBefore ) {
+            const size_t availableHeroesBefore = availableHeroes.size();
+
             addHeroToMove( heroes.back(), availableHeroes );
+
+            if ( availableHeroesBefore < availableHeroes.size() ) {
+                ++heroesToMoveTotalCount;
+
+                if ( endProgressValue < 8 ) {
+                    ++endProgressValue;
+                    turnProgressScale += 4;
+                }
+            }
         }
 
         availableHeroes.erase( std::remove_if( availableHeroes.begin(), availableHeroes.end(),
                                                []( const Heroes * hero ) { return !hero->MayStillMove( false, false ); } ),
                                availableHeroes.end() );
 
-        // The size of heroes can be increased if a new hero is released from Jail.
-        const size_t maxHeroCount = std::max( heroes.size(), availableHeroes.size() );
-
-        if ( maxHeroCount > 0 ) {
-            // At least one hero still exist in the kingdom.
-            const size_t progressValue = ( endProgressValue - startProgressValue ) * ( maxHeroCount - availableHeroes.size() ) / maxHeroCount + startProgressValue;
-            if ( currentProgressValue < progressValue ) {
-                currentProgressValue = static_cast<uint32_t>( progressValue );
-                status.DrawAITurnProgress( currentProgressValue );
-            }
+        progressValue = ( turnProgressScale * ( heroesToMoveTotalCount - static_cast<uint32_t>( availableHeroes.size() ) ) + heroesToMoveTotalCount )
+                            / ( 4 * heroesToMoveTotalCount )
+                        + startProgressValue;
+        if ( currentProgressValue < progressValue ) {
+            currentProgressValue = progressValue;
+            status.drawAITurnProgress( currentProgressValue );
         }
     }
 
-    status.DrawAITurnProgress( endProgressValue );
+    status.drawAITurnProgress( endProgressValue );
 
     return availableHeroes.empty();
 }

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2792,7 +2792,7 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValu
             }
         }
 
-        // Calculate turn progress taking into account that the current 'betsHero' most likely will end his turn
+        // Calculate turn progress taking into account that the current 'bestHero' most likely will end his turn
         // and will be removed from 'availableHeroes' vector: we add 3/4 (not 1/2) to help rounding the result.
         uint32_t progressValue = ( turnProgressScale * ( heroesToMoveTotalCount - static_cast<uint32_t>( availableHeroes.size() ) ) + 3 * heroesToMoveTotalCount )
                                      / ( 4 * heroesToMoveTotalCount )

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -891,7 +891,8 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
 
         // If AI has less than three heroes at the start of the turn we assume
         // that he will buy another one in this turn and allow progress to increase only for 2 points.
-        uint32_t const endProgressValue = ( progressStatus == 1 ) ? std::min( static_cast<uint32_t>( heroes.size() ) * 2U + 1U, 8U ) : std::min( progressStatus + 2U, 9U );
+        uint32_t const endProgressValue
+            = ( progressStatus == 1 ) ? std::min( static_cast<uint32_t>( heroes.size() ) * 2U + 1U, 8U ) : std::min( progressStatus + 2U, 9U );
 
         bool moreTaskForHeroes = HeroesTurn( heroes, progressStatus, endProgressValue );
 

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -754,7 +754,7 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
 
     // Reset the turn progress indicator
     Interface::StatusWindow & status = Interface::AdventureMap::Get().getStatusWindow();
-    status.DrawAITurnProgress( 0 );
+    status.drawAITurnProgress( 0 );
 
     AudioManager::PlayMusicAsync( MUS::COMPUTER_TURN, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
@@ -861,7 +861,7 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
     updateKingdomBudget( kingdom );
 
     uint32_t progressStatus = 1;
-    status.DrawAITurnProgress( progressStatus );
+    status.drawAITurnProgress( progressStatus );
 
     std::set<int> castlesInDanger;
     std::vector<AICastle> sortedCastleList;
@@ -889,15 +889,11 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
 
         sortedCastleList = getSortedCastleList( castles, castlesInDanger );
 
-        const uint32_t startProgressValue = progressStatus;
-        const uint32_t endProgressValue = ( progressStatus == 1 ) ? 8 : std::max( progressStatus + 1U, 9U );
+        // If AI has less than three heroes at the start of the turn we assume
+        // that he will buy another one in this turn and allow progress to increase only for 2 points.
+        uint32_t endProgressValue = ( progressStatus == 1 ) ? std::min( static_cast<uint32_t>( heroes.size() ) * 2U + 1U, 8U ) : std::min( progressStatus + 2U, 9U );
 
-        bool moreTaskForHeroes = HeroesTurn( heroes, startProgressValue, endProgressValue );
-
-        if ( progressStatus == 1 ) {
-            progressStatus = 8;
-            status.DrawAITurnProgress( progressStatus );
-        }
+        bool moreTaskForHeroes = HeroesTurn( heroes, progressStatus, endProgressValue );
 
         // Step 4. Buy new heroes, adjust roles, sort heroes based on priority or strength
         if ( purchaseNewHeroes( sortedCastleList, castlesInDanger, availableHeroCount, moreTaskForHeroes ) ) {
@@ -933,7 +929,7 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
         break;
     }
 
-    status.DrawAITurnProgress( 9 );
+    status.drawAITurnProgress( 9 );
 
     // Sync the list of castles (if new ones were captured during the turn)
     if ( castles.size() != sortedCastleList.size() ) {
@@ -960,7 +956,7 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
         transferSlowestTroopsToGarrison( hero, castle );
     }
 
-    status.DrawAITurnProgress( 10 );
+    status.resetAITurnProgress();
 }
 
 bool AI::Planner::purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, const int32_t availableHeroCount,

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -891,7 +891,7 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
 
         // If AI has less than three heroes at the start of the turn we assume
         // that he will buy another one in this turn and allow progress to increase only for 2 points.
-        uint32_t endProgressValue = ( progressStatus == 1 ) ? std::min( static_cast<uint32_t>( heroes.size() ) * 2U + 1U, 8U ) : std::min( progressStatus + 2U, 9U );
+        uint32_t const endProgressValue = ( progressStatus == 1 ) ? std::min( static_cast<uint32_t>( heroes.size() ) * 2U + 1U, 8U ) : std::min( progressStatus + 2U, 9U );
 
         bool moreTaskForHeroes = HeroesTurn( heroes, progressStatus, endProgressValue );
 

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -563,7 +563,7 @@ void Interface::AdventureMap::EventSwitchShowStatus() const
         }
         else {
             conf.SetShowStatus( true );
-            _statusWindow.SetRedraw();
+            _statusWindow.setRedraw();
         }
     }
 }

--- a/src/fheroes2/gui/interface_focus.cpp
+++ b/src/fheroes2/gui/interface_focus.cpp
@@ -299,5 +299,5 @@ void Interface::AdventureMap::RedrawFocus()
         iconsPanel.SetRedraw( ICON_CASTLES );
     }
 
-    _statusWindow.SetRedraw();
+    _statusWindow.setRedraw();
 }

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -62,7 +62,7 @@ namespace Interface
 
         void SetPos( const int32_t ox, const int32_t oy ) override;
         void SavePosition() override;
-        void SetRedraw() const;
+        void setRedraw() const;
 
         void Reset()
         {
@@ -75,7 +75,14 @@ namespace Interface
 
         void SetState( const StatusType status );
         void SetResource( const int resource, const uint32_t count );
-        void DrawAITurnProgress( const uint32_t progressValue );
+        void drawAITurnProgress( const uint32_t progressValue );
+
+        void resetAITurnProgress()
+        {
+            // We set _aiTurnProgress equal to 10 to properly handle the first draw call for the '0' progress.
+            _aiTurnProgress = 10;
+        }
+
         void QueueEventProcessing();
         void TimerEventProcessing();
 
@@ -91,14 +98,15 @@ namespace Interface
         void _drawBackground() const;
         void _drawAITurns() const;
 
+        fheroes2::TimeDelay _showLastResourceDelay{ 2500 };
+
         BaseInterface & _interface;
 
         StatusType _state{ StatusType::STATUS_UNKNOWN };
         int _lastResource{ Resource::UNKNOWN };
         uint32_t _lastResourceCount{ 0 };
-        uint32_t _aiTurnProgress{ 0 };
-
-        fheroes2::TimeDelay _showLastResourceDelay{ 2500 };
+        uint32_t _aiTurnProgress{ 10 };
+        uint32_t _grainsAnimationIndexOffset{ 0 };
     };
 }
 

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -30,6 +30,7 @@
 #include "audio_manager.h"
 #include "castle.h"
 #include "direction.h"
+#include "game.h"
 #include "game_delays.h"
 #include "game_interface.h"
 #include "ground.h"
@@ -508,6 +509,14 @@ void Heroes::FadeOut( const int animSpeedMultiplier, const fheroes2::Point & off
             gamearea.ShiftCenter( offset );
         }
 
+        if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+            Game::updateAdventureMapAnimationIndex();
+            if ( isControlAI() ) {
+                // Draw hourglass sand grains animation.
+                iface.setRedraw( Interface::REDRAW_STATUS );
+            }
+        }
+
         _alphaValue = std::max( 0, _alphaValue - 8 * animSpeedMultiplier );
 
         iface.redraw( Interface::REDRAW_GAMEAREA );
@@ -541,6 +550,14 @@ void Heroes::FadeIn( const int animSpeedMultiplier, const fheroes2::Point & offs
 
         if ( offset.x != 0 || offset.y != 0 ) {
             gamearea.ShiftCenter( offset );
+        }
+
+        if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+            Game::updateAdventureMapAnimationIndex();
+            if ( isControlAI() ) {
+                // Draw hourglass sand grains animation.
+                iface.setRedraw( Interface::REDRAW_STATUS );
+            }
         }
 
         _alphaValue = std::min( _alphaValue + 8 * animSpeedMultiplier, 255 );


### PR DESCRIPTION
This PR makes the AI turn hourglass animation more smooth and makes sand grains animation to update along with the map animation.

![fheroes2 2024-10-07 18-45-22-941__](https://github.com/user-attachments/assets/1a50d820-3bb1-497f-9876-a659efd45526)

It also reworks the AI turn progress calculation a bit.

https://github.com/user-attachments/assets/d59f8587-e1ba-4776-931d-aec1fa84a8ce


https://github.com/user-attachments/assets/0e3fa9e6-c7b6-4918-961e-0a10f197de2c

