### PR TITLE
Update PS Vita touchpad ID after it has changed in SDL2 v2.30.7

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1034,11 +1034,23 @@ namespace EventProcessing
         static void onTouchEvent( LocalEvent & eventHandler, const SDL_TouchFingerEvent & event )
         {
 #if defined( TARGET_PS_VITA )
-            // PS Vita has two touchpads: front (ID = 1 since SDL 2.30.7) and rear (ID = 2 since SDL 2.30.7).
-            // The IDs should correspond the 'SDL_TouchID' set in 'SDL_AddTouch() ' in VITA_InitTouch()' in SDL2 source: video/vita/SDL_vitatouch.c.
-            if ( event.touchId != 1 ) {
+            {
+                // PS Vita has two touchpads: front and rear. The ID of the front touchpad must match the value of
+                // 'SDL_TouchID' used in the 'SDL_AddTouch()' call in the 'VITA_InitTouch()' function in this SDL2
+                // source file: video/vita/SDL_vitatouch.c.
+                constexpr SDL_TouchID frontTouchpadDeviceID
+                {
+#if SDL_VERSION_ATLEAST( 2, 30, 7 )
+                    1
+#else
+                    0
+#endif
+                };
+
                 // Use only front touchpad on PS Vita.
-                return;
+                if ( event.touchId != frontTouchpadDeviceID ) {
+                    return;
+                }
             }
 #endif
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1034,8 +1034,10 @@ namespace EventProcessing
         static void onTouchEvent( LocalEvent & eventHandler, const SDL_TouchFingerEvent & event )
         {
 #if defined( TARGET_PS_VITA )
-            if ( event.touchId != 0 ) {
-                // Ignore rear touchpad on PS Vita
+            // PS Vita has two touchpads: front (ID = 1 since SDL 2.30.7) and rear (ID = 2 since SDL 2.30.7).
+            // The IDs should correspond the 'SDL_TouchID' set in 'SDL_AddTouch() ' in VITA_InitTouch()' in SDL2 source: video/vita/SDL_vitatouch.c.
+            if ( event.touchId != 1 ) {
+                // Use only front touchpad on PS Vita.
                 return;
             }
 #endif


### PR DESCRIPTION
fix #9305

In SDL2 v.2.30.7 the touchpads IDs for PS Vita have been changed: https://github.com/libsdl-org/SDL/pull/10537
Unfortunately, the change was done not in all the code and the front touch do not work in the current release version of SDL2 yet. :(
But a fix has already been made for the future version of SDL2: https://github.com/libsdl-org/SDL/pull/11442

It's good that the VitaSDK developers forced the specified fix: https://github.com/vitasdk/packages/pull/324
and everything should work fine after we update the ID for touchpad.