### PR TITLE
Add proper translation support for Sign objects

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -340,7 +340,6 @@ namespace
             return;
         }
 
-
         const fheroes2::Text title{ MP2::StringObject( MP2::OBJ_SIGN ), fheroes2::FontType::normalYellow() };
         const fheroes2::Text body{ sign->message.text, fheroes2::FontType::normalWhite(), sign->message.language };
         fheroes2::showMessage( title, body, Dialog::OK );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -49,6 +49,7 @@
 #include "game_delays.h"
 #include "game_interface.h"
 #include "game_static.h"
+#include "game_string.h"
 #include "heroes.h" // IWYU pragma: associated
 #include "icn.h"
 #include "image.h"

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -332,6 +332,20 @@ namespace
         }
     }
 
+    void showSignMessage( const int32_t tileIndex )
+    {
+        const MapSign * sign = dynamic_cast<MapSign *>( world.GetMapObject( tileIndex ) );
+        if ( sign == nullptr ) {
+            assert( sign != nullptr );
+            return;
+        }
+
+
+        const fheroes2::Text title{ MP2::StringObject( MP2::OBJ_SIGN ), fheroes2::FontType::normalYellow() };
+        const fheroes2::Text body{ sign->message.text, fheroes2::FontType::normalWhite(), sign->message.language };
+        fheroes2::showMessage( title, body, Dialog::OK );
+    }
+
     void ActionToMonster( Heroes & hero, int32_t dst_index )
     {
         Maps::Tile & tile = world.getTile( dst_index );
@@ -741,8 +755,7 @@ namespace
         Maps::Tile & tile = world.getTile( dst_index );
 
         if ( objectType == MP2::OBJ_BOTTLE ) {
-            const MapSign * sign = dynamic_cast<MapSign *>( world.GetMapObject( dst_index ) );
-            fheroes2::showStandardTextMessage( MP2::StringObject( objectType ), ( sign ? sign->message : "No message provided" ), Dialog::OK );
+            showSignMessage( dst_index );
         }
         else {
             const Funds funds = getFundsFromTile( tile );
@@ -1219,15 +1232,14 @@ namespace
         }
     }
 
-    void ActionToSign( const Heroes & hero, int32_t dst_index )
+    void ActionToSign( const Heroes & hero, const int32_t tileIndex )
     {
-        DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() )
+        DEBUG_LOG( DBG_GAME, DBG_INFO, hero.GetName() << " approached sign at index " << tileIndex )
 #ifndef WITH_DEBUG
         (void)hero;
 #endif
 
-        const MapSign * sign = dynamic_cast<MapSign *>( world.GetMapObject( dst_index ) );
-        fheroes2::showStandardTextMessage( MP2::StringObject( MP2::OBJ_SIGN ), ( sign ? sign->message : "" ), Dialog::OK );
+        showSignMessage( tileIndex );
     }
 
     void ActionToMagicWell( Heroes & hero, int32_t dst_index )

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -315,7 +315,7 @@ void MapSign::setDefaultMessage()
 {
     message.language = fheroes2::getLanguageFromAbbreviation( Settings::Get().getGameLanguage() );
 
-    // This container must not be static as it depends on in-game language.
+    // This container must not be static as it depends on an in-game language.
     const std::vector<std::string> randomMessage{ _( "Next sign 50 miles." ), _( "Burma shave." ), _( "See Rock City." ), _( "This space for rent." ) };
     message.text = Rand::Get( randomMessage );
 }

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -390,7 +390,7 @@ OStreamBase & operator<<( OStreamBase & stream, const MapSign & obj )
 IStreamBase & operator>>( IStreamBase & stream, MapSign & obj )
 {
     stream >> static_cast<MapBaseObject &>( obj );
-    
+
     static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1107_RELEASE, "Remove the logic below." );
     if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1107_RELEASE ) {
         stream >> obj.message.text;

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <optional>
 #include <ostream>
 #include <vector>
 

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -35,8 +35,10 @@
 #include "rand.h"
 #include "save_format_version.h"
 #include "serialize.h"
+#include "settings.h"
 #include "tools.h"
 #include "translations.h"
+#include "ui_language.h"
 
 void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & data )
 {
@@ -298,21 +300,24 @@ void MapSign::LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & 
 
     ROStreamBuf dataStream( data );
     dataStream.skip( 9 );
-    message = dataStream.getString();
+    message.text = dataStream.getString();
 
-    if ( message.empty() ) {
+    if ( message.text.empty() ) {
         setDefaultMessage();
     }
 
     setUIDAndIndex( mapIndex );
 
-    DEBUG_LOG( DBG_GAME, DBG_INFO, "Sign at location " << mapIndex << " has a message: " << message )
+    DEBUG_LOG( DBG_GAME, DBG_INFO, "Sign at location " << mapIndex << " has a message: " << message.text )
 }
 
 void MapSign::setDefaultMessage()
 {
+    message.language = fheroes2::getLanguageFromAbbreviation( Settings::Get().getGameLanguage() );
+
+    // This container must not be static as it depends on in-game language.
     const std::vector<std::string> randomMessage{ _( "Next sign 50 miles." ), _( "Burma shave." ), _( "See Rock City." ), _( "This space for rent." ) };
-    message = Rand::Get( randomMessage );
+    message.text = Rand::Get( randomMessage );
 }
 
 OStreamBase & operator<<( OStreamBase & stream, const MapBaseObject & obj )
@@ -384,5 +389,16 @@ OStreamBase & operator<<( OStreamBase & stream, const MapSign & obj )
 
 IStreamBase & operator>>( IStreamBase & stream, MapSign & obj )
 {
-    return stream >> static_cast<MapBaseObject &>( obj ) >> obj.message;
+    stream >> static_cast<MapBaseObject &>( obj );
+    
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1107_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1107_RELEASE ) {
+        stream >> obj.message.text;
+        obj.message.language = {};
+    }
+    else {
+        stream >> obj.message;
+    }
+
+    return stream;
 }

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -30,6 +30,7 @@
 #include <vector>
 
 #include "artifact.h"
+#include "game_string.h"
 #include "position.h"
 #include "resource.h"
 #include "skill.h"
@@ -148,7 +149,7 @@ struct MapSign final : public MapBaseObject
 
     void setDefaultMessage();
 
-    std::string message;
+    fheroes2::LocalizedString message;
 };
 
 OStreamBase & operator<<( OStreamBase & stream, const MapEvent & obj );

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -27,6 +27,7 @@ enum SaveFileFormat : uint16_t
     // !!! IMPORTANT !!!
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
+    FORMAT_VERSION_1107_RELEASE = 10028,
     FORMAT_VERSION_1106_RELEASE = 10027,
     FORMAT_VERSION_PPRE1_1106_RELEASE = 10026,
     FORMAT_VERSION_1104_RELEASE = 10025,
@@ -48,5 +49,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_1005_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1106_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1107_RELEASE
 };

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -29,6 +29,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <optional>
 #include <ostream>
 #include <set>
 #include <string>

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -950,10 +950,13 @@ bool World::loadResurrectionMap( const std::string & filename )
                     auto & signInfo = map.signMetadata[object.id];
 
                     auto signObject = std::make_unique<MapSign>();
-                    signObject->message = std::move( signInfo.message );
+                    signObject->message.text = std::move( signInfo.message );
                     signObject->setUIDAndIndex( static_cast<int32_t>( tileId ) );
-                    if ( signObject->message.empty() ) {
+                    if ( signObject->message.text.empty() ) {
                         signObject->setDefaultMessage();
+                    }
+                    else {
+                        signObject->message.language = map.mainLanguage;
                     }
 
                     map_objects.add( std::move( signObject ) );
@@ -1042,10 +1045,13 @@ bool World::loadResurrectionMap( const std::string & filename )
                     auto & signInfo = map.signMetadata[object.id];
 
                     auto signObject = std::make_unique<MapSign>();
-                    signObject->message = std::move( signInfo.message );
+                    signObject->message.text = std::move( signInfo.message );
                     signObject->setUIDAndIndex( static_cast<int32_t>( tileId ) );
-                    if ( signObject->message.empty() ) {
+                    if ( signObject->message.text.empty() ) {
                         signObject->setDefaultMessage();
+                    }
+                    else {
+                        signObject->message.language = map.mainLanguage;
                     }
 
                     map_objects.add( std::move( signObject ) );


### PR DESCRIPTION
This pull request fixes the problem with incorrect text display in Sign and Bottle Adventure Map objects for the following situations:
- a save file with sign text was saved under one in-game language but then loaded under another one
- a sign was saved for a map of language A then the map was started to be played with an in-game language B

The first case will be also fixed for the original maps.

relates to #8589