### PR TITLE
Limit the use of VPATH for GNU Make

### DIFF
--- a/src/dist/engine/Makefile
+++ b/src/dist/engine/Makefile
@@ -22,20 +22,16 @@ ifndef FHEROES2_WITH_SYSTEM_SMACKER
 CCFLAGS := $(CCFLAGS) -I../../thirdparty/libsmacker
 endif
 
-SOURCEROOT := ../../engine
-SOURCEDIRS := $(SOURCEROOT)
-SOURCES := $(wildcard $(SOURCEDIRS)/*.cpp)
+SOURCEDIR := ../../engine
 
 .PHONY: all clean
 
 all: libengine.a
 
-libengine.a: $(notdir $(patsubst %.cpp, %.o, $(SOURCES)))
+libengine.a: $(notdir $(patsubst %.cpp, %.o, $(wildcard $(SOURCEDIR)/*.cpp)))
 	$(AR) crvs $@ $^
 
-VPATH := $(SOURCEDIRS)
-
-%.o: %.cpp
+%.o: $(SOURCEDIR)/%.cpp
 	$(CXX) -c -MD $< $(CCFLAGS) $(CXXFLAGS) $(CPPFLAGS)
 
 include $(wildcard *.d)

--- a/src/dist/fheroes2/Makefile
+++ b/src/dist/fheroes2/Makefile
@@ -18,11 +18,11 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-LIBENGINE := ../engine/libengine.a
+DEPLIBS := ../engine/libengine.a
 CCFLAGS := $(CCFLAGS) -I../../engine
 
 ifndef FHEROES2_WITH_SYSTEM_SMACKER
-LIBENGINE := $(LIBENGINE) ../thirdparty/libsmacker/libsmacker.a
+DEPLIBS := $(DEPLIBS) ../thirdparty/libsmacker/libsmacker.a
 CCFLAGS := $(CCFLAGS) -I../../thirdparty/libsmacker
 endif
 
@@ -30,23 +30,23 @@ SOURCEROOT := ../../fheroes2
 SOURCEDIRS := $(filter %/,$(wildcard $(SOURCEROOT)/*/))
 SOURCES := $(wildcard $(SOURCEROOT)/*/*.cpp)
 
+VPATH := $(SOURCEDIRS)
+
 .PHONY: all pot clean
 
 all: fheroes2 pot
 
 pot: fheroes2.pot
 
-fheroes2: $(notdir $(patsubst %.cpp, %.o, $(SOURCES))) $(LIBENGINE)
+fheroes2: $(notdir $(patsubst %.cpp, %.o, $(SOURCES))) $(DEPLIBS)
 	$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
 fheroes2.pot: $(SOURCES)
 	xgettext -d fheroes2 -C -F -k_ -k_n:1,2 -o fheroes2.pot $(sort $(SOURCES))
 	sed -i~ -e 's/, c-format//' fheroes2.pot
 
-VPATH := $(SOURCEDIRS)
-
 %.o: %.cpp
-	$(CXX) -c -MD $(addprefix -I, $(SOURCEDIRS)) $< $(CCFLAGS) $(CXXFLAGS) $(CPPFLAGS)
+	$(CXX) -c -MD $< $(addprefix -I, $(SOURCEDIRS)) $(CCFLAGS) $(CXXFLAGS) $(CPPFLAGS)
 
 include $(wildcard *.d)
 

--- a/src/dist/thirdparty/libsmacker/Makefile
+++ b/src/dist/thirdparty/libsmacker/Makefile
@@ -18,9 +18,6 @@
 #   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             #
 ###########################################################################
 
-SOURCEROOT := ../../../thirdparty/libsmacker
-SOURCEDIRS := $(SOURCEROOT)
-
 .PHONY: all clean
 
 all: libsmacker.a
@@ -28,9 +25,7 @@ all: libsmacker.a
 libsmacker.a: smacker.o
 	$(AR) crvs $@ $^
 
-VPATH := $(SOURCEDIRS)
-
-smacker.o: smacker.c
+smacker.o: ../../../thirdparty/libsmacker/smacker.c
 	$(CC) -c -MD $< $(CCFLAGS) $(CFLAGS) $(CPPFLAGS)
 
 include $(wildcard *.d)

--- a/src/dist/tools/Makefile
+++ b/src/dist/tools/Makefile
@@ -20,23 +20,15 @@
 
 TARGETS := 82m2wav bin2txt extractor h2dmgr icn2img pal2img til2img xmi2midi
 
-LIBENGINE := ../engine/libengine.a
-CCFLAGS := $(CCFLAGS) -I../../engine
-
-SOURCEROOT := ../../tools
-SOURCEDIRS := $(SOURCEROOT)
-
 .PHONY: all clean
 
 all: $(TARGETS)
 
-$(TARGETS): %: %.o $(LIBENGINE)
+$(TARGETS): %: %.o ../engine/libengine.a
 	$(CXX) -o $@ $^ $(LIBS) $(LDFLAGS)
 
-VPATH := $(SOURCEDIRS)
-
-%.o: %.cpp
-	$(CXX) -c -MD $< $(CCFLAGS) $(CXXFLAGS) $(CPPFLAGS)
+%.o: ../../tools/%.cpp
+	$(CXX) -c -MD $< -I../../engine $(CCFLAGS) $(CXXFLAGS) $(CPPFLAGS)
 
 include $(wildcard *.d)
 


### PR DESCRIPTION
Follow-up to #9328
Related to #9331

#9331 has occurred due to `VPATH` logic. When `VPATH` is used, all prerequisites which are not found at their paths are also looked at paths listed in `VPATH`. For instance, if we have a `Makefile` like this:

```make
VPATH := ../src/engine

all: libengine.a

[...]
```

then, if `libengine.a` is not located in the current directory, it will be looked in the `../src/engine` directory, and, if it's here (left from the previous build) and is up-to-date, it will not be rebuilt and will not be created at the current directory.

With this PR, I minimized the use of `VPATH` just to the `fheroes2` directory (there are no other options here because there are many subdirectories). For the rest of the cases, I have specified the paths to dependencies explicitly. I also removed variables that were used only once.