### PR TITLE
Add a button to toggle developer mode in debug build

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -613,6 +613,8 @@ namespace EventProcessing
                 return SDLK_AMPERSAND;
             case fheroes2::Key::KEY_QUOTE:
                 return SDLK_QUOTE;
+            case fheroes2::Key::KEY_BACKQUOTE:
+                return SDLK_BACKQUOTE;
             case fheroes2::Key::KEY_LEFT_PARENTHESIS:
                 return SDLK_LEFTPAREN;
             case fheroes2::Key::KEY_RIGHT_PARENTHESIS:

--- a/src/engine/localevent.h
+++ b/src/engine/localevent.h
@@ -55,6 +55,7 @@ namespace fheroes2
         KEY_DOLLAR,
         KEY_AMPERSAND,
         KEY_QUOTE,
+        KEY_BACKQUOTE,
         KEY_LEFT_PARENTHESIS,
         KEY_RIGHT_PARENTHESIS,
         KEY_ASTERISK,

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -106,6 +106,10 @@ namespace
             = { Game::HotKeyCategory::GLOBAL, gettext_noop( "hotkey|toggle fullscreen" ), fheroes2::Key::KEY_F4 };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::GLOBAL_TOGGLE_TEXT_SUPPORT_MODE )]
             = { Game::HotKeyCategory::GLOBAL, gettext_noop( "hotkey|toggle text support mode" ), fheroes2::Key::KEY_F10 };
+#if defined( WITH_DEBUG )
+        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::DEBUG_TOGGLE_DEVELOPER_MODE )]
+            = { Game::HotKeyCategory::GLOBAL, gettext_noop( "hotkey|toggle developer mode" ), fheroes2::Key::KEY_BACKQUOTE };
+#endif
 
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::MAIN_MENU_NEW_GAME )]
             = { Game::HotKeyCategory::MAIN_MENU, gettext_noop( "hotkey|new game" ), fheroes2::Key::KEY_N };
@@ -532,6 +536,9 @@ void Game::globalKeyDownEvent( const fheroes2::Key key, const int32_t modifier )
                 }
             }
         }
+    }
+    else if ( key == hotKeyEventInfo[hotKeyEventToInt( HotKeyEvent::DEBUG_TOGGLE_DEVELOPER_MODE )].key ) {
+        Logging::setDebugLevel( DBG_DEVEL ^ Logging::getDebugLevel() );
     }
 #endif
 }

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -106,6 +106,7 @@ namespace
             = { Game::HotKeyCategory::GLOBAL, gettext_noop( "hotkey|toggle fullscreen" ), fheroes2::Key::KEY_F4 };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::GLOBAL_TOGGLE_TEXT_SUPPORT_MODE )]
             = { Game::HotKeyCategory::GLOBAL, gettext_noop( "hotkey|toggle text support mode" ), fheroes2::Key::KEY_F10 };
+
 #if defined( WITH_DEBUG )
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::DEBUG_TOGGLE_DEVELOPER_MODE )]
             = { Game::HotKeyCategory::GLOBAL, gettext_noop( "hotkey|toggle developer mode" ), fheroes2::Key::KEY_BACKQUOTE };
@@ -486,6 +487,9 @@ void Game::globalKeyDownEvent( const fheroes2::Key key, const int32_t modifier )
         conf.Save( Settings::configFileName );
     }
 #if defined( WITH_DEBUG )
+    else if ( key == hotKeyEventInfo[hotKeyEventToInt( HotKeyEvent::DEBUG_TOGGLE_DEVELOPER_MODE )].key ) {
+        Logging::setDebugLevel( DBG_DEVEL ^ Logging::getDebugLevel() );
+    }
     else if ( key == hotKeyEventInfo[hotKeyEventToInt( HotKeyEvent::WORLD_TRANSFER_CONTROL_TO_AI )].key ) {
         static bool recursiveCall = false;
 
@@ -536,9 +540,6 @@ void Game::globalKeyDownEvent( const fheroes2::Key key, const int32_t modifier )
                 }
             }
         }
-    }
-    else if ( key == hotKeyEventInfo[hotKeyEventToInt( HotKeyEvent::DEBUG_TOGGLE_DEVELOPER_MODE )].key ) {
-        Logging::setDebugLevel( DBG_DEVEL ^ Logging::getDebugLevel() );
     }
 #endif
 }

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -45,6 +45,7 @@ namespace Game
 
         GLOBAL_TOGGLE_FULLSCREEN,
         GLOBAL_TOGGLE_TEXT_SUPPORT_MODE,
+
 #if defined( WITH_DEBUG )
         // This hotkey is only for debug mode.
         DEBUG_TOGGLE_DEVELOPER_MODE,

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2024                                             *
+ *   Copyright (C) 2022 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -45,6 +45,10 @@ namespace Game
 
         GLOBAL_TOGGLE_FULLSCREEN,
         GLOBAL_TOGGLE_TEXT_SUPPORT_MODE,
+#if defined( WITH_DEBUG )
+        // This hotkey is only for debug mode.
+        DEBUG_TOGGLE_DEVELOPER_MODE,
+#endif
 
         MAIN_MENU_NEW_GAME,
         MAIN_MENU_LOAD_GAME,


### PR DESCRIPTION
Sometimes it is needed to debug with and without the developer mode.
In example: when you need to check the rendering (and you don't need the extra rendered passabilities and other) and also to check the tile info in console.

Without this PR you need to quit fheroes2, edit the fheroes2.cfg by setting the magic debug value and restart fheroes2.

This PR also adds **\`** (backquote) and **~** (tilde) to the processed keys and makes ` the default key to toggle the developer mode.