### PR TITLE
Fix a bug when picking up an object whose type does not match its sprite on the map

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -225,12 +225,13 @@ namespace
     {
         uint32_t objectUID = 0;
 
-        // There are hacked maps (or made with the original editor's bugs) that have not corresponding object type ant its sprite.
-        // So we also search object ID by checking if the object is action because on one tile there might be only one action object.
+        // There are original hacked maps (or made with exploitation of the original Editor's bugs) that have wrong object type in relation to its image sprite.
+        // So, we also search for object ID by checking if the object is an action type because one tile can have only one action object.
         MP2::MapObjectType actualObjectType = MP2::OBJ_NONE;
+        const bool isActionObject = MP2::isInGameActionObject( objectType );
 
         if ( const MP2::MapObjectType mainObjectType = Maps::getObjectTypeByIcn( tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex );
-             mainObjectType == objectType || MP2::isInGameActionObject( mainObjectType ) ) {
+             mainObjectType == objectType || ( isActionObject && MP2::isInGameActionObject( mainObjectType ) ) ) {
             objectUID = tile.getMainObjectPart()._uid;
 
             actualObjectType = mainObjectType;
@@ -239,7 +240,7 @@ namespace
             // In maps made by the original map editor the action object can be in the ground layer.
             for ( auto iter = tile.getGroundObjectParts().rbegin(); iter != tile.getGroundObjectParts().rend(); ++iter ) {
                 if ( const MP2::MapObjectType partObjectType = Maps::getObjectTypeByIcn( iter->icnType, iter->icnIndex );
-                     partObjectType == objectType || MP2::isInGameActionObject( partObjectType ) ) {
+                     partObjectType == objectType || ( isActionObject && MP2::isInGameActionObject( partObjectType ) ) ) {
                     objectUID = iter->_uid;
 
                     actualObjectType = partObjectType;
@@ -254,7 +255,7 @@ namespace
         I.getGameArea().runSingleObjectAnimation( std::make_shared<Interface::ObjectFadingOutInfo>( objectUID, tile.GetIndex(), objectType ) );
 
         // If there is a map bug the Object Animation destructor is not able to properly remove this object from the map.
-        if ( actualObjectType != objectType ) {
+        if ( actualObjectType != objectType && actualObjectType != MP2::OBJ_NONE ) {
             // Remove an object by its actual sprite type.
             removeObjectFromTileByType( tile, actualObjectType );
         }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -783,7 +783,8 @@ namespace
         switch ( objectType ) {
         case MP2::OBJ_WINDMILL:
             msg = funds.GetValidItemsCount() > 0
-                      ? _( "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
+                      ? _(
+                          "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
                       : _( "The keeper of the mill announces:\n\"Milord, I am sorry, there are no resources currently available. Please try again next week.\"" );
             break;
 
@@ -800,8 +801,10 @@ namespace
 
         case MP2::OBJ_MAGIC_GARDEN:
             msg = funds.GetValidItemsCount() > 0
-                      ? _( "You catch a leprechaun foolishly sleeping amidst a cluster of magic mushrooms.\nIn exchange for his freedom, he guides you to a small pot filled with precious things." )
-                      : _( "You've found a magic garden, the kind of place that leprechauns and faeries like to cavort in, but there is no one here today.\nPerhaps you should try again next week." );
+                      ? _(
+                          "You catch a leprechaun foolishly sleeping amidst a cluster of magic mushrooms.\nIn exchange for his freedom, he guides you to a small pot filled with precious things." )
+                      : _(
+                          "You've found a magic garden, the kind of place that leprechauns and faeries like to cavort in, but there is no one here today.\nPerhaps you should try again next week." );
             break;
 
         default:
@@ -1099,15 +1102,16 @@ namespace
             break;
 
         case MP2::OBJ_IDOL:
-            msg = visited
-                      ? _( "You've found an ancient and weathered stone idol.\nIt is supposed to grant luck to visitors, but since the stars are already smiling upon you, it does nothing." )
-                      : _( "You've found an ancient and weathered stone idol.\nKissing it is supposed to be lucky, so you do. The stone is very cold to the touch." );
+            msg = visited ? _(
+                      "You've found an ancient and weathered stone idol.\nIt is supposed to grant luck to visitors, but since the stars are already smiling upon you, it does nothing." )
+                          : _( "You've found an ancient and weathered stone idol.\nKissing it is supposed to be lucky, so you do. The stone is very cold to the touch." );
             break;
 
         case MP2::OBJ_MERMAID:
             msg = visited
                       ? _( "The mermaids silently entice you to return later and be blessed again." )
-                      : _( "The magical, soothing beauty of the Mermaids reaches you and your crew.\nJust for a moment, you forget your worries and bask in the beauty of the moment.\nThe mermaids' charms bless you with increased luck for your next combat." );
+                      : _(
+                          "The magical, soothing beauty of the Mermaids reaches you and your crew.\nJust for a moment, you forget your worries and bask in the beauty of the moment.\nThe mermaids' charms bless you with increased luck for your next combat." );
             break;
 
         default:
@@ -1282,23 +1286,25 @@ namespace
 
         case MP2::OBJ_MERCENARY_CAMP:
             skill = Skill::Primary::ATTACK;
-            msg = visited
-                      ? _( "You've come upon a mercenary camp practicing their tactics. \"You're too advanced for us,\" the mercenary captain says. \"We can teach nothing more.\"" )
-                      : _( "You've come upon a mercenary camp practicing their tactics. The mercenaries welcome you and your troops and invite you to train with them." );
+            msg = visited ? _(
+                      "You've come upon a mercenary camp practicing their tactics. \"You're too advanced for us,\" the mercenary captain says. \"We can teach nothing more.\"" )
+                          : _(
+                              "You've come upon a mercenary camp practicing their tactics. The mercenaries welcome you and your troops and invite you to train with them." );
             break;
 
         case MP2::OBJ_WITCH_DOCTORS_HUT:
             skill = Skill::Primary::KNOWLEDGE;
             msg = visited
                       ? _( "\"Go 'way!\", the witch doctor barks, \"you know all I know.\"" )
-                      : _( "An Orcish witch doctor living in the hut deepens your knowledge of magic by showing you how to cast stones, read portents, and decipher the intricacies of chicken entrails." );
+                      : _(
+                          "An Orcish witch doctor living in the hut deepens your knowledge of magic by showing you how to cast stones, read portents, and decipher the intricacies of chicken entrails." );
             break;
 
         case MP2::OBJ_STANDING_STONES:
             skill = Skill::Primary::POWER;
-            msg = visited
-                      ? _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, the Druids turn you away, indicating they have nothing new to teach you." )
-                      : _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, they teach you new ways to cast spells." );
+            msg = visited ? _(
+                      "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, the Druids turn you away, indicating they have nothing new to teach you." )
+                          : _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, they teach you new ways to cast spells." );
             break;
 
         default:
@@ -1455,9 +1461,9 @@ namespace
             break;
 
         case MP2::OBJ_WATERING_HOLE:
-            msg = visited
-                      ? _( "The drink at the watering hole is refreshing, but offers no further benefit. The watering hole might help again if you fought a battle first." )
-                      : _( "A drink at the watering hole fills your troops with strength and lifts their spirits. You can travel a bit further today." );
+            msg = visited ? _(
+                      "The drink at the watering hole is refreshing, but offers no further benefit. The watering hole might help again if you fought a battle first." )
+                          : _( "A drink at the watering hole fills your troops with strength and lifts their spirits. You can travel a bit further today." );
             move = GameStatic::getMovementPointBonus( MP2::OBJ_WATERING_HOLE );
             break;
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2263,12 +2263,16 @@ namespace Maps
                 // On original map "Alteris 2" there is a treasure chest placed on the water and there might be other maps with such bug.
                 // If there is a bug then remove of the MP2::OBJ_TREASURE_CHEST will return 'true' and we can replace it with a Sea Chest object.
                 if ( removeObjectFromTileByType( tile, MP2::OBJ_TREASURE_CHEST ) ) {
-                    // WARNING. The 'seaChestObjectId' must match the Sea Chest object info position in 'Maps::ObjectGroup::ADVENTURE_WATER' group.
-                    const int32_t seaChestObjectId = 1;
-                    const auto & objectInfo = Maps::getObjectInfo( Maps::ObjectGroup::ADVENTURE_WATER, seaChestObjectId );
-                    assert( objectInfo.objectType == MP2::OBJ_SEA_CHEST );
+                    const auto & objects = Maps::getObjectsByGroup( Maps::ObjectGroup::ADVENTURE_WATER );
 
-                    setObjectOnTile( tile, objectInfo, true );
+                    for ( size_t i = 0; i < objects.size(); ++i ) {
+                        if ( objects[i].objectType == MP2::OBJ_SEA_CHEST ) {
+                            const auto & objectInfo = Maps::getObjectInfo( Maps::ObjectGroup::ADVENTURE_WATER, static_cast<int32_t>( i ) );
+                            setObjectOnTile( tile, objectInfo, true );
+
+                            break;
+                        }
+                    }
                 }
                 else {
                     tile.setMainObjectType( MP2::OBJ_SEA_CHEST );

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2260,8 +2260,6 @@ namespace Maps
             assert( isFirstLoad );
 
             if ( tile.isWater() ) {
-                const MP2::MapObjectType mainObjectType = Maps::getObjectTypeByIcn( tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex );
-
                 // On original map "Alteris 2" there is a treasure chest placed on the water and there might be other maps with such bug.
                 // If there is a bug then remove of the MP2::OBJ_TREASURE_CHEST will return 'true' and we can replace it with a Sea Chest object.
                 if ( removeObjectFromTileByType( tile, MP2::OBJ_TREASURE_CHEST ) ) {

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2260,7 +2260,22 @@ namespace Maps
             assert( isFirstLoad );
 
             if ( tile.isWater() ) {
-                tile.setMainObjectType( MP2::OBJ_SEA_CHEST );
+                const MP2::MapObjectType mainObjectType = Maps::getObjectTypeByIcn( tile.getMainObjectPart().icnType, tile.getMainObjectPart().icnIndex );
+
+                // On original map "Alteris 2" there is a treasure chest placed on the water and there might be other maps with such bug.
+                // If there is a bug then remove of the MP2::OBJ_TREASURE_CHEST will return 'true' and we can replace it with a Sea Chest object.
+                if ( removeObjectFromTileByType( tile, MP2::OBJ_TREASURE_CHEST ) ) {
+                    // WARNING. The 'seaChestObjectId' must match the Sea Chest object info position in 'Maps::ObjectGroup::ADVENTURE_WATER' group.
+                    const int32_t seaChestObjectId = 1;
+                    const auto & objectInfo = Maps::getObjectInfo( Maps::ObjectGroup::ADVENTURE_WATER, seaChestObjectId );
+                    assert( objectInfo.objectType == MP2::OBJ_SEA_CHEST );
+
+                    setObjectOnTile( tile, objectInfo, true );
+                }
+                else {
+                    tile.setMainObjectType( MP2::OBJ_SEA_CHEST );
+                }
+
                 updateObjectInfoTile( tile, isFirstLoad );
                 return;
             }


### PR DESCRIPTION
Fix  #9322 and fix #9184

This PR fixes such chest objects during map load and take into account a possible case when object type does not match the ICN while performing the fade-out animation.

~It also has some lines updated by the new clang-format. :)~