### PR TITLE
Fix overlap of FPS info and popup message in the Editor

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2024                                             *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -687,8 +687,6 @@ namespace Interface
 
     void EditorInterface::redraw( const uint32_t force )
     {
-        fheroes2::Display & display = fheroes2::Display::instance();
-
         const uint32_t combinedRedraw = _redraw | force;
 
         if ( combinedRedraw & REDRAW_GAMEAREA ) {
@@ -696,6 +694,8 @@ namespace Interface
             if ( combinedRedraw & REDRAW_PASSABILITIES ) {
                 renderFlags |= LEVEL_PASSABILITIES;
             }
+
+            fheroes2::Display & display = fheroes2::Display::instance();
 
             // Render all except the fog.
             _gameArea.Redraw( display, renderFlags );
@@ -707,7 +707,9 @@ namespace Interface
                 // Keep 4 pixels from each edge.
                 text.fitToOneRow( roi.width - 8 );
 
-                text.draw( roi.x + 4, roi.y + roi.height - text.height() - 4, display );
+                const bool isSystemInfoShown = Settings::Get().isSystemInfoEnabled();
+
+                text.draw( roi.x + 4, roi.y + roi.height - text.height() - ( isSystemInfoShown ? 14 : 4 ), display );
             }
 
             // TODO:: Render horizontal and vertical map tiles scale and highlight with yellow text cursor position.


### PR DESCRIPTION
Relates to #8589 

![img](https://github.com/user-attachments/assets/ab560abc-efbc-4775-a6f5-b8acc415be58)
