### PR TITLE
Fix selected Ore mine reset in Mine placing dialog (Editor)

### DIFF
--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -1481,7 +1481,7 @@ void Dialog::selectMineType( int32_t & type, int32_t & color )
     uint32_t selectedResourceType = 0;
 
     const std::vector<Maps::ObjectInfo> & allObjectInfo = Maps::getObjectsByGroup( Maps::ObjectGroup::ADVENTURE_MINES );
-    if ( type > 0 ) {
+    if ( type >= 0 ) {
         assert( static_cast<size_t>( type ) < allObjectInfo.size() );
 
         if ( allObjectInfo[type].objectType == MP2::OBJ_ABANDONED_MINE ) {


### PR DESCRIPTION
This PR fixes the reset of Ore mine selection in Editor after clicking OK and then reopening this dialog:
![dialog](https://github.com/user-attachments/assets/4f909e29-19da-4cc0-af62-2979f28b8460)
