### PR TITLE
MIDI: allow to pick up custom timidity.cfg

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -104,7 +104,7 @@ tasks.register('copyTimidity', Copy) {
         include 'instruments/*.pat'
         include 'timidity.cfg'
     }
-    into 'src/main/assets'
+    into 'src/main/assets/files/timidity'
 }
 
 tasks.register('copyTranslations', Copy) {

--- a/src/dist/Makefile.emscripten
+++ b/src/dist/Makefile.emscripten
@@ -32,7 +32,7 @@ CCFLAGS := $(CCFLAGS) \
 LDFLAGS := $(LDFLAGS) \
 	--preload-file ../../../files/data/resurrection.h2d@/files/data/resurrection.h2d \
 	--preload-file ../../../files/lang/@/files/lang/ \
-	--preload-file ../../../files/timidity/@/etc/ \
+	--preload-file ../../../files/timidity/@/files/timidity/ \
 	-sALLOW_MEMORY_GROWTH \
 	-sASYNCIFY \
 	-sASYNCIFY_STACK_SIZE=64kb \

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -1134,3 +1134,16 @@ void Music::SetMidiSoundFonts( const ListFiles & files )
         ERROR_LOG( "Failed to set MIDI SoundFonts using paths " << filePaths << ". The error: " << Mix_GetError() )
     }
 }
+
+void Music::SetMidiTimidityCfg( const std::string & timidityCfgPath )
+{
+    const std::scoped_lock<std::recursive_mutex> lock( audioMutex );
+
+    if ( !isInitialized ) {
+        return;
+    }
+
+    if ( Mix_SetTimidityCfg( System::encLocalToUTF8( timidityCfgPath ).c_str() ) == 0 ) {
+        ERROR_LOG( "Failed to set the path to the timidity.cfg file to " << timidityCfgPath << ". The error: " << Mix_GetError() )
+    }
+}

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -1108,7 +1108,7 @@ bool Music::isPlaying()
     return isInitialized && Mix_PlayingMusic();
 }
 
-void Music::SetMidiSoundFonts( const ListFiles & files )
+void Music::setMidiSoundFonts( const ListFiles & files )
 {
     const std::scoped_lock<std::recursive_mutex> lock( audioMutex );
 
@@ -1135,7 +1135,7 @@ void Music::SetMidiSoundFonts( const ListFiles & files )
     }
 }
 
-void Music::SetMidiTimidityCfg( const std::string & timidityCfgPath )
+void Music::setMidiTimidityCfg( const std::string & timidityCfgPath )
 {
     const std::scoped_lock<std::recursive_mutex> lock( audioMutex );
 

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -1135,7 +1135,7 @@ void Music::setMidiSoundFonts( const ListFiles & files )
     }
 }
 
-void Music::setMidiTimidityCfg( const std::string & timidityCfgPath )
+void Music::setMidiTimidityCfg( const std::string & path )
 {
     const std::scoped_lock<std::recursive_mutex> lock( audioMutex );
 
@@ -1144,10 +1144,10 @@ void Music::setMidiTimidityCfg( const std::string & timidityCfgPath )
     }
 
 #if SDL_MIXER_VERSION_ATLEAST( 2, 6, 0 )
-    if ( Mix_SetTimidityCfg( System::encLocalToUTF8( timidityCfgPath ).c_str() ) == 0 ) {
-        ERROR_LOG( "Failed to set the path to the timidity.cfg file to " << timidityCfgPath << ". The error: " << Mix_GetError() )
+    if ( Mix_SetTimidityCfg( System::encLocalToUTF8( path ).c_str() ) == 0 ) {
+        ERROR_LOG( "Failed to set the path to the timidity.cfg file to " << path << ". The error: " << Mix_GetError() )
     }
 #else
-    ERROR_LOG( "Failed to set the path to the timidity.cfg file to " << timidityCfgPath << ". The error: operation not supported" )
+    ERROR_LOG( "Failed to set the path to the timidity.cfg file to " << path << ". The error: operation not supported" )
 #endif
 }

--- a/src/engine/audio.cpp
+++ b/src/engine/audio.cpp
@@ -1143,7 +1143,11 @@ void Music::setMidiTimidityCfg( const std::string & timidityCfgPath )
         return;
     }
 
+#if SDL_MIXER_VERSION_ATLEAST( 2, 6, 0 )
     if ( Mix_SetTimidityCfg( System::encLocalToUTF8( timidityCfgPath ).c_str() ) == 0 ) {
         ERROR_LOG( "Failed to set the path to the timidity.cfg file to " << timidityCfgPath << ". The error: " << Mix_GetError() )
     }
+#else
+    ERROR_LOG( "Failed to set the path to the timidity.cfg file to " << timidityCfgPath << ". The error: operation not supported" )
+#endif
 }

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -106,6 +106,7 @@ namespace Music
     bool isPlaying();
 
     void SetMidiSoundFonts( const ListFiles & files );
+    void SetMidiTimidityCfg( const std::string & timidityCfgPath );
 
     std::vector<uint8_t> Xmi2Mid( const std::vector<uint8_t> & buf );
 }

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -106,7 +106,7 @@ namespace Music
     bool isPlaying();
 
     void setMidiSoundFonts( const ListFiles & files );
-    void setMidiTimidityCfg( const std::string & timidityCfgPath );
+    void setMidiTimidityCfg( const std::string & path );
 
     std::vector<uint8_t> Xmi2Mid( const std::vector<uint8_t> & buf );
 }

--- a/src/engine/audio.h
+++ b/src/engine/audio.h
@@ -105,8 +105,8 @@ namespace Music
 
     bool isPlaying();
 
-    void SetMidiSoundFonts( const ListFiles & files );
-    void SetMidiTimidityCfg( const std::string & timidityCfgPath );
+    void setMidiSoundFonts( const ListFiles & files );
+    void setMidiTimidityCfg( const std::string & timidityCfgPath );
 
     std::vector<uint8_t> Xmi2Mid( const std::vector<uint8_t> & buf );
 }

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2024                                             *
+ *   Copyright (C) 2022 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -789,6 +789,8 @@ namespace AudioManager
                 Music::setMidiSoundFonts( midiSoundFonts );
             }
 
+            // Some platforms (e.g. Linux) may have their own timidity.cfg file, the path to which is set when building the corresponding library, don't overwrite this
+            // path if we don't have our own file
             if ( !timidityCfgPath.empty() ) {
                 Music::setMidiTimidityCfg( timidityCfgPath );
             }

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -786,11 +786,11 @@ namespace AudioManager
 
             // Some platforms (e.g. Linux) may have their own predefined soundfonts, don't overwrite them if we don't have our own
             if ( !midiSoundFonts.empty() ) {
-                Music::SetMidiSoundFonts( midiSoundFonts );
+                Music::setMidiSoundFonts( midiSoundFonts );
             }
 
             if ( !timidityCfgPath.empty() ) {
-                Music::SetMidiTimidityCfg( timidityCfgPath );
+                Music::setMidiTimidityCfg( timidityCfgPath );
             }
 
             Mixer::setVolume( 100 * Settings::Get().SoundVolume() / 10 );

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -778,7 +778,8 @@ namespace
 
 namespace AudioManager
 {
-    AudioInitializer::AudioInitializer( const std::string & originalAGGFilePath, const std::string & expansionAGGFilePath, const ListFiles & midiSoundFonts )
+    AudioInitializer::AudioInitializer( const std::string & originalAGGFilePath, const std::string & expansionAGGFilePath, const ListFiles & midiSoundFonts,
+                                        const std::string & timidityCfgPath )
     {
         if ( Audio::isValid() ) {
             Mixer::SetChannels( 32 );
@@ -786,6 +787,10 @@ namespace AudioManager
             // Some platforms (e.g. Linux) may have their own predefined soundfonts, don't overwrite them if we don't have our own
             if ( !midiSoundFonts.empty() ) {
                 Music::SetMidiSoundFonts( midiSoundFonts );
+            }
+
+            if ( !timidityCfgPath.empty() ) {
+                Music::SetMidiTimidityCfg( timidityCfgPath );
             }
 
             Mixer::setVolume( 100 * Settings::Get().SoundVolume() / 10 );

--- a/src/fheroes2/audio/audio_manager.cpp
+++ b/src/fheroes2/audio/audio_manager.cpp
@@ -789,8 +789,7 @@ namespace AudioManager
                 Music::setMidiSoundFonts( midiSoundFonts );
             }
 
-            // Some platforms (e.g. Linux) may have their own timidity.cfg file, the path to which is set when building the corresponding library, don't overwrite this
-            // path if we don't have our own file
+            // Some platforms (e.g. Linux) may have their own timidity.cfg file, don't overwrite the path to this file if we don't have our own
             if ( !timidityCfgPath.empty() ) {
                 Music::setMidiTimidityCfg( timidityCfgPath );
             }

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2024                                             *
+ *   Copyright (C) 2022 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/audio/audio_manager.h
+++ b/src/fheroes2/audio/audio_manager.h
@@ -44,7 +44,8 @@ namespace AudioManager
     public:
         AudioInitializer() = delete;
 
-        AudioInitializer( const std::string & originalAGGFilePath, const std::string & expansionAGGFilePath, const ListFiles & midiSoundFonts );
+        AudioInitializer( const std::string & originalAGGFilePath, const std::string & expansionAGGFilePath, const ListFiles & midiSoundFonts,
+                          const std::string & timidityCfgPath );
         AudioInitializer( const AudioInitializer & ) = delete;
         AudioInitializer & operator=( const AudioInitializer & ) = delete;
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -324,7 +324,22 @@ int main( int argc, char ** argv )
         }
 #endif
 
-        const AudioManager::AudioInitializer audioInitializer( dataInitializer.getOriginalAGGFilePath(), dataInitializer.getExpansionAGGFilePath(), midiSoundFonts );
+        const std::string timidityCfgPath = []() -> std::string {
+            if ( std::string path; Settings::findFile( System::concatPath( "files", "timidity" ), "timidity.cfg", path ) ) {
+                return path;
+            }
+
+            return {};
+        }();
+
+#ifdef WITH_DEBUG
+        if ( !timidityCfgPath.empty() ) {
+            DEBUG_LOG( DBG_GAME, DBG_INFO, "Path to the timidity.cfg file: " << timidityCfgPath )
+        }
+#endif
+
+        const AudioManager::AudioInitializer audioInitializer( dataInitializer.getOriginalAGGFilePath(), dataInitializer.getExpansionAGGFilePath(), midiSoundFonts,
+                                                               timidityCfgPath );
 
         // Load palette.
         fheroes2::setGamePalette( AGG::getDataFromAggFile( "KB.PAL", false ) );


### PR DESCRIPTION
This PR is a part of the effort to fix the #8375,  #8376, #8379, #8795.

The idea is as follows: while Fluidsynth MIDI backend operates with heavy soundfont file (which it apparently loads every time it tries to play a MIDI file), Timidity MIDI backend operates with relatively small GUS patches (and apparently it does not load those instruments that are not needed to play a specific MIDI file or maybe uses other optimizations), which minimizes the delay at the start of the playback.

To test this idea, I made a special build of `SDL_mixer` with Timidity MIDI backend on Windows and used it along with this PR. The results are shown below.

Further roadmap:

* Merge this PR;
* Merge the https://github.com/microsoft/vcpkg/pull/45141 to add the Timidity backend support to the vcpkg port;
* Build the "transitional" dependency package for Windows both with Fluidsynth and Timidity backends;
* Allow the willing to compare the behavior of these backends (this can be easily done by simply deleting the `soundfonts` subdirectory from the files directory and adding the `timidity` directory instead, and then vice versa);
* If the test results are satisfactory (I think that's most likely what will happen), then we can remove the Fluidsynth backend from our Windows dependency package.

Please keep in mind that, although this replacement should help dramatically on Windows, we still don't control all platforms in the world, so on those platforms where Fluidsynth is used, MIDI playback can still start with a delay.

Effect from #8379 in the `master` branch build:

https://github.com/user-attachments/assets/5456f20f-6691-49a7-af0f-7418a70bba97

No effect from #8379 in the build based on this PR along with Timidity MIDI backend:

https://github.com/user-attachments/assets/a916086e-e094-4180-8def-e01bcaa600c6

Save file from #8795 loaded to the `master` branch build:

https://github.com/user-attachments/assets/98e4cbe4-66b6-497a-875a-3802e7ac111e

Save file from #8795 loaded to the build based on this PR along with Timidity MIDI backend:

https://github.com/user-attachments/assets/403a5766-425b-4456-8842-c7d5cfe69ced


