### PR TITLE
Move the Battle::Unit::isUnderSpellEffect() with the AI-only logic to the AI code

### DIFF
--- a/src/fheroes2/ai/ai_battle_spell.cpp
+++ b/src/fheroes2/ai/ai_battle_spell.cpp
@@ -55,6 +55,66 @@ namespace
 
         return result;
     }
+
+    bool isUnitUnderSpellEffect( const Battle::Unit & unit, const Spell & spell )
+    {
+        switch ( spell.GetID() ) {
+        case Spell::BLESS:
+        case Spell::MASSBLESS:
+            return unit.Modes( Battle::SP_BLESS );
+
+        case Spell::BLOODLUST:
+            return unit.Modes( Battle::SP_BLOODLUST );
+
+        case Spell::CURSE:
+        case Spell::MASSCURSE:
+            return unit.Modes( Battle::SP_CURSE );
+
+        case Spell::HASTE:
+        case Spell::MASSHASTE:
+            return unit.Modes( Battle::SP_HASTE );
+
+        case Spell::SHIELD:
+        case Spell::MASSSHIELD:
+            return unit.Modes( Battle::SP_SHIELD );
+
+        case Spell::SLOW:
+        case Spell::MASSSLOW:
+            return unit.Modes( Battle::SP_SLOW );
+
+        case Spell::STONESKIN:
+        case Spell::STEELSKIN:
+            return unit.Modes( Battle::SP_STONESKIN | Battle::SP_STEELSKIN );
+
+        case Spell::BLIND:
+        case Spell::PARALYZE:
+        case Spell::PETRIFY:
+            return unit.Modes( Battle::SP_BLIND | Battle::SP_PARALYZE | Battle::SP_STONE );
+
+        case Spell::DRAGONSLAYER:
+            return unit.Modes( Battle::SP_DRAGONSLAYER );
+
+        case Spell::ANTIMAGIC:
+            return unit.Modes( Battle::SP_ANTIMAGIC );
+
+        case Spell::BERSERKER:
+            return unit.Modes( Battle::SP_BERSERKER );
+
+        case Spell::HYPNOTIZE:
+            return unit.Modes( Battle::SP_HYPNOTIZE );
+
+        case Spell::MIRRORIMAGE:
+            return unit.Modes( Battle::CAP_MIRROROWNER );
+
+        case Spell::DISRUPTINGRAY:
+            return unit.GetDefense() < spell.ExtraValue();
+
+        default:
+            break;
+        }
+
+        return false;
+    }
 }
 
 AI::SpellSelection AI::BattlePlanner::selectBestSpell( Battle::Arena & arena, const Battle::Unit & currentUnit, bool retreating ) const
@@ -330,7 +390,7 @@ double AI::BattlePlanner::spellEffectValue( const Spell & spell, const Battle::U
 
     // Make sure this spell can be applied to the current unit (skip check for dispel estimation)
     if ( !forDispel
-         && ( ( target.isImmovable() && spellID != Spell::ANTIMAGIC ) || target.isUnderSpellEffect( spell ) || !target.AllowApplySpell( spell, _commander ) ) ) {
+         && ( ( target.isImmovable() && spellID != Spell::ANTIMAGIC ) || isUnitUnderSpellEffect( target, spell ) || !target.AllowApplySpell( spell, _commander ) ) ) {
         return 0.0;
     }
 

--- a/src/fheroes2/ai/ai_battle_spell.cpp
+++ b/src/fheroes2/ai/ai_battle_spell.cpp
@@ -58,6 +58,10 @@ namespace
 
     bool isSpellcastUselessForUnit( const Battle::Unit & unit, const Spell & spell )
     {
+        if ( unit.isImmovable() && spell.GetID() != Spell::ANTIMAGIC ) {
+            return true;
+        }
+
         switch ( spell.GetID() ) {
         case Spell::BLESS:
         case Spell::MASSBLESS:
@@ -388,9 +392,8 @@ double AI::BattlePlanner::spellEffectValue( const Spell & spell, const Battle::U
 {
     const int spellID = spell.GetID();
 
-    // Make sure this spell can be applied to the current unit (skip check for dispel estimation)
-    if ( !forDispel
-         && ( ( target.isImmovable() && spellID != Spell::ANTIMAGIC ) || isSpellcastUselessForUnit( target, spell ) || !target.AllowApplySpell( spell, _commander ) ) ) {
+    // Make sure that this spell makes sense to apply (skip this check to evaluate the effect of dispelling)
+    if ( !forDispel && ( isSpellcastUselessForUnit( target, spell ) || !target.AllowApplySpell( spell, _commander ) ) ) {
         return 0.0;
     }
 

--- a/src/fheroes2/ai/ai_battle_spell.cpp
+++ b/src/fheroes2/ai/ai_battle_spell.cpp
@@ -58,11 +58,13 @@ namespace
 
     bool isSpellcastUselessForUnit( const Battle::Unit & unit, const Spell & spell )
     {
-        if ( unit.isImmovable() && spell.GetID() != Spell::ANTIMAGIC ) {
+        const int spellID = spell.GetID();
+
+        if ( unit.isImmovable() && spellID != Spell::ANTIMAGIC ) {
             return true;
         }
 
-        switch ( spell.GetID() ) {
+        switch ( spellID ) {
         case Spell::BLESS:
         case Spell::MASSBLESS:
             return unit.Modes( Battle::SP_BLESS );

--- a/src/fheroes2/ai/ai_battle_spell.cpp
+++ b/src/fheroes2/ai/ai_battle_spell.cpp
@@ -56,7 +56,7 @@ namespace
         return result;
     }
 
-    bool isUnitUnderSpellEffect( const Battle::Unit & unit, const Spell & spell )
+    bool isSpellcastUselessForUnit( const Battle::Unit & unit, const Spell & spell )
     {
         switch ( spell.GetID() ) {
         case Spell::BLESS:
@@ -390,7 +390,7 @@ double AI::BattlePlanner::spellEffectValue( const Spell & spell, const Battle::U
 
     // Make sure this spell can be applied to the current unit (skip check for dispel estimation)
     if ( !forDispel
-         && ( ( target.isImmovable() && spellID != Spell::ANTIMAGIC ) || isUnitUnderSpellEffect( target, spell ) || !target.AllowApplySpell( spell, _commander ) ) ) {
+         && ( ( target.isImmovable() && spellID != Spell::ANTIMAGIC ) || isSpellcastUselessForUnit( target, spell ) || !target.AllowApplySpell( spell, _commander ) ) ) {
         return 0.0;
     }
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -831,65 +831,6 @@ bool Battle::Unit::AllowApplySpell( const Spell & spell, const HeroBase * applyi
     return ( GetMagicResist( spell, applyingHero ) < 100 );
 }
 
-bool Battle::Unit::isUnderSpellEffect( const Spell & spell ) const
-{
-    switch ( spell.GetID() ) {
-    case Spell::BLESS:
-    case Spell::MASSBLESS:
-        return Modes( SP_BLESS );
-
-    case Spell::BLOODLUST:
-        return Modes( SP_BLOODLUST );
-
-    case Spell::CURSE:
-    case Spell::MASSCURSE:
-        return Modes( SP_CURSE );
-
-    case Spell::HASTE:
-    case Spell::MASSHASTE:
-        return Modes( SP_HASTE );
-
-    case Spell::SHIELD:
-    case Spell::MASSSHIELD:
-        return Modes( SP_SHIELD );
-
-    case Spell::SLOW:
-    case Spell::MASSSLOW:
-        return Modes( SP_SLOW );
-
-    case Spell::STONESKIN:
-    case Spell::STEELSKIN:
-        return Modes( SP_STONESKIN | SP_STEELSKIN );
-
-    case Spell::BLIND:
-    case Spell::PARALYZE:
-    case Spell::PETRIFY:
-        return Modes( SP_BLIND | SP_PARALYZE | SP_STONE );
-
-    case Spell::DRAGONSLAYER:
-        return Modes( SP_DRAGONSLAYER );
-
-    case Spell::ANTIMAGIC:
-        return Modes( SP_ANTIMAGIC );
-
-    case Spell::BERSERKER:
-        return Modes( SP_BERSERKER );
-
-    case Spell::HYPNOTIZE:
-        return Modes( SP_HYPNOTIZE );
-
-    case Spell::MIRRORIMAGE:
-        return Modes( CAP_MIRROROWNER );
-
-    case Spell::DISRUPTINGRAY:
-        return GetDefense() < spell.ExtraValue();
-
-    default:
-        break;
-    }
-    return false;
-}
-
 bool Battle::Unit::ApplySpell( const Spell & spell, const HeroBase * applyingHero, TargetInfo & target )
 {
     // HACK!!! Chain lightning is the only spell which can't be cast on allies but could be applied on them

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -204,7 +204,6 @@ namespace Battle
 
         bool ApplySpell( const Spell & spell, const HeroBase * applyingHero, TargetInfo & target );
         bool AllowApplySpell( const Spell & spell, const HeroBase * applyingHero, const bool forceApplyToAlly = false ) const;
-        bool isUnderSpellEffect( const Spell & spell ) const;
         std::vector<Spell> getCurrentSpellEffects() const;
 
         void PostAttackAction( const Unit & enemy );


### PR DESCRIPTION
This method has the logic specific for AI - for instance, it considers the unit to be affected by the Blind spell if unit is affected by the Paralyze spell. This is handy for AI, but is not suitable for general use.