### PR TITLE
Fix German original assets MIN button

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -1910,18 +1910,6 @@ namespace
                 Copy( fheroes2::AGG::GetICN( ICN::BTNNEWGM, 4 + i ), 36 - i, 23, out, 78 - i, 23, 10, 14 );
             }
             return true;
-        case ICN::BUTTON_SMALL_MIN_GOOD:
-            _icnVsSprite[id].resize( 2 );
-            for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                fheroes2::Sprite & out = _icnVsSprite[id][i];
-                out = fheroes2::AGG::GetICN( ICN::RECRUIT, 4 + i );
-                // clean the button
-                Blit( fheroes2::AGG::GetICN( ICN::SYSTEM, 11 + i ), 10, 6 + i, out, 30 - 2 * i, 5 + i, 31, 15 );
-                // add 'IN'
-                Copy( fheroes2::AGG::GetICN( ICN::APANEL, 4 + i ), 23 - i, 22 + i, out, 33 - i, 6 + i, 8, 14 ); // letter 'I'
-                Copy( fheroes2::AGG::GetICN( ICN::APANEL, 4 + i ), 31 - i, 22 + i, out, 44 - i, 6 + i, 17, 14 ); // letter 'N'
-            }
-            return true;
         default:
             break;
         }


### PR DESCRIPTION
This fixes a case where min button and max button's don't have the same shadow and are not at the same offset in dialogs when using German assets. This is due to #9525 where embedded shadows were removed from these buttons. The German Min button was forgotten.

The German min/max buttons are the same as the engine generated ones and equal to the English ones anyways.

