### PR TITLE
Do not allow to place "movable" action objects on a tile with other objects

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -185,9 +185,10 @@ namespace
                 return false;
             }
 
-            if ( MP2::isOffGameActionObject( objectPart.objectType ) && MP2::isPickupObject( objectPart.objectType ) && !Maps::isClearGround( tile ) ) {
-                // We are trying to place a pickup action object on a tile that has some other objects.
-                // Since, pickup objects are tend to be removed we are not allowing to put them on top of other objects.
+            if ( MP2::isOffGameActionObject( objectPart.objectType ) && MP2::getActionObjectPassability( objectPart.objectType ) == DIRECTION_ALL
+                 && !Maps::isClearGround( tile ) ) {
+                // We are trying to place a "movable" action object on a tile that has some other objects.
+                // Since, "movable" objects are tend to be removed we do not allow to put them on top of other objects.
                 return false;
             }
         }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -185,8 +185,9 @@ namespace
                 return false;
             }
 
-            if ( MP2::isOffGameActionObject( objectPart.objectType ) && !Maps::isClearGround( tile ) ) {
-                // We are trying to place an action object on a tile that has some other objects.
+            if ( MP2::isOffGameActionObject( objectPart.objectType ) && MP2::isPickupObject( objectPart.objectType ) && !Maps::isClearGround( tile ) ) {
+                // We are trying to place a pickup action object on a tile that has some other objects.
+                // Since, pickup objects are tend to be removed we are not allowing to put them on top of other objects.
                 return false;
             }
         }

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -658,7 +658,7 @@ int Maps::Tile::getTileIndependentPassability() const
         if ( MP2::isOffGameActionObject( type ) ) {
             // This is an action object part.
             isActionObject = true;
-            return MP2::getActionObjectDirection( type );
+            return MP2::getActionObjectPassability( type );
         }
 
         if ( type == MP2::OBJ_REEFS ) {

--- a/src/fheroes2/maps/mp2.cpp
+++ b/src/fheroes2/maps/mp2.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -799,7 +799,7 @@ bool MP2::isNeedStayFront( const MapObjectType objectType )
     return isPickupObject( objectType );
 }
 
-int MP2::getActionObjectDirection( const MapObjectType objectType )
+int MP2::getActionObjectPassability( const MapObjectType objectType )
 {
     switch ( objectType ) {
     case OBJ_ARTIFACT:

--- a/src/fheroes2/maps/mp2.h
+++ b/src/fheroes2/maps/mp2.h
@@ -534,7 +534,7 @@ namespace MP2
     bool isBattleLife( const MapObjectType objectType );
 
     // Make sure that you pass a valid action object.
-    int getActionObjectDirection( const MapObjectType objectType );
+    int getActionObjectPassability( const MapObjectType objectType );
 
     bool getDiggingHoleSprite( const int terrainType, ObjectIcnType & objectIcnType, uint8_t & index );
     bool isDiggingHoleSprite( const int terrainType, const ObjectIcnType objectIcnType, const uint8_t index );


### PR DESCRIPTION
While the rest of action objects are allowed to be placed everywhere except for tiles with other action objects.

close #9435

This pull request requires thoughtful testing to make sure that we don't introduce some bugs in gameplay.