### PR TITLE
Do not make the ability to use an Earthquake spell dependent on the magical resistance of units on the battlefield

### DIFF
--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -952,11 +952,15 @@ bool Battle::Arena::isDisableCastSpell( const Spell & spell, std::string * msg /
         return false;
     }
 
-    if ( spell == Spell::EARTHQUAKE && !castle ) {
-        if ( msg ) {
-            *msg = _( "That spell will have no effect!" );
+    if ( spell == Spell::EARTHQUAKE ) {
+        if ( castle == nullptr ) {
+            if ( msg ) {
+                *msg = _( "That spell will have no effect!" );
+            }
+            return true;
         }
-        return true;
+
+        return false;
     }
 
     if ( spell.isSummon() ) {


### PR DESCRIPTION
fix #9368