### PR TITLE
Battlefield: fix incorrect pixels near the SKIP button when Hero's options are opened

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3023,6 +3023,16 @@ namespace
                 Blit( fheroes2::AGG::GetICN( ICN::STREAM, 2 ), 0, 0, _icnVsSprite[id][17], 1, 8, 24, 11 );
             }
             return true;
+        case ICN::TEXTBAR:
+            LoadOriginalICN( id );
+            if ( _icnVsSprite[id].size() > 9 ) {
+                // Remove the slightly corrupted rightmost column from the text bar background image.
+                for ( size_t i = 8; i < 10; ++i )
+                    if ( _icnVsSprite[id][i].width() == 543 ) {
+                        _icnVsSprite[id][i] = Crop( _icnVsSprite[id][i], 0, 0, _icnVsSprite[id][i].width() - 1, _icnVsSprite[id][i].height() );
+                    }
+            }
+            return true;
         case ICN::TWNWUP_5:
         case ICN::EDITOR:
             LoadOriginalICN( id );

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -1018,7 +1018,7 @@ int Battle::Arena::DialogBattleHero( HeroBase & hero, const bool buttons, Status
     // The Hero Screen is available for a Hero only (not Captain) and only when the corresponding player has a turn.
     Heroes * heroForHeroScreen = ( currentColor == hero.GetColor() ) ? dynamic_cast<Heroes *>( &hero ) : nullptr;
 
-    std::string statusMessage = _( "Hero's Options" );
+    std::string statusMessage;
 
     while ( le.HandleEvents() && !result ) {
         if ( btnCast.isEnabled() ) {
@@ -1109,7 +1109,7 @@ int Battle::Arena::DialogBattleHero( HeroBase & hero, const bool buttons, Status
         }
 
         if ( statusMessage != status.getMessage() ) {
-            status.setMessage( statusMessage, false );
+            status.setMessage( std::move( statusMessage ), false );
             status.redraw( display );
             display.render( status );
         }

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1025,7 +1025,7 @@ void Battle::Status::setMessage( std::string messageString, const bool top )
     if ( top ) {
         _upperText.set( messageString, fheroes2::FontType::normalWhite() );
         // The text cannot go beyond the text area so it is important to truncate it when necessary.
-        _upperText.fitToOneRow( _upperBackground.width() - offsetForTextBar * 2 );
+        _upperText.fitToOneRow( width - offsetForTextBar * 2 );
 
         if ( _battleStatusLog ) {
             _battleStatusLog->AddMessage( std::move( messageString ) );
@@ -1034,7 +1034,7 @@ void Battle::Status::setMessage( std::string messageString, const bool top )
     else if ( messageString != _lastMessage ) {
         _lowerText.set( messageString, fheroes2::FontType::normalWhite() );
         // The text cannot go beyond the text area so it is important to truncate it when necessary.
-        _lowerText.fitToOneRow( _upperBackground.width() - offsetForTextBar * 2 );
+        _lowerText.fitToOneRow( width - offsetForTextBar * 2 );
 
         _lastMessage = std::move( messageString );
     }
@@ -1042,15 +1042,15 @@ void Battle::Status::setMessage( std::string messageString, const bool top )
 
 void Battle::Status::redraw( fheroes2::Image & output ) const
 {
-    fheroes2::Copy( _upperBackground, 0, 0, output, x, y, _upperBackground.width(), _upperBackground.height() );
-    fheroes2::Copy( _lowerBackground, 0, 0, output, x, y + _upperBackground.height(), _lowerBackground.width(), _lowerBackground.height() );
+    fheroes2::Copy( _upperBackground, 0, 0, output, x, y, width, _upperBackground.height() );
+    fheroes2::Copy( _lowerBackground, 0, 0, output, x, y + _upperBackground.height(), width, _lowerBackground.height() );
 
     if ( !_upperText.empty() ) {
-        _upperText.draw( x + ( _upperBackground.width() - _upperText.width() ) / 2, y + 4, output );
+        _upperText.draw( x + ( width - _upperText.width() ) / 2, y + 4, output );
     }
 
     if ( !_lowerText.empty() ) {
-        _lowerText.draw( x + ( _lowerBackground.width() - _lowerText.width() ) / 2, y + _upperBackground.height(), output );
+        _lowerText.draw( x + ( width - _lowerText.width() ) / 2, y + _upperBackground.height(), output );
     }
 }
 


### PR DESCRIPTION
fix #4471

The original status bar background image has incorrect pixels in the rightmost column that are automatically covered by the SKIP button when in the battlefield. And when the Hero's Options dialog is opened the SKIP button is not re-rendered so these pixels become visible.
This PR does crop the original image to remove the incorrect rightmost image column.
Probably this column is a leftover from the leftmost parts of two buttons (SKIP and WAIT?).

It also slightly optimizes:
- the `Status` class to use `width` initialized by `_upperBackground.width()` instead on calling `_upperBackground.width()`;
- removes `std::string statusMessage` initialization because it will be always unused and overwritten in the next loop.

This PR:
![img](https://github.com/user-attachments/assets/1ce77ef6-7c60-463d-8e0a-784497c591ce)
