### PR TITLE
WebAssembly: improve the logging

### DIFF
--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -143,7 +143,8 @@ namespace Logging
         _log_strstream << x;                                                                                                                                             \
         emscripten_out( _log_strstream.str().c_str() );                                                                                                                  \
     }
-#else // Default: log to STDERR
+#else
+// Default: log to stderr
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
         std::cerr << x << std::endl;                                                                                                                                     \

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -117,7 +117,7 @@ namespace Logging
     {                                                                                                                                                                    \
         std::ostringstream oss;                                                                                                                                          \
         oss << x << std::endl;                                                                                                                                           \
-        sceClibPrintf( oss.str().c_str() );                                                                                                                              \
+        sceClibPrintf( "%s", oss.str().c_str() );                                                                                                                        \
     }
 #elif defined( MACOS_APP_BUNDLE )
 #include <syslog.h>

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -115,25 +115,33 @@ namespace Logging
 #include <psp2/kernel/clib.h>
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
-        std::ostringstream osss;                                                                                                                                         \
-        osss << x << std::endl;                                                                                                                                          \
-        sceClibPrintf( osss.str().c_str() );                                                                                                                             \
+        std::ostringstream oss;                                                                                                                                          \
+        oss << x << std::endl;                                                                                                                                           \
+        sceClibPrintf( oss.str().c_str() );                                                                                                                              \
     }
 #elif defined( MACOS_APP_BUNDLE )
 #include <syslog.h>
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
-        std::ostringstream logMessage;                                                                                                                                   \
-        logMessage << x;                                                                                                                                                 \
-        syslog( LOG_WARNING, "fheroes2_log: %s", logMessage.str().c_str() );                                                                                             \
+        std::ostringstream oss;                                                                                                                                          \
+        oss << x;                                                                                                                                                        \
+        syslog( LOG_WARNING, "fheroes2_log: %s", oss.str().c_str() );                                                                                                    \
     }
 #elif defined( ANDROID )
 #include <android/log.h>
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
-        std::ostringstream osss;                                                                                                                                         \
-        osss << x << std::endl;                                                                                                                                          \
-        __android_log_print( ANDROID_LOG_INFO, "fheroes2", "%s", osss.str().c_str() );                                                                                   \
+        std::ostringstream oss;                                                                                                                                          \
+        oss << x;                                                                                                                                                        \
+        __android_log_print( ANDROID_LOG_INFO, "fheroes2", "%s", oss.str().c_str() );                                                                                    \
+    }
+#elif defined( __EMSCRIPTEN__ )
+#include <emscripten/console.h>
+#define COUT( x )                                                                                                                                                        \
+    {                                                                                                                                                                    \
+        std::ostringstream oss;                                                                                                                                          \
+        oss << x;                                                                                                                                                        \
+        emscripten_out( oss.str().c_str() );                                                                                                                             \
     }
 #else // Default: log to STDERR
 #define COUT( x )                                                                                                                                                        \

--- a/src/engine/logging.h
+++ b/src/engine/logging.h
@@ -115,33 +115,33 @@ namespace Logging
 #include <psp2/kernel/clib.h>
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
-        std::ostringstream oss;                                                                                                                                          \
-        oss << x << std::endl;                                                                                                                                           \
-        sceClibPrintf( "%s", oss.str().c_str() );                                                                                                                        \
+        std::ostringstream _log_strstream; /* The name was chosen on purpose to avoid name collisions with outer code blocks. */                                         \
+        _log_strstream << x << std::endl;                                                                                                                                \
+        sceClibPrintf( "%s", _log_strstream.str().c_str() );                                                                                                             \
     }
 #elif defined( MACOS_APP_BUNDLE )
 #include <syslog.h>
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
-        std::ostringstream oss;                                                                                                                                          \
-        oss << x;                                                                                                                                                        \
-        syslog( LOG_WARNING, "fheroes2_log: %s", oss.str().c_str() );                                                                                                    \
+        std::ostringstream _log_strstream; /* The name was chosen on purpose to avoid name collisions with outer code blocks. */                                         \
+        _log_strstream << x;                                                                                                                                             \
+        syslog( LOG_WARNING, "fheroes2_log: %s", _log_strstream.str().c_str() );                                                                                         \
     }
 #elif defined( ANDROID )
 #include <android/log.h>
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
-        std::ostringstream oss;                                                                                                                                          \
-        oss << x;                                                                                                                                                        \
-        __android_log_print( ANDROID_LOG_INFO, "fheroes2", "%s", oss.str().c_str() );                                                                                    \
+        std::ostringstream _log_strstream; /* The name was chosen on purpose to avoid name collisions with outer code blocks. */                                         \
+        _log_strstream << x;                                                                                                                                             \
+        __android_log_print( ANDROID_LOG_INFO, "fheroes2", "%s", _log_strstream.str().c_str() );                                                                         \
     }
 #elif defined( __EMSCRIPTEN__ )
 #include <emscripten/console.h>
 #define COUT( x )                                                                                                                                                        \
     {                                                                                                                                                                    \
-        std::ostringstream oss;                                                                                                                                          \
-        oss << x;                                                                                                                                                        \
-        emscripten_out( oss.str().c_str() );                                                                                                                             \
+        std::ostringstream _log_strstream; /* The name was chosen on purpose to avoid name collisions with outer code blocks. */                                         \
+        _log_strstream << x;                                                                                                                                             \
+        emscripten_out( _log_strstream.str().c_str() );                                                                                                                  \
     }
 #else // Default: log to STDERR
 #define COUT( x )                                                                                                                                                        \


### PR DESCRIPTION
Related to the https://github.com/ihhub/fheroes2/pull/9444#issuecomment-2592428569

Here is the version with our "custom" launcher (non-multithreaded build, because GitHub Pages doesn't allow to return the custom HTTP headers):

https://oleg-derevenetz.github.io/fheroes2/

And here is the version with the "stock" launcher from Emscripten (and with bundled assets from the demo version):

https://oleg-derevenetz.github.io/fheroes2/demo/

I prefer to use the `emscripten_out()` and not JS `console.*` because it can be intercepted by the custom printing function in the launcher (see how it's done in the "stock" launcher above, it has a sort of "console" below the game canvas - it can be also useful for the text support mode, BTW). I don't use the `emscripten_dbg()` though, because its limitations (like "this symbol is only available in debug builds") do not look acceptable, because It's not too good to be bound by such restrictions when it comes to debugging - Emscripten debug builds are quite large and slow. If there is a need to quickly do some debugging in the console, then there is no reason to always build with `-O0`.