### PR TITLE
Added Czech Virtual Keyboard

### DIFF
--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -68,13 +68,13 @@ namespace
     bool isSupportedForLanguageSwitching( const fheroes2::SupportedLanguage language )
     {
         switch ( language ) {
+		case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::English:
             // English is a default language so it is not considered as an extra language.
             return false;
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
-        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::Ukrainian:
             return true;
         default:
@@ -285,11 +285,11 @@ namespace
     {
         // Numeric layout can be used for special letters as well.
         switch ( language ) {
+		case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
-        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "1234567890", "-:;()_+=", "[].,!'?" };
         default:
@@ -304,6 +304,8 @@ namespace
     std::vector<std::string> getCapitalCharacterLayout( const fheroes2::SupportedLanguage language )
     {
         switch ( language ) {
+        case fheroes2::SupportedLanguage::Czech:
+            return { "\xCC\x8A\xC8\xD8\x8E\xDD\xC1\xCD\xC9", "QWERTZUIOP\xDA", "ASDFGHJKL\xD9", "YXCVBNM" };
         case fheroes2::SupportedLanguage::English:
             return { "QWERTYUIOP", "ASDFGHJKL", "ZXCVBNM" };
         case fheroes2::SupportedLanguage::Polish:
@@ -312,8 +314,6 @@ namespace
             return { "\xC9\xD6\xD3\xCA\xC5\xCD\xC3\xD8\xD9\xC7\xD5\xDA", "\xD4\xDB\xC2\xC0\xCF\xD0\xCE\xCB\xC4\xC6\xDD", "\xDF\xD7\xD1\xCC\xC8\xD2\xDC\xC1\xDE\xA8" };
         case fheroes2::SupportedLanguage::Slovak:
             return { "\xCF\xBC\x8A\xC8\x8D\x8E\xDD\xC1\xCD\xC9\xD3", "QWERTZUIOP\xDA", "ASDFGHJKL\xD4\xD2", "\xC4YXCVBNM\xC5\xC0" };
-        case fheroes2::SupportedLanguage::Czech:
-            return { "\xCC\x8A\xC8\xD8\x8E\xDD\xC1\xCD\xC9", "QWERTZUIOP\xDA", "ASDFGHJKL\xD9", "YXCVBNM" };
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "\xC9\xD6\xD3\xCA\xC5\xCD\xC3\xD8\xD9\xC7\xD5\xAF", "\xD4\xB2\xC2\xC0\xCF\xD0\xCE\xCB\xC4\xC6\xAA", "\xDF\xD7\xD1\xCC\xC8\xD2\xDC\xC1\xDE\xA5" };
         default:
@@ -328,6 +328,8 @@ namespace
     std::vector<std::string> getNonCapitalCharacterLayout( const fheroes2::SupportedLanguage language )
     {
         switch ( language ) {
+        case fheroes2::SupportedLanguage::Czech:
+            return { "\xEC\x9A\xE8\xF8\xBE\xFD\xE1\xED\xE9", "qwertzuiop\xFA", "asdfghjkl\xF9", "yxcvbnm" };
         case fheroes2::SupportedLanguage::English:
             return { "qwertyuiop", "asdfghjkl", "zxcvbnm" };
         case fheroes2::SupportedLanguage::Polish:
@@ -336,8 +338,6 @@ namespace
             return { "\xE9\xF6\xF3\xEA\xE5\xED\xE3\xF8\xF9\xE7\xF5\xFA", "\xF4\xFB\xE2\xE0\xEF\xF0\xEE\xEB\xE4\xE6\xFD", "\xFF\xF7\xF1\xEC\xE8\xF2\xFC\xE1\xFE\xB8" };
         case fheroes2::SupportedLanguage::Slovak:
             return { "\xEF\xBE\x9A\xE8\x9D\x9E\xFD\xE1\xED\xE9\xF3", "qwertzuiop\xFA", "asdfghjkl\xF4\xF2", "\xE4yxcvbnm\xE5\xE0" };
-        case fheroes2::SupportedLanguage::Czech:
-            return { "\xEC\x9A\xE8\xF8\xBE\xFD\xE1\xED\xE9", "qwertzuiop\xFA", "asdfghjkl\xF9", "yxcvbnm" };
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "\xE9\xF6\xF3\xEA\xE5\xED\xE3\xF8\xF9\xE7\xF5\xBF", "\xF4\xB3\xE2\xE0\xEF\xF0\xEE\xEB\xE4\xE6\xBA", "\xFF\xF7\xF1\xEC\xE8\xF2\xFC\xE1\xFE\xB4" };
         default:
@@ -377,12 +377,12 @@ namespace
         // Different languages have different number of letters per row.
         // We cannot expand the virtual keyboard window beyond 640 pixels but we can change the size of buttons.
         switch ( language ) {
+        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::Polish:
             return 30;
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
-        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::Ukrainian:
             return 24;
         default:
@@ -502,11 +502,11 @@ namespace
                           const bool isEvilInterface, const bool isExtraLanguageSupported )
     {
         switch ( language ) {
+        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
-        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::Ukrainian:
             addExtraStandardButtons( buttons, layoutType, isEvilInterface, isExtraLanguageSupported, language );
             break;

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -74,6 +74,7 @@ namespace
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
+        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::Ukrainian:
             return true;
         default:
@@ -288,6 +289,7 @@ namespace
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
+        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "1234567890", "-:;()_+=", "[].,!'?" };
         default:
@@ -310,6 +312,8 @@ namespace
             return { "\xC9\xD6\xD3\xCA\xC5\xCD\xC3\xD8\xD9\xC7\xD5\xDA", "\xD4\xDB\xC2\xC0\xCF\xD0\xCE\xCB\xC4\xC6\xDD", "\xDF\xD7\xD1\xCC\xC8\xD2\xDC\xC1\xDE\xA8" };
         case fheroes2::SupportedLanguage::Slovak:
             return { "\xCF\xBC\x8A\xC8\x8D\x8E\xDD\xC1\xCD\xC9\xD3", "QWERTZUIOP\xDA", "ASDFGHJKL\xD4\xD2", "\xC4YXCVBNM\xC5\xC0" };
+        case fheroes2::SupportedLanguage::Czech:
+            return { "\xCC\x8A\xC8\xD8\x8E\xDD\xC1\xCD\xC9", "QWERTZUIOP\xDA", "ASDFGHJKL\xD9", "YXCVBNM" };
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "\xC9\xD6\xD3\xCA\xC5\xCD\xC3\xD8\xD9\xC7\xD5\xAF", "\xD4\xB2\xC2\xC0\xCF\xD0\xCE\xCB\xC4\xC6\xAA", "\xDF\xD7\xD1\xCC\xC8\xD2\xDC\xC1\xDE\xA5" };
         default:
@@ -332,6 +336,8 @@ namespace
             return { "\xE9\xF6\xF3\xEA\xE5\xED\xE3\xF8\xF9\xE7\xF5\xFA", "\xF4\xFB\xE2\xE0\xEF\xF0\xEE\xEB\xE4\xE6\xFD", "\xFF\xF7\xF1\xEC\xE8\xF2\xFC\xE1\xFE\xB8" };
         case fheroes2::SupportedLanguage::Slovak:
             return { "\xEF\xBE\x9A\xE8\x9D\x9E\xFD\xE1\xED\xE9\xF3", "qwertzuiop\xFA", "asdfghjkl\xF4\xF2", "\xE4yxcvbnm\xE5\xE0" };
+        case fheroes2::SupportedLanguage::Czech:
+            return { "\xEC\x9A\xE8\xF8\xBE\xFD\xE1\xED\xE9", "qwertzuiop\xFA", "asdfghjkl\xF9", "yxcvbnm" };
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "\xE9\xF6\xF3\xEA\xE5\xED\xE3\xF8\xF9\xE7\xF5\xBF", "\xF4\xB3\xE2\xE0\xEF\xF0\xEE\xEB\xE4\xE6\xBA", "\xFF\xF7\xF1\xEC\xE8\xF2\xFC\xE1\xFE\xB4" };
         default:
@@ -376,6 +382,7 @@ namespace
             return 30;
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
+        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::Ukrainian:
             return 24;
         default:
@@ -499,6 +506,7 @@ namespace
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
+        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::Ukrainian:
             addExtraStandardButtons( buttons, layoutType, isEvilInterface, isExtraLanguageSupported, language );
             break;

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -68,7 +68,7 @@ namespace
     bool isSupportedForLanguageSwitching( const fheroes2::SupportedLanguage language )
     {
         switch ( language ) {
-		case fheroes2::SupportedLanguage::Czech:
+        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::English:
             // English is a default language so it is not considered as an extra language.
             return false;
@@ -285,7 +285,7 @@ namespace
     {
         // Numeric layout can be used for special letters as well.
         switch ( language ) {
-		case fheroes2::SupportedLanguage::Czech:
+        case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:


### PR DESCRIPTION
Added Czech Virtual Keyboard

![image](https://github.com/user-attachments/assets/1df1c0a6-b0ef-46b9-9a55-782ce23a43db)


P.S. Special letters Ť, Ó, Ň, Ď that are not available on physical keyboard are not included.