### PR TITLE
Add missing popup dialogs to buttons within View World mode

### DIFF
--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -52,7 +52,6 @@
 #include "ui_button.h"
 #include "ui_constants.h"
 #include "ui_dialog.h"
-#include "ui_constants.h"
 #include "ui_tool.h"
 #include "world.h"
 

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -50,6 +50,7 @@
 #include "settings.h"
 #include "translations.h"
 #include "ui_button.h"
+#include "ui_constants.h"
 #include "ui_dialog.h"
 #include "ui_constants.h"
 #include "ui_tool.h"

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -48,7 +48,9 @@
 #include "resource.h"
 #include "screen.h"
 #include "settings.h"
+#include "translations.h"
 #include "ui_button.h"
+#include "ui_dialog.h"
 #include "ui_constants.h"
 #include "ui_tool.h"
 #include "world.h"
@@ -709,6 +711,12 @@ void ViewWorld::ViewWorldWindow( const int32_t color, const ViewWorldMode mode, 
         }
         else if ( le.isMouseWheelDown() ) {
             changed = currentROI.zoomOut( false );
+        }
+        else if ( le.isMouseRightButtonPressedInArea( buttonExit.area() ) ) {
+            fheroes2::showStandardTextMessage( _( "Exit" ), _( "Exit this menu." ), Dialog::ZERO );
+        }
+        else if ( le.isMouseRightButtonPressedInArea( buttonZoom.area() ) ) {
+            fheroes2::showStandardTextMessage( _( "Zoom" ), _( "Click this button to change zoom." ), Dialog::ZERO );
         }
 
         if ( !le.isMouseLeftButtonPressedInArea( visibleScreenInPixels ) || !le.isMouseCursorPosInArea( visibleScreenInPixels ) ) {

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -717,7 +717,7 @@ void ViewWorld::ViewWorldWindow( const int32_t color, const ViewWorldMode mode, 
             fheroes2::showStandardTextMessage( _( "Exit" ), _( "Exit this menu." ), Dialog::ZERO );
         }
         else if ( le.isMouseRightButtonPressedInArea( buttonZoom.area() ) ) {
-            fheroes2::showStandardTextMessage( _( "Zoom" ), _( "Click this button to change zoom." ), Dialog::ZERO );
+            fheroes2::showStandardTextMessage( _( "Zoom" ), _( "Click this button to adjust the level of zoom." ), Dialog::ZERO );
         }
 
         if ( !le.isMouseLeftButtonPressedInArea( visibleScreenInPixels ) || !le.isMouseCursorPosInArea( visibleScreenInPixels ) ) {

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -32,6 +32,7 @@
 #include "castle.h"
 #include "color.h"
 #include "cursor.h"
+#include "dialog.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "icn.h"


### PR DESCRIPTION
Even the original game doesn't have the popup dialogs but we need them to be consistent with UI everywhere.