### PR TITLE
Fix some of the HTML errors reported by SonarQube

### DIFF
--- a/files/emscripten/index.html
+++ b/files/emscripten/index.html
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html lang="en">
 <head>
   <title>fheroes2</title>

--- a/files/emscripten/index.html
+++ b/files/emscripten/index.html
@@ -24,14 +24,12 @@
           position: absolute;
           color: #fff;
           font-size: 30px;
-          text-stroke: 1px #000;
           -webkit-text-stroke: 1px #000;
           height: 100vh;
           width: 100vw;
       }
       #launcher {
           display: none;
-          text-stroke: 1px #fff;
           -webkit-text-stroke: 1px #fff;
       }
       #uploader input[type=file] {


### PR DESCRIPTION
* Add the `<!DOCTYPE html>`;
* Remove the `text-stroke` CSS property. This property is non-standard and should be used with the `-webkit-` vendor prefix only (and property with the correct name is already in use).