### PR TITLE
Shorten map title when too long in several places

### DIFF
--- a/src/fheroes2/dialog/dialog_selectscenario.cpp
+++ b/src/fheroes2/dialog/dialog_selectscenario.cpp
@@ -286,7 +286,8 @@ void ScenarioListBox::_renderSelectedScenarioInfo( fheroes2::Display & display, 
     _renderMapIcon( info.width, display, dst.x + SELECTED_SCENARIO_MAP_SIZE_OFFSET_X, dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
     fheroes2::Blit( _getMapTypeIcon( info.version ), display, dst.x + SELECTED_SCENARIO_MAP_TYPE_OFFSET_X, dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y );
 
-    const fheroes2::Text mapNameText{ info.name, fheroes2::FontType::normalWhite(), info.getSupportedLanguage() };
+    fheroes2::Text mapNameText{ info.name, fheroes2::FontType::normalWhite(), info.getSupportedLanguage() };
+    mapNameText.fitToOneRow( SCENARIO_LIST_MAP_NAME_WIDTH );
     mapNameText.draw( GetCenteredTextXCoordinate( dst.x + SELECTED_SCENARIO_MAP_NAME_OFFSET_X, SELECTED_SCENARIO_MAP_NAME_WIDTH, mapNameText.width() ),
                       dst.y + SELECTED_SCENARIO_GENERAL_OFFSET_Y + 2, display );
 
@@ -310,9 +311,10 @@ void ScenarioListBox::_renderSelectedScenarioInfo( fheroes2::Display & display, 
 
 void ScenarioListBox::_renderMapName( const Maps::FileInfo & info, bool selected, const int32_t & baseYOffset, fheroes2::Display & display ) const
 {
-    const fheroes2::Text mapName{ info.name,
+    fheroes2::Text mapName{ info.name,
                                   { fheroes2::FontSize::NORMAL, ( selected ? fheroes2::FontColor::YELLOW : fheroes2::FontColor::WHITE ) },
                                   info.getSupportedLanguage() };
+    mapName.fitToOneRow( SCENARIO_LIST_MAP_NAME_WIDTH );
     const int32_t xCoordinate = GetCenteredTextXCoordinate( _offsetX + SCENARIO_LIST_MAP_NAME_OFFSET_X, SCENARIO_LIST_MAP_NAME_WIDTH, mapName.width() );
     const int32_t yCoordinate = baseYOffset + MAP_LIST_ROW_SPACING_Y - 1;
     mapName.draw( xCoordinate, yCoordinate, display );

--- a/src/fheroes2/dialog/dialog_selectscenario.cpp
+++ b/src/fheroes2/dialog/dialog_selectscenario.cpp
@@ -312,8 +312,8 @@ void ScenarioListBox::_renderSelectedScenarioInfo( fheroes2::Display & display, 
 void ScenarioListBox::_renderMapName( const Maps::FileInfo & info, bool selected, const int32_t & baseYOffset, fheroes2::Display & display ) const
 {
     fheroes2::Text mapName{ info.name,
-                                  { fheroes2::FontSize::NORMAL, ( selected ? fheroes2::FontColor::YELLOW : fheroes2::FontColor::WHITE ) },
-                                  info.getSupportedLanguage() };
+                            { fheroes2::FontSize::NORMAL, ( selected ? fheroes2::FontColor::YELLOW : fheroes2::FontColor::WHITE ) },
+                            info.getSupportedLanguage() };
     mapName.fitToOneRow( SCENARIO_LIST_MAP_NAME_WIDTH );
     const int32_t xCoordinate = GetCenteredTextXCoordinate( _offsetX + SCENARIO_LIST_MAP_NAME_OFFSET_X, SCENARIO_LIST_MAP_NAME_WIDTH, mapName.width() );
     const int32_t yCoordinate = baseYOffset + MAP_LIST_ROW_SPACING_Y - 1;

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -191,7 +191,7 @@ namespace
         coordDifficulty.emplace_back( roi.x + 238, roi.y + 78, difficultyCursorWidth, difficultyCursorHeight );
         coordDifficulty.emplace_back( roi.x + 315, roi.y + 78, difficultyCursorWidth, difficultyCursorHeight );
 
-        const uint32_t buttonSelectWidth = fheroes2::AGG::GetICN( ICN::BUTTON_MAP_SELECT_GOOD, 0 ).width();
+        const int32_t buttonSelectWidth = fheroes2::AGG::GetICN( ICN::BUTTON_MAP_SELECT_GOOD, 0 ).width();
 
         fheroes2::Button buttonSelectMaps( scenarioBoxRoi.x + scenarioBoxRoi.width - 6 - buttonSelectWidth, scenarioBoxRoi.y + 5,
                                            isEvilInterface ? ICN::BUTTON_MAP_SELECT_EVIL : ICN::BUTTON_MAP_SELECT_GOOD, 0, 1 );
@@ -247,9 +247,9 @@ namespace
         }
 
         // We calculate the allowed text width according to the select button's width while ensuring symmetric placement of the map title.
-        const uint32_t boxBorder = 6;
-        const uint32_t halfBoxTextAreaWidth = ( scenarioBoxRoi.width - ( 2 * boxBorder ) ) / 2;
-        const uint32_t rightSideAvailableTextWidth
+        const int32_t boxBorder = 6;
+        const int32_t halfBoxTextAreaWidth = ( scenarioBoxRoi.width - ( 2 * boxBorder ) ) / 2;
+        const int32_t rightSideAvailableTextWidth
             = halfBoxTextAreaWidth > buttonSelectWidth ? halfBoxTextAreaWidth - buttonSelectWidth : buttonSelectWidth - halfBoxTextAreaWidth;
 
         // Set up restorers.


### PR DESCRIPTION
Fixed in map info in editor, and map info and title in scenario setup.

The map title in the map setup dialog aka `game_scenarioinfo` will adjust the available length according to the width of the select button which can vary according to the language.

I chose to always center-align the text because making the text move to the left and make use of the available space there looked weird. The empty space on the left will always be equal to the width of the select button, this will ensure that if we implement a second button there with a new feature, there will be space for this new button to be of equal length to the select button so that we keep symmetry.

This PR:
![image](https://github.com/user-attachments/assets/0231486a-481f-41e5-ac63-225498571637)

![image](https://github.com/user-attachments/assets/24e810dd-3997-4920-9421-65e28b276a92)

