### PR TITLE
Fix a few recently introduced code smells

### DIFF
--- a/src/dist/Makefile.emscripten
+++ b/src/dist/Makefile.emscripten
@@ -21,8 +21,7 @@
 CCFLAGS := $(filter-out -pthread,$(CCFLAGS)) \
 	--use-port=sdl2 \
 	--use-port=sdl2_mixer \
-	--use-port=zlib \
-	-Wno-variadic-macro-arguments-omitted
+	--use-port=zlib
 
 LDFLAGS := $(filter-out -pthread,$(LDFLAGS)) \
 	--preload-file ../../../files/data/resurrection.h2d@/files/data/resurrection.h2d \

--- a/src/engine/serialize.cpp
+++ b/src/engine/serialize.cpp
@@ -659,12 +659,22 @@ int StreamFile::closeFile( std::FILE * f )
 
 #ifdef __EMSCRIPTEN__
     if ( needSyncFS ) {
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+
+#pragma GCC diagnostic ignored "-Wvariadic-macro-arguments-omitted"
+#endif
+
         EM_ASM(
             // The following code is not C++ code, but JavaScript code.
             // clang-format off
             FS.syncfs( err => err && console.warn( "FS.syncfs() error:", err ) )
             // clang-format on
         );
+
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
     }
 #endif
 

--- a/src/engine/thread.cpp
+++ b/src/engine/thread.cpp
@@ -23,9 +23,9 @@
 #include <cassert>
 #include <memory>
 
+#ifdef __EMSCRIPTEN__
 namespace
 {
-#ifdef __EMSCRIPTEN__
     class MutexUnlocker
     {
     public:
@@ -47,8 +47,8 @@ namespace
     private:
         std::mutex & _mutex;
     };
-#endif
 }
+#endif
 
 namespace MultiThreading
 {


### PR DESCRIPTION
* Don't create an empty anonymous namespace for non-Emscripten builds (code smell from SonarCloud);
* Limit the scope of the disabled Emscripten-specific `-Wvariadic-macro-arguments-omitted` warning.