### PR TITLE
Fix reef passability

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -471,7 +471,7 @@ void Maps::Tile::Init( int32_t index, const MP2::MP2TileInfo & mp2 )
         _isTileMarkedAsRoad = true;
     }
 
-    if ( mp2.mapObjectType == MP2::OBJ_NONE && ( layerType == ObjectLayerType::SHADOW_LAYER || layerType == ObjectLayerType::TERRAIN_LAYER ) ) {
+    if ( _mainObjectType == MP2::OBJ_NONE && ( layerType == ObjectLayerType::SHADOW_LAYER || layerType == ObjectLayerType::TERRAIN_LAYER ) ) {
         // If an object sits on shadow or terrain layer then we should put it as a bottom layer add-on.
         if ( bottomObjectIcnType != MP2::ObjectIcnType::OBJ_ICN_TYPE_UNKNOWN ) {
             _groundObjectPart.emplace_back( layerType, mp2.level1ObjectUID, bottomObjectIcnType, mp2.bottomIcnImageIndex );
@@ -662,6 +662,16 @@ int Maps::Tile::getBoatDirection() const
 
 int Maps::Tile::getOriginalPassability() const
 {
+    if ( isValidReefsSprite( _mainObjectPart.icnType, _mainObjectPart.icnIndex ) ) {
+        return 0;
+    }
+
+    for ( const auto & part : _groundObjectPart ) {
+        if ( isValidReefsSprite( part.icnType, part.icnIndex ) ) {
+            return 0;
+        }
+    }
+
     const MP2::MapObjectType objectType = getMainObjectType( false );
 
     if ( MP2::isOffGameActionObject( objectType ) ) {
@@ -671,16 +681,6 @@ int Maps::Tile::getOriginalPassability() const
     if ( _mainObjectPart.icnType == MP2::OBJ_ICN_TYPE_UNKNOWN || _mainObjectPart.isPassabilityTransparent() || isShadow() ) {
         // No object exists. Make it fully passable.
         return DIRECTION_ALL;
-    }
-
-    if ( isValidReefsSprite( _mainObjectPart.icnType, _mainObjectPart.icnIndex ) ) {
-        return 0;
-    }
-
-    for ( const auto & part : _groundObjectPart ) {
-        if ( isValidReefsSprite( part.icnType, part.icnIndex ) ) {
-            return 0;
-        }
     }
 
     // Objects have fixed passability.

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -42,12 +42,17 @@ class OStreamBase;
 
 namespace Maps
 {
+    // Layer types. They affect passability and also rendering. Rendering must be in the following order:
+    // - terrain objects (they have no shadows)
+    // - shadows
+    // - background objects
+    // - objects
     enum ObjectLayerType : uint8_t
     {
-        OBJECT_LAYER = 0, // main and action objects like mines, forest, mountains, castles and etc.
-        BACKGROUND_LAYER = 1, // background objects like lakes or bushes.
-        SHADOW_LAYER = 2, // shadows and some special objects like castle's entrance road.
-        TERRAIN_LAYER = 3 // roads, water flaws and cracks. Essentially everything what is a part of terrain.
+        OBJECT_LAYER = 0, // Common objects like mines, forest, mountains, castles and etc. They affect passability.
+        BACKGROUND_LAYER = 1, // Objects that still affect passability but they must be rendered as background. Such objects are lakes, bushes and etc.
+        SHADOW_LAYER = 2, // Shadows and some special objects like castle's entrance road. No passability changes.
+        TERRAIN_LAYER = 3 // Roads, water flaws and cracks. Essentially everything what is a part of terrain. No passability changes.
     };
 
     struct ObjectPart


### PR DESCRIPTION
The code was taken from #8429.

Reefs are always impassable so we need to check them before any other object part on a tile.