### PR TITLE
Clean up code for Morale and Luck effect Adventure Map objects

### DIFF
--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -174,25 +174,36 @@ uint32_t GameStatic::GetCastleGrownMonthOf()
     return 100;
 }
 
-int32_t GameStatic::ObjectVisitedModifiers( const MP2::MapObjectType objectType )
+int32_t GameStatic::getObjectLuckEffect( const MP2::MapObjectType objectType )
+{
+    switch ( objectType ) {
+    case MP2::OBJ_FAERIE_RING:
+    case MP2::OBJ_FOUNTAIN:
+    case MP2::OBJ_IDOL:
+    case MP2::OBJ_MERMAID:
+        return 1;
+    case MP2::OBJ_PYRAMID:
+        return -2;
+    default:
+        break;
+    }
+
+    return 0;
+}
+
+int32_t GameStatic::getObjectMoraleEffect( const MP2::MapObjectType objectType )
 {
     switch ( objectType ) {
     case MP2::OBJ_BUOY:
     case MP2::OBJ_OASIS:
     case MP2::OBJ_WATERING_HOLE:
-    case MP2::OBJ_MERMAID:
-    case MP2::OBJ_FAERIE_RING:
-    case MP2::OBJ_FOUNTAIN:
-    case MP2::OBJ_IDOL:
         return 1;
     case MP2::OBJ_TEMPLE:
         return 2;
-    case MP2::OBJ_GRAVEYARD:
     case MP2::OBJ_DERELICT_SHIP:
+    case MP2::OBJ_GRAVEYARD:
     case MP2::OBJ_SHIPWRECK:
         return -1;
-    case MP2::OBJ_PYRAMID:
-        return -2;
     default:
         break;
     }

--- a/src/fheroes2/game/game_static.h
+++ b/src/fheroes2/game/game_static.h
@@ -62,7 +62,11 @@ namespace GameStatic
 
     uint32_t GetHeroesRestoreSpellPointsPerDay();
 
-    int32_t ObjectVisitedModifiers( const MP2::MapObjectType objectType );
+    // Returns 0 if no effects exist.
+    int32_t getObjectLuckEffect( const MP2::MapObjectType objectType );
+
+    // Returns 0 if no effects exist.
+    int32_t getObjectMoraleEffect( const MP2::MapObjectType objectType );
 
     int GetBattleMoatReduceDefense();
     // Returns the percentage penalty for the damage dealt by shooters firing at targets protected by castle walls.

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1313,7 +1313,7 @@ bool Heroes::isObjectTypeVisited( const MP2::MapObjectType objectType, Visit::Ty
 
 std::set<MP2::MapObjectType> Heroes::getAllVisitedObjectTypes() const
 {
-    std::set<MP2::MapObjectType> objectTypes = GetKingdom().getAllVisitedObjectTypes();
+    std::set<MP2::MapObjectType> objectTypes;
 
     for ( const auto & object : visit_object ) {
         objectTypes.emplace( object.second );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -99,43 +99,73 @@ namespace
         return { Heroes::LORDKILBURN, Heroes::CELIA };
     }
 
-    int ObjectVisitedModifiersResult( const std::vector<MP2::MapObjectType> & objectTypes, const Heroes & hero, std::string * strs )
+    int getObjectMoraleModifiers( const std::set<MP2::MapObjectType> & objectTypes, std::string * output )
     {
         int result = 0;
 
         for ( const MP2::MapObjectType objectType : objectTypes ) {
-            if ( hero.isObjectTypeVisited( objectType ) ) {
-                result += GameStatic::ObjectVisitedModifiers( objectType );
-
-                if ( strs ) {
-                    switch ( objectType ) {
-                    case MP2::OBJ_GRAVEYARD:
-                    case MP2::OBJ_NON_ACTION_GRAVEYARD:
-                    case MP2::OBJ_SHIPWRECK:
-                    case MP2::OBJ_NON_ACTION_SHIPWRECK:
-                    case MP2::OBJ_DERELICT_SHIP:
-                    case MP2::OBJ_NON_ACTION_DERELICT_SHIP: {
-                        std::string modRobber = _( "shipAndGraveyard|%{object} robber" );
-                        StringReplace( modRobber, "%{object}", MP2::StringObject( objectType ) );
-                        strs->append( modRobber );
-                        break;
-                    }
-                    case MP2::OBJ_PYRAMID:
-                    case MP2::OBJ_NON_ACTION_PYRAMID: {
-                        std::string modRaided = _( "pyramid|%{object} raided" );
-                        StringReplace( modRaided, "%{object}", MP2::StringObject( objectType ) );
-                        strs->append( modRaided );
-                        break;
-                    }
-                    default:
-                        strs->append( MP2::StringObject( objectType ) );
-                        break;
-                    }
-
-                    fheroes2::appendModifierToString( *strs, GameStatic::ObjectVisitedModifiers( objectType ) );
-                    strs->append( "\n" );
-                }
+            const int32_t modifier = GameStatic::getObjectMoraleEffect( objectType );
+            if ( modifier == 0 ) {
+                continue;
             }
+
+            result += modifier;
+
+            if ( output == nullptr ) {
+                continue;
+            }
+
+            switch ( objectType ) {
+            case MP2::OBJ_DERELICT_SHIP:
+            case MP2::OBJ_GRAVEYARD:
+            case MP2::OBJ_SHIPWRECK: {
+                std::string modRobber = _( "shipAndGraveyard|%{object} robber" );
+                StringReplace( modRobber, "%{object}", MP2::StringObject( objectType ) );
+                output->append( modRobber );
+                break;
+            }
+            default:
+                output->append( MP2::StringObject( objectType ) );
+                break;
+            }
+
+            fheroes2::appendModifierToString( *output, modifier );
+            output->append( "\n" );
+        }
+
+        return result;
+    }
+
+    int getObjectLuckModifiers( const std::set<MP2::MapObjectType> & objectTypes, std::string * output )
+    {
+        int result = 0;
+
+        for ( const MP2::MapObjectType objectType : objectTypes ) {
+            const int32_t modifier = GameStatic::getObjectLuckEffect( objectType );
+            if ( modifier == 0 ) {
+                continue;
+            }
+
+            result += modifier;
+
+            if ( output == nullptr ) {
+                continue;
+            }
+
+            switch ( objectType ) {
+            case MP2::OBJ_PYRAMID: {
+                std::string modRaided = _( "pyramid|%{object} raided" );
+                StringReplace( modRaided, "%{object}", MP2::StringObject( objectType ) );
+                output->append( modRaided );
+                break;
+            }
+            default:
+                output->append( MP2::StringObject( objectType ) );
+                break;
+            }
+
+            fheroes2::appendModifierToString( *output, modifier );
+            output->append( "\n" );
         }
 
         return result;
@@ -1042,10 +1072,7 @@ int Heroes::GetMoraleWithModificators( std::string * strs ) const
     // bonus leadership
     result += Skill::GetLeadershipModifiers( GetLevelSkill( Skill::Secondary::LEADERSHIP ), strs );
 
-    // object visited
-    const std::vector<MP2::MapObjectType> objectTypes{ MP2::OBJ_BUOY,      MP2::OBJ_OASIS,         MP2::OBJ_WATERING_HOLE, MP2::OBJ_TEMPLE,
-                                                       MP2::OBJ_GRAVEYARD, MP2::OBJ_DERELICT_SHIP, MP2::OBJ_SHIPWRECK };
-    result += ObjectVisitedModifiersResult( objectTypes, *this, strs );
+    result += getObjectMoraleModifiers( getAllVisitedObjectTypes(), strs );
 
     // bonus artifact
     result += GetMoraleModificator( strs );
@@ -1080,8 +1107,7 @@ int Heroes::GetLuckWithModificators( std::string * strs ) const
     result += Skill::GetLuckModifiers( GetLevelSkill( Skill::Secondary::LUCK ), strs );
 
     // object visited
-    const std::vector<MP2::MapObjectType> objectTypes{ MP2::OBJ_MERMAID, MP2::OBJ_FAERIE_RING, MP2::OBJ_FOUNTAIN, MP2::OBJ_IDOL, MP2::OBJ_PYRAMID };
-    result += ObjectVisitedModifiersResult( objectTypes, *this, strs );
+    result += getObjectLuckModifiers( getAllVisitedObjectTypes(), strs );
 
     // bonus artifact
     result += GetLuckModificator( strs );
@@ -1283,6 +1309,17 @@ bool Heroes::isObjectTypeVisited( const MP2::MapObjectType objectType, Visit::Ty
     }
 
     return std::any_of( visit_object.begin(), visit_object.end(), [objectType]( const IndexObject & v ) { return v.isObject( objectType ); } );
+}
+
+std::set<MP2::MapObjectType> Heroes::getAllVisitedObjectTypes() const
+{
+    std::set<MP2::MapObjectType> objectTypes = GetKingdom().getAllVisitedObjectTypes();
+
+    for ( const auto & object : visit_object ) {
+        objectTypes.emplace( object.second );
+    }
+
+    return objectTypes;
 }
 
 void Heroes::SetVisited( int32_t index, Visit::Type type )

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -29,6 +29,7 @@
 #include <exception>
 #include <list>
 #include <memory>
+#include <set>
 #include <string>
 #include <vector>
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -539,6 +539,8 @@ public:
     bool isObjectTypeVisited( const MP2::MapObjectType object, Visit::Type = Visit::LOCAL ) const;
     bool isVisited( const Maps::Tile &, Visit::Type = Visit::LOCAL ) const;
 
+    std::set<MP2::MapObjectType> getAllVisitedObjectTypes() const;
+
     // These methods are used only for AI.
     bool hasMetWithHero( int heroID ) const;
     void markHeroMeeting( int heroID );

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -436,17 +436,6 @@ bool Kingdom::isVisited( const MP2::MapObjectType objectType ) const
     return std::any_of( visit_object.begin(), visit_object.end(), [objectType]( const IndexObject & v ) { return v.isObject( objectType ); } );
 }
 
-std::set<MP2::MapObjectType> Kingdom::getAllVisitedObjectTypes() const
-{
-    std::set<MP2::MapObjectType> objectTypes;
-
-    for ( const auto & object : visit_object ) {
-        objectTypes.emplace( object.second );
-    }
-
-    return objectTypes;
-}
-
 uint32_t Kingdom::CountVisitedObjects( const MP2::MapObjectType objectType ) const
 {
     // Safe to downcast as we don't deal with gigantic amount of data.

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -434,6 +434,17 @@ bool Kingdom::isVisited( int32_t index, const MP2::MapObjectType objectType ) co
 bool Kingdom::isVisited( const MP2::MapObjectType objectType ) const
 {
     return std::any_of( visit_object.begin(), visit_object.end(), [objectType]( const IndexObject & v ) { return v.isObject( objectType ); } );
+}
+
+std::set<MP2::MapObjectType> Kingdom::getAllVisitedObjectTypes() const
+{
+    std::set<MP2::MapObjectType> objectTypes;
+
+    for ( const auto & object : visit_object ) {
+        objectTypes.emplace( object.second );
+    }
+
+    return objectTypes;
 }
 
 uint32_t Kingdom::CountVisitedObjects( const MP2::MapObjectType objectType ) const

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -191,8 +191,6 @@ public:
     bool isVisited( const Maps::Tile & ) const;
     bool isVisited( int32_t, const MP2::MapObjectType objectType ) const;
 
-    std::set<MP2::MapObjectType> getAllVisitedObjectTypes() const;
-
     bool isValidKingdomObject( const Maps::Tile & tile, const MP2::MapObjectType objectType ) const;
 
     bool opponentsCanRecruitMoreHeroes() const;

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -190,6 +190,8 @@ public:
     bool isVisited( const MP2::MapObjectType objectType ) const;
     bool isVisited( const Maps::Tile & ) const;
     bool isVisited( int32_t, const MP2::MapObjectType objectType ) const;
+
+    std::set<MP2::MapObjectType> getAllVisitedObjectTypes() const;
 
     bool isValidKingdomObject( const Maps::Tile & tile, const MP2::MapObjectType objectType ) const;
 


### PR DESCRIPTION
The previous logic was not intuitive to understand as we were mixing objects that effect Morale and Luck. These 2 effects are now separate. This change removes hardcoded list of objects so while adding new ones we don't need to modify the hardcoded stuff all over the code. Moreover, since Morale and Luck are separated so we could in the future add objects that affect both types.

A bonus point: the logic is much faster now since we run through a list of visited objects only once.