### PR TITLE
Fix some code smells related to the resource management

### DIFF
--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -37,6 +37,7 @@ namespace fheroes2
     public:
         Image() = default;
         Image( const int32_t width_, const int32_t height_ );
+
         Image( const Image & image_ );
         Image( Image && image_ ) noexcept;
 
@@ -115,6 +116,7 @@ namespace fheroes2
         Sprite() = default;
         Sprite( const int32_t width_, const int32_t height_, const int32_t x_ = 0, const int32_t y_ = 0 );
         Sprite( const Image & image, const int32_t x_ = 0, const int32_t y_ = 0 );
+
         Sprite( const Sprite & sprite ) = default;
         Sprite( Sprite && sprite ) noexcept;
 

--- a/src/fheroes2/battle/battle_animation.h
+++ b/src/fheroes2/battle/battle_animation.h
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_ANIMATION_H
-#define H2BATTLE_ANIMATION_H
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -88,7 +87,7 @@ public:
     explicit AnimationReference( int id );
 
     AnimationReference( const AnimationReference & ) = delete;
-    AnimationReference( AnimationReference && ) = delete;
+    AnimationReference( AnimationReference && ) = default;
 
     virtual ~AnimationReference() = default;
 
@@ -158,4 +157,3 @@ private:
     int _animState;
     AnimationSequence _currentSequence;
 };
-#endif

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -82,9 +82,9 @@ namespace
     }
 }
 
-Captain::Captain( Castle & cstl )
-    : HeroBase( HeroBase::CAPTAIN, cstl.GetRace() )
-    , home( cstl )
+Captain::Captain( Castle & castle )
+    : HeroBase( HeroBase::CAPTAIN, castle.GetRace() )
+    , home( castle )
 {
     SetCenter( home.GetCenter() );
 }

--- a/src/fheroes2/castle/captain.h
+++ b/src/fheroes2/castle/captain.h
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2CAPTAIN_H
-#define H2CAPTAIN_H
+
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -35,7 +35,8 @@ class Castle;
 class Captain final : public HeroBase
 {
 public:
-    explicit Captain( Castle & );
+    explicit Captain( Castle & castle );
+
     Captain( const Captain & ) = delete;
 
     ~Captain() override = default;
@@ -87,5 +88,3 @@ private:
 
     Castle & home;
 };
-
-#endif

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2CASTLE_H
-#define H2CASTLE_H
+
+#pragma once
 
 #include <array>
 #include <cstddef>
@@ -146,7 +146,9 @@ public:
 
     Castle() = default;
     Castle( const int32_t posX, const int32_t posY, int race );
+
     Castle( const Castle & ) = delete;
+
     ~Castle() override = default;
 
     Castle & operator=( const Castle & ) = delete;
@@ -511,12 +513,6 @@ namespace CastleDialog
 struct VecCastles : public std::vector<Castle *>
 {
     VecCastles() = default;
-    VecCastles( const VecCastles & ) = delete;
-
-    ~VecCastles() = default;
-
-    VecCastles & operator=( const VecCastles & ) = delete;
-    VecCastles & operator=( VecCastles && ) = default;
 
     Castle * GetFirstCastle() const;
 };
@@ -590,5 +586,3 @@ IStreamBase & operator>>( IStreamBase & stream, VecCastles & castles );
 
 OStreamBase & operator<<( OStreamBase & stream, const AllCastles & castles );
 IStreamBase & operator>>( IStreamBase & stream, AllCastles & castles );
-
-#endif

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_GAMEAREA_H
-#define H2INTERFACE_GAMEAREA_H
+#pragma once
 
 #include <algorithm>
 #include <cstdint>
@@ -153,13 +152,6 @@ namespace Interface
     {
     public:
         explicit GameArea( BaseInterface & interface );
-        GameArea( const GameArea & ) = default;
-        GameArea( GameArea && ) = delete;
-
-        ~GameArea() = default;
-
-        GameArea & operator=( const GameArea & ) = delete;
-        GameArea & operator=( GameArea && ) = delete;
 
         void generate( const fheroes2::Size & screenSize, const bool withoutBorders );
 
@@ -318,5 +310,3 @@ namespace Interface
         void updateObjectAnimationInfo() const;
     };
 }
-
-#endif

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2HEROES_H
-#define H2HEROES_H
+#pragma once
 
 #include <cassert> // IWYU pragma: keep
 #include <cmath>
@@ -251,10 +250,6 @@ public:
         }
 
         AIHeroMeetingUpdater( const AIHeroMeetingUpdater & ) = delete;
-        AIHeroMeetingUpdater( AIHeroMeetingUpdater && ) = delete;
-
-        AIHeroMeetingUpdater & operator=( const AIHeroMeetingUpdater & ) = delete;
-        AIHeroMeetingUpdater & operator=( AIHeroMeetingUpdater && ) = delete;
 
         ~AIHeroMeetingUpdater()
         {
@@ -276,6 +271,8 @@ public:
             }
         }
 
+        AIHeroMeetingUpdater & operator=( const AIHeroMeetingUpdater & ) = delete;
+
     private:
         Heroes & _hero;
         const double _initialArmyStrength;
@@ -286,6 +283,7 @@ public:
     Heroes();
     Heroes( int heroid, int rc );
     Heroes( const int heroID, const int race, const uint32_t additionalExperience );
+
     Heroes( const Heroes & ) = delete;
 
     ~Heroes() override = default;
@@ -777,12 +775,6 @@ private:
 struct VecHeroes : public std::vector<Heroes *>
 {
     VecHeroes() = default;
-    VecHeroes( const VecHeroes & ) = delete;
-
-    ~VecHeroes() = default;
-
-    VecHeroes & operator=( const VecHeroes & ) = delete;
-    VecHeroes & operator=( VecHeroes && ) = default;
 };
 
 class AllHeroes
@@ -848,5 +840,3 @@ private:
 
 OStreamBase & operator<<( OStreamBase & stream, const VecHeroes & heroes );
 IStreamBase & operator>>( IStreamBase & stream, VecHeroes & heroes );
-
-#endif

--- a/src/fheroes2/heroes/heroes_recruits.h
+++ b/src/fheroes2/heroes/heroes_recruits.h
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2RECRUITS_H
-#define H2RECRUITS_H
+#pragma once
 
 #include <cstdint>
 #include <utility>
@@ -38,12 +37,6 @@ public:
     Recruit();
     Recruit( const Heroes & hero, const uint32_t surrenderDay );
     explicit Recruit( const Heroes & hero );
-    Recruit( const Recruit & ) = delete;
-
-    ~Recruit() = default;
-
-    Recruit & operator=( const Recruit & ) = delete;
-    Recruit & operator=( Recruit && ) = default;
 
     int getID() const
     {
@@ -87,5 +80,3 @@ public:
 
 OStreamBase & operator<<( OStreamBase & stream, const Recruit & recruit );
 IStreamBase & operator>>( IStreamBase & stream, Recruit & recruit );
-
-#endif

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -662,7 +662,7 @@ Skill::SecSkills::SecSkills()
     reserve( Heroes::maxNumOfSecSkills );
 }
 
-Skill::SecSkills::SecSkills( int race )
+Skill::SecSkills::SecSkills( const int race )
 {
     reserve( Heroes::maxNumOfSecSkills );
 

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2SKILL_H
-#define H2SKILL_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -131,13 +130,7 @@ namespace Skill
     {
     public:
         SecSkills();
-        explicit SecSkills( int race );
-        SecSkills( const SecSkills & ) = delete;
-
-        ~SecSkills() = default;
-
-        SecSkills & operator=( const SecSkills & ) = delete;
-        SecSkills & operator=( SecSkills && ) = default;
+        explicit SecSkills( const int race );
 
         int Count() const;
         int GetLevel( int skill ) const;
@@ -156,7 +149,6 @@ namespace Skill
         std::vector<Secondary> & ToVector();
         const std::vector<Secondary> & ToVector() const;
 
-    private:
         friend OStreamBase & operator<<( OStreamBase & stream, const SecSkills & ss );
         friend IStreamBase & operator>>( IStreamBase & stream, SecSkills & ss );
     };
@@ -214,4 +206,3 @@ namespace Skill
     OStreamBase & operator<<( OStreamBase & stream, const Primary & skill );
     IStreamBase & operator>>( IStreamBase & stream, Primary & skill );
 }
-#endif

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2KINGDOM_H
-#define H2KINGDOM_H
+
+#pragma once
 
 #include <algorithm>
 #include <array>
@@ -60,7 +60,7 @@ class Kingdom : public BitModes, public Control
 public:
     enum
     {
-        // UNDEF      = 0x0001,
+        // UNUSED = 0x0001,
         IDENTIFYHERO = 0x0002,
         // UNUSED = 0x0004,
         KINGDOM_OVERVIEW_CASTLE_SELECTION = 0x0008
@@ -77,7 +77,9 @@ public:
     };
 
     Kingdom();
+
     Kingdom( const Kingdom & ) = delete;
+    Kingdom( Kingdom && ) = default;
 
     ~Kingdom() override = default;
 
@@ -268,5 +270,3 @@ private:
 
     std::array<Kingdom, maxNumOfPlayers + 1> _kingdoms;
 };
-
-#endif


### PR DESCRIPTION
* `AnimationReference`: already has defaulted move assignment operator, no harm to have defaulted move constructor as well;
* `VecCastles`: just a non-owning vector of pointers, no restrictions on copy/move are needed;
* `GameArea`: already has the defaulted copy constructor, no harm to have defaulted move constructor, default assignment operators are always deleted because of the `BaseInterface & _interface` member;
* `VecHeroes`: just a non-owning vector of pointers, no restrictions on copy/move are needed;
* `Recruit`: just a POD type, no restrictions on copy/move are needed;
* `SecSkills`: just a vector of POD types, no restrictions on copy/move are needed;
* `Kingdom`: already has defaulted move assignment operator, no harm to have defaulted move constructor as well.