### PR TITLE
Fix spell randomization logic for Artifacts and the Adventure Map objects

### DIFF
--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -1961,19 +1961,19 @@ namespace Maps
         case MP2::OBJ_SHRINE_FIRST_CIRCLE:
             assert( isFirstLoad );
 
-            tile.metadata()[0] = Rand::Get( 1 ) ? Spell::RandCombat( 1 ).GetID() : Spell::RandAdventure( 1 ).GetID();
+            setSpellOnTile( tile, Spell::getRandomSpell( 1 ).GetID() );
             break;
 
         case MP2::OBJ_SHRINE_SECOND_CIRCLE:
             assert( isFirstLoad );
 
-            tile.metadata()[0] = Rand::Get( 1 ) ? Spell::RandCombat( 2 ).GetID() : Spell::RandAdventure( 2 ).GetID();
+            setSpellOnTile( tile, Spell::getRandomSpell( 2 ).GetID() );
             break;
 
         case MP2::OBJ_SHRINE_THIRD_CIRCLE:
             assert( isFirstLoad );
 
-            tile.metadata()[0] = Rand::Get( 1 ) ? Spell::RandCombat( 3 ).GetID() : Spell::RandAdventure( 3 ).GetID();
+            setSpellOnTile( tile, Spell::getRandomSpell( 3 ).GetID() );
             break;
 
         case MP2::OBJ_SKELETON: {
@@ -2379,8 +2379,7 @@ namespace Maps
             assert( isFirstLoad );
 
             // Random spell of level 5.
-            const Spell & spell = Rand::Get( 1 ) ? Spell::RandCombat( 5 ) : Spell::RandAdventure( 5 );
-            setSpellOnTile( tile, spell.GetID() );
+            setSpellOnTile( tile, Spell::getRandomSpell( 5 ).GetID() );
             break;
         }
 

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -391,7 +391,7 @@ void Artifact::SetSpell( const int v )
 
     switch ( v ) {
     case Spell::RANDOM:
-        ext = Spell::getRandomSpell( Rand::Get( 1, 5 ) ).GetID();
+        ext = Spell::getRandomSpell( static_cast<int>( Rand::Get( 1, 5 ) ) ).GetID();
         break;
     case Spell::RANDOM1:
         ext = Spell::getRandomSpell( 1 ).GetID();

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -389,26 +389,24 @@ void Artifact::SetSpell( const int v )
         return;
     }
 
-    const bool adv = Rand::Get( 1 ) != 0;
-
     switch ( v ) {
     case Spell::RANDOM:
-        ext = Spell::Rand( Rand::Get( 1, 5 ), adv ).GetID();
+        ext = Spell::getRandomSpell( static_cast<uint8_t>( Rand::Get( 1, 5 ) ) ).GetID();
         break;
     case Spell::RANDOM1:
-        ext = Spell::Rand( 1, adv ).GetID();
+        ext = Spell::getRandomSpell( 1 ).GetID();
         break;
     case Spell::RANDOM2:
-        ext = Spell::Rand( 2, adv ).GetID();
+        ext = Spell::getRandomSpell( 2 ).GetID();
         break;
     case Spell::RANDOM3:
-        ext = Spell::Rand( 3, adv ).GetID();
+        ext = Spell::getRandomSpell( 3 ).GetID();
         break;
     case Spell::RANDOM4:
-        ext = Spell::Rand( 4, adv ).GetID();
+        ext = Spell::getRandomSpell( 4 ).GetID();
         break;
     case Spell::RANDOM5:
-        ext = Spell::Rand( 5, adv ).GetID();
+        ext = Spell::getRandomSpell( 5 ).GetID();
         break;
     default:
         ext = v;

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -391,7 +391,7 @@ void Artifact::SetSpell( const int v )
 
     switch ( v ) {
     case Spell::RANDOM:
-        ext = Spell::getRandomSpell( static_cast<uint8_t>( Rand::Get( 1, 5 ) ) ).GetID();
+        ext = Spell::getRandomSpell( Rand::Get( 1, 5 ) ).GetID();
         break;
     case Spell::RANDOM1:
         ext = Spell::getRandomSpell( 1 ).GetID();

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -511,10 +511,9 @@ uint32_t Spell::weightForRace( const int race ) const
     return 10;
 }
 
-Spell Spell::Rand( const int level, const bool isAdventure )
+Spell Spell::getRandomSpell( const uint8_t level )
 {
-    std::vector<Spell> vec;
-    vec.reserve( 15 );
+    std::vector<Spell> validSpells;
 
     for ( int32_t spellId = NONE; spellId < PETRIFY; ++spellId ) {
         const Spell spell( spellId );
@@ -523,33 +522,12 @@ Spell Spell::Rand( const int level, const bool isAdventure )
             continue;
         }
 
-        if ( isAdventure ) {
-            if ( !spell.isAdventure() ) {
-                continue;
-            }
-        }
-        else {
-            if ( !spell.isCombat() ) {
-                continue;
-            }
-        }
-
-        vec.push_back( spell );
+        validSpells.push_back( spell );
     }
 
-    return !vec.empty() ? Rand::Get( vec ) : Spell::NONE;
-}
+    assert( !validSpells.empty() );
 
-Spell Spell::RandCombat( const int level )
-{
-    return Rand( level, false );
-}
-
-Spell Spell::RandAdventure( const int level )
-{
-    const Spell spell = Rand( level, true );
-
-    return spell.isValid() ? spell : RandCombat( level );
+    return validSpells.empty() ? Spell::NONE : Rand::Get( validSpells );
 }
 
 std::vector<int> Spell::getAllSpellIdsSuitableForSpellBook( const int spellLevel /* = -1 */ )

--- a/src/fheroes2/spell/spell.cpp
+++ b/src/fheroes2/spell/spell.cpp
@@ -511,9 +511,12 @@ uint32_t Spell::weightForRace( const int race ) const
     return 10;
 }
 
-Spell Spell::getRandomSpell( const uint8_t level )
+Spell Spell::getRandomSpell( const int level )
 {
+    assert( level > 0 && level < 6 );
+
     std::vector<Spell> validSpells;
+    validSpells.reserve( Spell::SPELL_COUNT );
 
     for ( int32_t spellId = NONE; spellId < PETRIFY; ++spellId ) {
         const Spell spell( spellId );

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -251,7 +251,7 @@ public:
     // Returns the index of the spell sprite in SPELLS.ICN
     uint32_t IndexSprite() const;
 
-    static Spell getRandomSpell( const uint8_t level );
+    static Spell getRandomSpell( const int level );
 
     // Returns the IDs of all spells of a given level that are suitable for the spell book (i.e. no placeholders or exclusive
     // built-in spells for monsters are returned). If 'spellLevel' is less than 1, suitable spells of all levels are returned.

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -251,9 +251,7 @@ public:
     // Returns the index of the spell sprite in SPELLS.ICN
     uint32_t IndexSprite() const;
 
-    static Spell Rand( const int level, const bool isAdventure );
-    static Spell RandCombat( const int level );
-    static Spell RandAdventure( const int level );
+    static Spell getRandomSpell( const uint8_t level );
 
     // Returns the IDs of all spells of a given level that are suitable for the spell book (i.e. no placeholders or exclusive
     // built-in spells for monsters are returned). If 'spellLevel' is less than 1, suitable spells of all levels are returned.


### PR DESCRIPTION
The original game does not have logic where it chooses whether a spell should be Combat or Adventure and only then does randomization based on the chosen category. Instead, it simply picks a random spell based on a level.

How it was discovered: I put 30 Shrine of the First Circle on a map and visited all of them by a hero. I counted how many spells belong to Adventure category while playing the map in the original game. It was only 3 spells out of 30 instead of expected ~15 per our old logic.

The old logic in the engine also explains why the Dimension Door spell was so often in Pyramids as the chance of getting this spell was wooping 25%.