### PR TITLE
Remove SonarCloud badges from the main website page

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -45,11 +45,6 @@ This repository is a place for everyone. If you want to contribute, please read 
 
 To build the project from source, please follow [**this guide**](DEVELOPMENT.md).
 
-[![Build Status](https://github.com/ihhub/fheroes2/actions/workflows/push.yml/badge.svg)](https://github.com/ihhub/fheroes2/actions)
-[![Bugs](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=bugs)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)
-[![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=code_smells)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)
-[![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=ihhub_fheroes2&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=ihhub_fheroes2)
-
 To assist with the graphical asset efforts of the project, please look at our [**graphical artist guide**](GRAPHICAL_ASSETS.md).
 
 If you would like to help translating the project, please read the [**translation guide**](TRANSLATION.md).


### PR DESCRIPTION
They are not needed for end users but only useful for development on GitHub.

relates to #9775