### PR TITLE
Android: update the desugar_jdk_libs_nio dependency to 2.1.3

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,7 +82,7 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.1.2'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.1.3'
 
     implementation project(':isotools')
     implementation project(':sdl2')


### PR DESCRIPTION
Here is the changelog:

https://github.com/google/desugar_jdk_libs/blob/master/CHANGELOG.md

In theory, there are no critical changes that can break something.