### PR TITLE
Fix Barbarian castle Shipyard rendering

### DIFF
--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -348,7 +348,9 @@ namespace
 
         // Bay animation. The Wizard's castle is "special": its "bay" is not actually a bay, but a river flowing through a gorge in the wastelands, which must be drawn
         // and animated, even if the castle itself is not located on the seashore.
-        if ( castleRace == Race::WZRD || ( castle.HasSeaAccess() && ( !castle.isBuild( BUILD_SHIPYARD ) || fadingInBuildingId == BUILD_SHIPYARD ) ) ) {
+        // We should also draw a bay for the Barbarian castle, even if the Shipyard is built.
+        if ( castleRace == Race::WZRD
+             || ( castle.HasSeaAccess() && ( castleRace == Race::BARB || !castle.isBuild( BUILD_SHIPYARD ) || fadingInBuildingId == BUILD_SHIPYARD ) ) ) {
             int bayIcnId = 0;
             const uint32_t bayExtraIndex = 1 + animationIndex % 5;
 


### PR DESCRIPTION
fix #2303

We should always render the Bay animation for Barbarian castle with sea access even if we have the Shipyard built to properly render the bay around the shipyard.

https://github.com/user-attachments/assets/6ee895d6-6557-48b8-a8dd-7f8257598dfa




