### PR TITLE
Android: set the application category to "game"

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,6 +30,7 @@
 
     <application
         android:allowBackup="true"
+        android:appCategory="game"
         android:dataExtractionRules="@xml/data_extraction_rules"
         android:fullBackupContent="@xml/full_backup_content"
         android:hardwareAccelerated="true"


### PR DESCRIPTION
Android 16 introduces feature "adaptive layouts" that will [ignore](https://developer.android.com/about/versions/16/behavior-changes-16?hl=en#adaptive-layouts) the orientation, resizability, and aspect ratio restrictions when app is running on screens with certain size, unless the app is a game. fheroes2 is not targeting the Android 16 yet, but it eventually will, so care should be taken to set the correct application category in advance.