### PR TITLE
Speed up getting a list of files on PS Vita

### DIFF
--- a/Makefile.vita
+++ b/Makefile.vita
@@ -29,6 +29,7 @@ MAKE := make
 
 PROJECT_TITLE := fheroes2
 PROJECT_TITLEID := FHOMM0002
+PROJECT_VERSION := $(file < version.txt)
 
 .PHONY: all clean $(TARGET).vpk param.sfo $(TARGET).elf translations
 
@@ -56,7 +57,7 @@ eboot.bin: $(TARGET).velf
 	vita-make-fself $(TARGET).velf eboot.bin
 
 param.sfo:
-	vita-mksfoex -s TITLE_ID="$(PROJECT_TITLEID)" "$(PROJECT_TITLE)" param.sfo
+	vita-mksfoex -s TITLE_ID="$(PROJECT_TITLEID)" -s APP_VER="$(PROJECT_VERSION)" "$(PROJECT_TITLE)" param.sfo
 
 $(TARGET).velf: $(TARGET).elf
 	arm-vita-eabi-strip -g $<

--- a/Makefile.vita
+++ b/Makefile.vita
@@ -1,6 +1,6 @@
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2021 - 2023                                             #
+#   Copyright (C) 2021 - 2024                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #

--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -174,7 +174,7 @@ void ListFiles::FindFileInDir( const std::string_view path, const std::string_vi
         return;
     }
 
-    // In case the file system is case insensitive, we additionally check the file for existence.
+    // In case the file system is case-insensitive, we additionally check the file for existence.
     if ( !System::IsFile( correctedFilePath ) ) {
         return;
     }

--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -179,7 +179,7 @@ void ListFiles::FindFileInDir( const std::string_view path, const std::string_vi
         return;
     }
 
-    emplace_back( correctedFilePath );
+    emplace_back( std::move( correctedFilePath ) );
 }
 
 bool ListFiles::IsEmpty( const std::string & path, const std::string & filter )

--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -164,9 +164,22 @@ void ListFiles::ReadDir( const std::string & path, const std::string & filter )
     getFilesFromDirectory( path, filter, false, *this );
 }
 
-void ListFiles::FindFileInDir( const std::string & path, const std::string & fileName )
+void ListFiles::FindFileInDir( const std::string_view path, const std::string_view fileName )
 {
-    getFilesFromDirectory( path, fileName, true, *this );
+    std::string correctedFilePath;
+    // If the file system is case-sensitive, then here we will get the actual file path using the case-insensitive
+    // search (if such a file exists). If the file system is case-insensitive, we will just get the passed path to
+    // the file back intact.
+    if ( !System::GetCaseInsensitivePath( System::concatPath( path, fileName ), correctedFilePath ) ) {
+        return;
+    }
+
+    // In case the file system is case insensitive, we additionally check the file for existence.
+    if ( !System::IsFile( correctedFilePath ) ) {
+        return;
+    }
+
+    emplace_back( correctedFilePath );
 }
 
 bool ListFiles::IsEmpty( const std::string & path, const std::string & filter )

--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -92,7 +92,7 @@ namespace
                 continue;
             }
 
-            files.emplace_back( System::concatPath( path, entry.d_name ); );
+            files.emplace_back( System::concatPath( path, entry.d_name ) );
         }
 
         sceIoDclose( uid );

--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -62,7 +62,7 @@ namespace
         return ( strCmp( filenamePtr, filter.c_str() ) == 0 );
     }
 
-    void getFilesFromDirectory( const std::string_view path, const std::string & filter, const bool needExactMatch, ListFiles & files )
+    void getFilesFromDirectory( const std::string & path, const std::string & filter, const bool needExactMatch, ListFiles & files )
     {
         std::string correctedPath;
         if ( !System::GetCaseInsensitivePath( path, correctedPath ) ) {
@@ -125,17 +125,17 @@ void ListFiles::Append( ListFiles && files )
     }
 }
 
-void ListFiles::ReadDir( const std::string_view path, const std::string & filter )
+void ListFiles::ReadDir( const std::string & path, const std::string & filter )
 {
     getFilesFromDirectory( path, filter, false, *this );
 }
 
-void ListFiles::FindFileInDir( const std::string_view path, const std::string & fileName )
+void ListFiles::FindFileInDir( const std::string & path, const std::string & fileName )
 {
     getFilesFromDirectory( path, fileName, true, *this );
 }
 
-bool ListFiles::IsEmpty( const std::string_view path, const std::string & filter )
+bool ListFiles::IsEmpty( const std::string & path, const std::string & filter )
 {
     ListFiles list;
     list.ReadDir( path, filter );

--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -119,6 +119,7 @@ namespace
         SceIoDirent entry;
 
         while ( sceIoDread( uid.get(), &entry ) > 0 ) {
+            // Ensure that this directory entry is a regular file
             if ( !SCE_S_ISREG( entry.d_stat.st_mode ) ) {
                 continue;
             }

--- a/src/engine/dir.cpp
+++ b/src/engine/dir.cpp
@@ -76,16 +76,17 @@ namespace
 #endif
 
 #if defined( TARGET_PS_VITA )
-        class SceUIDManager
+        // On PS Vita, getting a list of files using std::filesystem for some reason works much slower than using the native file system API
+        class SceUIDWrapper
         {
         public:
-            SceUIDManager( const std::string & path )
+            SceUIDWrapper( const std::string & path )
                 : uid( sceIoDopen( path.c_str() ) )
             {}
 
-            SceUIDManager( const SceUIDManager & ) = delete;
+            SceUIDWrapper( const SceUIDWrapper & ) = delete;
 
-            ~SceUIDManager()
+            ~SceUIDWrapper()
             {
                 if ( !isValid() ) {
                     return;
@@ -94,14 +95,14 @@ namespace
                 sceIoDclose( uid );
             }
 
-            SceUIDManager & operator=( const SceUIDManager & ) = delete;
+            SceUIDWrapper & operator=( const SceUIDWrapper & ) = delete;
 
             bool isValid() const
             {
                 return uid >= 0;
             }
 
-            SceUID getUID() const
+            SceUID get() const
             {
                 return uid;
             }
@@ -110,14 +111,14 @@ namespace
             const SceUID uid;
         };
 
-        const SceUIDManager uidManager( path );
-        if ( !uidManager.isValid() ) {
+        const SceUIDWrapper uid( path );
+        if ( !uid.isValid() ) {
             return;
         }
 
         SceIoDirent entry;
 
-        while ( sceIoDread( uidManager.getUID(), &entry ) > 0 ) {
+        while ( sceIoDread( uid.get(), &entry ) > 0 ) {
             if ( !SCE_S_ISREG( entry.d_stat.st_mode ) ) {
                 continue;
             }

--- a/src/engine/dir.h
+++ b/src/engine/dir.h
@@ -25,20 +25,19 @@
 
 #include <list>
 #include <string>
-#include <string_view>
 
 struct ListFiles : public std::list<std::string>
 {
     void Append( ListFiles && files );
 
     // Adds files from the 'path' directory ending in 'filter' to the list, case-insensitive.
-    void ReadDir( const std::string_view path, const std::string & filter );
+    void ReadDir( const std::string & path, const std::string & filter );
 
     // Adds files from the 'path' directory with names matching 'fileName' to the list, case-insensitive.
-    void FindFileInDir( const std::string_view path, const std::string & fileName );
+    void FindFileInDir( const std::string & path, const std::string & fileName );
 
     // Returns true if there are no files in the 'path' directory with names ending in 'filter', case-insensitive, otherwise returns false.
-    static bool IsEmpty( const std::string_view path, const std::string & filter );
+    static bool IsEmpty( const std::string & path, const std::string & filter );
 };
 
 #endif

--- a/src/engine/dir.h
+++ b/src/engine/dir.h
@@ -25,6 +25,7 @@
 
 #include <list>
 #include <string>
+#include <string_view>
 
 struct ListFiles : public std::list<std::string>
 {
@@ -33,8 +34,8 @@ struct ListFiles : public std::list<std::string>
     // Adds files from the 'path' directory ending in 'filter' to the list, case-insensitive.
     void ReadDir( const std::string & path, const std::string & filter );
 
-    // Adds files from the 'path' directory with names matching 'fileName' to the list, case-insensitive.
-    void FindFileInDir( const std::string & path, const std::string & fileName );
+    // Adds the first found file from the 'path' directory with a name matching 'fileName' to the list, case-insensitive.
+    void FindFileInDir( const std::string_view path, const std::string_view fileName );
 
     // Returns true if there are no files in the 'path' directory with names ending in 'filter', case-insensitive, otherwise returns false.
     static bool IsEmpty( const std::string & path, const std::string & filter );

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -42,7 +42,7 @@
 #include <algorithm>
 #endif
 
-#if !defined( _WIN32 ) && !defined( ANDROID )
+#if !defined( _WIN32 ) && !defined( ANDROID ) && !defined( TARGET_PS_VITA )
 #include <dirent.h>
 #include <strings.h>
 #endif
@@ -447,7 +447,7 @@ bool System::IsDirectory( const std::string_view path )
 
 bool System::GetCaseInsensitivePath( const std::string_view path, std::string & correctedPath )
 {
-#if !defined( _WIN32 ) && !defined( ANDROID )
+#if !defined( _WIN32 ) && !defined( ANDROID ) && !defined( TARGET_PS_VITA )
     // The following code is based on https://github.com/OneSadCookie/fcaseopen and assumes the use of POSIX IEEE Std 1003.1-2001 pathnames
     correctedPath.clear();
 

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -40,8 +40,6 @@
 #include <windows.h>
 #elif defined( TARGET_PS_VITA )
 #include <algorithm>
-
-#include <psp2/io/stat.h>
 #endif
 
 #if !defined( _WIN32 ) && !defined( ANDROID ) && !defined( TARGET_PS_VITA )
@@ -411,7 +409,7 @@ std::string System::GetStem( const std::string_view path )
     return fsPathToString( std::filesystem::path{ path }.stem() );
 }
 
-bool System::IsFile( const std::string & path )
+bool System::IsFile( const std::string_view path )
 {
     if ( path.empty() ) {
         // An empty path cannot be a file.
@@ -423,23 +421,13 @@ bool System::IsFile( const std::string & path )
         return false;
     }
 
-#if defined( TARGET_PS_VITA )
-    SceIoStat stat;
-
-    if ( sceIoGetstat( path.c_str(), &stat ) < 0 ) {
-        return false;
-    }
-
-    return ( SCE_S_ISREG( stat.st_mode ) );
-#else
     std::error_code ec;
 
     // Using the non-throwing overload
     return std::filesystem::is_regular_file( correctedPath, ec );
-#endif
 }
 
-bool System::IsDirectory( const std::string & path )
+bool System::IsDirectory( const std::string_view path )
 {
     if ( path.empty() ) {
         // An empty path cannot be a directory.
@@ -451,20 +439,10 @@ bool System::IsDirectory( const std::string & path )
         return false;
     }
 
-#if defined( TARGET_PS_VITA )
-    SceIoStat stat;
-
-    if ( sceIoGetstat( path.c_str(), &stat ) < 0 ) {
-        return false;
-    }
-
-    return ( SCE_S_ISDIR( stat.st_mode ) );
-#else
     std::error_code ec;
 
     // Using the non-throwing overload
     return std::filesystem::is_directory( correctedPath, ec );
-#endif
 }
 
 bool System::GetCaseInsensitivePath( const std::string_view path, std::string & correctedPath )

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -40,6 +40,8 @@
 #include <windows.h>
 #elif defined( TARGET_PS_VITA )
 #include <algorithm>
+
+#include <psp2/io/stat.h>
 #endif
 
 #if !defined( _WIN32 ) && !defined( ANDROID ) && !defined( TARGET_PS_VITA )
@@ -409,7 +411,7 @@ std::string System::GetStem( const std::string_view path )
     return fsPathToString( std::filesystem::path{ path }.stem() );
 }
 
-bool System::IsFile( const std::string_view path )
+bool System::IsFile( const std::string & path )
 {
     if ( path.empty() ) {
         // An empty path cannot be a file.
@@ -421,13 +423,23 @@ bool System::IsFile( const std::string_view path )
         return false;
     }
 
+#if defined( TARGET_PS_VITA )
+    SceIoStat stat;
+
+    if ( sceIoGetstat( path.c_str(), &stat ) < 0 ) {
+        return false;
+    }
+
+    return ( SCE_S_ISREG( stat.st_mode ) );
+#else
     std::error_code ec;
 
     // Using the non-throwing overload
     return std::filesystem::is_regular_file( correctedPath, ec );
+#endif
 }
 
-bool System::IsDirectory( const std::string_view path )
+bool System::IsDirectory( const std::string & path )
 {
     if ( path.empty() ) {
         // An empty path cannot be a directory.
@@ -439,10 +451,20 @@ bool System::IsDirectory( const std::string_view path )
         return false;
     }
 
+#if defined( TARGET_PS_VITA )
+    SceIoStat stat;
+
+    if ( sceIoGetstat( path.c_str(), &stat ) < 0 ) {
+        return false;
+    }
+
+    return ( SCE_S_ISDIR( stat.st_mode ) );
+#else
     std::error_code ec;
 
     // Using the non-throwing overload
     return std::filesystem::is_directory( correctedPath, ec );
+#endif
 }
 
 bool System::GetCaseInsensitivePath( const std::string_view path, std::string & correctedPath )

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -59,8 +59,8 @@ namespace System
     std::string GetFileName( std::string_view path );
     std::string GetStem( const std::string_view path );
 
-    bool IsFile( const std::string & path );
-    bool IsDirectory( const std::string & path );
+    bool IsFile( const std::string_view path );
+    bool IsDirectory( const std::string_view path );
 
     bool GetCaseInsensitivePath( const std::string_view path, std::string & correctedPath );
 

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -59,8 +59,8 @@ namespace System
     std::string GetFileName( std::string_view path );
     std::string GetStem( const std::string_view path );
 
-    bool IsFile( const std::string_view path );
-    bool IsDirectory( const std::string_view path );
+    bool IsFile( const std::string & path );
+    bool IsDirectory( const std::string & path );
 
     bool GetCaseInsensitivePath( const std::string_view path, std::string & correctedPath );
 


### PR DESCRIPTION
fix #9309

* Don't try to find the actual case-sensitive path using its case-insensitive variant;
* Use the native filesystem API to get the list of files in a directory instead of `std::filesystem::directory_iterator`;
* Place the fheroes2 version info into the `param.sfo`;
* Optimize the `ListFiles::FindFileInDir()`.