### PR TITLE
Remove additional passability marks on the bottom part of tiles

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -790,24 +790,30 @@ void Maps::Tile::updatePassability()
         const MP2::MapObjectType correctedObjectType = MP2::getBaseActionObjectType( bottomTileObjectType );
 
         if ( MP2::isOffGameActionObject( bottomTileObjectType ) || MP2::isOffGameActionObject( correctedObjectType ) ) {
-            if ( ( bottomTile.getTileIndependentPassability() & Direction::TOP ) == 0 ) {
-                if ( isShortObject( bottomTileObjectType ) || isShortObject( correctedObjectType ) ) {
-                    _tilePassabilityDirections &= ~Direction::BOTTOM;
-                }
-                else {
-                    _tilePassabilityDirections = 0;
-                    return;
-                }
+            if ( ( bottomTile.getTileIndependentPassability() & Direction::TOP ) != 0 ) {
+                // This is an action object with unrestricted access from top.
+
+                // Only main action object parts can have unrestricted access.
+                assert( MP2::isOffGameActionObject( bottomTileObjectType ) );
+                return;
             }
+
+            if ( !isShortObject( bottomTileObjectType ) && !isShortObject( correctedObjectType ) ) {
+                // Since the object on the tile below is considered as tall we must mark this tile as impassable.
+                _tilePassabilityDirections = 0;
+            }
+
+            return;
         }
-        else if ( isShortObject( bottomTileObjectType )
+
+        if ( isShortObject( bottomTileObjectType )
                   || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() )
                        && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
-            _tilePassabilityDirections &= ~Direction::BOTTOM;
+            // If this assertion blows up then the above checks are invalid!
+            assert( ( bottomTile.getTileIndependentPassability() & Direction::TOP ) == 0 );
         }
         else {
             _tilePassabilityDirections = 0;
-            return;
         }
     }
 }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -807,8 +807,7 @@ void Maps::Tile::updatePassability()
         }
 
         if ( isShortObject( bottomTileObjectType )
-                  || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() )
-                       && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
+             || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() ) && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
             // If this assertion blows up then the above checks are invalid!
             assert( ( bottomTile.getTileIndependentPassability() & Direction::TOP ) == 0 );
         }


### PR DESCRIPTION
If a tile below has impassable top part then there is no need to mark the bottom part of the current tile as impassable. These changes do **not** affect the passability.

Before:
![image](https://github.com/user-attachments/assets/67fed9ff-41d8-4456-887d-93e90507f161)

After:
![image](https://github.com/user-attachments/assets/c85104a1-a7d2-45d0-8131-b7f9fbf7952e)

