### PR TITLE
Modernize the clang-format config file syntax

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,8 +1,10 @@
 ---
 AccessModifierOffset: -4
 AlignAfterOpenBracket: Align
-AlignConsecutiveAssignments: false
-AlignConsecutiveDeclarations: false
+AlignConsecutiveAssignments:
+  Enabled: false
+AlignConsecutiveDeclarations:
+  Enabled: false
 AlignEscapedNewlinesLeft: Right
 AlignOperands: true
 AlignTrailingComments: false


### PR DESCRIPTION
Starting with `clang-format` 15, these options are not just Boolean options, but have multiple different sub-knobs. The old syntax is not valid anymore.