### PR TITLE
Allow to move the virtual keyboard cursor using the hardware keyboard buttons

### DIFF
--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -26,6 +26,7 @@
 #include <functional>
 #include <limits>
 #include <memory>
+#include <optional>
 #include <stdexcept>
 #include <utility>
 #include <vector>

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -116,8 +116,8 @@ namespace
     {
         PrevCharacter,
         NextCharacter,
-        FirstCharacter,
-        LastCharacter
+        BeginningOfText,
+        EndOfText
     };
 
     class KeyboardRenderer
@@ -271,11 +271,11 @@ namespace
                 ++_cursorPosition;
 
                 break;
-            case CursorPosition::FirstCharacter:
+            case CursorPosition::BeginningOfText:
                 _cursorPosition = 0;
 
                 break;
-            case CursorPosition::LastCharacter:
+            case CursorPosition::EndOfText:
                 _cursorPosition = _info.size();
 
                 break;
@@ -855,9 +855,9 @@ namespace
                  case fheroes2::Key::KEY_RIGHT:
                      return CursorPosition::NextCharacter;
                  case fheroes2::Key::KEY_HOME:
-                     return CursorPosition::FirstCharacter;
+                     return CursorPosition::BeginningOfText;
                  case fheroes2::Key::KEY_END:
-                     return CursorPosition::LastCharacter;
+                     return CursorPosition::EndOfText;
                  default:
                      break;
                  }

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -114,9 +114,9 @@ namespace
 
     enum class CursorPosition
     {
-        PrevCharacter,
-        NextCharacter,
-        BeginningOfText,
+        PrevChar,
+        NextChar,
+        BegOfText,
         EndOfText
     };
 
@@ -253,7 +253,7 @@ namespace
         void setCursorPosition( const CursorPosition pos )
         {
             switch ( pos ) {
-            case CursorPosition::PrevCharacter:
+            case CursorPosition::PrevChar:
                 if ( _cursorPosition == 0 ) {
                     return;
                 }
@@ -261,7 +261,7 @@ namespace
                 --_cursorPosition;
 
                 break;
-            case CursorPosition::NextCharacter:
+            case CursorPosition::NextChar:
                 assert( _cursorPosition <= _info.size() );
 
                 if ( _cursorPosition == _info.size() ) {
@@ -271,7 +271,7 @@ namespace
                 ++_cursorPosition;
 
                 break;
-            case CursorPosition::BeginningOfText:
+            case CursorPosition::BegOfText:
                 _cursorPosition = 0;
 
                 break;
@@ -851,11 +851,11 @@ namespace
         if ( const std::optional<CursorPosition> pos = [key]() -> std::optional<CursorPosition> {
                  switch ( key ) {
                  case fheroes2::Key::KEY_LEFT:
-                     return CursorPosition::PrevCharacter;
+                     return CursorPosition::PrevChar;
                  case fheroes2::Key::KEY_RIGHT:
-                     return CursorPosition::NextCharacter;
+                     return CursorPosition::NextChar;
                  case fheroes2::Key::KEY_HOME:
-                     return CursorPosition::BeginningOfText;
+                     return CursorPosition::BegOfText;
                  case fheroes2::Key::KEY_END:
                      return CursorPosition::EndOfText;
                  default:


### PR DESCRIPTION
Follow-up to the #9690

Unlike the #9690, this PR works both on virtual keyboard and virtual numpad. Currently, the "left", "right", "home" and "end" keys are supported.