### PR TITLE
Improve side tile passability logic

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -742,10 +742,10 @@ void Maps::Tile::updatePassability()
         return;
     }
 
-    const Tile & belowTile = world.getTile( GetDirectionIndex( _index, Direction::BOTTOM ) );
+    const Tile & bottomTile = world.getTile( GetDirectionIndex( _index, Direction::BOTTOM ) );
     // If an object locates on land and the below tile is water, mark the current tile as impassable.
     // It's done for cases that a hero won't be able to disembark on the tile.
-    if ( !isWater() && belowTile.isWater() ) {
+    if ( !isWater() && bottomTile.isWater() ) {
         _tilePassabilityDirections = 0;
         return;
     }
@@ -766,7 +766,7 @@ void Maps::Tile::updatePassability()
     }
 
     for ( const uint32_t objectId : tileUIDs ) {
-        if ( belowTile.doesObjectExist( objectId ) ) {
+        if ( bottomTile.doesObjectExist( objectId ) ) {
             _tilePassabilityDirections = 0;
             return;
         }
@@ -781,17 +781,17 @@ void Maps::Tile::updatePassability()
         return part.icnType != MP2::OBJ_ICN_TYPE_ROAD && part.icnType != MP2::OBJ_ICN_TYPE_STREAM;
     } );
 
-    const bool singleObjectTile = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( belowTile._mainObjectPart.icnType != _mainObjectPart.icnType );
+    const bool singleObjectTile = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( bottomTile._mainObjectPart.icnType != _mainObjectPart.icnType );
 
     // TODO: we might need to simplify the logic below as singleObjectTile might cover most of it.
-    if ( !singleObjectTile && !isDetachedObject() && ( belowTile._mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN )
-         && !belowTile._mainObjectPart.isPassabilityTransparent() ) {
-        const MP2::MapObjectType belowTileObjectType = belowTile.getMainObjectType( false );
-        const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( belowTileObjectType );
+    if ( !singleObjectTile && !isDetachedObject() && ( bottomTile._mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN )
+         && !bottomTile._mainObjectPart.isPassabilityTransparent() ) {
+        const MP2::MapObjectType bottomTileObjectType = bottomTile.getMainObjectType( false );
+        const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( bottomTileObjectType );
 
-        if ( MP2::isOffGameActionObject( belowTileObjectType ) || MP2::isOffGameActionObject( correctedObjectType ) ) {
-            if ( ( belowTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
-                if ( isShortObject( belowTileObjectType ) || isShortObject( correctedObjectType ) ) {
+        if ( MP2::isOffGameActionObject( bottomTileObjectType ) || MP2::isOffGameActionObject( correctedObjectType ) ) {
+            if ( ( bottomTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
+                if ( isShortObject( bottomTileObjectType ) || isShortObject( correctedObjectType ) ) {
                     _tilePassabilityDirections &= ~Direction::BOTTOM;
                 }
                 else {
@@ -800,9 +800,9 @@ void Maps::Tile::updatePassability()
                 }
             }
         }
-        else if ( isShortObject( belowTileObjectType )
-                  || ( !belowTile.containsAnyObjectIcnType( getValidObjectIcnTypes() )
-                       && ( isCombinedObject( objectType ) || isCombinedObject( belowTileObjectType ) ) ) ) {
+        else if ( isShortObject( bottomTileObjectType )
+                  || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() )
+                       && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
             _tilePassabilityDirections &= ~Direction::BOTTOM;
         }
         else {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -735,7 +735,7 @@ void Maps::Tile::updatePassability()
         return;
     }
 
-    // Check a tile below which can affect the passability.
+    // Check the tile located below the object, which may affect the passability.
     if ( !isValidDirection( _index, Direction::BOTTOM ) ) {
         // This object "touches" the bottom part of the map. Mark is as inaccessible.
         _tilePassabilityDirections = 0;
@@ -743,8 +743,8 @@ void Maps::Tile::updatePassability()
     }
 
     const Tile & bottomTile = world.getTile( GetDirectionIndex( _index, Direction::BOTTOM ) );
-    // If an object locates on land and the below tile is water, mark the current tile as impassable.
-    // It's done for cases that a hero won't be able to disembark on the tile.
+    // If an object is located on land and the tile below it is a water tile, then mark the current tile as impassable.
+    // It's done for cases when a hero won't be able to disembark on the tile.
     if ( !isWater() && bottomTile.isWater() ) {
         _tilePassabilityDirections = 0;
         return;

--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -51,7 +51,7 @@ BEGIN
             VALUE "FileDescription",  "Free implementation of the Heroes of Might and Magic II game engine\0"
             VALUE "FileVersion",      FH2_VERSION_STR
             VALUE "InternalName",     "fheroes2\0"
-            VALUE "LegalCopyright",   "\251 2024 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
+            VALUE "LegalCopyright",   "\251 2025 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"
             VALUE "OriginalFilename", "fheroes2.exe\0"
             VALUE "ProductName",      "fheroes2 engine\0"
             VALUE "ProductVersion",   FH2_VERSION_STR

--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *


### PR DESCRIPTION
This is more a cosmetic change. The passability in general has not been changed. However, you will see less red corners for tiles.

Before the changes:
![image](https://github.com/user-attachments/assets/b812b4cf-1b46-4825-a7d7-b90a503aab38)

After the changes:
![image](https://github.com/user-attachments/assets/c3084ac8-d256-40ba-947e-1821f25baf8d)


You can save 2 images and compare them to see what I mean by "red corners".