### PR TITLE
Speed up GitHub Actions

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -54,7 +54,7 @@ jobs:
       if: ${{ github.event_name == 'push' && env.KEYSTORE_BASE64 != '' }}
       run: |
         cd android
-        ./gradlew assembleRelease bundleRelease --max-workers=4
+        ./gradlew assembleRelease bundleRelease
         cp app/build/outputs/apk/release/app-release.apk ../fheroes2.apk
         cp app/build/outputs/bundle/release/app-release.aab ../fheroes2.aab
       env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,7 +37,7 @@ jobs:
         sudo apt-get -y install gettext
     - name: Generate translations
       run: |
-        make -C files/lang -j $(nproc --all)
+        make -C files/lang -j "$(nproc)"
     - name: Create keystore
       if: ${{ github.event_name == 'push' && env.KEYSTORE_BASE64 != '' }}
       run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,7 +47,7 @@ jobs:
       if: ${{ github.event_name == 'pull_request' || env.KEYSTORE_BASE64 == '' }}
       run: |
         cd android
-        ./gradlew assembleDebug bundleDebug --max-workers=4
+        ./gradlew assembleDebug bundleDebug
         cp app/build/outputs/apk/debug/app-debug.apk ../fheroes2.apk
         cp app/build/outputs/bundle/debug/app-debug.aab ../fheroes2.aab
     - name: Build release AAB and APK

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -47,14 +47,14 @@ jobs:
       if: ${{ github.event_name == 'pull_request' || env.KEYSTORE_BASE64 == '' }}
       run: |
         cd android
-        ./gradlew assembleDebug bundleDebug
+        ./gradlew assembleDebug bundleDebug --max-workers=4
         cp app/build/outputs/apk/debug/app-debug.apk ../fheroes2.apk
         cp app/build/outputs/bundle/debug/app-debug.aab ../fheroes2.aab
     - name: Build release AAB and APK
       if: ${{ github.event_name == 'push' && env.KEYSTORE_BASE64 != '' }}
       run: |
         cd android
-        ./gradlew assembleRelease bundleRelease
+        ./gradlew assembleRelease bundleRelease --max-workers=4
         cp app/build/outputs/apk/release/app-release.apk ../fheroes2.apk
         cp app/build/outputs/bundle/release/app-release.aab ../fheroes2.aab
       env:

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,7 +37,7 @@ jobs:
         sudo apt-get -y install gettext
     - name: Generate translations
       run: |
-        make -C files/lang -j 4
+        make -C files/lang -j $(nproc --all)
     - name: Create keystore
       if: ${{ github.event_name == 'push' && env.KEYSTORE_BASE64 != '' }}
       run: |

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -37,7 +37,7 @@ jobs:
         sudo apt-get -y install gettext
     - name: Generate translations
       run: |
-        make -C files/lang -j 2
+        make -C files/lang -j 4
     - name: Create keystore
       if: ${{ github.event_name == 'push' && env.KEYSTORE_BASE64 != '' }}
       run: |

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -70,7 +70,7 @@ jobs:
     - name: Build
       run: |
         cmake.exe -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON \
-                           -DENABLE_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE="C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake" \
+                           -DENABLE_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake \
                            -DVCPKG_TARGET_TRIPLET=x64-windows
         cmake.exe --build build --config Debug
     - name: Install

--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -26,9 +26,9 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
-        export PATH="$HOME/.python-venv/bin:$PATH"
+        export PATH=$HOME/.python-venv/bin:$PATH
         CodeChecker analyze --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output --ignore .codechecker-ignore build/compile_commands.json
     - name: Display results
       run: |
-        export PATH="$HOME/.python-venv/bin:$PATH"
+        export PATH=$HOME/.python-venv/bin:$PATH
         CodeChecker parse --print-steps codechecker-output

--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Analyze
       run: |
         export PATH="$HOME/.python-venv/bin:$PATH"
-        CodeChecker analyze --jobs 4 --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output --ignore .codechecker-ignore build/compile_commands.json
+        CodeChecker analyze --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output --ignore .codechecker-ignore build/compile_commands.json
     - name: Display results
       run: |
         export PATH="$HOME/.python-venv/bin:$PATH"

--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Analyze
       run: |
         export PATH="$HOME/.python-venv/bin:$PATH"
-        CodeChecker analyze --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output --ignore .codechecker-ignore build/compile_commands.json
+        CodeChecker analyze --jobs 2 --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output --ignore .codechecker-ignore build/compile_commands.json
     - name: Display results
       run: |
         export PATH="$HOME/.python-venv/bin:$PATH"

--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Analyze
       run: |
         export PATH="$HOME/.python-venv/bin:$PATH"
-        CodeChecker analyze --jobs 2 --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output --ignore .codechecker-ignore build/compile_commands.json
+        CodeChecker analyze --jobs 4 --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output --ignore .codechecker-ignore build/compile_commands.json
     - name: Display results
       run: |
         export PATH="$HOME/.python-venv/bin:$PATH"

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -24,6 +24,7 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
+        echo $(nproc --all)
         iwyu_tool -p build -j $(nproc --all) -- -Xiwyu --cxx17ns -Xiwyu --error -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" | (grep -E -v "^$|has correct #includes/fwd-decls" || true) \
                                                                                                                       | tee iwyu-result.txt
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -24,8 +24,8 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
-        iwyu_tool -p build -j $(nproc --all) -- -Xiwyu --cxx17ns -Xiwyu --error -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" | (grep -E -v "^$|has correct #includes/fwd-decls" || true) \
-                                                                                                                      | tee iwyu-result.txt
+        iwyu_tool -p build -j $(nproc --all) -- -Xiwyu --cxx17ns -Xiwyu --error -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" \
+            | (grep -E -v "^$|has correct #includes/fwd-decls" || true) | tee iwyu-result.txt
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}
       with:

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -24,7 +24,7 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
-        iwyu_tool -p build -j $(nproc --all) -- -Xiwyu --cxx17ns -Xiwyu --error -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" \
+        iwyu_tool -p build -j "$(nproc)" -- -Xiwyu --cxx17ns -Xiwyu --error -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" \
             | (grep -E -v "^$|has correct #includes/fwd-decls" || true) | tee iwyu-result.txt
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -24,7 +24,7 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
-        iwyu_tool -p build -j 2 -- -Xiwyu --cxx17ns -Xiwyu --error -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" | (grep -E -v "^$|has correct #includes/fwd-decls" || true) \
+        iwyu_tool -p build -j $(nproc --all) -- -Xiwyu --cxx17ns -Xiwyu --error -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" | (grep -E -v "^$|has correct #includes/fwd-decls" || true) \
                                                                                                                       | tee iwyu-result.txt
     - uses: actions/upload-artifact@v4
       if: ${{ failure() }}

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -24,7 +24,6 @@ jobs:
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
     - name: Analyze
       run: |
-        echo $(nproc --all)
         iwyu_tool -p build -j $(nproc --all) -- -Xiwyu --cxx17ns -Xiwyu --error -Xiwyu --mapping_file="$GITHUB_WORKSPACE/iwyu.map" | (grep -E -v "^$|has correct #includes/fwd-decls" || true) \
                                                                                                                       | tee iwyu-result.txt
     - uses: actions/upload-artifact@v4

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -174,7 +174,7 @@ jobs:
     - name: Build (Linux)
       if: ${{ startsWith( matrix.config.os, 'ubuntu-' ) }}
       run: |
-        make -j $(nproc --all)
+        make -j "$(nproc)"
       env: ${{ matrix.config.env }}
     - name: Build (MacOS)
       if: ${{ startsWith( matrix.config.os, 'macos-' ) }}
@@ -265,7 +265,7 @@ jobs:
     - name: Build
       run: |
         export PATH="$VITASDK/bin:$PATH"
-        make -f Makefile.vita -j $(nproc --all)
+        make -f Makefile.vita -j "$(nproc)"
       env:
         FHEROES2_STRICT_COMPILATION: ON
         VITASDK: /usr/local/vitasdk
@@ -314,13 +314,13 @@ jobs:
     - name: Build
       run: |
         export PATH="$DEVKITPRO/tools/bin:$DEVKITPRO/portlibs/switch/bin:$DEVKITPRO/devkitA64/bin:$PATH"
-        make -f Makefile.switch -j $(nproc --all)
+        make -f Makefile.switch -j "$(nproc)"
       env:
         FHEROES2_STRICT_COMPILATION: ON
         DEVKITPRO: /opt/devkitpro
     - name: Generate translations
       run: |
-        make -C files/lang -j $(nproc --all)
+        make -C files/lang -j "$(nproc)"
     - name: Create package
       run: |
         7z a -bb1 -tzip -- fheroes2_switch.zip LICENSE changelog.txt fheroes2.nro ./docs/README.txt ./docs/README_switch.md files/data/*.h2d files/lang/*.mo

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -171,9 +171,15 @@ jobs:
       env:
         # Do not update outdated dependencies of installed packages
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: ON
-    - name: Build
+    - name: Build (Linux)
+      if: ${{ startsWith( matrix.config.os, 'ubuntu-' ) }}
       run: |
-        make -j 4
+        make -j $(nproc --all)
+      env: ${{ matrix.config.env }}
+    - name: Build (MacOS)
+      if: ${{ startsWith( matrix.config.os, 'macos-' ) }}
+      run: |
+        make -j $(sysctl -n hw.ncpu)
       env: ${{ matrix.config.env }}
     - name: Create package
       if: ${{ matrix.config.package_name != '' && matrix.config.package_files != '' }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -259,7 +259,7 @@ jobs:
     - name: Build
       run: |
         export PATH="$VITASDK/bin:$PATH"
-        make -f Makefile.vita -j 2
+        make -f Makefile.vita -j 4
       env:
         FHEROES2_STRICT_COMPILATION: ON
         VITASDK: /usr/local/vitasdk
@@ -308,7 +308,7 @@ jobs:
     - name: Build
       run: |
         export PATH="$DEVKITPRO/tools/bin:$DEVKITPRO/portlibs/switch/bin:$DEVKITPRO/devkitA64/bin:$PATH"
-        make -f Makefile.switch -j 2
+        make -f Makefile.switch -j 4
       env:
         FHEROES2_STRICT_COMPILATION: ON
         DEVKITPRO: /opt/devkitpro

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -179,7 +179,7 @@ jobs:
     - name: Build (MacOS)
       if: ${{ startsWith( matrix.config.os, 'macos-' ) }}
       run: |
-        make -j $(sysctl -n hw.ncpu)
+        make -j "$(sysctl -n hw.logicalcpu)"
       env: ${{ matrix.config.env }}
     - name: Create package
       if: ${{ matrix.config.package_name != '' && matrix.config.package_files != '' }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -173,7 +173,7 @@ jobs:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: ON
     - name: Build
       run: |
-        make -j 2
+        make -j $(nproc --all)
       env: ${{ matrix.config.env }}
     - name: Create package
       if: ${{ matrix.config.package_name != '' && matrix.config.package_files != '' }}
@@ -259,7 +259,7 @@ jobs:
     - name: Build
       run: |
         export PATH="$VITASDK/bin:$PATH"
-        make -f Makefile.vita -j 4
+        make -f Makefile.vita -j $(nproc --all)
       env:
         FHEROES2_STRICT_COMPILATION: ON
         VITASDK: /usr/local/vitasdk
@@ -308,13 +308,13 @@ jobs:
     - name: Build
       run: |
         export PATH="$DEVKITPRO/tools/bin:$DEVKITPRO/portlibs/switch/bin:$DEVKITPRO/devkitA64/bin:$PATH"
-        make -f Makefile.switch -j 4
+        make -f Makefile.switch -j $(nproc --all)
       env:
         FHEROES2_STRICT_COMPILATION: ON
         DEVKITPRO: /opt/devkitpro
     - name: Generate translations
       run: |
-        make -C files/lang -j 2
+        make -C files/lang -j $(nproc --all)
     - name: Create package
       run: |
         7z a -bb1 -tzip -- fheroes2_switch.zip LICENSE changelog.txt fheroes2.nro ./docs/README.txt ./docs/README_switch.md files/data/*.h2d files/lang/*.mo

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -173,7 +173,7 @@ jobs:
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: ON
     - name: Build
       run: |
-        make -j $(nproc --all)
+        make -j 4
       env: ${{ matrix.config.env }}
     - name: Create package
       if: ${{ matrix.config.package_name != '' && matrix.config.package_files != '' }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -250,7 +250,7 @@ jobs:
       run: |
         git clone --depth 1 https://github.com/vitasdk/vdpm
         cd vdpm
-        export PATH="$VITASDK/bin:$PATH"
+        export PATH=$VITASDK/bin:$PATH
         ./bootstrap-vitasdk.sh
         ./install-all.sh
         rm -rf ~/.vitasdk-cache
@@ -264,7 +264,7 @@ jobs:
         fi
     - name: Build
       run: |
-        export PATH="$VITASDK/bin:$PATH"
+        export PATH=$VITASDK/bin:$PATH
         make -f Makefile.vita -j "$(nproc)"
       env:
         FHEROES2_STRICT_COMPILATION: ON
@@ -313,7 +313,7 @@ jobs:
         sudo apt-get -y install gettext p7zip-full
     - name: Build
       run: |
-        export PATH="$DEVKITPRO/tools/bin:$DEVKITPRO/portlibs/switch/bin:$DEVKITPRO/devkitA64/bin:$PATH"
+        export PATH=$DEVKITPRO/tools/bin:$DEVKITPRO/portlibs/switch/bin:$DEVKITPRO/devkitA64/bin:$PATH
         make -f Makefile.switch -j "$(nproc)"
       env:
         FHEROES2_STRICT_COMPILATION: ON

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -82,7 +82,7 @@ jobs:
     - name: Commit changes
       run: |
         git diff --name-only -z -- files/lang/*.po \
-        | xargs -r0 bash -c 'set -e; for NAME in "$@"; do if [[ -n "$(git diff "-I^\"POT-Creation-Date:[^\"]*\"$" -- "$NAME")" ]]; then git add -- "$NAME"; fi; done' dummy
+            | xargs -r0 bash -c 'set -e; for NAME in "$@"; do if [[ -n "$(git diff "-I^\"POT-Creation-Date:[^\"]*\"$" -- "$NAME")" ]]; then git add -- "$NAME"; fi; done' dummy
         git add -- docs/json/lang_*.json
         if git commit -m "Update translation files"; then git push origin HEAD; echo "CREATE_PR=YES" >> "$GITHUB_ENV"; fi
     - name: Create PR

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -33,10 +33,10 @@ jobs:
         echo "PR_BRANCH=$PR_BRANCH" >> "$GITHUB_ENV"
     - name: Generate POT
       run: |
-        make -C src/dist/fheroes2 -j $(nproc --all) pot
+        make -C src/dist/fheroes2 -j "$(nproc)" pot
     - name: Merge PO with POT
       run: |
-        make -C files/lang -j $(nproc --all) merge
+        make -C files/lang -j "$(nproc)" merge
     - name: Generate statistics
       run: |
         mkdir -p docs/json

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -33,10 +33,10 @@ jobs:
         echo "PR_BRANCH=$PR_BRANCH" >> "$GITHUB_ENV"
     - name: Generate POT
       run: |
-        make -C src/dist/fheroes2 -j 2 pot
+        make -C src/dist/fheroes2 -j $(nproc --all) pot
     - name: Merge PO with POT
       run: |
-        make -C files/lang -j 2 merge
+        make -C files/lang -j $(nproc --all) merge
     - name: Generate statistics
       run: |
         mkdir -p docs/json

--- a/.github/workflows/translation_update.yml
+++ b/.github/workflows/translation_update.yml
@@ -28,7 +28,7 @@ jobs:
         git config user.email "action@github.com"
     - name: Create PR branch
       run: |
-        PR_BRANCH="translation-update-$(uuidgen)"
+        PR_BRANCH=translation-update-$(uuidgen)
         git switch -c "$PR_BRANCH"
         echo "PR_BRANCH=$PR_BRANCH" >> "$GITHUB_ENV"
     - name: Generate POT
@@ -41,20 +41,20 @@ jobs:
       run: |
         mkdir -p docs/json
         for PO_FILE in files/lang/*.po; do
-            STATISTICS="$(msgfmt --statistics --output-file=/dev/null -- "$PO_FILE" 2>&1)"
+            STATISTICS=$(msgfmt --statistics --output-file=/dev/null -- "$PO_FILE" 2>&1)
             echo "$PO_FILE: $STATISTICS"
             if [[ "$STATISTICS" =~ ([0-9]+)\ translated\ messages? ]]; then
-                TRANSLATED="${BASH_REMATCH[1]}"
+                TRANSLATED=${BASH_REMATCH[1]}
             else
                 TRANSLATED=0
             fi
             if [[ "$STATISTICS" =~ ([0-9]+)\ fuzzy\ translations? ]]; then
-                FUZZY="${BASH_REMATCH[1]}"
+                FUZZY=${BASH_REMATCH[1]}
             else
                 FUZZY=0
             fi
             if [[ "$STATISTICS" =~ ([0-9]+)\ untranslated\ messages? ]]; then
-                UNTRANSLATED="${BASH_REMATCH[1]}"
+                UNTRANSLATED=${BASH_REMATCH[1]}
             else
                 UNTRANSLATED=0
             fi
@@ -64,11 +64,11 @@ jobs:
             else
                 PERCENT=$((TRANSLATED * 100 / OVERALL))
             fi
-            LANGUAGE="$(basename "${PO_FILE%.po}")"
+            LANGUAGE=$(basename "${PO_FILE%.po}")
             if [[ "$(head -n1 -- "$PO_FILE")" =~ ^\#\ (.+)\ translation ]]; then
-                LABEL="${BASH_REMATCH[1]}"
+                LABEL=${BASH_REMATCH[1]}
             else
-                LABEL="$LANGUAGE"
+                LABEL=$LANGUAGE
             fi
             if ((PERCENT < 75)); then
                 COLOR="red"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,7 @@ sonar.sources=.
 #sonar.sourceEncoding=UTF-8
 
 # Properties specific to the C/C++ analyzer.
-sonar.cfamily.threads=2
+#sonar.cfamily.threads=2
 
 # List of files completely excluded from the analysis.
 sonar.exclusions=src/thirdparty/**/*

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,9 +17,6 @@ sonar.sources=.
 # Encoding of the source code. Default is default system encoding.
 #sonar.sourceEncoding=UTF-8
 
-# Properties specific to the C/C++ analyzer.
-#sonar.cfamily.threads=2
-
 # List of files completely excluded from the analysis.
 sonar.exclusions=src/thirdparty/**/*
 


### PR DESCRIPTION
According to the information about GitHub Runners which can be found [here](https://docs.github.com/en/actions/using-github-hosted-runners/using-github-hosted-runners/about-github-hosted-runners) Ubuntu runners have 4 cores. This means that we can speed up the compilation as previously every runner had only 2 cores.

What was changed:
- remove the hardcoded number of threads for Sonar Scanner. It can detect them automatically.

Before:
```bash
04:35:10.371 INFO  Available processors: 4
04:35:10.373 INFO  Using 2 threads for analysis, according to value of "sonar.cfamily.threads" property.
```

After:
```bash
02:09:57.107 INFO  Available processors: 4
02:09:57.109 INFO  Using 4 threads for analysis.
```

- use `$(nproc --all)` where possible for all Ubuntu runners. This approach makes us to avoid hardcoded values and also adjust to GitHub runner configuration.
- use `$(nproc --all)` where possible for all MacOS runners. This approach makes us to avoid hardcoded values and also adjust to GitHub runner configuration.