### PR TITLE
Update Windows & Android dependencies

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -82,12 +82,12 @@ android {
 }
 
 dependencies {
-    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.1.4'
+    coreLibraryDesugaring 'com.android.tools:desugar_jdk_libs_nio:2.1.5'
 
     implementation project(':isotools')
     implementation project(':sdl2')
 
-    implementation group: 'commons-io', name: 'commons-io', version: '2.18.0'
+    implementation group: 'commons-io', name: 'commons-io', version: '2.19.0'
 
     implementation 'com.google.android.material:material:1.12.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 plugins {
-    id 'com.android.application' version '8.7.3' apply false
-    id 'com.android.library' version '8.7.3' apply false
+    id 'com.android.application' version '8.9.2' apply false
+    id 'com.android.library' version '8.9.2' apply false
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Mon Nov 04 18:10:00 MSK 2024
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=1096CF14707DC4C35E79E91E4F87BC3F781DF2CCFA4D4E2B93BCB051FACB655E
+set PKG_FILE_SHA256=A6150FAA0FE0FD3BE2C8466D27FC34EBCC715608D5F2360CB613F9EAD058FA41
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -23,7 +23,7 @@
 set -e -o pipefail
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="1096cf14707dc4c35e79e91e4f87bc3f781df2ccfa4d4e2b93bcb051facb655e"
+PKG_FILE_SHA256="a6150faa0fe0fd3be2c8466d27fc34ebcc715608d5f2360cb613f9ead058fa41"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=471DB7F8B7B698E4704C408FDD4898AB7100ED9A95E51C1B54C16C6A98CB12CA
+set PKG_FILE_SHA256=422D3AFE6A211DB9A7F46C836F1E5A27D1655068BF5960F2E64B60B03EA88679
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
See https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/59 for details.

Android: AGP and some dependencies have been updated.
Windows: SDL_mixer has been build both with fluidsynth and timidity MIDI backends, so you can always switch between them by removing either `files/soundfonts` or `files/timidity` directory.