### PR TITLE
GitHub Actions: run the CodeChecker and IWYU workflows only if some C/C++ files were changed

### DIFF
--- a/.github/workflows/codechecker.yml
+++ b/.github/workflows/codechecker.yml
@@ -2,12 +2,17 @@ name: CodeChecker
 
 on:
   workflow_call:
+    inputs:
+      run:
+        required: true
+        type: boolean
 
 permissions: {}
 
 jobs:
   codechecker:
     name: CodeChecker
+    if: ${{ inputs.run }}
     runs-on: ubuntu-24.04
     timeout-minutes: 60
     defaults:

--- a/.github/workflows/iwyu.yml
+++ b/.github/workflows/iwyu.yml
@@ -2,12 +2,17 @@ name: IWYU
 
 on:
   workflow_call:
+    inputs:
+      run:
+        required: true
+        type: boolean
 
 permissions: {}
 
 jobs:
   iwyu:
     name: IWYU
+    if: ${{ inputs.run }}
     runs-on: ubuntu-24.04
     timeout-minutes: 30
     defaults:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -47,16 +47,20 @@ jobs:
     uses: ./.github/workflows/code_style_check.yml
   codechecker:
     name: CodeChecker
-    if: ${{ needs.dispatcher.outputs.runCxxAnalyzers == 'YES' }}
     needs:
+    - dispatcher
     - style
     uses: ./.github/workflows/codechecker.yml
+    with:
+      run: ${{ needs.dispatcher.outputs.runCxxAnalyzers == 'YES' }}
   iwyu:
     name: IWYU
-    if: ${{ needs.dispatcher.outputs.runCxxAnalyzers == 'YES' }}
     needs:
+    - dispatcher
     - style
     uses: ./.github/workflows/iwyu.yml
+    with:
+      run: ${{ needs.dispatcher.outputs.runCxxAnalyzers == 'YES' }}
   msvc:
     name: MSVC
     needs:

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -12,16 +12,48 @@ permissions:
   contents: write
 
 jobs:
+  dispatcher:
+    name: Job dispatcher
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    defaults:
+      run:
+        shell: bash
+    outputs:
+      runCxxAnalyzers: ${{ steps.dispatch.outputs.runCxxAnalyzers }}
+    steps:
+    - uses: actions/github-script@v7
+      id: dispatch
+      with:
+        script: |
+          for await (const files of github.paginate.iterator(
+              github.rest.pulls.listFiles, {
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  pull_number: ${{ github.event.number }},
+              }
+          )) {
+              if (files.data.some((fileMetadata) =>
+                  [/\.c$/, /\.cpp$/, /\.h$/, /CMakeLists\.txt$/].some((pattern) => pattern.test(fileMetadata.filename))
+              )) {
+                  core.setOutput("runCxxAnalyzers", "YES");
+                  break;
+              }
+          }
   style:
     name: Code style check
+    needs:
+    - dispatcher
     uses: ./.github/workflows/code_style_check.yml
   codechecker:
     name: CodeChecker
+    if: ${{ needs.dispatcher.outputs.runCxxAnalyzers == 'YES' }}
     needs:
     - style
     uses: ./.github/workflows/codechecker.yml
   iwyu:
     name: IWYU
+    if: ${{ needs.dispatcher.outputs.runCxxAnalyzers == 'YES' }}
     needs:
     - style
     uses: ./.github/workflows/iwyu.yml

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -26,14 +26,14 @@ jobs:
       id: dispatch
       with:
         script: |
-          for await (const files of github.paginate.iterator(
+          for await (const modifiedFiles of github.paginate.iterator(
               github.rest.pulls.listFiles, {
                   owner: context.repo.owner,
                   repo: context.repo.repo,
                   pull_number: ${{ github.event.number }},
               }
           )) {
-              if (files.data.some((fileMetadata) =>
+              if (modifiedFiles.data.some((fileMetadata) =>
                   [/\.c$/, /\.cpp$/, /\.h$/, /CMakeLists\.txt$/].some((pattern) => pattern.test(fileMetadata.filename))
               )) {
                   core.setOutput("runCxxAnalyzers", "YES");


### PR DESCRIPTION
Related to #9721

Since we have a complex structure of interdependent reusable workflows, we cannot just use the `paths` option as proposed in #9721. However, we can perform the relevant filtering ourselves by writing quite a bit of code.

Unlike build workflows, which may depend on files of a diverse kind (C/C++, Java, Gradle, shell, Python, translations, even documentation, which is bundled into resulting artifacts), CodeChecker and IWYU workflows should only be run if the source files related to C/C++ were changed, so this restriction looks relatively safe. Also the CodeChecker is the slowest workflow we have.