### PR TITLE
Add a dialog pop up when pressing standing horse

### DIFF
--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -190,7 +190,8 @@ fheroes2::GameMode Interface::AdventureMap::EventHeroMovement()
             return EventDefaultAction();
         }
         else if ( hero->GetPath().isValidForMovement() ) {
-            fheroes2::showStandardTextMessage( "", "The hero's army is exhausted and cannot move anymore today. A night's rest will replenish the movement points.",
+            fheroes2::showStandardTextMessage( "Hero Movement Points",
+                                               "The hero's army cannot move anymore today. The movement points will be refilled tomorrow after you end your turn.",
                                                Dialog::OK );
         }
     }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -189,6 +189,12 @@ fheroes2::GameMode Interface::AdventureMap::EventHeroMovement()
         else if ( MP2::isInGameActionObject( hero->getObjectTypeUnderHero(), hero->isShipMaster() ) ) {
             return EventDefaultAction();
         }
+        else if ( !hero->MayStillMove( false, true ) ) {
+            fheroes2::
+                showStandardTextMessage( "",
+                                         "The hero's army cannot be expected to move anymore this day. Let them rest for a night and they will be able to move again.",
+                                         Dialog::OK );
+        }
     }
 
     return fheroes2::GameMode::CANCEL;

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -189,7 +189,7 @@ fheroes2::GameMode Interface::AdventureMap::EventHeroMovement()
         else if ( MP2::isInGameActionObject( hero->getObjectTypeUnderHero(), hero->isShipMaster() ) ) {
             return EventDefaultAction();
         }
-        else if ( !hero->MayStillMove( false, true ) ) {
+        else if ( hero->GetPath().isValidForMovement() ) {
             fheroes2::showStandardTextMessage( "", "The hero's army is exhausted and cannot move anymore today. A night's rest will replenish the movement points.",
                                                Dialog::OK );
         }

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -190,10 +190,8 @@ fheroes2::GameMode Interface::AdventureMap::EventHeroMovement()
             return EventDefaultAction();
         }
         else if ( !hero->MayStillMove( false, true ) ) {
-            fheroes2::
-                showStandardTextMessage( "",
-                                         "The hero's army cannot be expected to move anymore this day. Let them rest for a night and they will be able to move again.",
-                                         Dialog::OK );
+            fheroes2::showStandardTextMessage( "", "The hero's army is exhausted and cannot move anymore today. A night's rest will replenish the movement points.",
+                                               Dialog::OK );
         }
     }
 


### PR DESCRIPTION
This PR is a suggested fix/compromise and works as a draft to test. More polish needs to be done before it can be merged.
fix #9474 (proposal)

This gives feedback when pressing and has the small additional bonus of helping completely new players understand why the hero can't move anymore (I've seen and heard about impatient gamers quit the game after this).


https://github.com/user-attachments/assets/82c94804-0238-47b6-a3da-b59973606cf1

The current dialog:
![image](https://github.com/user-attachments/assets/81de6318-153b-4dc8-a2c1-e5476758c8eb)
