### PR TITLE
Fix status bar offset to prevent text from overlapping status bar bottom border

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -316,7 +316,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
     StatusBar statusBar;
     // Status bar must be smaller due to extra art on both sides.
-    statusBar.setRoi( { statusBarPosition.x + 16, statusBarPosition.y + 3, bar.width() - 16 * 2, 0 } );
+    statusBar.setRoi( { statusBarPosition.x + 16, statusBarPosition.y, bar.width() - 16 * 2, 0 } );
 
     // Next castle button.
     fheroes2::Button buttonNextCastle( statusBarPosition.x + bar.width(), statusBarPosition.y, ICN::SMALLBAR, 3, 4 );

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -463,7 +463,7 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
 
     StatusBar statusBar;
     // Status bar must be smaller due to extra art on both sides.
-    statusBar.setRoi( { dst_pt.x + 16, dst_pt.y + 3, statusBarWidth - 16 * 2, 0 } );
+    statusBar.setRoi( { dst_pt.x + 16, dst_pt.y, statusBarWidth - 16 * 2, 0 } );
 
     // button next castle
     fheroes2::Button buttonNextCastle( dst_pt.x + statusBarWidth, dst_pt.y, ICN::SMALLBAR, 3, 4 );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -385,8 +385,9 @@ void Castle::_wellRedrawBackground( fheroes2::Image & background ) const
     // The original assets Well background has a transparent line to the right of EXIT button and it is not covered by any other image. Fill it with the black color.
     fheroes2::Fill( background, background.width() - 1, bottomBarOffsetY, 1, bottomBar.height(), static_cast<uint8_t>( 0 ) );
 
+    const fheroes2::Rect textRoi{ 0, bottomBarOffsetY, backgroundWidth, bottomBar.height() - 1 };
     fheroes2::Text text( _( "Town Population Information and Statistics" ), fheroes2::FontType::normalWhite() );
-    text.draw( 315 - text.width() / 2, bottomBarOffsetY + 3, background );
+    text.drawInRoi( 315 - text.width() / 2, bottomBarOffsetY + 2, background, textRoi );
 
     const fheroes2::FontType statsFontType = fheroes2::FontType::smallWhite();
 

--- a/src/fheroes2/editor/editor_castle_details_window.cpp
+++ b/src/fheroes2/editor/editor_castle_details_window.cpp
@@ -459,7 +459,7 @@ namespace Editor
         dstPt.y = dialogRoi.y + dialogRoi.height - statusBarheight;
         fheroes2::Copy( statusBarSprite, 0, 0, display, dialogRoi.x, dstPt.y, statusBarWidth, statusBarheight );
         StatusBar statusBar;
-        statusBar.setRoi( { dialogRoi.x, dstPt.y + 3, statusBarWidth, 0 } );
+        statusBar.setRoi( { dialogRoi.x, dstPt.y, statusBarWidth, 0 } );
 
         display.render( dialogWithShadowRoi );
 

--- a/src/fheroes2/gui/statusbar.cpp
+++ b/src/fheroes2/gui/statusbar.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/statusbar.cpp
+++ b/src/fheroes2/gui/statusbar.cpp
@@ -58,7 +58,7 @@ void StatusBar::ShowMessage( std::string msg )
     update( std::move( text ) );
 
     // Draw text aligned and cutoff with the ROI, accounting for the +3 ROI offset
-    drawRoi( messageRoi.x, messageRoi.y + 3, messageRoi );
+    drawInRoi( messageRoi.x, messageRoi.y + 3, messageRoi );
 
     fheroes2::Display::instance().render( fheroes2::getBoundaryRect( _prevMessageRoi, messageRoi ) );
     _prevMessageRoi = messageRoi;

--- a/src/fheroes2/gui/statusbar.cpp
+++ b/src/fheroes2/gui/statusbar.cpp
@@ -49,16 +49,16 @@ void StatusBar::ShowMessage( std::string msg )
     // Create text with normal white font (with shadow)
     auto text = std::make_unique<fheroes2::Text>( std::move( msg ), fheroes2::FontType::normalWhite() );
 
-    // Calculate the inner area where text should be drawn
+    // Cut off the end of the text if it exceeds the given width
     text->fitToOneRow( _roi.width );
 
     const int32_t textWidth = text->width();
-    const fheroes2::Rect messageRoi{ _roi.x + ( _roi.width - textWidth ) / 2, _roi.y, textWidth, text->height() };
+    const fheroes2::Rect messageRoi{ _roi.x + ( _roi.width - textWidth ) / 2, _roi.y + 1, textWidth, text->height() };
 
     update( std::move( text ) );
 
     // Draw text aligned and cutoff with the ROI, accounting for the +3 ROI offset
-    drawInRoi( messageRoi.x, messageRoi.y + 3, messageRoi );
+    drawInRoi( messageRoi.x, messageRoi.y + 2, messageRoi );
 
     fheroes2::Display::instance().render( fheroes2::getBoundaryRect( _prevMessageRoi, messageRoi ) );
     _prevMessageRoi = messageRoi;

--- a/src/fheroes2/gui/statusbar.cpp
+++ b/src/fheroes2/gui/statusbar.cpp
@@ -46,7 +46,10 @@ void StatusBar::ShowMessage( std::string msg )
 
     _prevMessage = msg;
 
+    // Create text with normal white font (with shadow)
     auto text = std::make_unique<fheroes2::Text>( std::move( msg ), fheroes2::FontType::normalWhite() );
+
+    // Calculate the inner area where text should be drawn
     text->fitToOneRow( _roi.width );
 
     const int32_t textWidth = text->width();
@@ -54,7 +57,8 @@ void StatusBar::ShowMessage( std::string msg )
 
     update( std::move( text ) );
 
-    draw( messageRoi.x, messageRoi.y );
+    // Draw text aligned and cutoff with the ROI, accounting for the +3 ROI offset
+    drawRoi( messageRoi.x, messageRoi.y + 3, messageRoi );
 
     fheroes2::Display::instance().render( fheroes2::getBoundaryRect( _prevMessageRoi, messageRoi ) );
     _prevMessageRoi = messageRoi;

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -202,6 +202,16 @@ namespace fheroes2
         _isHidden = false;
     }
 
+    void MovableText::drawRoi( const int32_t x, const int32_t y, const Rect & roi )
+    {
+        hide();
+
+        _restorer.update( x, y, _text->width(), _text->height() );
+        _text->drawInRoi( x, y, _output, roi );
+
+        _isHidden = false;
+    }
+
     void MovableText::hide()
     {
         if ( !_isHidden ) {

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -202,7 +202,7 @@ namespace fheroes2
         _isHidden = false;
     }
 
-    void MovableText::drawRoi( const int32_t x, const int32_t y, const Rect & roi )
+    void MovableText::drawInRoi( const int32_t x, const int32_t y, const Rect & roi )
     {
         hide();
 

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -103,7 +103,7 @@ namespace fheroes2
         void draw( const int32_t x, const int32_t y );
 
         // Draw text within a specified ROI (Region of Interest) that acts as a bounding box
-        void drawRoi( const int32_t x, const int32_t y, const Rect & roi );
+        void drawInRoi( const int32_t x, const int32_t y, const Rect & roi );
 
         void hide();
 

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -102,6 +102,9 @@ namespace fheroes2
 
         void draw( const int32_t x, const int32_t y );
 
+        // Draw text within a specified ROI (Region of Interest) that acts as a bounding box
+        void drawRoi( const int32_t x, const int32_t y, const Rect & roi );
+
         void hide();
 
     private:

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -313,11 +313,11 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     dst_pt.x = dialogRoi.x + 22;
     dst_pt.y = dialogRoi.y + 460;
     const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::HSBTNS, 8 );
-    fheroes2::Copy( bar, 0, 0, display, dst_pt.x, dst_pt.y - 1, bar.width(), bar.height() );
+    fheroes2::Copy( bar, 0, 0, display, dst_pt.x, dst_pt.y, bar.width(), bar.height() );
 
     StatusBar statusBar;
     // Status bar must be smaller due to extra art on both sides.
-    statusBar.setRoi( { dst_pt.x + 16, dst_pt.y, bar.width() - 16 * 2, 0 } );
+    statusBar.setRoi( { dst_pt.x + 16, dst_pt.y + 1, bar.width() - 16 * 2, 0 } );
 
     // Artifacts bar.
     dst_pt.x = dialogRoi.x + 51;

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -317,7 +317,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
     StatusBar statusBar;
     // Status bar must be smaller due to extra art on both sides.
-    statusBar.setRoi( { dst_pt.x + 16, dst_pt.y + 3, bar.width() - 16 * 2, 0 } );
+    statusBar.setRoi( { dst_pt.x + 16, dst_pt.y, bar.width() - 16 * 2, 0 } );
 
     // Artifacts bar.
     dst_pt.x = dialogRoi.x + 51;

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -313,7 +313,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     dst_pt.x = dialogRoi.x + 22;
     dst_pt.y = dialogRoi.y + 460;
     const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::HSBTNS, 8 );
-    fheroes2::Copy( bar, 0, 0, display, dst_pt.x, dst_pt.y, bar.width(), bar.height() );
+    fheroes2::Copy( bar, 0, 0, display, dst_pt.x, dst_pt.y - 1, bar.width(), bar.height() );
 
     StatusBar statusBar;
     // Status bar must be smaller due to extra art on both sides.


### PR DESCRIPTION
# Fix Status Bar Text Alignment and Add ROI Text Drawing

This PR fixes text alignment issues with descenders in status bars across the game and adds a new ROI-based text drawing method to improve text rendering control. The issue was most noticeable with characters like `g, j, p, q, y`


Closes https://github.com/ihhub/fheroes2/issues/1745
Closes https://github.com/ihhub/fheroes2/issues/1675
Closes https://github.com/ihhub/fheroes2/issues/1728

> [!IMPORTANT]
> I'm new to C++ and this project. I'm sure there are test cases I'm missing. Please let me know and I'll work to improve! 

## Key Changes
- Fixed status bar text alignment by removing the +3 Y-offset in ROI definitions
- Added a new `drawRoi` method to `MovableText` class for region-based text rendering
- Updated status bar text rendering to use the new ROI-based drawing method
- Improved text positioning in castle dialogs and well information screen

## Technical Details
- Modified `StatusBar::setRoi` calls to remove the +3 Y-offset that was redundant
- Added `drawRoi` method to `MovableText` class to support drawing text within a specific region
- Updated `StatusBar::ShowMessage` to use the new `drawRoi` method with proper alignment
- Fixed text positioning in castle dialogs, well information screen, and editor castle details window

## Screenshots
<details><summary>Expand for sreenshots</summary>
<p>


<img width="990" alt="Screenshot_2025-04-05_at_9_51_17 PM" src="https://github.com/user-attachments/assets/b3d5058c-4d09-44cf-8e3a-eece1cca8ab7" />
<img width="983" alt="Screenshot_2025-04-05_at_9_51_01 PM" src="https://github.com/user-attachments/assets/008d32b8-bf2a-48a1-be4f-d77e607986d3" />
<img width="990" alt="Screenshot_2025-04-05_at_9_50_54 PM" src="https://github.com/user-attachments/assets/09a5c915-88c9-4ca1-be92-42262c411075" />
<img width="995" alt="Screenshot_2025-04-05_at_9_50_46 PM" src="https://github.com/user-attachments/assets/b8cfd5ca-5301-471c-b49e-749a313bf8d6" />
<img width="1000" alt="Screenshot_2025-04-05_at_9_50_06 PM" src="https://github.com/user-attachments/assets/e3c3fa5f-5ee3-4fd6-977a-acb1f2bbbc83" />


</p>
</details> 

## Testing
- [x] Verified status bar text alignment in all dialogs
- [x] Tested text rendering in castle dialogs
- [x] Checked text positioning in well information screen
- [x] Confirmed proper text alignment in editor castle details window
- [x] Confirmed castle edit screen in map editor
- [x] Confirmed hero detail screen

Todo (IDK what needs to be done here to verify the work)
- [ ] Test Android?
- [ ] Test other build targets?
- [ ] ???

## Impact
These changes improve text alignment consistency across the game's UI, particularly in status bars and information displays, resulting in a more polished user experience.