### PR TITLE
Remove the Linux ARM64 build

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -53,54 +53,6 @@ jobs:
             FHEROES2_WITH_IMAGE: ON
             FHEROES2_WITH_DEBUG: ON
             FHEROES2_WITH_ASAN: ON
-        - name: Linux ARM64 SDL2 Release
-          os: ubuntu-22.04
-          dependencies: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libsdl2-dev:arm64 libsdl2-mixer-dev:arm64 libsdl2-image-dev:arm64 libpng-dev:arm64 gettext
-          env:
-            FHEROES2_STRICT_COMPILATION: ON
-            FHEROES2_WITH_TOOLS: ON
-            FHEROES2_WITH_IMAGE: ON
-            CC: aarch64-linux-gnu-gcc
-            CXX: aarch64-linux-gnu-g++
-            AR: aarch64-linux-gnu-ar
-          package_name: fheroes2_ubuntu_arm64_SDL2.zip
-          package_files: >-
-            LICENSE
-            changelog.txt
-            fheroes2
-            ./docs/README.txt
-            files/data/*.h2d
-            files/lang/*.mo
-            ./script/demo/download_demo_version.sh
-            ./script/homm2/extract_homm2_resources.sh
-            script/linux/install_sdl2.sh
-          tools_package_name: fheroes2_tools_ubuntu_arm64_SDL2.zip
-          tools_package_files: >-
-            LICENSE
-            ./docs/GRAPHICAL_ASSETS.md
-            ./script/agg/extract_agg.sh
-            ./src/dist/tools/82m2wav
-            ./src/dist/tools/bin2txt
-            ./src/dist/tools/extractor
-            ./src/dist/tools/h2dmgr
-            ./src/dist/tools/icn2img
-            ./src/dist/tools/pal2img
-            ./src/dist/tools/til2img
-            ./src/dist/tools/xmi2midi
-          release_name: Ubuntu ARM64 (Linux) build with SDL2 (latest commit)
-          release_tag: fheroes2-linux-arm-sdl2_dev
-        - name: Linux ARM64 SDL2 Debug
-          os: ubuntu-latest
-          dependencies: gcc-aarch64-linux-gnu g++-aarch64-linux-gnu libsdl2-dev:arm64 libsdl2-mixer-dev:arm64 libsdl2-image-dev:arm64 libpng-dev:arm64 gettext
-          env:
-            FHEROES2_STRICT_COMPILATION: ON
-            FHEROES2_WITH_TOOLS: ON
-            FHEROES2_WITH_IMAGE: ON
-            FHEROES2_WITH_DEBUG: ON
-            FHEROES2_WITH_TSAN: ON
-            CC: aarch64-linux-gnu-gcc
-            CXX: aarch64-linux-gnu-g++
-            AR: aarch64-linux-gnu-ar
         - name: macOS SDL2
           os: macos-13
           dependencies: sdl2 sdl2_mixer sdl2_image
@@ -152,16 +104,6 @@ jobs:
     - name: Install dependencies (Linux)
       if: ${{ startsWith( matrix.config.os, 'ubuntu-' ) }}
       run: |
-        if [[ "${{ matrix.config.name }}" == *ARM64* ]]
-        then
-          sudo sed -i -e 's/^deb /deb [arch=amd64] /' /etc/apt/sources.list
-          sudo dpkg --add-architecture arm64
-          sudo sh -c '. /etc/os-release;
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${VERSION_CODENAME} main restricted universe multiverse" > /etc/apt/sources.list.d/arm64.list;
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${VERSION_CODENAME}-updates main restricted universe multiverse" >> /etc/apt/sources.list.d/arm64.list;
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${VERSION_CODENAME}-security main restricted universe multiverse" >> /etc/apt/sources.list.d/arm64.list;
-          echo "deb [arch=arm64] http://ports.ubuntu.com/ubuntu-ports ${VERSION_CODENAME}-backports main restricted universe multiverse" >> /etc/apt/sources.list.d/arm64.list;'
-        fi
         sudo apt-get -y update
         sudo apt-get -y install ${{ matrix.config.dependencies }}
     - name: Install dependencies (macOS)


### PR DESCRIPTION
An alternative to #9359.

`ubuntu-24.04` is now `ubuntu-latest`, and all this voodoo magic that was used to install ARM64 packages on the Ubuntu GitHub image no longer works, because `apt` now uses new configs of a different format, located in different places.

This PR fixes the build by removing all ARM64 targets.