### PR TITLE
Render the main menu after calling settings dialog from new game dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -232,6 +232,7 @@ namespace fheroes2
     void openGameSettings()
     {
         drawMainMenuScreen();
+        fheroes2::Display::instance().render();
 
         Settings & conf = Settings::Get();
 


### PR DESCRIPTION
Fixes this:
<details>

![image](https://github.com/user-attachments/assets/0274f22c-f03a-41ad-a5f9-022766d44c12)

</details>

Likely related #9471 
