### PR TITLE
Update the sources.props for tools

### DIFF
--- a/VisualStudio/tools/h2dmgr/sources.props
+++ b/VisualStudio/tools/h2dmgr/sources.props
@@ -12,6 +12,7 @@
     <ClCompile Include="h2dmgr.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\engine\agg_file.h" />
     <ClInclude Include="..\engine\h2d_file.h" />
     <ClInclude Include="..\engine\image.h" />
     <ClInclude Include="..\engine\image_palette.h" />

--- a/VisualStudio/tools/pal2img/sources.props
+++ b/VisualStudio/tools/pal2img/sources.props
@@ -10,6 +10,7 @@
     <ClCompile Include="pal2img.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\engine\agg_file.h" />
     <ClInclude Include="..\engine\image.h" />
     <ClInclude Include="..\engine\image_palette.h" />
     <ClInclude Include="..\engine\image_tool.h" />

--- a/VisualStudio/tools/til2img/sources.props
+++ b/VisualStudio/tools/til2img/sources.props
@@ -10,6 +10,7 @@
     <ClCompile Include="til2img.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\engine\agg_file.h" />
     <ClInclude Include="..\engine\image.h" />
     <ClInclude Include="..\engine\image_palette.h" />
     <ClInclude Include="..\engine\image_tool.h" />


### PR DESCRIPTION
After #9063, `engine/image_tool.cpp` depends on the `engine/agg.file.h`, which is not included in the `sources.props` of the corresponding tools. This doesn't break the build because the file itself is in place, but it still need to be added to the corresponding `sources.props` for the sake of convenience of working with relevant projects in the Visual Studio IDE.