### PR TITLE
Fix the operation of MIN/MAX buttons in various dialogs

### DIFF
--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -145,15 +145,16 @@ bool Dialog::SelectCount( std::string header, const int32_t min, const int32_t m
             needRedraw = true;
         }
         else if ( buttonMax.isVisible() && le.MouseClickLeft( buttonMax.area() ) ) {
+            selectedValue = max;
             valueSelectionElement.setValue( max );
             needRedraw = true;
         }
         else if ( buttonMin.isVisible() && le.MouseClickLeft( buttonMin.area() ) ) {
+            selectedValue = min;
             valueSelectionElement.setValue( min );
             needRedraw = true;
         }
-
-        if ( valueSelectionElement.processEvents() ) {
+        else if ( valueSelectionElement.processEvents() ) {
             selectedValue = valueSelectionElement.getValue();
             needRedraw = true;
         }

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -204,13 +204,15 @@ bool PrimarySkillsBar::ActionBarLeftMouseSingleClick( int & skill )
     }
 
     // The case when we are in Editor mode.
-    auto primarySkillEditDialog = [&skill]( int32_t & skillValue ) {
+    auto primarySkillEditDialog = [skill]( int32_t & skillValue ) {
         std::string header = _( "Set %{skill} Skill" );
         StringReplace( header, "%{skill}", Skill::Primary::String( skill ) );
 
+        const auto [min, max] = Skill::Primary::getSkillValueRange( skill );
+
         const fheroes2::PrimarySkillDialogElement skillUI{ skill, {} };
 
-        return Dialog::SelectCount( std::move( header ), skill == Skill::Primary::POWER ? 1 : 0, 99, skillValue, 1, &skillUI );
+        return Dialog::SelectCount( std::move( header ), min, max, skillValue, 1, &skillUI );
     };
 
     int32_t value;

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/skill.cpp
+++ b/src/fheroes2/heroes/skill.cpp
@@ -197,6 +197,23 @@ int Skill::Primary::getHeroDefaultSkillValue( const int skill, const int race )
     return ( skill == POWER || skill == KNOWLEDGE ) ? 1 : 0;
 }
 
+std::pair<int, int> Skill::Primary::getSkillValueRange( const int skill )
+{
+    switch ( skill ) {
+    case ATTACK:
+    case DEFENSE:
+        return { 0, 99 };
+    case POWER:
+    case KNOWLEDGE:
+        return { 1, 99 };
+    default:
+        assert( 0 );
+        break;
+    }
+
+    return { 0, 0 };
+}
+
 int Skill::Primary::LevelUp( int race, int level, uint32_t seed )
 {
     const FactionProperties * ptr = GameStatic::GetFactionProperties( race );

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/skill.h
+++ b/src/fheroes2/heroes/skill.h
@@ -186,6 +186,7 @@ namespace Skill
         static std::string StringDescription( int, const Heroes * );
         static int GetInitialSpell( int race );
         static int getHeroDefaultSkillValue( const int skill, const int race );
+        static std::pair<int, int> getSkillValueRange( const int skill );
 
     protected:
         void LoadDefaults( int type, int race );


### PR DESCRIPTION
This PR:

* Fixes the minimum value of the Knowledge skill (it should be 1 and not 0);
* Fixes the MIN/MAX buttons operation in the `Dialog::SelectCount()`. How to reproduce:
  * Open the dialog;
  * Try to enter some value other than min/max value using the keyboard;
  * Press the MIN or MAX button;
  * Try to edit the new value (e.g. by pressing the Backspace button).

In the `master` branch:

https://github.com/user-attachments/assets/186643b6-4caa-4ec4-aead-3fe184a2fabb

With this PR:

https://github.com/user-attachments/assets/417318f1-c0d6-485f-a4f5-5ebea7b850cd
