### PR TITLE
Fix rendering of tall objects and extra objects (ghosts and flags) over the top map edge

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -510,9 +510,8 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 if ( isTileUnderFog && ( isUpperTileUnderFog || !hero->isShipMaster() ) ) {
                     // AI heroes can go out of fog so we have to render them one step earlier than getting out of fog.
                     if ( hero->isControlAI() && hero->isMoveEnabled() ) {
-                        const Route::Path & path = hero->GetPath();
                         // Check if the next AI hero path point will not be seen on map to skip it.
-                        if ( path.isValidForMovement() && ( world.getTile( path.GetFrontIndex() ).getFogDirection() == DIRECTION_ALL ) ) {
+                        if ( world.getTile( hero->GetPath().GetFrontIndex() ).getFogDirection() == DIRECTION_ALL ) {
                             continue;
                         }
                     }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -496,7 +496,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
             MP2::MapObjectType objectType = tile.getMainObjectType();
 
             // We will skip objects which are fully under the fog.
-            const uint16_t fogDirection = renderFog ? tile.getFogDirection() : Direction::UNKNOWN;
+            const uint16_t fogDirection = renderFog ? tile.getFogDirection() : 0;
             const bool isTileUnderFog = ( fogDirection == DIRECTION_ALL );
 
             switch ( objectType ) {

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -508,8 +508,8 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
 
                 // Boats are 2 tiles high so for hero on the boat we have to populate info for boat one tile lower than the fog.
                 if ( isTileUnderFog && ( isUpperTileUnderFog || !hero->isShipMaster() ) ) {
-                    // AI heroes can go out of fog so we have to render them one step earlier than getting out of fog.
-                    if ( hero->isControlAI() && hero->isMoveEnabled() ) {
+                    // Enemy heroes can go out of fog (our heroes are always seen) so we have to render them one step earlier than getting out of fog.
+                    if ( hero->isMoveEnabled() ) {
                         // Check if the next AI hero path point will not be seen on map to skip it.
                         if ( world.getTile( hero->GetPath().GetFrontIndex() ).getFogDirection() == DIRECTION_ALL ) {
                             continue;

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -253,7 +253,7 @@ namespace
                     tileUnfit.bottomImages[imagePos + heroPos].emplace_back( objectInfo );
                 }
             }
-            else {
+            else if ( imagePos.y != 0 && ( world.getTile( heroPos.x, heroPos.y ).getFogDirection() & Direction::TOP ) != Direction::TOP ) {
                 if ( imagePos.x < 0 ) {
                     tileUnfit.topImages[imagePos + heroPos].emplace_front( objectInfo );
                 }
@@ -509,7 +509,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 // Boats are 2 tiles high so for hero on the boat we have to populate info for boat one tile lower than the fog.
                 if ( isTileUnderFog && ( isUpperTileUnderFog || !hero->isShipMaster() ) ) {
                     // AI heroes can go out of fog so we have to render them one step earlier than getting out of fog.
-                    if ( hero->isControlAI() ) {
+                    if ( hero->isControlAI() && hero->isMoveEnabled() ) {
                         const Route::Path & path = hero->GetPath();
                         // Check if the next AI hero path point will not be seen on map to skip it.
                         if ( path.isValidForMovement() && ( world.getTile( path.GetFrontIndex() ).getFogDirection() == DIRECTION_ALL ) ) {

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -503,21 +503,14 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                     continue;
                 }
 
-                const bool isUpperTileUnderFog = ( posY > 0 ) ? ( world.getTile( tileIndex - worldWidth ).getFogDirection() == DIRECTION_ALL ) : true;
                 const Heroes * hero = tile.getHero();
 
+                // We do not render heroes and boats that are covered with the fog.
                 // Boats are 2 tiles high so for hero on the boat we have to populate info for boat one tile lower than the fog.
-                if ( isTileUnderFog && ( isUpperTileUnderFog || !hero->isShipMaster() ) ) {
-                    // Enemy heroes can go out of fog (our heroes are always seen) so we have to render them one step earlier than getting out of fog.
-                    if ( hero->isMoveEnabled() ) {
-                        // Check if the next AI hero path point will not be seen on map to skip it.
-                        if ( world.getTile( hero->GetPath().GetFrontIndex() ).getFogDirection() == DIRECTION_ALL ) {
-                            continue;
-                        }
-                    }
-                    else {
-                        continue;
-                    }
+                // While moving enemy heroes can go out of the fog so we need to render them one step earlier than getting out of the fog.
+                if ( isTileUnderFog && ( !hero->isShipMaster() || ( posY > 0 ? ( world.getTile( tileIndex - worldWidth ).getFogDirection() == DIRECTION_ALL ) : true ) )
+                     && ( !hero->isMoveEnabled() || ( world.getTile( hero->GetPath().GetFrontIndex() ).getFogDirection() == DIRECTION_ALL ) ) ) {
+                    continue;
                 }
 
                 populateHeroObjectInfo( tileUnfit, hero );

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -253,7 +253,7 @@ namespace
                     tileUnfit.bottomImages[imagePos + heroPos].emplace_back( objectInfo );
                 }
             }
-            else if ( imagePos.y != 0 && ( world.getTile( heroPos.x, heroPos.y ).getFogDirection() & Direction::TOP ) != Direction::TOP ) {
+            else if ( ( world.getTile( heroPos.x, heroPos.y ).getFogDirection() & Direction::TOP ) != Direction::TOP ) {
                 if ( imagePos.x < 0 ) {
                     tileUnfit.topImages[imagePos + heroPos].emplace_front( objectInfo );
                 }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -253,7 +253,8 @@ namespace
                     tileUnfit.bottomImages[imagePos + heroPos].emplace_back( objectInfo );
                 }
             }
-            else if ( ( world.getTile( heroPos.x, heroPos.y ).getFogDirection() & Direction::TOP ) != Direction::TOP ) {
+            // TODO: Use "fog directions" to emplace only needed image parts here and in other "populate ObjectInfo" functions.
+            else if ( ( heroPos.y != 0 ) || ( world.getTile( heroPos.x, heroPos.y ).getFogDirection() & Direction::TOP ) != Direction::TOP ) {
                 if ( imagePos.x < 0 ) {
                     tileUnfit.topImages[imagePos + heroPos].emplace_front( objectInfo );
                 }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -495,7 +495,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                     auto spriteInfo = getEditorHeroSpritesPerTile( tile );
 
                     std::vector<fheroes2::ObjectRenderingInfo> temp;
-                    populateStaticTileUnfitObjectInfo( tileUnfit, spriteInfo, temp, tile.GetCenter(), alphaValue );
+                    populateStaticTileUnfitObjectInfo( tileUnfit, spriteInfo, temp, { posX, posY }, alphaValue );
                     continue;
                 }
 
@@ -531,7 +531,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 auto spriteInfo = getMonsterSpritesPerTile( tile, isEditor );
                 auto spriteShadowInfo = getMonsterShadowSpritesPerTile( tile, isEditor );
 
-                populateStaticTileUnfitObjectInfo( tileUnfit, spriteInfo, spriteShadowInfo, tile.GetCenter(), alphaValue );
+                populateStaticTileUnfitObjectInfo( tileUnfit, spriteInfo, spriteShadowInfo, { posX, posY }, alphaValue );
 
                 continue;
             }
@@ -550,7 +550,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 auto spriteInfo = getBoatSpritesPerTile( tile );
                 auto spriteShadowInfo = getBoatShadowSpritesPerTile( tile );
 
-                populateStaticTileUnfitObjectInfo( tileUnfit, spriteInfo, spriteShadowInfo, tile.GetCenter(), alphaValue );
+                populateStaticTileUnfitObjectInfo( tileUnfit, spriteInfo, spriteShadowInfo, { posX, posY }, alphaValue );
 
                 continue;
             }
@@ -564,7 +564,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 auto spriteInfo = getMineGuardianSpritesPerTile( tile );
                 if ( !spriteInfo.empty() ) {
                     const uint8_t alphaValue = getObjectAlphaValue( tile.getMainObjectPart()._uid );
-                    populateStaticTileUnfitBackgroundObjectInfo( tileUnfit, spriteInfo, tile.GetCenter(), alphaValue );
+                    populateStaticTileUnfitBackgroundObjectInfo( tileUnfit, spriteInfo, { posX, posY }, alphaValue );
                 }
             }
         }

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -55,6 +55,7 @@
 #include "screen.h"
 #include "settings.h"
 #include "skill.h"
+#include "spell.h"
 #include "ui_constants.h"
 #include "ui_object_rendering.h"
 #include "world.h"

--- a/src/fheroes2/gui/interface_gamearea.h
+++ b/src/fheroes2/gui/interface_gamearea.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -273,16 +273,16 @@ namespace Interface
         fheroes2::Point _topLeftTileOffset; // offset of tiles to be drawn (from here we can find any tile ID)
 
         // boundaries for World Map
-        int32_t _minLeftOffset;
-        int32_t _maxLeftOffset;
-        int32_t _minTopOffset;
-        int32_t _maxTopOffset;
+        int32_t _minLeftOffset{ 0 };
+        int32_t _maxLeftOffset{ 0 };
+        int32_t _minTopOffset{ 0 };
+        int32_t _maxTopOffset{ 0 };
 
         fheroes2::Size _visibleTileCount; // number of tiles to be drawn on screen
 
-        int32_t _prevIndexPos;
-        int scrollDirection;
-        bool updateCursor;
+        int32_t _prevIndexPos{ 0 };
+        int scrollDirection{ 0 };
+        bool updateCursor{ false };
 
         fheroes2::Time scrollTime;
 
@@ -291,11 +291,11 @@ namespace Interface
 
         fheroes2::Point _lastMouseDragPosition;
         fheroes2::Point _mousePositionForFastScroll;
-        bool _mouseDraggingInitiated;
-        bool _mouseDraggingMovement;
-        bool _needRedrawByMouseDragging;
-        bool _isFastScrollEnabled;
-        bool _resetMousePositionForFastScroll;
+        bool _mouseDraggingInitiated{ false };
+        bool _mouseDraggingMovement{ false };
+        bool _needRedrawByMouseDragging{ false };
+        bool _isFastScrollEnabled{ false };
+        bool _resetMousePositionForFastScroll{ false };
 
         // Returns middle point of window ROI.
         fheroes2::Point _middlePoint() const

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -652,60 +652,53 @@ namespace Maps
         }
     }
 
-    void redrawTopLayerExtraObjects( const Tile & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area )
+    void redrawFlyingGhostsOnMap( const Tile & tile, fheroes2::Image & dst, const fheroes2::Point & pos, const Interface::GameArea & area, const bool isEditor )
     {
-        if ( isPuzzleDraw ) {
-            // Extra objects should not be shown on Puzzle Map as they are temporary objects appearing under specific conditions like flags.
+        const MP2::MapObjectType objectType = tile.getMainObjectType( false );
+        if ( ( objectType != MP2::OBJ_ABANDONED_MINE ) && !( ( objectType == MP2::OBJ_MINE ) && ( Maps::getMineSpellIdFromTile( tile ) == Spell::HAUNT ) ) ) {
+            // No ghost animation is needed.
             return;
         }
+        // This sprite is bigger than tileWidthPx but rendering is correct for heroes and boats.
+        // TODO: consider adding this sprite as a part of an object part.
 
-        // Ghost animation is unique and can be rendered in multiple cases.
-        bool renderFlyingGhosts = false;
+        const fheroes2::Sprite & image = fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::getAdventureMapAnimationIndex() % 15 );
 
-        const MP2::MapObjectType objectType = tile.getMainObjectType( false );
-        if ( objectType == MP2::OBJ_ABANDONED_MINE ) {
-            renderFlyingGhosts = true;
+        // We should not render ghosts over the map top border if the tile near this border is not revealed.
+        if ( !isEditor && ( pos.y == 1 ) && ( image.y() < -32 ) && ( world.getTile( pos.x, pos.y - 1 ).getFogDirection() & Direction::TOP ) == Direction::TOP ) {
+            const int32_t cutY = 32 + image.y();
+            const fheroes2::Rect roi( 0, -cutY, image.width(), image.height() + cutY );
+
+            area.BlitOnTile( dst, image, roi, image.x(), -32, pos, false, 255 );
         }
-        else if ( objectType == MP2::OBJ_MINE ) {
-            const int32_t spellID = Maps::getMineSpellIdFromTile( tile );
-
-            switch ( spellID ) {
-            case Spell::NONE:
-                // No spell exists. Nothing we need to render.
-            case Spell::SETEGUARDIAN:
-            case Spell::SETAGUARDIAN:
-            case Spell::SETFGUARDIAN:
-            case Spell::SETWGUARDIAN:
-                // The logic for these spells is done while rendering the bottom layer. Nothing should be done here.
-                break;
-            case Spell::HAUNT:
-                renderFlyingGhosts = true;
-                break;
-            default:
-                // Did you add a new spell for mines? Add the rendering for it above!
-                assert( 0 );
-                break;
-            }
-        }
-
-        if ( renderFlyingGhosts ) {
-            // This sprite is bigger than tileWidthPx but rendering is correct for heroes and boats.
-            // TODO: consider adding this sprite as a part of an object part.
-            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::getAdventureMapAnimationIndex() % 15 );
-
-            const uint8_t alphaValue = area.getObjectAlphaValue( tile.getMainObjectPart()._uid );
-
-            area.BlitOnTile( dst, image, image.x(), image.y(), Maps::GetPoint( tile.GetIndex() ), false, alphaValue );
+        else {
+            area.BlitOnTile( dst, image, image.x(), image.y(), pos, false, 255 );
         }
     }
 
-    void redrawTopLayerObject( const Tile & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area, const ObjectPart & part )
+    void redrawTopLayerObject( const Tile & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const fheroes2::Point & pos, const Interface::GameArea & area,
+                               const ObjectPart & part )
     {
         if ( isPuzzleDraw && MP2::isHiddenForPuzzle( tile.GetGround(), part.icnType, part.icnIndex ) ) {
             return;
         }
 
-        renderObjectPart( dst, area, Maps::GetPoint( tile.GetIndex() ), part );
+        // We should not render flags over the map top border if the tile near this border is not revealed.
+        if ( ( pos.y == 0 ) && ( part.icnType == MP2::OBJ_ICN_TYPE_FLAG32 ) && ( tile.getFogDirection() & Direction::TOP ) == Direction::TOP ) {
+            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( MP2::getIcnIdFromObjectIcnType( part.icnType ), part.icnIndex );
+
+            if ( image.y() < 0 ) {
+                const fheroes2::Rect roi( 0, -image.y(), image.width(), image.height() + image.y() );
+
+                area.BlitOnTile( dst, image, roi, image.x(), 0, pos, false, 255 );
+            }
+            else {
+                area.BlitOnTile( dst, image, image.x(), image.y(), pos, false, 255 );
+            }
+        }
+        else {
+            renderObjectPart( dst, area, pos, part );
+        }
     }
 
     void drawFog( const Tile & tile, fheroes2::Image & dst, const Interface::GameArea & area )

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -655,7 +655,7 @@ namespace Maps
     void redrawFlyingGhostsOnMap( const Tile & tile, fheroes2::Image & dst, const fheroes2::Point & pos, const Interface::GameArea & area, const bool isEditor )
     {
         const MP2::MapObjectType objectType = tile.getMainObjectType( false );
-        if ( ( objectType != MP2::OBJ_ABANDONED_MINE ) && !( ( objectType == MP2::OBJ_MINE ) && ( Maps::getMineSpellIdFromTile( tile ) == Spell::HAUNT ) ) ) {
+        if ( ( objectType != MP2::OBJ_ABANDONED_MINE ) && ( ( objectType != MP2::OBJ_MINE ) || ( Maps::getMineSpellIdFromTile( tile ) != Spell::HAUNT ) ) ) {
             // No ghost animation is needed.
             return;
         }

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -652,13 +652,8 @@ namespace Maps
         }
     }
 
-    void redrawFlyingGhostsOnMap( const Tile & tile, fheroes2::Image & dst, const fheroes2::Point & pos, const Interface::GameArea & area, const bool isEditor )
+    void redrawFlyingGhostsOnMap( fheroes2::Image & dst, const fheroes2::Point & pos, const Interface::GameArea & area, const bool isEditor )
     {
-        const MP2::MapObjectType objectType = tile.getMainObjectType( false );
-        if ( ( objectType != MP2::OBJ_ABANDONED_MINE ) && ( ( objectType != MP2::OBJ_MINE ) || ( Maps::getMineSpellIdFromTile( tile ) != Spell::HAUNT ) ) ) {
-            // No ghost animation is needed.
-            return;
-        }
         // This sprite is bigger than tileWidthPx but rendering is correct for heroes and boats.
         // TODO: consider adding this sprite as a part of an object part.
 

--- a/src/fheroes2/maps/maps_tiles_render.h
+++ b/src/fheroes2/maps/maps_tiles_render.h
@@ -50,7 +50,7 @@ namespace Maps
 
     void redrawEmptyTile( fheroes2::Image & dst, const fheroes2::Point & mp, const Interface::GameArea & area );
 
-    void redrawFlyingGhostsOnMap( const Tile & tile, fheroes2::Image & dst, const fheroes2::Point & pos, const Interface::GameArea & area, const bool isEditor );
+    void redrawFlyingGhostsOnMap( fheroes2::Image & dst, const fheroes2::Point & pos, const Interface::GameArea & area, const bool isEditor );
     void redrawTopLayerObject( const Tile & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const fheroes2::Point & pos, const Interface::GameArea & area,
                                const ObjectPart & part );
 

--- a/src/fheroes2/maps/maps_tiles_render.h
+++ b/src/fheroes2/maps/maps_tiles_render.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2024                                             *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -50,8 +50,9 @@ namespace Maps
 
     void redrawEmptyTile( fheroes2::Image & dst, const fheroes2::Point & mp, const Interface::GameArea & area );
 
-    void redrawTopLayerExtraObjects( const Tile & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area );
-    void redrawTopLayerObject( const Tile & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const Interface::GameArea & area, const ObjectPart & part );
+    void redrawFlyingGhostsOnMap( const Tile & tile, fheroes2::Image & dst, const fheroes2::Point & pos, const Interface::GameArea & area, const bool isEditor );
+    void redrawTopLayerObject( const Tile & tile, fheroes2::Image & dst, const bool isPuzzleDraw, const fheroes2::Point & pos, const Interface::GameArea & area,
+                               const ObjectPart & part );
 
     void drawFog( const Tile & tile, fheroes2::Image & dst, const Interface::GameArea & area );
 


### PR DESCRIPTION
Relates to #5716

This PR makes rendering of tall top layer objects after rendering the "ufit" sprites (heroes, monsters and other sprites that do not fit one tile). This fixes the issues: https://github.com/ihhub/fheroes2/issues/5716#issuecomment-1596156366, https://github.com/ihhub/fheroes2/issues/5716#issuecomment-1595729230, https://github.com/ihhub/fheroes2/issues/5716#issuecomment-1594354665
It also adds a check not to render flags and ghosts over the top map edge if the nearby tile is not revealed. This fixes this issue: https://github.com/ihhub/fheroes2/issues/5716#issuecomment-2678953114

The flags of enemy heroes, boats and monster's heads that are near the top map border and are under the fog are also not rendered now.

Ghosts for abandoned and haunted mines are now drawn over all other objects (they float high in the sky) to fix this issue:
https://github.com/ihhub/fheroes2/issues/5716#issuecomment-1946024656

This PR also does some rendering optimizations:
- makes renderer to skip the tiles fully covered with fog for top layer objects and for mine guardians;
- caches the `y * worldWidth` value not to calculate it for every tile in a row.

Master build:
![изображение](https://github.com/user-attachments/assets/4054f85f-0f26-45ac-b9c9-a1f89873b563) ![изображение](https://github.com/user-attachments/assets/f810023a-19bd-4707-bfc0-f6782c3c8a99) ![изображение](https://github.com/user-attachments/assets/0977764c-80f8-45a7-af08-32814ae089f5) ![изображение](https://github.com/user-attachments/assets/1f5fba15-0dbf-43ad-b26b-fc35bf4794c6)


This PR:
![изображение](https://github.com/user-attachments/assets/cd8c2337-226d-499c-a9f2-e29c3fb3472b) ![изображение](https://github.com/user-attachments/assets/991c5f99-602d-495c-ba17-f65e9c21d8ab) ![изображение](https://github.com/user-attachments/assets/4da0934a-6837-4d2d-b184-572623bef809) ![изображение](https://github.com/user-attachments/assets/15efa644-6b0c-4cf4-9bc0-af87897e21b6)


