### PR TITLE
Improve the input of numbers from the hardware keyboard

### DIFF
--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -443,6 +443,15 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
         }
     };
 
+    std::string typedValueBuf;
+
+    // Sets the result to the specified value and resets the typed value buffer so that the result value is overwritten on subsequent keystrokes.
+    const auto resetResult = [&result, &typedValueBuf]( const uint32_t value ) {
+        result = value;
+
+        typedValueBuf.clear();
+    };
+
     while ( le.HandleEvents() ) {
         bool redraw = false;
 
@@ -534,9 +543,9 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
                 buttonMin.enable();
             }
 
-            result = max;
             paymentMonster = monster.GetCost();
 
+            resetResult( max );
             updateCurrentInfo();
             RedrawMonsterInfo( windowActiveArea, monster, available, true );
 
@@ -559,8 +568,8 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
             continue;
         }
 
-        if ( int32_t temp = static_cast<int32_t>( result ); fheroes2::processIntegerValueTyping( 0, static_cast<int32_t>( max ), temp ) ) {
-            result = temp;
+        if ( const auto value = fheroes2::processIntegerValueTyping( 0, static_cast<int32_t>( max ), typedValueBuf ); value ) {
+            result = *value;
 
             updateCurrentInfo();
 
@@ -573,8 +582,7 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
             fheroes2::openVirtualNumpad( temp, 0, static_cast<int32_t>( max ) );
             assert( temp >= 0 && temp <= static_cast<int32_t>( max ) );
 
-            result = temp;
-
+            resetResult( temp );
             updateCurrentInfo();
 
             redraw = true;
@@ -582,31 +590,27 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
         else if ( ( le.isMouseWheelUpInArea( rtWheel ) || le.MouseClickLeft( buttonUp.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_UP )
                     || timedButtonUp.isDelayPassed() )
                   && result < max ) {
-            ++result;
-
+            resetResult( result + 1 );
             updateCurrentInfo();
 
             redraw = true;
         }
         else if ( ( le.isMouseWheelDownInArea( rtWheel ) || le.MouseClickLeft( buttonDn.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_DOWN )
                     || timedButtonDn.isDelayPassed() )
-                  && result ) {
-            --result;
-
+                  && result > 0 ) {
+            resetResult( result - 1 );
             updateCurrentInfo();
 
             redraw = true;
         }
         else if ( buttonMax.isEnabled() && le.MouseClickLeft( buttonMax.area() ) && result != max ) {
-            result = max;
-
+            resetResult( max );
             updateCurrentInfo();
 
             redraw = true;
         }
         else if ( buttonMin.isEnabled() && le.MouseClickLeft( buttonMin.area() ) && result != 1 ) {
-            result = 1;
-
+            resetResult( 1 );
             updateCurrentInfo();
 
             redraw = true;

--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -575,8 +575,7 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
 
             redraw = true;
         }
-
-        if ( le.MouseClickLeft( recruitCountInputArea ) ) {
+        else if ( le.MouseClickLeft( recruitCountInputArea ) ) {
             int32_t temp = static_cast<int32_t>( result );
 
             fheroes2::openVirtualNumpad( temp, 0, static_cast<int32_t>( max ) );

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -127,6 +127,7 @@ bool Dialog::SelectCount( std::string header, const int32_t min, const int32_t m
     const fheroes2::Rect uiRect = uiElement ? fheroes2::Rect{ uiOffset, uiElement->area() } : fheroes2::Rect{};
 
     int result = Dialog::ZERO;
+    std::string typedValueBuf;
     LocalEvent & le = LocalEvent::Get();
 
     while ( result == Dialog::ZERO && le.HandleEvents() ) {
@@ -140,22 +141,26 @@ bool Dialog::SelectCount( std::string header, const int32_t min, const int32_t m
             buttonMin.drawOnState( le.isMouseLeftButtonPressedInArea( buttonMin.area() ) );
         }
 
-        if ( fheroes2::processIntegerValueTyping( min, max, selectedValue ) ) {
-            valueSelectionElement.setValue( selectedValue );
+        if ( const auto value = fheroes2::processIntegerValueTyping( min, max, typedValueBuf ); value ) {
+            valueSelectionElement.setValue( *value );
 
             needRedraw = true;
         }
         else if ( buttonMax.isVisible() && le.MouseClickLeft( buttonMax.area() ) ) {
             valueSelectionElement.setValue( max );
+            typedValueBuf.clear();
 
             needRedraw = true;
         }
         else if ( buttonMin.isVisible() && le.MouseClickLeft( buttonMin.area() ) ) {
             valueSelectionElement.setValue( min );
+            typedValueBuf.clear();
 
             needRedraw = true;
         }
         else if ( valueSelectionElement.processEvents() ) {
+            typedValueBuf.clear();
+
             needRedraw = true;
         }
         else if ( uiElement && ( le.isMouseLeftButtonReleasedInArea( uiRect ) || le.isMouseRightButtonPressedInArea( uiRect ) ) ) {
@@ -484,6 +489,7 @@ int Dialog::ArmySplitTroop( const int32_t freeSlots, const int32_t redistributeM
     display.render();
 
     int btnResult = Dialog::ZERO;
+    std::string typedValueBuf;
     LocalEvent & le = LocalEvent::Get();
 
     while ( btnResult == Dialog::ZERO && le.HandleEvents() ) {
@@ -497,22 +503,26 @@ int Dialog::ArmySplitTroop( const int32_t freeSlots, const int32_t redistributeM
             buttonMin.drawOnState( le.isMouseLeftButtonPressedInArea( buttonMin.area() ) );
         }
 
-        if ( fheroes2::processIntegerValueTyping( redistributeMin, redistributeMax, redistributeCount ) ) {
-            valueSelectionElement.setValue( redistributeCount );
+        if ( const auto value = fheroes2::processIntegerValueTyping( redistributeMin, redistributeMax, typedValueBuf ); value ) {
+            valueSelectionElement.setValue( *value );
 
             needRedraw = true;
         }
         else if ( buttonMax.isVisible() && le.MouseClickLeft( buttonMax.area() ) ) {
             valueSelectionElement.setValue( redistributeMax );
+            typedValueBuf.clear();
 
             needRedraw = true;
         }
         else if ( buttonMin.isVisible() && le.MouseClickLeft( buttonMin.area() ) ) {
             valueSelectionElement.setValue( redistributeMin );
+            typedValueBuf.clear();
 
             needRedraw = true;
         }
         else if ( valueSelectionElement.processEvents() ) {
+            typedValueBuf.clear();
+
             needRedraw = true;
         }
         else {

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -23,12 +23,13 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <charconv>
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
 #include <ctime>
+#include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 
 #include "agg_image.h"

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -835,7 +835,7 @@ namespace fheroes2
                 return {};
             }
 
-            valueBuf.insert( 0, 1, '-' );
+            valueBuf = "-";
 
             return zeroBufValue;
         }

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -226,7 +226,10 @@ namespace fheroes2
 
     void InvertedShadow( Image & image, const Rect & roi, const Rect & excludedRoi, const uint8_t paletteId, const int32_t paletteCount );
 
-    bool processIntegerValueTyping( const int32_t minimum, const int32_t maximum, int32_t & value );
+    // Updates `valueBuf` based on keyboard input relevant to modifying an integer. Returns a non-empty `std::optional` instance containing the entered
+    // value if this value can be interpreted as modified, otherwise returns an empty instance. If a non-empty instance was returned, then its value is
+    // always valid (falls within the range [min, max]). See the implementation for details.
+    std::optional<int32_t> processIntegerValueTyping( const int32_t min, const int32_t max, std::string & valueBuf );
 
     // Render "hero on a horse" portrait dependent from hero race. Used in Editor.
     void renderHeroRacePortrait( const int race, const fheroes2::Rect & portPos, fheroes2::Image & output );

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -26,6 +26,8 @@
 #include <deque>
 #include <functional>
 #include <memory>
+#include <optional>
+#include <string>
 #include <string_view>
 #include <vector>
 

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -228,9 +228,8 @@ namespace fheroes2
 
     void InvertedShadow( Image & image, const Rect & roi, const Rect & excludedRoi, const uint8_t paletteId, const int32_t paletteCount );
 
-    // Updates `valueBuf` based on keyboard input relevant to modifying an integer. Returns a non-empty `std::optional` instance containing the entered
-    // value if this value can be interpreted as modified, otherwise returns an empty instance. If a non-empty instance was returned, then its value is
-    // always valid (falls within the range [min, max]). See the implementation for details.
+    // Updates `valueBuf` based on keyboard input relevant to modifying an integer. Returns a non-empty `std::optional` instance containing the entered value
+    // if this value has been both changed and is within the range [min, max], otherwise returns an empty instance. See the implementation for details.
     std::optional<int32_t> processIntegerValueTyping( const int32_t min, const int32_t max, std::string & valueBuf );
 
     // Render "hero on a horse" portrait dependent from hero race. Used in Editor.

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -229,7 +229,7 @@ namespace fheroes2
     void InvertedShadow( Image & image, const Rect & roi, const Rect & excludedRoi, const uint8_t paletteId, const int32_t paletteCount );
 
     // Updates `valueBuf` based on keyboard input relevant to modifying an integer. Returns a non-empty `std::optional` instance containing the entered value
-    // if this value has been both changed and is within the range [min, max], otherwise returns an empty instance. See the implementation for details.
+    // if this value has been both changed and is within the range [`min`, `max`], otherwise returns an empty instance. See the implementation for details.
     std::optional<int32_t> processIntegerValueTyping( const int32_t min, const int32_t max, std::string & valueBuf );
 
     // Render "hero on a horse" portrait dependent from hero race. Used in Editor.


### PR DESCRIPTION
close #1631
related to #9672

Key changes compared to `master` branch:

1. The value starts to be entered from scratch when the corresponding dialog window is opened or when value has been changed not using keyboard events.
2. The Backspace and Delete keys both clear the input buffer completely (the value starts to be entered from scratch - exactly as in paragraph 1). This makes the behavior more sane in a number of scenarios (especially when the range of acceptable values does not include zero).
3. The minus sign can only be entered at the beginning of the number input. The corresponding key is ignored when the number is already partially entered from the keyboard. This makes the behavior more sane when the range of acceptable negative values does not match the range of acceptable positive values.
4. The input visually stops completely if the entered value does not fall within the valid range. For instance, if the range is `[0, 99]` (with the initial value `0`), and we press keys `1`, `0`, `0`, then the entered value will be as follows: `1`->`10`->`10` (not `99`). However, if the range is `[20, 1000]` (with the initial value `20`), and we press the same keys `1`, `0`, `0`, then the entered value will be as follows: `20`->`20`->`100`. In other words, you can now enter any valid value if you just type it completely on the keyboard. In the `master` branch, in certain cases, it is just impossible to enter a perfectly valid value using only the keyboard.

Still no perfect WYSIWYG, but IMHO it's much better than what we currently have in `master`.