### PR TITLE
Add defense penalty to moat building info and adjust wording

### DIFF
--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -992,7 +992,7 @@ bool Battle::Board::CanAttackTargetFromPosition( const Unit & attacker, const Un
 
 std::string Battle::Board::GetMoatInfo()
 {
-    std::string msg = _( "The Moat reduces the defense skill of troops trapped in it by %{count} and restricts their movement range." );
+    std::string msg = _( "The Moat interrupts movement on foot and reduces the defense skill of troops standing in it by %{count}." );
     StringReplace( msg, "%{count}", GameStatic::GetBattleMoatReduceDefense() );
 
     return msg;

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -992,7 +992,7 @@ bool Battle::Board::CanAttackTargetFromPosition( const Unit & attacker, const Un
 
 std::string Battle::Board::GetMoatInfo()
 {
-    std::string msg = _( "The Moat interrupts movement on foot and reduces the defense skill of troops standing in it by %{count}." );
+    std::string msg = _( "The Moat interrupts any movement through it and reduces the defense skill of troops present in it by %{count}." );
     StringReplace( msg, "%{count}", GameStatic::GetBattleMoatReduceDefense() );
 
     return msg;

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -34,6 +34,7 @@
 #include "castle_building_info.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_static.h"
 #include "icn.h"
 #include "localevent.h"
 #include "m82.h"
@@ -53,7 +54,6 @@
 #include "ui_constants.h"
 #include "ui_dialog.h"
 #include "ui_text.h"
-#include "game_static.h"
 
 namespace
 {

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -53,6 +53,7 @@
 #include "ui_constants.h"
 #include "ui_dialog.h"
 #include "ui_text.h"
+#include "game_static.h"
 
 namespace
 {
@@ -311,6 +312,9 @@ std::string BuildingInfo::getBuildingDescription( const int race, const uint32_t
             StringReplace( description, "%{count}", Castle::GetGrownWel2() );
             break;
         case BUILD_CASTLE:
+        case BUILD_MOAT:
+            StringReplace( description, "%{count}", GameStatic::GetBattleMoatReduceDefense() );
+            break;
         case BUILD_STATUE:
         case BUILD_SPEC: {
             const Funds profit = ProfitConditions::FromBuilding( buildingId, race );

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -311,10 +311,10 @@ std::string BuildingInfo::getBuildingDescription( const int race, const uint32_t
         case BUILD_WEL2:
             StringReplace( description, "%{count}", Castle::GetGrownWel2() );
             break;
-        case BUILD_CASTLE:
         case BUILD_MOAT:
             StringReplace( description, "%{count}", GameStatic::GetBattleMoatReduceDefense() );
             break;
+        case BUILD_CASTLE:
         case BUILD_STATUE:
         case BUILD_SPEC: {
             const Funds profit = ProfitConditions::FromBuilding( buildingId, race );

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2515,6 +2515,9 @@ std::string Castle::GetDescriptionBuilding( const uint32_t buildingType ) const
         }
         break;
     }
+    case BUILD_MOAT:
+        StringReplace( res, "%{count}", GameStatic::GetBattleMoatReduceDefense() );
+        break;
 
     case BUILD_SPEC:
     case BUILD_STATUE: {

--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2024                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -931,7 +931,7 @@ namespace fheroes2
         case BUILD_MARKETPLACE:
             return _( "The Marketplace can be used to convert one type of resource into another. The more marketplaces you control, the better the exchange rate." );
         case BUILD_MOAT:
-            return _( "The Moat slows and weakens attacking units. Any walking unit entering the moat must end its turn there and can only move within the moat one hex at a time. Any creature present in the the moat will have its defense skill reduced by 3." );
+            return _( "The Moat slows and weakens attacking units. Any walking unit entering the moat must end its turn there and can only move within the moat one hex at a time. Any creature present in the moat will have its defense skill reduced by %{count}." );
         case BUILD_CASTLE:
             return _( "The Castle improves the town's defense and increases its income to %{count} gold per day." );
         case BUILD_TENT:

--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -931,7 +931,7 @@ namespace fheroes2
         case BUILD_MARKETPLACE:
             return _( "The Marketplace can be used to convert one type of resource into another. The more marketplaces you control, the better the exchange rate." );
         case BUILD_MOAT:
-            return _( "The Moat slows attacking units. Any unit entering the moat must end its turn there and becomes more vulnerable to attack." );
+            return _( "The Moat slows and weakens attacking units. Any unit taking a step in the moat must end its turn there and becomes more vulnerable to attack (defense skill reduced by 3)." );
         case BUILD_CASTLE:
             return _( "The Castle improves the town's defense and increases its income to %{count} gold per day." );
         case BUILD_TENT:

--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -931,7 +931,7 @@ namespace fheroes2
         case BUILD_MARKETPLACE:
             return _( "The Marketplace can be used to convert one type of resource into another. The more marketplaces you control, the better the exchange rate." );
         case BUILD_MOAT:
-            return _( "The Moat slows and weakens attacking units. Any unit taking a step in the moat must end its turn there and becomes more vulnerable to attack (defense skill reduced by 3)." );
+            return _( "The Moat slows and weakens attacking units. Any walking unit entering the moat must end its turn there and can only move within the moat one hex at a time. Any creature present in the the moat will have its defense skill reduced by 3." );
         case BUILD_CASTLE:
             return _( "The Castle improves the town's defense and increases its income to %{count} gold per day." );
         case BUILD_TENT:

--- a/src/fheroes2/castle/castle_building_info.cpp
+++ b/src/fheroes2/castle/castle_building_info.cpp
@@ -931,7 +931,9 @@ namespace fheroes2
         case BUILD_MARKETPLACE:
             return _( "The Marketplace can be used to convert one type of resource into another. The more marketplaces you control, the better the exchange rate." );
         case BUILD_MOAT:
-            return _( "The Moat slows and weakens attacking units. Any walking unit entering the moat must end its turn there and can only move within the moat one hex at a time. Any creature present in the moat will have its defense skill reduced by %{count}." );
+            return _( "The Moat slows and weakens attacking units. "
+                      "Any walking unit entering the moat must end its turn there and can only move within the moat one hex at a time. "
+                      "Any creature present in the moat will have its defense skill reduced by %{count}." );
         case BUILD_CASTLE:
             return _( "The Castle improves the town's defense and increases its income to %{count} gold per day." );
         case BUILD_TENT:


### PR DESCRIPTION
Fixes #8808.

I also slightly adjusted the wording to more clearly indicate that:
* Flying units aren't affected by the moat's movement penalty, but do still suffer the defense penalty if they land in it.
* The moat ends a unit's turn on *any* movement in it, not just entering.