### PR TITLE
Add OGG audio format support for Emscripten build

### DIFF
--- a/src/dist/Makefile.emscripten
+++ b/src/dist/Makefile.emscripten
@@ -20,7 +20,7 @@
 
 TARGET := fheroes2.js
 
-SDL2_MIXER_FORMATS := mid,mp3
+SDL2_MIXER_FORMATS := mid,mp3,ogg
 
 CCFLAGS := $(CCFLAGS) \
 	--use-port=sdl2 \


### PR DESCRIPTION
When I attempted to load the game with OGG files from the GOG distribution, the emscripten build did not work out of the box.

This adds the OGG video format to the SDL2 mixer formakes to enable those music files to work.