### PR TITLE
Fix the Linux ARM64 build

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -90,7 +90,7 @@ jobs:
           release_name: Ubuntu ARM64 (Linux) build with SDL2 (latest commit)
           release_tag: fheroes2-linux-arm-sdl2_dev
         - name: Linux ARM64 SDL2 Debug
-          os: ubuntu-latest
+          os: ubuntu-22.04
           dependencies: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libsdl2-dev:arm64 libsdl2-mixer-dev:arm64 libsdl2-image-dev:arm64 libpng-dev:arm64 gettext
           env:
             FHEROES2_STRICT_COMPILATION: ON


### PR DESCRIPTION
An alternative to #9360.

`ubuntu-24.04` is now `ubuntu-latest`, and all this voodoo magic that was used to install ARM64 packages on the Ubuntu GitHub image no longer works, because `apt` now uses new configs of a different format, located in different places.

This PR fixes the build by downgrading the `ubuntu-latest` to `ubuntu-22.04` for all ARM64 targets.