### PR TITLE
Fix the attack value estimation for a Hypnotized unit with the ALL_ADJACENT_CELL_MELEE_ATTACK ability

### DIFF
--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -168,7 +168,8 @@ namespace
             for ( const int32_t index : Battle::Board::GetAroundIndexes( attackPos ) ) {
                 const Battle::Unit * unit = board->at( index ).GetUnit();
 
-                if ( unit == nullptr || unit->GetColor() == attacker.GetCurrentColor() ) {
+                // Attacking unit can be under the influence of the Hypnotize spell
+                if ( unit == nullptr || unit == &attacker || unit->GetColor() == attacker.GetCurrentColor() ) {
                     continue;
                 }
 


### PR DESCRIPTION
fix #9254

https://github.com/user-attachments/assets/e3b1a880-127a-47b5-b732-c2a1e5eb79f9
