### PR TITLE
Add shadow for Heroes Meeting dialog

### DIFF
--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -874,11 +874,6 @@ namespace fheroes2
             return;
         }
 
-        const int32_t outWidth = out.width();
-
-        // Ensure the shadow is within the bounds of the 'out' image
-        assert( outPos.x + shadowOffset >= 0 && outPos.x + dialogWidth <= outWidth && outPos.y + dialogHeight + shadowOffset <= out.height() );
-
         // Render shadow at the left side of the window
         int32_t offsetY = outPos.y + shadowOffset;
         ApplyTransform( out, outPos.x - shadowOffset, offsetY, shadowOffset, 1, 5 );

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -736,7 +736,7 @@ namespace fheroes2
         }
     }
 
-    void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset )
+    void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset, const bool slopeEffect )
     {
         if ( in.empty() || out.empty() || ( shadowOffset.x == 0 && shadowOffset.y == 0 ) || ( outPos.x < 0 ) || ( outPos.y < 0 ) ) {
             return;
@@ -766,7 +766,7 @@ namespace fheroes2
                 shadowLine.emplace_back( 0, y );
             }
         }
-        else {
+        else if ( slopeEffect ) {
             const double slopeFactor = static_cast<double>( shadowOffset.y ) / shadowOffset.x;
 
             if ( absOffsetX >= absOffsetY ) {
@@ -782,8 +782,21 @@ namespace fheroes2
                 }
             }
         }
+        else {
+            if ( absOffsetX >= absOffsetY ) {
+                const int32_t maxX = inWidth;
+                for ( int32_t x = 0; x < maxX; ++x ) {
+                    shadowLine.emplace_back( x + shadowOffset.x, shadowOffset.y );
+                }
+            } else {
+                const int32_t maxY = absOffsetY;
+                for ( int32_t y = 0; y < maxY; ++y ) {
+                    shadowLine.emplace_back( shadowOffset.x, y + shadowOffset.y );
+                }
+            }
+        }
 
-        const int32_t maxX = inWidth + absOffsetX;
+        const int32_t maxX = slopeEffect ? inWidth + absOffsetX : inWidth;
         const int32_t maxY = inHeight + absOffsetY;
 
         // If image is single-layer then pointer to its transform layer is 'nullptr'

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -784,6 +784,7 @@ namespace fheroes2
         }
 
         const int32_t maxX = inWidth + absOffsetX;
+        const int32_t maxY = inHeight + absOffsetY;
 
         // If image is single-layer then pointer to its transform layer is 'nullptr'
         const uint8_t * transformIn = in.singleLayer() ? nullptr : in.transform();

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -882,7 +882,7 @@ namespace fheroes2
         }
     }
 
-    void addShadowForRectangularDialog( Image & out, const Point & outPos,  const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize )
+    void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize )
     {
         if ( out.empty() || shadowSize == 0 || outPos.x < 0 || outPos.y < 0 ) {
             return;

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -736,7 +736,7 @@ namespace fheroes2
         }
     }
 
-    void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset, const bool slopeEffect )
+    void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset )
     {
         if ( in.empty() || out.empty() || ( shadowOffset.x == 0 && shadowOffset.y == 0 ) || ( outPos.x < 0 ) || ( outPos.y < 0 ) ) {
             return;
@@ -766,7 +766,7 @@ namespace fheroes2
                 shadowLine.emplace_back( 0, y );
             }
         }
-        else if ( slopeEffect ) {
+        else {
             const double slopeFactor = static_cast<double>( shadowOffset.y ) / shadowOffset.x;
 
             if ( absOffsetX >= absOffsetY ) {
@@ -782,23 +782,8 @@ namespace fheroes2
                 }
             }
         }
-        else {
-            if ( absOffsetX >= absOffsetY ) {
-                const int32_t maxX = inWidth;
-                for ( int32_t x = 0; x < maxX; ++x ) {
-                    shadowLine.emplace_back( x + shadowOffset.x, shadowOffset.y );
-                }
-            }
-            else {
-                const int32_t maxY = absOffsetY;
-                for ( int32_t y = 0; y < maxY; ++y ) {
-                    shadowLine.emplace_back( shadowOffset.x, y + shadowOffset.y );
-                }
-            }
-        }
 
-        const int32_t maxX = slopeEffect ? inWidth + absOffsetX : inWidth;
-        const int32_t maxY = inHeight + absOffsetY;
+        const int32_t maxX = inWidth + absOffsetX;
 
         // If image is single-layer then pointer to its transform layer is 'nullptr'
         const uint8_t * transformIn = in.singleLayer() ? nullptr : in.transform();

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -882,7 +882,7 @@ namespace fheroes2
         }
     }
 
-    void addShadowForRectangularDialog( Image &out, const Point &outPos,  const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize )
+    void addShadowForRectangularDialog( Image & out, const Point & outPos,  const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize )
     {
         if ( out.empty() || shadowSize == 0 || outPos.x < 0 || outPos.y < 0 ) {
             return;
@@ -891,18 +891,16 @@ namespace fheroes2
         const int32_t outWidth = out.width();
 
         // Ensure the shadow is within the bounds of the 'out' image
-        assert( outPos.x + shadowSize >= 0 &&
-                outPos.x + dialogWidth <= outWidth &&
-                outPos.y + dialogHeight + shadowSize <= out.height() );
+        assert( outPos.x + shadowSize >= 0 && outPos.x + dialogWidth <= outWidth && outPos.y + dialogHeight + shadowSize <= out.height() );
 
         // Render shadow at the left side of the window
         int32_t offsetY = outPos.y + shadowSize;
         ApplyTransform( out, outPos.x - shadowSize, offsetY, shadowSize, 1, 5 );
         ++offsetY;
         ApplyTransform( out, outPos.x - shadowSize, offsetY, 1, dialogHeight, 5 );
-        ApplyTransform( out, outPos.x - shadowSize+ 1, offsetY, shadowSize - 1, 1, 4 );
+        ApplyTransform( out, outPos.x - shadowSize + 1, offsetY, shadowSize - 1, 1, 4 );
         ++offsetY;
-        ApplyTransform( out, outPos.x - shadowSize+ 1, offsetY, 1, dialogHeight - 4, 4 );
+        ApplyTransform( out, outPos.x - shadowSize + 1, offsetY, 1, dialogHeight - 4, 4 );
         ApplyTransform( out, outPos.x - shadowSize + 2, offsetY, shadowSize - 2, 1, 3 );
         ++offsetY;
         ApplyTransform( out, outPos.x - shadowSize + 2, offsetY, 1, dialogHeight - 6, 3 );

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -882,6 +882,44 @@ namespace fheroes2
         }
     }
 
+    void addShadowForRectangularDialog( Image &out, const Point &outPos,  const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize )
+    {
+        if ( out.empty() || shadowSize == 0 || outPos.x < 0 || outPos.y < 0 ) {
+            return;
+        }
+
+        const int32_t outWidth = out.width();
+
+        // Ensure the shadow is within the bounds of the 'out' image
+        assert( outPos.x + shadowSize >= 0 &&
+                outPos.x + dialogWidth <= outWidth &&
+                outPos.y + dialogHeight + shadowSize <= out.height() );
+
+        // Render shadow at the left side of the window
+        int32_t offsetY = outPos.y + shadowSize;
+        ApplyTransform( out, outPos.x - shadowSize, offsetY, shadowSize, 1, 5 );
+        ++offsetY;
+        ApplyTransform( out, outPos.x - shadowSize, offsetY, 1, dialogHeight, 5 );
+        ApplyTransform( out, outPos.x - shadowSize+ 1, offsetY, shadowSize - 1, 1, 4 );
+        ++offsetY;
+        ApplyTransform( out, outPos.x - shadowSize+ 1, offsetY, 1, dialogHeight - 4, 4 );
+        ApplyTransform( out, outPos.x - shadowSize + 2, offsetY, shadowSize - 2, 1, 3 );
+        ++offsetY;
+        ApplyTransform( out, outPos.x - shadowSize + 2, offsetY, 1, dialogHeight - 6, 3 );
+        ApplyTransform( out, outPos.x - shadowSize + 3, offsetY, shadowSize - 3, dialogHeight - shadowSize - 3, 2 );
+
+        // Render shadow at the bottom side of the window
+        offsetY = outPos.y + dialogHeight;
+        const int32_t shadowBottomEdge = outPos.y + dialogHeight + shadowSize;
+        ApplyTransform( out, outPos.x - shadowSize + 3, offsetY, dialogWidth - 6, shadowSize - 3, 2 );
+        ApplyTransform( out, outPos.x - shadowSize + 2, shadowBottomEdge - 3, dialogWidth - 4, 1, 3 );
+        ApplyTransform( out, outPos.x - shadowSize + dialogWidth - 3, offsetY, 1, shadowSize - 3, 3 );
+        ApplyTransform( out, outPos.x - shadowSize + 1, shadowBottomEdge - 2, dialogWidth - 2, 1, 4 );
+        ApplyTransform( out, outPos.x - shadowSize + dialogWidth - 2, offsetY, 1, shadowSize - 2, 4 );
+        ApplyTransform( out, outPos.x - shadowSize, shadowBottomEdge - 1, dialogWidth, 1, 5 );
+        ApplyTransform( out, outPos.x - shadowSize + dialogWidth - 1, offsetY, 1, shadowSize, 5 );
+    }
+
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId )
     {
         if ( in.empty() || shadowOffset.x > 0 || shadowOffset.y < 0 ) {

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -788,7 +788,8 @@ namespace fheroes2
                 for ( int32_t x = 0; x < maxX; ++x ) {
                     shadowLine.emplace_back( x + shadowOffset.x, shadowOffset.y );
                 }
-            } else {
+            }
+            else {
                 const int32_t maxY = absOffsetY;
                 for ( int32_t y = 0; y < maxY; ++y ) {
                     shadowLine.emplace_back( shadowOffset.x, y + shadowOffset.y );

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -868,40 +868,40 @@ namespace fheroes2
         }
     }
 
-    void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize )
+    void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowOffset )
     {
-        if ( out.empty() || shadowSize == 0 || outPos.x < 0 || outPos.y < 0 ) {
+        if ( out.empty() || outPos.x < 0 || outPos.y < 0 || shadowOffset < 1 ) {
             return;
         }
 
         const int32_t outWidth = out.width();
 
         // Ensure the shadow is within the bounds of the 'out' image
-        assert( outPos.x + shadowSize >= 0 && outPos.x + dialogWidth <= outWidth && outPos.y + dialogHeight + shadowSize <= out.height() );
+        assert( outPos.x + shadowOffset >= 0 && outPos.x + dialogWidth <= outWidth && outPos.y + dialogHeight + shadowOffset <= out.height() );
 
         // Render shadow at the left side of the window
-        int32_t offsetY = outPos.y + shadowSize;
-        ApplyTransform( out, outPos.x - shadowSize, offsetY, shadowSize, 1, 5 );
+        int32_t offsetY = outPos.y + shadowOffset;
+        ApplyTransform( out, outPos.x - shadowOffset, offsetY, shadowOffset, 1, 5 );
         ++offsetY;
-        ApplyTransform( out, outPos.x - shadowSize, offsetY, 1, dialogHeight, 5 );
-        ApplyTransform( out, outPos.x - shadowSize + 1, offsetY, shadowSize - 1, 1, 4 );
+        ApplyTransform( out, outPos.x - shadowOffset, offsetY, 1, dialogHeight, 5 );
+        ApplyTransform( out, outPos.x - shadowOffset + 1, offsetY, shadowOffset - 1, 1, 4 );
         ++offsetY;
-        ApplyTransform( out, outPos.x - shadowSize + 1, offsetY, 1, dialogHeight - 4, 4 );
-        ApplyTransform( out, outPos.x - shadowSize + 2, offsetY, shadowSize - 2, 1, 3 );
+        ApplyTransform( out, outPos.x - shadowOffset + 1, offsetY, 1, dialogHeight - 4, 4 );
+        ApplyTransform( out, outPos.x - shadowOffset + 2, offsetY, shadowOffset - 2, 1, 3 );
         ++offsetY;
-        ApplyTransform( out, outPos.x - shadowSize + 2, offsetY, 1, dialogHeight - 6, 3 );
-        ApplyTransform( out, outPos.x - shadowSize + 3, offsetY, shadowSize - 3, dialogHeight - shadowSize - 3, 2 );
+        ApplyTransform( out, outPos.x - shadowOffset + 2, offsetY, 1, dialogHeight - 6, 3 );
+        ApplyTransform( out, outPos.x - shadowOffset + 3, offsetY, shadowOffset - 3, dialogHeight - shadowOffset - 3, 2 );
 
         // Render shadow at the bottom side of the window
         offsetY = outPos.y + dialogHeight;
-        const int32_t shadowBottomEdge = outPos.y + dialogHeight + shadowSize;
-        ApplyTransform( out, outPos.x - shadowSize + 3, offsetY, dialogWidth - 6, shadowSize - 3, 2 );
-        ApplyTransform( out, outPos.x - shadowSize + 2, shadowBottomEdge - 3, dialogWidth - 4, 1, 3 );
-        ApplyTransform( out, outPos.x - shadowSize + dialogWidth - 3, offsetY, 1, shadowSize - 3, 3 );
-        ApplyTransform( out, outPos.x - shadowSize + 1, shadowBottomEdge - 2, dialogWidth - 2, 1, 4 );
-        ApplyTransform( out, outPos.x - shadowSize + dialogWidth - 2, offsetY, 1, shadowSize - 2, 4 );
-        ApplyTransform( out, outPos.x - shadowSize, shadowBottomEdge - 1, dialogWidth, 1, 5 );
-        ApplyTransform( out, outPos.x - shadowSize + dialogWidth - 1, offsetY, 1, shadowSize, 5 );
+        const int32_t shadowBottomEdge = outPos.y + dialogHeight + shadowOffset;
+        ApplyTransform( out, outPos.x - shadowOffset + 3, offsetY, dialogWidth - 6, shadowOffset - 3, 2 );
+        ApplyTransform( out, outPos.x - shadowOffset + 2, shadowBottomEdge - 3, dialogWidth - 4, 1, 3 );
+        ApplyTransform( out, outPos.x - shadowOffset + dialogWidth - 3, offsetY, 1, shadowOffset - 3, 3 );
+        ApplyTransform( out, outPos.x - shadowOffset + 1, shadowBottomEdge - 2, dialogWidth - 2, 1, 4 );
+        ApplyTransform( out, outPos.x - shadowOffset + dialogWidth - 2, offsetY, 1, shadowOffset - 2, 4 );
+        ApplyTransform( out, outPos.x - shadowOffset, shadowBottomEdge - 1, dialogWidth, 1, 5 );
+        ApplyTransform( out, outPos.x - shadowOffset + dialogWidth - 1, offsetY, 1, shadowOffset, 5 );
     }
 
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId )

--- a/src/engine/image.cpp
+++ b/src/engine/image.cpp
@@ -868,35 +868,35 @@ namespace fheroes2
         }
     }
 
-    void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowOffset )
+    void addGradientShadowForArea( Image & out, const Point & outPos, const int32_t areaWidth, const int32_t areaHeight, const int32_t shadowOffset )
     {
         if ( out.empty() || outPos.x < 0 || outPos.y < 0 || shadowOffset < 1 ) {
             return;
         }
 
-        // Render shadow at the left side of the window
+        // Render shadow at the left side of the area
         int32_t offsetY = outPos.y + shadowOffset;
         ApplyTransform( out, outPos.x - shadowOffset, offsetY, shadowOffset, 1, 5 );
         ++offsetY;
-        ApplyTransform( out, outPos.x - shadowOffset, offsetY, 1, dialogHeight, 5 );
+        ApplyTransform( out, outPos.x - shadowOffset, offsetY, 1, areaHeight, 5 );
         ApplyTransform( out, outPos.x - shadowOffset + 1, offsetY, shadowOffset - 1, 1, 4 );
         ++offsetY;
-        ApplyTransform( out, outPos.x - shadowOffset + 1, offsetY, 1, dialogHeight - 4, 4 );
+        ApplyTransform( out, outPos.x - shadowOffset + 1, offsetY, 1, areaHeight - 4, 4 );
         ApplyTransform( out, outPos.x - shadowOffset + 2, offsetY, shadowOffset - 2, 1, 3 );
         ++offsetY;
-        ApplyTransform( out, outPos.x - shadowOffset + 2, offsetY, 1, dialogHeight - 6, 3 );
-        ApplyTransform( out, outPos.x - shadowOffset + 3, offsetY, shadowOffset - 3, dialogHeight - shadowOffset - 3, 2 );
+        ApplyTransform( out, outPos.x - shadowOffset + 2, offsetY, 1, areaHeight - 6, 3 );
+        ApplyTransform( out, outPos.x - shadowOffset + 3, offsetY, shadowOffset - 3, areaHeight - shadowOffset - 3, 2 );
 
-        // Render shadow at the bottom side of the window
-        offsetY = outPos.y + dialogHeight;
-        const int32_t shadowBottomEdge = outPos.y + dialogHeight + shadowOffset;
-        ApplyTransform( out, outPos.x - shadowOffset + 3, offsetY, dialogWidth - 6, shadowOffset - 3, 2 );
-        ApplyTransform( out, outPos.x - shadowOffset + 2, shadowBottomEdge - 3, dialogWidth - 4, 1, 3 );
-        ApplyTransform( out, outPos.x - shadowOffset + dialogWidth - 3, offsetY, 1, shadowOffset - 3, 3 );
-        ApplyTransform( out, outPos.x - shadowOffset + 1, shadowBottomEdge - 2, dialogWidth - 2, 1, 4 );
-        ApplyTransform( out, outPos.x - shadowOffset + dialogWidth - 2, offsetY, 1, shadowOffset - 2, 4 );
-        ApplyTransform( out, outPos.x - shadowOffset, shadowBottomEdge - 1, dialogWidth, 1, 5 );
-        ApplyTransform( out, outPos.x - shadowOffset + dialogWidth - 1, offsetY, 1, shadowOffset, 5 );
+        // Render shadow at the bottom side of the area
+        offsetY = outPos.y + areaHeight;
+        const int32_t shadowBottomEdge = outPos.y + areaHeight + shadowOffset;
+        ApplyTransform( out, outPos.x - shadowOffset + 3, offsetY, areaWidth - 6, shadowOffset - 3, 2 );
+        ApplyTransform( out, outPos.x - shadowOffset + 2, shadowBottomEdge - 3, areaWidth - 4, 1, 3 );
+        ApplyTransform( out, outPos.x - shadowOffset + areaWidth - 3, offsetY, 1, shadowOffset - 3, 3 );
+        ApplyTransform( out, outPos.x - shadowOffset + 1, shadowBottomEdge - 2, areaWidth - 2, 1, 4 );
+        ApplyTransform( out, outPos.x - shadowOffset + areaWidth - 2, offsetY, 1, shadowOffset - 2, 4 );
+        ApplyTransform( out, outPos.x - shadowOffset, shadowBottomEdge - 1, areaWidth, 1, 5 );
+        ApplyTransform( out, outPos.x - shadowOffset + areaWidth - 1, offsetY, 1, shadowOffset, 5 );
     }
 
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId )

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -203,7 +203,7 @@ namespace fheroes2
     };
 
     // Apply shadow that gradually reduces strength using 'in' image shape. Shadow is applied to the 'out' image.
-    void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset );
+    void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset, const bool slopeEffect = true );
 
     // Generates a new image with a shadow of the shape of existing image. Shadow must have only (-x, +y) offset.
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId );

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -204,6 +204,7 @@ namespace fheroes2
 
     // Apply shadow that gradually reduces strength using 'in' image shape. Shadow is applied to the 'out' image.
     void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset, const bool slopeEffect = true );
+    void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize );
 
     // Generates a new image with a shadow of the shape of existing image. Shadow must have only (-x, +y) offset.
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId );

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -203,7 +203,7 @@ namespace fheroes2
     };
 
     // Apply shadow that gradually reduces strength using 'in' image shape. Shadow is applied to the 'out' image.
-    void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset, const bool slopeEffect = true );
+    void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset );
     void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize );
 
     // Generates a new image with a shadow of the shape of existing image. Shadow must have only (-x, +y) offset.

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -204,7 +204,7 @@ namespace fheroes2
 
     // Apply shadow that gradually reduces strength using 'in' image shape. Shadow is applied to the 'out' image.
     void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset );
-    void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowOffset );
+    void addGradientShadowForArea( Image & out, const Point & outPos, const int32_t areaWidth, const int32_t areaHeight, const int32_t shadowOffset );
 
     // Generates a new image with a shadow of the shape of existing image. Shadow must have only (-x, +y) offset.
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId );

--- a/src/engine/image.h
+++ b/src/engine/image.h
@@ -204,7 +204,7 @@ namespace fheroes2
 
     // Apply shadow that gradually reduces strength using 'in' image shape. Shadow is applied to the 'out' image.
     void addGradientShadow( const Sprite & in, Image & out, const Point & outPos, const Point & shadowOffset );
-    void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowSize );
+    void addShadowForRectangularDialog( Image & out, const Point & outPos, const int32_t & dialogWidth, const int32_t & dialogHeight, const int32_t shadowOffset );
 
     // Generates a new image with a shadow of the shape of existing image. Shadow must have only (-x, +y) offset.
     Sprite addShadow( const Sprite & in, const Point & shadowOffset, const uint8_t transformId );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -113,8 +113,6 @@ namespace
 
     const int32_t battleLogElementWidth{ fheroes2::Display::DEFAULT_WIDTH - 32 - 16 };
 
-    const fheroes2::Point damageImageShadowOffset{ -5, 5 };
-
     struct LightningPoint
     {
         explicit LightningPoint( const fheroes2::Point & p = fheroes2::Point(), const int32_t thick = 1 )
@@ -6773,32 +6771,24 @@ void Battle::PopupDamageInfo::_makeDamageImage()
 
     const fheroes2::Rect & unitRect = _defender->GetRectPosition();
 
-    const int32_t shadowOffsetX = std::abs( damageImageShadowOffset.x );
-    const int32_t shadowOffsetY = std::abs( damageImageShadowOffset.y );
     // Get the border width and set the popup parameters.
     const int32_t borderWidth = BorderWidth();
     const int32_t x = _battleUIRect.x + unitRect.x + unitRect.width;
     const int32_t y = _battleUIRect.y + unitRect.y;
-    const int32_t w = std::max( damageText.width(), killedText.width() ) + 2 * borderWidth + shadowOffsetX;
-    const int32_t h = damageText.height() + killedText.height() + 2 * borderWidth + shadowOffsetY;
+    const int32_t w = std::max( damageText.width(), killedText.width() ) + 2 * borderWidth;
+    const int32_t h = damageText.height() + killedText.height() + 2 * borderWidth;
 
     // If the damage info popup doesn't fit the battlefield draw surface, then try to place it on the left side of the cell
     const bool isLeftSidePopup = ( unitRect.x + unitRect.width + w ) > _battleUIRect.width;
     const fheroes2::Rect borderRect( isLeftSidePopup ? ( x - w - unitRect.width - borderWidth ) : x, y, w, h );
-    _damageImage.resize( borderRect.width, borderRect.height );
-    _damageImage.reset();
 
-    const fheroes2::Sprite & backgroundIcn = fheroes2::AGG::GetICN( ICN::CELLWIN, 1 );
-    fheroes2::Image backgroundImage
-        = fheroes2::Stretch( backgroundIcn, 0, 0, backgroundIcn.width(), backgroundIcn.height(), borderRect.width - shadowOffsetX, borderRect.height - shadowOffsetY );
-    damageText.draw( borderWidth, borderWidth + 2, backgroundImage );
-    killedText.draw( borderWidth, ( borderRect.height - shadowOffsetY ) / 2 + 2, backgroundImage );
-
-    fheroes2::Copy( backgroundImage, 0, 0, _damageImage, shadowOffsetX, 0, borderRect.width - shadowOffsetX, borderRect.height - shadowOffsetY );
-
+    const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( ICN::CELLWIN, 1 );
+    _damageImage = fheroes2::Stretch( backgroundImage, 0, 0, backgroundImage.width(), backgroundImage.height(), borderRect.width, borderRect.height );
     _damageImage.setPosition( borderRect.x, borderRect.y );
+    _damageImage._disableTransformLayer();
 
-    fheroes2::addGradientShadow( backgroundImage, _damageImage, { shadowOffsetX, 0 }, damageImageShadowOffset );
+    damageText.draw( borderWidth, borderWidth + 2, _damageImage );
+    killedText.draw( borderWidth, borderRect.height / 2 + 2, _damageImage );
 }
 
 void Battle::PopupDamageInfo::redraw() const
@@ -6809,5 +6799,6 @@ void Battle::PopupDamageInfo::redraw() const
 
     assert( !_damageImage.empty() );
 
-    fheroes2::Blit( _damageImage, 0, 0, fheroes2::Display::instance(), _damageImage.x(), _damageImage.y(), _damageImage.width(), _damageImage.height() );
+    fheroes2::Copy( _damageImage, 0, 0, fheroes2::Display::instance(), _damageImage.x(), _damageImage.y(), _damageImage.width(), _damageImage.height() );
+    fheroes2::addShadowForRectangularDialog( fheroes2::Display::instance(), { _damageImage.x(), _damageImage.y() }, _damageImage.width(), _damageImage.height(), 5 );
 }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6799,6 +6799,8 @@ void Battle::PopupDamageInfo::redraw() const
 
     assert( !_damageImage.empty() );
 
-    fheroes2::Copy( _damageImage, 0, 0, fheroes2::Display::instance(), _damageImage.x(), _damageImage.y(), _damageImage.width(), _damageImage.height() );
-    fheroes2::addShadowForRectangularDialog( fheroes2::Display::instance(), { _damageImage.x(), _damageImage.y() }, _damageImage.width(), _damageImage.height(), 5 );
+    fheroes2::Display & display = fheroes2::Display::instance();
+
+    fheroes2::Copy( _damageImage, 0, 0, display, _damageImage.x(), _damageImage.y(), _damageImage.width(), _damageImage.height() );
+    fheroes2::addGradientShadowForArea( display, { _damageImage.x(), _damageImage.y() }, _damageImage.width(), _damageImage.height(), 5 );
 }

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -345,7 +345,7 @@ namespace fheroes2
         CreateDitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, bottomBorderSpriteOffsetY, _output, optputRightCornerEdgeX, bottomCornerOffsetY,
                                    transitionSize, cornerSize, true, false );
 
-        fheroes2::addShadowForRectangularDialog( _output, { _windowArea.x, _windowArea.y }, _windowArea.width, _windowArea.height, borderSize );
+        fheroes2::addGradientShadowForArea( _output, { _windowArea.x, _windowArea.y }, _windowArea.width, _windowArea.height, borderSize );
     }
 
     void StandardWindow::applyTextBackgroundShading( const Rect & roi )

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -345,29 +345,7 @@ namespace fheroes2
         CreateDitheringTransition( horizontalSprite, horizontalSpriteRightCornerEdgeX, bottomBorderSpriteOffsetY, _output, optputRightCornerEdgeX, bottomCornerOffsetY,
                                    transitionSize, cornerSize, true, false );
 
-        // Render shadow at the left side of the window.
-        int32_t offsetY = _windowArea.y + borderSize;
-        ApplyTransform( _output, _totalArea.x, offsetY, borderSize, 1, 5 );
-        ++offsetY;
-        ApplyTransform( _output, _totalArea.x, offsetY, 1, _windowArea.height - 2, 5 );
-        ApplyTransform( _output, _totalArea.x + 1, offsetY, borderSize - 1, 1, 4 );
-        ++offsetY;
-        ApplyTransform( _output, _totalArea.x + 1, offsetY, 1, _windowArea.height - 4, 4 );
-        ApplyTransform( _output, _totalArea.x + 2, offsetY, borderSize - 2, 1, 3 );
-        ++offsetY;
-        ApplyTransform( _output, _totalArea.x + 2, offsetY, 1, _windowArea.height - 6, 3 );
-        ApplyTransform( _output, _totalArea.x + 3, offsetY, borderSize - 3, _windowArea.height - borderSize - 3, 2 );
-
-        // Render shadow at the bottom side of the window.
-        offsetY = _windowArea.y + _windowArea.height;
-        const int32_t shadowBottomEdge = _windowArea.y + _totalArea.height;
-        ApplyTransform( _output, _totalArea.x + 3, offsetY, _windowArea.width - 6, borderSize - 3, 2 );
-        ApplyTransform( _output, _totalArea.x + 2, shadowBottomEdge - 3, _windowArea.width - 4, 1, 3 );
-        ApplyTransform( _output, _totalArea.x + _windowArea.width - 3, offsetY, 1, borderSize - 3, 3 );
-        ApplyTransform( _output, _totalArea.x + 1, shadowBottomEdge - 2, _windowArea.width - 2, 1, 4 );
-        ApplyTransform( _output, _totalArea.x + _windowArea.width - 2, offsetY, 1, borderSize - 2, 4 );
-        ApplyTransform( _output, _totalArea.x, shadowBottomEdge - 1, _windowArea.width, 1, 5 );
-        ApplyTransform( _output, _totalArea.x + _windowArea.width - 1, offsetY, 1, borderSize - 1, 5 );
+        fheroes2::addShadowForRectangularDialog( _output, { _windowArea.x, _windowArea.y }, _windowArea.width, _windowArea.height, borderSize );
     }
 
     void StandardWindow::applyTextBackgroundShading( const Rect & roi )

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -318,7 +318,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
     // shadow
     if ( !isDefaultScreenSize ) {
-        fheroes2::addGradientShadow( backSprite, display, { dst_pt.x, dst_pt.y }, { -15, 15 }, false );
+        fheroes2::addShadowForRectangularDialog( display, dst_pt, backSprite.width(), backSprite.height(), 16 );
     }
 
     // header

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -316,6 +316,11 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     fheroes2::Point dst_pt( cur_pt );
     fheroes2::Blit( backSprite, src_rt.x, src_rt.y, display, dst_pt.x, dst_pt.y, src_rt.width, src_rt.height );
 
+    // shadow
+    if ( !isDefaultScreenSize ) {
+        fheroes2::addGradientShadow( backSprite, display, { dst_pt.x, dst_pt.y }, { -15, 15 } );
+    }
+
     // header
     std::string message( _( "%{name1} meets %{name2}" ) );
     StringReplace( message, "%{name1}", GetName() );

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -318,7 +318,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
     // shadow
     if ( !isDefaultScreenSize ) {
-        fheroes2::addGradientShadow( backSprite, display, { dst_pt.x, dst_pt.y }, { -15, 15 } );
+        fheroes2::addGradientShadow( backSprite, display, { dst_pt.x, dst_pt.y }, { -15, 15 }, false );
     }
 
     // header

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -318,7 +318,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
     // shadow
     if ( !isDefaultScreenSize ) {
-        fheroes2::addShadowForRectangularDialog( display, dst_pt, backSprite.width(), backSprite.height(), 16 );
+        fheroes2::addShadowForRectangularDialog( display, dst_pt, backSprite.width(), backSprite.height(), fheroes2::borderWidthPx );
     }
 
     // header

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -318,7 +318,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
 
     // shadow
     if ( !isDefaultScreenSize ) {
-        fheroes2::addShadowForRectangularDialog( display, dst_pt, backSprite.width(), backSprite.height(), fheroes2::borderWidthPx );
+        fheroes2::addGradientShadowForArea( display, dst_pt, backSprite.width(), backSprite.height(), fheroes2::borderWidthPx );
     }
 
     // header


### PR DESCRIPTION
Fixes: https://github.com/ihhub/fheroes2/issues/7106
Previous pr with duscussions: https://github.com/ihhub/fheroes2/pull/9654
I moved the shadow generation from `StandardWindow::render()` to new function - `addShadowForRectangularDialog()`.  `StandartWindow`, `Heroes::MeetingDialog` and `Battle::PopupDamageInfo` are using this function 