### PR TITLE
Fix clearing diacritic signs in movable text used in status bar

### DIFF
--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -387,7 +387,7 @@ void Castle::_wellRedrawBackground( fheroes2::Image & background ) const
 
     const fheroes2::Rect textRoi{ 0, bottomBarOffsetY, backgroundWidth, bottomBar.height() - 1 };
     fheroes2::Text text( _( "Town Population Information and Statistics" ), fheroes2::FontType::normalWhite() );
-    text.drawInRoi( 315 - text.width() / 2, bottomBarOffsetY + 2, background, textRoi );
+    text.drawInRoi( 315 - text.width() / 2, bottomBarOffsetY + 3, background, textRoi );
 
     const fheroes2::FontType statsFontType = fheroes2::FontType::smallWhite();
 

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -452,6 +452,10 @@ namespace fheroes2
 
     Rect Text::area() const
     {
+        if ( _text.empty() ) {
+            return {};
+        }
+
         const auto languageSwitcher = getLanguageSwitcher( *this );
         const fheroes2::FontCharHandler charHandler( _fontType );
 

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -831,19 +831,27 @@ namespace fheroes2
     Rect MultiFontText::area() const
     {
         Rect area;
-        bool isFirsText = true;
+        bool isFirstText = true;
 
         for ( const Text & text : _texts ) {
-            if ( isFirsText ) {
-                isFirsText = false;
+            if ( isFirstText ) {
+                isFirstText = false;
                 area = text.area();
                 continue;
             }
 
             const fheroes2::Rect & textArea = text.area();
 
-            area.height = std::max( area.height, textArea.y - area.y + textArea.height );
-            area.y = std::min( area.y, textArea.y );
+            if ( textArea.y < area.y ) {
+                // This character sprite is drawn higher than all previous - update `height` and `y`.
+                area.height += area.y - textArea.y;
+                area.y = textArea.y;
+                area.height = std::max( area.height, textArea.height );
+            }
+            else {
+                area.height = std::max( area.height, textArea.y - area.y + textArea.height );
+            }
+
             area.width += textArea.x + textArea.width;
         }
 

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -366,7 +366,7 @@ namespace fheroes2
     // TODO: Properly handle strings with many text lines ('\n'). Now their widths are counted as if they're one line.
     int32_t Text::width() const
     {
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         const fheroes2::FontCharHandler charHandler( _fontType );
 
         return getLineWidth( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), charHandler, _keepLineTrailingSpaces );
@@ -375,7 +375,7 @@ namespace fheroes2
     // TODO: Properly handle strings with many text lines ('\n'). Now their heights are counted as if they're one line.
     int32_t Text::height() const
     {
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         return getFontHeight( _fontType.size );
     }
 
@@ -385,7 +385,7 @@ namespace fheroes2
             return 0;
         }
 
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         const int32_t fontHeight = height();
 
         std::vector<TextLineInfo> lineInfos;
@@ -428,7 +428,7 @@ namespace fheroes2
             return 0;
         }
 
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         const int32_t fontHeight = height();
 
         std::vector<TextLineInfo> lineInfos;
@@ -443,7 +443,7 @@ namespace fheroes2
             return 0;
         }
 
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         std::vector<TextLineInfo> lineInfos;
         getTextLineInfos( lineInfos, maxWidth, height(), false );
 
@@ -452,7 +452,7 @@ namespace fheroes2
 
     Rect Text::area() const
     {
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         const fheroes2::FontCharHandler charHandler( _fontType );
 
         return getTextLineArea( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), charHandler );
@@ -465,7 +465,7 @@ namespace fheroes2
             return;
         }
 
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         const fheroes2::FontCharHandler charHandler( _fontType );
 
         renderSingleLine( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), x, y, output, imageRoi, charHandler );
@@ -483,7 +483,7 @@ namespace fheroes2
             return;
         }
 
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
 
         std::vector<TextLineInfo> lineInfos;
         getTextLineInfos( lineInfos, maxWidth, height(), false );
@@ -516,7 +516,7 @@ namespace fheroes2
             return;
         }
 
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         const fheroes2::FontCharHandler charHandler( _fontType );
 
         const int32_t originalTextWidth
@@ -540,7 +540,7 @@ namespace fheroes2
             return;
         }
 
-        const auto langugeSwitcher = getLanguageSwitcher( *this );
+        const auto languageSwitcher = getLanguageSwitcher( *this );
         const fheroes2::FontCharHandler charHandler( _fontType );
         const int32_t fullLineWidth = getLineWidth( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), charHandler, true );
         if ( fullLineWidth < maxWidth ) {
@@ -869,7 +869,7 @@ namespace fheroes2
 
         int32_t offsetX = x;
         for ( const Text & text : _texts ) {
-            const auto langugeSwitcher = getLanguageSwitcher( text );
+            const auto languageSwitcher = getLanguageSwitcher( text );
             const int32_t fontHeight = getFontHeight( text._fontType.size );
             const fheroes2::FontCharHandler charHandler( text._fontType );
 
@@ -914,7 +914,7 @@ namespace fheroes2
         auto infoIter = lineInfos.cbegin();
 
         for ( const Text & singleText : _texts ) {
-            const auto langugeSwitcher = getLanguageSwitcher( singleText );
+            const auto languageSwitcher = getLanguageSwitcher( singleText );
             const uint8_t * data = reinterpret_cast<const uint8_t *>( singleText._text.data() );
 
             const uint8_t * dataEnd = data + singleText._text.size();
@@ -953,7 +953,7 @@ namespace fheroes2
     {
         const size_t textsCount = _texts.size();
         for ( size_t i = 0; i < textsCount; ++i ) {
-            const auto langugeSwitcher = getLanguageSwitcher( _texts[i] );
+            const auto languageSwitcher = getLanguageSwitcher( _texts[i] );
 
             // To properly render a multi-font text we must not ignore spaces at the end of a text entry which is not the last one.
             const bool isNotLastTextEntry = ( i != textsCount - 1 );

--- a/src/fheroes2/gui/ui_text.h
+++ b/src/fheroes2/gui/ui_text.h
@@ -141,6 +141,9 @@ namespace fheroes2
         // Returns number of multi-line text rows limited by width of a line. It can be 0 if the text is empty.
         virtual int32_t rows( const int32_t maxWidth ) const = 0;
 
+        // Returns the text line ROI relative to the text line begin. It analyzes offset and size of all characters in the text.
+        virtual Rect area() const = 0;
+
         // Draw text as a single line text.
         void draw( const int32_t x, const int32_t y, Image & output ) const
         {
@@ -216,6 +219,8 @@ namespace fheroes2
         int32_t height( const int32_t maxWidth ) const override;
 
         int32_t rows( const int32_t maxWidth ) const override;
+
+        Rect area() const override;
 
         void drawInRoi( const int32_t x, const int32_t y, Image & output, const Rect & imageRoi ) const override;
         void drawInRoi( const int32_t x, const int32_t y, const int32_t maxWidth, Image & output, const Rect & imageRoi ) const override;
@@ -308,6 +313,8 @@ namespace fheroes2
         int32_t height( const int32_t maxWidth ) const override;
 
         int32_t rows( const int32_t maxWidth ) const override;
+
+        Rect area() const override;
 
         void drawInRoi( const int32_t x, const int32_t y, Image & output, const Rect & imageRoi ) const override;
         void drawInRoi( const int32_t x, const int32_t y, const int32_t maxWidth, Image & output, const Rect & imageRoi ) const override;

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -30,7 +30,6 @@
 #include <stdexcept>
 #include <string>
 #include <type_traits>
-#include <utility>
 
 #include "agg_image.h"
 #include "cursor.h"

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -182,45 +182,19 @@ namespace fheroes2
         }
     }
 
-    MovableText::MovableText( Image & output )
-        : _output( output )
-        , _restorer( output, 0, 0, 0, 0 )
-        , _isHidden( false )
-    {
-        // Do nothing.
-    }
-
-    void MovableText::update( std::unique_ptr<TextBase> text )
-    {
-        _text = std::move( text );
-    }
-
-    void MovableText::draw( const int32_t x, const int32_t y )
-    {
-        hide();
-
-        _restorer.update( x, y, _text->width(), _text->height() );
-        _text->draw( x, y, _output );
-
-        _isHidden = false;
-    }
-
     void MovableText::drawInRoi( const int32_t x, const int32_t y, const Rect & roi )
     {
         hide();
 
-        _restorer.update( x, y, _text->width(), _text->height() );
-        _text->drawInRoi( x, y, _output, roi );
+        // We should not try to draw the unset text.
+        assert( _text != nullptr );
+
+        const Rect overlappedRoi = ( _text->area() + Point( x, y ) ) ^ roi;
+
+        _restorer.update( overlappedRoi.x, overlappedRoi.y, overlappedRoi.width, overlappedRoi.height );
+        _text->drawInRoi( x, y, _output, overlappedRoi );
 
         _isHidden = false;
-    }
-
-    void MovableText::hide()
-    {
-        if ( !_isHidden ) {
-            _restorer.restore();
-            _isHidden = true;
-        }
     }
 
     SystemInfoRenderer::SystemInfoRenderer()

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -187,7 +187,9 @@ namespace fheroes2
 
         assert( _text != nullptr );
 
-        Rect textArea = _text->area() + Point( x, y );
+        Rect textArea = _text->area();
+        textArea.x += x;
+        textArea.y += y;
 
         // Not to cut off the top of diacritic signs in capital letters we shift the text down.
         const int32_t extraShiftY = textArea.y < roi.y ? roi.y - textArea.y : 0;

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -188,10 +188,11 @@ namespace fheroes2
         // We should not try to draw the unset text.
         assert( _text != nullptr );
 
-        const Rect overlappedRoi = ( _text->area() + Point( x, y ) ) ^ roi;
+        const Rect textArea = _text->area() + Point( x, y );
+        const Rect overlappedRoi = textArea ^ roi;
 
         _restorer.update( overlappedRoi.x, overlappedRoi.y, overlappedRoi.width, overlappedRoi.height );
-        _text->drawInRoi( x, y, _output, overlappedRoi );
+        _text->drawInRoi( x, y - ( textArea.y < roi.y ? textArea.y - roi.y : 0 ), _output, overlappedRoi );
 
         _isHidden = false;
     }

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -185,14 +185,18 @@ namespace fheroes2
     {
         hide();
 
-        // We should not try to draw the unset text.
         assert( _text != nullptr );
 
-        const Rect textArea = _text->area() + Point( x, y );
+        Rect textArea = _text->area() + Point( x, y );
+
+        // Not to cut off the top of diacritic signs in capital letters we shift the text down.
+        const int32_t extraShiftY = textArea.y < roi.y ? roi.y - textArea.y : 0;
+        textArea.height += extraShiftY;
+
         const Rect overlappedRoi = textArea ^ roi;
 
         _restorer.update( overlappedRoi.x, overlappedRoi.y, overlappedRoi.width, overlappedRoi.height );
-        _text->drawInRoi( x, y - ( textArea.y < roi.y ? textArea.y - roi.y : 0 ), _output, overlappedRoi );
+        _text->drawInRoi( x, y + extraShiftY, _output, overlappedRoi );
 
         _isHidden = false;
     }

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -92,7 +92,12 @@ namespace fheroes2
     class MovableText
     {
     public:
-        explicit MovableText( Image & output );
+        explicit MovableText( Image & output )
+            : _output( output )
+            , _restorer( output, 0, 0, 0, 0 )
+        {
+            // Do nothing.
+        }
 
         MovableText( const MovableText & ) = delete;
 
@@ -100,20 +105,32 @@ namespace fheroes2
 
         MovableText & operator=( const MovableText & ) = delete;
 
-        void update( std::unique_ptr<TextBase> text );
+        void update( std::unique_ptr<TextBase> text )
+        {
+            _text = std::move( text );
+        }
 
-        void draw( const int32_t x, const int32_t y );
+        void draw( const int32_t x, const int32_t y )
+        {
+            drawInRoi( x, y, { 0, 0, _output.width(), _output.height() } );
+        }
 
         // Draw text within a specified ROI (Region of Interest) that acts as a bounding box
         void drawInRoi( const int32_t x, const int32_t y, const Rect & roi );
 
-        void hide();
+        void hide()
+        {
+            if ( !_isHidden ) {
+                _restorer.restore();
+                _isHidden = true;
+            }
+        }
 
     private:
         Image & _output;
         ImageRestorer _restorer;
         std::unique_ptr<TextBase> _text;
-        bool _isHidden;
+        bool _isHidden{ true };
     };
 
     // Renderer of current time and FPS on screen

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -29,6 +29,7 @@
 #include <optional>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 #include "image.h"


### PR DESCRIPTION
fix #9728
Relates to #9730 

This PR adds an `area()` method to the `Text` class that calculates the area that the displayed text string will occupy.
The multi-line text version of this method is not implemented in this PR and may be implemented later when needed.

https://github.com/user-attachments/assets/3d202691-d165-4fba-9b14-7cc65f827dd8
