### PR TITLE
Rename Addon into Object Part

### DIFF
--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1959,7 +1959,7 @@ int32_t Castle::getTileIndexToPlaceBoat() const
             return false;
         }
 
-        // Mark the tile as worthy to a place a boat if the main addon does not exist on this tile.
+        // Mark the tile as worthy to a place a boat if the main object part does not exist on this tile.
         // This means that all objects on this tile are not primary objects (like shadows or some parts of objects).
         return ( tile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_UNKNOWN || tile.isPassabilityTransparent() );
     };

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -298,8 +298,8 @@ namespace
         // There is a tile below the current.
         const Maps::Tiles & tileBelow = world.GetTiles( x, y + 1 );
 
-        for ( const auto & lowerAddon : tileBelow.getTopLayerAddons() ) {
-            if ( lowerAddon._uid == uid ) {
+        for ( const auto & lowerPart : tileBelow.getTopObjectParts() ) {
+            if ( lowerPart._uid == uid ) {
                 // This is a tall object.
                 return true;
             }
@@ -646,7 +646,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
     // High priority images are drawn after any other object on this tile.
     renderImagesOnTiles( dst, tileUnfit.highPriorityBottomImages, *this );
 
-    std::vector<const Maps::TilesAddon *> topLayerTallObjects;
+    std::vector<const Maps::ObjectPart *> topLayerTallObjects;
 
     // Expand  ROI to properly render very tall objects (1 tile - left and right; 2 tiles - bottom): Abandoned mine Ghosts, Flag on the Alchemist lab, and others.
     const int32_t roiExtraObjectsMaxX = std::min( maxX + 1, world.w() );
@@ -672,19 +672,19 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
             // any other level 2 objects with the same UID.
 
             topLayerTallObjects.clear();
-            for ( const auto & addon : tile.getTopLayerAddons() ) {
-                if ( isTallTopLayerObject( x, y, addon._uid ) ) {
-                    topLayerTallObjects.emplace_back( &addon );
+            for ( const auto & part : tile.getTopObjectParts() ) {
+                if ( isTallTopLayerObject( x, y, part._uid ) ) {
+                    topLayerTallObjects.emplace_back( &part );
                 }
                 else {
-                    redrawTopLayerObject( tile, dst, isPuzzleDraw, *this, addon );
+                    redrawTopLayerObject( tile, dst, isPuzzleDraw, *this, part );
                 }
             }
 
             redrawTopLayerExtraObjects( tile, dst, isPuzzleDraw, *this );
 
-            for ( const auto * addon : topLayerTallObjects ) {
-                redrawTopLayerObject( tile, dst, isPuzzleDraw, *this, *addon );
+            for ( const auto * part : topLayerTallObjects ) {
+                redrawTopLayerObject( tile, dst, isPuzzleDraw, *this, *part );
             }
         }
     }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -229,8 +229,8 @@ namespace
             objectUID = tile.getMainObjectPart()._uid;
         }
         else {
-            // In maps made by the original map editor the action object can be in the bottom layer addons.
-            for ( auto iter = tile.getBottomLayerAddons().rbegin(); iter != tile.getBottomLayerAddons().rend(); ++iter ) {
+            // In maps made by the original map editor the action object can be in the ground layer.
+            for ( auto iter = tile.getGroundObjectParts().rbegin(); iter != tile.getGroundObjectParts().rend(); ++iter ) {
                 if ( Maps::getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex ) == objectType ) {
                     objectUID = iter->_uid;
                     break;

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -232,12 +232,12 @@ namespace Maps
             streamParts.emplace( tile.getMainObjectPart()._uid, tile.getMainObjectPart()._imageIndex );
         }
 
-        for ( const auto & addon : tile.getBottomLayerAddons() ) {
-            if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
-                roadParts.emplace( addon._uid, addon._imageIndex );
+        for ( const auto & part : tile.getGroundObjectParts() ) {
+            if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
+                roadParts.emplace( part._uid, part._imageIndex );
             }
-            else if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
-                streamParts.emplace( addon._uid, addon._imageIndex );
+            else if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
+                streamParts.emplace( part._uid, part._imageIndex );
             }
         }
 

--- a/src/fheroes2/maps/map_object_info.h
+++ b/src/fheroes2/maps/map_object_info.h
@@ -31,7 +31,7 @@
 namespace Maps
 {
     // An object usually contains of multiple parts / tiles. Each part has its own features like object layer type or image index.
-    // An object always contains a main object part (addon).
+    // An object always contains a main object part.
     // All object's parts shares images from the same ICN source (MP2::ObjectIcnType).
     struct ObjectPartInfo
     {
@@ -71,7 +71,7 @@ namespace Maps
             // Do nothing.
         }
 
-        // A layer where this object part / addon sits on.
+        // A layer where this object part sits on.
         // The layer is used for passability calculations as well as an order of rendering objects.
         ObjectLayerType layerType{ OBJECT_LAYER };
     };

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -484,12 +484,12 @@ Maps::Indexes Maps::GetObjectPositions( const MP2::MapObjectType objectType )
     return MapsIndexesObject( objectType, true );
 }
 
-std::vector<std::pair<int32_t, const Maps::TilesAddon *>> Maps::getObjectParts( const MP2::MapObjectType objectType )
+std::vector<std::pair<int32_t, const Maps::ObjectPart *>> Maps::getObjectParts( const MP2::MapObjectType objectType )
 {
-    std::vector<std::pair<int32_t, const TilesAddon *>> result;
+    std::vector<std::pair<int32_t, const ObjectPart *>> result;
     const int32_t size = static_cast<int32_t>( world.getSize() );
     for ( int32_t idx = 0; idx < size; ++idx ) {
-        const Maps::TilesAddon * objectPart = getObjectPartByActionType( world.GetTiles( idx ), objectType );
+        const Maps::ObjectPart * objectPart = getObjectPartByActionType( world.GetTiles( idx ), objectType );
         if ( objectPart != nullptr ) {
             result.emplace_back( idx, objectPart );
         }
@@ -725,10 +725,10 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
                 tile.updateObjectImageIndex( castleID, MP2::OBJ_ICN_TYPE_OBJNTOWN, -16 );
 
             if ( index == 0 ) {
-                TilesAddon * addon = tile.getTopLayerAddon( castleID );
-                if ( addon && addon->_objectIcnType == MP2::OBJ_ICN_TYPE_OBJNTWRD ) {
-                    addon->_objectIcnType = MP2::OBJ_ICN_TYPE_OBJNTOWN;
-                    addon->_imageIndex = fullTownIndex - 16;
+                ObjectPart * part = tile.getTopObjectPart( castleID );
+                if ( part && part->_objectIcnType == MP2::OBJ_ICN_TYPE_OBJNTWRD ) {
+                    part->_objectIcnType = MP2::OBJ_ICN_TYPE_OBJNTOWN;
+                    part->_imageIndex = fullTownIndex - 16;
                 }
             }
         }

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -41,7 +41,7 @@ using MapsIndexes = std::vector<int32_t>;
 
 namespace Maps
 {
-    struct TilesAddon;
+    struct ObjectPart;
 
     enum mapsize_t : int
     {
@@ -95,7 +95,7 @@ namespace Maps
     Indexes GetObjectPositions( const MP2::MapObjectType objectType );
 
     // This is a very slow function by performance. Use it only while loading a map.
-    std::vector<std::pair<int32_t, const TilesAddon *>> getObjectParts( const MP2::MapObjectType objectType );
+    std::vector<std::pair<int32_t, const ObjectPart *>> getObjectParts( const MP2::MapObjectType objectType );
 
     Indexes GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes );
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -752,7 +752,8 @@ void Maps::Tiles::updatePassability()
             return part._objectIcnType != MP2::OBJ_ICN_TYPE_ROAD && part._objectIcnType != MP2::OBJ_ICN_TYPE_STREAM;
         } );
 
-        const bool singleObjectTile = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( bottomTile._mainObjectPart._objectIcnType != _mainObjectPart._objectIcnType );
+        const bool singleObjectTile
+            = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( bottomTile._mainObjectPart._objectIcnType != _mainObjectPart._objectIcnType );
 
         // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
         if ( !singleObjectTile && !isDetachedObject() && !bottomTile._mainObjectPart.isPassabilityTransparent()
@@ -1090,8 +1091,7 @@ bool Maps::Tiles::isStream() const
 {
     for ( const auto & part : _groundObjectPart ) {
         if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM
-             || ( part._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNMUL2
-                  && ( part._imageIndex < 14 || ( part._imageIndex > 217 && part._imageIndex < ( 218 + 14 ) ) ) ) ) {
+             || ( part._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNMUL2 && ( part._imageIndex < 14 || ( part._imageIndex > 217 && part._imageIndex < ( 218 + 14 ) ) ) ) ) {
             return true;
         }
     }
@@ -1864,13 +1864,15 @@ OStreamBase & Maps::operator<<( OStreamBase & stream, const Tiles & tile )
 {
     // TODO: use operator<<() for _mainObjectPart.
     return stream << tile._index << tile._terrainImageIndex << tile._terrainFlags << tile._tilePassabilityDirections << tile._mainObjectPart._uid
-                  << tile._mainObjectPart._objectIcnType << tile._mainObjectPart._imageIndex << tile._mainObjectType << tile._fogColors << tile._metadata << tile._occupantHeroId
-                  << tile._isTileMarkedAsRoad << tile._groundObjectPart << tile._topObjectPart << tile._mainObjectPart._layerType << tile._boatOwnerColor;
+                  << tile._mainObjectPart._objectIcnType << tile._mainObjectPart._imageIndex << tile._mainObjectType << tile._fogColors << tile._metadata
+                  << tile._occupantHeroId << tile._isTileMarkedAsRoad << tile._groundObjectPart << tile._topObjectPart << tile._mainObjectPart._layerType
+                  << tile._boatOwnerColor;
 }
 
 IStreamBase & Maps::operator>>( IStreamBase & stream, Tiles & tile )
 {
-    stream >> tile._index >> tile._terrainImageIndex >> tile._terrainFlags >> tile._tilePassabilityDirections >> tile._mainObjectPart._uid >> tile._mainObjectPart._objectIcnType;
+    stream >> tile._index >> tile._terrainImageIndex >> tile._terrainFlags >> tile._tilePassabilityDirections >> tile._mainObjectPart._uid
+        >> tile._mainObjectPart._objectIcnType;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1009_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1009_RELEASE ) {

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -50,11 +50,11 @@ namespace Maps
         TERRAIN_LAYER = 3 // roads, water flaws and cracks. Essentially everything what is a part of terrain.
     };
 
-    struct TilesAddon
+    struct ObjectPart
     {
-        TilesAddon() = default;
+        ObjectPart() = default;
 
-        TilesAddon( const uint8_t layerType, const uint32_t uid, const MP2::ObjectIcnType objectIcnType, const uint8_t imageIndex )
+        ObjectPart( const uint8_t layerType, const uint32_t uid, const MP2::ObjectIcnType objectIcnType, const uint8_t imageIndex )
             : _uid( uid )
             , _layerType( layerType )
             , _objectIcnType( objectIcnType )
@@ -63,19 +63,19 @@ namespace Maps
             // Do nothing.
         }
 
-        TilesAddon( const TilesAddon & ) = default;
+        ObjectPart( const ObjectPart & ) = default;
 
-        ~TilesAddon() = default;
+        ~ObjectPart() = default;
 
-        // Returns true if it can be passed be hero/boat: addon's layer type is SHADOW or TERRAIN.
+        // Returns true if it can be passed be hero/boat: part's layer type is SHADOW or TERRAIN.
         bool isPassabilityTransparent() const
         {
             return _layerType == SHADOW_LAYER || _layerType == TERRAIN_LAYER;
         }
 
-        bool operator==( const TilesAddon & addon ) const
+        bool operator==( const ObjectPart & part ) const
         {
-            return ( _uid == addon._uid ) && ( _layerType == addon._layerType ) && ( _objectIcnType == addon._objectIcnType ) && ( _imageIndex == addon._imageIndex );
+            return ( _uid == part._uid ) && ( _layerType == part._layerType ) && ( _objectIcnType == part._objectIcnType ) && ( _imageIndex == part._imageIndex );
         }
 
         // Unique identifier of an object. UID can be shared among multiple object parts if an object is bigger than 1 tile.
@@ -98,8 +98,8 @@ namespace Maps
 
         bool operator==( const Tiles & tile ) const
         {
-            return ( _addonBottomLayer == tile._addonBottomLayer ) && ( _addonTopLayer == tile._addonTopLayer ) && ( _index == tile._index )
-                   && ( _terrainImageIndex == tile._terrainImageIndex ) && ( _terrainFlags == tile._terrainFlags ) && ( _mainAddon == tile._mainAddon )
+            return ( _groundObjectPart == tile._groundObjectPart ) && ( _topObjectPart == tile._topObjectPart ) && ( _index == tile._index )
+                   && ( _terrainImageIndex == tile._terrainImageIndex ) && ( _terrainFlags == tile._terrainFlags ) && ( _mainObjectPart == tile._mainObjectPart )
                    && ( _mainObjectType == tile._mainObjectType ) && ( _metadata == tile._metadata ) && ( _tilePassabilityDirections == tile._tilePassabilityDirections )
                    && ( _isTileMarkedAsRoad == tile._isTileMarkedAsRoad ) && ( _occupantHeroId == tile._occupantHeroId );
         }
@@ -125,14 +125,14 @@ namespace Maps
 
         MP2::MapObjectType GetObject( bool ignoreObjectUnderHero = true ) const;
 
-        const TilesAddon & getMainObjectPart() const
+        const ObjectPart & getMainObjectPart() const
         {
-            return _mainAddon;
+            return _mainObjectPart;
         }
 
-        TilesAddon & getMainObjectPart()
+        ObjectPart & getMainObjectPart()
         {
-            return _mainAddon;
+            return _mainObjectPart;
         }
 
         uint16_t GetPassable() const
@@ -155,7 +155,7 @@ namespace Maps
             return objectType == _mainObjectType;
         }
 
-        // Returns true if tile's main and bottom layer addons do not contain any objects: layer type is SHADOW or TERRAIN.
+        // Returns true if tile's main and ground layer object parts do not contain any objects: layer type is SHADOW or TERRAIN.
         bool isPassabilityTransparent() const;
 
         // Checks whether it is possible to move into this tile from the specified direction
@@ -181,8 +181,8 @@ namespace Maps
         bool isStream() const;
         bool GoodForUltimateArtifact() const;
 
-        TilesAddon * getBottomLayerAddon( const uint32_t uid );
-        TilesAddon * getTopLayerAddon( const uint32_t uid );
+        ObjectPart * getGroundObjectPart( const uint32_t uid );
+        ObjectPart * getTopObjectPart( const uint32_t uid );
 
         void SetObject( const MP2::MapObjectType objectType );
 
@@ -201,7 +201,7 @@ namespace Maps
 
         void resetMainObjectPart()
         {
-            _mainAddon = {};
+            _mainObjectPart = {};
         }
 
         uint32_t GetRegion() const
@@ -225,41 +225,41 @@ namespace Maps
             return _fogDirection;
         }
 
-        void pushBottomLayerAddon( const MP2::MP2AddonInfo & ma );
+        void pushGroundObjectPart( const MP2::MP2AddonInfo & ma );
 
-        void pushBottomLayerAddon( TilesAddon ta );
+        void pushGroundObjectPart( ObjectPart ta );
 
-        void pushTopLayerAddon( const MP2::MP2AddonInfo & ma );
+        void pushTopObjectPart( const MP2::MP2AddonInfo & ma );
 
-        void pushTopLayerAddon( TilesAddon ta )
+        void pushTopObjectPart( ObjectPart ta )
         {
-            _addonTopLayer.emplace_back( ta );
+            _topObjectPart.emplace_back( ta );
         }
 
-        const std::list<TilesAddon> & getBottomLayerAddons() const
+        const std::list<ObjectPart> & getGroundObjectParts() const
         {
-            return _addonBottomLayer;
+            return _groundObjectPart;
         }
 
-        std::list<TilesAddon> & getBottomLayerAddons()
+        std::list<ObjectPart> & getGroundObjectParts()
         {
-            return _addonBottomLayer;
+            return _groundObjectPart;
         }
 
-        const std::list<TilesAddon> & getTopLayerAddons() const
+        const std::list<ObjectPart> & getTopObjectParts() const
         {
-            return _addonTopLayer;
+            return _topObjectPart;
         }
 
-        void moveMainAddonToBottomLayer()
+        void moveMainObjectPartToGroundLevel()
         {
-            if ( _mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
-                _addonBottomLayer.emplace_back( _mainAddon );
-                _mainAddon = {};
+            if ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+                _groundObjectPart.emplace_back( _mainObjectPart );
+                _mainObjectPart = {};
             }
         }
 
-        void AddonsSort();
+        void sortObjectParts();
 
         // Returns true if any object part was removed.
         bool removeObjectPartsByUID( const uint32_t objectUID );
@@ -337,7 +337,7 @@ namespace Maps
     private:
         bool isShadow() const;
 
-        TilesAddon * getAddonWithFlag( const uint32_t uid );
+        ObjectPart * getObjectPartWithFlag( const uint32_t uid );
 
         // Set or remove a flag which belongs to UID of the object.
         void updateFlag( const int color, const uint8_t objectSpriteIndex, const uint32_t uid, const bool setOnUpperLayer );
@@ -359,11 +359,11 @@ namespace Maps
 
         // The following members are used in the Editor and in the game.
 
-        TilesAddon _mainAddon;
+        ObjectPart _mainObjectPart;
 
-        std::list<TilesAddon> _addonBottomLayer;
+        std::list<ObjectPart> _groundObjectPart;
 
-        std::list<TilesAddon> _addonTopLayer;
+        std::list<ObjectPart> _topObjectPart;
 
         int32_t _index{ 0 };
 
@@ -395,9 +395,9 @@ namespace Maps
         uint32_t _region{ REGION_NODE_BLOCKED };
     };
 
-    OStreamBase & operator<<( OStreamBase & stream, const TilesAddon & ta );
+    OStreamBase & operator<<( OStreamBase & stream, const ObjectPart & ta );
     OStreamBase & operator<<( OStreamBase & stream, const Tiles & tile );
-    IStreamBase & operator>>( IStreamBase & stream, TilesAddon & ta );
+    IStreamBase & operator>>( IStreamBase & stream, ObjectPart & ta );
     IStreamBase & operator>>( IStreamBase & stream, Tiles & tile );
 }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -825,9 +825,9 @@ namespace
                                     [&currentTile]( const uint8_t index ) { return currentTile.getMainObjectPart()._imageIndex == index; } );
             }
 
-            for ( const Maps::TilesAddon & addon : currentTile.getBottomLayerAddons() ) {
-                if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
-                    return std::any_of( roadIcnIndexes.begin(), roadIcnIndexes.end(), [&addon]( const uint8_t index ) { return addon._imageIndex == index; } );
+            for ( const Maps::ObjectPart & part : currentTile.getGroundObjectParts() ) {
+                if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
+                    return std::any_of( roadIcnIndexes.begin(), roadIcnIndexes.end(), [&part]( const uint8_t index ) { return part._imageIndex == index; } );
                 }
             }
 
@@ -1015,7 +1015,7 @@ namespace
         const uint32_t roadUid = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_ROAD );
 
         if ( roadUid == 0 ) {
-            tile.pushBottomLayerAddon( Maps::TilesAddon( Maps::TERRAIN_LAYER, Maps::getNewObjectUID(), MP2::OBJ_ICN_TYPE_ROAD, imageIndex ) );
+            tile.pushGroundObjectPart( Maps::ObjectPart( Maps::TERRAIN_LAYER, Maps::getNewObjectUID(), MP2::OBJ_ICN_TYPE_ROAD, imageIndex ) );
         }
         else {
             Maps::Tiles::updateTileObjectIcnIndex( tile, roadUid, imageIndex );
@@ -1140,7 +1140,7 @@ namespace
         const uint32_t streamUid = tile.getObjectIdByObjectIcnType( MP2::OBJ_ICN_TYPE_STREAM );
 
         if ( streamUid == 0 ) {
-            tile.pushBottomLayerAddon( Maps::TilesAddon( Maps::TERRAIN_LAYER, Maps::getNewObjectUID(), MP2::OBJ_ICN_TYPE_STREAM, imageIndex ) );
+            tile.pushGroundObjectPart( Maps::ObjectPart( Maps::TERRAIN_LAYER, Maps::getNewObjectUID(), MP2::OBJ_ICN_TYPE_STREAM, imageIndex ) );
         }
         else {
             Maps::Tiles::updateTileObjectIcnIndex( tile, streamUid, imageIndex );
@@ -1211,8 +1211,8 @@ namespace
             // The first case if the existing tile has no object type being set.
             const MP2::MapObjectType tileObjectType = currentTile.GetObject();
 
-            // Always move the current object part to the back of the bottom layer list to make proper sorting later.
-            currentTile.moveMainAddonToBottomLayer();
+            // Always move the current object part to the back of the ground layer list to make proper sorting later.
+            currentTile.moveMainObjectPartToGroundLevel();
 
             if ( tileObjectType == MP2::OBJ_NONE ) {
                 setObjectType = ( partInfo.objectType != MP2::OBJ_NONE );
@@ -1227,7 +1227,7 @@ namespace
                     // We need to run through each object part present at the tile and see if it has "higher" layer object.
                     bool higherObjectFound = false;
 
-                    for ( const auto & topPart : currentTile.getTopLayerAddons() ) {
+                    for ( const auto & topPart : currentTile.getTopObjectParts() ) {
                         const MP2::MapObjectType type = Maps::getObjectTypeByIcn( topPart._objectIcnType, topPart._imageIndex );
                         if ( type != MP2::OBJ_NONE ) {
                             // A top object part is present.
@@ -1237,7 +1237,7 @@ namespace
                     }
 
                     if ( !higherObjectFound ) {
-                        for ( const auto & groundPart : currentTile.getBottomLayerAddons() ) {
+                        for ( const auto & groundPart : currentTile.getGroundObjectParts() ) {
                             if ( groundPart._layerType >= partInfo.layerType ) {
                                 // A ground object part is has "lower" or equal layer type. Skip it.
                                 continue;
@@ -1258,17 +1258,17 @@ namespace
 
 #if defined( WITH_DEBUG )
             // Check that we don't put the same object part.
-            for ( const auto & groundPart : currentTile.getBottomLayerAddons() ) {
+            for ( const auto & groundPart : currentTile.getGroundObjectParts() ) {
                 assert( groundPart._uid != uid || groundPart._imageIndex != static_cast<uint8_t>( partInfo.icnIndex ) || groundPart._objectIcnType != partInfo.icnType
                         || groundPart._layerType != partInfo.layerType );
             }
 #endif
 
             // Push the object to the ground (bottom) object parts.
-            currentTile.pushBottomLayerAddon( Maps::TilesAddon( partInfo.layerType, uid, partInfo.icnType, static_cast<uint8_t>( partInfo.icnIndex ) ) );
+            currentTile.pushGroundObjectPart( Maps::ObjectPart( partInfo.layerType, uid, partInfo.icnType, static_cast<uint8_t>( partInfo.icnIndex ) ) );
 
             // Sort all objects.
-            currentTile.AddonsSort();
+            currentTile.sortObjectParts();
 
             // Set object type if needed.
             if ( setObjectType ) {
@@ -1286,7 +1286,7 @@ namespace
 
             Maps::Tiles & currentTile = world.GetTiles( pos.x, pos.y );
             // Top object parts do not need sorting.
-            currentTile.pushTopLayerAddon( Maps::TilesAddon( Maps::OBJECT_LAYER, uid, partInfo.icnType, static_cast<uint8_t>( partInfo.icnIndex ) ) );
+            currentTile.pushTopObjectPart( Maps::ObjectPart( Maps::OBJECT_LAYER, uid, partInfo.icnType, static_cast<uint8_t>( partInfo.icnIndex ) ) );
 
             // Set object type only if the current object part has a type and the object is not an action object.
             if ( partInfo.objectType != MP2::OBJ_NONE && !MP2::isOffGameActionObject( currentTile.GetObject() ) ) {
@@ -1593,7 +1593,7 @@ namespace Maps
         return 0;
     }
 
-    const TilesAddon * getObjectPartByActionType( const Tiles & tile, const MP2::MapObjectType type )
+    const ObjectPart * getObjectPartByActionType( const Tiles & tile, const MP2::MapObjectType type )
     {
         if ( !MP2::isOffGameActionObject( type ) ) {
             return nullptr;
@@ -1604,7 +1604,7 @@ namespace Maps
             return &tile.getMainObjectPart();
         }
 
-        for ( const auto & objectPart : tile.getBottomLayerAddons() ) {
+        for ( const auto & objectPart : tile.getGroundObjectParts() ) {
             objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
             if ( objectType == type ) {
                 return &objectPart;
@@ -2185,10 +2185,10 @@ namespace Maps
                 artifactSpriteIndex = tile.getMainObjectPart()._imageIndex;
             }
             else {
-                // On some hacked original maps artifact can be placed to the bottom layer addons.
-                for ( const auto & addon : tile.getBottomLayerAddons() ) {
-                    if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNARTI ) {
-                        artifactSpriteIndex = addon._imageIndex;
+                // On some hacked original maps artifact can be placed to the ground layer object parts.
+                for ( const auto & part : tile.getGroundObjectParts() ) {
+                    if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNARTI ) {
+                        artifactSpriteIndex = part._imageIndex;
                         break;
                     }
                 }
@@ -2243,9 +2243,9 @@ namespace Maps
                 resourceType = Resource::FromIndexSprite( tile.getMainObjectPart()._imageIndex );
             }
             else {
-                for ( const auto & addon : tile.getBottomLayerAddons() ) {
-                    if ( addon._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
-                        resourceType = Resource::FromIndexSprite( addon._imageIndex );
+                for ( const auto & part : tile.getGroundObjectParts() ) {
+                    if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
+                        resourceType = Resource::FromIndexSprite( part._imageIndex );
                         // If this happens we are in trouble. It looks like that map maker put the resource under an object which is impossible to do.
                         // Let's update the tile's object type to properly show the action object.
                         tile.updateObjectType();
@@ -2756,27 +2756,27 @@ namespace Maps
     {
         tile.SetObject( MP2::OBJ_MONSTER );
 
-        Maps::TilesAddon & mainAddon = tile.getMainObjectPart();
+        Maps::ObjectPart & mainObjectPart = tile.getMainObjectPart();
 
-        if ( mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 ) {
-            if ( mainAddon._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+        if ( mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 ) {
+            if ( mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
                 // If there is another object sprite here (shadow for example) push it down to add-ons.
-                tile.pushBottomLayerAddon( mainAddon );
+                tile.pushGroundObjectPart( mainObjectPart );
             }
 
             // Set unique UID for placed monster.
-            mainAddon._uid = getNewObjectUID();
-            mainAddon._objectIcnType = MP2::OBJ_ICN_TYPE_MONS32;
-            mainAddon._layerType = OBJECT_LAYER;
+            mainObjectPart._uid = getNewObjectUID();
+            mainObjectPart._objectIcnType = MP2::OBJ_ICN_TYPE_MONS32;
+            mainObjectPart._layerType = OBJECT_LAYER;
         }
 
-        using TileImageIndexType = decltype( mainAddon._imageIndex );
+        using TileImageIndexType = decltype( mainObjectPart._imageIndex );
         static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of _imageIndex has been changed, check the logic below" );
 
         const uint32_t monsSpriteIndex = mons.GetSpriteIndex();
         assert( monsSpriteIndex >= std::numeric_limits<TileImageIndexType>::min() && monsSpriteIndex <= std::numeric_limits<TileImageIndexType>::max() );
 
-        mainAddon._imageIndex = static_cast<TileImageIndexType>( monsSpriteIndex );
+        mainObjectPart._imageIndex = static_cast<TileImageIndexType>( monsSpriteIndex );
 
         const bool setDefinedCount = ( count > 0 );
 
@@ -2957,8 +2957,8 @@ namespace Maps
             if ( Maps::isValidDirection( tile.GetIndex(), directionVector ) ) {
                 Tiles & mineTile = world.GetTiles( Maps::GetDirectionIndex( tile.GetIndex(), directionVector ) );
                 if ( ( mineTile.GetObject() == MP2::OBJ_NON_ACTION_ABANDONED_MINE )
-                     && ( mineTile.getMainObjectPart()._uid == tile.getMainObjectPart()._uid || mineTile.getBottomLayerAddon( tile.getMainObjectPart()._uid )
-                          || mineTile.getTopLayerAddon( tile.getMainObjectPart()._uid ) ) ) {
+                     && ( mineTile.getMainObjectPart()._uid == tile.getMainObjectPart()._uid || mineTile.getGroundObjectPart( tile.getMainObjectPart()._uid )
+                          || mineTile.getTopObjectPart( tile.getMainObjectPart()._uid ) ) ) {
                     mineTile.SetObject( MP2::OBJ_NON_ACTION_MINE );
                 }
             }
@@ -2971,9 +2971,9 @@ namespace Maps
         tile.getMainObjectPart()._objectIcnType = objectIcnTypeTemp;
         tile.getMainObjectPart()._imageIndex = imageIndexTemp;
 
-        for ( auto & addon : tile.getBottomLayerAddons() ) {
-            if ( addon._uid == tile.getMainObjectPart()._uid ) {
-                restoreLeftSprite( addon._objectIcnType, addon._imageIndex );
+        for ( auto & part : tile.getGroundObjectParts() ) {
+            if ( part._uid == tile.getMainObjectPart()._uid ) {
+                restoreLeftSprite( part._objectIcnType, part._imageIndex );
             }
         }
 
@@ -2989,10 +2989,10 @@ namespace Maps
                 rightTile.getMainObjectPart()._imageIndex = imageIndexTemp;
             }
 
-            TilesAddon * addon = rightTile.getBottomLayerAddon( tile.getMainObjectPart()._uid );
+            ObjectPart * part = rightTile.getGroundObjectPart( tile.getMainObjectPart()._uid );
 
-            if ( addon ) {
-                restoreRightSprite( addon->_objectIcnType, addon->_imageIndex );
+            if ( part ) {
+                restoreRightSprite( part->_objectIcnType, part->_imageIndex );
             }
         }
 
@@ -3020,7 +3020,7 @@ namespace Maps
         }
 
         if ( objectUID == 0 ) {
-            for ( auto iter = tile.getTopLayerAddons().rbegin(); iter != tile.getTopLayerAddons().rend(); ++iter ) {
+            for ( auto iter = tile.getTopObjectParts().rbegin(); iter != tile.getTopObjectParts().rend(); ++iter ) {
                 if ( Maps::getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex ) == objectType ) {
                     objectUID = iter->_uid;
                     break;
@@ -3029,7 +3029,7 @@ namespace Maps
         }
 
         if ( objectUID == 0 ) {
-            for ( auto iter = tile.getBottomLayerAddons().rbegin(); iter != tile.getBottomLayerAddons().rend(); ++iter ) {
+            for ( auto iter = tile.getGroundObjectParts().rbegin(); iter != tile.getGroundObjectParts().rend(); ++iter ) {
                 if ( Maps::getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex ) == objectType ) {
                     objectUID = iter->_uid;
                     break;
@@ -3311,9 +3311,9 @@ namespace Maps
                     objectsUids.insert( currentTile.getMainObjectPart()._uid );
                 }
 
-                for ( const auto & addon : currentTile.getBottomLayerAddons() ) {
-                    if ( addon._uid != 0 && ( addon._layerType != SHADOW_LAYER ) ) {
-                        objectsUids.insert( addon._uid );
+                for ( const auto & part : currentTile.getGroundObjectParts() ) {
+                    if ( part._uid != 0 && ( part._layerType != SHADOW_LAYER ) ) {
+                        objectsUids.insert( part._uid );
                     }
                 }
 

--- a/src/fheroes2/maps/maps_tiles_helper.h
+++ b/src/fheroes2/maps/maps_tiles_helper.h
@@ -42,7 +42,7 @@ namespace MP2
 namespace Maps
 {
     class Tiles;
-    struct TilesAddon;
+    struct ObjectPart;
 
     struct ObjectInfo;
 
@@ -106,7 +106,7 @@ namespace Maps
     int getColorFromTravellerTentSprite( const MP2::ObjectIcnType objectIcnType, const uint8_t icnIndex );
 
     // Only works for action type of objects (ignoring top layer objects parts).
-    const TilesAddon * getObjectPartByActionType( const Tiles & tile, const MP2::MapObjectType type );
+    const ObjectPart * getObjectPartByActionType( const Tiles & tile, const MP2::MapObjectType type );
 
     Monster getMonsterFromTile( const Tiles & tile );
 

--- a/src/fheroes2/maps/maps_tiles_render.h
+++ b/src/fheroes2/maps/maps_tiles_render.h
@@ -46,12 +46,12 @@ namespace MP2
 namespace Maps
 {
     class Tiles;
-    struct TilesAddon;
+    struct ObjectPart;
 
     void redrawEmptyTile( fheroes2::Image & dst, const fheroes2::Point & mp, const Interface::GameArea & area );
 
     void redrawTopLayerExtraObjects( const Tiles & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area );
-    void redrawTopLayerObject( const Tiles & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area, const TilesAddon & addon );
+    void redrawTopLayerObject( const Tiles & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area, const ObjectPart & part );
 
     void drawFog( const Tiles & tile, fheroes2::Image & dst, const Interface::GameArea & area );
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -791,7 +791,7 @@ MapsIndexes World::GetTeleportEndPoints( const int32_t index ) const
         return result;
     }
 
-    const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_STONE_LITHS );
+    const Maps::ObjectPart * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_STONE_LITHS );
     if ( entranceObjectPart == nullptr ) {
         // This tile is marked as Stone Liths but somehow it doesn't even have Stone Liths' object parts.
         assert( 0 );
@@ -835,7 +835,7 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
         return result;
     }
 
-    const Maps::TilesAddon * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_WHIRLPOOL );
+    const Maps::ObjectPart * entranceObjectPart = Maps::getObjectPartByActionType( entranceTile, MP2::OBJ_WHIRLPOOL );
     if ( entranceObjectPart == nullptr ) {
         // This tile is marked as Whirlpool but somehow it doesn't even have whirlpool's object parts.
         assert( 0 );
@@ -848,7 +848,7 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
             continue;
         }
 
-        const Maps::TilesAddon * destinationObjectPart = Maps::getObjectPartByActionType( whirlpoolTile, MP2::OBJ_WHIRLPOOL );
+        const Maps::ObjectPart * destinationObjectPart = Maps::getObjectPartByActionType( whirlpoolTile, MP2::OBJ_WHIRLPOOL );
         if ( destinationObjectPart == nullptr ) {
             // This tile is marked as Whirlpool but somehow it doesn't even have whirlpool's object parts.
             assert( 0 );
@@ -964,7 +964,7 @@ bool World::DiggingForUltimateArtifact( const fheroes2::Point & center )
         return false;
     }
 
-    tile.pushBottomLayerAddon( Maps::TilesAddon( Maps::BACKGROUND_LAYER, Maps::getNewObjectUID(), objectIcnType, imageIndex ) );
+    tile.pushGroundObjectPart( Maps::ObjectPart( Maps::BACKGROUND_LAYER, Maps::getNewObjectUID(), objectIcnType, imageIndex ) );
 
     if ( ultimate_artifact.isPosition( tile.GetIndex() ) && !ultimate_artifact.isFound() ) {
         ultimate_artifact.markAsFound();
@@ -1388,12 +1388,12 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
     for ( const Maps::Tiles & tile : vec_tiles ) {
         maxUid = std::max( tile.getMainObjectPart()._uid, maxUid );
 
-        for ( const auto & addon : tile.getBottomLayerAddons() ) {
-            maxUid = std::max( addon._uid, maxUid );
+        for ( const auto & part : tile.getGroundObjectParts() ) {
+            maxUid = std::max( part._uid, maxUid );
         }
 
-        for ( const auto & addon : tile.getTopLayerAddons() ) {
-            maxUid = std::max( addon._uid, maxUid );
+        for ( const auto & part : tile.getTopObjectParts() ) {
+            maxUid = std::max( part._uid, maxUid );
         }
     }
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -275,12 +275,12 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
                 DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid MP2 format: incorrect addon index " << addonIndex )
                 break;
             }
-            tile.pushBottomLayerAddon( vec_mp2addons[addonIndex] );
-            tile.pushTopLayerAddon( vec_mp2addons[addonIndex] );
+            tile.pushGroundObjectPart( vec_mp2addons[addonIndex] );
+            tile.pushTopObjectPart( vec_mp2addons[addonIndex] );
             addonIndex = vec_mp2addons[addonIndex].nextAddonIndex;
         }
 
-        tile.AddonsSort();
+        tile.sortObjectParts();
 
         if ( MP2::doesObjectNeedExtendedMetadata( tile.GetObject() ) ) {
             vec_object.push_back( i );


### PR DESCRIPTION
As highlighted in #9217 map tile object related code is a black box for most of developers. This code is very convoluted and hard to read. This pull request does simple renaming of **Addon** into **Object Part** to make it easier to read.

Other naming is welcome as well!