### PR TITLE
Fix visited status for certain Adventure Map objects for AI

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -976,8 +976,6 @@ namespace
     {
         DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << ", object: " << MP2::StringObject( objectType ) )
 
-        const Maps::Tile & tile = world.getTile( dst_index );
-
         int skill = Skill::Primary::UNKNOWN;
 
         switch ( objectType ) {
@@ -997,10 +995,12 @@ namespace
             skill = AISelectSkillFromArena( hero );
             break;
         default:
+            // Did you add a new primary skill object? Add the logic for it!
+            assert( 0 );
             break;
         }
 
-        if ( ( MP2::OBJ_ARENA == objectType && !hero.isObjectTypeVisited( objectType ) ) || !hero.isVisited( tile ) ) {
+        if ( ( MP2::OBJ_ARENA == objectType && !hero.isObjectTypeVisited( objectType ) ) || !hero.isVisited( world.getTile( dst_index ) ) ) {
             // increase skill
             hero.IncreasePrimarySkill( skill );
             hero.SetVisited( dst_index );
@@ -1023,11 +1023,13 @@ namespace
             exp = 1000;
             break;
         default:
+            // Did you add a new experience object? Add the logic for it!
+            assert( 0 );
             break;
         }
 
         // check already visited
-        if ( !hero.isVisited( tile ) && exp ) {
+        if ( !hero.isVisited( tile ) ) {
             hero.SetVisited( dst_index );
             hero.IncreaseExperience( exp );
         }
@@ -1099,10 +1101,9 @@ namespace
 
         // check already visited
         if ( !hero.isObjectTypeVisited( objectType ) ) {
-            // modify morale
+            // Morale is modified while marking visited object.
             hero.SetVisited( dst_index );
-            if ( move )
-                hero.IncreaseMovePoints( move );
+            hero.IncreaseMovePoints( move );
 
             // fix double action tile
             hero.SetVisitedWideTile( dst_index, objectType );
@@ -1294,8 +1295,9 @@ namespace
         else if ( 0 == gold && !hero.isObjectTypeVisited( objectType ) ) {
             // Modify morale
             hero.SetVisited( dst_index );
-            hero.SetVisited( dst_index, Visit::GLOBAL );
         }
+
+        hero.SetVisited( dst_index, Visit::GLOBAL );
     }
 
     void AIToPyramid( Heroes & hero, int32_t dst_index )
@@ -1338,8 +1340,9 @@ namespace
         }
         else {
             hero.SetVisited( dst_index, Visit::LOCAL );
-            hero.SetVisited( dst_index, Visit::GLOBAL );
         }
+
+        hero.SetVisited( dst_index, Visit::GLOBAL );
     }
 
     void AIToObelisk( Heroes & hero, const Maps::Tile & tile )
@@ -1390,6 +1393,7 @@ namespace
         }
 
         Maps::Tile & tile = world.getTile( dst_index );
+        Kingdom & kingdom = hero.GetKingdom();
 
         if ( doesTileContainValuableItems( tile ) ) {
             Army army( tile );
@@ -1406,6 +1410,10 @@ namespace
 
             resetObjectMetadata( tile );
         }
+
+        // Even if the hero has been defeated by a demon (and no longer belongs to any
+        // valid kingdom), this tile should be marked as visited for his former kingdom.
+        kingdom.SetVisited( dst_index, tile.getMainObjectType( false ) );
     }
 
     void AIToDwellingJoinMonster( Heroes & hero, int32_t dst_index )
@@ -1429,6 +1437,8 @@ namespace
         }
 
         setMonsterCountOnTile( tile, 0 );
+
+        hero.SetVisited( dst_index, Visit::GLOBAL );
     }
 
     void AIToDwellingRecruitMonster( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )
@@ -1475,6 +1485,8 @@ namespace
             removeMainObjectFromTile( tile );
             resetObjectMetadata( tile );
         }
+
+        hero.SetVisited( dst_index, Visit::GLOBAL );
     }
 
     void AIToDwellingBattleMonster( Heroes & hero, const MP2::MapObjectType objectType, const int32_t tileIndex )
@@ -1631,8 +1643,9 @@ namespace
             }
         }
         else if ( condition == Maps::ArtifactCaptureCondition::HAVE_WISDOM_SKILL || condition == Maps::ArtifactCaptureCondition::HAVE_LEADERSHIP_SKILL ) {
-            // TODO: do we need to check this condition?
-            result = true;
+            const Skill::Secondary & skill = getArtifactSecondarySkillRequirement( tile );
+
+            result = hero.HasSecondarySkill( skill.Skill() );
         }
         else if ( condition >= Maps::ArtifactCaptureCondition::FIGHT_50_ROGUES && condition <= Maps::ArtifactCaptureCondition::FIGHT_1_BONE_DRAGON ) {
             Army army( tile );
@@ -1787,9 +1800,9 @@ namespace
                     artifact = Artifact::UNKNOWN;
                 }
             }
-        }
 
-        DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " removed " << cursed << " artifacts" )
+            DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " removed " << cursed << " artifacts" )
+        }
     }
 
     void AIToSirens( Heroes & hero, const MP2::MapObjectType objectType, const int32_t objectIndex )


### PR DESCRIPTION
The best way to observe the incorrect state is to give the control for the AI in debug mode.