### PR TITLE
Add disable/enable logic for Editor's undo/redo buttons (#9450)

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -810,8 +810,7 @@ namespace Interface
         reset();
 
         _historyManager.reset(
-                [this]( const bool isUndoAvailable, const bool isRedoAvailable ) {
-                    _editorPanel.updateUndoRedoButtonsStates(isUndoAvailable, isRedoAvailable); } );
+            [this]( const bool isUndoAvailable, const bool isRedoAvailable ) { _editorPanel.updateUndoRedoButtonsStates( isUndoAvailable, isRedoAvailable ); } );
 
         if ( isNewMap ) {
             _mapFormat = {};

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -831,6 +831,10 @@ namespace Interface
         _tileUnderCursor = -1;
         _areaSelectionStartTileId = -1;
 
+        _historyManager.setChangedCallback([this](const bool isUndoAvailable, const bool isRedoAvailable) {
+            _editorPanel._updateButtonStates(isUndoAvailable, isRedoAvailable);
+        });
+
         uint32_t redrawFlags = REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_PANEL | REDRAW_STATUS | REDRAW_BORDER;
         if ( conf.isEditorPassabilityEnabled() ) {
             redrawFlags |= REDRAW_PASSABILITIES;

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -809,7 +809,9 @@ namespace Interface
 
         reset();
 
-        _historyManager.reset();
+        _historyManager.reset(
+                [this]( const bool isUndoAvailable, const bool isRedoAvailable ) {
+                    _editorPanel.updateUndoRedoButtonsStates(isUndoAvailable, isRedoAvailable); } );
 
         if ( isNewMap ) {
             _mapFormat = {};
@@ -830,9 +832,6 @@ namespace Interface
         // The cursor parameters may contain values from a previously edited map that are not suitable for this one. Reset them.
         _tileUnderCursor = -1;
         _areaSelectionStartTileId = -1;
-
-        _historyManager.setChangedCallback(
-            [this]( const bool isUndoAvailable, const bool isRedoAvailable ) { _editorPanel._updateButtonStates( isUndoAvailable, isRedoAvailable ); } );
 
         uint32_t redrawFlags = REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_PANEL | REDRAW_STATUS | REDRAW_BORDER;
         if ( conf.isEditorPassabilityEnabled() ) {

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -831,9 +831,8 @@ namespace Interface
         _tileUnderCursor = -1;
         _areaSelectionStartTileId = -1;
 
-        _historyManager.setChangedCallback([this](const bool isUndoAvailable, const bool isRedoAvailable) {
-            _editorPanel._updateButtonStates(isUndoAvailable, isRedoAvailable);
-        });
+        _historyManager.setChangedCallback(
+            [this]( const bool isUndoAvailable, const bool isRedoAvailable ) { _editorPanel._updateButtonStates( isUndoAvailable, isRedoAvailable ); } );
 
         uint32_t redrawFlags = REDRAW_GAMEAREA | REDRAW_RADAR | REDRAW_PANEL | REDRAW_STATUS | REDRAW_BORDER;
         if ( conf.isEditorPassabilityEnabled() ) {

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -809,8 +809,7 @@ namespace Interface
 
         reset();
 
-        _historyManager.reset(
-            [this]( const bool isUndoAvailable, const bool isRedoAvailable ) { _editorPanel.updateUndoRedoButtonsStates( isUndoAvailable, isRedoAvailable ); } );
+        _historyManager.reset();
 
         if ( isNewMap ) {
             _mapFormat = {};

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2024                                             *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -142,7 +142,7 @@ namespace Interface
             , _warningMessage( *this )
         {
             _historyManager.setStateCallback(
-                [this]( const bool isUndoAvailable, const bool isRedoAvailable ) { _editorPanel.updateUndoRedoButtonsStates( isUndoAvailable, isRedoAvailable ); } );
+                [&editorPanel = _editorPanel]( const bool isUndoAvailable, const bool isRedoAvailable ) { editorPanel.updateUndoRedoButtonsStates( isUndoAvailable, isRedoAvailable ); } );
         }
 
         bool _setObjectOnTile( Maps::Tile & tile, const Maps::ObjectGroup groupType, const int32_t objectIndex );

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -141,7 +141,8 @@ namespace Interface
             , _editorPanel( *this )
             , _warningMessage( *this )
         {
-            // Do nothing.
+            _historyManager.setStateCallback(
+                [this]( const bool isUndoAvailable, const bool isRedoAvailable ) { _editorPanel.updateUndoRedoButtonsStates( isUndoAvailable, isRedoAvailable ); } );
         }
 
         bool _setObjectOnTile( Maps::Tile & tile, const Maps::ObjectGroup groupType, const int32_t objectIndex );

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -141,8 +141,9 @@ namespace Interface
             , _editorPanel( *this )
             , _warningMessage( *this )
         {
-            _historyManager.setStateCallback(
-                [&editorPanel = _editorPanel]( const bool isUndoAvailable, const bool isRedoAvailable ) { editorPanel.updateUndoRedoButtonsStates( isUndoAvailable, isRedoAvailable ); } );
+            _historyManager.setStateCallback( [&editorPanel = _editorPanel]( const bool isUndoAvailable, const bool isRedoAvailable ) {
+                editorPanel.updateUndoRedoButtonsStates( isUndoAvailable, isRedoAvailable );
+            } );
         }
 
         bool _setObjectOnTile( Maps::Tile & tile, const Maps::ObjectGroup groupType, const int32_t objectIndex );

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -214,7 +214,7 @@ namespace Interface
         _selectedAdventureObjectType.fill( -1 );
         _selectedKingdomObjectType.fill( -1 );
 
-        _updateButtonStates( false, false );
+        updateUndoRedoButtonsStates( false, false );
     }
 
     fheroes2::Rect EditorPanel::getBrushArea() const
@@ -896,24 +896,23 @@ namespace Interface
         _interface.setCursorUpdater( {} );
     }
 
-    void EditorPanel::_updateButtonStates( const bool isUndoAvailable, const bool isRedoAvailable )
+    void EditorPanel::updateUndoRedoButtonsStates(const bool isUndoAvailable, const bool isRedoAvailable )
     {
-        if ( isUndoAvailable ) {
-            _buttonUndo.enable();
-        }
-        else {
-            _buttonUndo.disable();
-        }
+        auto updateButtonState = []( fheroes2::ButtonBase & button, const bool isAvailable ) {
+            if ( isAvailable ) {
+                if ( button.isDisabled() ) {
+                    button.enable();
+                    button.draw();
+                }
+            }
+            else if ( button.isEnabled() ) {
+                button.disable();
+                button.draw();
+            }
+        };
 
-        if ( isRedoAvailable ) {
-            _buttonRedo.enable();
-        }
-        else {
-            _buttonRedo.disable();
-        }
-
-        _buttonUndo.draw();
-        _buttonRedo.draw();
+        updateButtonState( _buttonUndo, isUndoAvailable );
+        updateButtonState( _buttonRedo, isRedoAvailable );
     }
 
     fheroes2::GameMode EditorPanel::queueEventProcessing()

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -214,7 +214,7 @@ namespace Interface
         _selectedAdventureObjectType.fill( -1 );
         _selectedKingdomObjectType.fill( -1 );
 
-        _updateButtonStates(false, false);
+        _updateButtonStates( false, false );
     }
 
     fheroes2::Rect EditorPanel::getBrushArea() const
@@ -896,7 +896,7 @@ namespace Interface
         _interface.setCursorUpdater( {} );
     }
 
-    void EditorPanel::_updateButtonStates(const bool isUndoAvailable, const bool isRedoAvailable)
+    void EditorPanel::_updateButtonStates( const bool isUndoAvailable, const bool isRedoAvailable )
     {
         if ( isUndoAvailable ) {
             _buttonUndo.enable();

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -900,13 +900,15 @@ namespace Interface
     {
         if ( isUndoAvailable ) {
             _buttonUndo.enable();
-        } else {
+        }
+        else {
             _buttonUndo.disable();
         }
 
         if ( isRedoAvailable ) {
             _buttonRedo.enable();
-        } else {
+        }
+        else {
             _buttonRedo.disable();
         }
 

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -896,7 +896,7 @@ namespace Interface
         _interface.setCursorUpdater( {} );
     }
 
-    void EditorPanel::updateUndoRedoButtonsStates(const bool isUndoAvailable, const bool isRedoAvailable )
+    void EditorPanel::updateUndoRedoButtonsStates( const bool isUndoAvailable, const bool isRedoAvailable )
     {
         auto updateButtonState = []( fheroes2::ButtonBase & button, const bool isAvailable ) {
             if ( isAvailable ) {

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -213,6 +213,8 @@ namespace Interface
         _selectedLandscapeObjectType.fill( -1 );
         _selectedAdventureObjectType.fill( -1 );
         _selectedKingdomObjectType.fill( -1 );
+
+        _updateButtonStates(false, false);
     }
 
     fheroes2::Rect EditorPanel::getBrushArea() const
@@ -894,6 +896,24 @@ namespace Interface
         _interface.setCursorUpdater( {} );
     }
 
+    void EditorPanel::_updateButtonStates(const bool isUndoAvailable, const bool isRedoAvailable)
+    {
+        if ( isUndoAvailable ) {
+            _buttonUndo.enable();
+        } else {
+            _buttonUndo.disable();
+        }
+
+        if ( isRedoAvailable ) {
+            _buttonRedo.enable();
+        } else {
+            _buttonRedo.disable();
+        }
+
+        _buttonUndo.draw();
+        _buttonRedo.draw();
+    }
+
     fheroes2::GameMode EditorPanel::queueEventProcessing()
     {
         LocalEvent & le = LocalEvent::Get();
@@ -1197,11 +1217,9 @@ namespace Interface
         }
         else if ( _buttonUndo.isEnabled() && le.MouseClickLeft( _rectUndo ) ) {
             _interface.undoAction();
-            // TODO: Disable Undo button when there are no actions left to undo.
         }
         else if ( _buttonRedo.isEnabled() && le.MouseClickLeft( _rectRedo ) ) {
             _interface.redoAction();
-            // TODO: Disable Redo button when there are no actions left to redo.
         }
         else if ( le.MouseClickLeft( _rectSpecs ) ) {
             EditorInterface::Get().openMapSpecificationsDialog();

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -120,7 +120,7 @@ namespace Interface
 
         static const char * getObjectGroupName( const Maps::ObjectGroup groupName );
 
-        void _updateButtonStates( const bool isUndoAvailable, const bool isRedoAvailable );
+        void updateUndoRedoButtonsStates( const bool isUndoAvailable, const bool isRedoAvailable );
 
     private:
         static int _getGroundId( const uint8_t brushId );

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -120,7 +120,7 @@ namespace Interface
 
         static const char * getObjectGroupName( const Maps::ObjectGroup groupName );
 
-        void _updateButtonStates(const bool isUndoAvailable, const bool isRedoAvailable);
+        void _updateButtonStates( const bool isUndoAvailable, const bool isRedoAvailable );
 
     private:
         static int _getGroundId( const uint8_t brushId );

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -120,6 +120,8 @@ namespace Interface
 
         static const char * getObjectGroupName( const Maps::ObjectGroup groupName );
 
+        void _updateButtonStates(const bool isUndoAvailable, const bool isRedoAvailable);
+
     private:
         static int _getGroundId( const uint8_t brushId );
 

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2024                                             *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -76,16 +76,15 @@ namespace fheroes2
     class HistoryManager
     {
     public:
-        void setChangedCallback( const std::function<void( const bool, const bool )> & callback )
-        {
-            _changesCallback = callback;
-        }
-
-        void reset()
+        void reset( const std::function<void( const bool, const bool )> & undoRedoCallback = nullptr )
         {
             _actions.clear();
             _lastActionId = 0;
-            _changesCallback = nullptr;
+            _changesCallback = undoRedoCallback ;
+
+            if ( _changesCallback ) {
+                _changesCallback( false, false );
+            }
         }
 
         void add( std::unique_ptr<Action> action )

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -76,7 +76,7 @@ namespace fheroes2
     class HistoryManager
     {
     public:
-        void setChangedCallback( const std::function<void(const bool, const bool)>& callback )
+        void setChangedCallback( const std::function<void( const bool, const bool )>& callback )
         {
             _changesCallback = callback;
         }
@@ -145,7 +145,7 @@ namespace fheroes2
             const bool result = _actions[_lastActionId]->redo();
             ++_lastActionId;
 
-            if (  _changesCallback ) {
+            if ( _changesCallback ) {
                 _changesCallback( isUndoAvailable(), isRedoAvailable() );
             }
 

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -109,7 +109,7 @@ namespace fheroes2
             }
 
             if ( _stateCallback ) {
-                _stateCallback(isUndoAvailable(), isRedoAvailable() );
+                _stateCallback( isUndoAvailable(), isRedoAvailable() );
             }
 
             assert( _actions.size() <= maxActions );
@@ -136,7 +136,7 @@ namespace fheroes2
             const bool result = _actions[_lastActionId]->undo();
 
             if ( _stateCallback ) {
-                _stateCallback(isUndoAvailable(), isRedoAvailable() );
+                _stateCallback( isUndoAvailable(), isRedoAvailable() );
             }
 
             return result;
@@ -153,7 +153,7 @@ namespace fheroes2
             ++_lastActionId;
 
             if ( _stateCallback ) {
-                _stateCallback(isUndoAvailable(), isRedoAvailable() );
+                _stateCallback( isUndoAvailable(), isRedoAvailable() );
             }
 
             return result;

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -24,9 +24,9 @@
 #include <cassert>
 #include <cstddef>
 #include <deque>
+#include <functional>
 #include <memory>
 #include <utility>
-#include <functional>
 
 namespace Maps::Map_Format
 {
@@ -76,7 +76,7 @@ namespace fheroes2
     class HistoryManager
     {
     public:
-        void setChangedCallback(const std::function<void(const bool, const bool)>& callback)
+        void setChangedCallback( const std::function<void(const bool, const bool)>& callback )
         {
             _changesCallback = callback;
         }
@@ -102,7 +102,7 @@ namespace fheroes2
             }
 
             if ( _changesCallback ) {
-                _changesCallback(isUndoAvailable(), isRedoAvailable());
+                _changesCallback( isUndoAvailable(), isRedoAvailable() );
             }
 
             assert( _actions.size() <= maxActions );
@@ -129,7 +129,7 @@ namespace fheroes2
             const bool result = _actions[_lastActionId]->undo();
 
             if ( _changesCallback ) {
-                _changesCallback(isUndoAvailable(), isRedoAvailable());
+                _changesCallback( isUndoAvailable(), isRedoAvailable() );
             }
 
             return result;
@@ -146,7 +146,7 @@ namespace fheroes2
             ++_lastActionId;
 
             if (  _changesCallback ) {
-                _changesCallback(isUndoAvailable(), isRedoAvailable());
+                _changesCallback( isUndoAvailable(), isRedoAvailable() );
             }
 
             return result;
@@ -160,6 +160,6 @@ namespace fheroes2
 
         size_t _lastActionId{ 0 };
 
-        std::function<void(const bool, const bool)> _changesCallback = nullptr;
+        std::function<void( const bool, const bool )> _changesCallback = nullptr;
     };
 }

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -76,7 +76,7 @@ namespace fheroes2
     class HistoryManager
     {
     public:
-        void setChangedCallback( const std::function<void( const bool, const bool )>& callback )
+        void setChangedCallback( const std::function<void( const bool, const bool )> & callback )
         {
             _changesCallback = callback;
         }

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -80,7 +80,7 @@ namespace fheroes2
         {
             _actions.clear();
             _lastActionId = 0;
-            _changesCallback = undoRedoCallback ;
+            _changesCallback = undoRedoCallback;
 
             if ( _changesCallback ) {
                 _changesCallback( false, false );

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -79,10 +79,6 @@ namespace fheroes2
         void setStateCallback( std::function<void( const bool, const bool )> stateCallback )
         {
             _stateCallback = std::move( stateCallback );
-
-            if ( _stateCallback ) {
-                _stateCallback( isUndoAvailable(), isRedoAvailable() );
-            }
         }
 
         void reset()

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -76,14 +76,22 @@ namespace fheroes2
     class HistoryManager
     {
     public:
-        void reset( const std::function<void( const bool, const bool )> & undoRedoCallback = nullptr )
+        void setStateCallback( std::function<void( const bool, const bool )> stateCallback )
+        {
+            _stateCallback = std::move( stateCallback );
+
+            if ( _stateCallback ) {
+                _stateCallback( isUndoAvailable(), isRedoAvailable() );
+            }
+        }
+
+        void reset()
         {
             _actions.clear();
             _lastActionId = 0;
-            _changesCallback = undoRedoCallback;
 
-            if ( _changesCallback ) {
-                _changesCallback( false, false );
+            if ( _stateCallback ) {
+                _stateCallback( false, false );
             }
         }
 
@@ -100,8 +108,8 @@ namespace fheroes2
                 _actions.pop_front();
             }
 
-            if ( _changesCallback ) {
-                _changesCallback( isUndoAvailable(), isRedoAvailable() );
+            if ( _stateCallback ) {
+                _stateCallback(isUndoAvailable(), isRedoAvailable() );
             }
 
             assert( _actions.size() <= maxActions );
@@ -127,8 +135,8 @@ namespace fheroes2
             --_lastActionId;
             const bool result = _actions[_lastActionId]->undo();
 
-            if ( _changesCallback ) {
-                _changesCallback( isUndoAvailable(), isRedoAvailable() );
+            if ( _stateCallback ) {
+                _stateCallback(isUndoAvailable(), isRedoAvailable() );
             }
 
             return result;
@@ -144,8 +152,8 @@ namespace fheroes2
             const bool result = _actions[_lastActionId]->redo();
             ++_lastActionId;
 
-            if ( _changesCallback ) {
-                _changesCallback( isUndoAvailable(), isRedoAvailable() );
+            if ( _stateCallback ) {
+                _stateCallback(isUndoAvailable(), isRedoAvailable() );
             }
 
             return result;
@@ -159,6 +167,6 @@ namespace fheroes2
 
         size_t _lastActionId{ 0 };
 
-        std::function<void( const bool, const bool )> _changesCallback = nullptr;
+        std::function<void( const bool, const bool )> _stateCallback;
     };
 }


### PR DESCRIPTION
Buttons redu and undo are disable if no actions were made in the Editor.
Also they become disable/enable if actions were made/revert in the Editor.