### PR TITLE
Fix map titles not being cleared when changing map

### DIFF
--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -245,7 +245,7 @@ namespace
         }
 
         // Set up restorers.
-        fheroes2::ImageRestorer mapTitleArea( display, scenarioBoxRoi.x + 113, scenarioBoxRoi.y + 5, 141, scenarioBoxRoi.height );
+        fheroes2::ImageRestorer mapTitleArea( display, scenarioBoxRoi.x + 6, scenarioBoxRoi.y + 5, 279, scenarioBoxRoi.height );
         fheroes2::ImageRestorer opponentsArea( display, roi.x, pointOpponentInfo.y, roi.width, 65 );
         fheroes2::ImageRestorer classArea( display, roi.x, pointClassInfo.y, roi.width, 69 );
         fheroes2::ImageRestorer handicapArea( display, roi.x, pointClassInfo.y + 69, roi.width, 31 );


### PR DESCRIPTION
Fix #9177 

The total area being cleared/restored is now increased ~~because the new map editor allows for longer map names than the original.~~ <-This is wrong: 17 characters was the max amount for original maps and it's the same for fheroes2.