### PR TITLE
CMake (Windows SDL2) job: auto-update vcpkg to the latest version

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -57,6 +57,11 @@ jobs:
         shell: bash
     steps:
     - uses: actions/checkout@v4
+    - name: Update vcpkg
+      run: |
+        cd "$VCPKG_INSTALLATION_ROOT"
+        git.exe pull
+        bootstrap-vcpkg.bat
     - name: Prepare vcpkg cache
       uses: actions/cache@v4
       with:


### PR DESCRIPTION
I'm tired of waiting for GitHub to update its Windows image.