### PR TITLE
Editor: Reset the "tile under cursor" value, stored from a previously edited map

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -783,6 +783,10 @@ namespace Interface
 
         _gameArea.SetUpdateCursor();
 
+        // The cursor parameters may contain values from a previously edited map that are not suitable for this one. Reset them.
+        _tileUnderCursor = -1;
+        _areaSelectionStartTileId = -1;
+
         uint32_t redrawFlags = REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_PANEL | REDRAW_STATUS | REDRAW_BORDER;
         if ( conf.isEditorPassabilityEnabled() ) {
             redrawFlags |= REDRAW_PASSABILITIES;


### PR DESCRIPTION
Fix #9353
This PR force reset two cursor indicator parameters when loading or making a new map in editor.
Previously if you hold a cursor over game area when it has square cursor marker and press L to load a new map (or N to make a new one) the `_tileUnderCursor` index is stored and if a loaded/new map is smaller than this index you'll get an assertion because for the first frame it tries to render this marker beyond the map borders.