### PR TITLE
Update initial tile passability calculations

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -786,7 +786,7 @@ void Maps::Tile::updatePassability()
     if ( ( _tilePassabilityDirections & Direction::TOP_LEFT ) && isValidDirection( _index, Direction::LEFT ) ) {
         const Tile & leftTile = world.getTile( GetDirectionIndex( _index, Direction::LEFT ) );
 
-        if ( leftTile.anyTallObjectOnTile() && ( leftTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
+        if ( leftTile.isAnyTallObjectOnTile() && ( leftTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
             _tilePassabilityDirections &= ~Direction::TOP_LEFT;
         }
     }
@@ -794,7 +794,7 @@ void Maps::Tile::updatePassability()
     if ( ( _tilePassabilityDirections & Direction::TOP_RIGHT ) && isValidDirection( _index, Direction::RIGHT ) ) {
         const Tile & rightTile = world.getTile( GetDirectionIndex( _index, Direction::RIGHT ) );
 
-        if ( rightTile.anyTallObjectOnTile() && ( rightTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
+        if ( rightTile.isAnyTallObjectOnTile() && ( rightTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
             _tilePassabilityDirections &= ~Direction::TOP_RIGHT;
         }
     }
@@ -1687,7 +1687,7 @@ bool Maps::Tile::containsSprite( const MP2::ObjectIcnType objectIcnType, const u
                         [objectIcnType, imageIdx]( const auto & part ) { return part.icnType == objectIcnType && imageIdx == part.icnIndex; } );
 }
 
-bool Maps::Tile::anyTallObjectOnTile() const
+bool Maps::Tile::isAnyTallObjectOnTile() const
 {
     // TODO: possibly cache the output of the method.
     if ( !isValidDirection( _index, Direction::TOP ) ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -616,25 +616,35 @@ int Maps::Tile::getTileIndependentPassability() const
 {
     // Tile-independent passability is based purely on object parts located on this tile.
     // We need to run through all object parts on the ground level to calculate the resulting passability.
-    // Remember, top object parts do not affect passability.
+    //
+    // The total passability is a combination of all object parts on the tile.
+    // If we encounter any action object we have to stop calculations.
+    //
+    // All object parts should be verified in the following order:
+    // - main object part
+    // - from bottom object part from the end of the object list to the start
+    // In other words, we have to go through object parts in the reverse order as they are being rendered.
+    //
+    // Top object parts do not affect passability.
     int passability = DIRECTION_ALL;
 
-    const auto getObjectPartPassability = []( const Maps::ObjectPart & part ) {
+    const auto getObjectPartPassability = []( const Maps::ObjectPart & part, bool & isActionObject ) {
         if ( part.icnType == MP2::OBJ_ICN_TYPE_ROAD || part.icnType == MP2::OBJ_ICN_TYPE_STREAM ) {
             // Rivers and stream are completely passable.
             return DIRECTION_ALL;
         }
 
-        // The tile has a valid main object part. Check its passability.
+        // The tile has a valid object part. Check its passability.
         const MP2::MapObjectType type = getObjectTypeByIcn( part.icnType, part.icnIndex );
+        if ( MP2::isOffGameActionObject( type ) ) {
+            // This is an action object part.
+            isActionObject = true;
+            return MP2::getActionObjectDirection( type );
+        }
+
         if ( type == MP2::OBJ_REEFS ) {
             // Reefs are inaccessible.
             return 0;
-        }
-
-        if ( MP2::isOffGameActionObject( type ) ) {
-            // This is an action object part.
-            return MP2::getActionObjectDirection( type );
         }
 
         if ( !part.isPassabilityTransparent() && !isObjectPartShadow( part ) ) {
@@ -646,12 +656,20 @@ int Maps::Tile::getTileIndependentPassability() const
         return DIRECTION_ALL;
     };
 
+    bool isActionObject = false;
+
     if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN ) {
-        passability = passability & getObjectPartPassability( _mainObjectPart );
+        passability = passability & getObjectPartPassability( _mainObjectPart, isActionObject );
+        if ( isActionObject ) {
+            return passability;
+        }
     }
 
-    for ( const auto & part : _groundObjectPart ) {
-        passability = passability & getObjectPartPassability( part );
+    for ( auto iter = _groundObjectPart.crbegin(); iter != _groundObjectPart.crend(); ++iter ) {
+        passability = passability & getObjectPartPassability( *iter, isActionObject );
+        if ( isActionObject ) {
+            return passability;
+        }
     }
 
     return passability;
@@ -670,6 +688,12 @@ void Maps::Tile::setInitialPassability()
 
 void Maps::Tile::updatePassability()
 {
+    // If the passability is already 0 nothing we need to do.
+    if ( _tilePassabilityDirections == 0 ) {
+        // This tile is impassable.
+        return;
+    }
+
     // Get object type but ignore heroes as they are "temporary" objects.
     const MP2::MapObjectType objectType = getMainObjectType( false );
 
@@ -757,20 +781,20 @@ void Maps::Tile::updatePassability()
         }
     }
 
-    // Left side.
+    // Verify the neighboring tiles.
+    // If a tile contains a tall object then it affects the passability of diagonal moves to the top from the current tile.
     if ( ( _tilePassabilityDirections & Direction::TOP_LEFT ) && isValidDirection( _index, Direction::LEFT ) ) {
         const Tile & leftTile = world.getTile( GetDirectionIndex( _index, Direction::LEFT ) );
-        const bool leftTileTallObject = leftTile.isTallObject();
-        if ( leftTileTallObject && ( leftTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
+
+        if ( leftTile.anyTallObjectOnTile() && ( leftTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
             _tilePassabilityDirections &= ~Direction::TOP_LEFT;
         }
     }
 
-    // Right side.
     if ( ( _tilePassabilityDirections & Direction::TOP_RIGHT ) && isValidDirection( _index, Direction::RIGHT ) ) {
         const Tile & rightTile = world.getTile( GetDirectionIndex( _index, Direction::RIGHT ) );
-        const bool rightTileTallObject = rightTile.isTallObject();
-        if ( rightTileTallObject && ( rightTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
+
+        if ( rightTile.anyTallObjectOnTile() && ( rightTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
             _tilePassabilityDirections &= ~Direction::TOP_RIGHT;
         }
     }
@@ -1663,11 +1687,11 @@ bool Maps::Tile::containsSprite( const MP2::ObjectIcnType objectIcnType, const u
                         [objectIcnType, imageIdx]( const auto & part ) { return part.icnType == objectIcnType && imageIdx == part.icnIndex; } );
 }
 
-bool Maps::Tile::isTallObject() const
+bool Maps::Tile::anyTallObjectOnTile() const
 {
-    // TODO: possibly cache the output of the method as right now it's in average twice.
+    // TODO: possibly cache the output of the method.
     if ( !isValidDirection( _index, Direction::TOP ) ) {
-        // Nothing above so this object can't be tall.
+        // This tile is on the first row. Any object on this tile cannot be tall.
         return false;
     }
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -346,7 +346,7 @@ namespace Maps
 
         void _updateRoadFlag();
 
-        bool anyTallObjectOnTile() const;
+        bool isTallObject() const;
 
         bool isDetachedObject() const;
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -346,7 +346,7 @@ namespace Maps
 
         void _updateRoadFlag();
 
-        bool anyTallObjectOnTile() const;
+        bool isAnyTallObjectOnTile() const;
 
         bool isDetachedObject() const;
 

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -346,7 +346,7 @@ namespace Maps
 
         void _updateRoadFlag();
 
-        bool isTallObject() const;
+        bool anyTallObjectOnTile() const;
 
         bool isDetachedObject() const;
 


### PR DESCRIPTION
We need to check bottom objects from in an opposite order for passability as action objects are considered special ones and all calculations for object parts below them are nullified.