### PR TITLE
SonarCloud: Ignore cpp:S106 (Standard outputs should not be used directly to log anything) for command-line tools

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,11 @@ sonar.projectName=fheroes2
 # CI will automatically replace this with the contents of the version.txt file.
 sonar.projectVersion=%{version}
 
+sonar.links.homepage=https://github.com/ihhub/fheroes2
+sonar.links.ci=https://github.com/ihhub/fheroes2/actions
+sonar.links.scm=https://github.com/ihhub/fheroes2
+sonar.links.issue=https://github.com/ihhub/fheroes2/issues
+
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
 
@@ -15,11 +20,7 @@ sonar.sources=.
 # Properties specific to the C/C++ analyzer.
 sonar.cfamily.threads=2
 
-sonar.links.homepage=https://github.com/ihhub/fheroes2
-sonar.links.ci=https://github.com/ihhub/fheroes2/actions
-sonar.links.scm=https://github.com/ihhub/fheroes2
-sonar.links.issue=https://github.com/ihhub/fheroes2/issues
-
+# List of files completely excluded from the analysis.
 sonar.exclusions=src/thirdparty/**/*
 
 # List of issues to ignore.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -9,10 +9,10 @@ sonar.projectVersion=%{version}
 # Path is relative to the sonar-project.properties file. Replace "\" by "/" on Windows.
 sonar.sources=.
 
-# Encoding of the source code. Default is default system encoding
+# Encoding of the source code. Default is default system encoding.
 #sonar.sourceEncoding=UTF-8
 
-# Properties specific to the C/C++ analyzer:
+# Properties specific to the C/C++ analyzer.
 sonar.cfamily.threads=2
 
 sonar.links.homepage=https://github.com/ihhub/fheroes2
@@ -21,3 +21,11 @@ sonar.links.scm=https://github.com/ihhub/fheroes2
 sonar.links.issue=https://github.com/ihhub/fheroes2/issues
 
 sonar.exclusions=src/thirdparty/**/*
+
+# List of issues to ignore.
+sonar.issue.ignore.multicriteria=cppS106Tools
+
+# Ignore cpp:S106 (Standard outputs should not be used directly to log anything) for
+# command-line tools.
+sonar.issue.ignore.multicriteria.cppS106Tools.ruleKey=cpp:S106
+sonar.issue.ignore.multicriteria.cppS106Tools.resourceKey=src/tools/*.cpp


### PR DESCRIPTION
I'm not 100% sure that this will work, because, apparently, this cannot be checked using a pull request. 