### PR TITLE
Make the scouting area consistent with the original game

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1816,7 +1816,7 @@ namespace
             hero.SetVisited( tileIndex, Visit::GLOBAL );
 
             const auto & eyeMagiIndexes = world.getAllEyeOfMagiPositions();
-            const uint32_t distance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
+            const int32_t distance = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
             for ( const int32_t index : eyeMagiIndexes ) {
                 Maps::ClearFog( index, distance, hero.GetColor() );
             }

--- a/src/fheroes2/game/game_static.cpp
+++ b/src/fheroes2/game/game_static.cpp
@@ -121,7 +121,7 @@ uint32_t GameStatic::GetLostOnWhirlpoolPercent()
     return 50;
 }
 
-uint32_t GameStatic::getFogDiscoveryDistance( const FogDiscoveryType type )
+int32_t GameStatic::getFogDiscoveryDistance( const FogDiscoveryType type )
 {
     switch ( type ) {
     case FogDiscoveryType::CASTLE:
@@ -129,7 +129,7 @@ uint32_t GameStatic::getFogDiscoveryDistance( const FogDiscoveryType type )
     case FogDiscoveryType::HEROES:
         return 4;
     case FogDiscoveryType::OBSERVATION_TOWER:
-        return 20;
+        return 19;
     case FogDiscoveryType::MAGI_EYES:
         return 9;
     default:

--- a/src/fheroes2/game/game_static.h
+++ b/src/fheroes2/game/game_static.h
@@ -51,7 +51,7 @@ namespace GameStatic
 
     uint32_t GetLostOnWhirlpoolPercent();
     uint32_t GetGameOverLostDays();
-    uint32_t getFogDiscoveryDistance( const FogDiscoveryType type );
+    int32_t getFogDiscoveryDistance( const FogDiscoveryType type );
 
     uint32_t GetKingdomMaxHeroes();
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1801,10 +1801,10 @@ void Heroes::Scout( const int tileIndex ) const
 #endif
 }
 
-int Heroes::GetScoutingDistance() const
+int32_t Heroes::GetScoutingDistance() const
 {
-    return static_cast<int>( GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE )
-                             + GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::HEROES ) + GetSecondarySkillValue( Skill::Secondary::SCOUTING ) );
+    return GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE )
+           + GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::HEROES ) + static_cast<int32_t>( GetSecondarySkillValue( Skill::Secondary::SCOUTING ) );
 }
 
 fheroes2::Rect Heroes::GetScoutRoi() const

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -603,7 +603,7 @@ public:
     }
 
     void Scout( const int tileIndex ) const;
-    int GetScoutingDistance() const;
+    int32_t GetScoutingDistance() const;
 
     // Returns the area in map tiles around hero's position in his scout range.
     fheroes2::Rect GetScoutRoi() const;

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -537,7 +537,7 @@ namespace
 
             // If the enemy is not vanquished we update only the area around the castle on radar.
             if ( !enemyKingdom.isLoss() ) {
-                const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::CASTLE ) );
+                const int32_t scoutRange = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::CASTLE );
                 const fheroes2::Point castlePosition = Maps::GetPoint( dstIndex );
 
                 I.getRadar().SetRenderArea( { castlePosition.x - scoutRange, castlePosition.y - scoutRange, 2 * scoutRange + 1, 2 * scoutRange + 1 } );
@@ -2517,7 +2517,7 @@ namespace
             fheroes2::showStandardTextMessage( MP2::StringObject( objectType ), _( "From the observation tower, you are able to see distant lands." ), Dialog::OK );
         }
 
-        const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ) );
+        const int32_t scoutRange = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER );
         Maps::ClearFog( dst_index, scoutRange, hero.GetColor() );
 
         Interface::AdventureMap & I = Interface::AdventureMap::Get();
@@ -3439,7 +3439,7 @@ namespace
 
                 const size_t maxDelay = 7;
 
-                const int32_t scoutRange = static_cast<int32_t>( GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES ) );
+                const int32_t scoutRange = GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::MAGI_EYES );
                 bool skipAnimation = false;
                 fheroes2::Rect radarRenderArea;
 

--- a/src/fheroes2/maps/maps.h
+++ b/src/fheroes2/maps/maps.h
@@ -100,8 +100,8 @@ namespace Maps
 
     Indexes GetObjectPositions( int32_t center, const MP2::MapObjectType objectType, bool ignoreHeroes );
 
-    void ClearFog( const int32_t tileIndex, const int scoutingDistance, const int playerColor );
-    int32_t getFogTileCountToBeRevealed( const int32_t tileIndex, const int scoutingDistance, const int playerColor );
+    void ClearFog( const int32_t tileIndex, const int32_t scoutingDistance, const int playerColor );
+    int32_t getFogTileCountToBeRevealed( const int32_t tileIndex, const int32_t scoutingDistance, const int playerColor );
 
     // Returns the approximate distance between two tiles with given indexes. This distance is calculated as the number of
     // tiles (truncated to the nearest smaller integer value) that would need to be traversed in a straight direction to


### PR DESCRIPTION
fix #1434 

This PR makes the scouting (reveal) area to math the one in the original game.

The comparison of minimaps is shown on the screen shots below. The top revealed areas from the left to right for radius:
  - 4 (hero);
  - 5 (hero + Basic Scouting), the same will be for Town/Castle;
  - 6 (hero + Advanced Scouting);
  - 7 (hero + Expert Scouting);
  - 8 (hero + Expert Scouting + Telescope artifact);
  - 9 (Eye of the Magi);
  - 19 (Observation Tower);
  - in the bottom left - a hero at the Hut of the Magi.
  
Master build:
![изображение](https://github.com/user-attachments/assets/ce5b2cdf-512d-4c0c-a5d5-1c7cbb225ae3)

Original game:
![изображение](https://github.com/user-attachments/assets/55c29843-ae8c-4d11-8cd2-070147747afb)

This PR:
![изображение](https://github.com/user-attachments/assets/c781ed76-4ecb-4a56-9066-37276d2a5e36)
