### PR TITLE
Shorten hero name if name plus level is too long

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -718,19 +718,22 @@ namespace
 
         const bool isActiveHero = ( activeHero != nullptr );
 
-        std::string message;
         // hero's name
+        const fheroes2::FontType smallWhite = fheroes2::FontType::smallWhite();
+        std::string heroName = hero.GetName();
+        fheroes2::Text text( heroName, smallWhite );
+        // hero's level
         if ( isFullInfo && isActiveHero ) {
-            message = _( "%{name} (Level %{level})" );
-            StringReplace( message, "%{name}", hero.GetName() );
-            StringReplace( message, "%{level}", activeHero->GetLevel() );
-        }
-        else {
-            message = hero.GetName();
+            std::string heroLevel = _( "heroQuickInfo|(Level %{level})" );
+            StringReplace( heroLevel, "%{level}", activeHero->GetLevel() );
+            const fheroes2::Text levelText( heroLevel, smallWhite );
+            // if Identify Hero has been cast then we want to know the hero's level rather than name.
+            const uint32_t boxShadowAndBorder = 39;
+            text.fitToOneRow( box.width() - boxShadowAndBorder - levelText.width() );
+            const std::string fittedText = text.text() + " " + heroLevel;
+            text.set( fittedText, smallWhite );
         }
 
-        const fheroes2::FontType smallWhite = fheroes2::FontType::smallWhite();
-        fheroes2::Text text( message, smallWhite );
         dst_pt.x = cur_rt.x + ( cur_rt.width - text.width() ) / 2;
         dst_pt.y = cur_rt.y + 2;
         text.draw( dst_pt.x, dst_pt.y, display );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -720,8 +720,7 @@ namespace
 
         // hero's name
         const fheroes2::FontType smallWhite = fheroes2::FontType::smallWhite();
-        std::string heroName = hero.GetName();
-        fheroes2::Text text( heroName, smallWhite );
+        fheroes2::Text text( hero.GetName(), smallWhite );
         // hero's level
         if ( isFullInfo && isActiveHero ) {
             std::string heroLevel = _( "heroQuickInfo|(Level %{level})" );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -727,7 +727,7 @@ namespace
             StringReplace( heroLevel, "%{level}", activeHero->GetLevel() );
             const fheroes2::Text levelText( heroLevel, smallWhite );
             // if Identify Hero has been cast then we want to know the hero's level rather than name.
-            const uint32_t boxShadowAndBorder = 39;
+            const int32_t boxShadowAndBorder = 39;
             text.fitToOneRow( box.width() - boxShadowAndBorder - levelText.width() );
             const std::string fittedText = text.text() + " " + heroLevel;
             text.set( fittedText, smallWhite );

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -725,12 +725,11 @@ namespace
         if ( isFullInfo && isActiveHero ) {
             std::string heroLevel = _( "heroQuickInfo|(Level %{level})" );
             StringReplace( heroLevel, "%{level}", activeHero->GetLevel() );
-            const fheroes2::Text levelText( heroLevel, smallWhite );
+            heroLevel.insert( 0, " " );
             // if Identify Hero has been cast then we want to know the hero's level rather than name.
             const int32_t boxShadowAndBorder = 39;
-            text.fitToOneRow( box.width() - boxShadowAndBorder - levelText.width() );
-            const std::string fittedText = text.text() + " " + heroLevel;
-            text.set( fittedText, smallWhite );
+            text.fitToOneRow( box.width() - boxShadowAndBorder - fheroes2::Text{ heroLevel, smallWhite }.width() );
+            text.set( text.text() + heroLevel, smallWhite );
         }
 
         dst_pt.x = cur_rt.x + ( cur_rt.width - text.width() ) / 2;


### PR DESCRIPTION
Fix the hero + level being too long for the info box. We shorten the hero name and keep the level in case this is an enemy hero and we've cast Identify Hero. Knowing the level is more useful than the name because regardless of stats it can indicate other things.

Problem:
<details>

![image](https://github.com/user-attachments/assets/d25673bb-c8cc-424a-9828-1d6f855a92b6)
</details>


This PR:

![image](https://github.com/user-attachments/assets/559f6a5b-ebe4-41c8-ae6d-5c90aa5a35eb)

Reported on Discord

Current translations are compatible but they need to be updated. I suggest doing this after the merge and after the bot has updated the POs.