### PR TITLE
List item selection moves along with navigation keys

### DIFF
--- a/src/fheroes2/gui/interface_list.h
+++ b/src/fheroes2/gui/interface_list.h
@@ -340,31 +340,51 @@ namespace Interface
                 return false;
             }
 
-            if ( useHotkeys && le.isKeyPressed( fheroes2::Key::KEY_PAGE_UP ) && ( _topId > 0 ) ) {
-                needRedraw = true;
+            if ( useHotkeys && le.isKeyPressed( fheroes2::Key::KEY_PAGE_UP ) ) {
+                SetCurrentVisible();
+                if ( _topId > 0 ) {
+                    needRedraw = true;
 
-                if ( _topId > maxItems ) {
-                    _topId -= maxItems;
-                }
-                else {
-                    _topId = 0;
-                }
+                    const int prevTop = _topId;
+                    if ( _topId > maxItems ) {
+                        _topId -= maxItems;
+                    }
+                    else {
+                        _topId = 0;
+                    }
 
-                UpdateScrollbarRange();
-                _scrollbar.moveToIndex( _topId );
+                    UpdateScrollbarRange();
+                    _scrollbar.moveToIndex( _topId );
+                    _currentId = std::clamp( _currentId - ( prevTop - _topId ), _topId, _lastVisibleId() );
+                }
+                // The view is at the top of the list, but selection isn't
+                else if ( _currentId != 0 ) {
+                    _currentId = 0;
+                    needRedraw = true;
+                }
 
                 return true;
             }
-            if ( useHotkeys && le.isKeyPressed( fheroes2::Key::KEY_PAGE_DOWN ) && ( _topId + maxItems < _size() ) ) {
-                needRedraw = true;
+            if ( useHotkeys && le.isKeyPressed( fheroes2::Key::KEY_PAGE_DOWN ) ) {
+                SetCurrentVisible();
+                if ( _topId + maxItems < _size() ) {
+                    needRedraw = true;
 
-                _topId += maxItems;
-                if ( _topId + maxItems >= _size() ) {
-                    _topId = _size() - maxItems;
+                    const int prevTop = _topId;
+                    _topId += maxItems;
+                    if ( _topId + maxItems >= _size() ) {
+                        _topId = _size() - maxItems;
+                    }
+
+                    UpdateScrollbarRange();
+                    _scrollbar.moveToIndex( _topId );
+                    _currentId = std::clamp( _currentId + ( _topId - prevTop ), _topId, _lastVisibleId() );
                 }
-
-                UpdateScrollbarRange();
-                _scrollbar.moveToIndex( _topId );
+                // The view is at the bottom of the list, but the selection isn't
+                else if ( _currentId < _size() - 1 ) {
+                    _currentId = _size() - 1;
+                    needRedraw = true;
+                }
 
                 return true;
             }
@@ -386,20 +406,22 @@ namespace Interface
 
                 return true;
             }
-            if ( useHotkeys && le.isKeyPressed( fheroes2::Key::KEY_HOME ) && ( _topId > 0 ) ) {
+            if ( useHotkeys && le.isKeyPressed( fheroes2::Key::KEY_HOME ) && ( _topId > 0 || _currentId > 0 ) ) {
                 needRedraw = true;
 
                 _topId = 0;
+                _currentId = _topId;
 
                 UpdateScrollbarRange();
                 _scrollbar.moveToIndex( _topId );
 
                 return true;
             }
-            if ( useHotkeys && le.isKeyPressed( fheroes2::Key::KEY_END ) && ( _topId + maxItems < _size() ) ) {
+            if ( useHotkeys && le.isKeyPressed( fheroes2::Key::KEY_END ) && ( _topId + maxItems < _size() || _currentId < _lastVisibleId() ) ) {
                 needRedraw = true;
 
-                _topId = _size() - maxItems;
+                _topId = std::max( 0, _size() - maxItems );
+                _currentId = _size() - 1;
 
                 UpdateScrollbarRange();
                 _scrollbar.moveToIndex( _topId );
@@ -555,6 +577,11 @@ namespace Interface
 
         fheroes2::TimedEventValidator _timedButtonPgUp;
         fheroes2::TimedEventValidator _timedButtonPgDn;
+
+        int _lastVisibleId() const
+        {
+            return std::min( _topId + maxItems, _size() ) - 1;
+        }
 
         void Verify()
         {


### PR DESCRIPTION
Lists (save/load etc.) can be scrolled with arrow keys or navigation keys (page up/down, home, end), but the selection doesn't move with the latter, making them useless without additional mouse input and in conflict with arrows keys (list position jumps back to selection on arrow presses). This PR resolves that conflict by moving selection along with navigation keys, making all navigation keys useful and working together.