### PR TITLE
Emscripten: re-enable the -pthread compiler flag

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -356,6 +356,46 @@ jobs:
       run: |
         sudo apt-get -y update
         sudo apt-get -y install gettext p7zip-full
+    - name: Apply temporary patch
+      run: |
+        patch -d / -p0 -f <<EOF
+        --- emsdk/upstream/emscripten/tools/ports/sdl2_mixer.py
+        +++ emsdk/upstream/emscripten/tools/ports/sdl2_mixer.py
+        @@ -10,8 +10,10 @@
+
+         deps = ['sdl2']
+         variants = {
+        -  'sdl2_mixer_mp3': {'SDL2_MIXER_FORMATS': ["mp3"]},
+        -  'sdl2_mixer_none': {'SDL2_MIXER_FORMATS': []},
+        +  'sdl2_mixer-mp3': {'SDL2_MIXER_FORMATS': ['mp3']},
+        +  'sdl2_mixer-none': {'SDL2_MIXER_FORMATS': []},
+        +  'sdl2_mixer-mp3-mt': {'SDL2_MIXER_FORMATS': ['mp3'], 'PTHREADS': 1},
+        +  'sdl2_mixer-none-mt': {'SDL2_MIXER_FORMATS': [], 'PTHREADS': 1},
+         }
+
+
+        @@ -25,7 +27,9 @@ def get_lib_name(settings):
+
+           libname = 'libSDL2_mixer'
+           if formats != '':
+        -    libname += '_' + formats
+        +    libname += '-' + formats
+        +  if settings.PTHREADS:
+        +    libname += '-mt'
+           libname += '.a'
+
+           return libname
+        @@ -68,6 +72,9 @@ def create(final):
+                 '-DMUSIC_MID_TIMIDITY',
+               ]
+
+        +    if settings.PTHREADS:
+        +      flags.append('-pthread')
+        +
+             build_dir = ports.clear_project_build('sdl2_mixer')
+             include_path = os.path.join(source_path, 'include')
+             includes = [
+        EOF
     - name: Build
       run: |
         emmake make -f Makefile.emscripten -j "$(nproc)"

--- a/src/dist/Makefile.emscripten
+++ b/src/dist/Makefile.emscripten
@@ -20,11 +20,13 @@
 
 TARGET := fheroes2.js
 
+SDL2_MIXER_FORMATS := mid,mp3
+
 CCFLAGS := $(CCFLAGS) \
 	--use-port=sdl2 \
 	--use-port=sdl2_mixer \
 	--use-port=zlib \
-	-sSDL2_MIXER_FORMATS=mid,mp3,ogg
+	-sSDL2_MIXER_FORMATS=$(SDL2_MIXER_FORMATS)
 
 LDFLAGS := $(LDFLAGS) \
 	--preload-file ../../../files/data/resurrection.h2d@/files/data/resurrection.h2d \
@@ -36,7 +38,7 @@ LDFLAGS := $(LDFLAGS) \
 	-sINITIAL_MEMORY=128mb \
 	-sNO_DISABLE_EXCEPTION_CATCHING \
 	-sPTHREAD_POOL_SIZE=8 \
-	-sSDL2_MIXER_FORMATS=mid,mp3,ogg \
+	-sSDL2_MIXER_FORMATS=$(SDL2_MIXER_FORMATS) \
 	-sSTACK_SIZE=262144 \
 	-lidbfs.js
 

--- a/src/dist/Makefile.emscripten
+++ b/src/dist/Makefile.emscripten
@@ -20,21 +20,22 @@
 
 TARGET := fheroes2.js
 
-CCFLAGS := $(filter-out -pthread,$(CCFLAGS)) \
+CCFLAGS := $(CCFLAGS) \
 	--use-port=sdl2 \
 	--use-port=sdl2_mixer \
 	--use-port=zlib \
 	-sSDL2_MIXER_FORMATS=mid,mp3,ogg
 
-LDFLAGS := $(filter-out -pthread,$(LDFLAGS)) \
+LDFLAGS := $(LDFLAGS) \
 	--preload-file ../../../files/data/resurrection.h2d@/files/data/resurrection.h2d \
 	--preload-file ../../../files/lang/@/files/lang/ \
 	--preload-file ../../../files/timidity/@/etc/ \
 	-sASYNCIFY \
 	-sASYNCIFY_STACK_SIZE=20480 \
-	-sENVIRONMENT=web \
+	-sENVIRONMENT=web,worker \
 	-sINITIAL_MEMORY=128mb \
 	-sNO_DISABLE_EXCEPTION_CATCHING \
+	-sPTHREAD_POOL_SIZE=8 \
 	-sSDL2_MIXER_FORMATS=mid,mp3,ogg \
 	-sSTACK_SIZE=262144 \
 	-lidbfs.js

--- a/src/dist/Makefile.emscripten
+++ b/src/dist/Makefile.emscripten
@@ -32,14 +32,15 @@ LDFLAGS := $(LDFLAGS) \
 	--preload-file ../../../files/data/resurrection.h2d@/files/data/resurrection.h2d \
 	--preload-file ../../../files/lang/@/files/lang/ \
 	--preload-file ../../../files/timidity/@/etc/ \
+	-sALLOW_MEMORY_GROWTH \
 	-sASYNCIFY \
-	-sASYNCIFY_STACK_SIZE=20480 \
+	-sASYNCIFY_STACK_SIZE=32768 \
 	-sENVIRONMENT=web,worker \
 	-sINITIAL_MEMORY=128mb \
 	-sNO_DISABLE_EXCEPTION_CATCHING \
 	-sPTHREAD_POOL_SIZE=8 \
 	-sSDL2_MIXER_FORMATS=$(SDL2_MIXER_FORMATS) \
-	-sSTACK_SIZE=262144 \
+	-sSTACK_SIZE=256kb \
 	-lidbfs.js
 
 ifdef FHEROES2_WITH_DEBUG


### PR DESCRIPTION
https://github.com/emscripten-core/emscripten/pull/23094 was merged recently, but there is no new release with these changes yet (and accordingly, there is no new docker image), so I decided to apply a temporary patch for now using our CI (it will be removed when the new Emscripten docker image will be released).

* It works in general;
* Background music playback is now resumed correctly (more or less, see below);
* "Feeding" the player with musical chunks from MIDI/MP3/OGG decoders by SDL_mixer is still performed in the main thread, and not in the background threads, like it's done on other platforms, so the background music still chokes when the main thread is busy with something;
* OGG backend periodically crashes like this:
  
  ```
  res0.c:821 Uncaught RuntimeError: divide by zero
    at fheroes2.wasm.res2_inverse (res0.c:821:51)
    at fheroes2.wasm.mapping0_inverse (mapping0.c:750:5)
    at fheroes2.wasm.vorbis_synthesis (synthesis.c:88:10)
    at fheroes2.wasm._fetch_and_process_packet (vorbisfile.c:706:15)
    at fheroes2.wasm.ov_read_filter (vorbisfile.c:1977:15)
    at fheroes2.wasm.ov_read (vorbisfile.c:2097:10)
    at fheroes2.wasm.OGG_GetSome (music_ogg.c:390:19)
    at fheroes2.wasm.music_pcm_getaudio (music.c:302:24)
    at fheroes2.wasm.OGG_GetAudio (music_ogg.c:442:12)
    at fheroes2.wasm.music_mixer (music.c:364:24)
  ```
  
  or like this:
  
  ```
  res0.c:840 Uncaught RuntimeError: memory access out of bounds
    at fheroes2.wasm.res2_inverse (res0.c:840:33)
    at fheroes2.wasm.mapping0_inverse (mapping0.c:750:5)
    at fheroes2.wasm.vorbis_synthesis (synthesis.c:88:10)
    at fheroes2.wasm._fetch_and_process_packet (vorbisfile.c:706:15)
    at fheroes2.wasm.ov_read_filter (vorbisfile.c:1977:15)
    at fheroes2.wasm.ov_read (vorbisfile.c:2097:10)
    at fheroes2.wasm.OGG_GetSome (music_ogg.c:390:19)
    at fheroes2.wasm.music_pcm_getaudio (music.c:302:24)
    at fheroes2.wasm.OGG_GetAudio (music_ogg.c:442:12)
    at fheroes2.wasm.music_mixer (music.c:364:24)
  ```

* MP3 backend, however, seems to work correctly, except for spamming to the browser console by messages like this when the music is resumed from a previously remembered position (but resume mostly still works):

  ```
  fheroes2.js:2459 Note: Illegal Audio-MPEG-Header 0xf00ff082 at offset 182498.
  fheroes2.js:2459 Note: Trying to resync...
  fheroes2.js:2459 Note: Illegal Audio-MPEG-Header 0xf00ff082 at offset 181538.
  fheroes2.js:2459 Note: Skipped 490 bytes in input.
  fheroes2.js:2459 Note: Trying to resync...
  fheroes2.js:2459 
  fheroes2.js:2459 Warning: Big change from first (MPEG version, layer, rate). Frankenstein stream?
  fheroes2.js:2459 Note: Skipped 217 bytes in input.
  fheroes2.js:2459 Note: Illegal Audio-MPEG-Header 0xf00ff082 at offset 183458.
  fheroes2.js:2459 Note: Trying to resync...
  fheroes2.js:2459 Note: Illegal Audio-MPEG-Header 0xe0000010 at offset 184426.
  fheroes2.js:2459 Note: Skipped 490 bytes in input.
  fheroes2.js:2459 Note: Trying to resync...
  fheroes2.js:2459 Note: Illegal Audio-MPEG-Header 0x55555555 at offset 185161.
  fheroes2.js:2459 Note: Trying to resync...
  fheroes2.js:2459 Note: Skipped 213 bytes in input.
  fheroes2.js:2459 Note: Skipped 494 bytes in input.
  ```

  These messages are originated from the `libmpg123` backend internals:

  | Function | Address
  |-- | --
  | put_char | fheroes2.js:2459
  | write | fheroes2.js:2405
  | write | fheroes2.js:4441
  | doWritev | fheroes2.js:11089
  | _fd_write | fheroes2.js:11112
  | imports.<computed> | fheroes2.js:11238
  | $__stdio_write | __stdio_write.c:17
  | $__vfprintf_internal | vfprintf.c:748
  | $vfiprintf | vfprintf.c:769
  | $fiprintf | fprintf.c:21
  | $INT123_read_frame | parse.c:1323
  | $get_next_frame | libmpg123.c:695
  | $mpg123_decode | libmpg123.c:1052
  | $mpg123_read | libmpg123.c:944
  | $MPG123_GetSome | music_mpg123.c:383
  | $music_pcm_getaudio | music.c:302
  | $MPG123_GetAudio | music_mpg123.c:444
  | $music_mixer | music.c:364
  | $mix_channels | mixer.c:349
  | $HandleAudioProcess | SDL_emscriptenaudio.c:85
  | $dynCall_vi | fheroes2.wasm:0x21bcdd7
  | ret.<computed> | fheroes2.js:11270
  | (anonymous) | fheroes2.js:914
  | dynCallLegacy | fheroes2.js:11166
  | dynCall | fheroes2.js:11185
  | SDL2.audio.scriptProcessorNode.onaudioprocess | fheroes2.js:1238

* MIDI playback seems to work flawlessly.

Overall, I regard the Emscripten build as still quite unstable. It is playable, but it's very rough for now.

Also please note that Emscripten uses the `SharedArrayBuffer` to implement the cross-thread communication and synchronization. `SharedArrayBuffer` needs the specific cross origin policy headers to be set by the HTTP server, namely `Cross-Origin-Opener-Policy: same-origin` and `Cross-Origin-Embedder-Policy: require-corp`. These headers, in turn, will be accepted by a browser only if at least one of the following is true:

* Website is opened using HTTPS with the proper certificate;
* Website URL's host part is `localhost` (in this case, HTTPS is not required).