### PR TITLE
End game immediately during AI turn if there are changes in game

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -2163,6 +2163,12 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
 
             if ( hero.isAction() ) {
                 hero.ResetAction();
+
+                // Check if the game is over after the hero's action.
+                const fheroes2::GameMode gameState = GameOver::Result::Get().checkGameOver();
+                if ( gameState != fheroes2::GameMode::CANCEL ) {
+                    return gameState;
+                }
             }
 
             // Render a frame only if there is a need to show one.
@@ -2236,6 +2242,7 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
                 if ( hero.isAction() ) {
                     hero.ResetAction();
 
+                    // Check if the game is over after the hero's action.
                     const fheroes2::GameMode gameState = GameOver::Result::Get().checkGameOver();
                     if ( gameState != fheroes2::GameMode::CANCEL ) {
                         return gameState;

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -44,6 +44,7 @@
 #include "game.h"
 #include "game_delays.h"
 #include "game_interface.h"
+#include "game_mode.h"
 #include "game_over.h"
 #include "game_static.h"
 #include "heroes.h"

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -2106,8 +2106,6 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
 {
     const Route::Path & path = hero.GetPath();
 
-    fheroes2::GameMode gameState = fheroes2::GameMode::END_TURN;
-
     if ( path.isValidForTeleportation() ) {
         const int32_t targetIndex = path.GetFrontIndex();
 
@@ -2119,11 +2117,11 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
 
         // This is the end of a this hero's movement, even if the hero's full path doesn't end in this town or castle.
         // The further path of this hero will be re-planned by AI.
-        return gameState;
+        return fheroes2::GameMode::END_TURN;
     }
 
     if ( !path.isValidForMovement() ) {
-        return gameState;
+        return fheroes2::GameMode::END_TURN;
     }
 
     hero.SetMove( true );
@@ -2238,7 +2236,7 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
                 if ( hero.isAction() ) {
                     hero.ResetAction();
 
-                    gameState = GameOver::Result::Get().checkGameOver();
+                    const fheroes2::GameMode gameState = GameOver::Result::Get().checkGameOver();
                     if ( gameState != fheroes2::GameMode::CANCEL ) {
                         return gameState;
                     }
@@ -2263,7 +2261,7 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
 
     hero.SetMove( false );
 
-    return gameState;
+    return fheroes2::GameMode::END_TURN;
 }
 
 void AI::HeroesCastDimensionDoor( Heroes & hero, const int32_t targetIndex )

--- a/src/fheroes2/ai/ai_hero_action.h
+++ b/src/fheroes2/ai/ai_hero_action.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024                                                    *
+ *   Copyright (C) 2024 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/ai/ai_hero_action.h
+++ b/src/fheroes2/ai/ai_hero_action.h
@@ -25,10 +25,17 @@
 class Heroes;
 class Spell;
 
+namespace fheroes2
+{
+    enum class GameMode : int;
+}
+
 namespace AI
 {
     void HeroesAction( Heroes & hero, const int32_t dst_index );
-    void HeroesMove( Heroes & hero );
+
+    // Returns the state of the game. By default it should be end of turn.
+    fheroes2::GameMode HeroesMove( Heroes & hero );
 
     // Makes it so that the 'hero' casts the Dimension Door spell to the 'targetIndex'
     void HeroesCastDimensionDoor( Heroes & hero, const int32_t targetIndex );

--- a/src/fheroes2/ai/ai_planner.h
+++ b/src/fheroes2/ai/ai_planner.h
@@ -39,6 +39,11 @@ class Kingdom;
 struct VecCastles;
 struct VecHeroes;
 
+namespace fheroes2
+{
+    enum class GameMode : int;
+}
+
 namespace MP2
 {
     enum MapObjectType : uint16_t;
@@ -157,7 +162,8 @@ namespace AI
     public:
         static Planner & Get();
 
-        void KingdomTurn( Kingdom & kingdom );
+        // Returns the state of the game. By default it should be end of turn.
+        fheroes2::GameMode KingdomTurn( Kingdom & kingdom );
 
         // Implements the logic of transparent casting of the Summon Boat spell at the beginning of the hero's movement
         void HeroesBeginMovement( Heroes & hero );
@@ -196,7 +202,7 @@ namespace AI
         void reinforceCastle( Castle & castle );
 
         // Returns true if heroes can still do tasks but they have no move points.
-        bool HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue );
+        bool HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue, fheroes2::GameMode & gameState );
 
         bool recruitHero( Castle & castle, bool buyArmy );
 

--- a/src/fheroes2/ai/ai_planner.h
+++ b/src/fheroes2/ai/ai_planner.h
@@ -201,8 +201,8 @@ namespace AI
         // (if there is one) by giving him the best available troops.
         void reinforceCastle( Castle & castle );
 
-        // Returns true if heroes can still do tasks but they have no move points.
-        bool HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue, fheroes2::GameMode & gameState );
+        // Returns the state of the game. By default it should be end of turn.
+        fheroes2::GameMode HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue, bool & moreTasksAvailable );
 
         bool recruitHero( Castle & castle, bool buyArmy );
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -46,6 +46,7 @@
 #include "direction.h"
 #include "game.h"
 #include "game_interface.h"
+#include "game_mode.h"
 #include "game_over.h"
 #include "game_static.h"
 #include "ground.h"

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2751,11 +2751,14 @@ void AI::Planner::HeroesPreBattle( HeroBase & hero, bool isAttacking )
     }
 }
 
-bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue, fheroes2::GameMode & gameState )
+fheroes2::GameMode AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue, bool & moreTasksAvailable )
 {
+    // By default there are always more tasks for heroes.
+    moreTasksAvailable = true;
+
     if ( heroes.empty() ) {
         // No heroes so we indicate that all heroes moved.
-        return true;
+        return fheroes2::GameMode::END_TURN;
     }
 
     std::vector<Heroes *> availableHeroes;
@@ -2896,18 +2899,20 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValu
                     // The rest of the path the hero should do by foot.
                     bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ) );
 
-                    gameState = HeroesMove( *bestHero );
+                    const fheroes2::GameMode gameState = HeroesMove( *bestHero );
                     if ( gameState != fheroes2::GameMode::END_TURN ) {
-                        return false;
+                        moreTasksAvailable = false;
+                        return gameState;
                     }
                 }
             }
             else {
                 bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ) );
 
-                gameState = HeroesMove( *bestHero );
+                const fheroes2::GameMode gameState = HeroesMove( *bestHero );
                 if ( gameState != fheroes2::GameMode::END_TURN ) {
-                    return false;
+                    moreTasksAvailable = false;
+                    return gameState;
                 }
             }
         }
@@ -2951,5 +2956,6 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValu
 
     status.drawAITurnProgress( endProgressValue );
 
-    return availableHeroes.empty();
+    moreTasksAvailable = availableHeroes.empty();
+    return fheroes2::GameMode::END_TURN;
 }

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2897,7 +2897,7 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValu
                     bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ) );
 
                     gameState = HeroesMove( *bestHero );
-                    if ( gameState != fheroes2::GameMode::CANCEL ) {
+                    if ( gameState != fheroes2::GameMode::END_TURN ) {
                         return false;
                     }
                 }
@@ -2906,7 +2906,7 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValu
                 bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ) );
 
                 gameState = HeroesMove( *bestHero );
-                if ( gameState != fheroes2::GameMode::CANCEL ) {
+                if ( gameState != fheroes2::GameMode::END_TURN ) {
                     return false;
                 }
             }

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2751,7 +2751,7 @@ void AI::Planner::HeroesPreBattle( HeroBase & hero, bool isAttacking )
     }
 }
 
-bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue )
+bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValue, uint32_t endProgressValue, fheroes2::GameMode & gameState )
 {
     if ( heroes.empty() ) {
         // No heroes so we indicate that all heroes moved.
@@ -2896,13 +2896,19 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValu
                     // The rest of the path the hero should do by foot.
                     bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ) );
 
-                    HeroesMove( *bestHero );
+                    gameState = HeroesMove( *bestHero );
+                    if ( gameState != fheroes2::GameMode::CANCEL ) {
+                        return false;
+                    }
                 }
             }
             else {
                 bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ) );
 
-                HeroesMove( *bestHero );
+                 gameState = HeroesMove( *bestHero );
+                 if ( gameState != fheroes2::GameMode::CANCEL ) {
+                     return false;
+                 }
             }
         }
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2905,10 +2905,10 @@ bool AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & currentProgressValu
             else {
                 bestHero->GetPath().setPath( _pathfinder.buildPath( bestTargetIndex ) );
 
-                 gameState = HeroesMove( *bestHero );
-                 if ( gameState != fheroes2::GameMode::CANCEL ) {
-                     return false;
-                 }
+                gameState = HeroesMove( *bestHero );
+                if ( gameState != fheroes2::GameMode::CANCEL ) {
+                    return false;
+                }
             }
         }
 

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -43,6 +43,7 @@
 #include "difficulty.h"
 #include "game.h"
 #include "game_interface.h"
+#include "game_mode.h"
 #include "ground.h"
 #include "heroes.h"
 #include "heroes_recruits.h"

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -806,9 +806,9 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
         uint32_t const endProgressValue
             = ( currentProgressValue == 1 ) ? std::min( static_cast<uint32_t>( heroes.size() ) * 2U + 1U, 8U ) : std::min( currentProgressValue + 2U, 9U );
 
-        fheroes2::GameMode gameState = fheroes2::GameMode::CANCEL;
-        bool moreTaskForHeroes = HeroesTurn( heroes, currentProgressValue, endProgressValue, gameState );
-        if ( gameState != fheroes2::GameMode::CANCEL ) {
+        bool moreTaskForHeroes = false;
+        const fheroes2::GameMode gameState = HeroesTurn( heroes, currentProgressValue, endProgressValue, moreTaskForHeroes );
+        if ( gameState != fheroes2::GameMode::END_TURN ) {
             return gameState;
         }
 

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -616,7 +616,7 @@ void AI::Planner::updatePriorityAttackTarget( const Kingdom & kingdom, const Map
     updatePriorityForEnemyArmy( kingdom, *enemyArmy );
 }
 
-void AI::Planner::KingdomTurn( Kingdom & kingdom )
+fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
 {
 #if defined( WITH_DEBUG )
     class AIAutoControlModeCommitter
@@ -661,7 +661,7 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
 
     if ( kingdom.isLoss() || myColor == Color::NONE ) {
         kingdom.LossPostActions();
-        return;
+        return fheroes2::GameMode::END_TURN;
     }
 
     // Reset the turn progress indicator
@@ -806,7 +806,11 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
         uint32_t const endProgressValue
             = ( currentProgressValue == 1 ) ? std::min( static_cast<uint32_t>( heroes.size() ) * 2U + 1U, 8U ) : std::min( currentProgressValue + 2U, 9U );
 
-        bool moreTaskForHeroes = HeroesTurn( heroes, currentProgressValue, endProgressValue );
+        fheroes2::GameMode gameState = fheroes2::GameMode::CANCEL;
+        bool moreTaskForHeroes = HeroesTurn( heroes, currentProgressValue, endProgressValue, gameState );
+        if ( gameState != fheroes2::GameMode::CANCEL ) {
+            return gameState;
+        }
 
         // Step 4. Buy new heroes, adjust roles, sort heroes based on priority or strength
         if ( purchaseNewHeroes( sortedCastleList, castlesInDanger, availableHeroCount, moreTaskForHeroes ) ) {
@@ -870,6 +874,8 @@ void AI::Planner::KingdomTurn( Kingdom & kingdom )
     }
 
     status.resetAITurnProgress();
+
+    return fheroes2::GameMode::END_TURN;
 }
 
 bool AI::Planner::purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, const int32_t availableHeroCount,

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -868,7 +868,9 @@ fheroes2::GameMode Interface::AdventureMap::StartGame()
                     }
 #endif
 
-                    AI::Planner::Get().KingdomTurn( kingdom );
+                    res = AI::Planner::Get().KingdomTurn( kingdom );
+                    // This function must return only game state related values.
+                    assert( res != fheroes2::GameMode::CANCEL );
 
 #if defined( WITH_DEBUG )
                     if ( !isLoadedFromSave && player->isAIAutoControlMode() && !conf.isAutoSaveAtBeginningOfTurnEnabled() ) {


### PR DESCRIPTION
close #2625

The idea is to propagate game state value all up to the function where we check it. AI heroes never even reset their ACTION state.