### PR TITLE
Do not center on the defeated hero after an instant movement

### DIFF
--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -578,16 +578,16 @@ bool Heroes::Move( const bool jumpToNextTile /* = false */ )
         // Jump to the next position.
         if ( jumpToNextTile ) {
             direction = path.GetFrontDirection();
-            MoveStep( jumpToNextTile );
 
-            // TODO: why don't we check isActive() like it is done for a normal movement?
-            return true;
+            if ( !MoveStep( jumpToNextTile ) ) {
+                assert( 0 );
+            }
+
+            return isActive();
         }
 
-        // The hero is changing the direction of movement.
-        const int frontDirection = path.GetFrontDirection();
-
-        if ( GetDirection() != frontDirection ) {
+        if ( const int frontDirection = path.GetFrontDirection(); GetDirection() != frontDirection ) {
+            // The hero is changing the direction of movement.
             AngleStep( frontDirection );
         }
         else {


### PR DESCRIPTION
fix #9600

On the `master` branch:

https://github.com/user-attachments/assets/db0c90f8-0cf3-440a-a9b7-ee3bbc94c5d8

With this PR:

https://github.com/user-attachments/assets/4adeafe3-a656-40af-8b50-125e140d3ef1
