### PR TITLE
Add Belarusian language support for Virtual Keyboard

### DIFF
--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1415,6 +1415,10 @@ namespace
 
             size_t offset = 0;
 
+            // ' (right single quotation mark)
+            font[146 - 32] = font[44 - 32];
+            font[146 - 32].setPosition( font[146 - 32].x(), font[146 - 32].y() - 6 );
+
             // E with 2 dots on top.
             font[168 - 32].resize( font[37 + offset].width(), font[37 + offset].height() + 3 );
             font[168 - 32].reset();
@@ -1891,6 +1895,10 @@ namespace
             std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::SMALFONT];
 
             size_t offset = 0;
+
+            // ' (right single quotation mark)
+            font[146 - 32] = font[44 - 32];
+            font[146 - 32].setPosition( font[146 - 32].x(), font[146 - 32].y() - 4 );
 
             // E with 2 dots on top.
             font[168 - 32].resize( font[37].width(), font[37].height() + 2 );
@@ -5269,7 +5277,7 @@ namespace
         fheroes2::SetPixel( released[109], offset + 7, offset + 11, buttonGoodReleasedColor );
         fheroes2::DrawLine( released[109], { offset + 5, offset + 1 }, { offset + 6, offset + 0 }, buttonGoodReleasedColor );
 
-        // '
+        // ' (right single quotation mark)
         released[114].resize( 3 + offset * 2, 4 + offset * 2 );
         released[114].reset();
         fheroes2::DrawLine( released[114], { offset + 1, offset + 0 }, { offset + 1, offset + 2 }, buttonGoodReleasedColor );

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -72,6 +72,7 @@ namespace
         case fheroes2::SupportedLanguage::English:
             // English is a default language so it is not considered as an extra language.
             return false;
+        case fheroes2::SupportedLanguage::Belarusian:
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
@@ -285,6 +286,7 @@ namespace
     {
         // Numeric layout can be used for special letters as well.
         switch ( language ) {
+        case fheroes2::SupportedLanguage::Belarusian:
         case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::Polish:
@@ -304,6 +306,8 @@ namespace
     std::vector<std::string> getCapitalCharacterLayout( const fheroes2::SupportedLanguage language )
     {
         switch ( language ) {
+        case fheroes2::SupportedLanguage::Belarusian:
+            return { "\xC9\xD6\xD3\xCA\xC5\xCD\xC3\xD8\xA1\xC7\xD5\x92", "\xD4\xDB\xC2\xC0\xCF\xD0\xCE\xCB\xC4\xC6\xDD", "\xDF\xD7\xD1\xCC\xB2\xD2\xDC\xC1\xDE\xA8" };
         case fheroes2::SupportedLanguage::Czech:
             return { "\xCC\x8A\xC8\xD8\x8E\xDD\xC1\xCD\xC9", "QWERTZUIOP\xDA", "ASDFGHJKL\xD9", "YXCVBNM" };
         case fheroes2::SupportedLanguage::English:
@@ -328,6 +332,8 @@ namespace
     std::vector<std::string> getNonCapitalCharacterLayout( const fheroes2::SupportedLanguage language )
     {
         switch ( language ) {
+        case fheroes2::SupportedLanguage::Belarusian:
+            return { "\xE9\xF6\xF3\xEA\xE5\xED\xE3\xF8\xA2\xE7\xF5\x92", "\xF4\xFB\xE2\xE0\xEF\xF0\xEE\xEB\xE4\xE6\xFD", "\xFF\xF7\xF1\xEC\xB3\xF2\xFC\xE1\xFE\xB8" };
         case fheroes2::SupportedLanguage::Czech:
             return { "\xEC\x9A\xE8\xF8\xBE\xFD\xE1\xED\xE9", "qwertzuiop\xFA", "asdfghjkl\xF9", "yxcvbnm" };
         case fheroes2::SupportedLanguage::English:
@@ -381,6 +387,7 @@ namespace
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::Polish:
             return 30;
+        case fheroes2::SupportedLanguage::Belarusian:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
@@ -502,6 +509,7 @@ namespace
                           const bool isEvilInterface, const bool isExtraLanguageSupported )
     {
         switch ( language ) {
+        case fheroes2::SupportedLanguage::Belarusian:
         case fheroes2::SupportedLanguage::Czech:
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::Polish:


### PR DESCRIPTION
Add missing right single quotation mark letter generation.

It was easy to do since Russian and Ukrainian languages share the same letters and code page.

relates to #8826

![image](https://github.com/user-attachments/assets/e3b5c0a6-f69c-48cd-8d55-d0f47e67d07c)
