### PR TITLE
Fix a delay during battle after showing a monster info dialog by right clicking

### DIFF
--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -228,7 +228,7 @@ namespace Battle
         }
 
         void redraw( const Unit * current, const uint8_t currentUnitColor, fheroes2::Image & output );
-        void queueEventProcessing( std::string & msg, const fheroes2::Point & offset ) const;
+        bool queueEventProcessing( std::string & msg, const fheroes2::Point & offset ) const;
 
     private:
         enum ArmyColor : uint8_t
@@ -425,7 +425,7 @@ namespace Battle
         void OpenAutoModeDialog( const Unit & unit, Actions & actions );
         void EventShowOptions();
         void MouseLeftClickBoardAction( const int themes, const Cell & cell, const bool isConfirmed, Actions & actions );
-        void MousePressRightBoardAction( const Cell & cell ) const;
+        bool MousePressRightBoardAction( const Cell & cell ) const;
 
         int GetBattleCursor( std::string & statusMsg ) const;
         int GetBattleSpellCursor( std::string & statusMsg ) const;


### PR DESCRIPTION
`master` branch, notice that sometimes the dialog "freezes":

https://github.com/user-attachments/assets/30138933-0b12-4023-a956-6fbb8cc349a4

this branch:

https://github.com/user-attachments/assets/e84c55c1-6a3b-41b9-9708-b5084855b85d

