### PR TITLE
Fix skip of render end of hero's move before interacting with action object

### DIFF
--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3773,6 +3773,9 @@ void Heroes::Action( int tileIndex )
 
         I.getGameArea().SetCenter( GetCenter() );
         I.redraw( Interface::REDRAW_GAMEAREA | Interface::REDRAW_RADAR_CURSOR | Interface::REDRAW_HEROES );
+
+        // Render the screen with the hero at the action object before rendering the action.
+        fheroes2::Display::instance().render();
     }
 
     switch ( objectType ) {


### PR DESCRIPTION
fix #6965

This PR:

https://github.com/user-attachments/assets/48f430ba-4e1c-4ce2-9e29-7f374a4a35f9

