### PR TITLE
Allow to close a dialog with a single OK or CANCEL button in a button group by OK and CANCEL hotkeys

### DIFF
--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -676,7 +676,7 @@ namespace fheroes2
         }
 
         if ( ( buttonsCount == 1 ) && ( _value[0] == Dialog::OK || _value[0] == Dialog::CANCEL ) && Game::HotKeyCloseWindow() ) {
-            // This dialog has only one OK or CANCEL button so allow to close it by any hokey for these buttons.
+            // This dialog has only one OK or CANCEL button so allow to close it by any hotkey for these buttons.
             // Reset the hotkey pressed state.
             le.reset();
             return _value[0];

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -677,15 +677,21 @@ namespace fheroes2
 
         if ( ( buttonsCount == 1 ) && ( _value[0] == Dialog::OK || _value[0] == Dialog::CANCEL ) && Game::HotKeyCloseWindow() ) {
             // This dialog has only one OK or CANCEL button so allow to close it by any hokey for these buttons.
+            // Reset the hotkey pressed state.
+            le.reset();
             return _value[0];
         }
 
         for ( size_t i = 0; i < buttonsCount; ++i ) {
             if ( _button[i]->isEnabled() ) {
                 if ( ( _value[i] == Dialog::YES || _value[i] == Dialog::OK ) && Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) ) {
+                    // Reset the hotkey pressed state.
+                    le.reset();
                     return _value[i];
                 }
                 if ( ( _value[i] == Dialog::CANCEL || _value[i] == Dialog::NO ) && Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
+                    // Reset the hotkey pressed state.
+                    le.reset();
                     return _value[i];
                 }
             }

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -665,13 +665,22 @@ namespace fheroes2
             }
         }
 
-        for ( size_t i = 0; i < _button.size(); ++i ) {
+        const size_t buttonsCount = _button.size();
+
+        assert( buttonsCount == _value.size() );
+
+        for ( size_t i = 0; i < buttonsCount; ++i ) {
             if ( _button[i]->isEnabled() && le.MouseClickLeft( _button[i]->area() ) ) {
                 return _value[i];
             }
         }
 
-        for ( size_t i = 0; i < _button.size(); ++i ) {
+        if ( ( buttonsCount == 1 ) && ( _value[0] == Dialog::OK || _value[0] == Dialog::CANCEL ) && Game::HotKeyCloseWindow() ) {
+            // This dialog has only one OK or CANCEL button so allow to close it by any hokey for these buttons.
+            return _value[0];
+        }
+
+        for ( size_t i = 0; i < buttonsCount; ++i ) {
             if ( _button[i]->isEnabled() ) {
                 if ( ( _value[i] == Dialog::YES || _value[i] == Dialog::OK ) && Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) ) {
                     return _value[i];


### PR DESCRIPTION
This PR allows to use CANCEL hotkey or OK hotkey to close the dialog that has the only one OK or CANCEL button in the `buttonGroup` to assist players interaction with such dialogs.

This PR also adds reset of hotkey pressed state after hotkey is processed to avoid possible processing of this hotkey in the caller dialog.