### PR TITLE
Update hash for Android dependency package

### DIFF
--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=942A77944E76B1E2FEB3F73575C7517A1BF44441C51FD987D57800D8635847B9
+set PKG_FILE_SHA256=D28D37A09C9B995CB87C75CC6A8E92F3878B137FCEA3BED9155B9C67A3B5A575
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -23,7 +23,7 @@
 set -e -o pipefail
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="942a77944e76b1e2feb3f73575c7517a1bf44441c51fd987d57800d8635847b9"
+PKG_FILE_SHA256="d28d37a09c9b995cb87c75cc6a8e92f3878b137fcea3bed9155b9c67a3b5a575"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"


### PR DESCRIPTION
This PR should fix the #9234. See https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/55 for details.