### PR TITLE
Battlefield: make Disrupting Ray and Teleport spells animation closer to the original game

### DIFF
--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -1539,7 +1539,7 @@ void Battle::Arena::ApplyActionSpellTeleport( Command & cmd )
         targetsInfo.push_back( targetInfo );
 
         _interface->RedrawActionSpellCastStatus( Spell( Spell::TELEPORT ), src, commander->GetName(), targetsInfo );
-        _interface->RedrawActionTeleportSpell( *unit, pos.GetHead()->GetIndex() );
+        _interface->redrawActionTeleportSpell( *unit, pos.GetHead()->GetIndex() );
     }
 
     unit->SetPosition( pos );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1845,56 +1845,34 @@ void Battle::Interface::RedrawOpponentsFlags()
 
 void Battle::Interface::RedrawTroopSprite( const Unit & unit )
 {
-    if ( b_current_sprite && _currentUnit == &unit ) {
-        drawTroopSprite( unit, *b_current_sprite );
-    }
-    else if ( unit.Modes( SP_STONE ) ) {
-        // Current monster can't be active if it's under Stunning effect.
-        const int monsterIcnId = unit.GetMonsterSprite();
-        fheroes2::Sprite monsterSprite = fheroes2::AGG::GetICN( monsterIcnId, unit.GetFrame() );
-        fheroes2::ApplyPalette( monsterSprite, PAL::GetPalette( PAL::PaletteType::GRAY ) );
-        drawTroopSprite( unit, monsterSprite );
-    }
-    else if ( unit.Modes( CAP_MIRRORIMAGE ) ) {
-        fheroes2::Sprite monsterSprite;
+    const bool isCurrentMonsterAction = ( _currentUnit == &unit && _spriteInsteadCurrentUnit != nullptr );
 
-        if ( _currentUnit == &unit && b_current_sprite != nullptr ) {
-            monsterSprite = *b_current_sprite;
-        }
-        else {
-            const int monsterIcnId = unit.GetMonsterSprite();
-            monsterSprite = fheroes2::AGG::GetICN( monsterIcnId, unit.GetFrame() );
-        }
+    const fheroes2::Sprite & monsterSprite = isCurrentMonsterAction ? *_spriteInsteadCurrentUnit : fheroes2::AGG::GetICN( unit.GetMonsterSprite(), unit.GetFrame() );
 
-        fheroes2::ApplyPalette( monsterSprite, PAL::GetPalette( PAL::PaletteType::MIRROR_IMAGE ) );
+    fheroes2::Point drawnPosition;
 
-        const fheroes2::Point drawnPosition = drawTroopSprite( unit, monsterSprite );
+    if ( unit.Modes( SP_STONE | CAP_MIRRORIMAGE ) ) {
+        // Apply Stone or Mirror image visual effect.
+        fheroes2::Sprite modifiedMonsterSprite( monsterSprite );
+        const PAL::PaletteType paletteType = unit.Modes( SP_STONE ) ? PAL::PaletteType::GRAY : PAL::PaletteType::MIRROR_IMAGE;
 
-        if ( _currentUnit == &unit && b_current_sprite == nullptr ) {
-            // Current unit's turn which is idling.
-            const fheroes2::Sprite & monsterContour = fheroes2::CreateContour( monsterSprite, _contourColor );
-            fheroes2::Blit( monsterContour, _mainSurface, drawnPosition.x, drawnPosition.y, unit.isReflect() );
-        }
+        fheroes2::ApplyPalette( modifiedMonsterSprite, PAL::GetPalette( paletteType ) );
+
+        drawnPosition = _drawTroopSprite( unit, modifiedMonsterSprite );
     }
     else {
-        const int monsterIcnId = unit.GetMonsterSprite();
-        const bool isCurrentMonsterAction = ( _currentUnit == &unit && b_current_sprite != nullptr );
+        drawnPosition = _drawTroopSprite( unit, monsterSprite );
+    }
 
-        const fheroes2::Sprite & monsterSprite = isCurrentMonsterAction ? *b_current_sprite : fheroes2::AGG::GetICN( monsterIcnId, unit.GetFrame() );
-
-        const fheroes2::Point drawnPosition = drawTroopSprite( unit, monsterSprite );
-
-        if ( _currentUnit == &unit && b_current_sprite == nullptr ) {
-            // Current unit's turn which is idling.
-            const fheroes2::Sprite & monsterContour = fheroes2::CreateContour( monsterSprite, _contourColor );
-            fheroes2::Blit( monsterContour, _mainSurface, drawnPosition.x, drawnPosition.y, unit.isReflect() );
-        }
+    if ( _currentUnit == &unit && _spriteInsteadCurrentUnit == nullptr ) {
+        // Current unit's turn which is idling. Highlight this unit's contour.
+        const fheroes2::Sprite & monsterContour = fheroes2::CreateContour( monsterSprite, _contourColor );
+        fheroes2::Blit( monsterContour, _mainSurface, drawnPosition.x, drawnPosition.y, unit.isReflect() );
     }
 }
 
-fheroes2::Point Battle::Interface::drawTroopSprite( const Unit & unit, const fheroes2::Sprite & troopSprite )
+fheroes2::Point Battle::Interface::_drawTroopSprite( const Unit & unit, const fheroes2::Sprite & troopSprite )
 {
-    const fheroes2::Rect & unitPosition = unit.GetRectPosition();
     // Get the sprite rendering offset.
     fheroes2::Point offset = GetTroopPosition( unit, troopSprite );
 
@@ -1907,6 +1885,7 @@ fheroes2::Point Battle::Interface::drawTroopSprite( const Unit & unit, const fhe
 
         if ( _movingUnit->animation.animationLength() ) {
             // Get the horizontal and vertical movement projections.
+            const fheroes2::Rect & unitPosition = unit.GetRectPosition();
             const int32_t moveX = _movingPos.x - unitPosition.x;
             const int32_t moveY = _movingPos.y - unitPosition.y;
 
@@ -1926,6 +1905,7 @@ fheroes2::Point Battle::Interface::drawTroopSprite( const Unit & unit, const fhe
     else if ( _flyingUnit == &unit ) {
         // Monster is flying.
         // Get the horizontal and vertical movement projections.
+        const fheroes2::Rect & unitPosition = unit.GetRectPosition();
         const int32_t moveX = _flyingPos.x - unitPosition.x;
         const int32_t moveY = _flyingPos.y - unitPosition.y;
 
@@ -4583,13 +4563,13 @@ void Battle::Interface::RedrawActionSpellCastPart1( const Spell & spell, int32_t
                 RedrawActionColdRaySpell( *target );
                 break;
             case Spell::DISRUPTINGRAY:
-                RedrawActionDisruptingRaySpell( *target );
+                _redrawActionDisruptingRaySpell( *target );
                 break;
             case Spell::BLOODLUST:
-                RedrawActionBloodLustSpell( *target );
+                _redrawActionBloodLustSpell( *target );
                 break;
             case Spell::PETRIFY:
-                RedrawActionStoneSpell( *target );
+                _redrawActionStoneSpell( *target );
                 break;
             default:
                 break;
@@ -5191,46 +5171,99 @@ void Battle::Interface::RedrawActionArrowSpell( const Unit & target )
     }
 }
 
-void Battle::Interface::RedrawActionTeleportSpell( Unit & target, const int32_t dst )
+void Battle::Interface::redrawActionTeleportSpell( Unit & target, const int32_t dst )
 {
     LocalEvent & le = LocalEvent::Get();
 
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
 
-    uint8_t currentAlpha = target.GetCustomAlpha();
-    const uint8_t alphaStep = 15;
+    // Hide the counter.
+    target.SwitchAnimation( Monster_Info::STAND_STILL );
+
+    const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
+    fheroes2::Sprite rippleSprite;
+    _spriteInsteadCurrentUnit = &rippleSprite;
+    const int32_t spriteHeight = unitSprite.height();
+
+    const Unit * oldCurrent = _currentUnit;
+    _currentUnit = &target;
+
+    // Don't highlight the cursor position.
+    _curentCellIndex = -1;
+
+    // Don't highlight movement area cells while animating teleportation.
+    Settings & conf = Settings::Get();
+    const bool showMoveShadowState = conf.BattleShowMoveShadow();
+    if ( showMoveShadowState ) {
+        conf.SetBattleMovementShaded( false );
+    }
 
     AudioManager::PlaySound( M82::TELPTOUT );
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    int32_t frame = 1;
+    const int32_t frameLimit = 25;
+    const int32_t maxAmlitude = 3;
+    const int32_t imageCutFrames = 7;
+    const double phaseCoeff = 0.6;
+    const int32_t wavePeriod = 60;
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && Mixer::isPlaying( -1 ) ) {
+    Game::passAnimationDelay( Game::BATTLE_DISRUPTING_DELAY );
+
+    // Animate first teleportation phase: disappearing.
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && frame <= frameLimit ) {
         CheckGlobalEvents( le );
 
-        if ( currentAlpha >= alphaStep && Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
-            currentAlpha -= alphaStep;
-            target.SetCustomAlpha( currentAlpha );
+        if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
+            if ( frame == frameLimit ) {
+                // Render one frame without rendering this unit.
+                rippleSprite.clear();
+            }
+            else {
+                const int32_t amplitude = std::min( frame / 2, maxAmlitude );
+                rippleSprite = fheroes2::createRippleEffect( unitSprite, amplitude, -phaseCoeff * frame, wavePeriod );
+
+                if ( frame > frameLimit - imageCutFrames ) {
+                    // Animate disappearing by making sprite transparent starting from the top.
+                    fheroes2::FillTransform( rippleSprite, 0, 0, rippleSprite.width(), spriteHeight * ( frame - frameLimit + imageCutFrames ) / imageCutFrames, 1 );
+                }
+            }
+
             Redraw();
+
+            ++frame;
         }
     }
-
-    currentAlpha = 0;
-    Redraw();
 
     target.SetPosition( dst );
     AudioManager::PlaySound( M82::TELPTIN );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && Mixer::isPlaying( -1 ) ) {
+    frame = 1;
+    // Animate second teleportation phase: appearing.
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && frame < frameLimit ) {
         CheckGlobalEvents( le );
 
-        if ( currentAlpha <= ( 255 - alphaStep ) && Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
-            currentAlpha += alphaStep;
-            target.SetCustomAlpha( currentAlpha );
+        if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
+            const int32_t amplitude = std::min( ( frameLimit - frame ) / 2, maxAmlitude );
+            rippleSprite = fheroes2::createRippleEffect( unitSprite, amplitude, phaseCoeff * ( frame + frameLimit ), wavePeriod );
+
+            if ( frame < imageCutFrames ) {
+                // Animate appearing from bottom to top by making the top part transparent.
+                fheroes2::FillTransform( rippleSprite, 0, 0, rippleSprite.width(), spriteHeight * ( imageCutFrames - frame ) / imageCutFrames, 1 );
+            }
+
             Redraw();
+
+            ++frame;
         }
     }
 
-    target.SetCustomAlpha( 255 );
+    // Restore the initial state.
+    target.SwitchAnimation( Monster_Info::STATIC );
+    _currentUnit = oldCurrent;
+    _spriteInsteadCurrentUnit = nullptr;
+    if ( showMoveShadowState ) {
+        conf.SetBattleMovementShaded( true );
+    }
 }
 
 void Battle::Interface::RedrawActionSummonElementalSpell( Unit & target )
@@ -5435,47 +5468,27 @@ void Battle::Interface::RedrawActionChainLightningSpell( const TargetsInfo & tar
     RedrawLightningOnTargets( points, _surfaceInnerArea );
 }
 
-void Battle::Interface::RedrawActionBloodLustSpell( const Unit & target )
+void Battle::Interface::_redrawActionBloodLustSpell( const Unit & target )
 {
     LocalEvent & le = LocalEvent::Get();
 
-    fheroes2::Sprite unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
-
-    std::vector<std::vector<uint8_t>> originalPalette;
-    if ( target.Modes( SP_STONE ) ) {
-        originalPalette.push_back( PAL::GetPalette( PAL::PaletteType::GRAY ) );
-    }
-    else if ( target.Modes( CAP_MIRRORIMAGE ) ) {
-        originalPalette.push_back( PAL::GetPalette( PAL::PaletteType::MIRROR_IMAGE ) );
-    }
-
-    if ( !originalPalette.empty() ) {
-        for ( size_t i = 1; i < originalPalette.size(); ++i ) {
-            originalPalette[0] = PAL::CombinePalettes( originalPalette[0], originalPalette[i] );
-        }
-        fheroes2::ApplyPalette( unitSprite, originalPalette[0] );
-    }
-
-    std::vector<uint8_t> convert = PAL::GetPalette( PAL::PaletteType::RED );
-    if ( !originalPalette.empty() ) {
-        convert = PAL::CombinePalettes( PAL::GetPalette( PAL::PaletteType::GRAY ), convert );
-    }
+    const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
 
     fheroes2::Sprite bloodlustEffect( unitSprite );
-    fheroes2::ApplyPalette( bloodlustEffect, convert );
+    fheroes2::ApplyPalette( bloodlustEffect, PAL::GetPalette( PAL::PaletteType::RED ) );
 
-    fheroes2::Sprite mixSprite( unitSprite );
+    fheroes2::Sprite mixSprite;
 
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
 
     _currentUnit = &target;
-    b_current_sprite = &mixSprite;
+    _spriteInsteadCurrentUnit = &mixSprite;
 
     const uint32_t bloodlustDelay = 1800 / 20;
     // duration is 1900ms
     AudioManager::PlaySound( M82::BLOODLUS );
 
-    uint32_t alpha = 0;
+    uint8_t alpha = 0;
     uint32_t frame = 0;
 
     // Immediately indicate that the delay has passed to render first frame immediately.
@@ -5488,7 +5501,7 @@ void Battle::Interface::RedrawActionBloodLustSpell( const Unit & target )
 
         if ( frame < 20 && Game::validateCustomAnimationDelay( bloodlustDelay ) ) {
             mixSprite = unitSprite;
-            fheroes2::AlphaBlit( bloodlustEffect, mixSprite, static_cast<uint8_t>( alpha ) );
+            fheroes2::AlphaBlit( bloodlustEffect, mixSprite, alpha );
             Redraw();
 
             alpha += ( frame < 10 ) ? 20 : -20;
@@ -5497,10 +5510,10 @@ void Battle::Interface::RedrawActionBloodLustSpell( const Unit & target )
     }
 
     _currentUnit = nullptr;
-    b_current_sprite = nullptr;
+    _spriteInsteadCurrentUnit = nullptr;
 }
 
-void Battle::Interface::RedrawActionStoneSpell( const Unit & target )
+void Battle::Interface::_redrawActionStoneSpell( const Unit & target )
 {
     LocalEvent & le = LocalEvent::Get();
 
@@ -5509,23 +5522,33 @@ void Battle::Interface::RedrawActionStoneSpell( const Unit & target )
     fheroes2::Sprite stoneEffect( unitSprite );
     fheroes2::ApplyPalette( stoneEffect, PAL::GetPalette( PAL::PaletteType::GRAY ) );
 
-    fheroes2::Sprite mixSprite( unitSprite );
+    fheroes2::Sprite mixSprite;
 
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
 
+    // Don't highlight the cursor position.
+    _curentCellIndex = -1;
+
+    // Don't highlight movement area cells while animating teleportation.
+    Settings & conf = Settings::Get();
+    const bool showMoveShadowState = conf.BattleShowMoveShadow();
+    if ( showMoveShadowState ) {
+        conf.SetBattleMovementShaded( false );
+    }
+
     _currentUnit = &target;
-    b_current_sprite = &mixSprite;
+    _spriteInsteadCurrentUnit = &mixSprite;
 
     AudioManager::PlaySound( M82::PARALIZE );
 
-    uint32_t alpha = 0;
+    uint8_t alpha = 0;
     uint32_t frame = 0;
     while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && Mixer::isPlaying( -1 ) ) {
         CheckGlobalEvents( le );
 
         if ( frame < 25 && Game::validateCustomAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
-            mixSprite = fheroes2::Sprite( unitSprite );
-            fheroes2::AlphaBlit( stoneEffect, mixSprite, static_cast<uint8_t>( alpha ) );
+            mixSprite = unitSprite;
+            fheroes2::AlphaBlit( stoneEffect, mixSprite, alpha );
             Redraw();
 
             alpha += 10;
@@ -5534,7 +5557,10 @@ void Battle::Interface::RedrawActionStoneSpell( const Unit & target )
     }
 
     _currentUnit = nullptr;
-    b_current_sprite = nullptr;
+    _spriteInsteadCurrentUnit = nullptr;
+    if ( showMoveShadowState ) {
+        conf.SetBattleMovementShaded( true );
+    }
 }
 
 void Battle::Interface::RedrawActionResurrectSpell( Unit & target, const Spell & spell )
@@ -5604,37 +5630,59 @@ void Battle::Interface::RedrawRaySpell( const Unit & target, const int spellICN,
     }
 }
 
-void Battle::Interface::RedrawActionDisruptingRaySpell( const Unit & target )
+void Battle::Interface::_redrawActionDisruptingRaySpell( Unit & target )
 {
     LocalEvent & le = LocalEvent::Get();
 
     RedrawRaySpell( target, ICN::DISRRAY, M82::DISRUPTR, 24 );
 
+    // Hide the counter.
+    target.SwitchAnimation( Monster_Info::STAND_STILL );
+
     // Part 2 - ripple effect
     const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
     fheroes2::Sprite rippleSprite;
+    _spriteInsteadCurrentUnit = &rippleSprite;
 
-    const Unit * old_current = _currentUnit;
+    const Unit * oldCurrent = _currentUnit;
     _currentUnit = &target;
-    _movingPos = { 0, 0 };
 
-    int32_t frame = 0;
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && frame < 60 ) {
+    // Don't highlight the cursor position.
+    _curentCellIndex = -1;
+
+    // Don't highlight movement area cells while animating teleportation.
+    Settings & conf = Settings::Get();
+    const bool showMoveShadowState = conf.BattleShowMoveShadow();
+    if ( showMoveShadowState ) {
+        conf.SetBattleMovementShaded( false );
+    }
+
+    int32_t frame = 1;
+    const int32_t frameLimit = 60;
+    const int32_t maxAmlitude = 3;
+
+    Game::passAnimationDelay( Game::BATTLE_DISRUPTING_DELAY );
+
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && frame < frameLimit ) {
         CheckGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
-            rippleSprite = fheroes2::CreateRippleEffect( unitSprite, frame );
-            rippleSprite.setPosition( unitSprite.x(), unitSprite.y() );
+            const int32_t amplitude = std::min( std::min( frame, ( frameLimit - frame ) ) / 3, maxAmlitude );
+            rippleSprite = fheroes2::createRippleEffect( unitSprite, amplitude, -0.4 * frame, 60 );
 
-            b_current_sprite = &rippleSprite;
             Redraw();
 
-            frame += 2;
+            ++frame;
         }
     }
 
-    _currentUnit = old_current;
-    b_current_sprite = nullptr;
+    // Restore the initial state.
+    target.SwitchAnimation( Monster_Info::STATIC );
+    _currentUnit = oldCurrent;
+    _spriteInsteadCurrentUnit = nullptr;
+    if ( showMoveShadowState ) {
+        conf.SetBattleMovementShaded( true );
+    }
 }
 
 void Battle::Interface::RedrawActionDeathWaveSpell( const int32_t strength )

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -5206,7 +5206,7 @@ void Battle::Interface::redrawActionTeleportSpell( Unit & target, const int32_t 
 
     int32_t frame = 1;
     const int32_t frameLimit = 25;
-    const int32_t maxAmlitude = 3;
+    const int32_t maxAmplitude = 3;
     const int32_t imageCutFrames = 7;
     const double phaseCoeff = 0.6;
     const int32_t wavePeriod = 60;
@@ -5223,7 +5223,7 @@ void Battle::Interface::redrawActionTeleportSpell( Unit & target, const int32_t 
                 rippleSprite.clear();
             }
             else {
-                const int32_t amplitude = std::min( frame / 2, maxAmlitude );
+                const int32_t amplitude = std::min( frame / 2, maxAmplitude );
                 rippleSprite = fheroes2::createRippleEffect( unitSprite, amplitude, -phaseCoeff * frame, wavePeriod );
 
                 if ( frame > frameLimit - imageCutFrames ) {
@@ -5254,7 +5254,7 @@ void Battle::Interface::redrawActionTeleportSpell( Unit & target, const int32_t 
                 _spriteInsteadCurrentUnit = &unitSprite;
             }
             else {
-                const int32_t amplitude = std::min( ( frameLimit - frame ) / 2, maxAmlitude );
+                const int32_t amplitude = std::min( ( frameLimit - frame ) / 2, maxAmplitude );
                 rippleSprite = fheroes2::createRippleEffect( unitSprite, amplitude, phaseCoeff * ( frame + frameLimit ), wavePeriod );
 
                 if ( frame < imageCutFrames ) {
@@ -5671,7 +5671,7 @@ void Battle::Interface::_redrawActionDisruptingRaySpell( Unit & target )
 
     int32_t frame = 1;
     const int32_t frameLimit = 60;
-    const int32_t maxAmlitude = 3;
+    const int32_t maxAmplitude = 3;
 
     Game::passAnimationDelay( Game::BATTLE_DISRUPTING_DELAY );
 
@@ -5679,7 +5679,7 @@ void Battle::Interface::_redrawActionDisruptingRaySpell( Unit & target )
         CheckGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
-            const int32_t amplitude = std::min( std::min( frame, ( frameLimit - frame ) ) / 3, maxAmlitude );
+            const int32_t amplitude = std::min( std::min( frame, ( frameLimit - frame ) ) / 3, maxAmplitude );
             rippleSprite = fheroes2::createRippleEffect( unitSprite, amplitude, -0.4 * frame, 60 );
 
             Redraw();

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -341,7 +341,7 @@ namespace Battle
         void RedrawActionTowerPart2( const Tower & tower, const TargetInfo & target );
         void RedrawActionCatapultPart1( const CastleDefenseStructure catapultTarget, const bool isHit );
         void RedrawActionCatapultPart2( const CastleDefenseStructure catapultTarget );
-        void RedrawActionTeleportSpell( Unit & target, const int32_t dst );
+        void redrawActionTeleportSpell( Unit & target, const int32_t dst );
         void redrawActionEarthquakeSpellPart1( const std::vector<CastleDefenseStructure> & targets );
         void redrawActionEarthquakeSpellPart2( const std::vector<CastleDefenseStructure> & targets );
         void RedrawActionSummonElementalSpell( Unit & target );
@@ -377,16 +377,16 @@ namespace Battle
         void RedrawArmies();
         void RedrawTroopSprite( const Unit & unit );
 
-        fheroes2::Point drawTroopSprite( const Unit & unit, const fheroes2::Sprite & troopSprite );
+        fheroes2::Point _drawTroopSprite( const Unit & unit, const fheroes2::Sprite & troopSprite );
 
         void RedrawTroopCount( const Unit & unit );
 
         void RedrawActionWincesKills( const TargetsInfo & targets, Unit * attacker = nullptr, const Unit * defender = nullptr );
         void RedrawActionArrowSpell( const Unit & target );
         void RedrawActionColdRaySpell( Unit & target );
-        void RedrawActionDisruptingRaySpell( const Unit & target );
-        void RedrawActionBloodLustSpell( const Unit & target );
-        void RedrawActionStoneSpell( const Unit & target );
+        void _redrawActionDisruptingRaySpell( Unit & target );
+        void _redrawActionBloodLustSpell( const Unit & target );
+        void _redrawActionStoneSpell( const Unit & target );
         void RedrawActionColdRingSpell( const int32_t dst, const TargetsInfo & targets );
         void RedrawActionElementalStormSpell( const TargetsInfo & targets );
         void RedrawActionArmageddonSpell();
@@ -476,7 +476,7 @@ namespace Battle
         const Unit * _currentUnit{ nullptr };
         const Unit * _movingUnit{ nullptr };
         const Unit * _flyingUnit{ nullptr };
-        const fheroes2::Sprite * b_current_sprite{ nullptr };
+        const fheroes2::Sprite * _spriteInsteadCurrentUnit{ nullptr };
         fheroes2::Point _movingPos;
         fheroes2::Point _flyingPos;
 

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -592,24 +592,16 @@ namespace fheroes2
         return out;
     }
 
-    Image CreateRippleEffect( const Image & in, const int32_t frameId, const double scaleX /* = 0.05 */, const double waveFrequency /* = 20.0 */ )
+    Sprite createRippleEffect( const Sprite & in, const int32_t amplitudeInPixels, const double phaseAtImageTop, const int32_t periodInPixels )
     {
-        if ( in.empty() || in.singleLayer() ) {
-            return {};
+        if ( in.empty() || in.singleLayer() || amplitudeInPixels == 0 ) {
+            return in;
         }
 
         const int32_t widthIn = in.width();
         const int32_t height = in.height();
 
-        // convert frames to -10...10 range with a period of 40
-        const int32_t linearWave = std::abs( 20 - ( frameId + 10 ) % 40 ) - 10;
-        const int32_t progress = 7 - frameId / 10;
-
-        const double rippleXModifier = ( progress * scaleX + 0.3 ) * linearWave;
-        const int32_t offsetX = static_cast<int32_t>( std::abs( rippleXModifier ) );
-        const int32_t limitY = static_cast<int32_t>( waveFrequency * M_PI );
-
-        Image out( widthIn + offsetX * 2, height );
+        Sprite out( widthIn + amplitudeInPixels * 2, height, in.x() - amplitudeInPixels, in.y() );
         out.reset();
 
         const int32_t widthOut = out.width();
@@ -621,9 +613,9 @@ namespace fheroes2
         const uint8_t * inTransformY = in.transform();
 
         for ( int32_t y = 0; y < height; ++y, inImageY += widthIn, inTransformY += widthIn, outImageY += widthOut, outTransformY += widthOut ) {
-            // Take top half the sin wave starting at 0 with period set by waveFrequency, result is -1...1
-            const double sinYEffect = sin( ( y % limitY ) / waveFrequency ) * 2.0 - 1;
-            const int32_t offset = static_cast<int32_t>( rippleXModifier * sinYEffect ) + offsetX;
+            // Calculate sin starting at `phaseAtImageTop` with period set by `periodInPixels`, result is in interval [-1.0, 1.0].
+            const double sinResult = std::sin( ( 2.0 * M_PI ) * y / periodInPixels + phaseAtImageTop );
+            const int32_t offset = static_cast<int32_t>( std::round( amplitudeInPixels * ( sinResult + 1.0 ) ) );
 
             memcpy( outImageY + offset, inImageY, widthIn );
             memcpy( outTransformY + offset, inTransformY, widthIn );

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -24,7 +24,6 @@
 #include <array>
 #include <cassert>
 #include <cmath>
-#include <cstdlib>
 #include <cstring>
 #include <ctime>
 #include <stdexcept>

--- a/src/fheroes2/gui/ui_tool.h
+++ b/src/fheroes2/gui/ui_tool.h
@@ -260,7 +260,7 @@ namespace fheroes2
 
     Image CreateHolyShoutEffect( const Image & in, const int32_t blurRadius, const uint8_t darkredStrength );
 
-    Image CreateRippleEffect( const Image & in, const int32_t frameId, const double scaleX = 0.05, const double waveFrequency = 20.0 );
+    Sprite createRippleEffect( const Sprite & in, const int32_t amplitudeInPixels, const double phaseAtImageTop, const int32_t periodInPixels );
 
     // Fade-out the whole screen.
     void fadeOutDisplay();


### PR DESCRIPTION
fix #3301

This PR makes the Disruptive Ray and Teleport spells rendering look close to the original game. The "wave" effect in the original game looks a bit buggy (especially at the beginning of the Disruptive Ray spell effect) so i did not fully reproduce it.
The creatures count and movement grid are hidden during the animation like it is done in the original game.
The parameters of spell effects can be adjusted.

This PR also restructures the `RedrawTroopSprite()` method's code to apply Stone and Mirror Image visual effects also to the `_spriteInsteadCurrentUnit` that is used for some spells animations where there is a need to apply effects to the creature's sprite. Doing this there is no more need to apply such effects to `_spriteInsteadCurrentUnit` in every method that prepare it for rendering.

This PR:

https://github.com/user-attachments/assets/81025e7a-8b4e-4ff6-a9c5-5b2ed72b1444

Master build:

https://github.com/user-attachments/assets/769ef7d7-88aa-44f7-b6a0-dbe0cc82aac1

