### PR TITLE
Fix Spell Scroll artifact X position on the Adventure Map

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -4247,7 +4247,12 @@ namespace
         case ICN::OBJNARTI:
             LoadOriginalICN( id );
             if ( _icnVsSprite[id].size() == 206 ) {
-                // If we have the Price of Loyalty assets we make a map sprite for the Magic Book artifact.
+                // These are the Price of Loyalty assets.
+
+                // Spell Scroll has an invalid offset by X axis.
+                _icnVsSprite[id][173].setPosition( ( 32 - _icnVsSprite[id][173].width() ) / 2, _icnVsSprite[id][173].y() );
+
+                // Make a map sprite for the Magic Book artifact.
                 _icnVsSprite[id].resize( 208 );
 
                 // Magic book sprite shadow.

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -4250,7 +4250,9 @@ namespace
                 // These are the Price of Loyalty assets.
 
                 // Spell Scroll has an invalid offset by X axis.
-                _icnVsSprite[id][173].setPosition( ( 32 - _icnVsSprite[id][173].width() ) / 2, _icnVsSprite[id][173].y() );
+                if ( _icnVsSprite[id][173].width() == 21 ) {
+                    _icnVsSprite[id][173].setPosition( 2, _icnVsSprite[id][173].y() );
+                }
 
                 // Make a map sprite for the Magic Book artifact.
                 _icnVsSprite[id].resize( 208 );


### PR DESCRIPTION
Spell Scroll is the only artifact that consists of 1 image so what we needed to do is to center it properly in a tile.

![image](https://github.com/user-attachments/assets/5ee2b486-7313-418d-b4b9-e60b26b5b009)

close #8757 