### PR TITLE
Windows: remove fluidsynth from dependencies

### DIFF
--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=422D3AFE6A211DB9A7F46C836F1E5A27D1655068BF5960F2E64B60B03EA88679
+set PKG_FILE_SHA256=467575C34B191FD384A49CCA465E1FB2EA8F93FE5DB7389B91E69366436D0AFA
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
The final touch.

See https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/60 for details.

1. Much fewer DLLs are now required;
2. Now there is no problem which backend SDL_mixer will choose if both `soundfonts` and `timidity` folders are present in the `Program Files` at the same time.