### PR TITLE
Fix debug build crash with French and Italian assets

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2541,7 +2541,7 @@ namespace
             }
             // The French version replaces several ASCII special characters with language-specific characters.
             // In the engine we use CP1252 for the French translation but we have to preserve the homegrown encoding
-            // of the original so that original French maps's text is displayed correctly.
+            // of the original so that original French maps' texts are displayed correctly.
             if ( crc32 == 0xD9556567 || crc32 == 0x406967B9 ) {
                 // The engine expects that letter indexes correspond to charcode - 0x20, but the original French
                 // Price of Loyalty maps use 0x09 for lowercase i with circonflex. This is currently not supported
@@ -2560,27 +2560,11 @@ namespace
                 imageArray[232 - 32] = imageArray[64];
                 imageArray[233 - 32] = imageArray[94];
                 imageArray[234 - 32] = imageArray[92];
+                imageArray[238 - 32] = imageArray[93];
                 imageArray[239 - 32] = imageArray[91];
                 imageArray[244 - 32] = imageArray[3];
                 imageArray[249 - 32] = imageArray[6];
                 imageArray[251 - 32] = imageArray[4];
-                // The original small font has 1 letter at three indexes (30, 93, 95) that has an empty wide transparent
-                // area that we need to remove. Plus we need to add a missing pixel.
-                if ( id == ICN::SMALFONT && imageArray[93].width() > 19 ) {
-                    imageArray[238 - 32].resize( 4, 9 );
-                    imageArray[238 - 32].reset();
-                    Copy( imageArray[93], 0, 0, imageArray[238 - 32], 0, 1, 4, 8 );
-                    Copy( imageArray[93], 1, 0, imageArray[238 - 32], 2, 0, 1, 1 );
-                    imageArray[238 - 32].setPosition( 0, -1 );
-                    fheroes2::updateShadow( imageArray[238 - 32], { -1, 1 }, 2, true );
-                    // Copy the fixed sprite back.
-                    for ( const int & charCode : { 30, 93, 95 } ) {
-                        imageArray[charCode] = imageArray[238 - 32];
-                    }
-                }
-                else {
-                    imageArray[238 - 32] = imageArray[93];
-                }
                 imageArray.erase( imageArray.begin() + 220, imageArray.end() );
             }
             // Italian version uses CP1252

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2539,34 +2539,54 @@ namespace
                 std::swap( imageArray[220], imageArray[222] );
                 imageArray.erase( imageArray.begin() + 221, imageArray.end() );
             }
-            // French version has its own special encoding but should conform to CP1252 too
+            // The French version replaces several ASCII special characters with language-specific characters.
+            // In the engine we use CP1252 for the French translation but we have to preserve the homegrown encoding
+            // of the original so that original French maps's text is displayed correctly.
             if ( crc32 == 0xD9556567 || crc32 == 0x406967B9 ) {
+                // The engine expects that letter indexes correspond to charcode - 0x20, but the original French
+                // Price of Loyalty maps use 0x09 for lowercase i with circonflex. This is currently not supported
+                // by the engine.
                 const fheroes2::Sprite firstSprite{ imageArray[0] };
-                imageArray.insert( imageArray.begin() + 96, 160 - 32, firstSprite );
+                imageArray.insert( imageArray.begin() + 96, 128, firstSprite );
+                // Capital letters with accents aren't present in the original assets so we use unaccented letters.
                 imageArray[192 - 32] = imageArray[33];
                 imageArray[199 - 32] = imageArray[35];
                 imageArray[201 - 32] = imageArray[37];
                 imageArray[202 - 32] = imageArray[37];
-                imageArray[244 - 32] = imageArray[3];
-                imageArray[251 - 32] = imageArray[4];
-                imageArray[249 - 32] = imageArray[6];
-                imageArray[226 - 32] = imageArray[10];
-                imageArray[239 - 32] = imageArray[28];
-                imageArray[238 - 32] = imageArray[30];
+
                 imageArray[224 - 32] = imageArray[32];
+                imageArray[226 - 32] = imageArray[10];
                 imageArray[231 - 32] = imageArray[62];
                 imageArray[232 - 32] = imageArray[64];
-                imageArray[239 - 32] = imageArray[91];
-                imageArray[234 - 32] = imageArray[92];
-                imageArray[238 - 32] = imageArray[93];
                 imageArray[233 - 32] = imageArray[94];
-                imageArray[238 - 32] = imageArray[95];
-                imageArray.erase( imageArray.begin() + 252 - 32, imageArray.end() );
+                imageArray[234 - 32] = imageArray[92];
+                imageArray[239 - 32] = imageArray[91];
+                imageArray[244 - 32] = imageArray[3];
+                imageArray[249 - 32] = imageArray[6];
+                imageArray[251 - 32] = imageArray[4];
+                // The original small font has 1 letter at three indexes (30, 93, 95) that has an empty wide transparent
+                // area that we need to remove. Plus we need to add a missing pixel.
+                if ( id == ICN::SMALFONT && imageArray[93].width() > 19 ) {
+                    imageArray[238 - 32].resize( 4, 9 );
+                    imageArray[238 - 32].reset();
+                    Copy( imageArray[93], 0, 0, imageArray[238 - 32], 0, 1, 4, 8 );
+                    Copy( imageArray[93], 1, 0, imageArray[238 - 32], 2, 0, 1, 1 );
+                    imageArray[238 - 32].setPosition( 0, -1 );
+                    fheroes2::updateShadow( imageArray[238 - 32], { -1, 1 }, 2, true );
+                    // Copy the fixed sprite back.
+                    for ( const int & charCode : { 30, 93, 95 } ) {
+                        imageArray[charCode] = imageArray[238 - 32];
+                    }
+                }
+                else {
+                    imageArray[238 - 32] = imageArray[93];
+                }
+                imageArray.erase( imageArray.begin() + 220, imageArray.end() );
             }
             // Italian version uses CP1252
             if ( crc32 == 0x219B3124 || crc32 == 0x1F3C3C74 ) {
                 const fheroes2::Sprite firstSprite{ imageArray[0] };
-                imageArray.insert( imageArray.begin() + 101, 155 - 32, firstSprite );
+                imageArray.insert( imageArray.begin() + 101, 123, firstSprite );
                 imageArray[192 - 32] = imageArray[33];
                 imageArray[200 - 32] = imageArray[37];
                 imageArray[201 - 32] = imageArray[37];
@@ -2579,7 +2599,7 @@ namespace
                 imageArray[236 - 32] = imageArray[98];
                 imageArray[242 - 32] = imageArray[99];
                 imageArray[249 - 32] = imageArray[100];
-                imageArray.erase( imageArray.begin() + 250 - 32, imageArray.end() );
+                imageArray.erase( imageArray.begin() + 218, imageArray.end() );
             }
             return true;
         }


### PR DESCRIPTION
When using Italian and French assets the deletion call to the `imageArray` vector would go out of bounds. This did not happen in release builds.

The solution was to not use the subtraction operator `-` and instead write the result that gets added to the beginning position parameter of the delete() call. Using parentheses would have worked too.

Additionally this fixes the normal font î being empty in `master`.