### PR TITLE
Reset the damage info popup when the spell cast has been cancelled

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2775,6 +2775,7 @@ void Battle::Interface::HumanTurn( const Unit & unit, Actions & actions )
     }
 
     popup.reset();
+
     _currentUnit = nullptr;
 }
 
@@ -3071,6 +3072,8 @@ void Battle::Interface::HumanCastSpellTurn( const Unit & /* unused */, Actions &
 
     // Cancel the spellcast
     if ( le.isMouseRightButtonPressed() || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
+        popup.reset();
+
         humanturn_spell = Spell::NONE;
 
         _teleportSpellSrcIdx = -1;


### PR DESCRIPTION
fix #9338

With this PR:

https://github.com/user-attachments/assets/258448ad-3f2c-409c-a18a-0d32e7eb065a
