### PR TITLE
Fix close of the caller dialg when closing the Virtual keyboard dialog by a hotkey

### DIFF
--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -790,6 +790,8 @@ namespace
             okayButton.drawOnState( le.isMouseLeftButtonPressedInArea( okayButton.area() ) );
 
             if ( le.MouseClickLeft( okayButton.area() ) || Game::HotKeyCloseWindow() ) {
+                // Reset all event states including the hotkey pressed state so the caller dialog will not process it right after closing this dialog.
+                le.reset();
                 break;
             }
 


### PR DESCRIPTION
This PR fixes the issue posted by @oleg-derevenetz in https://github.com/ihhub/fheroes2/issues/9672#issuecomment-2755582485