### PR TITLE
Fix invalid behavior and crash while interacting with whirlpools by heroes on boats

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "ai_common.h"

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1729,9 +1729,9 @@ namespace
         if ( !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
             hero.SetVisited( tileIndex, Visit::GLOBAL );
 
-            const auto eyeMagiIndexes = Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI );
+            const auto & eyeMagiIndexes = world.getAllEyeOfMagiPositions();
             const uint32_t distance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
-            for ( const auto & [index, objectPart] : eyeMagiIndexes ) {
+            for ( const int32_t index : eyeMagiIndexes ) {
                 Maps::ClearFog( index, distance, hero.GetColor() );
             }
         }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1730,7 +1730,7 @@ namespace
 
             const auto eyeMagiIndexes = Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI );
             const uint32_t distance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
-            for ( const auto& [index, objectPart] : eyeMagiIndexes ) {
+            for ( const auto & [index, objectPart] : eyeMagiIndexes ) {
                 Maps::ClearFog( index, distance, hero.GetColor() );
             }
         }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1664,6 +1664,7 @@ namespace
         hero.setDirection( boatDirection );
 
         destinationTile.resetObjectSprite();
+        destinationTile.updateObjectType();
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
         destinationTile.SetObject( MP2::OBJ_HERO );
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1728,9 +1728,9 @@ namespace
         if ( !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
             hero.SetVisited( tileIndex, Visit::GLOBAL );
 
-            const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI );
+            const auto eyeMagiIndexes = Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI );
             const uint32_t distance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
-            for ( const int32_t index : eyeMagiIndexes ) {
+            for ( const auto& [index, objectPart] : eyeMagiIndexes ) {
                 Maps::ClearFog( index, distance, hero.GetColor() );
             }
         }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1666,7 +1666,7 @@ namespace
         destinationTile.resetObjectSprite();
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
         destinationTile.SetObject( MP2::OBJ_HERO );
-        
+
         hero.SetShipMaster( true );
 
         // Boat is no longer empty so we reset color to default

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1663,6 +1663,7 @@ namespace
         hero.setDirection( boatDirection );
 
         destinationTile.resetObjectSprite();
+        destinationTile.AddonsSort();
         destinationTile.updateObjectType();
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
         destinationTile.SetObject( MP2::OBJ_HERO );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1662,8 +1662,7 @@ namespace
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
         hero.setDirection( boatDirection );
 
-        destinationTile.resetObjectSprite();
-        destinationTile.AddonsSort();
+        destinationTile.resetMainObjectPart();
         destinationTile.updateObjectType();
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
         destinationTile.SetObject( MP2::OBJ_HERO );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1662,9 +1662,14 @@ namespace
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
         hero.setDirection( boatDirection );
 
+        // Remove boat object information from the tile.
         destinationTile.resetMainObjectPart();
+        // Update tile's object type if any object exists after removing the boat.
         destinationTile.updateObjectType();
+        // Set the newly updated object type to hero to remember it.
+        // It is needed in case of moving out from this tile and restoring the tile's original object type.
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
+        // Set the tile's object type as Hero.
         destinationTile.SetObject( MP2::OBJ_HERO );
 
         hero.SetShipMaster( true );

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -29,7 +29,6 @@
 #include <memory>
 #include <ostream>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "ai_common.h"

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1662,8 +1662,11 @@ namespace
 
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
         hero.setDirection( boatDirection );
-        hero.setObjectTypeUnderHero( MP2::OBJ_NONE );
+
         destinationTile.resetObjectSprite();
+        hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
+        destinationTile.SetObject( MP2::OBJ_HERO );
+        
         hero.SetShipMaster( true );
 
         // Boat is no longer empty so we reset color to default

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -1534,13 +1534,12 @@ double AI::Planner::getGeneralObjectValue( const Heroes & hero, const int32_t in
         return 3000;
     }
     case MP2::OBJ_HUT_OF_MAGI: {
-        // TODO: cache Maps::GetObjectPositions() call as this is a very heavy operation.
-        const auto eyeMagiIndexes = Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI );
+        const auto & eyeMagiIndexes = world.getAllEyeOfMagiPositions();
         int fogCountToUncover = 0;
         const int heroColor = hero.GetColor();
         const int eyeViewDistance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
 
-        for ( const auto & [eyeIndex, objectPart] : eyeMagiIndexes ) {
+        for ( const int32_t eyeIndex : eyeMagiIndexes ) {
             fogCountToUncover += Maps::getFogTileCountToBeRevealed( eyeIndex, eyeViewDistance, heroColor );
         }
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -1535,12 +1535,12 @@ double AI::Planner::getGeneralObjectValue( const Heroes & hero, const int32_t in
     }
     case MP2::OBJ_HUT_OF_MAGI: {
         // TODO: cache Maps::GetObjectPositions() call as this is a very heavy operation.
-        const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI );
+        const auto eyeMagiIndexes = Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI );
         int fogCountToUncover = 0;
         const int heroColor = hero.GetColor();
         const int eyeViewDistance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
 
-        for ( const int32_t eyeIndex : eyeMagiIndexes ) {
+        for ( const auto& [eyeIndex, objectPart] : eyeMagiIndexes ) {
             fogCountToUncover += Maps::getFogTileCountToBeRevealed( eyeIndex, eyeViewDistance, heroColor );
         }
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -1540,7 +1540,7 @@ double AI::Planner::getGeneralObjectValue( const Heroes & hero, const int32_t in
         const int heroColor = hero.GetColor();
         const int eyeViewDistance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
 
-        for ( const auto& [eyeIndex, objectPart] : eyeMagiIndexes ) {
+        for ( const auto & [eyeIndex, objectPart] : eyeMagiIndexes ) {
             fogCountToUncover += Maps::getFogTileCountToBeRevealed( eyeIndex, eyeViewDistance, heroColor );
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -663,8 +663,7 @@ namespace
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
         hero.setDirection( boatDirection );
 
-        destinationTile.resetObjectSprite();
-        destinationTile.AddonsSort();
+        destinationTile.resetMainObjectPart();
         destinationTile.updateObjectType();
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
         destinationTile.SetObject( MP2::OBJ_HERO );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -664,6 +664,7 @@ namespace
         hero.setDirection( boatDirection );
 
         destinationTile.resetObjectSprite();
+        destinationTile.updateObjectType();
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
         destinationTile.SetObject( MP2::OBJ_HERO );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -662,8 +662,11 @@ namespace
 
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
         hero.setDirection( boatDirection );
-        hero.setObjectTypeUnderHero( MP2::OBJ_NONE );
+
         destinationTile.resetObjectSprite();
+        hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
+        destinationTile.SetObject( MP2::OBJ_HERO );
+        
         hero.SetShipMaster( true );
 
         hero.ShowPath( true );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3344,7 +3344,7 @@ namespace
                 bool skipAnimation = false;
                 fheroes2::Rect radarRenderArea;
 
-                for ( const auto& [eyeIndex, objectPart] : eyeMagiIndexes ) {
+                for ( const auto & [eyeIndex, objectPart] : eyeMagiIndexes ) {
                     Maps::ClearFog( eyeIndex, scoutRange, hero.GetColor() );
 
                     const fheroes2::Point eyePosition = Maps::GetPoint( eyeIndex );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3332,7 +3332,7 @@ namespace
         if ( !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
             hero.SetVisited( dst_index, Visit::GLOBAL );
 
-            const auto eyeMagiIndexes = Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI );
+            const auto & eyeMagiIndexes = world.getAllEyeOfMagiPositions();
             if ( !eyeMagiIndexes.empty() ) {
                 Interface::AdventureMap & I = Interface::AdventureMap::Get();
 
@@ -3344,7 +3344,7 @@ namespace
                 bool skipAnimation = false;
                 fheroes2::Rect radarRenderArea;
 
-                for ( const auto & [eyeIndex, objectPart] : eyeMagiIndexes ) {
+                for ( const int32_t eyeIndex : eyeMagiIndexes ) {
                     Maps::ClearFog( eyeIndex, scoutRange, hero.GetColor() );
 
                     const fheroes2::Point eyePosition = Maps::GetPoint( eyeIndex );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -663,9 +663,14 @@ namespace
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
         hero.setDirection( boatDirection );
 
+        // Remove boat object information from the tile.
         destinationTile.resetMainObjectPart();
+        // Update tile's object type if any object exists after removing the boat.
         destinationTile.updateObjectType();
+        // Set the newly updated object type to hero to remember it.
+        // It is needed in case of moving out from this tile and restoring the tile's original object type.
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
+        // Set the tile's object type as Hero.
         destinationTile.SetObject( MP2::OBJ_HERO );
 
         hero.SetShipMaster( true );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3332,7 +3332,7 @@ namespace
         if ( !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) ) {
             hero.SetVisited( dst_index, Visit::GLOBAL );
 
-            const MapsIndexes eyeMagiIndexes = Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI );
+            const auto eyeMagiIndexes = Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI );
             if ( !eyeMagiIndexes.empty() ) {
                 Interface::AdventureMap & I = Interface::AdventureMap::Get();
 
@@ -3344,7 +3344,7 @@ namespace
                 bool skipAnimation = false;
                 fheroes2::Rect radarRenderArea;
 
-                for ( const int32_t eyeIndex : eyeMagiIndexes ) {
+                for ( const auto& [eyeIndex, objectPart] : eyeMagiIndexes ) {
                     Maps::ClearFog( eyeIndex, scoutRange, hero.GetColor() );
 
                     const fheroes2::Point eyePosition = Maps::GetPoint( eyeIndex );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -666,7 +666,7 @@ namespace
         destinationTile.resetObjectSprite();
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
         destinationTile.SetObject( MP2::OBJ_HERO );
-        
+
         hero.SetShipMaster( true );
 
         hero.ShowPath( true );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -664,6 +664,7 @@ namespace
         hero.setDirection( boatDirection );
 
         destinationTile.resetObjectSprite();
+        destinationTile.AddonsSort();
         destinationTile.updateObjectType();
         hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) );
         destinationTile.SetObject( MP2::OBJ_HERO );

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -489,7 +489,7 @@ std::vector<std::pair<int32_t, const Maps::TilesAddon *>> Maps::getObjectParts( 
     std::vector<std::pair<int32_t, const TilesAddon *>> result;
     const int32_t size = static_cast<int32_t>( world.getSize() );
     for ( int32_t idx = 0; idx < size; ++idx ) {
-        const Maps::TilesAddon * objectPart = getObjectPartByType( world.GetTiles( idx ), objectType );
+        const Maps::TilesAddon * objectPart = getObjectPartByActionType( world.GetTiles( idx ), objectType );
         if ( objectPart != nullptr ) {
             result.emplace_back( idx, objectPart );
         }

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -479,6 +479,11 @@ bool Maps::doesObjectExistOnMap( const MP2::MapObjectType objectType )
     return false;
 }
 
+Maps::Indexes Maps::GetObjectPositions( const MP2::MapObjectType objectType )
+{
+    return MapsIndexesObject( objectType, true );
+}
+
 std::vector<std::pair<int32_t, const Maps::TilesAddon *>> Maps::getObjectParts( const MP2::MapObjectType objectType )
 {
     std::vector<std::pair<int32_t, const TilesAddon *>> result;

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -479,9 +479,18 @@ bool Maps::doesObjectExistOnMap( const MP2::MapObjectType objectType )
     return false;
 }
 
-Maps::Indexes Maps::GetObjectPositions( const MP2::MapObjectType objectType )
+std::vector<std::pair<int32_t, const Maps::TilesAddon *>> Maps::getObjectParts( const MP2::MapObjectType objectType )
 {
-    return MapsIndexesObject( objectType, true );
+    std::vector<std::pair<int32_t, const TilesAddon *>> result;
+    const int32_t size = static_cast<int32_t>( world.getSize() );
+    for ( int32_t idx = 0; idx < size; ++idx ) {
+        const Maps::TilesAddon * objectPart = getObjectPartByType( world.GetTiles( idx ), objectType );
+        if ( objectPart != nullptr ) {
+            result.emplace_back( idx, objectPart );
+        }
+    }
+
+    return result;
 }
 
 Maps::Indexes Maps::GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes )

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -91,6 +91,9 @@ namespace Maps
     // This function always ignores heroes.
     bool doesObjectExistOnMap( const MP2::MapObjectType objectType );
 
+    // This function always ignores heroes.
+    Indexes GetObjectPositions( const MP2::MapObjectType objectType );
+
     // This is a very slow function by performance. Use it only while loading a map.
     std::vector<std::pair<int32_t, const TilesAddon *>> getObjectParts( const MP2::MapObjectType objectType );
 

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -40,6 +40,8 @@ using MapsIndexes = std::vector<int32_t>;
 
 namespace Maps
 {
+    struct TilesAddon;
+
     enum mapsize_t : int
     {
         ZERO = 0,
@@ -89,7 +91,7 @@ namespace Maps
     bool doesObjectExistOnMap( const MP2::MapObjectType objectType );
 
     // This function always ignores heroes.
-    Indexes GetObjectPositions( const MP2::MapObjectType objectType );
+    std::vector<std::pair<int32_t, const TilesAddon *>> getObjectParts( const MP2::MapObjectType objectType );
 
     Indexes GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes );
 

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -91,7 +91,7 @@ namespace Maps
     // This function always ignores heroes.
     bool doesObjectExistOnMap( const MP2::MapObjectType objectType );
 
-    // This function always ignores heroes.
+    // This is a very slow function by performance. Use it only while loading a map.
     std::vector<std::pair<int32_t, const TilesAddon *>> getObjectParts( const MP2::MapObjectType objectType );
 
     Indexes GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes );

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <utility>
 #include <vector>
 
 #include "math_base.h"

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -532,8 +532,21 @@ void Maps::Tiles::setHero( Heroes * hero )
         hero = getHero();
 
         if ( hero ) {
-            SetObject( hero->getObjectTypeUnderHero() );
+            const MP2::MapObjectType type = hero->getObjectTypeUnderHero();
             hero->setObjectTypeUnderHero( MP2::OBJ_NONE );
+            // While updating the main object type when a hero moves away from a tile we can have 3 situations:
+            // - the underlying object type is MP2::OBJ_NONE. In this case we should update the tile object type.
+            // - the underlying object type is MP2::OBJ_NONE:
+            //   - if the object exists then we do nothing.
+            //   - if the object doesn't exist then we have to update the tile object type.
+            //
+            // The last case can happen only when a hero boards a boat which is under another sea object, like whirlpool.
+            if ( ( type == MP2::OBJ_NONE ) || !doesTileContainObjectType( *this, type ) ) {
+                updateObjectType();
+            }
+            else {
+                SetObject( type );
+            }
         }
         else {
             updateObjectType();

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -540,7 +540,7 @@ void Maps::Tiles::setHero( Heroes * hero )
             //   - if the object exists then we do nothing.
             //   - if the object doesn't exist then we have to update the tile object type.
             //
-            // The last case can happen only when a hero boards a boat which is under another sea object, like whirlpool.
+            // The last case can happen only when a hero boards a boat which is above another sea object, like whirlpool.
             if ( ( type == MP2::OBJ_NONE ) || !doesTileContainObjectType( *this, type ) ) {
                 updateObjectType();
             }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -532,21 +532,8 @@ void Maps::Tiles::setHero( Heroes * hero )
         hero = getHero();
 
         if ( hero ) {
-            const MP2::MapObjectType type = hero->getObjectTypeUnderHero();
+            SetObject( hero->getObjectTypeUnderHero() );
             hero->setObjectTypeUnderHero( MP2::OBJ_NONE );
-            // While updating the main object type when a hero moves away from a tile we can have 3 situations:
-            // - the underlying object type is MP2::OBJ_NONE. In this case we should update the tile object type.
-            // - the underlying object type is MP2::OBJ_NONE:
-            //   - if the object exists then we do nothing.
-            //   - if the object doesn't exist then we have to update the tile object type.
-            //
-            // The last case can happen only when a hero boards a boat which is above another sea object, like whirlpool.
-            if ( ( type == MP2::OBJ_NONE ) || !doesTileContainObjectType( *this, type ) ) {
-                updateObjectType();
-            }
-            else {
-                SetObject( type );
-            }
         }
         else {
             updateObjectType();

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -203,8 +203,6 @@ namespace Maps
         {
             _mainAddon._objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
             _mainAddon._imageIndex = 255;
-
-            updateObjectType();
         }
 
         uint32_t GetRegion() const

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -199,10 +199,9 @@ namespace Maps
         void setBoat( const int direction, const int color );
         int getBoatDirection() const;
 
-        void resetObjectSprite()
+        void resetMainObjectPart()
         {
-            _mainAddon._objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
-            _mainAddon._imageIndex = 255;
+            _mainAddon = {};
         }
 
         uint32_t GetRegion() const

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -203,6 +203,8 @@ namespace Maps
         {
             _mainAddon._objectIcnType = MP2::OBJ_ICN_TYPE_UNKNOWN;
             _mainAddon._imageIndex = 255;
+
+            updateObjectType();
         }
 
         uint32_t GetRegion() const

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1593,6 +1593,54 @@ namespace Maps
         return 0;
     }
 
+    bool doesTileContainObjectType( const Tiles & tile, const MP2::MapObjectType type )
+    {
+        MP2::MapObjectType objectType = getObjectTypeByIcn( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex );
+        if ( objectType == type ) {
+            return true;
+        }
+
+        for ( const auto & objectPart : tile.getBottomLayerAddons() ) {
+            objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
+            if ( objectType == type ) {
+                return true;
+            }
+        }
+
+        for ( const auto & objectPart : tile.getTopLayerAddons() ) {
+            objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
+            if ( objectType == type ) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    const TilesAddon * getObjectPartByType( const Tiles & tile, const MP2::MapObjectType type )
+    {
+        MP2::MapObjectType objectType = getObjectTypeByIcn( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex );
+        if ( objectType == type ) {
+            return &tile.getMainObjectPart();
+        }
+
+        for ( const auto & objectPart : tile.getBottomLayerAddons() ) {
+            objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
+            if ( objectType == type ) {
+                return &objectPart;
+            }
+        }
+
+        for ( const auto & objectPart : tile.getTopLayerAddons() ) {
+            objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
+            if ( objectType == type ) {
+                return &objectPart;
+            }
+        }
+
+        return nullptr;
+    }
+
     Monster getMonsterFromTile( const Tiles & tile )
     {
         switch ( tile.GetObject( false ) ) {

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1593,30 +1593,6 @@ namespace Maps
         return 0;
     }
 
-    bool doesTileContainObjectType( const Tiles & tile, const MP2::MapObjectType type )
-    {
-        MP2::MapObjectType objectType = getObjectTypeByIcn( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex );
-        if ( objectType == type ) {
-            return true;
-        }
-
-        for ( const auto & objectPart : tile.getBottomLayerAddons() ) {
-            objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
-            if ( objectType == type ) {
-                return true;
-            }
-        }
-
-        for ( const auto & objectPart : tile.getTopLayerAddons() ) {
-            objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
-            if ( objectType == type ) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
     const TilesAddon * getObjectPartByActionType( const Tiles & tile, const MP2::MapObjectType type )
     {
         if ( !MP2::isOffGameActionObject( type ) ) {

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2734,7 +2734,7 @@ namespace Maps
         case MP2::OBJ_EVENT:
             assert( isFirstLoad );
             // Event should be invisible on Adventure Map.
-            tile.resetObjectSprite();
+            tile.resetMainObjectPart();
             resetObjectMetadata( tile );
             break;
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1617,21 +1617,18 @@ namespace Maps
         return false;
     }
 
-    const TilesAddon * getObjectPartByType( const Tiles & tile, const MP2::MapObjectType type )
+    const TilesAddon * getObjectPartByActionType( const Tiles & tile, const MP2::MapObjectType type )
     {
+        if ( !MP2::isOffGameActionObject( type ) ) {
+            return nullptr;
+        }
+
         MP2::MapObjectType objectType = getObjectTypeByIcn( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex );
         if ( objectType == type ) {
             return &tile.getMainObjectPart();
         }
 
         for ( const auto & objectPart : tile.getBottomLayerAddons() ) {
-            objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
-            if ( objectType == type ) {
-                return &objectPart;
-            }
-        }
-
-        for ( const auto & objectPart : tile.getTopLayerAddons() ) {
             objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
             if ( objectType == type ) {
                 return &objectPart;

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -42,6 +42,7 @@ namespace MP2
 namespace Maps
 {
     class Tiles;
+    struct TilesAddon;
 
     struct ObjectInfo;
 
@@ -103,6 +104,10 @@ namespace Maps
 
     int getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
     int getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
+
+    bool doesTileContainObjectType( const Tiles & tile, const MP2::MapObjectType type );
+
+    const TilesAddon * getObjectPartByType( const Tiles & tile, const MP2::MapObjectType type );
 
     Monster getMonsterFromTile( const Tiles & tile );
 

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -105,8 +105,6 @@ namespace Maps
     int getColorFromBarrierSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
     int getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
 
-    bool doesTileContainObjectType( const Tiles & tile, const MP2::MapObjectType type );
-
     // Only works for action type of objects (ignoring top layer objects parts).
     const TilesAddon * getObjectPartByActionType( const Tiles & tile, const MP2::MapObjectType type );
 

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -107,7 +107,8 @@ namespace Maps
 
     bool doesTileContainObjectType( const Tiles & tile, const MP2::MapObjectType type );
 
-    const TilesAddon * getObjectPartByType( const Tiles & tile, const MP2::MapObjectType type );
+    // Only works for action type of objects (ignoring top layer objects parts).
+    const TilesAddon * getObjectPartByActionType( const Tiles & tile, const MP2::MapObjectType type );
 
     Monster getMonsterFromTile( const Tiles & tile );
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1345,14 +1345,23 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
     // Cache all tiles that that contain stone liths of a certain type (depending on object sprite index).
     _allTeleports.clear();
 
-    for ( const auto & [index, objectPart] : Maps::getObjectParts( MP2::OBJ_STONE_LITHS ) ) {
-        assert( objectPart != nullptr );
+    for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_STONE_LITHS ) ) {
+        const auto * objectPart = Maps::getObjectPartByActionType( GetTiles( index ), MP2::OBJ_STONE_LITHS );
+        if ( objectPart == nullptr ) {
+            // It looks like it is a broken map. No way the tile doesn't have this object.
+            assert( 0 );
+            continue;
+        }
+
         _allTeleports[objectPart->_imageIndex].push_back( index );
     }
 
     // Cache all tiles that contain a certain part of the whirlpool (depending on object sprite index).
     _allWhirlpools.clear();
 
+    // Whirlpools are unique objects because they can have boats on them which are leftovers from heroes
+    // which disembarked on land. Tiles with boats and whirlpools are marked as Boat objects.
+    // So, searching by type is not accurate as these tiles will be skipped.
     for ( const auto & [index, objectPart] : Maps::getObjectParts( MP2::OBJ_WHIRLPOOL ) ) {
         assert( objectPart != nullptr );
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1373,7 +1373,7 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
         _allWhirlpools[objectPart->_imageIndex].push_back( index );
     }
 
-    // Cache all position of Eye of Magi objects.
+    // Cache all positions of Eye of Magi objects.
     _allEyeOfMagi.clear();
     for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI ) ) {
         _allEyeOfMagi.emplace_back( index );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -793,6 +793,7 @@ MapsIndexes World::GetTeleportEndPoints( const int32_t index ) const
 
     const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_STONE_LITHS );
     if ( entranceObjectPart == nullptr ) {
+        // This tile is marked as Stone Liths but somehow it doesn't even have whirlpool's object parts.
         assert( 0 );
         return result;
     }
@@ -836,6 +837,8 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
 
     const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_WHIRLPOOL );
     if ( entranceObjectPart == nullptr ) {
+        // This tile is marked as Whirlpool but somehow it doesn't even have whirlpool's object parts.
+        assert( 0 );
         return result;
     }
 
@@ -847,6 +850,8 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
 
         const Maps::TilesAddon * destinationObjectPart = Maps::getObjectPartByActionType( whirlpoolTile, MP2::OBJ_WHIRLPOOL );
         if ( destinationObjectPart == nullptr ) {
+            // This tile is marked as Whirlpool but somehow it doesn't even have whirlpool's object parts.
+            assert( 0 );
             continue;
         }
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -793,7 +793,7 @@ MapsIndexes World::GetTeleportEndPoints( const int32_t index ) const
 
     const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_STONE_LITHS );
     if ( entranceObjectPart == nullptr ) {
-        // This tile is marked as Stone Liths but somehow it doesn't even have whirlpool's object parts.
+        // This tile is marked as Stone Liths but somehow it doesn't even have Stone Liths' object parts.
         assert( 0 );
         return result;
     }

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1346,7 +1346,7 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
     // Cache all tiles that that contain stone liths of a certain type (depending on object sprite index).
     _allTeleports.clear();
 
-    for ( const auto& [index, objectPart] : Maps::getObjectParts( MP2::OBJ_STONE_LITHS ) ) {
+    for ( const auto & [index, objectPart] : Maps::getObjectParts( MP2::OBJ_STONE_LITHS ) ) {
         assert( objectPart != nullptr );
         _allTeleports[objectPart->_imageIndex].push_back( index );
     }
@@ -1354,7 +1354,7 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
     // Cache all tiles that contain a certain part of the whirlpool (depending on object sprite index).
     _allWhirlpools.clear();
 
-    for ( const auto& [index, objectPart] : Maps::getObjectParts( MP2::OBJ_WHIRLPOOL ) ) {
+    for ( const auto & [index, objectPart] : Maps::getObjectParts( MP2::OBJ_WHIRLPOOL ) ) {
         assert( objectPart != nullptr );
 
         _allWhirlpools[objectPart->_imageIndex].push_back( index );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -44,7 +44,6 @@
 #include "ground.h"
 #include "heroes.h"
 #include "logging.h"
-#include "map_object_info.h"
 #include "maps_fileinfo.h"
 #include "maps_objects.h"
 #include "maps_tiles_helper.h"

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -791,7 +791,7 @@ MapsIndexes World::GetTeleportEndPoints( const int32_t index ) const
         return result;
     }
 
-    const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByType( entranceTile, MP2::OBJ_STONE_LITHS );
+    const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_STONE_LITHS );
     if ( entranceObjectPart == nullptr ) {
         assert( 0 );
         return result;
@@ -834,7 +834,7 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
         return result;
     }
 
-    const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByType( entranceTile, MP2::OBJ_WHIRLPOOL );
+    const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_WHIRLPOOL );
     if ( entranceObjectPart == nullptr ) {
         return result;
     }
@@ -845,7 +845,7 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
             continue;
         }
 
-        const Maps::TilesAddon * destinationObjectPart = Maps::getObjectPartByType( whirlpoolTile, MP2::OBJ_WHIRLPOOL );
+        const Maps::TilesAddon * destinationObjectPart = Maps::getObjectPartByActionType( whirlpoolTile, MP2::OBJ_WHIRLPOOL );
         if ( destinationObjectPart == nullptr ) {
             continue;
         }

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1359,6 +1359,14 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
         _allWhirlpools[objectPart->_imageIndex].push_back( index );
     }
 
+    // Cache all position of Eye of Magi objects.
+    _allEyeOfMagi.clear();
+    for ( const auto & [index, objectPart] : Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI ) ) {
+        assert( objectPart != nullptr );
+
+        _allEyeOfMagi.emplace_back( index );
+    }
+
     resetPathfinder();
     ComputeStaticAnalysis();
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -846,8 +846,6 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
         return nullptr;
     };
 
-    // The exit point from the destination whirlpool must match the entry point in the source whirlpool.
-    // A whirlpool can be as a main addon / object part or bottom part. This is important to get a proper object part.
     const Maps::TilesAddon * entranceObjectPart = getWhirlPoolObjectPart( entranceTile );
     if ( entranceObjectPart == nullptr ) {
         return result;

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1361,9 +1361,7 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
 
     // Cache all position of Eye of Magi objects.
     _allEyeOfMagi.clear();
-    for ( const auto & [index, objectPart] : Maps::getObjectParts( MP2::OBJ_EYE_OF_MAGI ) ) {
-        assert( objectPart != nullptr );
-
+    for ( const int32_t index : Maps::GetObjectPositions( MP2::OBJ_EYE_OF_MAGI ) ) {
         _allEyeOfMagi.emplace_back( index );
     }
 

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -418,6 +418,11 @@ public:
 
     void updatePassabilities();
 
+    const std::vector<int32_t> & getAllEyeOfMagiPositions() const
+    {
+        return _allEyeOfMagi;
+    }
+
 private:
     World() = default;
 
@@ -468,6 +473,7 @@ private:
 
     std::map<uint8_t, Maps::Indexes> _allTeleports; // All indexes of tiles that contain stone liths of a certain type (sprite index)
     std::map<uint8_t, Maps::Indexes> _allWhirlpools; // All indexes of tiles that contain a certain part (sprite index) of the whirlpool
+    std::vector<int32_t> _allEyeOfMagi;
 
     uint8_t _waterPercentage{ 0 };
     double _landRoughness{ 1.0 };


### PR DESCRIPTION
- update object type after a hero boards a boat and removes the boat sprite from a tile (close #9141)
- fix a crash while a hero tries to disembark from a whirlpool (close #9214)

What was the problem:
1. A hero "owns" tile's object type while stepping on a tile. If a tile was for example marked as bush, then a hero class remembers this type and sets the tile's object type as a hero.
2. In case when a hero board a boat he remembers the type as "boat" and marks as a "hero" object type.
3. In situation when a hero travels by boat and "steps on" an object the tile is going to be marked as "hero" object type. More importantly, if an object was marked as main addon / main object part of that tile it will be moved to bottom layer objects (see `Maps::Tiles::setBoat()` method). This is the **first problem**.
4. However, when a hero standing on a tile with an object steps out of a boat the tile is marked as "boat" object type.
5. When a hero boards that boat based on the previous logic the tile is going to be marked as "empty" as no object exists (see `void ActionToBoat()` function and lines:
```cpp
hero.setObjectTypeUnderHero( MP2::OBJ_NONE ); <--- here we explicitly set that no object was under hero
destinationTile.resetObjectSprite(); <--- here we remove the boat information
```
This is the **second problem**.
6. When a hero steps out of the boat and a player makes a save the tile with a boat is going to be marked as "boat" object type. When the player loads this saves and we actually search for all tiles with Whirlpools that particular tile is not going to be marked as whirlpool since the object type is different. This is the **third problem**.

The solution:
1. To fix the first problem we introduce `Maps::getObjectPartByActionType()` function which search for any object part related to a specific object type. So, previously the logic was expecting whirlpool to be set as a main object part / addon but it could be moved by `Maps::Tiles::setBoat()` method to bottom layer. So, if a tile is marked as Whirlpool we search a whirpool part inside the main object part and within all objects on the bottom layer of the tile.
2. To fix the second problem we update tile's object type before a hero remember it but after we remove the boat:
```cpp
destinationTile.resetMainObjectPart(); <--- we remove boat's information from the tile
destinationTile.updateObjectType(); <--- update object type for this tile if any object previously existed
hero.setObjectTypeUnderHero( destinationTile.GetObject( true ) ); <--- set the updated object type for hero
destinationTile.SetObject( MP2::OBJ_HERO ); <-- set the tile's object type as hero
```
3. To fix the third problem we need to scan every tile on the map for existence of whirlpool object parts even if a tile is not marked as whirlpool. To solve this problem `Maps::getObjectParts()` function was introduced.