### PR TITLE
Cache translation file loading operations

### DIFF
--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -352,6 +352,20 @@ bool Translation::isDomainLoaded( const std::string & domain )
     return ( iter != domains.end() );
 }
 
+void Translation::markInvalidDomain( const std::string & domain )
+{
+    assert( !domain.empty() );
+
+    const auto iter = domains.find( domain );
+    if ( iter != domains.end() ) {
+        // Why are you calling this function for a domain which is valid?
+        assert( 0 );
+        return;
+    }
+
+    domains[domain].isValid = false;
+}
+
 bool Translation::bindDomain( const std::string & domain, const std::string & file )
 {
     assert( !domain.empty() );

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -36,7 +36,6 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 
 #include "logging.h"
@@ -219,7 +218,6 @@ namespace
         LocaleType locale{ LocaleType::LOCALE_EN };
         RWStreamBuf buf;
         std::map<uint32_t, Chunk> hashOffsets;
-        std::string domain;
         std::string encoding;
         bool isValid{ false };
 
@@ -245,12 +243,12 @@ namespace
             return reinterpret_cast<const char *>( ptr );
         }
 
-        bool open( const std::string & file )
+        bool load( const std::string & fileName )
         {
-            assert( buf.data() == nullptr && hashOffsets.empty() && encoding.empty() );
+            assert( buf.data() == nullptr && hashOffsets.empty() && encoding.empty() && !isValid );
 
             StreamFile sf;
-            if ( !sf.open( file, "rb" ) ) {
+            if ( !sf.open( fileName, "rb" ) ) {
                 return false;
             }
 
@@ -259,7 +257,7 @@ namespace
             sf >> magicNumber;
 
             if ( magicNumber != 0x950412de ) {
-                ERROR_LOG( "Incorrect magic number " << GetHexString( magicNumber ) << " for " << file )
+                ERROR_LOG( "Incorrect magic number " << GetHexString( magicNumber ) << " for " << fileName )
                 return false;
             }
 
@@ -268,7 +266,7 @@ namespace
             sf >> majorVersion >> minorVersion;
 
             if ( 0 != majorVersion ) {
-                ERROR_LOG( "Incorrect major version " << GetHexString( majorVersion, 4 ) << " for " << file )
+                ERROR_LOG( "Incorrect major version " << GetHexString( majorVersion, 4 ) << " for " << fileName )
                 return false;
             }
 
@@ -336,187 +334,183 @@ namespace
                 }
             }
 
-            return ( totalTranslationStrings > 0 );
+            if ( totalTranslationStrings == 0 ) {
+                return false;
+            }
+
+            isValid = true;
+
+            return true;
         }
     };
 
     MOFile * current = nullptr;
-    std::map<std::string, MOFile, std::less<>> domains;
+    std::map<std::string, MOFile, std::less<>> cache;
 }
 
-bool Translation::isDomainLoaded( const std::string & domain )
+std::pair<bool, bool> Translation::setLanguage( const std::string_view name )
 {
-    assert( !domain.empty() );
+    assert( !name.empty() );
 
-    const auto iter = domains.find( domain );
-    return ( iter != domains.end() );
-}
+    if ( const auto iter = cache.find( name ); iter != cache.end() ) {
+        MOFile & item = iter->second;
 
-void Translation::markInvalidDomain( const std::string & domain )
-{
-    assert( !domain.empty() );
-
-    const auto iter = domains.find( domain );
-    if ( iter != domains.end() ) {
-        // Why are you calling this function for a valid domain?
-        assert( 0 );
-        return;
-    }
-
-    domains[domain].isValid = false;
-}
-
-bool Translation::bindDomain( const std::string & domain, const std::string & file )
-{
-    assert( !domain.empty() );
-
-    // Search for already loaded domain or load from file
-    {
-        const auto iter = domains.find( domain );
-        if ( iter != domains.end() ) {
-            if ( !iter->second.isValid ) {
-                return false;
-            }
-
-            current = &iter->second;
-            return true;
+        if ( item.isValid ) {
+            current = &item;
         }
+
+        return { true, item.isValid };
     }
 
-    assert( !file.empty() );
+    return { false, false };
+}
 
-    if ( !domains[domain].open( file ) ) {
-        // This flag is set inside the constructor but to be verbose we set it again here.
-        current->isValid = false;
+bool Translation::setLanguage( const std::string & name, const std::string_view fileName )
+{
+    assert( !name.empty() );
+
+    const auto [cacheIter, inserted] = cache.try_emplace( name );
+    MOFile & item = cacheIter->second;
+
+    if ( !inserted ) {
+        if ( item.isValid ) {
+            current = &item;
+        }
+
+        return item.isValid;
+    }
+
+    if ( fileName.empty() || !item.load( std::string{ fileName } ) ) {
+        assert( !item.isValid );
+
         return false;
     }
 
-    current = &domains[domain];
-    current->isValid = true;
+    item.locale = [&name]() {
+        static const std::unordered_map<std::string_view, LocaleType> langToLocale{ // Afrikaans
+                                                                                    { "af", LocaleType::LOCALE_AF },
+                                                                                    { "afrikaans", LocaleType::LOCALE_AF },
+                                                                                    // Arabic
+                                                                                    { "ar", LocaleType::LOCALE_AR },
+                                                                                    { "arabic", LocaleType::LOCALE_AR },
+                                                                                    // Belarusian
+                                                                                    { "be", LocaleType::LOCALE_BE },
+                                                                                    { "belarusian", LocaleType::LOCALE_BE },
+                                                                                    // Bulgarian
+                                                                                    { "bg", LocaleType::LOCALE_BG },
+                                                                                    { "bulgarian", LocaleType::LOCALE_BG },
+                                                                                    // Catalan
+                                                                                    { "ca", LocaleType::LOCALE_CA },
+                                                                                    { "catalan", LocaleType::LOCALE_CA },
+                                                                                    // Czech
+                                                                                    { "cs", LocaleType::LOCALE_CS },
+                                                                                    { "czech", LocaleType::LOCALE_CS },
+                                                                                    // Danish
+                                                                                    { "dk", LocaleType::LOCALE_DK },
+                                                                                    { "danish", LocaleType::LOCALE_DK },
+                                                                                    // German
+                                                                                    { "de", LocaleType::LOCALE_DE },
+                                                                                    { "german", LocaleType::LOCALE_DE },
+                                                                                    // Greek
+                                                                                    { "el", LocaleType::LOCALE_EL },
+                                                                                    { "greek", LocaleType::LOCALE_EL },
+                                                                                    // Spanish
+                                                                                    { "es", LocaleType::LOCALE_ES },
+                                                                                    { "spanish", LocaleType::LOCALE_ES },
+                                                                                    // Estonian
+                                                                                    { "et", LocaleType::LOCALE_ET },
+                                                                                    { "estonian", LocaleType::LOCALE_ET },
+                                                                                    // Basque
+                                                                                    { "eu", LocaleType::LOCALE_EU },
+                                                                                    { "basque", LocaleType::LOCALE_EU },
+                                                                                    // Finnish
+                                                                                    { "fi", LocaleType::LOCALE_FI },
+                                                                                    { "finnish", LocaleType::LOCALE_FI },
+                                                                                    // French
+                                                                                    { "fr", LocaleType::LOCALE_FR },
+                                                                                    { "french", LocaleType::LOCALE_FR },
+                                                                                    // Galician
+                                                                                    { "gl", LocaleType::LOCALE_GL },
+                                                                                    { "galician", LocaleType::LOCALE_GL },
+                                                                                    // Hebrew
+                                                                                    { "he", LocaleType::LOCALE_HE },
+                                                                                    { "hebrew", LocaleType::LOCALE_HE },
+                                                                                    // Croatian
+                                                                                    { "hr", LocaleType::LOCALE_HR },
+                                                                                    { "croatian", LocaleType::LOCALE_HR },
+                                                                                    // Hungarian
+                                                                                    { "hu", LocaleType::LOCALE_HU },
+                                                                                    { "hungarian", LocaleType::LOCALE_HU },
+                                                                                    // Indonesian
+                                                                                    { "id", LocaleType::LOCALE_ID },
+                                                                                    { "indonesian", LocaleType::LOCALE_ID },
+                                                                                    // Italian
+                                                                                    { "it", LocaleType::LOCALE_IT },
+                                                                                    { "italian", LocaleType::LOCALE_IT },
+                                                                                    // Latin
+                                                                                    { "la", LocaleType::LOCALE_LA },
+                                                                                    { "latin", LocaleType::LOCALE_LA },
+                                                                                    // Lithuanian
+                                                                                    { "lt", LocaleType::LOCALE_LT },
+                                                                                    { "lithuanian", LocaleType::LOCALE_LT },
+                                                                                    // Latvian
+                                                                                    { "lv", LocaleType::LOCALE_LV },
+                                                                                    { "latvian", LocaleType::LOCALE_LV },
+                                                                                    // Macedonian
+                                                                                    { "mk", LocaleType::LOCALE_MK },
+                                                                                    { "macedonian", LocaleType::LOCALE_MK },
+                                                                                    // Norwegian
+                                                                                    { "nb", LocaleType::LOCALE_NB },
+                                                                                    { "norwegian", LocaleType::LOCALE_NB },
+                                                                                    // Dutch
+                                                                                    { "nl", LocaleType::LOCALE_NL },
+                                                                                    { "dutch", LocaleType::LOCALE_NL },
+                                                                                    // Polish
+                                                                                    { "pl", LocaleType::LOCALE_PL },
+                                                                                    { "polish", LocaleType::LOCALE_PL },
+                                                                                    // Portuguese
+                                                                                    { "pt", LocaleType::LOCALE_PT },
+                                                                                    { "portuguese", LocaleType::LOCALE_PT },
+                                                                                    // Romanian
+                                                                                    { "ro", LocaleType::LOCALE_RO },
+                                                                                    { "romanian", LocaleType::LOCALE_RO },
+                                                                                    // Russian
+                                                                                    { "ru", LocaleType::LOCALE_RU },
+                                                                                    { "russian", LocaleType::LOCALE_RU },
+                                                                                    // Slovak
+                                                                                    { "sk", LocaleType::LOCALE_SK },
+                                                                                    { "slovak", LocaleType::LOCALE_SK },
+                                                                                    // Slovenian
+                                                                                    { "sl", LocaleType::LOCALE_SL },
+                                                                                    { "slovenian", LocaleType::LOCALE_SL },
+                                                                                    // Serbian
+                                                                                    { "sr", LocaleType::LOCALE_SR },
+                                                                                    { "serbian", LocaleType::LOCALE_SR },
+                                                                                    // Swedish
+                                                                                    { "sv", LocaleType::LOCALE_SV },
+                                                                                    { "swedish", LocaleType::LOCALE_SV },
+                                                                                    // Turkish
+                                                                                    { "tr", LocaleType::LOCALE_TR },
+                                                                                    { "turkish", LocaleType::LOCALE_TR },
+                                                                                    // Ukrainian
+                                                                                    { "uk", LocaleType::LOCALE_UK },
+                                                                                    { "ukrainian", LocaleType::LOCALE_UK },
+                                                                                    // Vietnamese
+                                                                                    { "vi", LocaleType::LOCALE_VI },
+                                                                                    { "vietnamese", LocaleType::LOCALE_VI } };
 
-    // Update locale
-    current->domain = domain;
-    current->locale = [domain]() {
-        static const std::unordered_map<std::string_view, LocaleType> domainToLocale{ // Afrikaans
-                                                                                      { "af", LocaleType::LOCALE_AF },
-                                                                                      { "afrikaans", LocaleType::LOCALE_AF },
-                                                                                      // Arabic
-                                                                                      { "ar", LocaleType::LOCALE_AR },
-                                                                                      { "arabic", LocaleType::LOCALE_AR },
-                                                                                      // Belarusian
-                                                                                      { "be", LocaleType::LOCALE_BE },
-                                                                                      { "belarusian", LocaleType::LOCALE_BE },
-                                                                                      // Bulgarian
-                                                                                      { "bg", LocaleType::LOCALE_BG },
-                                                                                      { "bulgarian", LocaleType::LOCALE_BG },
-                                                                                      // Catalan
-                                                                                      { "ca", LocaleType::LOCALE_CA },
-                                                                                      { "catalan", LocaleType::LOCALE_CA },
-                                                                                      // Czech
-                                                                                      { "cs", LocaleType::LOCALE_CS },
-                                                                                      { "czech", LocaleType::LOCALE_CS },
-                                                                                      // Danish
-                                                                                      { "dk", LocaleType::LOCALE_DK },
-                                                                                      { "danish", LocaleType::LOCALE_DK },
-                                                                                      // German
-                                                                                      { "de", LocaleType::LOCALE_DE },
-                                                                                      { "german", LocaleType::LOCALE_DE },
-                                                                                      // Greek
-                                                                                      { "el", LocaleType::LOCALE_EL },
-                                                                                      { "greek", LocaleType::LOCALE_EL },
-                                                                                      // Spanish
-                                                                                      { "es", LocaleType::LOCALE_ES },
-                                                                                      { "spanish", LocaleType::LOCALE_ES },
-                                                                                      // Estonian
-                                                                                      { "et", LocaleType::LOCALE_ET },
-                                                                                      { "estonian", LocaleType::LOCALE_ET },
-                                                                                      // Basque
-                                                                                      { "eu", LocaleType::LOCALE_EU },
-                                                                                      { "basque", LocaleType::LOCALE_EU },
-                                                                                      // Finnish
-                                                                                      { "fi", LocaleType::LOCALE_FI },
-                                                                                      { "finnish", LocaleType::LOCALE_FI },
-                                                                                      // French
-                                                                                      { "fr", LocaleType::LOCALE_FR },
-                                                                                      { "french", LocaleType::LOCALE_FR },
-                                                                                      // Galician
-                                                                                      { "gl", LocaleType::LOCALE_GL },
-                                                                                      { "galician", LocaleType::LOCALE_GL },
-                                                                                      // Hebrew
-                                                                                      { "he", LocaleType::LOCALE_HE },
-                                                                                      { "hebrew", LocaleType::LOCALE_HE },
-                                                                                      // Croatian
-                                                                                      { "hr", LocaleType::LOCALE_HR },
-                                                                                      { "croatian", LocaleType::LOCALE_HR },
-                                                                                      // Hungarian
-                                                                                      { "hu", LocaleType::LOCALE_HU },
-                                                                                      { "hungarian", LocaleType::LOCALE_HU },
-                                                                                      // Indonesian
-                                                                                      { "id", LocaleType::LOCALE_ID },
-                                                                                      { "indonesian", LocaleType::LOCALE_ID },
-                                                                                      // Italian
-                                                                                      { "it", LocaleType::LOCALE_IT },
-                                                                                      { "italian", LocaleType::LOCALE_IT },
-                                                                                      // Latin
-                                                                                      { "la", LocaleType::LOCALE_LA },
-                                                                                      { "latin", LocaleType::LOCALE_LA },
-                                                                                      // Lithuanian
-                                                                                      { "lt", LocaleType::LOCALE_LT },
-                                                                                      { "lithuanian", LocaleType::LOCALE_LT },
-                                                                                      // Latvian
-                                                                                      { "lv", LocaleType::LOCALE_LV },
-                                                                                      { "latvian", LocaleType::LOCALE_LV },
-                                                                                      // Macedonian
-                                                                                      { "mk", LocaleType::LOCALE_MK },
-                                                                                      { "macedonian", LocaleType::LOCALE_MK },
-                                                                                      // Norwegian
-                                                                                      { "nb", LocaleType::LOCALE_NB },
-                                                                                      { "norwegian", LocaleType::LOCALE_NB },
-                                                                                      // Dutch
-                                                                                      { "nl", LocaleType::LOCALE_NL },
-                                                                                      { "dutch", LocaleType::LOCALE_NL },
-                                                                                      // Polish
-                                                                                      { "pl", LocaleType::LOCALE_PL },
-                                                                                      { "polish", LocaleType::LOCALE_PL },
-                                                                                      // Portuguese
-                                                                                      { "pt", LocaleType::LOCALE_PT },
-                                                                                      { "portuguese", LocaleType::LOCALE_PT },
-                                                                                      // Romanian
-                                                                                      { "ro", LocaleType::LOCALE_RO },
-                                                                                      { "romanian", LocaleType::LOCALE_RO },
-                                                                                      // Russian
-                                                                                      { "ru", LocaleType::LOCALE_RU },
-                                                                                      { "russian", LocaleType::LOCALE_RU },
-                                                                                      // Slovak
-                                                                                      { "sk", LocaleType::LOCALE_SK },
-                                                                                      { "slovak", LocaleType::LOCALE_SK },
-                                                                                      // Slovenian
-                                                                                      { "sl", LocaleType::LOCALE_SL },
-                                                                                      { "slovenian", LocaleType::LOCALE_SL },
-                                                                                      // Serbian
-                                                                                      { "sr", LocaleType::LOCALE_SR },
-                                                                                      { "serbian", LocaleType::LOCALE_SR },
-                                                                                      // Swedish
-                                                                                      { "sv", LocaleType::LOCALE_SV },
-                                                                                      { "swedish", LocaleType::LOCALE_SV },
-                                                                                      // Turkish
-                                                                                      { "tr", LocaleType::LOCALE_TR },
-                                                                                      { "turkish", LocaleType::LOCALE_TR },
-                                                                                      // Ukrainian
-                                                                                      { "uk", LocaleType::LOCALE_UK },
-                                                                                      { "ukrainian", LocaleType::LOCALE_UK },
-                                                                                      // Vietnamese
-                                                                                      { "vi", LocaleType::LOCALE_VI },
-                                                                                      { "vietnamese", LocaleType::LOCALE_VI } };
-
-        const auto iter = domainToLocale.find( domain );
-        if ( iter == domainToLocale.end() ) {
+        const auto iter = langToLocale.find( name );
+        if ( iter == langToLocale.end() ) {
             assert( 0 );
             return LocaleType::LOCALE_EN;
         }
 
         return iter->second;
     }();
+
+    assert( item.isValid );
+
+    current = &item;
 
     return true;
 }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -329,7 +329,7 @@ namespace
 
                 const uint32_t offset2 = buf.get32();
 
-                if ( const auto [dummy, inserted] = hashOffsets.try_emplace( crc, Chunk{ offset2, length2 } ); !inserted ) {
+                if ( const auto [dummy, inserted] = hashOffsets.try_emplace( crc, offset2, length2 ); !inserted ) {
                     ERROR_LOG( "Clashing hash value for: " << msg1 )
                 }
             }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -358,7 +358,7 @@ void Translation::markInvalidDomain( const std::string & domain )
 
     const auto iter = domains.find( domain );
     if ( iter != domains.end() ) {
-        // Why are you calling this function for a domain which is valid?
+        // Why are you calling this function for a valid domain?
         assert( 0 );
         return;
     }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -386,7 +386,7 @@ bool Translation::bindDomain( const std::string & domain, const std::string & fi
     assert( !file.empty() );
 
     if ( !domains[domain].open( file ) ) {
-        // This flag is set during the constructor but to be verbose we set it again here.
+        // This flag is set inside the constructor but to be verbose we set it again here.
         current->isValid = false;
         return false;
     }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -217,14 +217,14 @@ namespace
         // TODO: plural forms are not in use: Plural-Forms.
         LocaleType locale{ LocaleType::LOCALE_EN };
         RWStreamBuf buf;
-        std::map<uint32_t, Chunk> hashOffsets;
+        std::unordered_map<uint32_t, Chunk> hashOffsets;
         std::string encoding;
         bool isValid{ false };
 
         const char * ngettext( const char * str, size_t plural )
         {
             const auto iter = std::as_const( hashOffsets ).find( crc32b( str ) );
-            if ( iter == hashOffsets.end() ) {
+            if ( iter == hashOffsets.cend() ) {
                 return stripContext( str );
             }
 

--- a/src/engine/translations.h
+++ b/src/engine/translations.h
@@ -28,7 +28,9 @@
 
 namespace Translation
 {
-    bool bindDomain( const char * domain, const char * file );
+    bool isDomainLoaded( const std::string & domain );
+
+    bool bindDomain( const std::string & domain, const std::string & file );
 
     // Reset any translation to the default language - English.
     void reset();

--- a/src/engine/translations.h
+++ b/src/engine/translations.h
@@ -25,16 +25,25 @@
 
 #include <cstddef>
 #include <string>
+#include <string_view>
+#include <utility>
 
 namespace Translation
 {
-    bool isDomainLoaded( const std::string & domain );
+    // Sets the language with the given name as the current language if the translation for this language is
+    // already cached and valid, otherwise does nothing. Returns a pair of two flags, the first of which is
+    // set to true if the translation for the given language is already present in the cache (even if this
+    // translation is invalid), and the second is set to true if this translation is both present in the cache
+    // and valid.
+    std::pair<bool, bool> setLanguage( const std::string_view name );
 
-    void markInvalidDomain( const std::string & domain );
+    // Sets the language with the given name as the current language if the translation for this language is
+    // already cached and valid. If this translation is not yet cached, then tries to load it from the given
+    // file. If the load fails, then adds this language to the cache as invalid and does nothing else. Returns
+    // true if the current language has been successfully set, otherwise returns false.
+    bool setLanguage( const std::string & name, const std::string_view fileName );
 
-    bool bindDomain( const std::string & domain, const std::string & file );
-
-    // Reset any translation to the default language - English.
+    // Resets the current language to the default language (English).
     void reset();
 
     const char * gettext( const char * str );

--- a/src/engine/translations.h
+++ b/src/engine/translations.h
@@ -30,6 +30,8 @@ namespace Translation
 {
     bool isDomainLoaded( const std::string & domain );
 
+    void markInvalidDomain( const std::string & domain );
+
     bool bindDomain( const std::string & domain, const std::string & file );
 
     // Reset any translation to the default language - English.

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -513,6 +513,11 @@ bool Settings::setGameLanguage( const std::string & language )
         return true;
     }
 
+    // In order to avoid extra I/O operations we need to query a status of the domain first.
+    if ( Translation::isDomainLoaded( language ) ) {
+        return Translation::bindDomain( language, {} );
+    }
+
     const std::string fileName = std::string( _gameLanguage ).append( ".mo" );
 #if defined( MACOS_APP_BUNDLE )
     const ListFiles translations = Settings::FindFiles( "translations", fileName, false );
@@ -521,7 +526,7 @@ bool Settings::setGameLanguage( const std::string & language )
 #endif
 
     if ( !translations.empty() ) {
-        return Translation::bindDomain( language.c_str(), translations.back().c_str() );
+        return Translation::bindDomain( language, translations.back() );
     }
 
     ERROR_LOG( "Translation file " << fileName << " was not found." )

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -529,6 +529,8 @@ bool Settings::setGameLanguage( const std::string & language )
         return Translation::bindDomain( language, translations.back() );
     }
 
+    Translation::markInvalidDomain( language );
+
     ERROR_LOG( "Translation file " << fileName << " was not found." )
     return false;
 }


### PR DESCRIPTION
Since we support multi-language texts (see #9125) we do language switching, which results in heavy operations. We need to optimize the language switching work and this pull request addresses only I/O operations that usually are the slowest.

Partially relates to #6681