### PR TITLE
Rename all members of ObjectPart structure

### DIFF
--- a/src/fheroes2/agg/m82.cpp
+++ b/src/fheroes2/agg/m82.cpp
@@ -221,7 +221,7 @@ M82::SoundType M82::getAdventureMapTileSound( const Maps::Tiles & tile )
     case MP2::OBJ_STONE_LITHS:
         return LOOP0004;
     case MP2::OBJ_VOLCANO:
-        switch ( tile.getMainObjectPart()._objectIcnType ) {
+        switch ( tile.getMainObjectPart().icnType ) {
         // Tile with volcanic steam only
         case MP2::OBJ_ICN_TYPE_UNKNOWN:
             return UNKNOWN;

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1884,7 +1884,7 @@ bool Castle::HasSeaAccess() const
             return false;
         }
 
-        if ( tile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+        if ( tile.getMainObjectPart().icnType == MP2::OBJ_ICN_TYPE_UNKNOWN ) {
             // The main addon does not exist on this tile.
             // This means that all objects on this tile are not primary objects (like shadows or some parts of objects).
             return true;
@@ -1961,7 +1961,7 @@ int32_t Castle::getTileIndexToPlaceBoat() const
 
         // Mark the tile as worthy to a place a boat if the main object part does not exist on this tile.
         // This means that all objects on this tile are not primary objects (like shadows or some parts of objects).
-        return ( tile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_UNKNOWN || tile.isPassabilityTransparent() );
+        return ( tile.getMainObjectPart().icnType == MP2::OBJ_ICN_TYPE_UNKNOWN || tile.isPassabilityTransparent() );
     };
 
     const int32_t index = Maps::GetIndexFromAbsPoint( possibleSeaTile.x, possibleSeaTile.y );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -225,13 +225,13 @@ namespace
     {
         uint32_t objectUID = 0;
 
-        if ( Maps::getObjectTypeByIcn( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex ) == objectType ) {
+        if ( Maps::getObjectTypeByIcn( tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex ) == objectType ) {
             objectUID = tile.getMainObjectPart()._uid;
         }
         else {
             // In maps made by the original map editor the action object can be in the ground layer.
             for ( auto iter = tile.getGroundObjectParts().rbegin(); iter != tile.getGroundObjectParts().rend(); ++iter ) {
-                if ( Maps::getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex ) == objectType ) {
+                if ( Maps::getObjectTypeByIcn( iter->icnType, iter->icnIndex ) == objectType ) {
                     objectUID = iter->_uid;
                     break;
                 }

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -224,20 +224,20 @@ namespace Maps
         std::set<std::pair<uint32_t, uint8_t>> roadParts;
         std::set<std::pair<uint32_t, uint8_t>> streamParts;
 
-        const MP2::ObjectIcnType mainObjectIcnType = tile.getMainObjectPart()._objectIcnType;
+        const MP2::ObjectIcnType mainObjectIcnType = tile.getMainObjectPart().icnType;
         if ( mainObjectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
-            roadParts.emplace( tile.getMainObjectPart()._uid, tile.getMainObjectPart()._imageIndex );
+            roadParts.emplace( tile.getMainObjectPart()._uid, tile.getMainObjectPart().icnIndex );
         }
         else if ( mainObjectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
-            streamParts.emplace( tile.getMainObjectPart()._uid, tile.getMainObjectPart()._imageIndex );
+            streamParts.emplace( tile.getMainObjectPart()._uid, tile.getMainObjectPart().icnIndex );
         }
 
         for ( const auto & part : tile.getGroundObjectParts() ) {
-            if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
-                roadParts.emplace( part._uid, part._imageIndex );
+            if ( part.icnType == MP2::OBJ_ICN_TYPE_ROAD ) {
+                roadParts.emplace( part._uid, part.icnIndex );
             }
-            else if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM ) {
-                streamParts.emplace( part._uid, part._imageIndex );
+            else if ( part.icnType == MP2::OBJ_ICN_TYPE_STREAM ) {
+                streamParts.emplace( part._uid, part.icnIndex );
             }
         }
 

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -726,9 +726,9 @@ void Maps::UpdateCastleSprite( const fheroes2::Point & center, int race, bool is
 
             if ( index == 0 ) {
                 ObjectPart * part = tile.getTopObjectPart( castleID );
-                if ( part && part->_objectIcnType == MP2::OBJ_ICN_TYPE_OBJNTWRD ) {
-                    part->_objectIcnType = MP2::OBJ_ICN_TYPE_OBJNTOWN;
-                    part->_imageIndex = fullTownIndex - 16;
+                if ( part && part->icnType == MP2::OBJ_ICN_TYPE_OBJNTWRD ) {
+                    part->icnType = MP2::OBJ_ICN_TYPE_OBJNTOWN;
+                    part->icnIndex = fullTownIndex - 16;
                 }
             }
         }

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -325,7 +325,7 @@ bool Maps::FileInfo::readMP2Map( std::string filePath, const bool isForEditor )
         Maps::Tiles tile;
         tile.Init( 0, mp2tile );
 
-        const std::pair<int, int> colorRace = getColorRaceFromHeroSprite( tile.getMainObjectPart()._imageIndex );
+        const std::pair<int, int> colorRace = getColorRaceFromHeroSprite( tile.getMainObjectPart().icnIndex );
         if ( ( colorRace.first & colorsAvailableForHumans ) == 0 ) {
             const int side1 = colorRace.first | colorsAvailableForHumans;
             const int side2 = colorsAvailableForComp ^ colorRace.first;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -422,8 +422,8 @@ namespace
     void getObjectPartInfo( const Maps::ObjectPart & part, std::ostringstream & os )
     {
         os << "UID             : " << part._uid << std::endl
-           << "ICN object type : " << static_cast<int>( part.icnType ) << " (" << ICN::getIcnFileName( MP2::getIcnIdFromObjectIcnType( part.icnType ) )
-           << ")" << std::endl
+           << "ICN object type : " << static_cast<int>( part.icnType ) << " (" << ICN::getIcnFileName( MP2::getIcnIdFromObjectIcnType( part.icnType ) ) << ")"
+           << std::endl
            << "image index     : " << static_cast<int>( part.icnIndex ) << std::endl
            << "layer type      : " << static_cast<int>( part.layerType ) << " - " << getObjectLayerName( part.layerType ) << std::endl
            << "is shadow       : " << ( isObjectPartShadow( part ) ? "yes" : "no" ) << std::endl;
@@ -752,8 +752,7 @@ void Maps::Tiles::updatePassability()
             return part.icnType != MP2::OBJ_ICN_TYPE_ROAD && part.icnType != MP2::OBJ_ICN_TYPE_STREAM;
         } );
 
-        const bool singleObjectTile
-            = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( bottomTile._mainObjectPart.icnType != _mainObjectPart.icnType );
+        const bool singleObjectTile = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( bottomTile._mainObjectPart.icnType != _mainObjectPart.icnType );
 
         // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
         if ( !singleObjectTile && !isDetachedObject() && !bottomTile._mainObjectPart.isPassabilityTransparent()

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -416,16 +416,16 @@ namespace
 
     bool isObjectPartShadow( const Maps::ObjectPart & ta )
     {
-        return isValidShadowSprite( MP2::getIcnIdFromObjectIcnType( ta._objectIcnType ), ta._imageIndex );
+        return isValidShadowSprite( MP2::getIcnIdFromObjectIcnType( ta.icnType ), ta.icnIndex );
     }
 
     void getObjectPartInfo( const Maps::ObjectPart & part, std::ostringstream & os )
     {
         os << "UID             : " << part._uid << std::endl
-           << "ICN object type : " << static_cast<int>( part._objectIcnType ) << " (" << ICN::getIcnFileName( MP2::getIcnIdFromObjectIcnType( part._objectIcnType ) )
+           << "ICN object type : " << static_cast<int>( part.icnType ) << " (" << ICN::getIcnFileName( MP2::getIcnIdFromObjectIcnType( part.icnType ) )
            << ")" << std::endl
-           << "image index     : " << static_cast<int>( part._imageIndex ) << std::endl
-           << "layer type      : " << static_cast<int>( part._layerType ) << " - " << getObjectLayerName( part._layerType ) << std::endl
+           << "image index     : " << static_cast<int>( part.icnIndex ) << std::endl
+           << "layer type      : " << static_cast<int>( part.layerType ) << " - " << getObjectLayerName( part.layerType ) << std::endl
            << "is shadow       : " << ( isObjectPartShadow( part ) ? "yes" : "no" ) << std::endl;
     }
 
@@ -463,7 +463,7 @@ void Maps::Tiles::Init( int32_t index, const MP2::MP2TileInfo & mp2 )
 
     const MP2::ObjectIcnType bottomObjectIcnType = static_cast<MP2::ObjectIcnType>( mp2.objectName1 >> 2 );
 
-    const uint8_t layerType = ( mp2.quantity1 & 0x03 );
+    const ObjectLayerType layerType = static_cast<ObjectLayerType>( mp2.quantity1 & 0x03 );
 
     // In the original Editor the road bit is set even if no road exist.
     // It is important to verify the existence of a road without relying on this bit.
@@ -478,10 +478,10 @@ void Maps::Tiles::Init( int32_t index, const MP2::MP2TileInfo & mp2 )
         }
     }
     else {
-        _mainObjectPart._layerType = layerType;
+        _mainObjectPart.layerType = layerType;
         _mainObjectPart._uid = mp2.level1ObjectUID;
-        _mainObjectPart._objectIcnType = bottomObjectIcnType;
-        _mainObjectPart._imageIndex = mp2.bottomIcnImageIndex;
+        _mainObjectPart.icnType = bottomObjectIcnType;
+        _mainObjectPart.icnIndex = mp2.bottomIcnImageIndex;
     }
 
     const MP2::ObjectIcnType topObjectIcnType = static_cast<MP2::ObjectIcnType>( mp2.objectName2 >> 2 );
@@ -567,7 +567,7 @@ void Maps::Tiles::setMainObjectType( const MP2::MapObjectType objectType )
 
 void Maps::Tiles::setBoat( const int direction, const int color )
 {
-    if ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+    if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
         // It is important to preserve the order of objects for rendering purposes. Therefore, the main object should go to the front of objects.
         _groundObjectPart.emplace_front( _mainObjectPart );
     }
@@ -576,36 +576,36 @@ void Maps::Tiles::setBoat( const int direction, const int color )
     assert( isWater() );
 
     setMainObjectType( MP2::OBJ_BOAT );
-    _mainObjectPart._objectIcnType = MP2::OBJ_ICN_TYPE_BOAT32;
+    _mainObjectPart.icnType = MP2::OBJ_ICN_TYPE_BOAT32;
 
     switch ( direction ) {
     case Direction::TOP:
-        _mainObjectPart._imageIndex = 0;
+        _mainObjectPart.icnIndex = 0;
         break;
     case Direction::TOP_RIGHT:
-        _mainObjectPart._imageIndex = 9;
+        _mainObjectPart.icnIndex = 9;
         break;
     case Direction::RIGHT:
-        _mainObjectPart._imageIndex = 18;
+        _mainObjectPart.icnIndex = 18;
         break;
     case Direction::BOTTOM_RIGHT:
-        _mainObjectPart._imageIndex = 27;
+        _mainObjectPart.icnIndex = 27;
         break;
     case Direction::BOTTOM:
-        _mainObjectPart._imageIndex = 36;
+        _mainObjectPart.icnIndex = 36;
         break;
     // Left-side sprites have to be flipped, add 128 to index.
     case Direction::BOTTOM_LEFT:
-        _mainObjectPart._imageIndex = 27 + 128;
+        _mainObjectPart.icnIndex = 27 + 128;
         break;
     case Direction::LEFT:
-        _mainObjectPart._imageIndex = 18 + 128;
+        _mainObjectPart.icnIndex = 18 + 128;
         break;
     case Direction::TOP_LEFT:
-        _mainObjectPart._imageIndex = 9 + 128;
+        _mainObjectPart.icnIndex = 9 + 128;
         break;
     default:
-        _mainObjectPart._imageIndex = 18;
+        _mainObjectPart.icnIndex = 18;
         break;
     }
 
@@ -632,11 +632,11 @@ void Maps::Tiles::setBoat( const int direction, const int color )
 int Maps::Tiles::getBoatDirection() const
 {
     // Check if it really is a boat
-    if ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_BOAT32 )
+    if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_BOAT32 )
         return Direction::UNKNOWN;
 
     // Left-side sprites have to flipped, add 128 to index
-    switch ( _mainObjectPart._imageIndex ) {
+    switch ( _mainObjectPart.icnIndex ) {
     case 0:
         return Direction::TOP;
     case 9:
@@ -668,17 +668,17 @@ int Maps::Tiles::getOriginalPassability() const
         return MP2::getActionObjectDirection( objectType );
     }
 
-    if ( _mainObjectPart._objectIcnType == MP2::OBJ_ICN_TYPE_UNKNOWN || _mainObjectPart.isPassabilityTransparent() || isShadow() ) {
+    if ( _mainObjectPart.icnType == MP2::OBJ_ICN_TYPE_UNKNOWN || _mainObjectPart.isPassabilityTransparent() || isShadow() ) {
         // No object exists. Make it fully passable.
         return DIRECTION_ALL;
     }
 
-    if ( isValidReefsSprite( _mainObjectPart._objectIcnType, _mainObjectPart._imageIndex ) ) {
+    if ( isValidReefsSprite( _mainObjectPart.icnType, _mainObjectPart.icnIndex ) ) {
         return 0;
     }
 
     for ( const auto & part : _groundObjectPart ) {
-        if ( isValidReefsSprite( part._objectIcnType, part._imageIndex ) ) {
+        if ( isValidReefsSprite( part.icnType, part.icnIndex ) ) {
             return 0;
         }
     }
@@ -703,7 +703,7 @@ void Maps::Tiles::updatePassability()
     // Get object type but ignore heroes as they are "temporary" objects.
     const MP2::MapObjectType objectType = getMainObjectType( false );
 
-    if ( !MP2::isOffGameActionObject( objectType ) && ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && !_mainObjectPart.isPassabilityTransparent()
+    if ( !MP2::isOffGameActionObject( objectType ) && ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) && !_mainObjectPart.isPassabilityTransparent()
          && !isShadow() ) {
         // This is a non-action object.
 
@@ -749,15 +749,15 @@ void Maps::Tiles::updatePassability()
                 return false;
             }
 
-            return part._objectIcnType != MP2::OBJ_ICN_TYPE_ROAD && part._objectIcnType != MP2::OBJ_ICN_TYPE_STREAM;
+            return part.icnType != MP2::OBJ_ICN_TYPE_ROAD && part.icnType != MP2::OBJ_ICN_TYPE_STREAM;
         } );
 
         const bool singleObjectTile
-            = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( bottomTile._mainObjectPart._objectIcnType != _mainObjectPart._objectIcnType );
+            = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( bottomTile._mainObjectPart.icnType != _mainObjectPart.icnType );
 
         // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
         if ( !singleObjectTile && !isDetachedObject() && !bottomTile._mainObjectPart.isPassabilityTransparent()
-             && ( bottomTile._mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) ) {
+             && ( bottomTile._mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) ) {
             const MP2::MapObjectType bottomTileObjectType = bottomTile.getMainObjectType( false );
             const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( bottomTileObjectType );
 
@@ -841,7 +841,7 @@ void Maps::Tiles::pushGroundObjectPart( const MP2::MP2AddonInfo & ma )
         _isTileMarkedAsRoad = true;
     }
 
-    _groundObjectPart.emplace_back( static_cast<uint8_t>( ma.quantityN & 0x03 ), ma.level1ObjectUID, objectIcnType, ma.bottomIcnImageIndex );
+    _groundObjectPart.emplace_back( static_cast<ObjectLayerType>( ma.quantityN & 0x03 ), ma.level1ObjectUID, objectIcnType, ma.bottomIcnImageIndex );
 }
 
 void Maps::Tiles::pushTopObjectPart( const MP2::MP2AddonInfo & ma )
@@ -859,7 +859,7 @@ void Maps::Tiles::pushTopObjectPart( const MP2::MP2AddonInfo & ma )
 
 void Maps::Tiles::pushGroundObjectPart( ObjectPart ta )
 {
-    if ( isSpriteRoad( ta._objectIcnType, ta._imageIndex ) ) {
+    if ( isSpriteRoad( ta.icnType, ta.icnIndex ) ) {
         _isTileMarkedAsRoad = true;
     }
 
@@ -874,19 +874,19 @@ void Maps::Tiles::sortObjectParts()
     }
 
     // Push everything to the container and sort it by level.
-    if ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+    if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
         _groundObjectPart.emplace_front( _mainObjectPart );
     }
 
     // Sort by internal layers.
-    _groundObjectPart.sort( []( const auto & left, const auto & right ) { return ( left._layerType > right._layerType ); } );
+    _groundObjectPart.sort( []( const auto & left, const auto & right ) { return ( left.layerType > right.layerType ); } );
 
     if ( !_groundObjectPart.empty() ) {
         ObjectPart & highestPriorityPart = _groundObjectPart.back();
         std::swap( highestPriorityPart, _mainObjectPart );
 
         // If this assertion blows up then you are not storing correct values for layer type!
-        assert( _mainObjectPart._layerType <= TERRAIN_LAYER );
+        assert( _mainObjectPart.layerType <= TERRAIN_LAYER );
 
         _groundObjectPart.pop_back();
     }
@@ -1008,7 +1008,7 @@ bool Maps::Tiles::GoodForUltimateArtifact() const
         return false;
     }
 
-    if ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && !isObjectPartShadow( _mainObjectPart ) ) {
+    if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN && !isObjectPartShadow( _mainObjectPart ) ) {
         return false;
     }
 
@@ -1090,15 +1090,15 @@ void Maps::Tiles::SetObjectPassable( bool pass )
 bool Maps::Tiles::isStream() const
 {
     for ( const auto & part : _groundObjectPart ) {
-        if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM
-             || ( part._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNMUL2 && ( part._imageIndex < 14 || ( part._imageIndex > 217 && part._imageIndex < ( 218 + 14 ) ) ) ) ) {
+        if ( part.icnType == MP2::OBJ_ICN_TYPE_STREAM
+             || ( part.icnType == MP2::OBJ_ICN_TYPE_OBJNMUL2 && ( part.icnIndex < 14 || ( part.icnIndex > 217 && part.icnIndex < ( 218 + 14 ) ) ) ) ) {
             return true;
         }
     }
 
-    return _mainObjectPart._objectIcnType == MP2::OBJ_ICN_TYPE_STREAM
-           || ( _mainObjectPart._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNMUL2
-                && ( _mainObjectPart._imageIndex < 14 || ( _mainObjectPart._imageIndex > 217 && _mainObjectPart._imageIndex < ( 218 + 14 ) ) ) );
+    return _mainObjectPart.icnType == MP2::OBJ_ICN_TYPE_STREAM
+           || ( _mainObjectPart.icnType == MP2::OBJ_ICN_TYPE_OBJNMUL2
+                && ( _mainObjectPart.icnIndex < 14 || ( _mainObjectPart.icnIndex > 217 && _mainObjectPart.icnIndex < ( 218 + 14 ) ) ) );
 }
 
 bool Maps::Tiles::isShadow() const
@@ -1109,7 +1109,7 @@ bool Maps::Tiles::isShadow() const
 
 Maps::ObjectPart * Maps::Tiles::getObjectPartWithFlag( const uint32_t uid )
 {
-    const auto isFlag = [uid]( const auto & part ) { return part._uid == uid && part._objectIcnType == MP2::OBJ_ICN_TYPE_FLAG32; };
+    const auto isFlag = [uid]( const auto & part ) { return part._uid == uid && part.icnType == MP2::OBJ_ICN_TYPE_FLAG32; };
 
     auto iter = std::find_if( _groundObjectPart.begin(), _groundObjectPart.end(), isFlag );
     if ( iter != _groundObjectPart.end() ) {
@@ -1244,7 +1244,7 @@ void Maps::Tiles::updateFlag( const int color, const uint8_t objectSpriteIndex, 
 {
     // Flag deletion or installation must be done in relation to object UID as flag is attached to the object.
     if ( color == Color::NONE ) {
-        const auto isFlag = [uid]( const auto & part ) { return part._uid == uid && part._objectIcnType == MP2::OBJ_ICN_TYPE_FLAG32; };
+        const auto isFlag = [uid]( const auto & part ) { return part._uid == uid && part.icnType == MP2::OBJ_ICN_TYPE_FLAG32; };
         _groundObjectPart.remove_if( isFlag );
         _topObjectPart.remove_if( isFlag );
         return;
@@ -1253,7 +1253,7 @@ void Maps::Tiles::updateFlag( const int color, const uint8_t objectSpriteIndex, 
     ObjectPart * part = getObjectPartWithFlag( uid );
     if ( part != nullptr ) {
         // Replace an existing flag.
-        part->_imageIndex = objectSpriteIndex;
+        part->icnIndex = objectSpriteIndex;
     }
     else if ( setOnUpperLayer ) {
         _topObjectPart.emplace_back( OBJECT_LAYER, uid, MP2::OBJ_ICN_TYPE_FLAG32, objectSpriteIndex );
@@ -1265,14 +1265,14 @@ void Maps::Tiles::updateFlag( const int color, const uint8_t objectSpriteIndex, 
 
 void Maps::Tiles::_updateRoadFlag()
 {
-    _isTileMarkedAsRoad = isSpriteRoad( _mainObjectPart._objectIcnType, _mainObjectPart._imageIndex );
+    _isTileMarkedAsRoad = isSpriteRoad( _mainObjectPart.icnType, _mainObjectPart.icnIndex );
 
     if ( _isTileMarkedAsRoad ) {
         return;
     }
 
     for ( const auto & part : _groundObjectPart ) {
-        if ( isSpriteRoad( part._objectIcnType, part._imageIndex ) ) {
+        if ( isSpriteRoad( part.icnType, part.icnIndex ) ) {
             _isTileMarkedAsRoad = true;
             return;
         }
@@ -1284,7 +1284,7 @@ void Maps::Tiles::fixMP2MapTileObjectType( Tiles & tile )
     const MP2::MapObjectType originalObjectType = tile.getMainObjectType( false );
 
     // Left tile of a skeleton on Desert should be marked as non-action tile.
-    if ( originalObjectType == MP2::OBJ_SKELETON && tile._mainObjectPart._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNDSRT && tile._mainObjectPart._imageIndex == 83 ) {
+    if ( originalObjectType == MP2::OBJ_SKELETON && tile._mainObjectPart.icnType == MP2::OBJ_ICN_TYPE_OBJNDSRT && tile._mainObjectPart.icnIndex == 83 ) {
         tile.setMainObjectType( MP2::OBJ_NON_ACTION_SKELETON );
 
         // There is no need to check the rest of things as we fixed this object.
@@ -1292,8 +1292,8 @@ void Maps::Tiles::fixMP2MapTileObjectType( Tiles & tile )
     }
 
     // Oasis object has 2 top tiles being marked as part of bottom object layer while in reality they should be at the top level.
-    if ( originalObjectType == MP2::OBJ_NON_ACTION_OASIS && tile._mainObjectPart._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNDSRT
-         && ( tile._mainObjectPart._imageIndex == 105 || tile._mainObjectPart._imageIndex == 106 ) ) {
+    if ( originalObjectType == MP2::OBJ_NON_ACTION_OASIS && tile._mainObjectPart.icnType == MP2::OBJ_ICN_TYPE_OBJNDSRT
+         && ( tile._mainObjectPart.icnIndex == 105 || tile._mainObjectPart.icnIndex == 106 ) ) {
         tile._topObjectPart.emplace_back();
         std::swap( tile._topObjectPart.back(), tile._mainObjectPart );
 
@@ -1302,7 +1302,7 @@ void Maps::Tiles::fixMP2MapTileObjectType( Tiles & tile )
 
     // Original Editor marks Reefs as Stones. We're fixing this issue by changing the type of the object without changing the content of a tile.
     // This is also required in order to properly calculate Reefs' passability.
-    if ( originalObjectType == MP2::OBJ_ROCK && isValidReefsSprite( tile._mainObjectPart._objectIcnType, tile._mainObjectPart._imageIndex ) ) {
+    if ( originalObjectType == MP2::OBJ_ROCK && isValidReefsSprite( tile._mainObjectPart.icnType, tile._mainObjectPart.icnIndex ) ) {
         tile.setMainObjectType( MP2::OBJ_REEFS );
 
         // There is no need to check the rest of things as we fixed this object.
@@ -1327,10 +1327,10 @@ void Maps::Tiles::fixMP2MapTileObjectType( Tiles & tile )
     // On some maps (apparently created by some non-standard editors), the object type on tiles with random monsters does not match the index
     // of the monster placeholder sprite. While this engine looks at the object type when placing an actual monster on a tile, the original
     // HoMM2 apparently looks at the placeholder sprite, so we need to keep them in sync.
-    if ( tile._mainObjectPart._objectIcnType == MP2::OBJ_ICN_TYPE_MONS32 ) {
+    if ( tile._mainObjectPart.icnType == MP2::OBJ_ICN_TYPE_MONS32 ) {
         MP2::MapObjectType monsterObjectType = originalObjectType;
 
-        const uint8_t originalObjectSpriteIndex = tile.getMainObjectPart()._imageIndex;
+        const uint8_t originalObjectSpriteIndex = tile.getMainObjectPart().icnIndex;
         switch ( originalObjectSpriteIndex ) {
         // Random monster placeholder "MON"
         case 66:
@@ -1376,7 +1376,7 @@ void Maps::Tiles::fixMP2MapTileObjectType( Tiles & tile )
     case MP2::OBJ_EXPANSION_OBJECT: {
         // The type of expansion action object or dwelling is stored in object metadata.
         // However, we just ignore it.
-        MP2::MapObjectType objectType = getLoyaltyObject( tile._mainObjectPart._objectIcnType, tile._mainObjectPart._imageIndex );
+        MP2::MapObjectType objectType = getLoyaltyObject( tile._mainObjectPart.icnType, tile._mainObjectPart.icnIndex );
         if ( objectType != MP2::OBJ_NONE ) {
             tile.setMainObjectType( objectType );
             break;
@@ -1384,7 +1384,7 @@ void Maps::Tiles::fixMP2MapTileObjectType( Tiles & tile )
 
         // Add-ons of level 1 shouldn't even exist if no top object is present. However, let's play safe and verify it as well.
         for ( const auto & part : tile._groundObjectPart ) {
-            objectType = getLoyaltyObject( part._objectIcnType, part._imageIndex );
+            objectType = getLoyaltyObject( part.icnType, part.icnIndex );
             if ( objectType != MP2::OBJ_NONE )
                 break;
         }
@@ -1395,7 +1395,7 @@ void Maps::Tiles::fixMP2MapTileObjectType( Tiles & tile )
         }
 
         for ( const auto & part : tile._topObjectPart ) {
-            objectType = getLoyaltyObject( part._objectIcnType, part._imageIndex );
+            objectType = getLoyaltyObject( part.icnType, part.icnIndex );
             if ( objectType != MP2::OBJ_NONE )
                 break;
         }
@@ -1407,7 +1407,7 @@ void Maps::Tiles::fixMP2MapTileObjectType( Tiles & tile )
 
         DEBUG_LOG( DBG_GAME, DBG_WARN,
                    "Invalid object type index " << tile._index << ": type " << MP2::StringObject( originalObjectType ) << ", icn ID "
-                                                << static_cast<int>( tile._mainObjectPart._imageIndex ) )
+                                                << static_cast<int>( tile._mainObjectPart.icnIndex ) )
         break;
     }
 
@@ -1462,10 +1462,10 @@ bool Maps::Tiles::removeObjectPartsByUID( const uint32_t objectUID )
 
 void Maps::Tiles::removeObjects( const MP2::ObjectIcnType objectIcnType )
 {
-    _groundObjectPart.remove_if( [objectIcnType]( const auto & part ) { return part._objectIcnType == objectIcnType; } );
-    _topObjectPart.remove_if( [objectIcnType]( const auto & part ) { return part._objectIcnType == objectIcnType; } );
+    _groundObjectPart.remove_if( [objectIcnType]( const auto & part ) { return part.icnType == objectIcnType; } );
+    _topObjectPart.remove_if( [objectIcnType]( const auto & part ) { return part.icnType == objectIcnType; } );
 
-    if ( _mainObjectPart._objectIcnType == objectIcnType ) {
+    if ( _mainObjectPart.icnType == objectIcnType ) {
         _mainObjectPart = {};
     }
 
@@ -1479,24 +1479,24 @@ void Maps::Tiles::replaceObject( const uint32_t objectUid, const MP2::ObjectIcnT
 {
     // We can immediately return from the function as only one object per tile can have the same UID.
     for ( auto & part : _groundObjectPart ) {
-        if ( part._uid == objectUid && part._objectIcnType == originalObjectIcnType && part._imageIndex == originalImageIndex ) {
-            part._objectIcnType = newObjectIcnType;
-            part._imageIndex = newImageIndex;
+        if ( part._uid == objectUid && part.icnType == originalObjectIcnType && part.icnIndex == originalImageIndex ) {
+            part.icnType = newObjectIcnType;
+            part.icnIndex = newImageIndex;
             return;
         }
     }
 
     for ( auto & part : _topObjectPart ) {
-        if ( part._uid == objectUid && part._objectIcnType == originalObjectIcnType && part._imageIndex == originalImageIndex ) {
-            part._objectIcnType = newObjectIcnType;
-            part._imageIndex = newImageIndex;
+        if ( part._uid == objectUid && part.icnType == originalObjectIcnType && part.icnIndex == originalImageIndex ) {
+            part.icnType = newObjectIcnType;
+            part.icnIndex = newImageIndex;
             return;
         }
     }
 
-    if ( _mainObjectPart._uid == objectUid && _mainObjectPart._objectIcnType == originalObjectIcnType && _mainObjectPart._imageIndex == originalImageIndex ) {
-        _mainObjectPart._objectIcnType = newObjectIcnType;
-        _mainObjectPart._imageIndex = newImageIndex;
+    if ( _mainObjectPart._uid == objectUid && _mainObjectPart.icnType == originalObjectIcnType && _mainObjectPart.icnIndex == originalImageIndex ) {
+        _mainObjectPart.icnType = newObjectIcnType;
+        _mainObjectPart.icnIndex = newImageIndex;
     }
 }
 
@@ -1504,24 +1504,24 @@ void Maps::Tiles::updateObjectImageIndex( const uint32_t objectUid, const MP2::O
 {
     // We can immediately return from the function as only one object per tile can have the same UID.
     for ( auto & part : _groundObjectPart ) {
-        if ( part._uid == objectUid && part._objectIcnType == objectIcnType ) {
-            assert( part._imageIndex + imageIndexOffset >= 0 && part._imageIndex + imageIndexOffset < 255 );
-            part._imageIndex = static_cast<uint8_t>( part._imageIndex + imageIndexOffset );
+        if ( part._uid == objectUid && part.icnType == objectIcnType ) {
+            assert( part.icnIndex + imageIndexOffset >= 0 && part.icnIndex + imageIndexOffset < 255 );
+            part.icnIndex = static_cast<uint8_t>( part.icnIndex + imageIndexOffset );
             return;
         }
     }
 
     for ( auto & part : _topObjectPart ) {
-        if ( part._uid == objectUid && part._objectIcnType == objectIcnType ) {
-            assert( part._imageIndex + imageIndexOffset >= 0 && part._imageIndex + imageIndexOffset < 255 );
-            part._imageIndex = static_cast<uint8_t>( part._imageIndex + imageIndexOffset );
+        if ( part._uid == objectUid && part.icnType == objectIcnType ) {
+            assert( part.icnIndex + imageIndexOffset >= 0 && part.icnIndex + imageIndexOffset < 255 );
+            part.icnIndex = static_cast<uint8_t>( part.icnIndex + imageIndexOffset );
             return;
         }
     }
 
-    if ( _mainObjectPart._uid == objectUid && _mainObjectPart._objectIcnType == objectIcnType ) {
-        assert( _mainObjectPart._imageIndex + imageIndexOffset >= 0 && _mainObjectPart._imageIndex + imageIndexOffset < 255 );
-        _mainObjectPart._imageIndex = static_cast<uint8_t>( _mainObjectPart._imageIndex + imageIndexOffset );
+    if ( _mainObjectPart._uid == objectUid && _mainObjectPart.icnType == objectIcnType ) {
+        assert( _mainObjectPart.icnIndex + imageIndexOffset >= 0 && _mainObjectPart.icnIndex + imageIndexOffset < 255 );
+        _mainObjectPart.icnIndex = static_cast<uint8_t>( _mainObjectPart.icnIndex + imageIndexOffset );
     }
 }
 
@@ -1539,10 +1539,10 @@ void Maps::Tiles::updateTileObjectIcnIndex( Maps::Tiles & tile, const uint32_t u
 {
     ObjectPart * part = tile.getGroundObjectPart( uid );
     if ( part != nullptr ) {
-        part->_imageIndex = newIndex;
+        part->icnIndex = newIndex;
     }
     else if ( tile._mainObjectPart._uid == uid ) {
-        tile._mainObjectPart._imageIndex = newIndex;
+        tile._mainObjectPart.icnIndex = newIndex;
     }
 
     tile._updateRoadFlag();
@@ -1551,7 +1551,7 @@ void Maps::Tiles::updateTileObjectIcnIndex( Maps::Tiles & tile, const uint32_t u
 void Maps::Tiles::updateObjectType()
 {
     // After removing an object there could be an object part in the main object part.
-    MP2::MapObjectType objectType = getObjectTypeByIcn( _mainObjectPart._objectIcnType, _mainObjectPart._imageIndex );
+    MP2::MapObjectType objectType = getObjectTypeByIcn( _mainObjectPart.icnType, _mainObjectPart.icnIndex );
     if ( MP2::isOffGameActionObject( objectType ) ) {
         // Set object type only when this is an interactive object type to make sure that interaction can be done.
         setMainObjectType( objectType );
@@ -1561,7 +1561,7 @@ void Maps::Tiles::updateObjectType()
     // And sometimes even in the ground layer object parts.
     // Take a note that we iterate object parts from back to front as the latest object part has higher priority.
     for ( auto iter = _groundObjectPart.rbegin(); iter != _groundObjectPart.rend(); ++iter ) {
-        const MP2::MapObjectType type = getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex );
+        const MP2::MapObjectType type = getObjectTypeByIcn( iter->icnType, iter->icnIndex );
         if ( type == MP2::OBJ_NONE ) {
             continue;
         }
@@ -1580,7 +1580,7 @@ void Maps::Tiles::updateObjectType()
     // Or object part can be in the top layer object parts.
     // Take a note that we iterate object parts from back to front as the latest object part has higher priority.
     for ( auto iter = _topObjectPart.rbegin(); iter != _topObjectPart.rend(); ++iter ) {
-        const MP2::MapObjectType type = getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex );
+        const MP2::MapObjectType type = getObjectTypeByIcn( iter->icnType, iter->icnIndex );
 
         if ( type != MP2::OBJ_NONE ) {
             setMainObjectType( type );
@@ -1621,18 +1621,18 @@ void Maps::Tiles::updateObjectType()
 
 uint32_t Maps::Tiles::getObjectIdByObjectIcnType( const MP2::ObjectIcnType objectIcnType ) const
 {
-    if ( _mainObjectPart._objectIcnType == objectIcnType ) {
+    if ( _mainObjectPart.icnType == objectIcnType ) {
         return _mainObjectPart._uid;
     }
 
     for ( const auto & part : _groundObjectPart ) {
-        if ( part._objectIcnType == objectIcnType ) {
+        if ( part.icnType == objectIcnType ) {
             return part._uid;
         }
     }
 
     for ( const auto & part : _topObjectPart ) {
-        if ( part._objectIcnType == objectIcnType ) {
+        if ( part.icnType == objectIcnType ) {
             return part._uid;
         }
     }
@@ -1644,22 +1644,22 @@ std::vector<MP2::ObjectIcnType> Maps::Tiles::getValidObjectIcnTypes() const
 {
     std::vector<MP2::ObjectIcnType> objectIcnTypes;
 
-    if ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
-        objectIcnTypes.emplace_back( _mainObjectPart._objectIcnType );
+    if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+        objectIcnTypes.emplace_back( _mainObjectPart.icnType );
     }
 
     for ( const auto & part : _groundObjectPart ) {
         // If this assertion blows up then you put an empty object into an object part which makes no sense!
-        assert( part._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN );
+        assert( part.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN );
 
-        objectIcnTypes.emplace_back( part._objectIcnType );
+        objectIcnTypes.emplace_back( part.icnType );
     }
 
     for ( const auto & part : _topObjectPart ) {
         // If this assertion blows up then you put an empty object into an object part which makes no sense!
-        assert( part._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN );
+        assert( part.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN );
 
-        objectIcnTypes.emplace_back( part._objectIcnType );
+        objectIcnTypes.emplace_back( part.icnType );
     }
 
     return objectIcnTypes;
@@ -1668,18 +1668,18 @@ std::vector<MP2::ObjectIcnType> Maps::Tiles::getValidObjectIcnTypes() const
 bool Maps::Tiles::containsAnyObjectIcnType( const std::vector<MP2::ObjectIcnType> & objectIcnTypes ) const
 {
     for ( const MP2::ObjectIcnType objectIcnType : objectIcnTypes ) {
-        if ( _mainObjectPart._objectIcnType == objectIcnType ) {
+        if ( _mainObjectPart.icnType == objectIcnType ) {
             return true;
         }
 
         for ( const auto & part : _groundObjectPart ) {
-            if ( part._objectIcnType == objectIcnType ) {
+            if ( part.icnType == objectIcnType ) {
                 return true;
             }
         }
 
         for ( const auto & part : _topObjectPart ) {
-            if ( part._objectIcnType == objectIcnType ) {
+            if ( part.icnType == objectIcnType ) {
                 return true;
             }
         }
@@ -1690,17 +1690,17 @@ bool Maps::Tiles::containsAnyObjectIcnType( const std::vector<MP2::ObjectIcnType
 
 bool Maps::Tiles::containsSprite( const MP2::ObjectIcnType objectIcnType, const uint32_t imageIdx ) const
 {
-    if ( _mainObjectPart._objectIcnType == objectIcnType && imageIdx == _mainObjectPart._imageIndex ) {
+    if ( _mainObjectPart.icnType == objectIcnType && imageIdx == _mainObjectPart.icnIndex ) {
         return true;
     }
 
     if ( std::any_of( _groundObjectPart.cbegin(), _groundObjectPart.cend(),
-                      [objectIcnType, imageIdx]( const auto & part ) { return part._objectIcnType == objectIcnType && imageIdx == part._imageIndex; } ) ) {
+                      [objectIcnType, imageIdx]( const auto & part ) { return part.icnType == objectIcnType && imageIdx == part.icnIndex; } ) ) {
         return true;
     }
 
     return std::any_of( _topObjectPart.cbegin(), _topObjectPart.cend(),
-                        [objectIcnType, imageIdx]( const auto & part ) { return part._objectIcnType == objectIcnType && imageIdx == part._imageIndex; } );
+                        [objectIcnType, imageIdx]( const auto & part ) { return part.icnType == objectIcnType && imageIdx == part.icnIndex; } );
 }
 
 bool Maps::Tiles::isTallObject() const
@@ -1712,7 +1712,7 @@ bool Maps::Tiles::isTallObject() const
     }
 
     std::vector<uint32_t> tileUIDs;
-    if ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && _mainObjectPart._uid != 0 && !_mainObjectPart.isPassabilityTransparent() ) {
+    if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN && _mainObjectPart._uid != 0 && !_mainObjectPart.isPassabilityTransparent() ) {
         tileUIDs.emplace_back( _mainObjectPart._uid );
     }
 
@@ -1837,19 +1837,19 @@ bool Maps::Tiles::isDetachedObject() const
 
 OStreamBase & Maps::operator<<( OStreamBase & stream, const ObjectPart & ta )
 {
-    return stream << ta._layerType << ta._uid << ta._objectIcnType << ta._imageIndex;
+    return stream << ta.layerType << ta._uid << ta.icnType << ta.icnIndex;
 }
 
 IStreamBase & Maps::operator>>( IStreamBase & stream, ObjectPart & ta )
 {
-    stream >> ta._layerType;
+    stream >> ta.layerType;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1009_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1009_RELEASE ) {
-        ta._layerType = ( ta._layerType & 0x03 );
+        ta.layerType = static_cast<ObjectLayerType>( ta.layerType & 0x03 );
     }
 
-    stream >> ta._uid >> ta._objectIcnType;
+    stream >> ta._uid >> ta.icnType;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1009_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1009_RELEASE ) {
@@ -1857,7 +1857,7 @@ IStreamBase & Maps::operator>>( IStreamBase & stream, ObjectPart & ta )
         stream >> temp >> temp;
     }
 
-    return stream >> ta._imageIndex;
+    return stream >> ta.icnIndex;
 }
 
 OStreamBase & Maps::operator<<( OStreamBase & stream, const Tiles & tile )
@@ -1873,7 +1873,7 @@ IStreamBase & Maps::operator>>( IStreamBase & stream, Tiles & tile )
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1104_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1104_RELEASE ) {
-        stream >> tile._mainObjectPart._uid >> tile._mainObjectPart._objectIcnType;
+        stream >> tile._mainObjectPart._uid >> tile._mainObjectPart.icnType;
     }
     else {
         stream >> tile._mainObjectPart;
@@ -1886,7 +1886,7 @@ IStreamBase & Maps::operator>>( IStreamBase & stream, Tiles & tile )
     }
 
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1104_RELEASE ) {
-        stream >> tile._mainObjectPart._imageIndex;
+        stream >> tile._mainObjectPart.icnIndex;
     }
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE3_1100_RELEASE, "Remove the logic below." );
@@ -1903,7 +1903,7 @@ IStreamBase & Maps::operator>>( IStreamBase & stream, Tiles & tile )
     stream >> tile._fogColors >> tile._metadata >> tile._occupantHeroId >> tile._isTileMarkedAsRoad >> tile._groundObjectPart >> tile._topObjectPart;
 
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1104_RELEASE ) {
-        stream >> tile._mainObjectPart._layerType;
+        stream >> tile._mainObjectPart.layerType;
     }
 
     return stream >> tile._boatOwnerColor;

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -54,11 +54,11 @@ namespace Maps
     {
         ObjectPart() = default;
 
-        ObjectPart( const uint8_t layerType, const uint32_t uid, const MP2::ObjectIcnType objectIcnType, const uint8_t imageIndex )
+        ObjectPart( const ObjectLayerType layerType_, const uint32_t uid, const MP2::ObjectIcnType icnType_, const uint8_t icnIndex_ )
             : _uid( uid )
-            , _layerType( layerType )
-            , _objectIcnType( objectIcnType )
-            , _imageIndex( imageIndex )
+            , layerType( layerType_ )
+            , icnType( icnType_ )
+            , icnIndex( icnIndex_ )
         {
             // Do nothing.
         }
@@ -70,25 +70,25 @@ namespace Maps
         // Returns true if it can be passed be hero/boat: part's layer type is SHADOW or TERRAIN.
         bool isPassabilityTransparent() const
         {
-            return _layerType == SHADOW_LAYER || _layerType == TERRAIN_LAYER;
+            return layerType == SHADOW_LAYER || layerType == TERRAIN_LAYER;
         }
 
         bool operator==( const ObjectPart & part ) const
         {
-            return ( _uid == part._uid ) && ( _layerType == part._layerType ) && ( _objectIcnType == part._objectIcnType ) && ( _imageIndex == part._imageIndex );
+            return ( _uid == part._uid ) && ( layerType == part.layerType ) && ( icnType == part.icnType ) && ( icnIndex == part.icnIndex );
         }
 
         // Unique identifier of an object. UID can be shared among multiple object parts if an object is bigger than 1 tile.
         uint32_t _uid{ 0 };
 
         // Layer type shows how the object is rendered on Adventure Map. See ObjectLayerType enumeration.
-        uint8_t _layerType{ OBJECT_LAYER };
+        ObjectLayerType layerType{ OBJECT_LAYER };
 
         // The type of object which correlates to ICN id. See MP2::getIcnIdFromObjectIcnType() function for more details.
-        MP2::ObjectIcnType _objectIcnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
+        MP2::ObjectIcnType icnType{ MP2::OBJ_ICN_TYPE_UNKNOWN };
 
         // Image index to define which part of the object is. This index corresponds to an index in ICN objects storing multiple sprites (images).
-        uint8_t _imageIndex{ 255 };
+        uint8_t icnIndex{ 255 };
     };
 
     class Tiles
@@ -250,7 +250,7 @@ namespace Maps
 
         void moveMainObjectPartToGroundLevel()
         {
-            if ( _mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+            if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
                 _groundObjectPart.emplace_back( _mainObjectPart );
                 _mainObjectPart = {};
             }

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2273,8 +2273,8 @@ namespace Maps
             default:
                 // Some maps have broken resources being put which ideally we need to correct. Let's make them 0 Wood.
                 DEBUG_LOG( DBG_GAME, DBG_WARN,
-                           "Tile " << tile.GetIndex() << " contains unknown resource type. Object ICN type " << tile.getMainObjectPart().icnType
-                                   << ", image index " << tile.getMainObjectPart().icnIndex )
+                           "Tile " << tile.GetIndex() << " contains unknown resource type. Object ICN type " << tile.getMainObjectPart().icnType << ", image index "
+                                   << tile.getMainObjectPart().icnIndex )
                 resourceType = Resource::WOOD;
                 count = 0;
                 break;

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -186,12 +186,12 @@ namespace
 
         tile.setMainObjectType( MP2::OBJ_MONSTER );
 
-        using TileImageIndexType = decltype( tile.getMainObjectPart()._imageIndex );
-        static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of _imageIndex has been changed, check the logic below" );
+        using TileImageIndexType = decltype( tile.getMainObjectPart().icnIndex );
+        static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of icnIndex has been changed, check the logic below" );
 
         assert( mons.GetID() > std::numeric_limits<TileImageIndexType>::min() && mons.GetID() <= std::numeric_limits<TileImageIndexType>::max() );
 
-        tile.getMainObjectPart()._imageIndex = static_cast<TileImageIndexType>( mons.GetID() - 1 ); // ICN::MONS32 starts from PEASANT
+        tile.getMainObjectPart().icnIndex = static_cast<TileImageIndexType>( mons.GetID() - 1 ); // ICN::MONS32 starts from PEASANT
     }
 
     // Returns the direction vector bits from 'centerTileIndex' where the ground is 'groundId'.
@@ -820,14 +820,14 @@ namespace
         auto checkRoadIcnIndex = []( const int32_t tileIndex, const std::vector<uint8_t> & roadIcnIndexes ) {
             const Maps::Tiles & currentTile = world.GetTiles( tileIndex );
 
-            if ( currentTile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
+            if ( currentTile.getMainObjectPart().icnType == MP2::OBJ_ICN_TYPE_ROAD ) {
                 return std::any_of( roadIcnIndexes.begin(), roadIcnIndexes.end(),
-                                    [&currentTile]( const uint8_t index ) { return currentTile.getMainObjectPart()._imageIndex == index; } );
+                                    [&currentTile]( const uint8_t index ) { return currentTile.getMainObjectPart().icnIndex == index; } );
             }
 
             for ( const Maps::ObjectPart & part : currentTile.getGroundObjectParts() ) {
-                if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_ROAD ) {
-                    return std::any_of( roadIcnIndexes.begin(), roadIcnIndexes.end(), [&part]( const uint8_t index ) { return part._imageIndex == index; } );
+                if ( part.icnType == MP2::OBJ_ICN_TYPE_ROAD ) {
+                    return std::any_of( roadIcnIndexes.begin(), roadIcnIndexes.end(), [&part]( const uint8_t index ) { return part.icnIndex == index; } );
                 }
             }
 
@@ -1228,7 +1228,7 @@ namespace
                     bool higherObjectFound = false;
 
                     for ( const auto & topPart : currentTile.getTopObjectParts() ) {
-                        const MP2::MapObjectType type = Maps::getObjectTypeByIcn( topPart._objectIcnType, topPart._imageIndex );
+                        const MP2::MapObjectType type = Maps::getObjectTypeByIcn( topPart.icnType, topPart.icnIndex );
                         if ( type != MP2::OBJ_NONE ) {
                             // A top object part is present.
                             higherObjectFound = true;
@@ -1238,12 +1238,12 @@ namespace
 
                     if ( !higherObjectFound ) {
                         for ( const auto & groundPart : currentTile.getGroundObjectParts() ) {
-                            if ( groundPart._layerType >= partInfo.layerType ) {
+                            if ( groundPart.layerType >= partInfo.layerType ) {
                                 // A ground object part is has "lower" or equal layer type. Skip it.
                                 continue;
                             }
 
-                            const MP2::MapObjectType type = Maps::getObjectTypeByIcn( groundPart._objectIcnType, groundPart._imageIndex );
+                            const MP2::MapObjectType type = Maps::getObjectTypeByIcn( groundPart.icnType, groundPart.icnIndex );
                             if ( type != MP2::OBJ_NONE ) {
                                 // A ground object part is present and it has "higher" layer type.
                                 higherObjectFound = true;
@@ -1259,8 +1259,8 @@ namespace
 #if defined( WITH_DEBUG )
             // Check that we don't put the same object part.
             for ( const auto & groundPart : currentTile.getGroundObjectParts() ) {
-                assert( groundPart._uid != uid || groundPart._imageIndex != static_cast<uint8_t>( partInfo.icnIndex ) || groundPart._objectIcnType != partInfo.icnType
-                        || groundPart._layerType != partInfo.layerType );
+                assert( groundPart._uid != uid || groundPart.icnIndex != static_cast<uint8_t>( partInfo.icnIndex ) || groundPart.icnType != partInfo.icnType
+                        || groundPart.layerType != partInfo.layerType );
             }
 #endif
 
@@ -1599,13 +1599,13 @@ namespace Maps
             return nullptr;
         }
 
-        MP2::MapObjectType objectType = getObjectTypeByIcn( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex );
+        MP2::MapObjectType objectType = getObjectTypeByIcn( tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex );
         if ( objectType == type ) {
             return &tile.getMainObjectPart();
         }
 
         for ( const auto & objectPart : tile.getGroundObjectParts() ) {
-            objectType = getObjectTypeByIcn( objectPart._objectIcnType, objectPart._imageIndex );
+            objectType = getObjectTypeByIcn( objectPart.icnType, objectPart.icnIndex );
             if ( objectType == type ) {
                 return &objectPart;
             }
@@ -1664,7 +1664,7 @@ namespace Maps
         case MP2::OBJ_BARROW_MOUNDS:
             return { Monster::GHOST };
         case MP2::OBJ_MONSTER:
-            return { tile.getMainObjectPart()._imageIndex + 1 };
+            return { tile.getMainObjectPart().icnIndex + 1 };
         default:
             break;
         }
@@ -2181,14 +2181,14 @@ namespace Maps
             assert( isFirstLoad );
 
             uint8_t artifactSpriteIndex = Artifact::UNKNOWN;
-            if ( tile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNARTI ) {
-                artifactSpriteIndex = tile.getMainObjectPart()._imageIndex;
+            if ( tile.getMainObjectPart().icnType == MP2::OBJ_ICN_TYPE_OBJNARTI ) {
+                artifactSpriteIndex = tile.getMainObjectPart().icnIndex;
             }
             else {
                 // On some hacked original maps artifact can be placed to the ground layer object parts.
                 for ( const auto & part : tile.getGroundObjectParts() ) {
-                    if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNARTI ) {
-                        artifactSpriteIndex = part._imageIndex;
+                    if ( part.icnType == MP2::OBJ_ICN_TYPE_OBJNARTI ) {
+                        artifactSpriteIndex = part.icnIndex;
                         break;
                     }
                 }
@@ -2238,14 +2238,14 @@ namespace Maps
 
             int resourceType = Resource::UNKNOWN;
 
-            if ( tile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
+            if ( tile.getMainObjectPart().icnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
                 // The resource is located at the top.
-                resourceType = Resource::FromIndexSprite( tile.getMainObjectPart()._imageIndex );
+                resourceType = Resource::FromIndexSprite( tile.getMainObjectPart().icnIndex );
             }
             else {
                 for ( const auto & part : tile.getGroundObjectParts() ) {
-                    if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
-                        resourceType = Resource::FromIndexSprite( part._imageIndex );
+                    if ( part.icnType == MP2::OBJ_ICN_TYPE_OBJNRSRC ) {
+                        resourceType = Resource::FromIndexSprite( part.icnIndex );
                         // If this happens we are in trouble. It looks like that map maker put the resource under an object which is impossible to do.
                         // Let's update the tile's object type to properly show the action object.
                         tile.updateObjectType();
@@ -2273,8 +2273,8 @@ namespace Maps
             default:
                 // Some maps have broken resources being put which ideally we need to correct. Let's make them 0 Wood.
                 DEBUG_LOG( DBG_GAME, DBG_WARN,
-                           "Tile " << tile.GetIndex() << " contains unknown resource type. Object ICN type " << tile.getMainObjectPart()._objectIcnType
-                                   << ", image index " << tile.getMainObjectPart()._imageIndex )
+                           "Tile " << tile.GetIndex() << " contains unknown resource type. Object ICN type " << tile.getMainObjectPart().icnType
+                                   << ", image index " << tile.getMainObjectPart().icnIndex )
                 resourceType = Resource::WOOD;
                 count = 0;
                 break;
@@ -2574,13 +2574,13 @@ namespace Maps
         case MP2::OBJ_BARRIER:
             assert( isFirstLoad );
 
-            setColorOnTile( tile, getColorFromBarrierSprite( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex ) );
+            setColorOnTile( tile, getColorFromBarrierSprite( tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex ) );
             break;
 
         case MP2::OBJ_TRAVELLER_TENT:
             assert( isFirstLoad );
 
-            setColorOnTile( tile, getColorFromTravellerTentSprite( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex ) );
+            setColorOnTile( tile, getColorFromTravellerTentSprite( tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex ) );
             break;
 
         case MP2::OBJ_ALCHEMIST_LAB: {
@@ -2606,7 +2606,7 @@ namespace Maps
         case MP2::OBJ_MINE: {
             assert( isFirstLoad );
 
-            switch ( tile.getMainObjectPart()._imageIndex ) {
+            switch ( tile.getMainObjectPart().icnIndex ) {
             case 0: {
                 const auto resourceCount = fheroes2::checkedCast<uint32_t>( ProfitConditions::FromMine( Resource::ORE ).ore );
                 assert( resourceCount.has_value() && resourceCount > 0U );
@@ -2661,8 +2661,8 @@ namespace Maps
             assert( isFirstLoad );
 
             // This is a special case. Boats are different in the original editor.
-            tile.getMainObjectPart()._objectIcnType = MP2::OBJ_ICN_TYPE_BOAT32;
-            tile.getMainObjectPart()._imageIndex = 18;
+            tile.getMainObjectPart().icnType = MP2::OBJ_ICN_TYPE_BOAT32;
+            tile.getMainObjectPart().icnIndex = 18;
             break;
 
         case MP2::OBJ_RANDOM_ARTIFACT:
@@ -2748,7 +2748,7 @@ namespace Maps
 
     void updateMonsterInfoOnTile( Tiles & tile )
     {
-        const Monster mons = Monster( tile.getMainObjectPart()._imageIndex + 1 ); // ICN::MONS32 start from PEASANT
+        const Monster mons = Monster( tile.getMainObjectPart().icnIndex + 1 ); // ICN::MONS32 start from PEASANT
         setMonsterOnTile( tile, mons, tile.metadata()[0] );
     }
 
@@ -2758,25 +2758,25 @@ namespace Maps
 
         Maps::ObjectPart & mainObjectPart = tile.getMainObjectPart();
 
-        if ( mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_MONS32 ) {
-            if ( mainObjectPart._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
+        if ( mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_MONS32 ) {
+            if ( mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
                 // If there is another object sprite here (shadow for example) push it down to add-ons.
                 tile.pushGroundObjectPart( mainObjectPart );
             }
 
             // Set unique UID for placed monster.
             mainObjectPart._uid = getNewObjectUID();
-            mainObjectPart._objectIcnType = MP2::OBJ_ICN_TYPE_MONS32;
-            mainObjectPart._layerType = OBJECT_LAYER;
+            mainObjectPart.icnType = MP2::OBJ_ICN_TYPE_MONS32;
+            mainObjectPart.layerType = OBJECT_LAYER;
         }
 
-        using TileImageIndexType = decltype( mainObjectPart._imageIndex );
-        static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of _imageIndex has been changed, check the logic below" );
+        using TileImageIndexType = decltype( mainObjectPart.icnIndex );
+        static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of icnIndex has been changed, check the logic below" );
 
         const uint32_t monsSpriteIndex = mons.GetSpriteIndex();
         assert( monsSpriteIndex >= std::numeric_limits<TileImageIndexType>::min() && monsSpriteIndex <= std::numeric_limits<TileImageIndexType>::max() );
 
-        mainObjectPart._imageIndex = static_cast<TileImageIndexType>( monsSpriteIndex );
+        mainObjectPart.icnIndex = static_cast<TileImageIndexType>( monsSpriteIndex );
 
         const bool setDefinedCount = ( count > 0 );
 
@@ -2964,16 +2964,16 @@ namespace Maps
             }
         };
 
-        MP2::ObjectIcnType objectIcnTypeTemp{ tile.getMainObjectPart()._objectIcnType };
-        uint8_t imageIndexTemp{ tile.getMainObjectPart()._imageIndex };
+        MP2::ObjectIcnType objectIcnTypeTemp{ tile.getMainObjectPart().icnType };
+        uint8_t imageIndexTemp{ tile.getMainObjectPart().icnIndex };
 
         restoreLeftSprite( objectIcnTypeTemp, imageIndexTemp );
-        tile.getMainObjectPart()._objectIcnType = objectIcnTypeTemp;
-        tile.getMainObjectPart()._imageIndex = imageIndexTemp;
+        tile.getMainObjectPart().icnType = objectIcnTypeTemp;
+        tile.getMainObjectPart().icnIndex = imageIndexTemp;
 
         for ( auto & part : tile.getGroundObjectParts() ) {
             if ( part._uid == tile.getMainObjectPart()._uid ) {
-                restoreLeftSprite( part._objectIcnType, part._imageIndex );
+                restoreLeftSprite( part.icnType, part.icnIndex );
             }
         }
 
@@ -2981,18 +2981,18 @@ namespace Maps
             Tiles & rightTile = world.GetTiles( Maps::GetDirectionIndex( tile.GetIndex(), Direction::RIGHT ) );
 
             if ( rightTile.getMainObjectPart()._uid == tile.getMainObjectPart()._uid ) {
-                objectIcnTypeTemp = rightTile.getMainObjectPart()._objectIcnType;
-                imageIndexTemp = rightTile.getMainObjectPart()._imageIndex;
+                objectIcnTypeTemp = rightTile.getMainObjectPart().icnType;
+                imageIndexTemp = rightTile.getMainObjectPart().icnIndex;
                 restoreRightSprite( objectIcnTypeTemp, imageIndexTemp );
 
-                rightTile.getMainObjectPart()._objectIcnType = objectIcnTypeTemp;
-                rightTile.getMainObjectPart()._imageIndex = imageIndexTemp;
+                rightTile.getMainObjectPart().icnType = objectIcnTypeTemp;
+                rightTile.getMainObjectPart().icnIndex = imageIndexTemp;
             }
 
             ObjectPart * part = rightTile.getGroundObjectPart( tile.getMainObjectPart()._uid );
 
             if ( part ) {
-                restoreRightSprite( part->_objectIcnType, part->_imageIndex );
+                restoreRightSprite( part->icnType, part->icnIndex );
             }
         }
 
@@ -3015,13 +3015,13 @@ namespace Maps
         // Verify that this tile indeed contains an object with given object type.
         uint32_t objectUID = 0;
 
-        if ( Maps::getObjectTypeByIcn( tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex ) == objectType ) {
+        if ( Maps::getObjectTypeByIcn( tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex ) == objectType ) {
             objectUID = tile.getMainObjectPart()._uid;
         }
 
         if ( objectUID == 0 ) {
             for ( auto iter = tile.getTopObjectParts().rbegin(); iter != tile.getTopObjectParts().rend(); ++iter ) {
-                if ( Maps::getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex ) == objectType ) {
+                if ( Maps::getObjectTypeByIcn( iter->icnType, iter->icnIndex ) == objectType ) {
                     objectUID = iter->_uid;
                     break;
                 }
@@ -3030,7 +3030,7 @@ namespace Maps
 
         if ( objectUID == 0 ) {
             for ( auto iter = tile.getGroundObjectParts().rbegin(); iter != tile.getGroundObjectParts().rend(); ++iter ) {
-                if ( Maps::getObjectTypeByIcn( iter->_objectIcnType, iter->_imageIndex ) == objectType ) {
+                if ( Maps::getObjectTypeByIcn( iter->icnType, iter->icnIndex ) == objectType ) {
                     objectUID = iter->_uid;
                     break;
                 }
@@ -3059,8 +3059,8 @@ namespace Maps
             break;
         }
 
-        if ( ( tile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_UNKNOWN ) || ( tile.getMainObjectPart()._layerType == Maps::SHADOW_LAYER )
-             || ( tile.getMainObjectPart()._layerType == Maps::TERRAIN_LAYER ) ) {
+        if ( ( tile.getMainObjectPart().icnType == MP2::OBJ_ICN_TYPE_UNKNOWN ) || ( tile.getMainObjectPart().layerType == Maps::SHADOW_LAYER )
+             || ( tile.getMainObjectPart().layerType == Maps::TERRAIN_LAYER ) ) {
             return !MP2::isInGameActionObject( objectType, tile.isWater() );
         }
 
@@ -3307,12 +3307,12 @@ namespace Maps
             for ( int32_t x = startX; x <= endX; ++x ) {
                 const Maps::Tiles & currentTile = world.GetTiles( x + tileOffset );
 
-                if ( currentTile.getMainObjectPart()._uid != 0 && ( currentTile.getMainObjectPart()._layerType != SHADOW_LAYER ) ) {
+                if ( currentTile.getMainObjectPart()._uid != 0 && ( currentTile.getMainObjectPart().layerType != SHADOW_LAYER ) ) {
                     objectsUids.insert( currentTile.getMainObjectPart()._uid );
                 }
 
                 for ( const auto & part : currentTile.getGroundObjectParts() ) {
-                    if ( part._uid != 0 && ( part._layerType != SHADOW_LAYER ) ) {
+                    if ( part._uid != 0 && ( part.layerType != SHADOW_LAYER ) ) {
                         objectsUids.insert( part._uid );
                     }
                 }

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -99,16 +99,16 @@ namespace
 
     void renderObjectPart( fheroes2::Image & output, const Interface::GameArea & area, const fheroes2::Point & offset, const Maps::ObjectPart & part )
     {
-        assert( part._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && part._imageIndex != 255 );
+        assert( part.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN && part.icnIndex != 255 );
 
-        const int icn = MP2::getIcnIdFromObjectIcnType( part._objectIcnType );
+        const int icn = MP2::getIcnIdFromObjectIcnType( part.icnType );
         if ( isObjectPartDirectRenderingRestricted( icn ) ) {
             return;
         }
 
         const uint8_t alphaValue = area.getObjectAlphaValue( part._uid );
 
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, part._imageIndex );
+        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, part.icnIndex );
 
         // Ideally we need to check that the image is within a tile area. However, flags are among those for which this rule doesn't apply.
         if ( icn == ICN::FLAG32 ) {
@@ -120,7 +120,7 @@ namespace
 
         area.BlitOnTile( output, sprite, sprite.x(), sprite.y(), offset, false, alphaValue );
 
-        const uint32_t animationIndex = ICN::getAnimatedIcnIndex( icn, part._imageIndex, Game::getAdventureMapAnimationIndex() );
+        const uint32_t animationIndex = ICN::getAnimatedIcnIndex( icn, part.icnIndex, Game::getAdventureMapAnimationIndex() );
         if ( animationIndex > 0 ) {
             const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( icn, animationIndex );
 
@@ -134,16 +134,16 @@ namespace
 
     void renderMainObject( fheroes2::Image & output, const Interface::GameArea & area, const fheroes2::Point & offset, const Maps::Tiles & tile )
     {
-        assert( tile.getMainObjectPart()._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && tile.getMainObjectPart()._imageIndex != 255 );
+        assert( tile.getMainObjectPart().icnType != MP2::OBJ_ICN_TYPE_UNKNOWN && tile.getMainObjectPart().icnIndex != 255 );
 
-        const int mainObjectIcn = MP2::getIcnIdFromObjectIcnType( tile.getMainObjectPart()._objectIcnType );
+        const int mainObjectIcn = MP2::getIcnIdFromObjectIcnType( tile.getMainObjectPart().icnType );
         if ( isTileDirectRenderingRestricted( mainObjectIcn, tile.getMainObjectType() ) ) {
             return;
         }
 
         const uint8_t mainObjectAlphaValue = area.getObjectAlphaValue( tile.getMainObjectPart()._uid );
 
-        const fheroes2::Sprite & mainObjectSprite = fheroes2::AGG::GetICN( mainObjectIcn, tile.getMainObjectPart()._imageIndex );
+        const fheroes2::Sprite & mainObjectSprite = fheroes2::AGG::GetICN( mainObjectIcn, tile.getMainObjectPart().icnIndex );
 
         // If this assertion blows up we are trying to render an image bigger than a tile. Render this object properly as heroes or monsters!
         assert( mainObjectSprite.x() >= 0 && mainObjectSprite.width() + mainObjectSprite.x() <= fheroes2::tileWidthPx && mainObjectSprite.y() >= 0
@@ -154,7 +154,7 @@ namespace
         // Render possible animation image.
         // TODO: quantity2 is used in absolutely incorrect way! Fix all the logic for it. As of now (quantity2 != 0) expression is used only for Magic Garden.
         const uint32_t mainObjectAnimationIndex
-            = ICN::getAnimatedIcnIndex( mainObjectIcn, tile.getMainObjectPart()._imageIndex, Game::getAdventureMapAnimationIndex(), tile.metadata()[1] != 0 );
+            = ICN::getAnimatedIcnIndex( mainObjectIcn, tile.getMainObjectPart().icnIndex, Game::getAdventureMapAnimationIndex(), tile.metadata()[1] != 0 );
         if ( mainObjectAnimationIndex > 0 ) {
             const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( mainObjectIcn, mainObjectAnimationIndex );
 
@@ -681,7 +681,7 @@ namespace Maps
 
     void redrawTopLayerObject( const Tiles & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area, const ObjectPart & part )
     {
-        if ( isPuzzleDraw && MP2::isHiddenForPuzzle( tile.GetGround(), part._objectIcnType, part._imageIndex ) ) {
+        if ( isPuzzleDraw && MP2::isHiddenForPuzzle( tile.GetGround(), part.icnType, part.icnIndex ) ) {
             return;
         }
 
@@ -945,15 +945,15 @@ namespace Maps
         size_t postRenderObjectCount = 0;
 
         for ( const auto & part : tile.getGroundObjectParts() ) {
-            if ( part._layerType != level ) {
+            if ( part.layerType != level ) {
                 continue;
             }
 
-            if ( isPuzzleDraw && MP2::isHiddenForPuzzle( tile.GetGround(), part._objectIcnType, part._imageIndex ) ) {
+            if ( isPuzzleDraw && MP2::isHiddenForPuzzle( tile.GetGround(), part.icnType, part.icnIndex ) ) {
                 continue;
             }
 
-            if ( part._objectIcnType == MP2::OBJ_ICN_TYPE_FLAG32 ) {
+            if ( part.icnType == MP2::OBJ_ICN_TYPE_FLAG32 ) {
                 // Based on logically thinking it is impossible to have more than 16 flags on a single tile.
                 assert( postRenderObjectCount < maxPostRenderPart );
 
@@ -965,8 +965,8 @@ namespace Maps
             renderObjectPart( dst, area, mp, part );
         }
 
-        if ( tile.getMainObjectPart()._objectIcnType != MP2::OBJ_ICN_TYPE_UNKNOWN && tile.getMainObjectPart()._layerType == level
-             && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( tile.GetGround(), tile.getMainObjectPart()._objectIcnType, tile.getMainObjectPart()._imageIndex ) ) ) {
+        if ( tile.getMainObjectPart().icnType != MP2::OBJ_ICN_TYPE_UNKNOWN && tile.getMainObjectPart().layerType == level
+             && ( !isPuzzleDraw || !MP2::isHiddenForPuzzle( tile.GetGround(), tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex ) ) ) {
             renderMainObject( dst, area, mp, tile );
         }
 
@@ -982,17 +982,17 @@ namespace Maps
         const fheroes2::Point & tileOffset = Maps::GetPoint( tile.GetIndex() );
 
         for ( const auto & part : tile.getGroundObjectParts() ) {
-            if ( part._objectIcnType == objectIcnType ) {
+            if ( part.icnType == objectIcnType ) {
                 renderObjectPart( output, area, tileOffset, part );
             }
         }
 
-        if ( tile.getMainObjectPart()._objectIcnType == objectIcnType ) {
+        if ( tile.getMainObjectPart().icnType == objectIcnType ) {
             renderMainObject( output, area, tileOffset, tile );
         }
 
         for ( const auto & part : tile.getTopObjectParts() ) {
-            if ( part._objectIcnType == objectIcnType ) {
+            if ( part.icnType == objectIcnType ) {
                 renderObjectPart( output, area, tileOffset, part );
             }
         }
@@ -1089,7 +1089,7 @@ namespace Maps
         // TODO: combine both boat image generation for heroes and empty boats.
         assert( tile.getMainObjectType() == MP2::OBJ_BOAT );
 
-        const uint32_t spriteIndex = ( tile.getMainObjectPart()._imageIndex == 255 ) ? 18 : tile.getMainObjectPart()._imageIndex;
+        const uint32_t spriteIndex = ( tile.getMainObjectPart().icnIndex == 255 ) ? 18 : tile.getMainObjectPart().icnIndex;
 
         const bool isReflected = ( spriteIndex > 128 );
 
@@ -1120,7 +1120,7 @@ namespace Maps
         assert( tile.getMainObjectType() == MP2::OBJ_BOAT );
 
         // TODO: boat shadow logic is more complex than this and it is not directly depend on spriteIndex. Find the proper logic and fix it!
-        const uint32_t spriteIndex = ( tile.getMainObjectPart()._imageIndex == 255 ) ? 18 : tile.getMainObjectPart()._imageIndex;
+        const uint32_t spriteIndex = ( tile.getMainObjectPart().icnIndex == 255 ) ? 18 : tile.getMainObjectPart().icnIndex;
 
         const int icnId{ ICN::BOATSHAD };
         const uint32_t icnIndex = spriteIndex % 128;
@@ -1298,7 +1298,7 @@ namespace Maps
     {
         assert( tile.getMainObjectType() == MP2::OBJ_HERO );
 
-        const uint32_t icnIndex = tile.getMainObjectPart()._imageIndex;
+        const uint32_t icnIndex = tile.getMainObjectPart().icnIndex;
         const int icnId{ ICN::MINIHERO };
 
         const fheroes2::Sprite & boatSprite = fheroes2::AGG::GetICN( icnId, icnIndex );

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -799,7 +799,7 @@ MapsIndexes World::GetTeleportEndPoints( const int32_t index ) const
     }
 
     // The type of destination stone liths must match the type of the source stone liths.
-    for ( const int32_t teleportIndex : _allTeleports.at( entranceObjectPart->_imageIndex ) ) {
+    for ( const int32_t teleportIndex : _allTeleports.at( entranceObjectPart->icnIndex ) ) {
         const Maps::Tiles & teleportTile = GetTiles( teleportIndex );
 
         if ( teleportIndex == index || teleportTile.getMainObjectType() != MP2::OBJ_STONE_LITHS || teleportTile.isWater() != entranceTile.isWater() ) {
@@ -842,7 +842,7 @@ MapsIndexes World::GetWhirlpoolEndPoints( const int32_t index ) const
         return result;
     }
 
-    for ( const int32_t whirlpoolIndex : _allWhirlpools.at( entranceObjectPart->_imageIndex ) ) {
+    for ( const int32_t whirlpoolIndex : _allWhirlpools.at( entranceObjectPart->icnIndex ) ) {
         const Maps::Tiles & whirlpoolTile = GetTiles( whirlpoolIndex );
         if ( whirlpoolTile.getMainObjectType() != MP2::OBJ_WHIRLPOOL ) {
             continue;
@@ -1359,7 +1359,7 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
             continue;
         }
 
-        _allTeleports[objectPart->_imageIndex].push_back( index );
+        _allTeleports[objectPart->icnIndex].push_back( index );
     }
 
     // Cache all tiles that contain a certain part of the whirlpool (depending on object sprite index).
@@ -1371,7 +1371,7 @@ void World::PostLoad( const bool setTilePassabilities, const bool updateUidCount
     for ( const auto & [index, objectPart] : Maps::getObjectParts( MP2::OBJ_WHIRLPOOL ) ) {
         assert( objectPart != nullptr );
 
-        _allWhirlpools[objectPart->_imageIndex].push_back( index );
+        _allWhirlpools[objectPart->icnIndex].push_back( index );
     }
 
     // Cache all positions of Eye of Magi objects.

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -446,7 +446,7 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
 
         for ( const int32_t tileId : vec_object ) {
             const Maps::Tiles & tile = vec_tiles[tileId];
-            if ( ( tile.getMainObjectPart()._layerType & 0x3 ) != Maps::OBJECT_LAYER ) {
+            if ( ( tile.getMainObjectPart().layerType & 0x3 ) != Maps::OBJECT_LAYER ) {
                 continue;
             }
 
@@ -561,7 +561,7 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
                                    << "incorrect size block: " << pblock.size() )
                 }
                 else {
-                    std::pair<int, int> colorRace = Maps::getColorRaceFromHeroSprite( tile.getMainObjectPart()._imageIndex );
+                    std::pair<int, int> colorRace = Maps::getColorRaceFromHeroSprite( tile.getMainObjectPart().icnIndex );
                     const Kingdom & kingdom = GetKingdom( colorRace.first );
 
                     if ( colorRace.second == Race::RAND && colorRace.first != Color::NONE ) {
@@ -1267,7 +1267,7 @@ bool World::updateTileMetadata( Maps::Tiles & tile, const MP2::MapObjectType obj
 
     case MP2::OBJ_HERO: {
         // remove map editor sprite
-        if ( tile.getMainObjectPart()._objectIcnType == MP2::OBJ_ICN_TYPE_MINIHERO ) {
+        if ( tile.getMainObjectPart().icnType == MP2::OBJ_ICN_TYPE_MINIHERO ) {
             tile.removeObjectPartsByUID( tile.getMainObjectPart()._uid );
         }
 


### PR DESCRIPTION
This is an intermediate step towards unification of ObjectPart and ObjectPartInfo structures. The first one should be derived from the last but this will be done in another pull request.