### PR TITLE
Display a description of the mechanics of right-clicking on devices with touch input

### DIFF
--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -56,6 +56,7 @@
 #pragma GCC diagnostic ignored "-Wswitch-default"
 #endif
 
+#include <SDL_touch.h>
 #include <SDL_version.h>
 
 #if defined( ANDROID )
@@ -271,6 +272,11 @@ bool System::isHandheldDevice()
 #else
     return false;
 #endif
+}
+
+bool System::isTouchInputAvailable()
+{
+    return SDL_GetNumTouchDevices() > 0;
 }
 
 bool System::isVirtualKeyboardSupported()

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -34,6 +34,9 @@ namespace System
 {
     bool isHandheldDevice();
 
+    // Returns true if the target platform supports touch input, otherwise returns false.
+    bool isTouchInputAvailable();
+
     bool isVirtualKeyboardSupported();
 
     // Returns true if target platform supports shell-level globbing (Unix-like platforms with POSIX-compatible shells).

--- a/src/fheroes2/dialog/dialog_resolution.h
+++ b/src/fheroes2/dialog/dialog_resolution.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2022                                             *
+ *   Copyright (C) 2020 - 2024                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -22,5 +22,6 @@
 
 namespace Dialog
 {
-    bool SelectResolution(); // returns true if a new resolution is set
+    // Returns true if the screen resolution has been changed, otherwise returns false
+    bool SelectResolution();
 }

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -232,40 +232,48 @@ fheroes2::GameMode Game::MainMenu( const bool isFirstGameRun )
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    // image background
     fheroes2::drawMainMenuScreen();
+
     if ( isFirstGameRun ) {
         // Fade in Main Menu image before showing messages. This also resets the "need fade" state to have no fade-in after these messages.
         fheroes2::validateFadeInAndRender();
 
         fheroes2::selectLanguage( fheroes2::getSupportedLanguages(), fheroes2::getLanguageFromAbbreviation( conf.getGameLanguage() ), true );
 
-        if ( System::isHandheldDevice() ) {
+        {
+            std::string body = _( "Welcome to Heroes of Might and Magic II powered by fheroes2 engine!" );
+
+            if ( System::isTouchInputAvailable() ) {
+                body += _(
+                    "\n\nTo simulate a right-click with a touch to get info on various items, you need to first touch and keep touching on the item of interest and then touch anywhere else on the screen. You can then remove your first finger from the screen and keep viewing the info on the item." );
+            }
+
             // Handheld devices should use the minimal game's resolution. Users on handheld devices aren't asked to choose resolution.
-            fheroes2::showStandardTextMessage( _( "Greetings!" ), _( "Welcome to Heroes of Might and Magic II powered by fheroes2 engine!" ), Dialog::OK );
-        }
-        else {
-            fheroes2::showStandardTextMessage(
-                _( "Greetings!" ),
-                _( "Welcome to Heroes of Might and Magic II powered by the fheroes2 engine!\nBefore starting the game, please select a game resolution." ), Dialog::OK );
-            const bool isResolutionChanged = Dialog::SelectResolution();
-            if ( isResolutionChanged ) {
+            if ( !System::isHandheldDevice() ) {
+                body += _( "\n\nBefore starting the game, please select a game resolution." );
+            }
+
+            fheroes2::showStandardTextMessage( _( "Greetings!" ), body, Dialog::OK );
+
+            if ( !System::isHandheldDevice() && Dialog::SelectResolution() ) {
                 fheroes2::drawMainMenuScreen();
             }
         }
 
-        fheroes2::Text header( _( "Please Remember" ), fheroes2::FontType::normalYellow() );
+        {
+            fheroes2::Text header( _( "Please Remember" ), fheroes2::FontType::normalYellow() );
 
-        fheroes2::MultiFontText body;
-        body.add( { _( "You can always change the language, resolution and settings of the game by clicking on the " ), fheroes2::FontType::normalWhite() } );
-        body.add( { _( "door" ), fheroes2::FontType::normalYellow() } );
-        body.add( { _( " on the left side of the Main Menu, or with the " ), fheroes2::FontType::normalWhite() } );
-        body.add( { _( "CONFIG" ), fheroes2::FontType::normalYellow() } );
-        body.add( { _( " button from the " ), fheroes2::FontType::normalWhite() } );
-        body.add( { _( "NEW GAME" ), fheroes2::FontType::normalYellow() } );
-        body.add( { _( " menu. \n\nEnjoy the game!" ), fheroes2::FontType::normalWhite() } );
+            fheroes2::MultiFontText body;
+            body.add( { _( "You can always change the language, resolution and settings of the game by clicking on the " ), fheroes2::FontType::normalWhite() } );
+            body.add( { _( "door" ), fheroes2::FontType::normalYellow() } );
+            body.add( { _( " on the left side of the Main Menu, or with the " ), fheroes2::FontType::normalWhite() } );
+            body.add( { _( "CONFIG" ), fheroes2::FontType::normalYellow() } );
+            body.add( { _( " button from the " ), fheroes2::FontType::normalWhite() } );
+            body.add( { _( "NEW GAME" ), fheroes2::FontType::normalYellow() } );
+            body.add( { _( " menu. \n\nEnjoy the game!" ), fheroes2::FontType::normalWhite() } );
 
-        fheroes2::showMessage( header, body, Dialog::OK );
+            fheroes2::showMessage( header, body, Dialog::OK );
+        }
 
         conf.resetFirstGameRun();
         conf.Save( Settings::configFileName );


### PR DESCRIPTION
Related to https://github.com/ihhub/fheroes2/pull/9341#pullrequestreview-2504535675.

I would not like to make another dialog box at the first start of the game (we already have three (or even four) of them: "Select Game Language", "Greetings!", "Select Game Resolution" (not on all devices) and, finally, "Please Remember"), so I added this information to the "Greetings!" dialog box. This description will only be displayed if the user device has touch input support.

With this PR:

![greetings](https://github.com/user-attachments/assets/6a20243f-25cb-424d-a735-723510c83f1b)
