### PR TITLE
CodeChecker: use the new recently introduced config format

### DIFF
--- a/.codechecker-ignore
+++ b/.codechecker-ignore
@@ -1,4 +1,0 @@
-# LLVM header
-# cetintrin.h:49:10: 1st function call argument is an uninitialized value [core.CallAndMessage]
-#   return __builtin_ia32_rdsspd(t);
--/usr/lib/llvm-18/lib/clang/18/include/cetintrin.h

--- a/.codechecker-review-status-config
+++ b/.codechecker-review-status-config
@@ -1,0 +1,13 @@
+$version: 1
+
+rules:
+- filters:
+    report_hash: a95dbc87e7d4eb8c0bbf73c1ce08c6bb
+  actions:
+    review_status: false_positive
+    reason: "cetintrin.h:49:10: 1st function call argument is an uninitialized value"
+- filters:
+    report_hash: 076fdab99b1790475cd59e47054be43f
+  actions:
+    review_status: false_positive
+    reason: "cetintrin.h:62:10: 1st function call argument is an uninitialized value"

--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -27,8 +27,9 @@ jobs:
     - name: Analyze
       run: |
         export PATH=$HOME/.python-venv/bin:$PATH
-        CodeChecker analyze --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output --ignore .codechecker-ignore build/compile_commands.json
+        CodeChecker analyze --analyzers clangsa --ctu-all --ctu-ast-mode load-from-pch --output codechecker-output \
+                            --review-status-config .codechecker-review-status-config build/compile_commands.json
     - name: Display results
       run: |
         export PATH=$HOME/.python-venv/bin:$PATH
-        CodeChecker parse --print-steps --ignore .codechecker-ignore codechecker-output
+        CodeChecker parse --print-steps codechecker-output


### PR DESCRIPTION
See https://github.com/Ericsson/codechecker/blob/master/docs/analyzer/user_guide.md#setting-with-config-file for the config file syntax details.

The idea here is to mark as false positive hashes that correspond to the specific issues instead of ignoring the entire file (although, of course, we still can ignore the entire file if necessary). In any case, it will increase flexibility.