### PR TITLE
Fix cursor positioning with non-English characters and improve positioning at the end of the line

### DIFF
--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -252,6 +252,9 @@ bool Dialog::inputString( const fheroes2::TextBase & title, const fheroes2::Text
 
     display.render();
 
+    // We add extra 4 pixels to the click area width to help setting the cursor at the end of the line if it is fully filled with text characters.
+    const fheroes2::Rect textEditClickArea{ textInputArea.x, textInputArea.y, textInputArea.width + 4, textInputArea.height };
+
     LocalEvent & le = LocalEvent::Get();
 
     Game::AnimateResetDelay( Game::DelayType::CURSOR_BLINK_DELAY );
@@ -278,7 +281,7 @@ bool Dialog::inputString( const fheroes2::TextBase & title, const fheroes2::Text
             return false;
         }
 
-        if ( le.MouseClickLeft( buttonVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( textInputArea ) ) ) {
+        if ( le.MouseClickLeft( buttonVirtualKB.area() ) || ( isInGameKeyboardRequired && le.MouseClickLeft( textEditClickArea ) ) ) {
             if ( textLanguage.has_value() ) {
                 const fheroes2::LanguageSwitcher switcher( textLanguage.value() );
                 fheroes2::openVirtualKeyboard( result, charLimit );
@@ -304,8 +307,14 @@ bool Dialog::inputString( const fheroes2::TextBase & title, const fheroes2::Text
             }
             redraw = true;
         }
-        else if ( le.MouseClickLeft( textInputArea ) ) {
-            charInsertPos = fheroes2::getTextInputCursorPosition( text, charInsertPos, le.getMouseCursorPos(), textInputArea );
+        else if ( le.MouseClickLeft( textEditClickArea ) ) {
+            if ( textLanguage.has_value() ) {
+                const fheroes2::LanguageSwitcher switcher( textLanguage.value() );
+                charInsertPos = fheroes2::getTextInputCursorPosition( text, charInsertPos, le.getMouseCursorPos(), textInputArea );
+            }
+            else {
+                charInsertPos = fheroes2::getTextInputCursorPosition( text, charInsertPos, le.getMouseCursorPos(), textInputArea );
+            }
 
             redraw = true;
         }


### PR DESCRIPTION
Fix #9345

This PR applies language selection when positioning the text cursor and if the text language is different from the current selected language.
I also adds extra 4 pixels area at the right part of the text input field to the "positioning" clickable area to help position the cursor at the end of the line.