### PR TITLE
Fix incorrect Scrollbar position after it is upscaled

### DIFF
--- a/src/fheroes2/gui/ui_scrollbar.cpp
+++ b/src/fheroes2/gui/ui_scrollbar.cpp
@@ -68,10 +68,8 @@ namespace fheroes2
 
     bool Scrollbar::moveToIndex( const int indexId )
     {
-        if ( _currentIndex == indexId ) {
-            // Nothing to change.
-            return false;
-        }
+        // TODO: Make a function to update the Scrollbar position after its image is changed
+        // and call it in the code instead of this one with 'indexId' that is equal to '_currentId'.
 
         const int32_t roiWidth = _area.width - width();
         const int32_t roiHeight = _area.height - height();


### PR DESCRIPTION
Fix #9212

Currently to update the scrollbar image position after its image is changed we call `moveToIndex( _currentIndex )` just to update image and not to move the slider.

In the future we should do position update in `setImage()` function for this case and use `moveToIndex()` only when we want to move the scrollbar (by mouse or by keyboard).
This change needs many changes in the code and tests so in this PR I've only reverted a change in `moveToIndex()` done in #9201.