### PR TITLE
Speed up loading MP2 maps by reading map info structure at once

### DIFF
--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *


### PR DESCRIPTION
In theory this approach is faster than just reading from a file many times. However, since my machine has a very good SSD I do not see any difference in performance especially when files are cached by the system. This should be tested on low end SSD or HDD devices to verify any performance impact.

relates to #6681