### PR TITLE
Improved morale ui when all troops are undead

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1207,17 +1207,12 @@ int Army::GetMoraleModificator( std::string * strs ) const
     // different race penalty
     std::set<int> races;
     bool hasUndead = false;
-    bool allUndead = true;
 
     for ( const Troop * troop : *this )
         if ( troop->isValid() ) {
             races.insert( troop->GetRace() );
             hasUndead = hasUndead || troop->isUndead();
-            allUndead = allUndead && troop->isUndead();
         }
-
-    if ( allUndead )
-        return Morale::NORMAL;
 
     int result = Morale::NORMAL;
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -762,10 +762,9 @@ namespace
         if ( isFullInfo ) {
             const int32_t morale = hero.GetMorale();
             fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::MINILKMR, ( 0 > morale ? 3 : ( 0 < morale ? 4 : 5 ) ) );
-            if(hero.GetArmy().AllTroopsAreUndead())
-            {
-                fheroes2::ApplyPalette(sprite, PAL::GetPalette(PAL::PaletteType::GRAY));
-                fheroes2::ApplyPalette(sprite, PAL::GetPalette(PAL::PaletteType::DARKENING));
+            if ( hero.GetArmy().AllTroopsAreUndead() ) {
+                fheroes2::ApplyPalette( sprite, PAL::GetPalette( PAL::PaletteType::GRAY ) );
+                fheroes2::ApplyPalette( sprite, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
             }
             uint32_t count = ( 0 == morale ? 1 : std::abs( morale ) );
             dst_pt.x = cur_rt.x + 10;

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -55,6 +55,7 @@
 #include "maps_tiles_helper.h"
 #include "math_base.h"
 #include "mp2.h"
+#include "pal.h"
 #include "profit.h"
 #include "resource.h"
 #include "screen.h"
@@ -760,7 +761,12 @@ namespace
         // morale
         if ( isFullInfo ) {
             const int32_t morale = hero.GetMorale();
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINILKMR, ( 0 > morale ? 3 : ( 0 < morale ? 4 : 5 ) ) );
+            fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::MINILKMR, ( 0 > morale ? 3 : ( 0 < morale ? 4 : 5 ) ) );
+            if(hero.GetArmy().AllTroopsAreUndead())
+            {
+                fheroes2::ApplyPalette(sprite, PAL::GetPalette(PAL::PaletteType::GRAY));
+                fheroes2::ApplyPalette(sprite, PAL::GetPalette(PAL::PaletteType::DARKENING));
+            }
             uint32_t count = ( 0 == morale ? 1 : std::abs( morale ) );
             dst_pt.x = cur_rt.x + 10;
             dst_pt.y = cur_rt.y + ( count == 1 ? 20 : 13 );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -761,7 +761,16 @@ namespace
         // morale
         if ( isFullInfo ) {
             const int32_t morale = hero.GetMorale();
-            fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::MINILKMR, ( 0 > morale ? 3 : ( 0 < morale ? 4 : 5 ) ) );
+
+            uint32_t spriteInx = 5;
+            if ( morale < 0 ) {
+                spriteInx = 3;
+            }
+            else if ( morale > 0 ) {
+                spriteInx = 4;
+            }
+
+            fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::MINILKMR, spriteInx );
             if ( hero.GetArmy().AllTroopsAreUndead() ) {
                 fheroes2::ApplyPalette( sprite, PAL::GetPalette( PAL::PaletteType::GRAY ) );
                 fheroes2::ApplyPalette( sprite, PAL::GetPalette( PAL::PaletteType::DARKENING ) );

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -151,7 +151,15 @@ void MoraleIndicator::Redraw()
         _description.append( modificators );
     }
 
-    fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::HSICONS, ( 0 > _morale ? 5 : ( 0 < _morale ? 4 : 7 ) ) );
+    uint32_t spriteInx = 7;
+    if ( _morale < Morale::NORMAL ) {
+        spriteInx = 5;
+    }
+    else if ( _morale > Morale::NORMAL ) {
+        spriteInx = 4;
+    }
+
+    fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::HSICONS, spriteInx );
     if ( _hero->GetArmy().AllTroopsAreUndead() ) {
         _description.append( "\n\n" );
         _description.append( _( "Entire army is undead, so morale does not apply." ) );

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -33,7 +33,9 @@
 #include "dialog.h"
 #include "heroes.h"
 #include "icn.h"
+#include "image.h"
 #include "localevent.h"
+#include "pal.h"
 #include "screen.h"
 #include "tools.h"
 #include "translations.h"
@@ -149,12 +151,14 @@ void MoraleIndicator::Redraw()
         _description.append( modificators );
     }
 
+    fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::HSICONS, ( 0 > _morale ? 5 : ( 0 < _morale ? 4 : 7 ) ) );
     if ( _hero->GetArmy().AllTroopsAreUndead() ) {
         _description.append( "\n\n" );
         _description.append( _( "Entire army is undead, so morale does not apply." ) );
+        fheroes2::ApplyPalette( sprite, PAL::GetPalette( PAL::PaletteType::GRAY ) );
+        fheroes2::ApplyPalette( sprite, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
     }
 
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::HSICONS, ( 0 > _morale ? 5 : ( 0 < _morale ? 4 : 7 ) ) );
     const int32_t inter = 6;
     int32_t count = ( 0 == _morale ? 1 : std::abs( _morale ) );
     int32_t cx = _area.x + ( _area.width - ( sprite.width() + inter * ( count - 1 ) ) ) / 2;


### PR DESCRIPTION
The morale modifier is now calculated when using an undead army. The previous behaviour was inconsistent depending on where the modifier was coming from (artifact vs hero).

Grayed out the morale icon if the hero is using an undead army. 

![image](https://github.com/user-attachments/assets/c4666ce9-14f4-4c2a-81b9-6792f96c1d75)




fixes #2419 