### PR TITLE
Do not apply dynamic interface if the player is not ingame

### DIFF
--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -909,7 +909,7 @@ bool Settings::isEvilInterfaceEnabled() const
         return true;
     case InterfaceType::DYNAMIC: {
         const Player * player = GetPlayers().GetCurrent();
-        if ( !player ) {
+        if ( !player || !player->isPlay() ) {
             return false;
         }
 


### PR DESCRIPTION
This is the proposed fix to #9625.
The issue is that we are trying to find the race of a player that is not in game. I've added an extra check to return the "good" interface in that case.

We might disagree and say that we should instead use the race of the selected hero in battle only mode, but I wasn't sure if this is really what we wanted and felt it might be safer to simply consider it outside of a game and review the code later if we want to change that logic.

cc: @ihhub 

Fixes #9625 