### PR TITLE
Remove assertion for passability checks

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,4 @@
-version 1.1.6 (15 February 2025)
+version 1.1.6 (16 February 2025)
 - fix Ultimate Artifact being erased for any action done on a map
 - fix Editor buttons not being translated
 - fix an assertion regarding maximum spell points

--- a/script/packaging/common/fheroes2.metainfo.xml
+++ b/script/packaging/common/fheroes2.metainfo.xml
@@ -37,10 +37,10 @@
     <control>touch</control>
   </recommends>
   <releases>
-    <release date="2025-02-15" version="v1.1.6">
+    <release date="2025-02-16" version="v1.1.6">
       <url>https://github.com/ihhub/fheroes2/releases/tag/1.1.6</url>
       <description>
-        <p>Changes in v1.1.6 (15 February 2025):</p>
+        <p>Changes in v1.1.6 (16 February 2025):</p>
         <ul>
           <li>fix Ultimate Artifact being erased for any action done on a map</li>
           <li>fix Editor buttons not being translated</li>

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -828,8 +828,10 @@ void Maps::Tile::updatePassability()
 
         if ( isShortObject( bottomTileObjectType )
              || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() ) && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
-            // If this assertion blows up then the above checks are invalid!
-            assert( ( bottomTile.getTileIndependentPassability() & Direction::TOP ) == 0 );
+            // Checking the main object type of a tile is not entirely correct idea
+            // as some tiles can be mark as valid objects but nothing was set of them.
+            // As an example, Necroking map contains a tile with rock shadow which is marked as object.
+            // Most likely these maps are hacked but since we are reading old map we cannot assume things and assert them.
         }
         else {
             _tilePassabilityDirections = 0;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -828,10 +828,10 @@ void Maps::Tile::updatePassability()
 
         if ( isShortObject( bottomTileObjectType )
              || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() ) && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
-            // Checking the main object type of a tile is not entirely correct idea
-            // as some tiles can be mark as valid objects but nothing was set of them.
-            // As an example, Necroking map contains a tile with rock shadow which is marked as object.
-            // Most likely these maps are hacked but since we are reading old map we cannot assume things and assert them.
+            // Checking the main object type of a tile is not entirely the correct idea
+            // as some tiles can be marked as valid objects even though nothing was set of them.
+            // As an example, the Necroking map contains a tile with rock shadow which is marked as object.
+            // Most likely these maps are hacked but since we are reading from the old map format we cannot assume things and assert them.
         }
         else {
             _tilePassabilityDirections = 0;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -829,7 +829,7 @@ void Maps::Tile::updatePassability()
         if ( isShortObject( bottomTileObjectType )
              || ( !bottomTile.containsAnyObjectIcnType( getValidObjectIcnTypes() ) && ( isCombinedObject( objectType ) || isCombinedObject( bottomTileObjectType ) ) ) ) {
             // Checking the main object type of a tile is not entirely the correct idea
-            // as some tiles can be marked as valid objects even though nothing was set of them.
+            // as some tiles can be marked as valid objects even though nothing was set on them.
             // As an example, the Necroking map contains a tile with rock shadow which is marked as object.
             // Most likely these maps are hacked but since we are reading from the old map format we cannot assume things and assert them.
         }


### PR DESCRIPTION
This is due some maps being hacked or the OG editor's bugs.

Since, we haven't released 1.1.6 this PR serves as a hot fix which should go to the release.