### PR TITLE
Fix mine flag rendering and don't crop its sprite, remove unused flag setting logic

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -4666,22 +4666,24 @@ namespace
                 original = std::move( temp );
             }
             return true;
-        case ICN::FLAG32:
+        case ICN::FLAG32: {
             LoadOriginalICN( id );
-            if ( _icnVsSprite[id].size() == 49 ) {
+            auto & flagImages = _icnVsSprite[id];
+            if ( flagImages.size() == 49 ) {
                 // Shift and crop the Lighthouse flags to properly render them on the Adventure map.
-                _icnVsSprite[id].resize( 49 + 7 * 2 );
+                flagImages.resize( 49 + 7 * 2 );
                 for ( size_t i = 42; i < 42 + 7; ++i ) {
-                    const fheroes2::Sprite & original = _icnVsSprite[id][i];
+                    const fheroes2::Sprite & original = flagImages[i];
 
-                    _icnVsSprite[id][i + 7] = Crop( original, 0, 0, -original.x(), original.height() );
-                    _icnVsSprite[id][i + 7].setPosition( 32 + original.x(), original.y() );
+                    flagImages[i + 7] = Crop( original, 0, 0, -original.x(), original.height() );
+                    flagImages[i + 7].setPosition( 32 + original.x(), original.y() );
 
-                    _icnVsSprite[id][i + 7 + 7] = Crop( original, -original.x(), 0, original.width(), original.height() );
-                    _icnVsSprite[id][i + 7 + 7].setPosition( 0, original.y() );
+                    flagImages[i + 7 + 7] = Crop( original, -original.x(), 0, original.width(), original.height() );
+                    flagImages[i + 7 + 7].setPosition( 0, original.y() );
                 }
             }
             return true;
+        }
         case ICN::SHADOW32:
             LoadOriginalICN( id );
             // The shadow sprite of hero needs to be shifted to match the hero sprite.

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -4668,28 +4668,18 @@ namespace
             return true;
         case ICN::FLAG32:
             LoadOriginalICN( id );
-            // Only first 14 images are properly aligned within an Adventure Map tile. The rest of images should be rendered on multiple tiles.
-            // To keep proper rendering logic we are creating new images by diving existing ones into 2 parts and setting up new sprite offsets.
-            // This helps to solve the problem with rendering order.
-            _icnVsSprite[id].resize( 128 + _icnVsSprite[id].size() * 2 );
-            for ( int32_t i = 14; i < 14 + 7; ++i ) {
-                const fheroes2::Sprite & original = _icnVsSprite[id][i];
+            if ( _icnVsSprite[id].size() == 49 ) {
+                // Shift and crop the Lighthouse flags to properly render them on the Adventure map.
+                _icnVsSprite[id].resize( 49 + 7 * 2 );
+                for ( size_t i = 42; i < 42 + 7; ++i ) {
+                    const fheroes2::Sprite & original = _icnVsSprite[id][i];
 
-                _icnVsSprite[id][i + 128] = Crop( original, 0, 0, 32 - original.x(), original.height() );
-                _icnVsSprite[id][i + 128].setPosition( original.x(), 32 + original.y() );
+                    _icnVsSprite[id][i + 7] = Crop( original, 0, 0, -original.x(), original.height() );
+                    _icnVsSprite[id][i + 7].setPosition( 32 + original.x(), original.y() );
 
-                _icnVsSprite[id][i + 128 + 7] = Crop( original, 32 - original.x(), 0, original.width(), original.height() );
-                _icnVsSprite[id][i + 128 + 7].setPosition( 0, 32 + original.y() );
-            }
-
-            for ( int32_t i = 42; i < 42 + 7; ++i ) {
-                const fheroes2::Sprite & original = _icnVsSprite[id][i];
-
-                _icnVsSprite[id][i + 128] = Crop( original, 0, 0, -original.x(), original.height() );
-                _icnVsSprite[id][i + 128].setPosition( 32 + original.x(), original.y() );
-
-                _icnVsSprite[id][i + 128 + 7] = Crop( original, -original.x(), 0, original.width(), original.height() );
-                _icnVsSprite[id][i + 128 + 7].setPosition( 0, original.y() );
+                    _icnVsSprite[id][i + 7 + 7] = Crop( original, -original.x(), 0, original.width(), original.height() );
+                    _icnVsSprite[id][i + 7 + 7].setPosition( 0, original.y() );
+                }
             }
             return true;
         case ICN::SHADOW32:

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1208,34 +1208,15 @@ void Maps::Tile::setOwnershipFlag( const MP2::MapObjectType objectType, int colo
     }
 
     switch ( objectType ) {
-    case MP2::OBJ_MAGIC_GARDEN:
-        objectSpriteIndex += 128 + 14;
-        updateFlag( color, objectSpriteIndex, _mainObjectPart._uid, false );
-        objectSpriteIndex += 7;
-        if ( isValidDirection( _index, Direction::RIGHT ) ) {
-            Tile & tile = world.getTile( GetDirectionIndex( _index, Direction::RIGHT ) );
-            tile.updateFlag( color, objectSpriteIndex, _mainObjectPart._uid, false );
-        }
+    case MP2::OBJ_MINE: {
+        objectSpriteIndex += 14;
+        Tile & tile = world.getTile( _index );
+        tile.updateFlag( color, objectSpriteIndex, _mainObjectPart._uid, true );
         break;
+    }
 
-    case MP2::OBJ_WATER_WHEEL:
-    case MP2::OBJ_MINE:
-        objectSpriteIndex += 128 + 14;
-        if ( isValidDirection( _index, Direction::TOP ) ) {
-            Tile & tile = world.getTile( GetDirectionIndex( _index, Direction::TOP ) );
-            tile.updateFlag( color, objectSpriteIndex, _mainObjectPart._uid, true );
-        }
-
-        objectSpriteIndex += 7;
-        if ( isValidDirection( _index, Direction::TOP_RIGHT ) ) {
-            Tile & tile = world.getTile( GetDirectionIndex( _index, Direction::TOP_RIGHT ) );
-            tile.updateFlag( color, objectSpriteIndex, _mainObjectPart._uid, true );
-        }
-        break;
-
-    case MP2::OBJ_WINDMILL:
     case MP2::OBJ_LIGHTHOUSE:
-        objectSpriteIndex += 128 + 42;
+        objectSpriteIndex += 49;
         if ( isValidDirection( _index, Direction::LEFT ) ) {
             Tile & tile = world.getTile( GetDirectionIndex( _index, Direction::LEFT ) );
             tile.updateFlag( color, objectSpriteIndex, _mainObjectPart._uid, false );

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -27,7 +27,7 @@ enum SaveFileFormat : uint16_t
     // !!! IMPORTANT !!!
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
-    FORMAT_VERSION_PRE_1_1106_RELEASE = 10026,
+    FORMAT_VERSION_PRE1_1106_RELEASE = 10026,
     FORMAT_VERSION_1104_RELEASE = 10025,
     FORMAT_VERSION_1103_RELEASE = 10024,
     FORMAT_VERSION_PRE2_1103_RELEASE = 10023,
@@ -47,5 +47,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_1005_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE_1_1106_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE1_1106_RELEASE
 };

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -27,7 +27,7 @@ enum SaveFileFormat : uint16_t
     // !!! IMPORTANT !!!
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
-    FORMAT_VERSION_PRE1_1106_RELEASE = 10026,
+    FORMAT_VERSION_1106_RELEASE = 10026,
     FORMAT_VERSION_1104_RELEASE = 10025,
     FORMAT_VERSION_1103_RELEASE = 10024,
     FORMAT_VERSION_PRE2_1103_RELEASE = 10023,
@@ -47,5 +47,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_1005_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE1_1106_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1106_RELEASE
 };

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -27,6 +27,7 @@ enum SaveFileFormat : uint16_t
     // !!! IMPORTANT !!!
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
+    FORMAT_VERSION_PRE_1_1106_RELEASE = 10026,
     FORMAT_VERSION_1104_RELEASE = 10025,
     FORMAT_VERSION_1103_RELEASE = 10024,
     FORMAT_VERSION_PRE2_1103_RELEASE = 10023,
@@ -46,5 +47,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_1005_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1104_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_PRE_1_1106_RELEASE
 };

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1585,8 +1585,8 @@ IStreamBase & operator>>( IStreamBase & stream, World & w )
         ++w.heroIdAsLossCondition;
     }
 
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE_1_1106_RELEASE, "Remove the logic below." );
-    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE_1_1106_RELEASE ) {
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1106_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1106_RELEASE ) {
         // Update flags for Mine and Lighthouse captured objects.
         for ( const auto & [tileIndex, object] : w.map_captureobj ) {
             if ( object.objCol.first == MP2::OBJ_MINE ) {

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1589,26 +1589,29 @@ IStreamBase & operator>>( IStreamBase & stream, World & w )
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1106_RELEASE ) {
         // Update flags for Mine and Lighthouse captured objects.
         for ( const auto & [tileIndex, object] : w.map_captureobj ) {
+            if ( object.GetColor() == Color::NONE ) {
+                // This object is not owned by anyone.
+                continue;
+            }
+
             if ( object.objCol.first == MP2::OBJ_MINE ) {
                 // Update Mine flag.
-                if ( object.GetColor() != Color::NONE ) {
-                    // Remove old flag parts.
-                    int32_t topIndex = tileIndex - w.width;
-                    if ( topIndex >= 0 ) {
-                        // Remove top tile flag part.
-                        w.vec_tiles[topIndex].removeObjects( MP2::OBJ_ICN_TYPE_FLAG32 );
-                    }
-                    if ( ( topIndex % w.width ) < ( w.width - 1 ) ) {
-                        // Remove top-right tile flag part.
-                        ++topIndex;
-                        w.vec_tiles[topIndex].removeObjects( MP2::OBJ_ICN_TYPE_FLAG32 );
-                    }
-
-                    // Set new flag.
-                    w.vec_tiles[tileIndex].setOwnershipFlag( MP2::OBJ_MINE, object.GetColor() );
+                // Remove old flag parts.
+                int32_t topIndex = tileIndex - w.width;
+                if ( topIndex >= 0 ) {
+                    // Remove top tile flag part.
+                    w.vec_tiles[topIndex].removeObjects( MP2::OBJ_ICN_TYPE_FLAG32 );
                 }
+                if ( ( topIndex % w.width ) < ( w.width - 1 ) ) {
+                    // Remove top-right tile flag part.
+                    ++topIndex;
+                    w.vec_tiles[topIndex].removeObjects( MP2::OBJ_ICN_TYPE_FLAG32 );
+                }
+
+                // Set new flag.
+                w.vec_tiles[tileIndex].setOwnershipFlag( MP2::OBJ_MINE, object.GetColor() );
             }
-            else if ( object.objCol.first == MP2::OBJ_LIGHTHOUSE && object.GetColor() != Color::NONE ) {
+            else if ( object.objCol.first == MP2::OBJ_LIGHTHOUSE ) {
                 // Update Lighthouse flag parts.
                 w.vec_tiles[tileIndex].setOwnershipFlag( MP2::OBJ_LIGHTHOUSE, object.GetColor() );
             }

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1585,8 +1585,8 @@ IStreamBase & operator>>( IStreamBase & stream, World & w )
         ++w.heroIdAsLossCondition;
     }
 
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1106_RELEASE, "Remove the logic below." );
-    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1106_RELEASE ) {
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1106_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1106_RELEASE ) {
         // Update flags for Mine and Lighthouse captured objects.
         for ( const auto & [tileIndex, object] : w.map_captureobj ) {
             if ( object.objCol.first == MP2::OBJ_MINE ) {

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1597,15 +1597,14 @@ IStreamBase & operator>>( IStreamBase & stream, World & w )
             if ( object.objCol.first == MP2::OBJ_MINE ) {
                 // Update Mine flag.
                 // Remove old flag parts.
-                int32_t topIndex = tileIndex - w.width;
+                const int32_t topIndex = tileIndex - w.width;
                 if ( topIndex >= 0 ) {
                     // Remove top tile flag part.
                     w.vec_tiles[topIndex].removeObjects( MP2::OBJ_ICN_TYPE_FLAG32 );
                 }
                 if ( ( topIndex % w.width ) < ( w.width - 1 ) ) {
                     // Remove top-right tile flag part.
-                    ++topIndex;
-                    w.vec_tiles[topIndex].removeObjects( MP2::OBJ_ICN_TYPE_FLAG32 );
+                    w.vec_tiles[topIndex + 1].removeObjects( MP2::OBJ_ICN_TYPE_FLAG32 );
                 }
 
                 // Set new flag.


### PR DESCRIPTION
Relates to #5716

This PR:
- removes the logic for setting flags for pre v.1.0 experimental feature to capture Magic Garden, Windmill and Water Wheel;
- reduces the size of `ICN::FLAG32` sprites vector;
- fixes mine flag rendering when it is on (and mostly over) the top edge of the Adventure map:

Master build:

https://github.com/user-attachments/assets/aba99eeb-5597-4a09-b5a8-5b41bffeb7cb


This PR:

https://github.com/user-attachments/assets/02486932-3d6e-4fd7-8fbc-0f9212bd6578

