### PR TITLE
Do not set visited state if genie lamp is removed from the map

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1489,8 +1489,9 @@ namespace
             removeMainObjectFromTile( tile );
             resetObjectMetadata( tile );
         }
-
-        hero.SetVisited( dst_index, Visit::GLOBAL );
+        else {
+            hero.SetVisited( dst_index, Visit::GLOBAL );
+        }
     }
 
     void AIToDwellingBattleMonster( Heroes & hero, const MP2::MapObjectType objectType, const int32_t tileIndex )


### PR DESCRIPTION
Fix #9629 

If Genie Lamp is removed after all Genies are recruited AI should not mark this tile (without any object) as visited.