### PR TITLE
WebAssembly: build both the multithreaded and non-multithreaded versions in parallel, optimize the workflows a bit

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -9,7 +9,7 @@ jobs:
   cmake:
     strategy:
       matrix:
-        config:
+        include:
         - name: Linux SDL2
           os: ubuntu-latest
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext ninja-build
@@ -20,8 +20,8 @@ jobs:
           os: macos-latest
           dependencies: sdl2 sdl2_mixer sdl2_image ninja dylibbundler
           options: -DMACOS_APP_BUNDLE=ON
-    name: CMake (${{ matrix.config.name }})
-    runs-on: ${{ matrix.config.os }}
+    name: CMake (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     defaults:
       run:
@@ -29,21 +29,21 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - name: Install dependencies (Linux)
-      if: ${{ startsWith( matrix.config.os, 'ubuntu-' ) }}
+      if: ${{ startsWith( matrix.os, 'ubuntu-' ) }}
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install ${{ matrix.config.dependencies }}
+        sudo apt-get -y install ${{ matrix.dependencies }}
     - name: Install dependencies (macOS)
-      if: ${{ startsWith( matrix.config.os, 'macos-' ) }}
+      if: ${{ startsWith( matrix.os, 'macos-' ) }}
       run: |
-        brew install ${{ matrix.config.dependencies }}
+        brew install ${{ matrix.dependencies }}
       env:
         # Do not update outdated dependencies of installed packages
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: ON
     - name: Build
       run: |
         cmake -B build -G Ninja -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug -DENABLE_STRICT_COMPILATION=ON \
-                                -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON ${{ matrix.config.options }}
+                                -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON ${{ matrix.options }}
         cmake --build build
     - name: Install
       run: |

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -10,9 +10,10 @@ jobs:
   make:
     strategy:
       matrix:
-        config:
+        include:
         - name: Linux x86-64 SDL2 Release
-          os: ubuntu-20.04
+          on: [ 'pull_request', 'push' ]
+          os: ubuntu-22.04
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
           env:
             FHEROES2_STRICT_COMPILATION: ON
@@ -45,6 +46,7 @@ jobs:
           release_name: Ubuntu x86-64 (Linux) build with SDL2 (latest commit)
           release_tag: fheroes2-linux-sdl2_dev
         - name: Linux x86-64 SDL2 Debug
+          on: [ 'pull_request' ]
           os: ubuntu-latest
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
           env:
@@ -54,6 +56,7 @@ jobs:
             FHEROES2_WITH_DEBUG: ON
             FHEROES2_WITH_ASAN: ON
         - name: Linux ARM64 SDL2 Release
+          on: [ 'pull_request', 'push' ]
           os: ubuntu-22.04-arm
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
           env:
@@ -87,6 +90,7 @@ jobs:
           release_name: Ubuntu ARM64 (Linux) build with SDL2 (latest commit)
           release_tag: fheroes2-linux-arm-sdl2_dev
         - name: Linux ARM64 SDL2 Debug
+          on: [ 'pull_request' ]
           os: ubuntu-24.04-arm
           dependencies: libsdl2-dev libsdl2-mixer-dev libsdl2-image-dev gettext
           env:
@@ -96,6 +100,7 @@ jobs:
             FHEROES2_WITH_DEBUG: ON
             FHEROES2_WITH_TSAN: ON
         - name: macOS SDL2
+          on: [ 'pull_request', 'push' ]
           os: macos-13
           dependencies: sdl2 sdl2_mixer sdl2_image
           env:
@@ -129,82 +134,69 @@ jobs:
           release_name: macOS x86-64 build with SDL2 (latest commit)
           release_tag: fheroes2-osx-sdl2_dev
         - name: macOS SDL2 App Bundle
+          on: [ 'pull_request' ]
           os: macos-latest
           dependencies: sdl2 sdl2_mixer dylibbundler
           env:
             FHEROES2_STRICT_COMPILATION: ON
             FHEROES2_WITH_TOOLS: ON
             FHEROES2_MACOS_APP_BUNDLE: ON
-    name: Make (${{ matrix.config.name }})
-    runs-on: ${{ matrix.config.os }}
+    name: Make (${{ matrix.name }})
+    runs-on: ${{ matrix.os }}
     timeout-minutes: 30
     defaults:
       run:
         shell: bash
     steps:
     - uses: actions/checkout@v4
+      if: ${{ contains( matrix.on, github.event_name ) }}
     - name: Install dependencies (Linux)
-      if: ${{ startsWith( matrix.config.os, 'ubuntu-' ) }}
+      if: ${{ contains( matrix.on, github.event_name ) && startsWith( matrix.os, 'ubuntu-' ) }}
       run: |
         sudo apt-get -y update
-        sudo apt-get -y install ${{ matrix.config.dependencies }}
+        sudo apt-get -y install ${{ matrix.dependencies }}
     - name: Install dependencies (macOS)
-      if: ${{ startsWith( matrix.config.os, 'macos-' ) }}
+      if: ${{ contains( matrix.on, github.event_name ) && startsWith( matrix.os, 'macos-' ) }}
       run: |
-        brew install ${{ matrix.config.dependencies }}
+        brew install ${{ matrix.dependencies }}
       env:
         # Do not update outdated dependencies of installed packages
         HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: ON
     - name: Build (Linux)
-      if: ${{ startsWith( matrix.config.os, 'ubuntu-' ) }}
+      if: ${{ contains( matrix.on, github.event_name ) && startsWith( matrix.os, 'ubuntu-' ) }}
       run: |
         make -j "$(nproc)"
-      env: ${{ matrix.config.env }}
+      env: ${{ matrix.env }}
     - name: Build (MacOS)
-      if: ${{ startsWith( matrix.config.os, 'macos-' ) }}
+      if: ${{ contains( matrix.on, github.event_name ) && startsWith( matrix.os, 'macos-' ) }}
       run: |
         make -j "$(sysctl -n hw.logicalcpu)"
-      env: ${{ matrix.config.env }}
-    - name: Create package
-      if: ${{ matrix.config.package_name != '' && matrix.config.package_files != '' }}
+      env: ${{ matrix.env }}
+    - name: Create packages
+      if: ${{ contains( matrix.on, github.event_name ) && matrix.package_name != '' && matrix.tools_package_name != '' }}
       run: |
-        7z a -bb1 -tzip -- ${{ matrix.config.package_name }} ${{ matrix.config.package_files }}
-    - name: Create tools package
-      if: ${{ matrix.config.tools_package_name != '' && matrix.config.tools_package_files != '' }}
-      run: |
-        7z a -bb1 -tzip -- ${{ matrix.config.tools_package_name }} ${{ matrix.config.tools_package_files }}
+        7z a -bb1 -tzip -- ${{ matrix.package_name }} ${{ matrix.package_files }}
+        7z a -bb1 -tzip -- ${{ matrix.tools_package_name }} ${{ matrix.tools_package_files }}
     - uses: actions/upload-artifact@v4
-      if: ${{ github.event_name == 'pull_request' && matrix.config.package_name != '' }}
+      if: ${{ contains( matrix.on, github.event_name ) && github.event_name == 'pull_request' && matrix.package_name != '' }}
       with:
-        name: ${{ matrix.config.package_name }}
-        path: ${{ matrix.config.package_name }}
+        name: ${{ matrix.package_name }}
+        path: ${{ matrix.package_name }}
         if-no-files-found: error
     - uses: actions/upload-artifact@v4
-      if: ${{ github.event_name == 'pull_request' && matrix.config.tools_package_name != '' }}
+      if: ${{ contains( matrix.on, github.event_name ) && github.event_name == 'pull_request' && matrix.tools_package_name != '' }}
       with:
-        name: ${{ matrix.config.tools_package_name }}
-        path: ${{ matrix.config.tools_package_name }}
+        name: ${{ matrix.tools_package_name }}
+        path: ${{ matrix.tools_package_name }}
         if-no-files-found: error
     - uses: ncipollo/release-action@v1
-      if: ${{ github.event_name == 'push' && matrix.config.package_name != '' && matrix.config.tools_package_name == '' && matrix.config.release_name != '' && matrix.config.release_tag != '' }}
+      if: ${{ contains( matrix.on, github.event_name ) && github.event_name == 'push' }}
       with:
-        artifacts: ${{ matrix.config.package_name }}
+        artifacts: ${{ matrix.package_name }}, ${{ matrix.tools_package_name }}
         body: ${{ github.event.head_commit.message }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        name: ${{ matrix.config.release_name }}
-        tag: ${{ matrix.config.release_tag }}
-        allowUpdates: true
-        artifactErrorsFailBuild: true
-        prerelease: true
-        replacesArtifacts: true
-    - uses: ncipollo/release-action@v1
-      if: ${{ github.event_name == 'push' && matrix.config.package_name != '' && matrix.config.tools_package_name != '' && matrix.config.release_name != '' && matrix.config.release_tag != '' }}
-      with:
-        artifacts: ${{ matrix.config.package_name }}, ${{ matrix.config.tools_package_name }}
-        body: ${{ github.event.head_commit.message }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        name: ${{ matrix.config.release_name }}
-        tag: ${{ matrix.config.release_tag }}
+        name: ${{ matrix.release_name }}
+        tag: ${{ matrix.release_tag }}
         allowUpdates: true
         artifactErrorsFailBuild: true
         prerelease: true
@@ -327,7 +319,21 @@ jobs:
         prerelease: true
         replacesArtifacts: true
   make-emscripten:
-    name: Make (Emscripten)
+    strategy:
+      matrix:
+        include:
+        - name: Emscripten
+          on: [ 'pull_request' ]
+          env:
+            FHEROES2_STRICT_COMPILATION: ON
+          package_name: fheroes2_emscripten.zip
+        - name: Emscripten Multithreaded
+          on: [ 'pull_request' ]
+          env:
+            FHEROES2_STRICT_COMPILATION: ON
+            FHEROES2_WITH_THREADS: ON
+          package_name: fheroes2_emscripten_mt.zip
+    name: Make (${{ matrix.name }})
     runs-on: ubuntu-latest
     container: emscripten/emsdk:3.1.74
     timeout-minutes: 30
@@ -336,11 +342,14 @@ jobs:
         shell: bash
     steps:
     - uses: actions/checkout@v4
+      if: ${{ contains( matrix.on, github.event_name ) }}
     - name: Install dependencies
+      if: ${{ contains( matrix.on, github.event_name ) }}
       run: |
         sudo apt-get -y update
         sudo apt-get -y install gettext p7zip-full
     - name: Apply temporary patch
+      if: ${{ contains( matrix.on, github.event_name ) }}
       run: |
         patch -d / -p0 -f <<EOF
         --- emsdk/upstream/emscripten/tools/ports/sdl2_mixer.py
@@ -381,30 +390,18 @@ jobs:
              includes = [
         EOF
     - name: Build
+      if: ${{ contains( matrix.on, github.event_name ) }}
       run: |
         emmake make -f Makefile.emscripten -j "$(nproc)"
-      env:
-        FHEROES2_STRICT_COMPILATION: ON
-        FHEROES2_WITH_THREADS: ON
+      env: ${{ matrix.env }}
     - name: Create package
+      if: ${{ contains( matrix.on, github.event_name ) }}
       run: |
         # Translations and H2D files are already included in fheroes2.data
-        7z a -bb1 -tzip -- fheroes2_emscripten.zip LICENSE changelog.txt fheroes2.data fheroes2.js fheroes2.wasm ./docs/README.txt ./files/emscripten/*
+        7z a -bb1 -tzip -- ${{ matrix.package_name }} LICENSE changelog.txt fheroes2.data fheroes2.js fheroes2.wasm ./docs/README.txt ./files/emscripten/*
     - uses: actions/upload-artifact@v4
-      if: ${{ github.event_name == 'pull_request' }}
+      if: ${{ contains( matrix.on, github.event_name ) }}
       with:
-        name: fheroes2_emscripten.zip
-        path: fheroes2_emscripten.zip
+        name: ${{ matrix.package_name }}
+        path: ${{ matrix.package_name }}
         if-no-files-found: error
-    - uses: ncipollo/release-action@v1
-      if: ${{ github.event_name == 'push' }}
-      with:
-        artifacts: fheroes2_emscripten.zip
-        body: ${{ github.event.head_commit.message }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        name: Emscripten build (latest commit)
-        tag: fheroes2-emscripten-sdl2_dev
-        allowUpdates: true
-        artifactErrorsFailBuild: true
-        prerelease: true
-        replacesArtifacts: true

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -10,7 +10,7 @@ jobs:
   msvc:
     strategy:
       matrix:
-        config:
+        include:
         - name: SDL2 x86
           platform: x86
           build_config: Release-SDL2
@@ -29,7 +29,7 @@ jobs:
           tools_package_name: fheroes2_tools_windows_x64_SDL2.zip
           release_name: Windows x64 build with SDL2 (latest commit)
           release_tag: fheroes2-windows-x64-SDL2
-    name: MSVC (${{ matrix.config.name }})
+    name: MSVC (${{ matrix.name }})
     runs-on: windows-2019
     timeout-minutes: 30
     defaults:
@@ -51,7 +51,7 @@ jobs:
       shell: cmd
       env:
         # Permalink URL from https://learn.microsoft.com/en-us/cpp/windows/latest-supported-vc-redist?view=msvc-170
-        VCREDIST_URL: https://aka.ms/vs/17/release/vc_redist.${{ matrix.config.platform }}.exe
+        VCREDIST_URL: https://aka.ms/vs/17/release/vc_redist.${{ matrix.platform }}.exe
     - name: Verify MSVC Redistributable package
       run: |
         "%SIGNTOOL_DIR%\signtool.exe" verify /v /d /all /pa /r "Microsoft Root Certificate Authority" .vcredist\vcredist.exe
@@ -64,18 +64,18 @@ jobs:
     - uses: microsoft/setup-msbuild@v2
     - name: Build
       run: |
-        MSBuild.exe fheroes2-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
+        MSBuild.exe fheroes2-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
     - name: Build tools
       run: |
         cd src/tools
-        MSBuild.exe 82m2wav-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
-        MSBuild.exe bin2txt-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
-        MSBuild.exe extractor-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
-        MSBuild.exe h2dmgr-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
-        MSBuild.exe icn2img-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
-        MSBuild.exe pal2img-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
-        MSBuild.exe til2img-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
-        MSBuild.exe xmi2midi-vs2019.vcxproj /property:Platform=${{ matrix.config.platform }} /property:Configuration=${{ matrix.config.build_config }}
+        MSBuild.exe 82m2wav-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
+        MSBuild.exe bin2txt-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
+        MSBuild.exe extractor-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
+        MSBuild.exe h2dmgr-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
+        MSBuild.exe icn2img-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
+        MSBuild.exe pal2img-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
+        MSBuild.exe til2img-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
+        MSBuild.exe xmi2midi-vs2019.vcxproj /property:Platform=${{ matrix.platform }} /property:Configuration=${{ matrix.build_config }}
     - name: Generate translations
       run: |
         set PATH=C:\msys64\usr\bin;%PATH%
@@ -84,13 +84,13 @@ jobs:
     - name: Create Inno Setup package
       run: |
         iscc.exe script\windows\fheroes2.iss /DAppVersion="%FHEROES2_APP_VERSION%" /DBuildDir="..\..\%BUILD_DIR%" ^
-                 /DPlatform=${{ matrix.config.platform }} /DDeployConfName=${{ matrix.config.deploy_config }}
+                 /DPlatform=${{ matrix.platform }} /DDeployConfName=${{ matrix.deploy_config }}
       shell: cmd
       env:
-        BUILD_DIR: build\${{ matrix.config.platform }}\${{ matrix.config.build_config }}
-    - name: Create ZIP package
+        BUILD_DIR: build\${{ matrix.platform }}\${{ matrix.build_config }}
+    - name: Create ZIP packages
       run: |
-        7z.exe a -bb1 -tzip -- "$BUILD_DIR"\\${{ matrix.config.zip_package_name }} \
+        7z.exe a -bb1 -tzip -- "$BUILD_DIR"\\${{ matrix.zip_package_name }} \
                                .\\"$BUILD_DIR"\\fheroes2.exe \
                                .\\"$BUILD_DIR"\\*.dll \
                                LICENSE \
@@ -103,12 +103,7 @@ jobs:
                                .\\script\\demo\\*.ps1 \
                                .\\script\\homm2\\*.bat \
                                .\\script\\homm2\\*.ps1 
-      env:
-        BUILD_DIR: build\${{ matrix.config.platform }}\${{ matrix.config.build_config }}
-    - name: Create tools package
-      if: ${{ matrix.config.tools_package_name != '' }}
-      run: |
-        7z.exe a -bb1 -tzip -- "$BUILD_DIR"\\${{ matrix.config.tools_package_name }} \
+        7z.exe a -bb1 -tzip -- "$BUILD_DIR"\\${{ matrix.tools_package_name }} \
                                .\\"$BUILD_DIR"\\82m2wav.exe \
                                .\\"$BUILD_DIR"\\bin2txt.exe \
                                .\\"$BUILD_DIR"\\extractor.exe \
@@ -121,56 +116,43 @@ jobs:
                                LICENSE \
                                .\\docs\\GRAPHICAL_ASSETS.md \
                                .\\script\\agg\\extract_agg.bat
-        if [[ ${{ matrix.config.deploy_config }} == SDL2 ]]; then
-            7z.exe a -bb1 -tzip -- "$BUILD_DIR"\\${{ matrix.config.tools_package_name }} \
+        if [[ ${{ matrix.deploy_config }} == SDL2 ]]; then
+            7z.exe a -bb1 -tzip -- "$BUILD_DIR"\\${{ matrix.tools_package_name }} \
                                    .\\"$BUILD_DIR"\\SDL2.dll \
                                    .\\"$BUILD_DIR"\\SDL2_image.dll
         else
             false
         fi
       env:
-        BUILD_DIR: build\${{ matrix.config.platform }}\${{ matrix.config.build_config }}
+        BUILD_DIR: build\${{ matrix.platform }}\${{ matrix.build_config }}
     - uses: actions/upload-artifact@v4
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: ${{ matrix.config.installer_package_name }}
-        path: build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.installer_package_name }}
+        name: ${{ matrix.installer_package_name }}
+        path: build/${{ matrix.platform }}/${{ matrix.build_config }}/${{ matrix.installer_package_name }}
         if-no-files-found: error
     - uses: actions/upload-artifact@v4
       if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: ${{ matrix.config.zip_package_name }}
-        path: build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.zip_package_name }}
+        name: ${{ matrix.zip_package_name }}
+        path: build/${{ matrix.platform }}/${{ matrix.build_config }}/${{ matrix.zip_package_name }}
         if-no-files-found: error
     - uses: actions/upload-artifact@v4
-      if: ${{ github.event_name == 'pull_request' && matrix.config.tools_package_name != '' }}
+      if: ${{ github.event_name == 'pull_request' }}
       with:
-        name: ${{ matrix.config.tools_package_name }}
-        path: build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.tools_package_name }}
+        name: ${{ matrix.tools_package_name }}
+        path: build/${{ matrix.platform }}/${{ matrix.build_config }}/${{ matrix.tools_package_name }}
         if-no-files-found: error
     - uses: ncipollo/release-action@v1
-      if: ${{ github.event_name == 'push' && matrix.config.tools_package_name == '' }}
+      if: ${{ github.event_name == 'push' }}
       with:
-        artifacts: build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.installer_package_name }},
-                   build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.zip_package_name }}
+        artifacts: build/${{ matrix.platform }}/${{ matrix.build_config }}/${{ matrix.installer_package_name }},
+                   build/${{ matrix.platform }}/${{ matrix.build_config }}/${{ matrix.zip_package_name }},
+                   build/${{ matrix.platform }}/${{ matrix.build_config }}/${{ matrix.tools_package_name }}
         body: ${{ github.event.head_commit.message }}
         token: ${{ secrets.GITHUB_TOKEN }}
-        name: ${{ matrix.config.release_name }}
-        tag: ${{ matrix.config.release_tag }}
-        allowUpdates: true
-        artifactErrorsFailBuild: true
-        prerelease: true
-        replacesArtifacts: true
-    - uses: ncipollo/release-action@v1
-      if: ${{ github.event_name == 'push' && matrix.config.tools_package_name != '' }}
-      with:
-        artifacts: build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.installer_package_name }},
-                   build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.zip_package_name }},
-                   build/${{ matrix.config.platform }}/${{ matrix.config.build_config }}/${{ matrix.config.tools_package_name }}
-        body: ${{ github.event.head_commit.message }}
-        token: ${{ secrets.GITHUB_TOKEN }}
-        name: ${{ matrix.config.release_name }}
-        tag: ${{ matrix.config.release_tag }}
+        name: ${{ matrix.release_name }}
+        tag: ${{ matrix.release_tag }}
         allowUpdates: true
         artifactErrorsFailBuild: true
         prerelease: true


### PR DESCRIPTION
In this PR:

* Both multithreaded and non-multithreaded WebAssembly binaries are now built in parallel;
* The WebAssembly release is not created/updated anymore, since it is mostly useless without a Web server - you can't just run it locally using the `file://` URL. In future there will be GitHub Pages version instead;
* Workflows are optimized a bit. Although there is no way to skip the matrix jobs using the job-level `if:` statement (because it is evaluated [before](https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#jobsjob_idif) the matrix is applied), we still can skip the job steps depending on both external parameters (such as `github.event_name`) and matrix parameters. Thanks to this, now the jobs that should not be performed during the pushes to the `master` branch (e.g. any build jobs that don't create any artifacts to release them) will not be performed to save the GitHub Actions resources a bit;
* `matrix.config` is now replaced by the `matrix.include`, which is well-documented and allows to replace the `${{ matrix.config.param }}` substitutions by their shorter version - just `${{ matrix.param }}`.