### PR TITLE
Fix the resumption of music playback for Emscripten builds

### DIFF
--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -1105,7 +1105,7 @@ bool Music::isPlaying()
 {
     const std::scoped_lock<std::recursive_mutex> lock( audioMutex );
 
-    return !musicTrackManager.getCurrentTrack().expired() && Mix_PlayingMusic();
+    return isInitialized && Mix_PlayingMusic();
 }
 
 void Music::SetMidiSoundFonts( const ListFiles & files )


### PR DESCRIPTION
Currently, the resumption of music playback doesn't work in the non-multithreaded Emscripten builds (music tracks always start playing from the beginning), because the current logic in `master` branch relies on the use of inter-thread synchronization to ensure the correct order of actions. In the non-multithreaded Emscripten builds there are no threads, so this logic doesn't work as expected.