### PR TITLE
Improve & speed up the translation-related code a bit

### DIFF
--- a/src/engine/agg_file.cpp
+++ b/src/engine/agg_file.cpp
@@ -41,13 +41,13 @@ namespace fheroes2
             return false;
         }
 
-        RWStreamBuf fileEntries = _stream.toStreamBuf( count * fileRecordSize );
+        RWStreamBuf fileEntries = _stream.getStreamBuf( count * fileRecordSize );
         const size_t nameEntriesSize = _maxFilenameSize * count;
         _stream.seek( size - nameEntriesSize );
-        RWStreamBuf nameEntries = _stream.toStreamBuf( nameEntriesSize );
+        RWStreamBuf nameEntries = _stream.getStreamBuf( nameEntriesSize );
 
         for ( size_t i = 0; i < count; ++i ) {
-            std::string name = nameEntries.toString( _maxFilenameSize );
+            std::string name = nameEntries.getString( _maxFilenameSize );
 
             // Check 32-bit filename hash.
             if ( fileEntries.getLE32() != calculateAggFilenameHash( name ) ) {

--- a/src/engine/agg_file.cpp
+++ b/src/engine/agg_file.cpp
@@ -41,10 +41,10 @@ namespace fheroes2
             return false;
         }
 
-        RWStreamBuf fileEntries = _stream.getStreamBuf( count * fileRecordSize );
+        ROStreamBuf fileEntries = _stream.getStreamBuf( count * fileRecordSize );
         const size_t nameEntriesSize = _maxFilenameSize * count;
         _stream.seek( size - nameEntriesSize );
-        RWStreamBuf nameEntries = _stream.getStreamBuf( nameEntriesSize );
+        ROStreamBuf nameEntries = _stream.getStreamBuf( nameEntriesSize );
 
         for ( size_t i = 0; i < count; ++i ) {
             std::string name = nameEntries.getString( _maxFilenameSize );

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -24,7 +24,6 @@
 #include "serialize.h"
 
 #include <algorithm>
-#include <cassert>
 #include <cstring>
 #include <ostream>
 #include <string>
@@ -245,10 +244,10 @@ OStreamBase & OStreamBase::operator<<( const fheroes2::Point & v )
     return *this << v.x << v.y;
 }
 
-RWStreamBuf::RWStreamBuf( const size_t sz )
+RWStreamBuf::RWStreamBuf( const size_t size )
 {
-    if ( sz ) {
-        reallocBuf( sz );
+    if ( size ) {
+        reallocBuf( size );
     }
 
     setBigendian( IS_BIGENDIAN );
@@ -297,29 +296,29 @@ void RWStreamBuf::putLE32( uint32_t v )
     put8( v >> 24 );
 }
 
-void RWStreamBuf::putRaw( const void * ptr, size_t sz )
+void RWStreamBuf::putRaw( const void * ptr, size_t size )
 {
-    if ( sz == 0 ) {
+    if ( size == 0 ) {
         return;
     }
 
-    if ( sizep() < sz ) {
-        if ( sz < capacity() / 2 ) {
+    if ( sizep() < size ) {
+        if ( size < capacity() / 2 ) {
             reallocBuf( capacity() + capacity() / 2 );
         }
         else {
-            reallocBuf( capacity() + sz );
+            reallocBuf( capacity() + size );
         }
     }
 
-    if ( sizep() < sz ) {
+    if ( sizep() < size ) {
         assert( 0 );
         return;
     }
 
-    memcpy( _itput, ptr, sz );
+    memcpy( _itput, ptr, size );
 
-    _itput = _itput + sz;
+    _itput = _itput + size;
 }
 
 void RWStreamBuf::put8( const uint8_t v )
@@ -339,11 +338,15 @@ void RWStreamBuf::put8( const uint8_t v )
 
 size_t RWStreamBuf::tellp()
 {
+    assert( _itbeg <= _itput );
+
     return _itput - _itbeg;
 }
 
 size_t RWStreamBuf::sizep()
 {
+    assert( _itput <= _itend );
+
     return _itend - _itput;
 }
 
@@ -365,7 +368,8 @@ void RWStreamBuf::reallocBuf( size_t size )
         return;
     }
 
-    assert( ( []( const auto... args ) { return ( ( args != nullptr ) && ... ); }( _itbeg, _itget, _itput, _itend ) ) );
+    assert( ( []( const auto... args ) { return ( ( args != nullptr ) && ... ); }( _itbeg, _itget, _itput, _itend ) ) && _itbeg <= _itget && _itget <= _itput
+            && _itput <= _itend );
 
     if ( sizep() < size ) {
         size = std::max( size, minBufferCapacity );
@@ -382,6 +386,13 @@ void RWStreamBuf::reallocBuf( size_t size )
         _itbeg = _buf.get();
         _itend = _itbeg + size;
     }
+}
+
+void RWStreamBuf::advance( const size_t size )
+{
+    assert( size <= sizep() );
+
+    _itput += size;
 }
 
 ROStreamBuf::ROStreamBuf( const std::vector<uint8_t> & buf )
@@ -451,7 +462,7 @@ size_t StreamFile::tell()
     return tellg();
 }
 
-void StreamFile::seek( size_t pos )
+void StreamFile::seek( const size_t pos )
 {
     if ( !_file ) {
         return;
@@ -530,13 +541,13 @@ size_t StreamFile::tellp()
     return tellg();
 }
 
-void StreamFile::skip( size_t pos )
+void StreamFile::skip( size_t size )
 {
     if ( !_file ) {
         return;
     }
 
-    if ( std::fseek( _file.get(), static_cast<long int>( pos ), SEEK_CUR ) != 0 ) {
+    if ( std::fseek( _file.get(), static_cast<long int>( size ), SEEK_CUR ) != 0 ) {
         setFail();
     }
 }
@@ -571,24 +582,24 @@ uint32_t StreamFile::getLE32()
     return le32toh( getUint<uint32_t>() );
 }
 
-void StreamFile::putBE16( uint16_t val )
+void StreamFile::putBE16( uint16_t v )
 {
-    putUint<uint16_t>( htobe16( val ) );
+    putUint<uint16_t>( htobe16( v ) );
 }
 
-void StreamFile::putLE16( uint16_t val )
+void StreamFile::putLE16( uint16_t v )
 {
-    putUint<uint16_t>( htole16( val ) );
+    putUint<uint16_t>( htole16( v ) );
 }
 
-void StreamFile::putBE32( uint32_t val )
+void StreamFile::putBE32( uint32_t v )
 {
-    putUint<uint32_t>( htobe32( val ) );
+    putUint<uint32_t>( htobe32( v ) );
 }
 
-void StreamFile::putLE32( uint32_t val )
+void StreamFile::putLE32( uint32_t v )
 {
-    putUint<uint32_t>( htole32( val ) );
+    putUint<uint32_t>( htole32( v ) );
 }
 
 std::vector<uint8_t> StreamFile::getRaw( const size_t size )
@@ -609,9 +620,9 @@ std::vector<uint8_t> StreamFile::getRaw( const size_t size )
     return v;
 }
 
-void StreamFile::putRaw( const void * ptr, size_t sz )
+void StreamFile::putRaw( const void * ptr, size_t size )
 {
-    if ( sz == 0 ) {
+    if ( size == 0 ) {
         // Nothing to write. Ignore it.
         return;
     }
@@ -620,7 +631,7 @@ void StreamFile::putRaw( const void * ptr, size_t sz )
         return;
     }
 
-    if ( std::fwrite( ptr, sz, 1, _file.get() ) != 1 ) {
+    if ( std::fwrite( ptr, size, 1, _file.get() ) != 1 ) {
         setFail();
     }
 }

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -459,7 +459,18 @@ size_t StreamFile::size()
 
 size_t StreamFile::tell()
 {
-    return tellg();
+    if ( !_file ) {
+        return 0;
+    }
+
+    const long pos = std::ftell( _file.get() );
+    if ( pos < 0 ) {
+        setFail();
+
+        return 0;
+    }
+
+    return static_cast<size_t>( pos );
 }
 
 void StreamFile::seek( const size_t pos )
@@ -513,32 +524,6 @@ size_t StreamFile::sizeg()
     }
 
     return static_cast<size_t>( len - pos );
-}
-
-size_t StreamFile::tellg()
-{
-    if ( !_file ) {
-        return 0;
-    }
-
-    const long pos = std::ftell( _file.get() );
-    if ( pos < 0 ) {
-        setFail();
-
-        return 0;
-    }
-
-    return static_cast<size_t>( pos );
-}
-
-size_t StreamFile::sizep()
-{
-    return sizeg();
-}
-
-size_t StreamFile::tellp()
-{
-    return tellg();
 }
 
 void StreamFile::skip( size_t size )

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -636,7 +636,7 @@ void StreamFile::putRaw( const void * ptr, size_t size )
     }
 }
 
-RWStreamBuf StreamFile::toStreamBuf( const size_t size /* = 0 */ )
+RWStreamBuf StreamFile::getStreamBuf( const size_t size /* = 0 */ )
 {
     const size_t chunkSize = size > 0 ? size : sizeg();
     if ( chunkSize == 0 || !_file ) {
@@ -656,7 +656,7 @@ RWStreamBuf StreamFile::toStreamBuf( const size_t size /* = 0 */ )
     return buffer;
 }
 
-std::string StreamFile::toString( const size_t size /* = 0 */ )
+std::string StreamFile::getString( const size_t size /* = 0 */ )
 {
     const std::vector<uint8_t> buf = getRaw( size );
 

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -594,7 +594,7 @@ std::vector<uint8_t> StreamFile::getRaw( const size_t size )
         return {};
     }
 
-    std::vector<uint8_t> v( chunkSize );
+    std::vector<uint8_t> v( chunkSize, 0 );
 
     if ( std::fread( v.data(), chunkSize, 1, _file.get() ) != 1 ) {
         setFail();

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -278,9 +278,6 @@ protected:
     IStreamBase & operator=( IStreamBase && stream ) noexcept;
 
     virtual uint8_t get8() = 0;
-
-    virtual size_t sizeg() = 0;
-    virtual size_t tellg() = 0;
 };
 
 // Interface that declares the methods needed to write to a stream
@@ -378,9 +375,6 @@ protected:
     OStreamBase( OStreamBase && ) = default;
 
     virtual void put8( const uint8_t ) = 0;
-
-    virtual size_t sizep() = 0;
-    virtual size_t tellp() = 0;
 };
 
 // Interface that declares a stream with an in-memory storage backend that can be read from
@@ -531,18 +525,18 @@ protected:
         return *this;
     }
 
-    size_t tellg() override
-    {
-        assert( _itbeg <= _itget );
-
-        return _itget - _itbeg;
-    }
-
-    size_t sizeg() override
+    size_t sizeg()
     {
         assert( _itget <= _itput );
 
         return _itput - _itget;
+    }
+
+    size_t tellg()
+    {
+        assert( _itbeg <= _itget );
+
+        return _itget - _itbeg;
     }
 
     uint8_t get8() override
@@ -599,8 +593,8 @@ private:
 
     void put8( const uint8_t v ) override;
 
-    size_t sizep() override;
-    size_t tellp() override;
+    size_t sizep();
+    size_t tellp();
 
     void reallocBuf( size_t size );
 
@@ -674,10 +668,7 @@ public:
     std::string getString( const size_t size = 0 );
 
 private:
-    size_t sizeg() override;
-    size_t sizep() override;
-    size_t tellg() override;
-    size_t tellp() override;
+    size_t sizeg();
 
     uint8_t get8() override;
     void put8( const uint8_t v ) override;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -616,7 +616,7 @@ public:
     ROStreamBuf & operator=( const ROStreamBuf & ) = delete;
 
     // If a zero size is specified, then a view of all still unread data is returned
-    std::pair<const uint8_t *, size_t> getRawView( const size_t size )
+    std::pair<const uint8_t *, size_t> getRawView( const size_t size = 0 )
     {
         const size_t remainSize = sizeg();
         const size_t resultSize = size > 0 ? std::min( size, remainSize ) : remainSize;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -652,7 +652,7 @@ public:
         const uint8_t * strEnd = std::find( strBeg, _itget, 0 );
         assert( strBeg <= strEnd );
 
-        static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
+        static_assert( std::is_same_v<uint8_t, unsigned char> );
 
         return { reinterpret_cast<const char *>( strBeg ), static_cast<size_t>( strEnd - strBeg ) };
     }

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -493,7 +493,7 @@ public:
     // If a zero size is specified, then all still unread data is read, and from this data, a string is
     // formed that ends with the first null character found (or includes all data if no null character
     // was found), and this string is returned
-    std::string toString( const size_t size = 0 )
+    std::string getString( const size_t size = 0 )
     {
         const size_t length = ( size > 0 && size < sizeg() ) ? size : sizeg();
 
@@ -648,7 +648,7 @@ public:
     void close();
 
     // If a zero size is specified, then all still unread data is returned
-    RWStreamBuf toStreamBuf( const size_t size = 0 );
+    RWStreamBuf getStreamBuf( const size_t size = 0 );
 
     void seek( const size_t pos );
     void skip( size_t size ) override;
@@ -671,7 +671,7 @@ public:
     // If a zero size is specified, then all still unread data is read, and from this data, a string is
     // formed that ends with the first null character found (or includes all data if no null character
     // was found), and this string is returned
-    std::string toString( const size_t size = 0 );
+    std::string getString( const size_t size = 0 );
 
 private:
     size_t sizeg() override;

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -430,42 +430,42 @@ public:
 
     uint16_t getBE16() override
     {
-        uint16_t result = ( static_cast<uint16_t>( get8() ) << 8 );
+        uint16_t v = ( static_cast<uint16_t>( get8() ) << 8 );
 
-        result |= get8();
+        v |= get8();
 
-        return result;
+        return v;
     }
 
     uint16_t getLE16() override
     {
-        uint16_t result = get8();
+        uint16_t v = get8();
 
-        result |= ( static_cast<uint16_t>( get8() ) << 8 );
+        v |= ( static_cast<uint16_t>( get8() ) << 8 );
 
-        return result;
+        return v;
     }
 
     uint32_t getBE32() override
     {
-        uint32_t result = ( static_cast<uint32_t>( get8() ) << 24 );
+        uint32_t v = ( static_cast<uint32_t>( get8() ) << 24 );
 
-        result |= ( static_cast<uint32_t>( get8() ) << 16 );
-        result |= ( static_cast<uint32_t>( get8() ) << 8 );
-        result |= get8();
+        v |= ( static_cast<uint32_t>( get8() ) << 16 );
+        v |= ( static_cast<uint32_t>( get8() ) << 8 );
+        v |= get8();
 
-        return result;
+        return v;
     }
 
     uint32_t getLE32() override
     {
-        uint32_t result = get8();
+        uint32_t v = get8();
 
-        result |= ( static_cast<uint32_t>( get8() ) << 8 );
-        result |= ( static_cast<uint32_t>( get8() ) << 16 );
-        result |= ( static_cast<uint32_t>( get8() ) << 24 );
+        v |= ( static_cast<uint32_t>( get8() ) << 8 );
+        v |= ( static_cast<uint32_t>( get8() ) << 16 );
+        v |= ( static_cast<uint32_t>( get8() ) << 24 );
 
-        return result;
+        return v;
     }
 
     // If a zero size is specified, then all still unread data is returned
@@ -475,13 +475,13 @@ public:
         const size_t resultSize = size > 0 ? size : remainSize;
         const size_t sizeToCopy = std::min( resultSize, remainSize );
 
-        std::vector<uint8_t> result( resultSize, 0 );
+        std::vector<uint8_t> v( resultSize, 0 );
 
-        std::copy( _itget, _itget + sizeToCopy, result.data() );
+        std::copy( _itget, _itget + sizeToCopy, v.data() );
 
         _itget += sizeToCopy;
 
-        return result;
+        return v;
     }
 
     // Reads no more than 'size' bytes of data (if a zero size is specified, then all still unread data
@@ -629,11 +629,11 @@ public:
         const size_t remainSize = sizeg();
         const size_t resultSize = size > 0 ? std::min( size, remainSize ) : remainSize;
 
-        auto result = std::make_pair( _itget, resultSize );
+        auto v = std::make_pair( _itget, resultSize );
 
         _itget += resultSize;
 
-        return result;
+        return v;
     }
 
     // Returns a string view of no more than 'size' bytes of data ending with the first null character found in
@@ -750,16 +750,16 @@ namespace fheroes2
         const char * begin = data + base + offset * sizeof( T );
         const char * end = begin + sizeof( T );
 
-        T result;
+        T v;
 
 #if defined( BYTE_ORDER ) && defined( LITTLE_ENDIAN ) && BYTE_ORDER == LITTLE_ENDIAN
-        std::copy( begin, end, reinterpret_cast<char *>( &result ) );
+        std::copy( begin, end, reinterpret_cast<char *>( &v ) );
 #elif defined( BYTE_ORDER ) && defined( BIG_ENDIAN ) && BYTE_ORDER == BIG_ENDIAN
-        std::reverse_copy( begin, end, reinterpret_cast<char *>( &result ) );
+        std::reverse_copy( begin, end, reinterpret_cast<char *>( &v ) );
 #else
 #error "Unknown byte order"
 #endif
 
-        return result;
+        return v;
     }
 }

--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -616,38 +616,14 @@ public:
     ROStreamBuf & operator=( const ROStreamBuf & ) = delete;
 
     // If a zero size is specified, then a view of all still unread data is returned
-    std::pair<const uint8_t *, size_t> getRawView( const size_t size = 0 )
-    {
-        const size_t remainSize = sizeg();
-        const size_t resultSize = size > 0 ? std::min( size, remainSize ) : remainSize;
-
-        auto v = std::make_pair( _itget, resultSize );
-
-        _itget += resultSize;
-
-        return v;
-    }
+    std::pair<const uint8_t *, size_t> getRawView( const size_t size = 0 );
 
     // Returns a string view of no more than 'size' bytes of data ending with the first null character found in
     // this data (or of all the data in the corresponding range if this data does not contain null characters).
     // If a zero size is specified, then the entire unread amount of data is considered. Advances the cursor
     // intended for reading data forward by the full amount of the data used (regardless of the presence of null
     // characters in this data).
-    std::string_view getStringView( const size_t size = 0 )
-    {
-        const size_t remainSize = sizeg();
-        const size_t sizeToSkip = size > 0 ? std::min( size, remainSize ) : remainSize;
-
-        const uint8_t * strBeg = _itget;
-        _itget += sizeToSkip;
-
-        const uint8_t * strEnd = std::find( strBeg, _itget, 0 );
-        assert( strBeg <= strEnd );
-
-        static_assert( std::is_same_v<uint8_t, unsigned char> );
-
-        return { reinterpret_cast<const char *>( strBeg ), static_cast<size_t>( strEnd - strBeg ) };
-    }
+    std::string_view getStringView( const size_t size = 0 );
 
 private:
     // Buffer to which the transfer of ownership of the external buffer takes place. This buffer is not used in

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -83,7 +83,7 @@ bool TinyConfig::Load( const std::string & cfile )
         return false;
     }
 
-    std::vector<std::string> rows = StringSplit( sf.toString(), '\n' );
+    std::vector<std::string> rows = StringSplit( sf.getString(), '\n' );
 
     for ( std::vector<std::string>::const_iterator it = rows.begin(); it != rows.end(); ++it ) {
         std::string str = StringTrim( *it );

--- a/src/engine/tinyconfig.cpp
+++ b/src/engine/tinyconfig.cpp
@@ -83,10 +83,8 @@ bool TinyConfig::Load( const std::string & cfile )
         return false;
     }
 
-    std::vector<std::string> rows = StringSplit( sf.getString(), '\n' );
-
-    for ( std::vector<std::string>::const_iterator it = rows.begin(); it != rows.end(); ++it ) {
-        std::string str = StringTrim( *it );
+    for ( const std::string & line : StringSplit( sf.getString(), '\n' ) ) {
+        std::string str = StringTrim( line );
 
         if ( str.empty() || str[0] == comment ) {
             continue;

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -95,6 +95,8 @@ std::vector<std::string> StringSplit( const std::string_view str, const char sep
     size_t startPos = 0;
 
     for ( size_t sepPos = str.find( sep ); sepPos != std::string::npos; sepPos = str.find( sep, startPos ) ) {
+        assert( startPos < str.size() && sepPos < str.size() );
+
         result.emplace_back( str.begin() + startPos, str.begin() + sepPos );
 
         startPos = sepPos + 1;

--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -90,27 +90,21 @@ void StringReplace( std::string & dst, const char * pred, const std::string_view
 
 std::vector<std::string> StringSplit( const std::string_view str, const char sep )
 {
-    std::vector<std::string> vec;
+    std::vector<std::string> result;
 
-    size_t pos1 = 0;
-    size_t pos2 = 0;
+    size_t startPos = 0;
 
-    while ( pos1 < str.size() ) {
-        pos2 = str.find( sep, pos1 );
-        if ( pos2 == std::string::npos ) {
-            break;
-        }
+    for ( size_t sepPos = str.find( sep ); sepPos != std::string::npos; sepPos = str.find( sep, startPos ) ) {
+        result.emplace_back( str.begin() + startPos, str.begin() + sepPos );
 
-        vec.emplace_back( str.substr( pos1, pos2 - pos1 ) );
-
-        pos1 = pos2 + 1;
+        startPos = sepPos + 1;
     }
 
-    if ( pos1 < str.size() ) {
-        vec.emplace_back( str.substr( pos1, str.size() - pos1 ) );
-    }
+    assert( startPos <= str.size() );
 
-    return vec;
+    result.emplace_back( str.begin() + startPos, str.end() );
+
+    return result;
 }
 
 std::string insertCharToString( const std::string & inputString, const size_t position, const char character )

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -431,7 +431,7 @@ namespace
 
                 sb.seek( origStrOff );
 
-                const std::string origStr = sb.toString( origStrLen );
+                const std::string origStr = sb.getString( origStrLen );
                 if ( sb.fail() ) {
                     ERROR_LOG( "I/O error when parsing " << fileName )
                     return false;
@@ -488,7 +488,7 @@ namespace
 
                 sb.seek( off );
 
-                for ( const std::string & hdr : StringSplit( sb.toString( len ), '\n' ) ) {
+                for ( const std::string & hdr : StringSplit( sb.getString( len ), '\n' ) ) {
                     if ( getCharsetFromHeader( hdr, _encoding ) ) {
                         break;
                     }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -370,6 +370,10 @@ namespace
 
             {
                 const uint32_t magicNumber = sb.getLE32();
+                if ( sb.fail() ) {
+                    ERROR_LOG( "I/O error when parsing " << fileName )
+                    return false;
+                }
 
                 switch ( magicNumber ) {
                 case 0xde120495:
@@ -388,9 +392,17 @@ namespace
                 }
             }
 
-            if ( const uint16_t majorVersion = sb.get16(); majorVersion != 0 ) {
-                ERROR_LOG( "Incorrect major version " << GetHexString( majorVersion, 4 ) << " for " << fileName )
-                return false;
+            {
+                const uint16_t majorVersion = sb.get16();
+                if ( sb.fail() ) {
+                    ERROR_LOG( "I/O error when parsing " << fileName )
+                    return false;
+                }
+
+                if ( majorVersion != 0 ) {
+                    ERROR_LOG( "Incorrect major version " << GetHexString( majorVersion, 4 ) << " for " << fileName )
+                    return false;
+                }
             }
 
             // Skip the minor version
@@ -484,10 +496,20 @@ namespace
 
                 const uint32_t len = sb.get32();
                 const uint32_t off = sb.get32();
+                if ( sb.fail() ) {
+                    ERROR_LOG( "I/O error when parsing " << fileName )
+                    return false;
+                }
 
                 sb.seek( off );
 
-                for ( const std::string & hdr : StringSplit( sb.getStringView( len ), '\n' ) ) {
+                const std::string_view str = sb.getStringView( len );
+                if ( sb.fail() ) {
+                    ERROR_LOG( "I/O error when parsing " << fileName )
+                    return false;
+                }
+
+                for ( const std::string & hdr : StringSplit( str, '\n' ) ) {
                     if ( getCharsetFromHeader( hdr, _encoding ) ) {
                         break;
                     }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -452,14 +452,14 @@ namespace
 
                 static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
 
-                const auto [tranBuf, tranBufLen] = sb.getRawView( tranStrLen );
+                const auto [tranBufPtr, tranBufLen] = sb.getRawView( tranStrLen );
                 if ( sb.fail() ) {
                     ERROR_LOG( "I/O error when parsing " << fileName )
                     return false;
                 }
 
                 if ( const auto [dummy, inserted]
-                     = _translations.try_emplace( crc32b( origStr ), StringSplit( { reinterpret_cast<const char *>( tranBuf ), tranBufLen }, '\0' ) );
+                     = _translations.try_emplace( crc32b( origStr ), StringSplit( { reinterpret_cast<const char *>( tranBufPtr ), tranBufLen }, '\0' ) );
                      !inserted ) {
                     ERROR_LOG( "Hash collision detected for string \"" << origStr << "\"" )
                 }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -349,22 +349,18 @@ namespace
         {
             *this = {};
 
-            std::vector<uint8_t> buf;
-
-            {
-                StreamFile sf;
-                if ( !sf.open( fileName, "rb" ) ) {
-                    return false;
-                }
-
-                buf = sf.getRaw( 0 );
-                if ( sf.fail() ) {
-                    ERROR_LOG( "I/O error when reading " << fileName )
-                    return false;
-                }
+            StreamFile sf;
+            if ( !sf.open( fileName, "rb" ) ) {
+                return false;
             }
 
-            ROStreamBuf sb( buf );
+            ROStreamBuf sb = sf.getStreamBuf();
+            if ( sf.fail() ) {
+                ERROR_LOG( "I/O error when reading " << fileName )
+                return false;
+            }
+
+            sf.close();
 
             {
                 const uint32_t magicNumber = sb.getLE32();

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -35,6 +35,7 @@
 #include <ostream>
 #include <string>
 #include <string_view>
+#include <type_traits>
 #include <unordered_map>
 #include <vector>
 

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -450,13 +450,13 @@ namespace
 
                 sb.seek( tranStrOff );
 
-                static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
-
                 const auto [tranBufPtr, tranBufLen] = sb.getRawView( tranStrLen );
                 if ( sb.fail() ) {
                     ERROR_LOG( "I/O error when parsing " << fileName )
                     return false;
                 }
+
+                static_assert( std::is_same_v<std::remove_const_t<std::remove_reference_t<decltype( *tranBufPtr )>>, unsigned char> );
 
                 if ( const auto [dummy, inserted]
                      = _translations.try_emplace( crc32b( origStr ), StringSplit( { reinterpret_cast<const char *>( tranBufPtr ), tranBufLen }, '\0' ) );

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -150,18 +150,128 @@ namespace
         LOCALE_VI
     };
 
-    struct Chunk
+    LocaleType langToLocale( const std::string_view langName )
     {
-        uint32_t offset;
-        uint32_t length;
+        static const std::unordered_map<std::string_view, LocaleType> langLocale{ // Afrikaans
+                                                                                  { "af", LocaleType::LOCALE_AF },
+                                                                                  { "afrikaans", LocaleType::LOCALE_AF },
+                                                                                  // Arabic
+                                                                                  { "ar", LocaleType::LOCALE_AR },
+                                                                                  { "arabic", LocaleType::LOCALE_AR },
+                                                                                  // Belarusian
+                                                                                  { "be", LocaleType::LOCALE_BE },
+                                                                                  { "belarusian", LocaleType::LOCALE_BE },
+                                                                                  // Bulgarian
+                                                                                  { "bg", LocaleType::LOCALE_BG },
+                                                                                  { "bulgarian", LocaleType::LOCALE_BG },
+                                                                                  // Catalan
+                                                                                  { "ca", LocaleType::LOCALE_CA },
+                                                                                  { "catalan", LocaleType::LOCALE_CA },
+                                                                                  // Czech
+                                                                                  { "cs", LocaleType::LOCALE_CS },
+                                                                                  { "czech", LocaleType::LOCALE_CS },
+                                                                                  // Danish
+                                                                                  { "dk", LocaleType::LOCALE_DK },
+                                                                                  { "danish", LocaleType::LOCALE_DK },
+                                                                                  // German
+                                                                                  { "de", LocaleType::LOCALE_DE },
+                                                                                  { "german", LocaleType::LOCALE_DE },
+                                                                                  // Greek
+                                                                                  { "el", LocaleType::LOCALE_EL },
+                                                                                  { "greek", LocaleType::LOCALE_EL },
+                                                                                  // Spanish
+                                                                                  { "es", LocaleType::LOCALE_ES },
+                                                                                  { "spanish", LocaleType::LOCALE_ES },
+                                                                                  // Estonian
+                                                                                  { "et", LocaleType::LOCALE_ET },
+                                                                                  { "estonian", LocaleType::LOCALE_ET },
+                                                                                  // Basque
+                                                                                  { "eu", LocaleType::LOCALE_EU },
+                                                                                  { "basque", LocaleType::LOCALE_EU },
+                                                                                  // Finnish
+                                                                                  { "fi", LocaleType::LOCALE_FI },
+                                                                                  { "finnish", LocaleType::LOCALE_FI },
+                                                                                  // French
+                                                                                  { "fr", LocaleType::LOCALE_FR },
+                                                                                  { "french", LocaleType::LOCALE_FR },
+                                                                                  // Galician
+                                                                                  { "gl", LocaleType::LOCALE_GL },
+                                                                                  { "galician", LocaleType::LOCALE_GL },
+                                                                                  // Hebrew
+                                                                                  { "he", LocaleType::LOCALE_HE },
+                                                                                  { "hebrew", LocaleType::LOCALE_HE },
+                                                                                  // Croatian
+                                                                                  { "hr", LocaleType::LOCALE_HR },
+                                                                                  { "croatian", LocaleType::LOCALE_HR },
+                                                                                  // Hungarian
+                                                                                  { "hu", LocaleType::LOCALE_HU },
+                                                                                  { "hungarian", LocaleType::LOCALE_HU },
+                                                                                  // Indonesian
+                                                                                  { "id", LocaleType::LOCALE_ID },
+                                                                                  { "indonesian", LocaleType::LOCALE_ID },
+                                                                                  // Italian
+                                                                                  { "it", LocaleType::LOCALE_IT },
+                                                                                  { "italian", LocaleType::LOCALE_IT },
+                                                                                  // Latin
+                                                                                  { "la", LocaleType::LOCALE_LA },
+                                                                                  { "latin", LocaleType::LOCALE_LA },
+                                                                                  // Lithuanian
+                                                                                  { "lt", LocaleType::LOCALE_LT },
+                                                                                  { "lithuanian", LocaleType::LOCALE_LT },
+                                                                                  // Latvian
+                                                                                  { "lv", LocaleType::LOCALE_LV },
+                                                                                  { "latvian", LocaleType::LOCALE_LV },
+                                                                                  // Macedonian
+                                                                                  { "mk", LocaleType::LOCALE_MK },
+                                                                                  { "macedonian", LocaleType::LOCALE_MK },
+                                                                                  // Norwegian
+                                                                                  { "nb", LocaleType::LOCALE_NB },
+                                                                                  { "norwegian", LocaleType::LOCALE_NB },
+                                                                                  // Dutch
+                                                                                  { "nl", LocaleType::LOCALE_NL },
+                                                                                  { "dutch", LocaleType::LOCALE_NL },
+                                                                                  // Polish
+                                                                                  { "pl", LocaleType::LOCALE_PL },
+                                                                                  { "polish", LocaleType::LOCALE_PL },
+                                                                                  // Portuguese
+                                                                                  { "pt", LocaleType::LOCALE_PT },
+                                                                                  { "portuguese", LocaleType::LOCALE_PT },
+                                                                                  // Romanian
+                                                                                  { "ro", LocaleType::LOCALE_RO },
+                                                                                  { "romanian", LocaleType::LOCALE_RO },
+                                                                                  // Russian
+                                                                                  { "ru", LocaleType::LOCALE_RU },
+                                                                                  { "russian", LocaleType::LOCALE_RU },
+                                                                                  // Slovak
+                                                                                  { "sk", LocaleType::LOCALE_SK },
+                                                                                  { "slovak", LocaleType::LOCALE_SK },
+                                                                                  // Slovenian
+                                                                                  { "sl", LocaleType::LOCALE_SL },
+                                                                                  { "slovenian", LocaleType::LOCALE_SL },
+                                                                                  // Serbian
+                                                                                  { "sr", LocaleType::LOCALE_SR },
+                                                                                  { "serbian", LocaleType::LOCALE_SR },
+                                                                                  // Swedish
+                                                                                  { "sv", LocaleType::LOCALE_SV },
+                                                                                  { "swedish", LocaleType::LOCALE_SV },
+                                                                                  // Turkish
+                                                                                  { "tr", LocaleType::LOCALE_TR },
+                                                                                  { "turkish", LocaleType::LOCALE_TR },
+                                                                                  // Ukrainian
+                                                                                  { "uk", LocaleType::LOCALE_UK },
+                                                                                  { "ukrainian", LocaleType::LOCALE_UK },
+                                                                                  // Vietnamese
+                                                                                  { "vi", LocaleType::LOCALE_VI },
+                                                                                  { "vietnamese", LocaleType::LOCALE_VI } };
 
-        Chunk( const uint32_t off, const uint32_t len )
-            : offset( off )
-            , length( len )
-        {
-            // Do nothing.
+        const auto iter = langLocale.find( langName );
+        if ( iter == langLocale.end() ) {
+            assert( 0 );
+            return LocaleType::LOCALE_EN;
         }
-    };
+
+        return iter->second;
+    }
 
     uint32_t crc32b( const char * msg )
     {
@@ -212,303 +322,248 @@ namespace
         return pos ? ++pos : str;
     }
 
-    struct MOFile
+    class MOFile
     {
-        // TODO: plural forms are not in use: Plural-Forms.
-        LocaleType locale{ LocaleType::LOCALE_EN };
-        RWStreamBuf buf;
-        std::unordered_map<uint32_t, Chunk> hashOffsets;
-        std::string encoding;
-        bool isValid{ false };
+    public:
+        MOFile() = default;
 
-        const char * ngettext( const char * str, size_t plural )
+        const char * ngettext( const char * str, const size_t plural ) const
         {
-            const auto iter = std::as_const( hashOffsets ).find( crc32b( str ) );
-            if ( iter == hashOffsets.cend() ) {
+            if ( !_isValid ) {
+                assert( 0 );
+
                 return stripContext( str );
             }
 
-            buf.seek( iter->second.offset );
-            const uint8_t * ptr = buf.data();
-
-            while ( plural > 0 ) {
-                while ( *ptr ) {
-                    ++ptr;
-                }
-
-                --plural;
-                ++ptr;
+            const auto iter = std::as_const( _translations ).find( crc32b( str ) );
+            if ( iter == _translations.cend() ) {
+                return stripContext( str );
             }
 
-            return reinterpret_cast<const char *>( ptr );
+            if ( plural < iter->second.size() ) {
+                return iter->second[plural].data();
+            }
+
+            return stripContext( str );
         }
 
-        bool load( const std::string & fileName )
+        bool load( const std::string_view langName, const std::string & fileName )
         {
-            assert( buf.data() == nullptr && hashOffsets.empty() && encoding.empty() && !isValid );
+            *this = {};
 
-            StreamFile sf;
-            if ( !sf.open( fileName, "rb" ) ) {
-                return false;
+            std::vector<uint8_t> buf;
+
+            {
+                StreamFile sf;
+                if ( !sf.open( fileName, "rb" ) ) {
+                    return false;
+                }
+
+                buf = sf.getRaw( 0 );
+                if ( sf.fail() ) {
+                    ERROR_LOG( "I/O error when reading " << fileName )
+                    return false;
+                }
             }
 
-            const size_t fileSize = sf.size();
-            uint32_t magicNumber = 0;
-            sf >> magicNumber;
+            ROStreamBuf sb( buf );
 
-            if ( magicNumber != 0x950412de ) {
-                ERROR_LOG( "Incorrect magic number " << GetHexString( magicNumber ) << " for " << fileName )
-                return false;
+            {
+                const uint32_t magicNumber = sb.getLE32();
+
+                switch ( magicNumber ) {
+                case 0xde120495:
+                    sb.setBigendian( true );
+
+                    DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Setting big-endian mode for " << fileName )
+                    break;
+                case 0x950412de:
+                    sb.setBigendian( false );
+
+                    DEBUG_LOG( DBG_ENGINE, DBG_TRACE, "Setting little-endian mode for " << fileName )
+                    break;
+                default:
+                    ERROR_LOG( "Incorrect magic number " << GetHexString( magicNumber ) << " for " << fileName )
+                    return false;
+                }
             }
 
-            uint16_t majorVersion;
-            uint16_t minorVersion;
-            sf >> majorVersion >> minorVersion;
-
-            if ( 0 != majorVersion ) {
+            if ( const uint16_t majorVersion = sb.get16(); majorVersion != 0 ) {
                 ERROR_LOG( "Incorrect major version " << GetHexString( majorVersion, 4 ) << " for " << fileName )
                 return false;
             }
 
-            uint32_t originalOffset = 0;
-            uint32_t translationOffset = 0;
-            uint32_t stringCount = 0;
+            // Minor version
+            sb.skip( 2 );
 
-            // TODO: validate these values.
-            uint32_t hashSize = 0;
-            uint32_t hashOffset = 0;
+            const uint32_t stringsCount = sb.get32();
+            if ( stringsCount == 0 ) {
+                ERROR_LOG( "There are no translated strings in " << fileName )
+                return false;
+            }
 
-            sf >> stringCount >> originalOffset >> translationOffset >> hashSize >> hashOffset;
+            const uint32_t originalStringsTableOffset = sb.get32();
+            const uint32_t translationsTableOffset = sb.get32();
+            if ( sb.fail() ) {
+                ERROR_LOG( "I/O error when parsing " << fileName )
+                return false;
+            }
 
-            sf.seek( 0 );
-            buf = sf.toStreamBuf( fileSize );
-            sf.close();
+            // The hash table is optional and may be missing, and even if it is present, the actual hashing algorithm depends on the
+            // specific implementation and is not documented. See https://www.gnu.org/software/gettext/manual/html_node/MO-Files.html
+            // for details.
 
-            // Parse encoding.
-            // TODO: parse plural form information here and use it in the code.
-            if ( stringCount > 0 ) {
-                buf.seek( translationOffset );
-                const uint32_t length2 = buf.get32();
-                const uint32_t offset2 = buf.get32();
+            for ( uint32_t i = 0; i < stringsCount; ++i ) {
+                sb.seek( originalStringsTableOffset + i * 8 );
 
-                buf.seek( offset2 );
-                const std::vector<std::string> headers = StringSplit( buf.toString( length2 ), '\n' );
+                const uint32_t origStrLen = sb.get32();
+                const uint32_t origStrOff = sb.get32();
+                if ( sb.fail() ) {
+                    ERROR_LOG( "I/O error when parsing " << fileName )
+                    return false;
+                }
 
-                for ( const std::string & hdr : headers ) {
-                    if ( getCharsetFromHeader( hdr, encoding ) ) {
+                if ( origStrLen == 0 ) {
+                    // This is an empty original string. Skip it.
+                    continue;
+                }
+
+                sb.seek( origStrOff );
+
+                const std::string origStr = sb.toString( origStrLen );
+                if ( sb.fail() ) {
+                    ERROR_LOG( "I/O error when parsing " << fileName )
+                    return false;
+                }
+
+                sb.seek( translationsTableOffset + i * 8 );
+
+                const uint32_t tranStrLen = sb.get32();
+                const uint32_t tranStrOff = sb.get32();
+                if ( sb.fail() ) {
+                    ERROR_LOG( "I/O error when parsing " << fileName )
+                    return false;
+                }
+
+                if ( tranStrLen == 0 ) {
+                    // This is an empty translation. Skip it.
+                    continue;
+                }
+
+                sb.seek( tranStrOff );
+
+                static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
+
+                const std::vector<uint8_t> tranBuf = sb.getRaw( tranStrLen );
+                if ( sb.fail() ) {
+                    ERROR_LOG( "I/O error when parsing " << fileName )
+                    return false;
+                }
+
+                if ( const auto [dummy, inserted]
+                     = _translations.try_emplace( crc32b( origStr.data() ), StringSplit( { reinterpret_cast<const char *>( tranBuf.data() ), tranBuf.size() }, '\0' ) );
+                     !inserted ) {
+                    ERROR_LOG( "Hash collision detected for string \"" << origStr << "\"" )
+                }
+            }
+
+            if ( _translations.empty() ) {
+                ERROR_LOG( "There are no translated strings in " << fileName )
+                return false;
+            }
+
+            _locale = langToLocale( langName );
+
+            // The empty line in the MO file goes first (since the original lines in it are sorted in increasing lexicographical order),
+            // and its "translation" contains service information such as the encoding used and information about the plural form. See
+            // https://www.gnu.org/software/gettext/manual/html_node/MO-Files.html for details.
+            //
+            // TODO: parse the plural form information and use it in the code.
+            {
+                sb.seek( translationsTableOffset );
+
+                const uint32_t len = sb.get32();
+                const uint32_t off = sb.get32();
+
+                sb.seek( off );
+
+                for ( const std::string & hdr : StringSplit( sb.toString( len ), '\n' ) ) {
+                    if ( getCharsetFromHeader( hdr, _encoding ) ) {
                         break;
                     }
                 }
             }
 
-            uint32_t totalTranslationStrings = stringCount;
-
-            for ( uint32_t index = 0; index < stringCount; ++index ) {
-                buf.seek( originalOffset + index * 8 );
-
-                const uint32_t length1 = buf.get32();
-                if ( length1 == 0 ) {
-                    // This is an empty original text. Skip it.
-                    --totalTranslationStrings;
-                    continue;
-                }
-
-                const uint32_t offset1 = buf.get32();
-                buf.seek( offset1 );
-                const std::string msg1 = buf.toString( length1 );
-
-                const uint32_t crc = crc32b( msg1.data() );
-                buf.seek( translationOffset + index * 8 );
-
-                const uint32_t length2 = buf.get32();
-                if ( length2 == 0 ) {
-                    // This is an empty translation. Skip it.
-                    --totalTranslationStrings;
-                    continue;
-                }
-
-                const uint32_t offset2 = buf.get32();
-
-                if ( const auto [dummy, inserted] = hashOffsets.try_emplace( crc, offset2, length2 ); !inserted ) {
-                    ERROR_LOG( "Clashing hash value for: " << msg1 )
-                }
-            }
-
-            if ( totalTranslationStrings == 0 ) {
-                return false;
-            }
-
-            isValid = true;
+            _isValid = true;
 
             return true;
         }
+
+        LocaleType getLocale() const
+        {
+            return _locale;
+        }
+
+        bool isEncoding( const std::string_view encoding ) const
+        {
+            return ( _encoding == encoding );
+        }
+
+        bool isValid() const
+        {
+            return _isValid;
+        }
+
+    private:
+        LocaleType _locale{ LocaleType::LOCALE_EN };
+        std::unordered_map<uint32_t, std::vector<std::string>> _translations;
+        std::string _encoding;
+        bool _isValid{ false };
     };
 
     MOFile * current = nullptr;
     std::map<std::string, MOFile, std::less<>> cache;
 }
 
-std::pair<bool, bool> Translation::setLanguage( const std::string_view name )
+std::pair<bool, bool> Translation::setLanguage( const std::string_view langName )
 {
-    assert( !name.empty() );
+    assert( !langName.empty() );
 
-    if ( const auto iter = cache.find( name ); iter != cache.end() ) {
+    if ( const auto iter = cache.find( langName ); iter != cache.end() ) {
         MOFile & item = iter->second;
 
-        if ( item.isValid ) {
+        if ( item.isValid() ) {
             current = &item;
         }
 
-        return { true, item.isValid };
+        return { true, item.isValid() };
     }
 
     return { false, false };
 }
 
-bool Translation::setLanguage( const std::string & name, const std::string_view fileName )
+bool Translation::setLanguage( const std::string & langName, const std::string_view fileName )
 {
-    assert( !name.empty() );
+    assert( !langName.empty() );
 
-    const auto [cacheIter, inserted] = cache.try_emplace( name );
+    const auto [cacheIter, inserted] = cache.try_emplace( langName );
     MOFile & item = cacheIter->second;
 
     if ( !inserted ) {
-        if ( item.isValid ) {
+        if ( item.isValid() ) {
             current = &item;
         }
 
-        return item.isValid;
+        return item.isValid();
     }
 
-    if ( fileName.empty() || !item.load( std::string{ fileName } ) ) {
-        assert( !item.isValid );
+    if ( fileName.empty() || !item.load( langName, std::string{ fileName } ) ) {
+        assert( !item.isValid() );
 
         return false;
     }
 
-    item.locale = [&name]() {
-        static const std::unordered_map<std::string_view, LocaleType> langToLocale{ // Afrikaans
-                                                                                    { "af", LocaleType::LOCALE_AF },
-                                                                                    { "afrikaans", LocaleType::LOCALE_AF },
-                                                                                    // Arabic
-                                                                                    { "ar", LocaleType::LOCALE_AR },
-                                                                                    { "arabic", LocaleType::LOCALE_AR },
-                                                                                    // Belarusian
-                                                                                    { "be", LocaleType::LOCALE_BE },
-                                                                                    { "belarusian", LocaleType::LOCALE_BE },
-                                                                                    // Bulgarian
-                                                                                    { "bg", LocaleType::LOCALE_BG },
-                                                                                    { "bulgarian", LocaleType::LOCALE_BG },
-                                                                                    // Catalan
-                                                                                    { "ca", LocaleType::LOCALE_CA },
-                                                                                    { "catalan", LocaleType::LOCALE_CA },
-                                                                                    // Czech
-                                                                                    { "cs", LocaleType::LOCALE_CS },
-                                                                                    { "czech", LocaleType::LOCALE_CS },
-                                                                                    // Danish
-                                                                                    { "dk", LocaleType::LOCALE_DK },
-                                                                                    { "danish", LocaleType::LOCALE_DK },
-                                                                                    // German
-                                                                                    { "de", LocaleType::LOCALE_DE },
-                                                                                    { "german", LocaleType::LOCALE_DE },
-                                                                                    // Greek
-                                                                                    { "el", LocaleType::LOCALE_EL },
-                                                                                    { "greek", LocaleType::LOCALE_EL },
-                                                                                    // Spanish
-                                                                                    { "es", LocaleType::LOCALE_ES },
-                                                                                    { "spanish", LocaleType::LOCALE_ES },
-                                                                                    // Estonian
-                                                                                    { "et", LocaleType::LOCALE_ET },
-                                                                                    { "estonian", LocaleType::LOCALE_ET },
-                                                                                    // Basque
-                                                                                    { "eu", LocaleType::LOCALE_EU },
-                                                                                    { "basque", LocaleType::LOCALE_EU },
-                                                                                    // Finnish
-                                                                                    { "fi", LocaleType::LOCALE_FI },
-                                                                                    { "finnish", LocaleType::LOCALE_FI },
-                                                                                    // French
-                                                                                    { "fr", LocaleType::LOCALE_FR },
-                                                                                    { "french", LocaleType::LOCALE_FR },
-                                                                                    // Galician
-                                                                                    { "gl", LocaleType::LOCALE_GL },
-                                                                                    { "galician", LocaleType::LOCALE_GL },
-                                                                                    // Hebrew
-                                                                                    { "he", LocaleType::LOCALE_HE },
-                                                                                    { "hebrew", LocaleType::LOCALE_HE },
-                                                                                    // Croatian
-                                                                                    { "hr", LocaleType::LOCALE_HR },
-                                                                                    { "croatian", LocaleType::LOCALE_HR },
-                                                                                    // Hungarian
-                                                                                    { "hu", LocaleType::LOCALE_HU },
-                                                                                    { "hungarian", LocaleType::LOCALE_HU },
-                                                                                    // Indonesian
-                                                                                    { "id", LocaleType::LOCALE_ID },
-                                                                                    { "indonesian", LocaleType::LOCALE_ID },
-                                                                                    // Italian
-                                                                                    { "it", LocaleType::LOCALE_IT },
-                                                                                    { "italian", LocaleType::LOCALE_IT },
-                                                                                    // Latin
-                                                                                    { "la", LocaleType::LOCALE_LA },
-                                                                                    { "latin", LocaleType::LOCALE_LA },
-                                                                                    // Lithuanian
-                                                                                    { "lt", LocaleType::LOCALE_LT },
-                                                                                    { "lithuanian", LocaleType::LOCALE_LT },
-                                                                                    // Latvian
-                                                                                    { "lv", LocaleType::LOCALE_LV },
-                                                                                    { "latvian", LocaleType::LOCALE_LV },
-                                                                                    // Macedonian
-                                                                                    { "mk", LocaleType::LOCALE_MK },
-                                                                                    { "macedonian", LocaleType::LOCALE_MK },
-                                                                                    // Norwegian
-                                                                                    { "nb", LocaleType::LOCALE_NB },
-                                                                                    { "norwegian", LocaleType::LOCALE_NB },
-                                                                                    // Dutch
-                                                                                    { "nl", LocaleType::LOCALE_NL },
-                                                                                    { "dutch", LocaleType::LOCALE_NL },
-                                                                                    // Polish
-                                                                                    { "pl", LocaleType::LOCALE_PL },
-                                                                                    { "polish", LocaleType::LOCALE_PL },
-                                                                                    // Portuguese
-                                                                                    { "pt", LocaleType::LOCALE_PT },
-                                                                                    { "portuguese", LocaleType::LOCALE_PT },
-                                                                                    // Romanian
-                                                                                    { "ro", LocaleType::LOCALE_RO },
-                                                                                    { "romanian", LocaleType::LOCALE_RO },
-                                                                                    // Russian
-                                                                                    { "ru", LocaleType::LOCALE_RU },
-                                                                                    { "russian", LocaleType::LOCALE_RU },
-                                                                                    // Slovak
-                                                                                    { "sk", LocaleType::LOCALE_SK },
-                                                                                    { "slovak", LocaleType::LOCALE_SK },
-                                                                                    // Slovenian
-                                                                                    { "sl", LocaleType::LOCALE_SL },
-                                                                                    { "slovenian", LocaleType::LOCALE_SL },
-                                                                                    // Serbian
-                                                                                    { "sr", LocaleType::LOCALE_SR },
-                                                                                    { "serbian", LocaleType::LOCALE_SR },
-                                                                                    // Swedish
-                                                                                    { "sv", LocaleType::LOCALE_SV },
-                                                                                    { "swedish", LocaleType::LOCALE_SV },
-                                                                                    // Turkish
-                                                                                    { "tr", LocaleType::LOCALE_TR },
-                                                                                    { "turkish", LocaleType::LOCALE_TR },
-                                                                                    // Ukrainian
-                                                                                    { "uk", LocaleType::LOCALE_UK },
-                                                                                    { "ukrainian", LocaleType::LOCALE_UK },
-                                                                                    // Vietnamese
-                                                                                    { "vi", LocaleType::LOCALE_VI },
-                                                                                    { "vietnamese", LocaleType::LOCALE_VI } };
-
-        const auto iter = langToLocale.find( name );
-        if ( iter == langToLocale.end() ) {
-            assert( 0 );
-            return LocaleType::LOCALE_EN;
-        }
-
-        return iter->second;
-    }();
-
-    assert( item.isValid );
+    assert( item.isValid() );
 
     current = &item;
 
@@ -533,7 +588,7 @@ const char * Translation::gettext( const char * str )
 const char * Translation::ngettext( const char * str, const char * plural, size_t n )
 {
     if ( current )
-        switch ( current->locale ) {
+        switch ( current->getLocale() ) {
         case LocaleType::LOCALE_AF:
         case LocaleType::LOCALE_BG:
         case LocaleType::LOCALE_DE:
@@ -592,12 +647,12 @@ std::string Translation::StringLower( std::string str )
 {
     if ( current ) {
         // With German, lowercasing strings does more harm than good
-        if ( current->locale == LocaleType::LOCALE_DE ) {
+        if ( current->getLocale() == LocaleType::LOCALE_DE ) {
             return str;
         }
 
         // For CP1250/1251 codepages a custom lowercase LUT is implemented
-        if ( ( current->encoding == "CP1250" ) || ( current->encoding == "CP1251" ) ) {
+        if ( current->isEncoding( "CP1250" ) || current->isEncoding( "CP1251" ) ) {
             std::transform( str.begin(), str.end(), str.begin(), []( const unsigned char c ) { return tolowerLUT[c]; } );
             return str;
         }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -342,7 +342,7 @@ namespace
             }
 
             if ( plural < iter->second.size() ) {
-                return iter->second[plural].data();
+                return iter->second[plural].c_str();
             }
 
             return stripContext( str );
@@ -462,7 +462,7 @@ namespace
                 }
 
                 if ( const auto [dummy, inserted]
-                     = _translations.try_emplace( crc32b( origStr.data() ), StringSplit( { reinterpret_cast<const char *>( tranBuf.data() ), tranBuf.size() }, '\0' ) );
+                     = _translations.try_emplace( crc32b( origStr.c_str() ), StringSplit( { reinterpret_cast<const char *>( tranBuf.data() ), tranBuf.size() }, '\0' ) );
                      !inserted ) {
                     ERROR_LOG( "Hash collision detected for string \"" << origStr << "\"" )
                 }

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -338,11 +338,17 @@ namespace
                 return stripContext( str );
             }
 
-            if ( plural < iter->second.size() ) {
-                return iter->second[plural].c_str();
+            const auto & [dummy, pluralFormTranslations] = *iter;
+            if ( plural >= pluralFormTranslations.size() ) {
+                return stripContext( str );
             }
 
-            return stripContext( str );
+            const std::string & translatedStr = pluralFormTranslations[plural];
+            if ( translatedStr.empty() ) {
+                return stripContext( str );
+            }
+
+            return translatedStr.c_str();
         }
 
         bool load( const std::string_view langName, const std::string & fileName )

--- a/src/engine/translations.h
+++ b/src/engine/translations.h
@@ -35,13 +35,13 @@ namespace Translation
     // set to true if the translation for the given language is already present in the cache (even if this
     // translation is invalid), and the second is set to true if the current language has been successfully
     // set.
-    std::pair<bool, bool> setLanguage( const std::string_view name );
+    std::pair<bool, bool> setLanguage( const std::string_view langName );
 
     // Sets the language with the given name as the current language if the translation for this language is
     // already cached and valid. If this translation is not yet cached, then tries to load it from the given
     // file. If the load fails, then adds this language to the cache as invalid and does nothing else. Returns
     // true if the current language has been successfully set, otherwise returns false.
-    bool setLanguage( const std::string & name, const std::string_view fileName );
+    bool setLanguage( const std::string & langName, const std::string_view fileName );
 
     // Resets the current language to the default language (English).
     void reset();

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -282,8 +282,8 @@ namespace
         // Skip the second byte
         imageStream.get();
 
-        const int32_t width = imageStream.get16();
-        const int32_t height = imageStream.get16();
+        const int32_t width = imageStream.getLE16();
+        const int32_t height = imageStream.getLE16();
 
         if ( static_cast<int32_t>( data.size() ) != 6 + width * height ) {
             // It is an invalid BMP file.

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -711,7 +711,7 @@ void Battle::Arena::TowerAction( const Tower & twr )
     }
 
     using TowerGetTypeUnderlyingType = typename std::underlying_type_t<decltype( twr.GetType() )>;
-    static_assert( std::is_same_v<TowerGetTypeUnderlyingType, uint8_t>, "Type of Tower::GetType() has been changed, check the logic below" );
+    static_assert( std::is_same_v<TowerGetTypeUnderlyingType, uint8_t> );
 
     Command cmd( Command::TOWER, static_cast<TowerGetTypeUnderlyingType>( twr.GetType() ), targetInfo.first->GetUID() );
 

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -344,7 +344,7 @@ void Castle::LoadFromMP2( const std::vector<uint8_t> & data )
 
     const bool isCustomTownNameSet = ( dataStream.get() != 0 );
     if ( isCustomTownNameSet ) {
-        _name = dataStream.toString( 13 );
+        _name = dataStream.getString( 13 );
     }
     else {
         // Skip 13 bytes since the name is not set.

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -560,7 +560,7 @@ void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int
     const bool doesHeroHaveCustomName = ( dataStream.get() != 0 );
     if ( doesHeroHaveCustomName ) {
         // An empty name can be set in the original Editor which is wrong.
-        std::string temp = dataStream.toString( 13 );
+        std::string temp = dataStream.getString( 13 );
         if ( !temp.empty() ) {
             SetModes( CUSTOM );
             name = std::move( temp );

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -253,7 +253,6 @@ namespace
         decompressed >> map.dailyEvents >> map.rumors >> map.standardMetadata >> map.castleMetadata >> map.heroMetadata >> map.sphinxMetadata >> map.signMetadata
             >> map.adventureMapEventMetadata >> map.shrineMetadata;
 
-        static_assert( minimumSupportedVersion <= 2, "Remove the following function call." );
         convertFromV2ToV3( map );
         convertFromV3ToV4( map );
         convertFromV4ToV5( map );

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -168,8 +168,8 @@ void Maps::FileInfo::Reset()
     height = 0;
     difficulty = Difficulty::NORMAL;
 
-    static_assert( std::is_same_v<decltype( races ), std::array<uint8_t, maxNumOfPlayers>>, "Type of races has been changed, check the logic below" );
-    static_assert( std::is_same_v<decltype( unions ), std::array<uint8_t, maxNumOfPlayers>>, "Type of unions has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( races ), std::array<uint8_t, maxNumOfPlayers>> );
+    static_assert( std::is_same_v<decltype( unions ), std::array<uint8_t, maxNumOfPlayers>> );
 
     for ( int i = 0; i < maxNumOfPlayers; ++i ) {
         races[i] = Race::NONE;
@@ -292,7 +292,7 @@ bool Maps::FileInfo::readMP2Map( std::string filePath, const bool isForEditor )
     // Does the game start with a hero in the first castle?
     startWithHeroInFirstCastle = ( 0 == fs.get() );
 
-    static_assert( std::is_same_v<decltype( races ), std::array<uint8_t, maxNumOfPlayers>>, "Type of races has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( races ), std::array<uint8_t, maxNumOfPlayers>> );
 
     // Initial races.
     for ( const int color : colors ) {
@@ -530,7 +530,7 @@ bool Maps::FileInfo::loadResurrectionMap( const Map_Format::BaseMapFormat & map,
 
 void Maps::FileInfo::FillUnions( const int side1Colors, const int side2Colors )
 {
-    static_assert( std::is_same_v<decltype( unions ), std::array<uint8_t, maxNumOfPlayers>>, "Type of unions has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( unions ), std::array<uint8_t, maxNumOfPlayers>> );
 
     using UnionsItemType = decltype( unions )::value_type;
 
@@ -638,8 +638,8 @@ OStreamBase & Maps::operator<<( OStreamBase & stream, const FileInfo & fi )
     // Only the basename of map filename (fi.file) is saved
     stream << System::GetBasename( fi.filename ) << fi.name << fi.description << fi.width << fi.height << fi.difficulty << static_cast<uint8_t>( maxNumOfPlayers );
 
-    static_assert( std::is_same_v<decltype( fi.races ), std::array<uint8_t, maxNumOfPlayers>>, "Type of races has been changed, check the logic below" );
-    static_assert( std::is_same_v<decltype( fi.unions ), std::array<uint8_t, maxNumOfPlayers>>, "Type of unions has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( fi.races ), std::array<uint8_t, maxNumOfPlayers>> );
+    static_assert( std::is_same_v<decltype( fi.unions ), std::array<uint8_t, maxNumOfPlayers>> );
 
     for ( size_t i = 0; i < maxNumOfPlayers; ++i ) {
         stream << fi.races[i] << fi.unions[i];
@@ -658,8 +658,8 @@ IStreamBase & Maps::operator>>( IStreamBase & stream, FileInfo & fi )
     // Only the basename of map filename (fi.file) is loaded
     stream >> fi.filename >> fi.name >> fi.description >> fi.width >> fi.height >> fi.difficulty >> kingdommax;
 
-    static_assert( std::is_same_v<decltype( fi.races ), std::array<uint8_t, maxNumOfPlayers>>, "Type of races has been changed, check the logic below" );
-    static_assert( std::is_same_v<decltype( fi.unions ), std::array<uint8_t, maxNumOfPlayers>>, "Type of unions has been changed, check the logic below" );
+    static_assert( std::is_same_v<decltype( fi.races ), std::array<uint8_t, maxNumOfPlayers>> );
+    static_assert( std::is_same_v<decltype( fi.unions ), std::array<uint8_t, maxNumOfPlayers>> );
 
     using RacesItemType = decltype( fi.races )::value_type;
     using UnionsItemType = decltype( fi.unions )::value_type;

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -340,11 +340,11 @@ bool Maps::FileInfo::readMP2Map( std::string filePath, const bool isForEditor )
 
     // Map name
     fs.seek( 58 );
-    name = fs.toString( mapNameLength );
+    name = fs.getString( mapNameLength );
 
     // Map description
     fs.seek( 118 );
-    description = fs.toString( mapDescriptionLength );
+    description = fs.getString( mapDescriptionLength );
 
     // Alliances of kingdoms
     if ( victoryConditionType == VICTORY_DEFEAT_OTHER_SIDE && !skipUnionSetup ) {

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -246,7 +246,7 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
 
     // Get all possible answers.
     for ( uint32_t i = 0; i < 8; ++i ) {
-        std::string answer = dataStream.getString( 13 );
+        const std::string answer = dataStream.getString( 13 );
 
         if ( answerCount > 0 ) {
             --answerCount;

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -153,7 +153,7 @@ void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & da
         colors |= Color::PURPLE;
     }
 
-    message = dataStream.toString();
+    message = dataStream.getString();
 
     setUIDAndIndex( index );
 
@@ -246,7 +246,7 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
 
     // Get all possible answers.
     for ( uint32_t i = 0; i < 8; ++i ) {
-        std::string answer = dataStream.toString( 13 );
+        std::string answer = dataStream.getString( 13 );
 
         if ( answerCount > 0 ) {
             --answerCount;
@@ -256,7 +256,7 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
         }
     }
 
-    riddle = dataStream.toString();
+    riddle = dataStream.getString();
     if ( riddle.empty() ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Sphinx at tile index " << tileIndex << " does not have questions. Marking it as visited." )
         return;
@@ -298,7 +298,7 @@ void MapSign::LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & 
 
     ROStreamBuf dataStream( data );
     dataStream.skip( 9 );
-    message = dataStream.toString();
+    message = dataStream.getString();
 
     if ( message.empty() ) {
         setDefaultMessage();

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -470,13 +470,13 @@ Heroes * Maps::Tile::getHero() const
 void Maps::Tile::setHero( Heroes * hero )
 {
     if ( hero ) {
-        using HeroIDType = decltype( _occupantHeroId );
-        static_assert( std::is_same_v<HeroIDType, uint8_t>, "Type of heroID has been changed, check the logic below" );
+        using OccupantHeroIdType = decltype( _occupantHeroId );
+        static_assert( std::is_same_v<OccupantHeroIdType, uint8_t> );
 
         hero->setObjectTypeUnderHero( _mainObjectType );
 
-        assert( hero->GetID() >= std::numeric_limits<HeroIDType>::min() && hero->GetID() < std::numeric_limits<HeroIDType>::max() );
-        _occupantHeroId = static_cast<HeroIDType>( hero->GetID() );
+        assert( hero->GetID() >= std::numeric_limits<OccupantHeroIdType>::min() && hero->GetID() < std::numeric_limits<OccupantHeroIdType>::max() );
+        _occupantHeroId = static_cast<OccupantHeroIdType>( hero->GetID() );
 
         setMainObjectType( MP2::OBJ_HERO );
     }
@@ -574,7 +574,7 @@ void Maps::Tile::setBoat( const int direction, const int color )
 #endif // WITH_DEBUG
 
     using BoatOwnerColorType = decltype( _boatOwnerColor );
-    static_assert( std::is_same_v<BoatOwnerColorType, uint8_t>, "Type of _boatOwnerColor has been changed, check the logic below" );
+    static_assert( std::is_same_v<BoatOwnerColorType, uint8_t> );
 
     assert( color >= std::numeric_limits<BoatOwnerColorType>::min() && color <= std::numeric_limits<BoatOwnerColorType>::max() );
 
@@ -677,13 +677,13 @@ int Maps::Tile::getTileIndependentPassability() const
 
 void Maps::Tile::setInitialPassability()
 {
-    using TilePassableType = decltype( _tilePassabilityDirections );
-    static_assert( std::is_same_v<TilePassableType, uint16_t>, "Type of tilePassable has been changed, check the logic below" );
+    using TilePassabilityDirectionsType = decltype( _tilePassabilityDirections );
+    static_assert( std::is_same_v<TilePassabilityDirectionsType, uint16_t> );
 
     const int passability = getTileIndependentPassability();
-    assert( passability >= std::numeric_limits<TilePassableType>::min() && passability <= std::numeric_limits<TilePassableType>::max() );
+    assert( passability >= std::numeric_limits<TilePassabilityDirectionsType>::min() && passability <= std::numeric_limits<TilePassabilityDirectionsType>::max() );
 
-    _tilePassabilityDirections = static_cast<TilePassableType>( passability );
+    _tilePassabilityDirections = static_cast<TilePassabilityDirectionsType>( passability );
 }
 
 void Maps::Tile::updatePassability()

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -134,8 +134,7 @@ namespace
             uidArtifact = tile.getMainObjectPart()._uid;
         }
 
-        static_assert( std::is_same_v<decltype( Maps::Tile::updateTileObjectIcnIndex ), void( Maps::Tile &, uint32_t, uint8_t )>,
-                       "Type of updateTileObjectIcnIndex() has been changed, check the logic below" );
+        static_assert( std::is_same_v<decltype( Maps::Tile::updateTileObjectIcnIndex ), void( Maps::Tile &, uint32_t, uint8_t )> );
 
         // Please refer to ICN::OBJNARTI for artifact images. Since in the original game artifact UID start from 0 we have to deduct 1 from the current artifact ID.
         const uint32_t artSpriteIndex = ( art.GetID() - 1 ) * 2 + 1;
@@ -186,12 +185,12 @@ namespace
 
         tile.setMainObjectType( MP2::OBJ_MONSTER );
 
-        using TileImageIndexType = decltype( tile.getMainObjectPart().icnIndex );
-        static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of icnIndex has been changed, check the logic below" );
+        using IcnIndexType = decltype( tile.getMainObjectPart().icnIndex );
+        static_assert( std::is_same_v<IcnIndexType, uint8_t> );
 
-        assert( mons.GetID() > std::numeric_limits<TileImageIndexType>::min() && mons.GetID() <= std::numeric_limits<TileImageIndexType>::max() );
+        assert( mons.GetID() > std::numeric_limits<IcnIndexType>::min() && mons.GetID() <= std::numeric_limits<IcnIndexType>::max() );
 
-        tile.getMainObjectPart().icnIndex = static_cast<TileImageIndexType>( mons.GetID() - 1 ); // ICN::MONS32 starts from PEASANT
+        tile.getMainObjectPart().icnIndex = static_cast<IcnIndexType>( mons.GetID() - 1 ); // ICN::MONS32 starts from PEASANT
     }
 
     // Returns the direction vector bits from 'centerTileIndex' where the ground is 'groundId'.
@@ -2770,13 +2769,13 @@ namespace Maps
             mainObjectPart.layerType = OBJECT_LAYER;
         }
 
-        using TileImageIndexType = decltype( mainObjectPart.icnIndex );
-        static_assert( std::is_same_v<TileImageIndexType, uint8_t>, "Type of icnIndex has been changed, check the logic below" );
+        using IcnIndexType = decltype( mainObjectPart.icnIndex );
+        static_assert( std::is_same_v<IcnIndexType, uint8_t> );
 
         const uint32_t monsSpriteIndex = mons.GetSpriteIndex();
-        assert( monsSpriteIndex >= std::numeric_limits<TileImageIndexType>::min() && monsSpriteIndex <= std::numeric_limits<TileImageIndexType>::max() );
+        assert( monsSpriteIndex >= std::numeric_limits<IcnIndexType>::min() && monsSpriteIndex <= std::numeric_limits<IcnIndexType>::max() );
 
-        mainObjectPart.icnIndex = static_cast<TileImageIndexType>( monsSpriteIndex );
+        mainObjectPart.icnIndex = static_cast<IcnIndexType>( monsSpriteIndex );
 
         const bool setDefinedCount = ( count > 0 );
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1716,7 +1716,7 @@ void EventDate::LoadFromMP2( const std::vector<uint8_t> & data )
         colors |= Color::PURPLE;
     }
 
-    message = dataStream.toString();
+    message = dataStream.getString();
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, "A timed event which occurs at day " << firstOccurrenceDay << " contains a message: " << message )
 }

--- a/src/tools/82m2wav.cpp
+++ b/src/tools/82m2wav.cpp
@@ -129,7 +129,7 @@ int main( int argc, char ** argv )
             return EXIT_FAILURE;
         }
 
-        static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
+        static_assert( std::is_same_v<uint8_t, unsigned char> );
 
         RWStreamBuf wavHeader( wavHeaderLen );
         wavHeader.putLE32( 0x46464952 ); // RIFF marker ("RIFF")

--- a/src/tools/extractor.cpp
+++ b/src/tools/extractor.cpp
@@ -102,9 +102,9 @@ int main( int argc, char ** argv )
         const size_t inputStreamSize = inputStream.size();
         const uint16_t itemsCount = inputStream.getLE16();
 
-        RWStreamBuf itemsStream = inputStream.getStreamBuf( static_cast<size_t>( itemsCount ) * 4 * 3 /* hash, offset, size */ );
+        ROStreamBuf itemsStream = inputStream.getStreamBuf( static_cast<size_t>( itemsCount ) * 4 * 3 /* hash, offset, size */ );
         inputStream.seek( inputStreamSize - AGGItemNameLen * itemsCount );
-        RWStreamBuf namesStream = inputStream.getStreamBuf( AGGItemNameLen * itemsCount );
+        ROStreamBuf namesStream = inputStream.getStreamBuf( AGGItemNameLen * itemsCount );
 
         std::map<std::string, AGGItemInfo, std::less<>> aggItemsMap;
 

--- a/src/tools/extractor.cpp
+++ b/src/tools/extractor.cpp
@@ -102,14 +102,14 @@ int main( int argc, char ** argv )
         const size_t inputStreamSize = inputStream.size();
         const uint16_t itemsCount = inputStream.getLE16();
 
-        RWStreamBuf itemsStream = inputStream.toStreamBuf( static_cast<size_t>( itemsCount ) * 4 * 3 /* hash, offset, size */ );
+        RWStreamBuf itemsStream = inputStream.getStreamBuf( static_cast<size_t>( itemsCount ) * 4 * 3 /* hash, offset, size */ );
         inputStream.seek( inputStreamSize - AGGItemNameLen * itemsCount );
-        RWStreamBuf namesStream = inputStream.toStreamBuf( AGGItemNameLen * itemsCount );
+        RWStreamBuf namesStream = inputStream.getStreamBuf( AGGItemNameLen * itemsCount );
 
         std::map<std::string, AGGItemInfo, std::less<>> aggItemsMap;
 
         for ( uint16_t i = 0; i < itemsCount; ++i ) {
-            AGGItemInfo & info = aggItemsMap[StringLower( namesStream.toString( AGGItemNameLen ) )];
+            AGGItemInfo & info = aggItemsMap[StringLower( namesStream.getString( AGGItemNameLen ) )];
 
             info.hash = itemsStream.getLE32();
             info.offset = itemsStream.getLE32();

--- a/src/tools/extractor.cpp
+++ b/src/tools/extractor.cpp
@@ -137,7 +137,7 @@ int main( int argc, char ** argv )
 
             inputStream.seek( info.offset );
 
-            static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
+            static_assert( std::is_same_v<uint8_t, unsigned char> );
 
             const std::vector<uint8_t> buf = inputStream.getRaw( info.size );
             if ( buf.size() != info.size ) {

--- a/src/tools/h2dmgr.cpp
+++ b/src/tools/h2dmgr.cpp
@@ -154,7 +154,7 @@ namespace
                     }
                 }
                 else {
-                    static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
+                    static_assert( std::is_same_v<uint8_t, unsigned char> );
 
                     const std::vector<uint8_t> buf = reader.getFile( name );
 
@@ -278,7 +278,7 @@ namespace
                     return EXIT_FAILURE;
                 }
 
-                static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
+                static_assert( std::is_same_v<uint8_t, unsigned char> );
 
                 std::vector<uint8_t> buf( size.value() );
 

--- a/src/tools/xmi2midi.cpp
+++ b/src/tools/xmi2midi.cpp
@@ -90,7 +90,7 @@ int main( int argc, char ** argv )
             return EXIT_FAILURE;
         }
 
-        static_assert( std::is_same_v<uint8_t, unsigned char>, "uint8_t is not the same as char, check the logic below" );
+        static_assert( std::is_same_v<uint8_t, unsigned char> );
 
         std::vector<uint8_t> buf( size.value() );
 


### PR DESCRIPTION
* Added more sanity checks when loading a MO file;
* Store the translated strings themselves instead of just pointers to parts of the buffer. Previously, it was assumed that the strings in the buffer always null-terminated (and that's how it should be according to the MO format specification), but if the MO file is corrupted, then this may not be the case. As a result, this may result in reading beyond the buffer boundaries.
* Added support for both big-endian and little-endian versions of MO files with endianness autodetection;
* Removed the TODO comment regarding the hash table and an explanatory comment was written instead;
* Fixed a suspicious place in `agg_image.cpp` in regard to endianness;
* Added the ability for `ROStreamBuf` to work in two modes: "view mode" (working on top of the external buffer - same as before) and "owning mode" (transferring the ownership of an external buffer to the `ROStreamBuf` through the move operation). `StreamFile::getStreamBuf()` now returns the owning `ROStreamBuf` instead of the `RWStreamBuf`;
* `ROStreamBuf` is now able to create const "views" of data inside itself (no copies -> no dynamic memory allocations):
  * `getRawView()` as a "copyless" alternative to `getRaw()`;
  * `getStringView()` as a "copyless" alternative to `getString()`;
* Removed some obsolete or trivial `static_assert()` messages in various places;
* Fixed the behavior of `StringSplit()` function - in the `master` branch, it produces wrong results in certain cases, e.g. `StringSplit( "", '#' )` produces `{}` (should be `{ "" }`), `StringSplit( "#", '#' )` produces `{ "" }` (should be `{ "", "" }`), etc. The logic of this method is incorrect from the moment the original fheroes2 sources are imported.