### PR TITLE
Rework rendering of experience indicator

### DIFF
--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -217,7 +217,7 @@ void ExperienceIndicator::Redraw() const
     fheroes2::Blit( experienceImage, display, _area.x, _area.y );
 
     const fheroes2::Rect renderRoi{ _area.x + 1, _area.y + 24, 33, 9 };
-    const int32_t widthReduction = experienceImage.width() - renderRoi.width;
+    const int32_t widthReduction = experienceImage.width() - renderRoi.width - 1;
 
     if ( _isDefault ) {
         // For the default range of experience see Heroes::GetStartingXp() method.

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -227,7 +227,7 @@ void ExperienceIndicator::Redraw() const
     }
     else {
         // Experience can be longer than the width of the rendering area.
-        // This is why it is important to either take into an account letter shadows or change the value of the experience.
+        // This is why it is important to either take into account letter shadows or change the experience value.
         const uint32_t experienceValue = _hero->GetExperience();
         std::string experienceString = std::to_string( _hero->GetExperience() );
 
@@ -237,10 +237,10 @@ void ExperienceIndicator::Redraw() const
             const uint32_t millions = experienceValue / 1000000;
 
             if ( experienceValue < 10000000 ) {
-                experienceString = std::to_string( millions ) + "." + std::to_string( ( experienceValue - millions * 1000000 ) / 10000 ) + "M";
+                experienceString = std::to_string( millions ) + "." + std::to_string( ( experienceValue - millions * 1000000 ) / 10000 ) + _( "million|M" );
             }
             else {
-                experienceString = std::to_string( millions ) + "." + std::to_string( ( experienceValue - millions * 1000000 ) / 100000 ) + "M";
+                experienceString = std::to_string( millions ) + "." + std::to_string( ( experienceValue - millions * 1000000 ) / 100000 ) + _( "million|M" );
             }
 
             text.set( experienceString, fheroes2::FontType::smallWhite() );

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -282,25 +282,12 @@ void SpellPointsIndicator::Redraw() const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    const fheroes2::Sprite & spellPointImage = fheroes2::AGG::GetICN( ICN::HSICONS, 8 );
-    fheroes2::Blit( spellPointImage, display, _area.x, _area.y );
+    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::HSICONS, 1 );
+    fheroes2::Blit( sprite, display, _area.x, _area.y );
 
-    const fheroes2::Rect renderRoi{ _area.x + 1, _area.y + 22, 33, 9 };
-    const int32_t widthReduction = spellPointImage.width() - renderRoi.width;
-
-    if ( _isDefault ) {
-        const fheroes2::Text text{ std::to_string( _hero->GetMaxSpellPoints() ), fheroes2::FontType::smallWhite() };
-        text.drawInRoi( renderRoi.x + ( spellPointImage.width() - text.width() ) / 2 - widthReduction, _area.y + 23, display, renderRoi );
-    }
-    else {
-        fheroes2::Text text{ std::to_string( _hero->GetSpellPoints() ) + "/" + std::to_string( _hero->GetMaxSpellPoints() ), fheroes2::FontType::smallWhite() };
-        if ( text.width() > renderRoi.width + 1 ) {
-            // Spell points are too long. Display only available spell points.
-            text.set( std::to_string( _hero->GetSpellPoints() ), fheroes2::FontType::smallWhite() );
-        }
-
-        text.drawInRoi( renderRoi.x + ( spellPointImage.width() - text.width() ) / 2 - widthReduction, _area.y + 23, display, renderRoi );
-    }
+    // For the default range of experience see Heroes::GetStartingXp() method.
+    const fheroes2::Text text( _isDefault ? "40-90" : std::to_string( _hero->GetExperience() ), fheroes2::FontType::smallWhite() );
+    text.draw( _area.x + 17 - text.width() / 2, _area.y + 25, display );
 }
 
 void SpellPointsIndicator::QueueEventProcessing() const

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -282,12 +282,13 @@ void SpellPointsIndicator::Redraw() const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::HSICONS, 1 );
+    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::HSICONS, 8 );
     fheroes2::Blit( sprite, display, _area.x, _area.y );
 
-    // For the default range of experience see Heroes::GetStartingXp() method.
-    const fheroes2::Text text( _isDefault ? "40-90" : std::to_string( _hero->GetExperience() ), fheroes2::FontType::smallWhite() );
-    text.draw( _area.x + 17 - text.width() / 2, _area.y + 25, display );
+    const fheroes2::Text text( _isDefault ? std::to_string( _hero->GetMaxSpellPoints() )
+                                          : std::to_string( _hero->GetSpellPoints() ) + "/" + std::to_string( _hero->GetMaxSpellPoints() ),
+                               fheroes2::FontType::smallWhite() );
+    text.draw( _area.x + sprite.width() / 2 - text.width() / 2, _area.y + 23, display );
 }
 
 void SpellPointsIndicator::QueueEventProcessing() const

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -297,7 +297,6 @@ void SpellPointsIndicator::Redraw() const
         if ( text.width() > renderRoi.width + 1 ) {
             // Spell points are too long. Display only available spell points.
             text.set( std::to_string( _hero->GetSpellPoints() ), fheroes2::FontType::smallWhite() );
-            
         }
 
         text.drawInRoi( renderRoi.x + ( spellPointImage.width() - text.width() ) / 2 - widthReduction, _area.y + 23, display, renderRoi );


### PR DESCRIPTION
- all values are going to be rendered strictly within the given black area.
- if an experience string is too long "M" (million) notation is going to be used

relates to #9433