### PR TITLE
Replace the macro-based include guards by #pragma once

### DIFF
--- a/src/engine/agg_file.h
+++ b/src/engine/agg_file.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2024                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef AGG_FILE_H
-#define AGG_FILE_H
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -70,5 +69,3 @@ namespace fheroes2
 }
 
 IStreamBase & operator>>( IStreamBase & stream, fheroes2::ICNHeader & icn );
-
-#endif

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2008 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2AUDIO_H
-#define H2AUDIO_H
+#pragma once
 
 #include <cstdint>
 #include <optional>
@@ -110,5 +109,3 @@ namespace Music
 
     std::vector<uint8_t> Xmi2Mid( const std::vector<uint8_t> & buf );
 }
-
-#endif

--- a/src/engine/dir.h
+++ b/src/engine/dir.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2DIR_H
-#define H2DIR_H
+
+#pragma once
 
 #include <list>
 #include <string>
@@ -40,5 +40,3 @@ struct ListFiles : public std::list<std::string>
     // Returns true if there are no files in the 'path' directory with names ending in 'filter', case-insensitive, otherwise returns false.
     static bool IsEmpty( const std::string & path, const std::string & filter );
 };
-
-#endif

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2008 by Josh Matthews <josh@joshmatthews.net>           *
@@ -21,8 +21,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2LOCALEVENT_H
-#define H2LOCALEVENT_H
+
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -519,5 +519,3 @@ private:
         _actionStates &= ~states;
     }
 };
-
-#endif

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2LOGGING_H
-#define H2LOGGING_H
+#pragma once
 
 #include <iostream>
 #include <sstream> // IWYU pragma: keep
@@ -191,5 +190,3 @@ namespace Logging
         return;                                                                                                                                                          \
     }                                                                                                                                                                    \
     const Logging::TextSupportLogger _temp_logger; // The name was chosen on purpose to avoid collisions with other variable names within a code block.
-
-#endif // H2LOGGING_H

--- a/src/engine/pal.h
+++ b/src/engine/pal.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2024                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -17,8 +17,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2PAL_H
-#define H2PAL_H
+
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -47,5 +47,3 @@ namespace PAL
     const std::vector<uint8_t> & GetPalette( const PaletteType type );
     std::vector<uint8_t> CombinePalettes( const std::vector<uint8_t> & first, const std::vector<uint8_t> & second );
 }
-
-#endif

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2013 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2SYSTEM_H
-#define H2SYSTEM_H
+#pragma once
 
 #include <ctime>
 #include <filesystem>
@@ -88,5 +87,3 @@ namespace System
 
     tm GetTM( const time_t time );
 }
-
-#endif

--- a/src/engine/tinyconfig.h
+++ b/src/engine/tinyconfig.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef TINYCONFIG_H
-#define TINYCONFIG_H
+#pragma once
 
 #include <functional>
 #include <map>
@@ -53,5 +52,3 @@ private:
     const char separator;
     const char comment;
 };
-
-#endif

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2TOOLS_H
-#define H2TOOLS_H
+
+#pragma once
 
 #include <bitset>
 #include <cstddef>
@@ -148,5 +148,3 @@ namespace fheroes2
         }
     }
 }
-
-#endif

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2ZLIB_H
-#define H2ZLIB_H
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -56,5 +55,3 @@ namespace Compression
 
     fheroes2::Image CreateImageFromZlib( int32_t width, int32_t height, const uint8_t * imageData, size_t imageSize, bool doubleLayer );
 }
-
-#endif

--- a/src/fheroes2/agg/agg.h
+++ b/src/fheroes2/agg/agg.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2AGG_H
-#define H2AGG_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -58,5 +57,3 @@ namespace AGG
 
     std::vector<uint8_t> getDataFromAggFile( const std::string & key, const bool ignoreExpansion );
 }
-
-#endif

--- a/src/fheroes2/agg/bin_info.h
+++ b/src/fheroes2/agg/bin_info.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2024                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BIN_FRM_H
-#define H2BIN_FRM_H
+#pragma once
 
 #include <algorithm>
 #include <cstddef>
@@ -93,4 +92,3 @@ namespace Bin_Info
 
     MonsterAnimInfo GetMonsterInfo( uint32_t monsterID );
 }
-#endif

--- a/src/fheroes2/agg/icn.h
+++ b/src/fheroes2/agg/icn.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2ICN_H
-#define H2ICN_H
+#pragma once
 
 #include <cstdint>
 
@@ -1143,5 +1142,3 @@ namespace ICN
 
     int getFlagIcnId( const int color );
 }
-
-#endif

--- a/src/fheroes2/agg/m82.h
+++ b/src/fheroes2/agg/m82.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2M82_H
-#define H2M82_H
+#pragma once
 
 namespace Maps
 {
@@ -359,5 +358,3 @@ namespace M82
     // Returns the ambient soundtrack for a given tile or M82::UNKNOWN if there is no track
     SoundType getAdventureMapTileSound( const Maps::Tile & tile );
 }
-
-#endif

--- a/src/fheroes2/agg/mus.h
+++ b/src/fheroes2/agg/mus.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2008 by Josh Matthews <josh@joshmatthews.net>           *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2MUS_H
-#define H2MUS_H
+#pragma once
 
 #include <string>
 
@@ -94,5 +93,3 @@ namespace MUS
 
     int GetBattleRandom();
 }
-
-#endif

--- a/src/fheroes2/agg/til.h
+++ b/src/fheroes2/agg/til.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2TIL_H
-#define H2TIL_H
+#pragma once
 
 namespace TIL
 {
@@ -37,5 +36,3 @@ namespace TIL
         LASTTIL
     };
 }
-
-#endif

--- a/src/fheroes2/agg/xmi.h
+++ b/src/fheroes2/agg/xmi.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2XMI_H
-#define H2XMI_H
+#pragma once
 
 namespace XMI
 {
@@ -57,5 +56,3 @@ namespace XMI
     const char * GetString( int track );
     int FromMUS( int track, bool expansion );
 }
-
-#endif

--- a/src/fheroes2/army/army_bar.h
+++ b/src/fheroes2/army/army_bar.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2ARMYBAR_H
-#define H2ARMYBAR_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -89,5 +88,3 @@ private:
     std::string msg;
     int32_t _troopWindowOffsetY{ 0 };
 };
-
-#endif

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_H
-#define H2BATTLE_H
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -139,5 +138,3 @@ namespace Battle
         BOTTOM_BRIDGE_TOWER = 10
     };
 }
-
-#endif

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_ARENA_H
-#define H2BATTLE_ARENA_H
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -364,5 +363,3 @@ namespace Battle
 
     Arena * GetArena();
 }
-
-#endif

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_BOARD_H
-#define H2BATTLE_BOARD_H
+#pragma once
 
 #include <algorithm>
 #include <cstdint>
@@ -135,5 +134,3 @@ namespace Battle
         void SetCobjObject( const int icn, const uint32_t dst );
     };
 }
-
-#endif

--- a/src/fheroes2/battle/battle_bridge.h
+++ b/src/fheroes2/battle/battle_bridge.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_BRIDGE_H
-#define H2BATTLE_BRIDGE_H
+#pragma once
 
 #include <cassert>
 #include <cstdint>
@@ -91,5 +90,3 @@ namespace Battle
         };
     };
 }
-
-#endif

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_CATAPULT_H
-#define H2BATTLE_CATAPULT_H
+#pragma once
 
 #include <cstdint>
 #include <map>
@@ -67,5 +66,3 @@ namespace Battle
         bool canMiss;
     };
 }
-
-#endif

--- a/src/fheroes2/battle/battle_cell.h
+++ b/src/fheroes2/battle/battle_cell.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_CELL_H
-#define H2BATTLE_CELL_H
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -159,5 +158,3 @@ namespace Battle
         bool operator<( const Position & other ) const;
     };
 }
-
-#endif

--- a/src/fheroes2/battle/battle_command.h
+++ b/src/fheroes2/battle/battle_command.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_COMMAND_H
-#define H2BATTLE_COMMAND_H
+#pragma once
 
 #include <cassert>
 #include <cstddef>
@@ -159,5 +158,3 @@ namespace std
         }
     };
 }
-
-#endif

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_INTERFACE_H
-#define H2BATTLE_INTERFACE_H
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -619,5 +618,3 @@ namespace Battle
         };
     };
 }
-
-#endif

--- a/src/fheroes2/battle/battle_only.h
+++ b/src/fheroes2/battle/battle_only.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_ONLY_H
-#define H2BATTLE_ONLY_H
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -139,5 +138,3 @@ namespace Battle
         static void copyHero( const Heroes & in, Heroes & out );
     };
 }
-
-#endif

--- a/src/fheroes2/battle/battle_tower.h
+++ b/src/fheroes2/battle/battle_tower.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BATTLE_TOWER_H
-#define H2BATTLE_TOWER_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -70,5 +69,3 @@ namespace Battle
         bool _isValid;
     };
 }
-
-#endif

--- a/src/fheroes2/campaign/campaign_data.h
+++ b/src/fheroes2/campaign/campaign_data.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2CAMPAIGN_DATA_H
-#define H2CAMPAIGN_DATA_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -116,5 +115,3 @@ namespace Campaign
         static const char * getBaneFleeingMessage( const int monsterId );
     };
 }
-
-#endif

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2CAMPAIGN_SAVEDATA_H
-#define H2CAMPAIGN_SAVEDATA_H
+#pragma once
 
 #include <cstdint>
 #include <optional>
@@ -151,5 +150,3 @@ namespace Campaign
     // that case the difficulty of the corresponding campaign map should be used). Call this function only when playing campaign scenario.
     std::optional<int> getCurrentScenarioDifficultyLevel();
 }
-
-#endif

--- a/src/fheroes2/campaign/campaign_scenariodata.h
+++ b/src/fheroes2/campaign/campaign_scenariodata.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2CAMPAIGN_SCENARIODATA_H
-#define H2CAMPAIGN_SCENARIODATA_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -207,5 +206,3 @@ namespace Campaign
 
     const char * getCampaignName( const int campaignId );
 }
-
-#endif

--- a/src/fheroes2/castle/buildinginfo.h
+++ b/src/fheroes2/castle/buildinginfo.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BUILDINGINFO_H
-#define H2BUILDINGINFO_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -107,5 +106,3 @@ private:
     fheroes2::Image backsf;
     std::vector<DwellingItem> content;
 };
-
-#endif

--- a/src/fheroes2/castle/mageguild.h
+++ b/src/fheroes2/castle/mageguild.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2MAGEGUILD_H
-#define H2MAGEGUILD_H
+#pragma once
 
 #include "spell_storage.h"
 
@@ -50,5 +49,3 @@ private:
     SpellStorage general;
     SpellStorage library;
 };
-
-#endif

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2DIALOG_H
-#define H2DIALOG_H
+
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -222,5 +222,3 @@ namespace Dialog
         int border;
     };
 }
-
-#endif

--- a/src/fheroes2/dialog/dialog_selectitems.h
+++ b/src/fheroes2/dialog/dialog_selectitems.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2EDITOR_DIALOGS_H
-#define H2EDITOR_DIALOGS_H
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -151,5 +150,3 @@ namespace Dialog
 
     int selectAdventureMiscellaneousObjectType( const int objectType );
 }
-
-#endif

--- a/src/fheroes2/dialog/dialog_selectscenario.h
+++ b/src/fheroes2/dialog/dialog_selectscenario.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2SELECT_SCENARIO_H
-#define H2SELECT_SCENARIO_H
+#pragma once
 
 #include <cstdint>
 
@@ -104,5 +103,3 @@ namespace Dialog
 {
     const Maps::FileInfo * SelectScenario( const MapsFileInfoList & allMaps, const bool isForEditor );
 }
-
-#endif

--- a/src/fheroes2/game/difficulty.h
+++ b/src/fheroes2/game/difficulty.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2DIFFICULTY_H
-#define H2DIFFICULTY_H
+
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -72,5 +72,3 @@ namespace Difficulty
     bool allowAIToDevelopCastlesOnDay( const int difficulty, const bool isCampaign, const uint32_t day );
     bool allowAIToBuildCastleBuilding( const int difficulty, const bool isCampaign, const BuildingType building );
 }
-
-#endif

--- a/src/fheroes2/game/game.h
+++ b/src/fheroes2/game/game.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2GAME_H
-#define H2GAME_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -128,5 +127,3 @@ namespace Game
     // (unless the abbreviated number is requested), otherwise, a qualitative estimate is returned (Few, Several, etc).
     std::string formatMonsterCount( const uint32_t count, const bool isDetailedView, const bool abbreviateNumber = false );
 }
-
-#endif

--- a/src/fheroes2/game/game_delays.h
+++ b/src/fheroes2/game/game_delays.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2GAME_DELAYS_H
-#define H2GAME_DELAYS_H
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -103,5 +102,3 @@ namespace Game
     // Custom delay must never be called in this function.
     uint64_t getAnimationDelayValue( const DelayType delayType );
 }
-
-#endif

--- a/src/fheroes2/game/game_interface.h
+++ b/src/fheroes2/game/game_interface.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2GAMEINTERFACE_H
-#define H2GAMEINTERFACE_H
+#pragma once
 
 #include <cstdint>
 
@@ -178,5 +177,3 @@ namespace Interface
         bool _lockRedraw;
     };
 }
-
-#endif

--- a/src/fheroes2/game/game_io.h
+++ b/src/fheroes2/game/game_io.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2GAMEIO_H
-#define H2GAMEIO_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -57,5 +56,3 @@ namespace Game
 
     bool SaveCompletedCampaignScenario();
 }
-
-#endif

--- a/src/fheroes2/game/game_over.h
+++ b/src/fheroes2/game/game_over.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2GAMEOVER_H
-#define H2GAMEOVER_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -95,5 +94,3 @@ namespace GameOver
     OStreamBase & operator<<( OStreamBase & stream, const Result & res );
     IStreamBase & operator>>( IStreamBase & stream, Result & res );
 }
-
-#endif

--- a/src/fheroes2/game/game_static.h
+++ b/src/fheroes2/game/game_static.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2GAMESTATIC_H
-#define H2GAMESTATIC_H
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -78,5 +77,3 @@ namespace GameStatic
 
     bool isHeroWorthyToVisitXanadu( const Heroes & hero );
 }
-
-#endif

--- a/src/fheroes2/game/highscores.h
+++ b/src/fheroes2/game/highscores.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2024                                             *
+ *   Copyright (C) 2022 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2HIGHSCORES_H
-#define H2HIGHSCORES_H
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -125,5 +124,3 @@ namespace fheroes2
     OStreamBase & operator<<( OStreamBase & stream, const HighscoreData & data );
     IStreamBase & operator>>( IStreamBase & stream, HighscoreData & data );
 }
-
-#endif

--- a/src/fheroes2/gui/cursor.h
+++ b/src/fheroes2/gui/cursor.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2CURSOR_H
-#define H2CURSOR_H
+
+#pragma once
 
 #include <cassert>
 #include <cstdint>
@@ -238,5 +238,3 @@ private:
     const int _theme{ Cursor::Get().Themes() };
     const bool _visible{ fheroes2::cursor().isVisible() };
 };
-
-#endif

--- a/src/fheroes2/gui/interface_border.h
+++ b/src/fheroes2/gui/interface_border.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_BORDER_H
-#define H2INTERFACE_BORDER_H
+#pragma once
 
 #include <cstdint>
 
@@ -73,5 +72,3 @@ namespace Interface
         bool _isMouseCaptured{ false };
     };
 }
-
-#endif

--- a/src/fheroes2/gui/interface_buttons.h
+++ b/src/fheroes2/gui/interface_buttons.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_BUTTONS_H
-#define H2INTERFACE_BUTTONS_H
+#pragma once
 
 #include <cstdint>
 
@@ -85,5 +84,3 @@ namespace Interface
         fheroes2::Rect _systemRect;
     };
 }
-
-#endif

--- a/src/fheroes2/gui/interface_cpanel.h
+++ b/src/fheroes2/gui/interface_cpanel.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_CPANEL_H
-#define H2INTERFACE_CPANEL_H
+#pragma once
 
 #include <cstdint>
 #include <memory>
@@ -90,5 +89,3 @@ namespace Interface
         fheroes2::Rect rt_end;
     };
 }
-
-#endif

--- a/src/fheroes2/gui/interface_icons.h
+++ b/src/fheroes2/gui/interface_icons.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_ICONS_H
-#define H2INTERFACE_ICONS_H
+#pragma once
 
 #include <cassert>
 #include <cstdint>
@@ -215,5 +214,3 @@ namespace Interface
         HeroesIcons _heroesIcons{ 4, _sfMarker };
     };
 }
-
-#endif

--- a/src/fheroes2/gui/interface_itemsbar.h
+++ b/src/fheroes2/gui/interface_itemsbar.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_ITEMSBAR_H
-#define H2INTERFACE_ITEMSBAR_H
+#pragma once
 
 #include <algorithm>
 #include <cassert>
@@ -582,5 +581,3 @@ namespace Interface
         ItemIterPos curItemPos;
     };
 }
-
-#endif

--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_LIST_H
-#define H2INTERFACE_LIST_H
+#pragma once
 
 #include <algorithm>
 
@@ -601,5 +600,3 @@ namespace Interface
         }
     };
 }
-
-#endif

--- a/src/fheroes2/gui/interface_radar.h
+++ b/src/fheroes2/gui/interface_radar.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_RADAR_H
-#define H2INTERFACE_RADAR_H
+#pragma once
 
 #include <cstdint>
 
@@ -102,5 +101,3 @@ namespace Interface
         bool _hide{ true };
     };
 }
-
-#endif

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2INTERFACE_STATUS_H
-#define H2INTERFACE_STATUS_H
+#pragma once
 
 #include <cstdint>
 
@@ -109,5 +108,3 @@ namespace Interface
         uint32_t _grainsAnimationIndexOffset{ 0 };
     };
 }
-
-#endif

--- a/src/fheroes2/gui/statusbar.h
+++ b/src/fheroes2/gui/statusbar.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2STATUSBAR_H
-#define H2STATUSBAR_H
+#pragma once
 
 #include <string>
 
@@ -47,5 +46,3 @@ private:
     std::string _prevMessage;
     fheroes2::Rect _prevMessageRoi;
 };
-
-#endif

--- a/src/fheroes2/heroes/direction.h
+++ b/src/fheroes2/heroes/direction.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2DIRECTION_H
-#define H2DIRECTION_H
+
+#pragma once
 
 #include <string>
 #include <vector>
@@ -67,5 +67,3 @@ namespace Direction
 #define DIRECTION_BOTTOM_RIGHT_CORNER ( Direction::BOTTOM | Direction::BOTTOM_RIGHT | Direction::RIGHT )
 #define DIRECTION_BOTTOM_LEFT_CORNER ( Direction::BOTTOM | Direction::BOTTOM_LEFT | Direction::LEFT )
 #define DIRECTION_ALL_CORNERS ( Direction::TOP_RIGHT | Direction::BOTTOM_RIGHT | Direction::BOTTOM_LEFT | Direction::TOP_LEFT )
-
-#endif

--- a/src/fheroes2/heroes/heroes_base.h
+++ b/src/fheroes2/heroes/heroes_base.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Josh Matthews  <josh@joshmatthews.net>          *
@@ -22,8 +22,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2HEROESBASE_H
-#define H2HEROESBASE_H
+#pragma once
 
 #include <cstdint>
 #include <functional>
@@ -184,5 +183,3 @@ protected:
 
 OStreamBase & operator<<( OStreamBase & stream, const HeroBase & hero );
 IStreamBase & operator>>( IStreamBase & stream, HeroBase & hero );
-
-#endif

--- a/src/fheroes2/heroes/heroes_indicator.h
+++ b/src/fheroes2/heroes/heroes_indicator.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2HEROESIND_H
-#define H2HEROESIND_H
+#pragma once
 
 #include <string>
 
@@ -140,5 +139,3 @@ private:
     // This state is used in Editor to show that default value is used.
     bool _isDefault{ false };
 };
-
-#endif

--- a/src/fheroes2/heroes/route.h
+++ b/src/fheroes2/heroes/route.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2ROUTE_H
-#define H2ROUTE_H
+
+#pragma once
 
 #include <cstdint>
 #include <list>
@@ -206,5 +206,3 @@ namespace Route
 
     uint32_t calculatePathPenalty( const std::list<Step> & path );
 }
-
-#endif

--- a/src/fheroes2/heroes/skill_static.h
+++ b/src/fheroes2/heroes/skill_static.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2SKILL_STATIC_H
-#define H2SKILL_STATIC_H
+#pragma once
 
 #include <cstdint>
 
@@ -80,5 +79,3 @@ namespace Skill
         ValuesPerLevel values;
     };
 }
-
-#endif

--- a/src/fheroes2/kingdom/color.h
+++ b/src/fheroes2/kingdom/color.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2COLOR_H
-#define H2COLOR_H
+
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -94,5 +94,3 @@ public:
         return color;
     }
 };
-
-#endif

--- a/src/fheroes2/kingdom/luck.h
+++ b/src/fheroes2/kingdom/luck.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2LUCK_H
-#define H2LUCK_H
+
+#pragma once
 
 #include <string>
 
@@ -43,5 +43,3 @@ namespace Luck
     std::string Description( int );
     int Normalize( const int luck );
 }
-
-#endif

--- a/src/fheroes2/kingdom/morale.h
+++ b/src/fheroes2/kingdom/morale.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2022                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2MORALE_H
-#define H2MORALE_H
+
+#pragma once
 
 #include <string>
 
@@ -43,5 +43,3 @@ namespace Morale
     std::string Description( int );
     int Normalize( const int morale );
 }
-
-#endif

--- a/src/fheroes2/kingdom/payment.h
+++ b/src/fheroes2/kingdom/payment.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2PAYMENT_H
-#define H2PAYMENT_H
+#pragma once
 
 #include <cstdint>
 
@@ -38,5 +37,3 @@ namespace PaymentConditions
 
     Funds getMagellansMapsPurchasePrice();
 }
-
-#endif

--- a/src/fheroes2/kingdom/profit.h
+++ b/src/fheroes2/kingdom/profit.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2PROFIT_H
-#define H2PROFIT_H
+#pragma once
 
 #include <cstdint>
 
@@ -34,5 +33,3 @@ namespace ProfitConditions
     Funds FromArtifact( int );
     Funds FromMine( int );
 }
-
-#endif

--- a/src/fheroes2/kingdom/puzzle.h
+++ b/src/fheroes2/kingdom/puzzle.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2PUZZLE_H
-#define H2PUZZLE_H
+#pragma once
 
 #include <bitset>
 #include <cstddef>
@@ -52,5 +51,3 @@ public:
 
 OStreamBase & operator<<( OStreamBase & stream, const Puzzle & pzl );
 IStreamBase & operator>>( IStreamBase & stream, Puzzle & pzl );
-
-#endif

--- a/src/fheroes2/kingdom/race.h
+++ b/src/fheroes2/kingdom/race.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2RACE_H
-#define H2RACE_H
+
+#pragma once
 
 #include <cstdint>
 
@@ -54,5 +54,3 @@ namespace Race
 
     bool isMagicalRace( const int race );
 }
-
-#endif

--- a/src/fheroes2/kingdom/speed.h
+++ b/src/fheroes2/kingdom/speed.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2023                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2SPEED_H
-#define H2SPEED_H
+
+#pragma once
 
 #include <string>
 
@@ -48,5 +48,3 @@ namespace Speed
     int GetSlowSpeedFromSpell( const int currentSpeed );
     int GetHasteSpeedFromSpell( const int currentSpeed );
 }
-
-#endif

--- a/src/fheroes2/kingdom/view_world.h
+++ b/src/fheroes2/kingdom/view_world.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2VIEWWORLD_H
-#define H2VIEWWORLD_H
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -88,5 +87,3 @@ public:
         fheroes2::Rect _visibleROI;
     };
 };
-
-#endif

--- a/src/fheroes2/kingdom/week.h
+++ b/src/fheroes2/kingdom/week.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2WEEK_H
-#define H2WEEK_H
+#pragma once
 
 #include <cstdint>
 
@@ -93,5 +92,3 @@ private:
     WeekName _week;
     Monster::MonsterType _monster;
 };
-
-#endif

--- a/src/fheroes2/maps/ground.h
+++ b/src/fheroes2/maps/ground.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2MAPSGROUND_H
-#define H2MAPSGROUND_H
+
+#pragma once
 
 #include <cstdint>
 
@@ -67,5 +67,3 @@ namespace Maps
         uint16_t getRandomTerrainImageIndex( const int groundId, const bool allowEmbeddedObjectsAppearOnTerrain );
     }
 }
-
-#endif

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2MAPS_H
-#define H2MAPS_H
+
+#pragma once
 
 #include <algorithm>
 #include <cstdint>
@@ -128,5 +128,3 @@ namespace Maps
     void UpdateCastleSprite( const fheroes2::Point & center, int race, bool isCastle = false, bool isRandom = false );
     void ReplaceRandomCastleObjectId( const fheroes2::Point & );
 }
-
-#endif

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2MAPSFILEINFO_H
-#define H2MAPSFILEINFO_H
+
+#pragma once
 
 #include <algorithm>
 #include <array>
@@ -238,5 +238,3 @@ namespace Maps
     // Only for RESURRECTION map files.
     MapsFileInfoList getResurrectionMapFileInfos( const bool isForEditor, const uint8_t humanPlayerCount );
 }
-
-#endif

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2013 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2MAPS_OBJECTS_H
-#define H2MAPS_OBJECTS_H
+
+#pragma once
 
 #include <cstdint>
 #include <initializer_list>
@@ -155,5 +155,3 @@ IStreamBase & operator>>( IStreamBase & stream, MapSphinx & obj );
 
 OStreamBase & operator<<( OStreamBase & stream, const MapSign & obj );
 IStreamBase & operator>>( IStreamBase & stream, MapSign & obj );
-
-#endif

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2TILES_H
-#define H2TILES_H
+
+#pragma once
 
 #include <array>
 #include <cstdint>
@@ -405,5 +405,3 @@ namespace Maps
     IStreamBase & operator>>( IStreamBase & stream, ObjectPart & ta );
     IStreamBase & operator>>( IStreamBase & stream, Tile & tile );
 }
-
-#endif

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2MP2_H
-#define H2MP2_H
+
+#pragma once
 
 #include <cstdint>
 
@@ -546,5 +546,3 @@ namespace MP2
     // Only specific objects from the original MP2 format contain metadata (quantity1 and quantity2 values).
     bool doesObjectContainMetadata( const MP2::MapObjectType type );
 }
-
-#endif

--- a/src/fheroes2/maps/position.h
+++ b/src/fheroes2/maps/position.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2POSITION_H
-#define H2POSITION_H
+#pragma once
 
 #include <cstdint>
 
@@ -62,5 +61,3 @@ protected:
 
     fheroes2::Point center;
 };
-
-#endif

--- a/src/fheroes2/maps/visit.h
+++ b/src/fheroes2/maps/visit.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2MAPSVISIT_H
-#define H2MAPSVISIT_H
+#pragma once
 
 class IndexObject;
 
@@ -39,5 +38,3 @@ namespace Visit
     bool isMonthLife( const IndexObject & visit );
     bool isBattleLife( const IndexObject & visit );
 }
-
-#endif

--- a/src/fheroes2/monster/monster_info.h
+++ b/src/fheroes2/monster/monster_info.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2MONSTER_INFO_H
-#define H2MONSTER_INFO_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -239,4 +238,3 @@ namespace fheroes2
     bool isAbilityPresent( const std::vector<MonsterAbility> & abilities, const MonsterAbilityType abilityType );
     bool isWeaknessPresent( const std::vector<MonsterWeakness> & weaknesses, const MonsterWeaknessType weaknessType );
 }
-#endif

--- a/src/fheroes2/resource/artifact_ultimate.h
+++ b/src/fheroes2/resource/artifact_ultimate.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2ARTIFACT_ULTIMATE_H
-#define H2ARTIFACT_ULTIMATE_H
+#pragma once
 
 #include <cstdint>
 
@@ -69,5 +68,3 @@ private:
     int32_t _index;
     bool _isFound;
 };
-
-#endif

--- a/src/fheroes2/resource/resource.h
+++ b/src/fheroes2/resource/resource.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2RESOURCE_H
-#define H2RESOURCE_H
+
+#pragma once
 
 #include <cstdint>
 #include <limits>
@@ -212,5 +212,3 @@ namespace Resource
         }
     }
 }
-
-#endif

--- a/src/fheroes2/spell/spell.h
+++ b/src/fheroes2/spell/spell.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2SPELL_H
-#define H2SPELL_H
+
+#pragma once
 
 #include <cstdint>
 #include <vector>
@@ -265,5 +265,3 @@ private:
 
     int id;
 };
-
-#endif

--- a/src/fheroes2/spell/spell_book.h
+++ b/src/fheroes2/spell/spell_book.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2SPELLBOOK_H
-#define H2SPELLBOOK_H
+#pragma once
 
 #include <cstddef>
 #include <functional>
@@ -57,5 +56,3 @@ private:
 
     mutable Filter _spellFilter = Filter::ADVN;
 };
-
-#endif

--- a/src/fheroes2/spell/spell_info.h
+++ b/src/fheroes2/spell/spell_info.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -18,8 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2_SPELL_INFO_H
-#define H2_SPELL_INFO_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -55,5 +54,3 @@ namespace fheroes2
 
     bool isHeroNearWater( const Heroes & hero );
 }
-
-#endif

--- a/src/fheroes2/spell/spell_storage.h
+++ b/src/fheroes2/spell/spell_storage.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2SPELLSTORAGE_H
-#define H2SPELLSTORAGE_H
+#pragma once
 
 #include <string>
 #include <vector>
@@ -46,5 +45,3 @@ public:
     bool isPresentSpell( const Spell & ) const;
     std::string String() const;
 };
-
-#endif

--- a/src/fheroes2/system/bitmodes.h
+++ b/src/fheroes2/system/bitmodes.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2BITMODES_H
-#define H2BITMODES_H
+#pragma once
 
 #include <cstdint>
 
@@ -64,5 +63,3 @@ protected:
 
     uint32_t modes;
 };
-
-#endif

--- a/src/fheroes2/system/players.h
+++ b/src/fheroes2/system/players.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2PLAYERS_H
-#define H2PLAYERS_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -275,5 +274,3 @@ private:
 
 OStreamBase & operator<<( OStreamBase & stream, const Players & players );
 IStreamBase & operator>>( IStreamBase & stream, Players & players );
-
-#endif

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -21,8 +21,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#ifndef H2SETTINGS_H
-#define H2SETTINGS_H
+#pragma once
 
 #include <cstdint>
 #include <string>
@@ -394,5 +393,3 @@ private:
 
 OStreamBase & operator<<( OStreamBase & stream, const Settings & conf );
 IStreamBase & operator>>( IStreamBase & stream, Settings & conf );
-
-#endif

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -20,8 +20,8 @@
  *   Free Software Foundation, Inc.,                                       *
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
-#ifndef H2WORLD_H
-#define H2WORLD_H
+
+#pragma once
 
 #include <cstddef>
 #include <cstdint>
@@ -485,5 +485,3 @@ OStreamBase & operator<<( OStreamBase & stream, const CapturedObject & obj );
 IStreamBase & operator>>( IStreamBase & stream, CapturedObject & obj );
 
 extern World & world;
-
-#endif

--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -51,7 +51,7 @@ BEGIN
             VALUE "FileDescription",  "Free implementation of the Heroes of Might and Magic II game engine\0"
             VALUE "FileVersion",      FH2_VERSION_STR
             VALUE "InternalName",     "fheroes2\0"
-            VALUE "LegalCopyright",   "\251 2024 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
+            VALUE "LegalCopyright",   "\251 2025 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
             VALUE "OriginalFilename", "fheroes2.exe\0"
             VALUE "ProductName",      "fheroes2 engine\0"
             VALUE "ProductVersion",   FH2_VERSION_STR

--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
To be consistent with the new code. In addition, some old header files were renamed at the time, so their macro names do not match header file names anymore.