### PR TITLE
Simplify passability logic when a bottom tile is a true action object

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -473,8 +473,6 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
     TileUnfitRenderObjectInfo tileUnfit;
 
-    const Heroes * currentHero = drawHeroes ? GetFocusHeroes() : nullptr;
-
     // TODO: Dragon City with Object ICN Type OBJ_ICN_TYPE_OBJNMUL2 and object index 46 is a bottom layer sprite.
     // TODO: When a hero standing besides this turns a part of the hero is visible. This can be fixed only by some hack.
 
@@ -694,6 +692,8 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
     // Draw hero's route. It should be drawn on top of everything.
     const bool drawRoutes = ( flag & LEVEL_ROUTES ) != 0;
+
+    const Heroes * currentHero = drawHeroes ? GetFocusHeroes() : nullptr;
 
     if ( drawRoutes && ( currentHero != nullptr ) && currentHero->GetPath().isShow() ) {
         const Route::Path & path = currentHero->GetPath();

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -794,7 +794,7 @@ void Maps::Tile::updatePassability()
         }
     }
 
-    // If the tile below contains an action object and it has access from top, nothing we need to change for passability
+    // If the tile below contains an action object and it allows access from top, nothing we need to change for passability
     // as the object below does not affect it.
     const MP2::MapObjectType bottomTileObjectType = bottomTile.getMainObjectType( false );
     if ( MP2::isOffGameActionObject( bottomTileObjectType ) && ( bottomTile.getTileIndependentPassability() & Direction::TOP ) != 0 ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -713,6 +713,9 @@ void Maps::Tile::updatePassability()
         return;
     }
 
+    // If this assertion blows up then you are calling this method more than once!
+    assert( _tilePassabilityDirections == getTileIndependentPassability() );
+
     // Verify the neighboring tiles.
     // If a tile contains a tall object then it affects the passability of diagonal moves to the top from the current tile.
     if ( ( _tilePassabilityDirections & Direction::TOP_LEFT ) && isValidDirection( _index, Direction::LEFT ) ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -791,7 +791,7 @@ void Maps::Tile::updatePassability()
         }
     }
 
-    // If the tile below contains an action object and it has access from top, nothing we need to change for passbility
+    // If the tile below contains an action object and it has access from top, nothing we need to change for passability
     // as the object below does not affect it.
     const MP2::MapObjectType bottomTileObjectType = bottomTile.getMainObjectType( false );
     if ( MP2::isOffGameActionObject( bottomTileObjectType ) && ( bottomTile.getTileIndependentPassability() & Direction::TOP ) != 0 ) {


### PR DESCRIPTION
No passability was changed for 15 tested (mostly XL) maps.