### PR TITLE
Change encoding name from CP1258 to WINDOWS-1258 to avoid a msgfmt warning

### DIFF
--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -51,9 +51,9 @@ tr.mo: tr.po
 lt.mo: lt.po
 	$(call MSGFMT,CP1257)
 	
-# Vietnamese uses CP1258
+# Vietnamese uses WINDOWS-1258
 vi.mo: vi.po
-	$(call MSGFMT,CP1258)
+	$(call MSGFMT,WINDOWS-1258)
 
 # Romanian uses ISO-8859-16
 ro.mo: ro.po


### PR DESCRIPTION
According to msgfmt CP1258 is not a portable encoding name while WINDOWS-1258 is. Both are equal in terms of encoding so this is more a cosmetic change to make msgfmt happy.