### PR TITLE
Fix gap between buttons in symmetric button dialog

### DIFF
--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -148,7 +148,7 @@ namespace fheroes2
         // This assumes that the extra height always gets added above the buttons.
         buttonsOffset.y += extraHeight;
 
-        const int32_t verticalGapOffset = ( columns > 1 ) ? buttonsVerticalGap : 2 * buttonsVerticalGap;
+        const int32_t verticalGapOffset = isSingleColumn ? buttonsVerticalGap : 2 * buttonsVerticalGap;
 
         size_t buttonId = 0;
         for ( int32_t row = 0; row < rows; ++row ) {


### PR DESCRIPTION
A small mistake made in #9597.

With this PR:
![image](https://github.com/user-attachments/assets/e8fef299-ec5e-45d7-8d40-2dcae6f51ef3)
