### PR TITLE
Expand the functionality of the Adventure map event

### DIFF
--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -188,11 +188,6 @@ namespace fheroes2
             _isRestored = true;
         }
 
-        Rect area() const
-        {
-            return { _x, _y, _width, _height };
-        }
-
     private:
         Image & _image;
         Image _copy;

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2024                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -186,6 +186,11 @@ namespace fheroes2
         void reset()
         {
             _isRestored = true;
+        }
+
+        Rect area() const
+        {
+            return { _x, _y, _width, _height };
         }
 
     private:

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -486,9 +486,9 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
                 StringReplace( str, "%{monster}", mons.GetName() );
 
                 int32_t count = 1;
-                auto monsUi = std::make_unique<const fheroes2::MonsterDialogElement>( mons );
+                const fheroes2::MonsterDialogElement monsUi{ mons };
 
-                if ( Dialog::SelectCount( std::move( str ), 1, 500000, count, 1, monsUi.get() ) ) {
+                if ( Dialog::SelectCount( std::move( str ), 1, 500000, count, 1, &monsUi ) ) {
                     troop.Set( mons, static_cast<uint32_t>( count ) );
                 }
             }

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -488,7 +488,7 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
                 int32_t count = 1;
                 auto monsUi = std::make_unique<const fheroes2::MonsterDialogElement>( mons );
 
-                if ( Dialog::SelectCount( str, 1, 500000, count, 1, monsUi.get() ) ) {
+                if ( Dialog::SelectCount( std::move( str ), 1, 500000, count, 1, monsUi.get() ) ) {
                     troop.Set( mons, static_cast<uint32_t>( count ) );
                 }
             }

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -26,7 +26,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
-#include <memory>
+#include <utility>
 #include <vector>
 
 #include "agg_image.h"

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -150,6 +150,8 @@ namespace Dialog
 
         void redraw();
 
+        static int32_t getButtonAreaHeight();
+
     protected:
         std::unique_ptr<fheroes2::ImageRestorer> _restorer;
         fheroes2::Rect area;

--- a/src/fheroes2/dialog/dialog_box.cpp
+++ b/src/fheroes2/dialog/dialog_box.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_box.cpp
+++ b/src/fheroes2/dialog/dialog_box.cpp
@@ -176,3 +176,8 @@ Dialog::NonFixedFrameBox::~NonFixedFrameBox()
 
     fheroes2::Display::instance().render( _restorer->rect() );
 }
+
+int32_t Dialog::NonFixedFrameBox::getButtonAreaHeight()
+{
+    return buttonHeight;
+}

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -201,7 +201,7 @@ namespace
                     fheroes2::showStandardTextMessage( {}, std::move( msg ), Dialog::OK );
                 }
                 else {
-                    std::string msg = _( "Select count %{resource}:" );
+                    std::string msg = _( "Set %{resource-type} Count" );
                     StringReplace( msg, "%{resource}", Resource::String( rs ) );
 
                     if ( Dialog::SelectCount( std::move( msg ), 0, max, sel, step ) && cur != sel ) {

--- a/src/fheroes2/editor/editor_daily_event_spec_window.cpp
+++ b/src/fheroes2/editor/editor_daily_event_spec_window.cpp
@@ -102,7 +102,7 @@ namespace Editor
         text.draw( messageRoi.x + ( messageRoi.width - text.width() ) / 2, offsetY, display );
 
         text.set( eventMetadata.message, fheroes2::FontType::normalWhite(), language );
-        text.draw( messageRoi.x + 5, messageRoi.y + 5, messageRoi.width - 10, display );
+        text.drawInRoi( messageRoi.x + 5, messageRoi.y + 5, messageRoi.width - 10, display, messageRoi );
 
         // Resources
         text.set( _( "Reward:" ), fheroes2::FontType::normalWhite() );
@@ -340,7 +340,7 @@ namespace Editor
 
                     messageRoiRestorer.restore();
                     text.set( eventMetadata.message, fheroes2::FontType::normalWhite(), language );
-                    text.draw( messageRoi.x + 5, messageRoi.y + 5, messageRoi.width - 10, display );
+                    text.drawInRoi( messageRoi.x + 5, messageRoi.y + 5, messageRoi.width - 10, display, messageRoi );
                     isRedrawNeeded = true;
                 }
             }

--- a/src/fheroes2/editor/editor_daily_event_spec_window.cpp
+++ b/src/fheroes2/editor/editor_daily_event_spec_window.cpp
@@ -319,7 +319,7 @@ namespace Editor
                     std::string message = _( "Set %{resource-type} Count" );
                     StringReplace( message, "%{resource-type}", Resource::String( resourceType ) );
 
-                    if ( Dialog::SelectCount( message, -99999, 999999, temp, 1, &resourceUI ) ) {
+                    if ( Dialog::SelectCount( std::move( message ), -99999, 999999, temp, 1, &resourceUI ) ) {
                         *resourcePtr = temp;
                     }
 

--- a/src/fheroes2/editor/editor_daily_event_spec_window.cpp
+++ b/src/fheroes2/editor/editor_daily_event_spec_window.cpp
@@ -314,7 +314,12 @@ namespace Editor
 
                     int32_t temp = *resourcePtr;
 
-                    if ( Dialog::SelectCount( Resource::String( resourceType ), -99999, 999999, temp, 1 ) ) {
+                    const fheroes2::ResourceDialogElement resourceUI( resourceType, {} );
+
+                    std::string message = _( "Set %{resource-type} Count" );
+                    StringReplace( message, "%{resource-type}", Resource::String( resourceType ) );
+
+                    if ( Dialog::SelectCount( message, -99999, 999999, temp, 1, &resourceUI ) ) {
                         *resourcePtr = temp;
                     }
 

--- a/src/fheroes2/editor/editor_daily_event_spec_window.cpp
+++ b/src/fheroes2/editor/editor_daily_event_spec_window.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024                                                    *
+ *   Copyright (C) 2024 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -108,7 +108,7 @@ namespace Editor
         text.draw( messageRoi.x + ( messageRoi.width - text.width() ) / 2, offsetY, display );
 
         text.set( eventMetadata.message, fheroes2::FontType::normalWhite(), language );
-        text.draw( messageRoi.x + 5, messageRoi.y + 5, messageRoi.width - 10, display );
+        text.drawInRoi( messageRoi.x + 5, messageRoi.y + 5, messageRoi.width - 10, display, messageRoi );
 
         offsetY = startOffsetY;
         const int32_t secondColumnOffsetX = dialogRoi.x + sectionWidth + 2 * elementOffset;
@@ -351,7 +351,7 @@ namespace Editor
 
                     messageRoiRestorer.restore();
                     text.set( eventMetadata.message, fheroes2::FontType::normalWhite(), language );
-                    text.draw( messageRoi.x + 5, messageRoi.y + 5, messageRoi.width - 10, display );
+                    text.drawInRoi( messageRoi.x + 5, messageRoi.y + 5, messageRoi.width - 10, display, messageRoi );
                     isRedrawNeeded = true;
                 }
             }
@@ -419,7 +419,7 @@ namespace Editor
 
                 display.render( secondarySkillRoi );
             }
-            else if ( le.MouseClickLeft( experienceRoi ) ) {
+            else if ( le.MouseClickLeft( experienceRoiRestorer.area() ) ) {
                 const fheroes2::ExperienceDialogElement tempExperienceUI{ 0 };
                 int32_t tempValue{ eventMetadata.experience };
 
@@ -469,7 +469,7 @@ namespace Editor
             else if ( le.isMouseRightButtonPressedInArea( buttonDeleteSecondarySkill.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Delete Secondary Skill" ), _( "Delete the Secondary Skill from the event." ), Dialog::ZERO );
             }
-            else if ( le.isMouseRightButtonPressedInArea( experienceRoi ) ) {
+            else if ( le.isMouseRightButtonPressedInArea( experienceRoiRestorer.area() ) ) {
                 experienceUI->showPopup( Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( resourceRoi ) ) {

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -478,7 +478,7 @@ namespace Editor
                 }
                 else {
                     fheroes2::showResourceMessage( fheroes2::Text( _( "Resources" ), fheroes2::FontType::normalYellow() ),
-                                                   fheroes2::Text{ _( "These resources will be changed/affected by the event." ), fheroes2::FontType::normalWhite() },
+                                                   fheroes2::Text{ _( "These resources will be a part of the event." ), fheroes2::FontType::normalWhite() },
                                                    Dialog::ZERO, eventMetadata.resources );
                 }
             }

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -20,7 +20,6 @@
 
 #include "editor_event_details_window.h"
 
-#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstddef>
@@ -32,13 +31,13 @@
 
 #include "agg_image.h"
 #include "artifact.h"
-#include "artifact_info.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
 #include "editor_ui_helper.h"
 #include "game_hotkeys.h"
+#include "heroes.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -48,11 +47,11 @@
 #include "resource.h"
 #include "screen.h"
 #include "settings.h"
+#include "skill.h"
 #include "spell.h"
 #include "tools.h"
 #include "translations.h"
 #include "ui_button.h"
-#include "ui_constants.h"
 #include "ui_dialog.h"
 #include "ui_text.h"
 #include "ui_tool.h"
@@ -153,7 +152,7 @@ namespace Editor
         experienceUI->draw( display, experienceRoi.getPosition() );
 
         // Secondary Skill
-        Heroes fakeHero;
+        const Heroes fakeHero;
         auto secondarySkillUI
             = std::make_unique<fheroes2::SecondarySkillDialogElement>( Skill::Secondary{ eventMetadata.secondarySkill, eventMetadata.secondarySkillLevel }, fakeHero );
 
@@ -421,7 +420,7 @@ namespace Editor
                 const fheroes2::ExperienceDialogElement tempExperienceUI{ 0 };
                 int32_t tempValue{ eventMetadata.experience };
 
-                if ( Dialog::SelectCount( _( "Set Experience value" ), 0, Heroes::getExperienceMaxValue(), tempValue, 1, &tempExperienceUI ) ) {
+                if ( Dialog::SelectCount( _( "Set Experience value" ), 0, static_cast<int32_t>( Heroes::getExperienceMaxValue() ), tempValue, 1, &tempExperienceUI ) ) {
                     eventMetadata.experience = tempValue;
 
                     experienceUI = std::make_unique<fheroes2::ExperienceDialogElement>( eventMetadata.experience );

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -473,8 +473,8 @@ namespace Editor
                 }
                 else {
                     fheroes2::showResourceMessage( fheroes2::Text( _( "Resources" ), fheroes2::FontType::normalYellow() ),
-                                                   fheroes2::Text{ _( "Resources will be given by the event." ), fheroes2::FontType::normalWhite() }, Dialog::ZERO,
-                                                   eventMetadata.resources );
+                                                   fheroes2::Text{ _( "These resources will be changed/affected by the event." ), fheroes2::FontType::normalWhite() },
+                                                   Dialog::ZERO, eventMetadata.resources );
                 }
             }
             else if ( le.isMouseRightButtonPressedInArea( recurringEventArea ) ) {

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -113,7 +113,7 @@ namespace Editor
         offsetY = startOffsetY;
         const int32_t secondColumnOffsetX = dialogRoi.x + sectionWidth + 2 * elementOffset;
 
-        text.set( _( "Reward:" ), fheroes2::FontType::normalWhite() );
+        text.set( _( "Effects:" ), fheroes2::FontType::normalWhite() );
         text.draw( secondColumnOffsetX + ( sectionWidth - text.width() ) / 2, offsetY, display );
 
         offsetY += text.height( sectionWidth );
@@ -210,7 +210,7 @@ namespace Editor
 
         offsetY += 35;
 
-        text.set( _( "Computer colors allowed to get event:" ), fheroes2::FontType::normalWhite() );
+        text.set( _( "Computer colors allowed to get the event:" ), fheroes2::FontType::normalWhite() );
 
         textWidth = sectionWidth;
 
@@ -451,11 +451,11 @@ namespace Editor
                     artifactUI->showPopup( Dialog::ZERO );
                 }
                 else {
-                    fheroes2::showStandardTextMessage( _( "Artifact" ), _( "No artifact will be given as a reward." ), Dialog::ZERO );
+                    fheroes2::showStandardTextMessage( _( "Artifact" ), _( "No artifact will be given by the event." ), Dialog::ZERO );
                 }
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonDeleteArtifact.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "Delete Artifact" ), _( "Delete an artifact from the reward." ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Delete Artifact" ), _( "Delete an artifact from the event." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( secondarySkillRoi ) ) {
                 const Skill::Secondary skill( eventMetadata.secondarySkill, eventMetadata.secondarySkillLevel );
@@ -464,18 +464,18 @@ namespace Editor
                     secondarySkillUI->showPopup( Dialog::ZERO );
                 }
                 else {
-                    fheroes2::showStandardTextMessage( _( "Secondary Skill" ), _( "No SecondarySkill will be given as a reward." ), Dialog::ZERO );
+                    fheroes2::showStandardTextMessage( _( "Secondary Skill" ), _( "No Secondary Skill will be given by the event." ), Dialog::ZERO );
                 }
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonDeleteSecondarySkill.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "Delete Secondary Skill" ), _( "Delete a Secondary SKill from the reward." ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Delete Secondary Skill" ), _( "Delete the Secondary Skill from the event." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( experienceRoi ) ) {
                 experienceUI->showPopup( Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( resourceRoi ) ) {
                 if ( eventMetadata.resources.GetValidItemsCount() == 0 ) {
-                    fheroes2::showStandardTextMessage( _( "Resources" ), _( "No resources will be given as a reward." ), Dialog::ZERO );
+                    fheroes2::showStandardTextMessage( _( "Resources" ), _( "No resources will be part of this event." ), Dialog::ZERO );
                 }
                 else {
                     fheroes2::showResourceMessage( fheroes2::Text( _( "Resources" ), fheroes2::FontType::normalYellow() ),

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -479,7 +479,7 @@ namespace Editor
                 }
                 else {
                     fheroes2::showResourceMessage( fheroes2::Text( _( "Resources" ), fheroes2::FontType::normalYellow() ),
-                                                   fheroes2::Text{ _( "Resources will be given as a reward." ), fheroes2::FontType::normalWhite() }, Dialog::ZERO,
+                                                   fheroes2::Text{ _( "Resources will be given by the event." ), fheroes2::FontType::normalWhite() }, Dialog::ZERO,
                                                    eventMetadata.resources );
                 }
             }

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -478,8 +478,8 @@ namespace Editor
                 }
                 else {
                     fheroes2::showResourceMessage( fheroes2::Text( _( "Resources" ), fheroes2::FontType::normalYellow() ),
-                                                   fheroes2::Text{ _( "These resources will be a part of the event." ), fheroes2::FontType::normalWhite() },
-                                                   Dialog::ZERO, eventMetadata.resources );
+                                                   fheroes2::Text{ _( "These resources will be a part of the event." ), fheroes2::FontType::normalWhite() }, Dialog::ZERO,
+                                                   eventMetadata.resources );
                 }
             }
             else if ( le.isMouseRightButtonPressedInArea( recurringEventArea ) ) {

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -379,8 +379,6 @@ namespace Editor
 
                 // The opened selectArtifact() dialog might be bigger than this dialog so we render the whole screen.
                 display.render();
-
-                isRedrawNeeded = false;
             }
             else if ( le.MouseClickLeft( buttonDeleteArtifact.area() ) ) {
                 eventMetadata.artifact = 0;
@@ -404,8 +402,6 @@ namespace Editor
 
                 // The opened selectSecondarySkill() dialog might be bigger than this dialog so we render the whole screen.
                 display.render();
-
-                isRedrawNeeded = false;
             }
             else if ( le.MouseClickLeft( buttonDeleteSecondarySkill.area() ) ) {
                 eventMetadata.secondarySkill = 0;
@@ -433,8 +429,6 @@ namespace Editor
 
                 // The opened SelectCount() dialog might be bigger than this dialog so we render the whole screen.
                 display.render();
-
-                isRedrawNeeded = false;
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonCancel.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -144,12 +144,19 @@ namespace Editor
         buttonDeleteArtifact.draw();
 
         // Experience
-        auto experienceUI = std::make_unique<fheroes2::ExperienceDialogElement>( eventMetadata.experience );
+        auto experienceUI = std::make_unique<fheroes2::ExperienceDialogElement>( 0 );
         const fheroes2::Rect experienceRoi{ secondColumnOffsetX + sectionWidth - experienceUI->area().width,
                                             offsetY + ( artifactRoi.height - experienceUI->area().height ) / 2, experienceUI->area().width, experienceUI->area().height };
-        fheroes2::ImageRestorer experienceRoiRestorer( display, experienceRoi.x, experienceRoi.y, experienceRoi.width, experienceRoi.height );
+
+        const fheroes2::Rect experienceValueRoi{ experienceRoi.x, buttonDeleteArtifact.area().y, experienceRoi.width, buttonDeleteArtifact.area().height };
+        background.applyTextBackgroundShading( experienceValueRoi );
+
+        fheroes2::ImageRestorer experienceRoiRestorer( display, experienceRoi.x, experienceRoi.y, experienceRoi.width,
+                                                       experienceValueRoi.y + experienceValueRoi.height - experienceRoi.y );
 
         experienceUI->draw( display, experienceRoi.getPosition() );
+        text.set( std::to_string( eventMetadata.experience ), fheroes2::FontType::smallWhite() );
+        text.draw( experienceValueRoi.x + ( experienceValueRoi.width - text.width() ) / 2, experienceValueRoi.y + 5, display );
 
         // Secondary Skill
         const Heroes fakeHero;
@@ -419,12 +426,10 @@ namespace Editor
                 if ( Dialog::SelectCount( _( "Set Experience value" ), 0, static_cast<int32_t>( Heroes::getExperienceMaxValue() ), tempValue, 1, &tempExperienceUI ) ) {
                     eventMetadata.experience = tempValue;
 
-                    experienceUI = std::make_unique<fheroes2::ExperienceDialogElement>( eventMetadata.experience );
-
                     experienceRoiRestorer.restore();
-                    experienceRoiRestorer.update( experienceRoi.x, experienceRoi.y, experienceUI->area().width, experienceUI->area().height );
-
                     experienceUI->draw( display, experienceRoi.getPosition() );
+                    text.set( std::to_string( eventMetadata.experience ), fheroes2::FontType::smallWhite() );
+                    text.draw( experienceValueRoi.x + ( experienceValueRoi.width - text.width() ) / 2, experienceValueRoi.y + 5, display );
                 }
 
                 // The opened SelectCount() dialog might be bigger than this dialog so we render the whole screen.

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -419,7 +419,7 @@ namespace Editor
 
                 display.render( secondarySkillRoi );
             }
-            else if ( le.MouseClickLeft( experienceRoiRestorer.area() ) ) {
+            else if ( le.MouseClickLeft( experienceRoiRestorer.rect() ) ) {
                 const fheroes2::ExperienceDialogElement tempExperienceUI{ 0 };
                 int32_t tempValue{ eventMetadata.experience };
 
@@ -469,7 +469,7 @@ namespace Editor
             else if ( le.isMouseRightButtonPressedInArea( buttonDeleteSecondarySkill.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Delete Secondary Skill" ), _( "Delete the Secondary Skill from the event." ), Dialog::ZERO );
             }
-            else if ( le.isMouseRightButtonPressedInArea( experienceRoiRestorer.area() ) ) {
+            else if ( le.isMouseRightButtonPressedInArea( experienceRoiRestorer.rect() ) ) {
                 experienceUI->showPopup( Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( resourceRoi ) ) {

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -147,8 +147,7 @@ namespace Editor
         // Experience
         auto experienceUI = std::make_unique<fheroes2::ExperienceDialogElement>( eventMetadata.experience );
         const fheroes2::Rect experienceRoi{ secondColumnOffsetX + sectionWidth - experienceUI->area().width,
-                                            offsetY + ( artifactRoi.height - experienceUI->area().height ) / 2,
-                                            experienceUI->area().width, experienceUI->area().height };
+                                            offsetY + ( artifactRoi.height - experienceUI->area().height ) / 2, experienceUI->area().width, experienceUI->area().height };
         fheroes2::ImageRestorer experienceRoiRestorer( display, experienceRoi.x, experienceRoi.y, experienceRoi.width, experienceRoi.height );
 
         experienceUI->draw( display, experienceRoi.getPosition() );
@@ -159,13 +158,13 @@ namespace Editor
             = std::make_unique<fheroes2::SecondarySkillDialogElement>( Skill::Secondary{ eventMetadata.secondarySkill, eventMetadata.secondarySkillLevel }, fakeHero );
 
         const fheroes2::Rect secondarySkillRoi{ ( artifactRoi.x + artifactRoi.width + experienceRoi.x - secondarySkillUI->area().width ) / 2,
-                                                offsetY + ( artifactRoi.height - secondarySkillUI->area().height ) / 2,
-                                                secondarySkillUI->area().width, secondarySkillUI->area().height };
+                                                offsetY + ( artifactRoi.height - secondarySkillUI->area().height ) / 2, secondarySkillUI->area().width,
+                                                secondarySkillUI->area().height };
 
         secondarySkillUI->draw( display, secondarySkillRoi.getPosition() );
 
-        fheroes2::Button buttonDeleteSecondarySkill(
-            secondarySkillRoi.x + ( secondarySkillRoi.width - buttonWidth ) / 2, artifactRoi.y + artifactRoi.height + 5, minibuttonIcnId, 17, 18 );
+        fheroes2::Button buttonDeleteSecondarySkill( secondarySkillRoi.x + ( secondarySkillRoi.width - buttonWidth ) / 2, artifactRoi.y + artifactRoi.height + 5,
+                                                     minibuttonIcnId, 17, 18 );
         buttonDeleteSecondarySkill.draw();
 
         // Conditions

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -323,7 +323,7 @@ namespace Editor
                     std::string message = _( "Set %{resource-type} Count" );
                     StringReplace( message, "%{resource-type}", Resource::String( resourceType ) );
 
-                    if ( Dialog::SelectCount( message, -99999, 999999, temp, 1, &resourceUI ) ) {
+                    if ( Dialog::SelectCount( std::move( message ), -99999, 999999, temp, 1, &resourceUI ) ) {
                         *resourcePtr = temp;
                     }
 

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1330,7 +1330,8 @@ namespace Interface
                         monsterUi = std::make_unique<const fheroes2::MonsterDialogElement>( tempMonster );
                     }
 
-                    if ( Dialog::SelectCount( str, 0, 500000, monsterCount, 1, monsterUi.get() ) && _mapFormat.standardMetadata[object.id].metadata[0] != monsterCount ) {
+                    if ( Dialog::SelectCount( std::move( str ), 0, 500000, monsterCount, 1, monsterUi.get() )
+                         && _mapFormat.standardMetadata[object.id].metadata[0] != monsterCount ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
                         _mapFormat.standardMetadata[object.id] = { monsterCount, 0, Monster::JOIN_CONDITION_UNSET };
                         action.commit();
@@ -1356,7 +1357,8 @@ namespace Interface
                     StringReplace( str, "%{resource-type}", Resource::String( resourceType ) );
 
                     // We cannot support more than 6 digits in the dialog due to its UI element size.
-                    if ( Dialog::SelectCount( str, 0, 999999, resourceCount, 1, &resourceUI ) && _mapFormat.standardMetadata[object.id].metadata[0] != resourceCount ) {
+                    if ( Dialog::SelectCount( std::move( str ), 0, 999999, resourceCount, 1, &resourceUI )
+                         && _mapFormat.standardMetadata[object.id].metadata[0] != resourceCount ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
                         _mapFormat.standardMetadata[object.id] = { resourceCount, 0, 0 };
                         action.commit();

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -1756,7 +1756,7 @@ namespace
                 break;
             }
             case Maps::FileInfo::LOSS_OUT_OF_TIME: {
-                const fheroes2::Rect roi{ _restorer.x(), _restorer.y(), _restorer.width(), _restorer.height() };
+                const fheroes2::Rect roi = _restorer.area();
                 const fheroes2::Point uiOffset{ roi.x + ( roi.width - fheroes2::ValueSelectionDialogElement::getArea().width ) / 2, roi.y };
 
                 _outOfTimeValue.setOffset( uiOffset );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -1756,7 +1756,7 @@ namespace
                 break;
             }
             case Maps::FileInfo::LOSS_OUT_OF_TIME: {
-                const fheroes2::Rect roi = _restorer.area();
+                const fheroes2::Rect roi = _restorer.rect();
                 const fheroes2::Point uiOffset{ roi.x + ( roi.width - fheroes2::ValueSelectionDialogElement::getArea().width ) / 2, roi.y };
 
                 _outOfTimeValue.setOffset( uiOffset );

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -310,7 +310,9 @@ namespace Editor
 
                     int32_t temp = *resourcePtr;
 
-                    if ( Dialog::SelectCount( Resource::String( resourceType ), 0, 1000000, temp, 1 ) ) {
+                    const fheroes2::ResourceDialogElement resourceUI( resourceType, {} );
+
+                    if ( Dialog::SelectCount( Resource::String( resourceType ), 0, 1000000, temp, 1, &resourceUI ) ) {
                         *resourcePtr = temp;
                     }
 

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -316,7 +316,7 @@ namespace Editor
                     std::string str = _( "Set %{resource-type} Count" );
                     StringReplace( str, "%{resource-type}", Resource::String( resourceType ) );
 
-                    if ( Dialog::SelectCount( str, 0, 1000000, temp, 1, &resourceUI ) ) {
+                    if ( Dialog::SelectCount( std::move( str ), 0, 1000000, temp, 1, &resourceUI ) ) {
                         *resourcePtr = temp;
                     }
 

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -50,6 +50,7 @@
 #include "screen.h"
 #include "settings.h"
 #include "spell.h"
+#include "tools.h"
 #include "translations.h"
 #include "ui_button.h"
 #include "ui_dialog.h"
@@ -312,7 +313,10 @@ namespace Editor
 
                     const fheroes2::ResourceDialogElement resourceUI( resourceType, {} );
 
-                    if ( Dialog::SelectCount( Resource::String( resourceType ), 0, 1000000, temp, 1, &resourceUI ) ) {
+                    std::string str = _( "Set %{resource-type} Count" );
+                    StringReplace( str, "%{resource-type}", Resource::String( resourceType ) );
+
+                    if ( Dialog::SelectCount( str, 0, 1000000, temp, 1, &resourceUI ) ) {
                         *resourcePtr = temp;
                     }
 

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024                                                    *
+ *   Copyright (C) 2024 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -210,7 +210,7 @@ bool PrimarySkillsBar::ActionBarLeftMouseSingleClick( int & skill )
 
         const fheroes2::PrimarySkillDialogElement skillUI{ skill, {} };
 
-        return Dialog::SelectCount( header, skill == Skill::Primary::POWER ? 1 : 0, 99, skillValue, 1, &skillUI );
+        return Dialog::SelectCount( std::move( header ), skill == Skill::Primary::POWER ? 1 : 0, 99, skillValue, 1, &skillUI );
     };
 
     int32_t value;

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2024                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -208,7 +208,9 @@ bool PrimarySkillsBar::ActionBarLeftMouseSingleClick( int & skill )
         std::string header = _( "Set %{skill} Skill" );
         StringReplace( header, "%{skill}", Skill::Primary::String( skill ) );
 
-        return Dialog::SelectCount( header, skill == Skill::Primary::POWER ? 1 : 0, 99, skillValue );
+        const fheroes2::PrimarySkillDialogElement skillUI{ skill, {} };
+
+        return Dialog::SelectCount( header, skill == Skill::Primary::POWER ? 1 : 0, 99, skillValue, 1, &skillUI );
     };
 
     int32_t value;

--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -307,8 +307,6 @@ namespace fheroes2
     ArtifactDialogElement::ArtifactDialogElement( const Artifact & artifact )
         : _artifact( artifact )
     {
-        assert( artifact.GetID() == Artifact::EDITOR_ANY_ULTIMATE_ARTIFACT || artifact.isValid() );
-
         const Sprite & frame = AGG::GetICN( ICN::RESOURCE, 7 );
         _area = { frame.width(), frame.height() };
     }
@@ -318,7 +316,9 @@ namespace fheroes2
         const Sprite & frame = AGG::GetICN( ICN::RESOURCE, 7 );
         Blit( frame, 0, 0, output, offset.x, offset.y, frame.width(), frame.height() );
 
-        const Sprite & artifact = AGG::GetICN( ICN::ARTIFACT, _artifact.IndexSprite64() );
+        const uint32_t icnIndex = ( _artifact.GetID() == Artifact::EDITOR_ANY_ULTIMATE_ARTIFACT || _artifact.isValid() ) ? _artifact.IndexSprite64() : 0;
+
+        const Sprite & artifact = AGG::GetICN( ICN::ARTIFACT, icnIndex );
         Blit( artifact, output, offset.x + 6, offset.y + 6 );
     }
 
@@ -688,6 +688,14 @@ namespace fheroes2
     {
         const Sprite & background = AGG::GetICN( ICN::SECSKILL, 15 );
         Blit( background, 0, 0, output, offset.x, offset.y, background.width(), background.height() );
+
+        if ( !_skill.isValid() ) {
+            const Sprite & icn = AGG::GetICN( ICN::SECSKILL, 0 );
+            const Rect icnRect( offset.x + ( background.width() - icn.width() ) / 2, offset.y + ( background.height() - icn.height() ) / 2, icn.width(), icn.height() );
+            Copy( icn, 0, 0, output, icnRect );
+
+            return;
+        }
 
         const Sprite & icn = AGG::GetICN( ICN::SECSKILL, _skill.GetIndexSprite1() );
         const Rect icnRect( offset.x + ( background.width() - icn.width() ) / 2, offset.y + ( background.height() - icn.height() ) / 2, icn.width(), icn.height() );

--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -314,7 +314,7 @@ namespace fheroes2
             elementHeight += rowHeight.back();
         }
 
-        return overallTextHeight + elementHeight + ( ( buttons != 0 ) ? Dialog::FrameBox::getButtonAreaHeight() : 0 );
+        return overallTextHeight + elementHeight + ( ( buttons != 0 ) ? Dialog::FrameBox::getButtonAreaHeight() : 0 ) + fheroes2::borderWidthPx * 4;
     }
 
     int showStandardTextMessage( std::string headerText, std::string messageBody, const int buttons, const std::vector<const DialogElement *> & elements /* = {} */ )

--- a/src/fheroes2/gui/ui_dialog.h
+++ b/src/fheroes2/gui/ui_dialog.h
@@ -46,6 +46,8 @@ namespace fheroes2
 
     int showMessage( const TextBase & header, const TextBase & body, const int buttons, const std::vector<const DialogElement *> & elements = {} );
 
+    int32_t getDialogHeight( const TextBase & header, const TextBase & body, const int buttons, const std::vector<const DialogElement *> & elements = {} );
+
     // This is a simplified version of UI window which is used to display a window with a text.
     // Header text has yellow normal font style and body text - white normal font style.
     int showStandardTextMessage( std::string headerText, std::string messageBody, const int buttons, const std::vector<const DialogElement *> & elements = {} );

--- a/src/fheroes2/gui/ui_dialog.h
+++ b/src/fheroes2/gui/ui_dialog.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/ui_dialog.h
+++ b/src/fheroes2/gui/ui_dialog.h
@@ -360,7 +360,7 @@ namespace fheroes2
         const Monster _monster;
     };
 
-    class ValueSelectionDialogElement
+    class ValueSelectionDialogElement final
     {
     public:
         explicit ValueSelectionDialogElement( const int32_t minimum, const int32_t maximum, const int32_t current, const int32_t step, const Point & offset );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1570,6 +1570,11 @@ uint32_t Heroes::GetExperienceFromLevel( int lvl )
     return ( l1 + static_cast<uint32_t>( round( ( l1 - GetExperienceFromLevel( lvl - 2 ) ) * 1.2 / 100 ) * 100 ) );
 }
 
+uint32_t Heroes::getExperienceMaxValue()
+{
+    return 2990600;
+}
+
 bool Heroes::BuySpellBook( const Castle * castle )
 {
     if ( HaveSpellBook() || Color::NONE == GetColor() ) {

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -687,6 +687,8 @@ public:
     static int GetLevelFromExperience( uint32_t exp );
     static uint32_t GetExperienceFromLevel( int lvl );
 
+    static uint32_t getExperienceMaxValue();
+
     static const fheroes2::Sprite & GetPortrait( int heroid, int type );
     static const char * GetName( int heroid );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2854,7 +2854,7 @@ namespace
 
         int32_t dialogHeight = fheroes2::getDialogHeight( emptyText, body, Dialog::OK, elementUI );
         const int32_t displayHeight = fheroes2::Display::instance().height();
-        if ( dialogHeight > displayHeight && elementUI.size() > 0 ) {
+        if ( dialogHeight > displayHeight && !elementUI.empty() ) {
             // We have to split the message into 2 as it is too big.
             std::vector<const fheroes2::DialogElement *> secondDialogUIElement;
             while ( dialogHeight > displayHeight && !elementUI.empty() ) {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2854,7 +2854,7 @@ namespace
 
         int32_t dialogHeight = fheroes2::getDialogHeight( emptyText, body, Dialog::OK, elementUI );
         const int32_t displayHeight = fheroes2::Display::instance().height();
-        if ( dialogHeight > displayHeight ) {
+        if ( dialogHeight > displayHeight && elementUI.size() > 1 ) {
             // We have to split the message into 2 as it is too big.
             std::vector<const fheroes2::DialogElement *> secondDialogUIElement;
             while ( dialogHeight > displayHeight && !elementUI.empty() ) {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2854,7 +2854,7 @@ namespace
 
         int32_t dialogHeight = fheroes2::getDialogHeight( emptyText, body, Dialog::OK, elementUI );
         const int32_t displayHeight = fheroes2::Display::instance().height();
-        if ( dialogHeight > displayHeight && elementUI.size() > 1 ) {
+        if ( dialogHeight > displayHeight && elementUI.size() > 0 ) {
             // We have to split the message into 2 as it is too big.
             std::vector<const fheroes2::DialogElement *> secondDialogUIElement;
             while ( dialogHeight > displayHeight && !elementUI.empty() ) {
@@ -2864,7 +2864,7 @@ namespace
             }
 
             fheroes2::showMessage( emptyText, body, Dialog::OK, elementUI );
-            fheroes2::showMessage( emptyText, body, Dialog::OK, secondDialogUIElement );
+            fheroes2::showMessage( emptyText, emptyText, Dialog::OK, secondDialogUIElement );
         }
         else {
             fheroes2::showMessage( emptyText, body, Dialog::OK, elementUI );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2808,7 +2808,7 @@ namespace
             elementUI.emplace_back( &element );
         }
 
-        // Check for the presence of an artifact as a reward in the event and display it in the dialog.
+        // Check for the presence of an artifact in the event and display it in the dialog.
         std::unique_ptr<fheroes2::ArtifactDialogElement> artifactUI;
         const Artifact & art = mapEvent->artifact;
         if ( art.isValid() ) {
@@ -2856,7 +2856,7 @@ namespace
         fheroes2::showMessage( header, body, Dialog::OK, elementUI );
 
         // PickupArtifact() has a built-in check for Artifact correctness, the presence of a magic book
-        // and the fullness of the bag. Is also displays appropriate text when an artifact cannot be picked up.
+        // and the fullness of the bag. It also displays appropriate text when an artifact cannot be picked up.
         hero.PickupArtifact( art );
 
         if ( mapEvent->experience > 0 ) {

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -2849,11 +2849,26 @@ namespace
             elementUI.emplace_back( experienceUI.get() );
         }
 
-        // TODO: this dialog might be too long to be displayed on small resolutions.
-        //       Find a way how to make this text scrollable or conditionally reduce the number of UI elements.
-        const fheroes2::Text header( {}, fheroes2::FontType::normalYellow() );
+        const fheroes2::Text emptyText;
         const fheroes2::Text body( mapEvent->message, fheroes2::FontType::normalWhite(), Settings::Get().getCurrentMapInfo().getSupportedLanguage() );
-        fheroes2::showMessage( header, body, Dialog::OK, elementUI );
+
+        int32_t dialogHeight = fheroes2::getDialogHeight( emptyText, body, Dialog::OK, elementUI );
+        const int32_t displayHeight = fheroes2::Display::instance().height();
+        if ( dialogHeight > displayHeight ) {
+            // We have to split the message into 2 as it is too big.
+            std::vector<const fheroes2::DialogElement *> secondDialogUIElement;
+            while ( dialogHeight > displayHeight && !elementUI.empty() ) {
+                secondDialogUIElement.push_back( elementUI.back() );
+                elementUI.pop_back();
+                dialogHeight = fheroes2::getDialogHeight( emptyText, body, Dialog::OK, elementUI );
+            }
+
+            fheroes2::showMessage( emptyText, body, Dialog::OK, elementUI );
+            fheroes2::showMessage( emptyText, body, Dialog::OK, secondDialogUIElement );
+        }
+        else {
+            fheroes2::showMessage( emptyText, body, Dialog::OK, elementUI );
+        }
 
         // PickupArtifact() has a built-in check for Artifact correctness, the presence of a magic book
         // and the fullness of the bag. It also displays appropriate text when an artifact cannot be picked up.

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -742,6 +742,8 @@ namespace
 
         if ( objectType == MP2::OBJ_BOTTLE ) {
             const MapSign * sign = dynamic_cast<MapSign *>( world.GetMapObject( dst_index ) );
+            assert( sign != nullptr );
+
             fheroes2::showStandardTextMessage( MP2::StringObject( objectType ), ( sign ? sign->message : "No message provided" ), Dialog::OK );
         }
         else {
@@ -2778,55 +2780,95 @@ namespace
         }
     }
 
-    void ActionToEvent( Heroes & hero, int32_t dst_index )
+    void ActionToEvent( Heroes & hero, const int32_t tileIndex )
     {
         DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
 
-        MapEvent * event_maps = world.GetMapEvent( Maps::GetPoint( dst_index ) );
+        MapEvent * mapEvent = world.GetMapEvent( Maps::GetPoint( tileIndex ) );
+        if ( mapEvent == nullptr ) {
+            DEBUG_LOG( DBG_AI, DBG_INFO, "Adventure Map event at index " << tileIndex << " is missing!" )
+            return;
+        }
 
-        if ( event_maps && event_maps->isAllow( hero.GetColor() ) ) {
-            hero.SetMove( false );
+        if ( !mapEvent->isAllow( hero.GetColor() ) ) {
+            return;
+        }
 
-            const Funds fundsToUpdate = Resource::CalculateEventResourceUpdate( hero.GetKingdom().GetFunds(), event_maps->resources );
+        hero.SetMove( false );
 
-            if ( event_maps->resources.GetValidItemsCount() ) {
-                hero.GetKingdom().AddFundsResource( event_maps->resources );
+        const Funds fundsToUpdate = Resource::CalculateEventResourceUpdate( hero.GetKingdom().GetFunds(), mapEvent->resources );
+
+        if ( mapEvent->resources.GetValidItemsCount() ) {
+            hero.GetKingdom().AddFundsResource( mapEvent->resources );
+        }
+
+        const std::vector<fheroes2::ResourceDialogElement> resourceUI = fheroes2::getResourceDialogElements( fundsToUpdate );
+
+        std::vector<const fheroes2::DialogElement *> elementUI;
+        for ( const fheroes2::ResourceDialogElement & element : resourceUI ) {
+            elementUI.emplace_back( &element );
+        }
+
+        // Check for the presence of an artifact as a reward in the event and display it in the dialog.
+        std::unique_ptr<fheroes2::ArtifactDialogElement> artifactUI;
+        const Artifact & art = mapEvent->artifact;
+        if ( art.isValid() ) {
+            artifactUI = std::make_unique<fheroes2::ArtifactDialogElement>( art );
+            AudioManager::PlaySound( M82::TREASURE );
+            elementUI.emplace_back( artifactUI.get() );
+        }
+
+        std::unique_ptr<fheroes2::SecondarySkillDialogElement> secondarySkillUI;
+        const auto & skill = mapEvent->secondarySkill;
+        if ( skill.isValid() ) {
+            bool addSkill = false;
+
+            if ( hero.HasSecondarySkill( skill.Skill() ) ) {
+                addSkill = ( hero.GetSecondarySkills().GetLevel( skill.Skill() ) < skill.Level() );
+            }
+            else {
+                addSkill = !hero.HasMaxSecondarySkill();
             }
 
-            const Artifact & art = event_maps->artifact;
-            const bool hasValidArtifact = art.isValid();
+            if ( addSkill ) {
+                secondarySkillUI = std::make_unique<fheroes2::SecondarySkillDialogElement>( skill, hero );
+                elementUI.emplace_back( secondarySkillUI.get() );
 
-            const std::vector<fheroes2::ResourceDialogElement> resourceUI = fheroes2::getResourceDialogElements( fundsToUpdate );
+                hero.LearnSkill( skill );
 
-            std::vector<const fheroes2::DialogElement *> elementUI;
-            elementUI.reserve( resourceUI.size() + ( hasValidArtifact ? 1 : 0 ) );
-
-            for ( const fheroes2::ResourceDialogElement & element : resourceUI ) {
-                elementUI.emplace_back( &element );
+                // When Scouting skill is learned we reveal the fog and redraw the radar map image in a new scout area of the hero.
+                if ( skill.Skill() == Skill::Secondary::SCOUTING ) {
+                    hero.Scout( hero.GetIndex() );
+                    hero.ScoutRadar();
+                }
             }
+        }
 
-            // Check for the presence of an artifact as a reward in the event and display it in the dialog.
-            std::unique_ptr<fheroes2::ArtifactDialogElement> artifactUI;
-            if ( hasValidArtifact ) {
-                artifactUI = std::make_unique<fheroes2::ArtifactDialogElement>( art );
-                AudioManager::PlaySound( M82::TREASURE );
-                elementUI.emplace_back( artifactUI.get() );
-            }
+        std::unique_ptr<fheroes2::ExperienceDialogElement> experienceUI;
+        if ( mapEvent->experience > 0 ) {
+            experienceUI = std::make_unique<fheroes2::ExperienceDialogElement>( mapEvent->experience );
+            elementUI.emplace_back( experienceUI.get() );
+        }
 
-            const fheroes2::Text header( {}, fheroes2::FontType::normalYellow() );
-            const fheroes2::Text body( event_maps->message, fheroes2::FontType::normalWhite(), Settings::Get().getCurrentMapInfo().getSupportedLanguage() );
-            fheroes2::showMessage( header, body, Dialog::OK, elementUI );
+        // TODO: this dialog might be too long to be displayed on small resolutions.
+        //       Find a way how to make this text scrollable or conditionally reduce the number of UI elements.
+        const fheroes2::Text header( {}, fheroes2::FontType::normalYellow() );
+        const fheroes2::Text body( mapEvent->message, fheroes2::FontType::normalWhite(), Settings::Get().getCurrentMapInfo().getSupportedLanguage() );
+        fheroes2::showMessage( header, body, Dialog::OK, elementUI );
 
-            // PickupArtifact() has a built-in check for Artifact correctness, the presence of a magic book
-            // and the fullness of the bag. Is also displays appropriate text when an artifact cannot be picked up.
-            hero.PickupArtifact( art );
+        // PickupArtifact() has a built-in check for Artifact correctness, the presence of a magic book
+        // and the fullness of the bag. Is also displays appropriate text when an artifact cannot be picked up.
+        hero.PickupArtifact( art );
 
-            event_maps->SetVisited();
+        if ( mapEvent->experience > 0 ) {
+            hero.IncreaseExperience( static_cast<uint32_t>( mapEvent->experience ) );
+        }
 
-            if ( event_maps->isSingleTimeEvent ) {
-                hero.setObjectTypeUnderHero( MP2::OBJ_NONE );
-                world.RemoveMapObject( event_maps );
-            }
+        mapEvent->SetVisited();
+
+        if ( mapEvent->isSingleTimeEvent ) {
+            hero.setObjectTypeUnderHero( MP2::OBJ_NONE );
+            world.RemoveMapObject( mapEvent );
         }
     }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -742,8 +742,6 @@ namespace
 
         if ( objectType == MP2::OBJ_BOTTLE ) {
             const MapSign * sign = dynamic_cast<MapSign *>( world.GetMapObject( dst_index ) );
-            assert( sign != nullptr );
-
             fheroes2::showStandardTextMessage( MP2::StringObject( objectType ), ( sign ? sign->message : "No message provided" ), Dialog::OK );
         }
         else {
@@ -2805,6 +2803,7 @@ namespace
         const std::vector<fheroes2::ResourceDialogElement> resourceUI = fheroes2::getResourceDialogElements( fundsToUpdate );
 
         std::vector<const fheroes2::DialogElement *> elementUI;
+        elementUI.reserve( resourceUI.size() );
         for ( const fheroes2::ResourceDialogElement & element : resourceUI ) {
             elementUI.emplace_back( &element );
         }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -504,7 +504,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
                     const fheroes2::ExperienceDialogElement tempExperienceUI{ 0 };
                     int32_t value = static_cast<int32_t>( experience );
 
-                    if ( Dialog::SelectCount( _( "Set Experience value" ), 0, Heroes::getExperienceMaxValue(), value, 1, &tempExperienceUI ) ) {
+                    if ( Dialog::SelectCount( _( "Set Experience value" ), 0, static_cast<int32_t>( Heroes::getExperienceMaxValue() ), value, 1, &tempExperienceUI ) ) {
                         useDefaultExperience = false;
                         experience = static_cast<uint32_t>( value );
                         experienceInfo.setDefaultState( useDefaultExperience );

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -68,7 +68,6 @@
 namespace
 {
     const fheroes2::Size primarySkillIconSize{ 82, 93 };
-    const uint32_t experienceMaxValue{ 2990600 };
     const uint32_t spellPointsMaxValue{ 999 };
 }
 
@@ -502,8 +501,10 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
                                                : _( "Change Experience value. Right-click to reset to default value." );
 
                 if ( le.MouseClickLeft() ) {
+                    const fheroes2::ExperienceDialogElement tempExperienceUI{ 0 };
                     int32_t value = static_cast<int32_t>( experience );
-                    if ( Dialog::SelectCount( _( "Set Experience value" ), 0, experienceMaxValue, value ) ) {
+
+                    if ( Dialog::SelectCount( _( "Set Experience value" ), 0, Heroes::getExperienceMaxValue(), value, 1, &tempExperienceUI ) ) {
                         useDefaultExperience = false;
                         experience = static_cast<uint32_t>( value );
                         experienceInfo.setDefaultState( useDefaultExperience );

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2024                                             *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -225,7 +225,7 @@ namespace Maps::Map_Format
 
         int32_t experience{ 0 };
 
-        int8_t secondarySkill{ 0 };
+        uint8_t secondarySkill{ 0 };
         uint8_t secondarySkillLevel{ 0 };
 
         int32_t monsterType{ 0 };

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -120,7 +120,7 @@ void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & da
     artifact = dataStream.getLE16() + 1;
 
     // The event applies to AI players as well.
-    computer = ( dataStream.get() != 0 );
+    isComputerPlayerAllowed = ( dataStream.get() != 0 );
 
     // Does event occur only once?
     isSingleTimeEvent = ( dataStream.get() != 0 );
@@ -315,12 +315,12 @@ void MapSign::setDefaultMessage()
     message = Rand::Get( randomMessage );
 }
 
-OStreamBase & operator<<( OStreamBase & stream, const MapObjectSimple & obj )
+OStreamBase & operator<<( OStreamBase & stream, const MapBaseObject & obj )
 {
     return stream << static_cast<const MapPosition &>( obj ) << obj.uid;
 }
 
-IStreamBase & operator>>( IStreamBase & stream, MapObjectSimple & obj )
+IStreamBase & operator>>( IStreamBase & stream, MapBaseObject & obj )
 {
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE2_1103_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE2_1103_RELEASE ) {
@@ -337,22 +337,34 @@ IStreamBase & operator>>( IStreamBase & stream, MapObjectSimple & obj )
 
 OStreamBase & operator<<( OStreamBase & stream, const MapEvent & obj )
 {
-    return stream << static_cast<const MapObjectSimple &>( obj ) << obj.resources << obj.artifact << obj.computer << obj.isSingleTimeEvent << obj.colors << obj.message;
+    return stream << static_cast<const MapBaseObject &>( obj ) << obj.resources << obj.artifact << obj.isComputerPlayerAllowed << obj.isSingleTimeEvent << obj.colors
+                  << obj.message << obj.secondarySkill;
 }
 
 IStreamBase & operator>>( IStreamBase & stream, MapEvent & obj )
 {
-    return stream >> static_cast<MapObjectSimple &>( obj ) >> obj.resources >> obj.artifact >> obj.computer >> obj.isSingleTimeEvent >> obj.colors >> obj.message;
+    stream >> static_cast<MapBaseObject &>( obj ) >> obj.resources >> obj.artifact >> obj.isComputerPlayerAllowed >> obj.isSingleTimeEvent >> obj.colors >> obj.message;
+
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1106_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1106_RELEASE ) {
+        obj.secondarySkill = {};
+        obj.experience = 0;
+    }
+    else {
+        stream >> obj.secondarySkill >> obj.experience;
+    }
+
+    return stream;
 }
 
 OStreamBase & operator<<( OStreamBase & stream, const MapSphinx & obj )
 {
-    return stream << static_cast<const MapObjectSimple &>( obj ) << obj.resources << obj.artifact << obj.answers << obj.riddle << obj.valid << obj.isTruncatedAnswer;
+    return stream << static_cast<const MapBaseObject &>( obj ) << obj.resources << obj.artifact << obj.answers << obj.riddle << obj.valid << obj.isTruncatedAnswer;
 }
 
 IStreamBase & operator>>( IStreamBase & stream, MapSphinx & obj )
 {
-    stream >> static_cast<MapObjectSimple &>( obj ) >> obj.resources >> obj.artifact >> obj.answers >> obj.riddle >> obj.valid;
+    stream >> static_cast<MapBaseObject &>( obj ) >> obj.resources >> obj.artifact >> obj.answers >> obj.riddle >> obj.valid;
 
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1100_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1100_RELEASE ) {
@@ -367,10 +379,10 @@ IStreamBase & operator>>( IStreamBase & stream, MapSphinx & obj )
 
 OStreamBase & operator<<( OStreamBase & stream, const MapSign & obj )
 {
-    return stream << static_cast<const MapObjectSimple &>( obj ) << obj.message;
+    return stream << static_cast<const MapBaseObject &>( obj ) << obj.message;
 }
 
 IStreamBase & operator>>( IStreamBase & stream, MapSign & obj )
 {
-    return stream >> static_cast<MapObjectSimple &>( obj ) >> obj.message;
+    return stream >> static_cast<MapBaseObject &>( obj ) >> obj.message;
 }

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2013 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -32,14 +32,15 @@
 #include "artifact.h"
 #include "position.h"
 #include "resource.h"
+#include "skill.h"
 
 class IStreamBase;
 class OStreamBase;
 
-class MapObjectSimple : public MapPosition
+class MapBaseObject : public MapPosition
 {
 public:
-    MapObjectSimple() = default;
+    MapBaseObject() = default;
 
     uint32_t GetUID() const
     {
@@ -58,13 +59,13 @@ public:
     }
 
 protected:
-    friend OStreamBase & operator<<( OStreamBase & stream, const MapObjectSimple & obj );
-    friend IStreamBase & operator>>( IStreamBase & stream, MapObjectSimple & obj );
+    friend OStreamBase & operator<<( OStreamBase & stream, const MapBaseObject & obj );
+    friend IStreamBase & operator>>( IStreamBase & stream, MapBaseObject & obj );
 
     uint32_t uid{ 0 };
 };
 
-struct MapEvent : public MapObjectSimple
+struct MapEvent final : public MapBaseObject
 {
     MapEvent() = default;
 
@@ -84,13 +85,16 @@ struct MapEvent : public MapObjectSimple
 
     Funds resources;
     Artifact artifact;
-    bool computer{ false };
+    bool isComputerPlayerAllowed{ false };
     bool isSingleTimeEvent{ true };
     int colors{ 0 };
     std::string message;
+
+    Skill::Secondary secondarySkill;
+    int32_t experience{ 0 };
 };
 
-struct MapSphinx : public MapObjectSimple
+struct MapSphinx final : public MapBaseObject
 {
     MapSphinx() = default;
 
@@ -136,7 +140,7 @@ struct MapSphinx : public MapObjectSimple
     bool isTruncatedAnswer{ true };
 };
 
-struct MapSign : public MapObjectSimple
+struct MapSign final : public MapBaseObject
 {
     MapSign() = default;
 

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -27,7 +27,8 @@ enum SaveFileFormat : uint16_t
     // !!! IMPORTANT !!!
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
-    FORMAT_VERSION_1106_RELEASE = 10026,
+    FORMAT_VERSION_1106_RELEASE = 10027,
+    FORMAT_VERSION_PPRE1_1106_RELEASE = 10026,
     FORMAT_VERSION_1104_RELEASE = 10025,
     FORMAT_VERSION_1103_RELEASE = 10024,
     FORMAT_VERSION_PRE2_1103_RELEASE = 10023,

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -146,7 +146,7 @@ namespace
     }
 }
 
-MapObjectSimple * MapObjects::get( const uint32_t uid ) const
+MapBaseObject * MapObjects::get( const uint32_t uid ) const
 {
     if ( const auto iter = _objects.find( uid ); iter != _objects.end() ) {
         return iter->second.get();
@@ -155,9 +155,9 @@ MapObjectSimple * MapObjects::get( const uint32_t uid ) const
     return nullptr;
 }
 
-std::list<MapObjectSimple *> MapObjects::get( const fheroes2::Point & pos ) const
+std::list<MapBaseObject *> MapObjects::get( const fheroes2::Point & pos ) const
 {
-    std::list<MapObjectSimple *> result;
+    std::list<MapBaseObject *> result;
 
     for ( const auto & [dummy, obj] : _objects ) {
         assert( obj );
@@ -1033,7 +1033,7 @@ void World::ActionForMagellanMaps( int color )
 
 MapEvent * World::GetMapEvent( const fheroes2::Point & pos )
 {
-    std::list<MapObjectSimple *> res = map_objects.get( pos );
+    std::list<MapBaseObject *> res = map_objects.get( pos );
     if ( res.empty() ) {
         return nullptr;
     }
@@ -1041,12 +1041,12 @@ MapEvent * World::GetMapEvent( const fheroes2::Point & pos )
     return dynamic_cast<MapEvent *>( res.front() );
 }
 
-MapObjectSimple * World::GetMapObject( uint32_t uid )
+MapBaseObject * World::GetMapObject( uint32_t uid )
 {
     return uid ? map_objects.get( uid ) : nullptr;
 }
 
-void World::RemoveMapObject( const MapObjectSimple * obj )
+void World::RemoveMapObject( const MapBaseObject * obj )
 {
     if ( obj )
         map_objects.remove( obj->GetUID() );
@@ -1450,7 +1450,7 @@ IStreamBase & operator>>( IStreamBase & stream, CapturedObject & obj )
 
 OStreamBase & operator<<( OStreamBase & stream, const MapObjects & objs )
 {
-    const std::map<uint32_t, std::unique_ptr<MapObjectSimple>> & objectsRef = objs._objects;
+    const std::map<uint32_t, std::unique_ptr<MapBaseObject>> & objectsRef = objs._objects;
 
     stream.put32( static_cast<uint32_t>( objectsRef.size() ) );
 
@@ -1484,7 +1484,7 @@ OStreamBase & operator<<( OStreamBase & stream, const MapObjects & objs )
 
 IStreamBase & operator>>( IStreamBase & stream, MapObjects & objs )
 {
-    std::map<uint32_t, std::unique_ptr<MapObjectSimple>> & objectsRef = objs._objects;
+    std::map<uint32_t, std::unique_ptr<MapBaseObject>> & objectsRef = objs._objects;
 
     const uint32_t size = stream.get32();
 
@@ -1506,7 +1506,7 @@ IStreamBase & operator>>( IStreamBase & stream, MapObjects & objs )
             stream >> type;
         }
 
-        std::unique_ptr<MapObjectSimple> obj = [&stream, type]() -> std::unique_ptr<MapObjectSimple> {
+        std::unique_ptr<MapBaseObject> obj = [&stream, type]() -> std::unique_ptr<MapBaseObject> {
             switch ( type ) {
             case MP2::OBJ_EVENT: {
                 auto ptr = std::make_unique<MapEvent>();
@@ -1589,8 +1589,8 @@ IStreamBase & operator>>( IStreamBase & stream, World & w )
         ++w.heroIdAsLossCondition;
     }
 
-    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1106_RELEASE, "Remove the logic below." );
-    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1106_RELEASE ) {
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PPRE1_1106_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PPRE1_1106_RELEASE ) {
         // Update flags for Mine and Lighthouse captured objects.
         for ( const auto & [tileIndex, object] : w.map_captureobj ) {
             if ( object.GetColor() == Color::NONE ) {

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -86,7 +86,7 @@ public:
         _objects.clear();
     }
 
-    template <typename T, std::enable_if_t<std::is_base_of_v<MapObjectSimple, T>, bool> = true>
+    template <typename T, std::enable_if_t<std::is_base_of_v<MapBaseObject, T>, bool> = true>
     void add( std::unique_ptr<T> && obj )
     {
         if ( !obj ) {
@@ -100,14 +100,14 @@ public:
 
     void remove( const uint32_t uid );
 
-    MapObjectSimple * get( const uint32_t uid ) const;
-    std::list<MapObjectSimple *> get( const fheroes2::Point & pos ) const;
+    MapBaseObject * get( const uint32_t uid ) const;
+    std::list<MapBaseObject *> get( const fheroes2::Point & pos ) const;
 
 private:
     friend OStreamBase & operator<<( OStreamBase & stream, const MapObjects & objs );
     friend IStreamBase & operator>>( IStreamBase & stream, MapObjects & objs );
 
-    std::map<uint32_t, std::unique_ptr<MapObjectSimple>> _objects;
+    std::map<uint32_t, std::unique_ptr<MapBaseObject>> _objects;
 };
 
 struct CapturedObject
@@ -389,8 +389,8 @@ public:
     EventsDate GetEventsDate( int color ) const;
 
     MapEvent * GetMapEvent( const fheroes2::Point & );
-    MapObjectSimple * GetMapObject( uint32_t uid );
-    void RemoveMapObject( const MapObjectSimple * );
+    MapBaseObject * GetMapObject( uint32_t uid );
+    void RemoveMapObject( const MapBaseObject * );
     const MapRegion & getRegion( size_t id ) const;
     size_t getRegionCount() const;
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -878,7 +878,6 @@ bool World::loadResurrectionMap( const std::string & filename )
                         break;
                     }
 
-                    // TODO: change MapEvent to support map format functionality.
                     auto eventObject = std::make_unique<MapEvent>();
                     eventObject->resources = eventInfo.resources;
                     eventObject->artifact = eventInfo.artifact;
@@ -886,10 +885,12 @@ bool World::loadResurrectionMap( const std::string & filename )
                         eventObject->artifact.SetSpell( eventInfo.artifactMetadata );
                     }
 
-                    eventObject->computer = ( computerColors != 0 );
+                    eventObject->isComputerPlayerAllowed = ( computerColors != 0 );
                     eventObject->colors = humanColors | computerColors;
                     eventObject->message = std::move( eventInfo.message );
                     eventObject->isSingleTimeEvent = !eventInfo.isRecurringEvent;
+                    eventObject->secondarySkill = { eventInfo.secondarySkill, eventInfo.secondarySkillLevel };
+                    eventObject->experience = eventInfo.experience;
 
                     eventObject->setUIDAndIndex( static_cast<int32_t>( tileId ) );
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -63,6 +63,7 @@
 #include "resource.h"
 #include "serialize.h"
 #include "settings.h"
+#include "skill.h"
 #include "spell.h"
 #include "world.h" // IWYU pragma: associated
 #include "world_object_uid.h"


### PR DESCRIPTION
- the Adventure Map event now supports giving a Secondary Skill and also Experience
- the corresponding Editor dialog was reworked to add the new functionality
- many other places where we call a separate dialog to set amount of something were lacking needed images

![image](https://github.com/user-attachments/assets/33e7d37f-1368-41e3-ae74-b47bb9f75615)
![image](https://github.com/user-attachments/assets/f7680ac0-5c74-4df2-81f0-92acef379192)

close #8731