### PR TITLE
Fix map center positioning when AI interacts with action object

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1883,8 +1883,14 @@ void AI::HeroesAction( Heroes & hero, const int32_t dst_index )
     const MP2::MapObjectType objectType = tile.getMainObjectType( dst_index != hero.GetIndex() );
 
     const bool isActionObject = MP2::isInGameActionObject( objectType, hero.isShipMaster() );
-    if ( isActionObject )
+    if ( isActionObject ) {
         hero.SetModes( Heroes::ACTION );
+
+        if ( AIIsShowAnimationForHero( hero, AIGetAllianceColors() ) ) {
+            // Most likely there will be some action, center the map on the hero to avoid subsequent minor screen movements.
+            Interface::AdventureMap::Get().getGameArea().SetCenter( hero.GetCenter() );
+        }
+    }
 
     switch ( objectType ) {
     case MP2::OBJ_BOAT:
@@ -2237,14 +2243,17 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
 
                 gameArea.ShiftCenter( { heroAnimationOffset.x * heroMovementSkipValue, heroAnimationOffset.y * heroMovementSkipValue } );
                 gameArea.SetRedraw();
+
                 heroAnimationFrameCount -= heroMovementSkipValue;
                 if ( ( heroAnimationFrameCount & 0x3 ) == 0 ) { // % 4
                     hero.SetSpriteIndex( heroAnimationSpriteId );
 
-                    if ( heroAnimationFrameCount == 0 )
+                    if ( heroAnimationFrameCount == 0 ) {
                         resetHeroSprite = true;
-                    else
+                    }
+                    else {
                         ++heroAnimationSpriteId;
+                    }
                 }
                 const int offsetStep = ( ( 4 - ( heroAnimationFrameCount & 0x3 ) ) & 0x3 ); // % 4
                 hero.SetOffset( { heroAnimationOffset.x * offsetStep, heroAnimationOffset.y * offsetStep } );
@@ -2267,6 +2276,7 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
 
                         heroAnimationOffset = movement;
                         gameArea.ShiftCenter( movement );
+
                         heroAnimationFrameCount = 32 - heroMovementSkipValue;
                         heroAnimationSpriteId = hero.GetSpriteIndex();
                         if ( heroMovementSkipValue < 4 ) {


### PR DESCRIPTION
fix #4141, fix #5146

This PR adds extra centering map on the hero when he interacts with an action object:

https://github.com/user-attachments/assets/348e11c7-9d79-4796-9f0f-e50e0deadb36


https://github.com/user-attachments/assets/2184e9d7-e684-48bf-950e-0b24abe06396

