### PR TITLE
Windows CMake workflow: use $VCPKG_INSTALLATION_ROOT instead of the hardcoded path

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -75,7 +75,7 @@ jobs:
     - name: Build
       run: |
         cmake.exe -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_IMAGE=ON \
-                           -DENABLE_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE=C:\\vcpkg\\scripts\\buildsystems\\vcpkg.cmake \
+                           -DENABLE_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT\\scripts\\buildsystems\\vcpkg.cmake" \
                            -DVCPKG_TARGET_TRIPLET=x64-windows
         cmake.exe --build build --config Debug
     - name: Install


### PR DESCRIPTION
It's better to be safe than sorry.