### PR TITLE
Standartize code to update POL objects

### DIFF
--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -4960,7 +4960,7 @@ namespace Maps
         return objectInfo[objectIndex];
     }
 
-    MP2::MapObjectType getObjectTypeByIcn( const MP2::ObjectIcnType icnType, const uint32_t icnIndex )
+    const ObjectPartInfo * getObjectPartByIcn( const MP2::ObjectIcnType icnType, const uint32_t icnIndex )
     {
         populateObjectData();
 
@@ -4970,13 +4970,13 @@ namespace Maps
 
                 for ( const auto & info : object.groundLevelParts ) {
                     if ( info.icnType == icnType && info.icnIndex == icnIndex ) {
-                        return info.objectType;
+                        return &info;
                     }
                 }
 
                 for ( const auto & info : object.topLevelParts ) {
                     if ( info.icnType == icnType && info.icnIndex == icnIndex ) {
-                        return info.objectType;
+                        return &info;
                     }
                 }
             }
@@ -4986,6 +4986,16 @@ namespace Maps
         // - you are passing invalid object information
         // - you updated object properties but didn't do object info migration for save files
         // - you are trying to get info of an object created by an original Editor
+        return nullptr;
+    }
+
+    MP2::MapObjectType getObjectTypeByIcn( const MP2::ObjectIcnType icnType, const uint32_t icnIndex )
+    {
+        const ObjectPartInfo * objectPart = getObjectPartByIcn( icnType, icnIndex );
+        if ( objectPart != nullptr ) {
+            return objectPart->objectType;
+        }
+
         return MP2::OBJ_NONE;
     }
 

--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -42,7 +42,7 @@ namespace
 
     // This map is used for searching object parts based on their ICN information.
     // Since we have a lot of objects it is important to speed up the search even if we take several more KB of memory.
-    std::map<std::pair<MP2::ObjectIcnType, uint32_t>, const Maps::ObjectPartInfo*> objectInfoByIcn;
+    std::map<std::pair<MP2::ObjectIcnType, uint32_t>, const Maps::ObjectPartInfo *> objectInfoByIcn;
 
     void populateRoads( std::vector<Maps::ObjectInfo> & objects )
     {

--- a/src/fheroes2/maps/map_object_info.cpp
+++ b/src/fheroes2/maps/map_object_info.cpp
@@ -40,6 +40,10 @@ namespace
     // the fheroes2 Editor requires to have resources from the expansion.
     std::array<std::vector<Maps::ObjectInfo>, static_cast<size_t>( Maps::ObjectGroup::GROUP_COUNT )> objectData;
 
+    // This map is used for searching object parts based on their ICN information.
+    // Since we have a lot of objects it is important to speed up the search even if we take several more KB of memory.
+    std::map<std::pair<MP2::ObjectIcnType, uint32_t>, const Maps::ObjectPartInfo*> objectInfoByIcn;
+
     void populateRoads( std::vector<Maps::ObjectInfo> & objects )
     {
         assert( objects.empty() );
@@ -4850,6 +4854,20 @@ namespace
 
         populateExtraBoatDirections( objectData[static_cast<size_t>( Maps::ObjectGroup::MAP_EXTRAS )] );
 
+        for ( const auto & objects : objectData ) {
+            for ( const auto & objectInfo : objects ) {
+                // We accept that there could be duplicates so we don't check if the insertion is successful for the map.
+
+                for ( const auto & info : objectInfo.groundLevelParts ) {
+                    objectInfoByIcn.try_emplace( std::make_pair( info.icnType, info.icnIndex ), &info );
+                }
+
+                for ( const auto & info : objectInfo.topLevelParts ) {
+                    objectInfoByIcn.try_emplace( std::make_pair( info.icnType, info.icnIndex ), &info );
+                }
+            }
+        }
+
 #if defined( WITH_DEBUG )
         // It is important to check that all data is accurately generated.
         for ( const auto & objects : objectData ) {
@@ -4964,22 +4982,9 @@ namespace Maps
     {
         populateObjectData();
 
-        for ( const auto & group : objectData ) {
-            for ( const auto & object : group ) {
-                assert( !object.groundLevelParts.empty() );
-
-                for ( const auto & info : object.groundLevelParts ) {
-                    if ( info.icnType == icnType && info.icnIndex == icnIndex ) {
-                        return &info;
-                    }
-                }
-
-                for ( const auto & info : object.topLevelParts ) {
-                    if ( info.icnType == icnType && info.icnIndex == icnIndex ) {
-                        return &info;
-                    }
-                }
-            }
+        auto iter = objectInfoByIcn.find( std::make_pair( icnType, icnIndex ) );
+        if ( iter != objectInfoByIcn.end() ) {
+            return iter->second;
         }
 
         // You can reach this code by 3 reasons:

--- a/src/fheroes2/maps/map_object_info.h
+++ b/src/fheroes2/maps/map_object_info.h
@@ -165,6 +165,10 @@ namespace Maps
 
     const ObjectInfo & getObjectInfo( const ObjectGroup group, const int32_t objectIndex );
 
+    // The function can return nullptr if an object does not exist.
+    // A valid pointer could also point to LayeredObjectPartInfo object.
+    const ObjectPartInfo * getObjectPartByIcn( const MP2::ObjectIcnType icnType, const uint32_t icnIndex );
+
     MP2::MapObjectType getObjectTypeByIcn( const MP2::ObjectIcnType icnType, const uint32_t icnIndex );
 
     // The function returns tile offsets only for ground level objects located on OBJECT_LAYER and BACKGROUND_LAYER layers.

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -332,7 +332,7 @@ namespace
             return false;
         }
 
-        auto * objectPart = Maps::getObjectPartByIcn( part.icnType, part.icnIndex );
+        const auto * objectPart = Maps::getObjectPartByIcn( part.icnType, part.icnIndex );
         if ( objectPart == nullptr ) {
             // This could be a hacked map.
             return false;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -319,34 +319,33 @@ namespace
         return "Unknown layer";
     }
 
-    bool updateLoyaltyObjectType( const Maps::ObjectPart & part, Maps::Tile & tile )
+    bool updatePriceOfLoyaltyObjectType( const Maps::ObjectPart & part, Maps::Tile & tile )
     {
-        // The Price of Loyalty' object should belong to certain ICN type.
+        // The Price of Loyalty' object should belong to a certain ICN type.
         switch ( part.icnType ) {
         case MP2::OBJ_ICN_TYPE_X_LOC1:
         case MP2::OBJ_ICN_TYPE_X_LOC2:
         case MP2::OBJ_ICN_TYPE_X_LOC3:
             break;
         default:
-            // This is not a POL object.
+            // This is not an original POL object.
             return false;
         }
 
         const auto * objectPart = Maps::getObjectPartByIcn( part.icnType, part.icnIndex );
         if ( objectPart == nullptr ) {
-            // This could be a hacked map.
+            // This could be a hacked map or an object part which we ignored in our list of objects (for example, an empty object part).
             return false;
         }
 
         if ( objectPart->objectType == MP2::OBJ_NONE ) {
-            // It looks like the object is not present in the list or the object is maked incorrectly.
+            // It looks like the object is not present in the list or the object is marked incorrectly.
             // Let's update the tile based on the object parts it has.
             tile.updateObjectType();
             return true;
         }
 
         tile.setMainObjectType( objectPart->objectType );
-
         return true;
     }
 
@@ -1332,19 +1331,19 @@ void Maps::Tile::fixMP2MapTileObjectType( Tile & tile )
     case MP2::OBJ_EXPANSION_OBJECT: {
         // The type of expansion action object or dwelling is stored in object metadata.
         // However, we just ignore it.
-        if ( updateLoyaltyObjectType( tile._mainObjectPart, tile ) ) {
+        if ( updatePriceOfLoyaltyObjectType( tile._mainObjectPart, tile ) ) {
             return;
         }
 
         // Object part of ground layer shouldn't even exist if no top object is present. However, let's play safe and verify it as well.
         for ( const auto & part : tile._groundObjectPart ) {
-            if ( updateLoyaltyObjectType( part, tile ) ) {
+            if ( updatePriceOfLoyaltyObjectType( part, tile ) ) {
                 return;
             }
         }
 
         for ( const auto & part : tile._topObjectPart ) {
-            if ( updateLoyaltyObjectType( part, tile ) ) {
+            if ( updatePriceOfLoyaltyObjectType( part, tile ) ) {
                 return;
             }
         }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1323,19 +1323,23 @@ void Maps::Tile::fixMP2MapTileObjectType( Tile & tile )
         }
     }
 
-    // Fix The Price of Loyalty objects even if the map is The Succession Wars type.
+    // The original maps do not have proper object type being set for The Price of Loyalty' objects.
+    // All of them are marked under few common types listed below.
+    // The type of an expansion action object or dwelling is stored in object metadata.
+    // However, we do not read this information and set the correct object type based on the object part information.
+    //
+    // We shouldn't even reach this code for Succession Wars maps but it is okay if we execute it since the map is most likely hacked.
     switch ( originalObjectType ) {
     case MP2::OBJ_NON_ACTION_EXPANSION_DWELLING:
     case MP2::OBJ_NON_ACTION_EXPANSION_OBJECT:
     case MP2::OBJ_EXPANSION_DWELLING:
     case MP2::OBJ_EXPANSION_OBJECT: {
-        // The type of expansion action object or dwelling is stored in object metadata.
-        // However, we just ignore it.
         if ( updatePriceOfLoyaltyObjectType( tile._mainObjectPart, tile ) ) {
             return;
         }
 
-        // Object part of ground layer shouldn't even exist if no top object is present. However, let's play safe and verify it as well.
+        // Object part of ground layer shouldn't even exist if no top object is present.
+        // However, let's play safe and verify it as well.
         for ( const auto & part : tile._groundObjectPart ) {
             if ( updatePriceOfLoyaltyObjectType( part, tile ) ) {
                 return;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -455,8 +455,6 @@ void Maps::Tile::setTerrain( const uint16_t terrainImageIndex, const bool horizo
 
     const int newGround = Ground::getGroundByImageIndex( terrainImageIndex );
 
-    // TODO: Remove all objects from map when changing water to land and vice-versa in both 'Map_Format' and 'tiles'.
-
     if ( ( _isTileMarkedAsRoad || isStream() ) && ( newGround != Ground::WATER ) && Ground::doesTerrainImageIndexContainEmbeddedObjects( terrainImageIndex ) ) {
         // There cannot be extra objects under the roads and streams.
         _terrainImageIndex = Ground::getRandomTerrainImageIndex( Ground::getGroundByImageIndex( terrainImageIndex ), false );

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -323,7 +323,7 @@ namespace
         }
 
         if ( hasBits( groundDirection, Direction::LEFT | Direction::TOP | Direction::BOTTOM )
-             && ( ( tile.GetGround() != Maps::Ground::WATER ) || hasBits( groundDirection, Direction::TOP_LEFT | Direction::BOTTOM_LEFT ) ) ) {
+             && ( !tile.isWater() || hasBits( groundDirection, Direction::TOP_LEFT | Direction::BOTTOM_LEFT ) ) ) {
             // There is no ground direction to the right.
             // NOTICE: Initially the whole 'DIRECTION_LEFT_COL' should have direction bits.
             // If ground is not Water we  do not check TOP_LEFT and BOTTOM_LEFT as there are no tile images for that cases.
@@ -355,7 +355,7 @@ namespace
         }
 
         if ( hasBits( groundDirection, Direction::RIGHT | Direction::TOP | Direction::BOTTOM )
-             && ( ( tile.GetGround() != Maps::Ground::WATER ) || hasBits( groundDirection, Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT ) ) ) {
+             && ( !tile.isWater() || hasBits( groundDirection, Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT ) ) ) {
             // There is no ground direction to the left.
             // NOTICE: Initially the whole 'DIRECTION_RIGHT_COL' should have direction bits.
             // If ground is not Water we do not check TOP_RIGHT and BOTTOM_RIGHT as there are no tile images for that cases.
@@ -387,7 +387,7 @@ namespace
         }
 
         if ( hasBits( groundDirection, Direction::BOTTOM | Direction::LEFT | Direction::RIGHT )
-             && ( ( tile.GetGround() != Maps::Ground::WATER ) || hasBits( groundDirection, Direction::BOTTOM_LEFT | Direction::BOTTOM_RIGHT ) ) ) {
+             && ( !tile.isWater() || hasBits( groundDirection, Direction::BOTTOM_LEFT | Direction::BOTTOM_RIGHT ) ) ) {
             // There is no ground direction to the top.
             // NOTICE: Initially the whole 'DIRECTION_BOTTOM_ROW' should have direction bits.
             // If ground is not Water we  do not check BOTTOM_LEFT and BOTTOM_RIGHT as there are no tile images for that cases.
@@ -419,7 +419,7 @@ namespace
         }
 
         if ( hasBits( groundDirection, Direction::TOP | Direction::LEFT | Direction::RIGHT )
-             && ( ( tile.GetGround() != Maps::Ground::WATER ) || hasBits( groundDirection, Direction::TOP_LEFT | Direction::TOP_RIGHT ) ) ) {
+             && ( !tile.isWater() || hasBits( groundDirection, Direction::TOP_LEFT | Direction::TOP_RIGHT ) ) ) {
             // There is no ground direction to the bottom.
             // NOTICE: Initially the whole 'DIRECTION_TOP_ROW' should have direction bits.
             // If ground is not Water we  do not check TOP_LEFT and TOP_RIGHT as there are no tile images for that cases.


### PR DESCRIPTION
The previous implementation was based on hardcoded values and differs from our set of object part information. Having a single source of truth is easier to handle the code.

As a bonus point this PR speeds up whirlpool initialization at map or save file loading.