### PR TITLE
Add ability to sort save files by name or date

### DIFF
--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -121,9 +121,6 @@ namespace fheroes2
             const CharType lc = std::tolower( *li, currentGlobalLocale );
             const CharType rc = std::tolower( *ri, currentGlobalLocale );
 
-            ++li;
-            ++ri;
-
             if ( lc < rc ) {
                 return true;
             }
@@ -131,6 +128,8 @@ namespace fheroes2
                 return false;
             }
             // The characters are "equal", so proceed to checking the next pair
+            ++li;
+            ++ri;
         }
 
         // We have reached the end of one (or both) of the strings, the first parameter is considered "less than" the second if it is shorter

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -30,6 +30,7 @@
 #include <functional>
 #include <iomanip>
 #include <limits>
+#include <locale>
 #include <optional>
 #include <sstream>
 #include <string>
@@ -105,6 +106,36 @@ namespace fheroes2
 
     // Appends the given modifier to the end of the given string (e.g. "Coliseum +2")
     void appendModifierToString( std::string & str, const int mod );
+
+    // Performs case-insensitive string comparison, suitable for string sorting purposes. Returns true if the first parameter is
+    // "less than" the second, otherwise returns false.
+    template <typename CharType>
+    bool compareStringsCaseInsensitively( const std::basic_string<CharType> & lhs, const std::basic_string<CharType> & rhs )
+    {
+        typename std::basic_string<CharType>::const_iterator li = lhs.begin();
+        typename std::basic_string<CharType>::const_iterator ri = rhs.begin();
+
+        const std::locale currentGlobalLocale;
+
+        while ( li != lhs.end() && ri != rhs.end() ) {
+            const CharType lc = std::tolower( *li, currentGlobalLocale );
+            const CharType rc = std::tolower( *ri, currentGlobalLocale );
+
+            ++li;
+            ++ri;
+
+            if ( lc < rc ) {
+                return true;
+            }
+            if ( lc > rc ) {
+                return false;
+            }
+            // The characters are "equal", so proceed to checking the next pair
+        }
+
+        // We have reached the end of one (or both) of the strings, the first parameter is considered "less than" the second if it is shorter
+        return li == lhs.end() && ri != rhs.end();
+    }
 
     // Performs a checked conversion of an integer value of type From to an integer type To. Returns an empty std::optional<To> if
     // the source value does not fit into the target type.

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -486,7 +486,7 @@ namespace
                 const int currentId = listbox.getCurrentId();
 
                 settings.changeSaveFileSortingMethod();
-                (void)settings.Save( Settings::configFileName );
+                settings.Save( Settings::configFileName );
                 sortMapInfos( lists );
                 listUpdated = true;
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -235,7 +235,7 @@ namespace
             std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByFileName );
         }
         else {
-            assert( sortType == SaveFileSortType::LATEST );
+            assert( sortType == SaveFileSortType::TIMESTAMP );
             std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByTimestamp );
         }
     }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -532,7 +532,7 @@ namespace
                     lastChoiceTimestamp = lists[currentId].timestamp;
                 }
 
-                settings.changeSaveFileSortingMethod();
+                settings.toggleSaveFileSortingMethod();
                 sortMapInfos( lists );
                 listUpdated = true;
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -236,7 +236,7 @@ namespace
         }
         else {
             assert( sortType == SaveFileSortType::LATEST );
-            std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByTimestampDescending );
+            std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByTimestamp );
         }
     }
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -573,7 +573,7 @@ namespace
                 fheroes2::showStandardTextMessage( _( "Sort" ), _( "Click to toggle sorting by name/date" ), Dialog::ZERO );
             }
 
-            const bool needRedrawListbox = listbox.IsNeedRedraw() || listUpdated;
+            const bool needRedrawListbox = listUpdated || listbox.IsNeedRedraw();
 
             if ( isEditing && !needRedraw && !isListboxSelected && textInput->eventProcessing() ) {
                 // Text input blinking cursor render is done in Save Game dialog when no file is selected

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -570,7 +570,7 @@ namespace
                 fheroes2::showStandardTextMessage( _( "Open Virtual Keyboard" ), _( "Click to open the Virtual Keyboard dialog." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonSort.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "Sort" ), _( "Click to toggle sorting by name/date" ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Sort" ), _( "Click to toggle sorting by name/date." ), Dialog::ZERO );
             }
 
             const bool needRedrawListbox = listUpdated || listbox.IsNeedRedraw();

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -262,6 +262,12 @@ namespace
     }
 
     MapsFileInfoList::const_iterator findInMapInfos( const MapsFileInfoList::const_iterator & begin, const MapsFileInfoList::const_iterator & end,
+                                                     const std::string & lastChoice )
+    {
+        return std::find_if( begin, end, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
+    }
+
+    MapsFileInfoList::const_iterator findInMapInfos( const MapsFileInfoList::const_iterator & begin, const MapsFileInfoList::const_iterator & end,
                                                      const std::string & lastChoice, const uint32_t lastChoiceTimestamp, const SaveFileSortingMethod sortingMethod )
     {
         switch ( sortingMethod ) {
@@ -273,9 +279,7 @@ namespace
             // With case-insensitive sorting, there may be several "identical" file names on the case-sensitive file system
             const auto [beginSameFileName, endSameFileName] = std::equal_range( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
 
-            if ( const MapsFileInfoList::const_iterator iter
-                 = std::find_if( beginSameFileName, endSameFileName, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
-                 iter != endSameFileName ) {
+            if ( const MapsFileInfoList::const_iterator iter = findInMapInfos( beginSameFileName, endSameFileName, lastChoice ); iter != endSameFileName ) {
                 return iter;
             }
 
@@ -288,9 +292,7 @@ namespace
 
             const auto [beginSameTimestamp, endSameTimestamp] = std::equal_range( begin, end, lastChoiceTimestamp, Maps::FileInfo::CompareByTimestamp{} );
 
-            if ( const MapsFileInfoList::const_iterator iter
-                 = std::find_if( beginSameTimestamp, endSameTimestamp, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
-                 iter != endSameTimestamp ) {
+            if ( const MapsFileInfoList::const_iterator iter = findInMapInfos( beginSameTimestamp, endSameTimestamp, lastChoice ); iter != endSameTimestamp ) {
                 return iter;
             }
 
@@ -316,16 +318,14 @@ namespace
             // With case-insensitive sorting, there may be several "identical" file names on the case-sensitive file system
             const auto [beginSameFileName, endSameFileName] = std::equal_range( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
 
-            if ( const MapsFileInfoList::const_iterator iter
-                 = std::find_if( beginSameFileName, endSameFileName, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
-                 iter != endSameFileName ) {
+            if ( const MapsFileInfoList::const_iterator iter = findInMapInfos( beginSameFileName, endSameFileName, lastChoice ); iter != endSameFileName ) {
                 return iter;
             }
 
             break;
         }
         case SaveFileSortingMethod::TIMESTAMP:
-            return std::find_if( begin, end, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
+            return findInMapInfos( begin, end, lastChoice );
         default:
             assert( 0 );
             break;

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -483,7 +483,7 @@ namespace
 
         // Redraw sort radio buttons, sort file list in new method, and return whether to redraw the list.
         auto switchFileSorting
-            = [&markBackgroundNameRoi, &markBackgroundDateRoi, &markBackground, &mark, &display, &listbox, &lists, &settings]( const bool isSortedByName ) {
+            = [&markBackgroundNameRoi, &markBackgroundDateRoi, &markBackground, &mark, &display, &listbox, &lists, &settings]( const bool doSortByDate ) {
                   const fheroes2::Rect roiMarkBackground = isSortedByName ? markBackgroundNameRoi : markBackgroundDateRoi;
                   const fheroes2::Rect roiMark = isSortedByName ? markBackgroundDateRoi : markBackgroundNameRoi;
                   fheroes2::Blit( markBackground, display, roiMarkBackground );
@@ -610,11 +610,11 @@ namespace
             }
             else if ( le.MouseClickLeft( nameHeaderRoi ) && settings.GetSaveFileSortingMethod() != SaveFileSortingMethod::FILENAME ) {
                 listUpdated = true;
-                needRedraw = switchFileSorting( settings.GetSaveFileSortingMethod() == SaveFileSortingMethod::FILENAME );
+                needRedraw = switchFileSorting( false );
             }
             else if ( le.MouseClickLeft( dateHeaderRoi ) && settings.GetSaveFileSortingMethod() != SaveFileSortingMethod::TIMESTAMP ) {
                 listUpdated = true;
-                needRedraw = switchFileSorting( settings.GetSaveFileSortingMethod() == SaveFileSortingMethod::FILENAME );
+                needRedraw = switchFileSorting( true );
             }
             else if ( isEditing ) {
                 assert( textInput != nullptr );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -573,6 +573,7 @@ namespace
                 fheroes2::showStandardTextMessage( _( "Sort" ), _( "Click to toggle sorting by name/date." ), Dialog::ZERO );
             }
 
+            // TODO: ListBox::SetCurrent() call should update needRedraw variable as it changes the internal UI view of the class.
             const bool needRedrawListbox = listUpdated || listbox.IsNeedRedraw();
 
             if ( isEditing && !needRedraw && !isListboxSelected && textInput->eventProcessing() ) {

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -269,7 +269,12 @@ namespace
             assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByFileName{} ) );
 #endif
 
-            if ( const auto iter = std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} ); iter != end && iter->filename == lastChoice ) {
+            // With case-insensitive sorting, there may be several "identical" file names on the case-sensitive file system
+            const auto [beginSameFileName, endSameFileName] = std::equal_range( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
+
+            if ( const MapsFileInfoList::const_iterator iter
+                 = std::find_if( beginSameFileName, endSameFileName, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
+                 iter != endSameFileName ) {
                 return iter;
             }
 
@@ -281,11 +286,13 @@ namespace
 #endif
 
         const auto [beginSameTimestamp, endSameTimestamp] = std::equal_range( begin, end, lastChoiceTimestamp, Maps::FileInfo::CompareByTimestamp{} );
-        const MapsFileInfoList::const_iterator it
-            = std::find_if( beginSameTimestamp, endSameTimestamp, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
-        if ( it != endSameTimestamp ) {
-            return it;
+
+        if ( const MapsFileInfoList::const_iterator iter
+             = std::find_if( beginSameTimestamp, endSameTimestamp, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
+             iter != endSameTimestamp ) {
+            return iter;
         }
+
         return end; // Not found.
     }
 
@@ -297,7 +304,12 @@ namespace
             assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByFileName{} ) );
 #endif
 
-            if ( const auto iter = std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} ); iter != end && iter->filename == lastChoice ) {
+            // With case-insensitive sorting, there may be several "identical" file names on the case-sensitive file system
+            const auto [beginSameFileName, endSameFileName] = std::equal_range( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
+
+            if ( const MapsFileInfoList::const_iterator iter
+                 = std::find_if( beginSameFileName, endSameFileName, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
+                 iter != endSameFileName ) {
                 return iter;
             }
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -389,7 +389,7 @@ namespace
         fheroes2::ButtonSprite buttonSort;
         // SORT should be in the middle if "..." isn't present, otherwise they should be side by side
         const int sortOffsetX = isEditing ? -offsetFromCenter : 0;
-        background.renderCustomButtonSprite( buttonSort, _( "SORT" ), { 56, 25 }, { sortOffsetX, 7 }, fheroes2::StandardWindow::Padding::BOTTOM_CENTER );
+        background.renderCustomButtonSprite( buttonSort, _( "SORT" ), { 80, 25 }, { sortOffsetX, 7 }, fheroes2::StandardWindow::Padding::BOTTOM_CENTER );
 
         if ( isEditing ) {
             // Render a button to open the Virtual Keyboard window.

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -115,26 +115,6 @@ namespace
         textInput.drawInRoi( field.x + 4 + ( maxFileNameWidth - textInput.width() ) / 2, field.y + 4, output, field );
     }
 
-    struct CompareByTimestamp
-    {
-        bool operator()( const Maps::FileInfo & info, uint32_t timestamp ) const
-        {
-            return info.timestamp > timestamp;
-        }
-        bool operator()( uint32_t timestamp, const Maps::FileInfo & info ) const
-        {
-            return timestamp > info.timestamp;
-        }
-    };
-
-    struct CompareByFilename
-    {
-        bool operator()( const Maps::FileInfo & info, const std::string & filename ) const
-        {
-            return fheroes2::compareStringsCaseInsensitively( info.filename, filename );
-        }
-    };
-
     class FileInfoListBox : public Interface::ListBox<Maps::FileInfo>
     {
     public:
@@ -252,11 +232,11 @@ namespace
     {
         const SaveFileSortingMethod sortType = Settings::Get().GetSaveFileSortingMethod();
         if ( sortType == SaveFileSortingMethod::FILENAME ) {
-            std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByFileName );
+            std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::CompareByFileName{} );
         }
         else {
             assert( sortType == SaveFileSortingMethod::TIMESTAMP );
-            std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByTimestamp );
+            std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::CompareByTimestamp{} );
         }
     }
 
@@ -285,10 +265,10 @@ namespace
                                                      const std::string & lastChoice, const uint32_t lastChoiceTimestamp, const SaveFileSortingMethod sortingMethod )
     {
         if ( sortingMethod == SaveFileSortingMethod::FILENAME ) {
-            return std::lower_bound( begin, end, lastChoice, CompareByFilename() );
+            return std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
         }
 
-        const auto [beginSameTimestamp, endSameTimestamp] = std::equal_range( begin, end, lastChoiceTimestamp, CompareByTimestamp() );
+        const auto [beginSameTimestamp, endSameTimestamp] = std::equal_range( begin, end, lastChoiceTimestamp, Maps::FileInfo::CompareByTimestamp() );
         const MapsFileInfoList::const_iterator it
             = std::find_if( beginSameTimestamp, endSameTimestamp, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
         if ( it != endSameTimestamp ) {
@@ -301,7 +281,7 @@ namespace
                                                      const std::string & lastChoice, const SaveFileSortingMethod sortingMethod )
     {
         if ( sortingMethod == SaveFileSortingMethod::FILENAME ) {
-            return std::lower_bound( begin, end, lastChoice, CompareByFilename() );
+            return std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName() );
         }
 
         return std::find_if( begin, end, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -244,7 +244,14 @@ namespace
             }
         }
 
-        std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByFileName );
+        const SaveFileSortType sortType = Settings::Get().GetSaveFileSortType();
+        if ( sortType == SaveFileSortType::FILENAME ) {
+            std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByFileName );
+        }
+        else {
+            assert( sortType == SaveFileSortType::LATEST );
+            std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByTimestampDescending );
+        }
 
         return mapInfos;
     }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -230,7 +230,7 @@ namespace
 
     void sortMapInfos( MapsFileInfoList & mapInfos )
     {
-        const SaveFileSortingMethod sortType = Settings::Get().GetSaveFileSortType();
+        const SaveFileSortingMethod sortType = Settings::Get().GetSaveFileSortingMethod();
         if ( sortType == SaveFileSortingMethod::FILENAME ) {
             std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByFileName );
         }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -497,7 +497,7 @@ namespace
                       lastChoiceTimestamp = lists[currentId].timestamp;
                   }
 
-                  settings.toggleSaveFileSortingMethod();
+                  settings.setSaveFileSortingMethod( doSortByDate ? SaveFileSortingMethod::TIMESTAMP : SaveFileSortingMethod::FILENAME );
                   sortMapInfos( lists );
 
                   bool redrawNeeded = false;

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -318,6 +318,7 @@ namespace
 
         Settings & settings = Settings::Get();
         const bool isEvilInterface = settings.isEvilInterfaceEnabled();
+        const SaveFileSortingMethod fileSortingMethod = settings.GetSaveFileSortingMethod();
 
         int32_t scrollbarOffsetX = dialogArea.x + dialogArea.width - 35;
         background.renderScrollbarBackground( { scrollbarOffsetX, listRoi.y, listRoi.width, listRoi.height }, isEvilInterface );
@@ -432,7 +433,7 @@ namespace
             }
 
             if ( le.MouseClickLeft( buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-                return {};
+                break;
             }
 
             const int listId = listbox.getCurrentId();
@@ -486,7 +487,6 @@ namespace
                 const int currentId = listbox.getCurrentId();
 
                 settings.changeSaveFileSortingMethod();
-                settings.Save( Settings::configFileName );
                 sortMapInfos( lists );
                 listUpdated = true;
 
@@ -620,6 +620,12 @@ namespace
             else {
                 display.render( textInputAndDateROI );
             }
+        }
+
+        const SaveFileSortingMethod lastFileSortingMethod = settings.GetSaveFileSortingMethod();
+
+        if ( lastFileSortingMethod != fileSortingMethod ) {
+            settings.Save( Settings::configFileName );
         }
 
         return result;

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -230,7 +230,7 @@ namespace
 
     void sortMapInfos( MapsFileInfoList & mapInfos )
     {
-        const SaveFileSortingMethod sortType = Settings::Get().GetSaveFileSortingMethod();
+        const SaveFileSortingMethod sortType = Settings::Get().getSaveFileSortingMethod();
         if ( sortType == SaveFileSortingMethod::FILENAME ) {
             std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::CompareByFileName{} );
         }
@@ -395,7 +395,7 @@ namespace
 
         Settings & settings = Settings::Get();
         const bool isEvilInterface = settings.isEvilInterfaceEnabled();
-        const SaveFileSortingMethod fileSortingMethod = settings.GetSaveFileSortingMethod();
+        const SaveFileSortingMethod fileSortingMethod = settings.getSaveFileSortingMethod();
 
         int32_t scrollbarOffsetX = dialogArea.x + dialogArea.width - 35;
         background.renderScrollbarBackground( { scrollbarOffsetX, listRoi.y, listRoi.width, listRoi.height }, isEvilInterface );
@@ -505,7 +505,7 @@ namespace
                   // Re-select the last selected file if any, unless we're typing in the list box
                   if ( !lastChoice.empty() ) {
                       const MapsFileInfoList::const_iterator it
-                          = findInMapInfos( lists.cbegin(), lists.cend(), lastChoice, lastChoiceTimestamp, settings.GetSaveFileSortingMethod() );
+                          = findInMapInfos( lists.cbegin(), lists.cend(), lastChoice, lastChoiceTimestamp, settings.getSaveFileSortingMethod() );
 
                       if ( it != lists.cend() ) {
                           const int newId = static_cast<int>( std::distance( lists.cbegin(), it ) );
@@ -608,11 +608,11 @@ namespace
                     result = System::concatPath( Game::GetSaveDir(), filename + Game::GetSaveFileExtension() );
                 }
             }
-            else if ( le.MouseClickLeft( nameHeaderRoi ) && settings.GetSaveFileSortingMethod() != SaveFileSortingMethod::FILENAME ) {
+            else if ( le.MouseClickLeft( nameHeaderRoi ) && settings.getSaveFileSortingMethod() != SaveFileSortingMethod::FILENAME ) {
                 listUpdated = true;
                 needRedraw = switchFileSorting( false );
             }
-            else if ( le.MouseClickLeft( dateHeaderRoi ) && settings.GetSaveFileSortingMethod() != SaveFileSortingMethod::TIMESTAMP ) {
+            else if ( le.MouseClickLeft( dateHeaderRoi ) && settings.getSaveFileSortingMethod() != SaveFileSortingMethod::TIMESTAMP ) {
                 listUpdated = true;
                 needRedraw = switchFileSorting( true );
             }
@@ -733,7 +733,7 @@ namespace
             }
         }
 
-        const SaveFileSortingMethod lastFileSortingMethod = settings.GetSaveFileSortingMethod();
+        const SaveFileSortingMethod lastFileSortingMethod = settings.getSaveFileSortingMethod();
 
         if ( lastFileSortingMethod != fileSortingMethod ) {
             settings.Save( Settings::configFileName );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -230,12 +230,12 @@ namespace
 
     void sortMapInfos( MapsFileInfoList & mapInfos )
     {
-        const SaveFileSortType sortType = Settings::Get().GetSaveFileSortType();
-        if ( sortType == SaveFileSortType::FILENAME ) {
+        const SaveFileSortingMethod sortType = Settings::Get().GetSaveFileSortType();
+        if ( sortType == SaveFileSortingMethod::FILENAME ) {
             std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByFileName );
         }
         else {
-            assert( sortType == SaveFileSortType::TIMESTAMP );
+            assert( sortType == SaveFileSortingMethod::TIMESTAMP );
             std::sort( mapInfos.begin(), mapInfos.end(), Maps::FileInfo::sortByTimestamp );
         }
     }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -131,7 +131,7 @@ namespace
     {
         bool operator()( const Maps::FileInfo & info, const std::string & filename ) const
         {
-            return Maps::CaseInsensitiveCompare( info.filename, filename );
+            return fheroes2::compareStringsCaseInsensitively( info.filename, filename );
         }
     };
 

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -265,10 +265,18 @@ namespace
                                                      const std::string & lastChoice, const uint32_t lastChoiceTimestamp, const SaveFileSortingMethod sortingMethod )
     {
         if ( sortingMethod == SaveFileSortingMethod::FILENAME ) {
+#ifdef WITH_DEBUG
+            assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByFileName{} ) );
+#endif
+
             return std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
         }
 
-        const auto [beginSameTimestamp, endSameTimestamp] = std::equal_range( begin, end, lastChoiceTimestamp, Maps::FileInfo::CompareByTimestamp() );
+#ifdef WITH_DEBUG
+        assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByTimestamp{} ) );
+#endif
+
+        const auto [beginSameTimestamp, endSameTimestamp] = std::equal_range( begin, end, lastChoiceTimestamp, Maps::FileInfo::CompareByTimestamp{} );
         const MapsFileInfoList::const_iterator it
             = std::find_if( beginSameTimestamp, endSameTimestamp, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
         if ( it != endSameTimestamp ) {
@@ -281,7 +289,11 @@ namespace
                                                      const std::string & lastChoice, const SaveFileSortingMethod sortingMethod )
     {
         if ( sortingMethod == SaveFileSortingMethod::FILENAME ) {
-            return std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName() );
+#ifdef WITH_DEBUG
+            assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByFileName{} ) );
+#endif
+
+            return std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
         }
 
         return std::find_if( begin, end, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -264,7 +264,8 @@ namespace
     MapsFileInfoList::const_iterator findInMapInfos( const MapsFileInfoList::const_iterator & begin, const MapsFileInfoList::const_iterator & end,
                                                      const std::string & lastChoice, const uint32_t lastChoiceTimestamp, const SaveFileSortingMethod sortingMethod )
     {
-        if ( sortingMethod == SaveFileSortingMethod::FILENAME ) {
+        switch ( sortingMethod ) {
+        case SaveFileSortingMethod::FILENAME: {
 #ifdef WITH_DEBUG
             assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByFileName{} ) );
 #endif
@@ -278,28 +279,36 @@ namespace
                 return iter;
             }
 
-            return end;
+            break;
         }
-
+        case SaveFileSortingMethod::TIMESTAMP: {
 #ifdef WITH_DEBUG
-        assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByTimestamp{} ) );
+            assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByTimestamp{} ) );
 #endif
 
-        const auto [beginSameTimestamp, endSameTimestamp] = std::equal_range( begin, end, lastChoiceTimestamp, Maps::FileInfo::CompareByTimestamp{} );
+            const auto [beginSameTimestamp, endSameTimestamp] = std::equal_range( begin, end, lastChoiceTimestamp, Maps::FileInfo::CompareByTimestamp{} );
 
-        if ( const MapsFileInfoList::const_iterator iter
-             = std::find_if( beginSameTimestamp, endSameTimestamp, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
-             iter != endSameTimestamp ) {
-            return iter;
+            if ( const MapsFileInfoList::const_iterator iter
+                 = std::find_if( beginSameTimestamp, endSameTimestamp, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
+                 iter != endSameTimestamp ) {
+                return iter;
+            }
+
+            break;
+        }
+        default:
+            assert( 0 );
+            break;
         }
 
-        return end; // Not found.
+        return end;
     }
 
     MapsFileInfoList::const_iterator findInMapInfos( const MapsFileInfoList::const_iterator & begin, const MapsFileInfoList::const_iterator & end,
                                                      const std::string & lastChoice, const SaveFileSortingMethod sortingMethod )
     {
-        if ( sortingMethod == SaveFileSortingMethod::FILENAME ) {
+        switch ( sortingMethod ) {
+        case SaveFileSortingMethod::FILENAME: {
 #ifdef WITH_DEBUG
             assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByFileName{} ) );
 #endif
@@ -313,10 +322,16 @@ namespace
                 return iter;
             }
 
-            return end;
+            break;
+        }
+        case SaveFileSortingMethod::TIMESTAMP:
+            return std::find_if( begin, end, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
+        default:
+            assert( 0 );
+            break;
         }
 
-        return std::find_if( begin, end, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );
+        return end;
     }
 
     std::string selectFileListSimple( const std::string & header, const std::string & lastfile, const bool isEditing )

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -485,7 +485,7 @@ namespace
             else if ( le.MouseClickLeft( buttonSort.area() ) ) {
                 const int currentId = listbox.getCurrentId();
 
-                settings.CycleSaveFileSortType();
+                settings.changeSaveFileSortingMethod();
                 (void)settings.Save( Settings::configFileName );
                 sortMapInfos( lists );
                 listUpdated = true;

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -389,7 +389,7 @@ namespace
         fheroes2::ButtonSprite buttonSort;
         // SORT should be in the middle if "..." isn't present, otherwise they should be side by side
         const int sortOffsetX = isEditing ? -offsetFromCenter : 0;
-        background.renderCustomButtonSprite( buttonSort, "SORT", { 56, 25 }, { sortOffsetX, 7 }, fheroes2::StandardWindow::Padding::BOTTOM_CENTER );
+        background.renderCustomButtonSprite( buttonSort, _( "SORT" ), { 56, 25 }, { sortOffsetX, 7 }, fheroes2::StandardWindow::Padding::BOTTOM_CENTER );
 
         if ( isEditing ) {
             // Render a button to open the Virtual Keyboard window.

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -316,7 +316,8 @@ namespace
 
         listbox.SetAreaItems( { listRoi.x, listRoi.y + 3, listRoi.width - listAreaOffsetY, listRoi.height - listAreaHeightDeduction } );
 
-        const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
+        Settings & settings = Settings::Get();
+        const bool isEvilInterface = settings.isEvilInterfaceEnabled();
 
         int32_t scrollbarOffsetX = dialogArea.x + dialogArea.width - 35;
         background.renderScrollbarBackground( { scrollbarOffsetX, listRoi.y, listRoi.width, listRoi.height }, isEvilInterface );
@@ -482,7 +483,8 @@ namespace
                 }
             }
             else if ( le.MouseClickLeft( buttonSort.area() ) ) {
-                Settings::Get().CycleSaveFileSortType();
+                settings.CycleSaveFileSortType();
+                (void)settings.Save( Settings::configFileName );
                 sortMapInfos( lists );
                 listUpdated = true;
             }

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -269,7 +269,11 @@ namespace
             assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByFileName{} ) );
 #endif
 
-            return std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
+            if ( const auto iter = std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} ); iter != end && iter->filename == lastChoice ) {
+                return iter;
+            }
+
+            return end;
         }
 
 #ifdef WITH_DEBUG
@@ -293,7 +297,11 @@ namespace
             assert( std::is_sorted( begin, end, Maps::FileInfo::CompareByFileName{} ) );
 #endif
 
-            return std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} );
+            if ( const auto iter = std::lower_bound( begin, end, lastChoice, Maps::FileInfo::CompareByFileName{} ); iter != end && iter->filename == lastChoice ) {
+                return iter;
+            }
+
+            return end;
         }
 
         return std::find_if( begin, end, [&lastChoice]( const Maps::FileInfo & info ) { return info.filename == lastChoice; } );

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -484,8 +484,8 @@ namespace
         // Redraw sort radio buttons, sort file list in new method, and return whether to redraw the list.
         auto switchFileSorting
             = [&markBackgroundNameRoi, &markBackgroundDateRoi, &markBackground, &mark, &display, &listbox, &lists, &settings]( const bool doSortByDate ) {
-                  const fheroes2::Rect roiMarkBackground = isSortedByName ? markBackgroundNameRoi : markBackgroundDateRoi;
-                  const fheroes2::Rect roiMark = isSortedByName ? markBackgroundDateRoi : markBackgroundNameRoi;
+                  const fheroes2::Rect roiMarkBackground = doSortByDate ? markBackgroundNameRoi : markBackgroundDateRoi;
+                  const fheroes2::Rect roiMark = doSortByDate ? markBackgroundDateRoi : markBackgroundNameRoi;
                   fheroes2::Blit( markBackground, display, roiMarkBackground );
                   fheroes2::Blit( mark, display, { roiMark.x + 3, roiMark.y + 3, roiMark.width, roiMark.height } );
 

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -28,7 +28,6 @@
 #include <cstring>
 #include <functional>
 #include <list>
-#include <locale>
 #include <map>
 #include <sstream>
 #include <type_traits>
@@ -58,32 +57,6 @@ namespace
 {
     const size_t mapNameLength = 16;
     const size_t mapDescriptionLength = 200;
-
-    template <typename CharType>
-    bool CaseInsensitiveCompare( const std::basic_string<CharType> & lhs, const std::basic_string<CharType> & rhs )
-    {
-        typename std::basic_string<CharType>::const_iterator li = lhs.begin();
-        typename std::basic_string<CharType>::const_iterator ri = rhs.begin();
-
-        while ( li != lhs.end() && ri != rhs.end() ) {
-            const CharType lc = std::tolower( *li, std::locale() );
-            const CharType rc = std::tolower( *ri, std::locale() );
-
-            ++li;
-            ++ri;
-
-            if ( lc < rc ) {
-                return true;
-            }
-            if ( lc > rc ) {
-                return false;
-            }
-            // the chars are "equal", so proceed to check the next pair
-        }
-
-        // we came to the end of either (or both) strings, left is "smaller" if it was shorter:
-        return li == lhs.end() && ri != rhs.end();
-    }
 
     // This function returns an unsorted array. It is a caller responsibility to take care of sorting if needed.
     MapsFileInfoList getValidMaps( const ListFiles & mapFiles, const uint8_t humanPlayerCount, const bool isForEditor, const bool isOriginalMapFormat )

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -536,12 +536,12 @@ void Maps::FileInfo::FillUnions( const PlayerColorsSet side1Colors, const Player
 
 bool Maps::FileInfo::sortByFileName( const FileInfo & lhs, const FileInfo & rhs )
 {
-    return CaseInsensitiveCompare( lhs.filename, rhs.filename );
+    return fheroes2::compareStringsCaseInsensitively( lhs.filename, rhs.filename );
 }
 
 bool Maps::FileInfo::sortByMapName( const FileInfo & lhs, const FileInfo & rhs )
 {
-    return CaseInsensitiveCompare( lhs.name, rhs.name );
+    return fheroes2::compareStringsCaseInsensitively( lhs.name, rhs.name );
 }
 
 int Maps::FileInfo::KingdomRace( const PlayerColor color ) const

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -571,6 +571,12 @@ bool Maps::FileInfo::sortByMapName( const FileInfo & lhs, const FileInfo & rhs )
     return CaseInsensitiveCompare( lhs.name, rhs.name );
 }
 
+bool Maps::FileInfo::sortByTimestampDescending( const FileInfo & lhs, const FileInfo & rhs )
+{
+    // we want the latest timestamp first
+    return lhs.timestamp > rhs.timestamp;
+}
+
 int Maps::FileInfo::KingdomRace( const PlayerColor color ) const
 {
     switch ( color ) {

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -534,9 +534,19 @@ void Maps::FileInfo::FillUnions( const PlayerColorsSet side1Colors, const Player
     }
 }
 
+bool Maps::FileInfo::CompareByFileName::operator()( const FileInfo & lhs, const FileInfo & rhs ) const
+{
+    return fheroes2::compareStringsCaseInsensitively( lhs.filename, rhs.filename );
+}
+
 bool Maps::FileInfo::CompareByFileName::operator()( const FileInfo & lhs, const std::string & rhs ) const
 {
     return fheroes2::compareStringsCaseInsensitively( lhs.filename, rhs );
+}
+
+bool Maps::FileInfo::CompareByFileName::operator()( const std::string & lhs, const FileInfo & rhs ) const
+{
+    return fheroes2::compareStringsCaseInsensitively( lhs, rhs.filename );
 }
 
 bool Maps::FileInfo::CompareByMapName::operator()( const FileInfo & lhs, const FileInfo & rhs ) const

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -571,12 +571,6 @@ bool Maps::FileInfo::sortByMapName( const FileInfo & lhs, const FileInfo & rhs )
     return CaseInsensitiveCompare( lhs.name, rhs.name );
 }
 
-bool Maps::FileInfo::sortByTimestampDescending( const FileInfo & lhs, const FileInfo & rhs )
-{
-    // we want the latest timestamp first
-    return lhs.timestamp > rhs.timestamp;
-}
-
 int Maps::FileInfo::KingdomRace( const PlayerColor color ) const
 {
     switch ( color ) {

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -534,12 +534,12 @@ void Maps::FileInfo::FillUnions( const PlayerColorsSet side1Colors, const Player
     }
 }
 
-bool Maps::FileInfo::sortByFileName( const FileInfo & lhs, const FileInfo & rhs )
+bool Maps::FileInfo::CompareByFileName::operator()( const FileInfo & lhs, const std::string & rhs ) const
 {
-    return fheroes2::compareStringsCaseInsensitively( lhs.filename, rhs.filename );
+    return fheroes2::compareStringsCaseInsensitively( lhs.filename, rhs );
 }
 
-bool Maps::FileInfo::sortByMapName( const FileInfo & lhs, const FileInfo & rhs )
+bool Maps::FileInfo::CompareByMapName::operator()( const FileInfo & lhs, const FileInfo & rhs ) const
 {
     return fheroes2::compareStringsCaseInsensitively( lhs.name, rhs.name );
 }
@@ -709,10 +709,10 @@ MapsFileInfoList Maps::getAllMapFileInfos( const bool isForEditor, const uint8_t
     }
 
     if ( isForEditor ) {
-        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::sortByFileName );
+        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByFileName{} );
     }
     else {
-        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::sortByMapName );
+        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByMapName{} );
     }
 
     return validMaps;
@@ -729,10 +729,10 @@ MapsFileInfoList Maps::getResurrectionMapFileInfos( const bool isForEditor, cons
     MapsFileInfoList validMaps = getValidMaps( maps, humanPlayerCount, isForEditor, false );
 
     if ( isForEditor ) {
-        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::sortByFileName );
+        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByFileName{} );
     }
     else {
-        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::sortByMapName );
+        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByMapName{} );
     }
 
     return validMaps;

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -26,7 +26,6 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
-#include <locale>
 #include <optional>
 #include <string>
 #include <type_traits>

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -147,7 +147,7 @@ namespace Maps
         static bool sortByFileName( const FileInfo & lhs, const FileInfo & rhs );
 
         static bool sortByMapName( const FileInfo & lhs, const FileInfo & rhs );
-        static bool sortByTimestampDescending( const FileInfo & lhs, const FileInfo & rhs )
+        static bool sortByTimestamp( const FileInfo & lhs, const FileInfo & rhs )
         {
             // we want the latest timestamp first
             return lhs.timestamp > rhs.timestamp;

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <array>
 #include <cstdint>
+#include <locale>
 #include <optional>
 #include <string>
 #include <type_traits>
@@ -234,6 +235,32 @@ namespace Maps
 
     OStreamBase & operator<<( OStreamBase & stream, const FileInfo & fi );
     IStreamBase & operator>>( IStreamBase & stream, FileInfo & fi );
+
+    template <typename CharType>
+    bool CaseInsensitiveCompare( const std::basic_string<CharType> & lhs, const std::basic_string<CharType> & rhs )
+    {
+        typename std::basic_string<CharType>::const_iterator li = lhs.begin();
+        typename std::basic_string<CharType>::const_iterator ri = rhs.begin();
+
+        while ( li != lhs.end() && ri != rhs.end() ) {
+            const CharType lc = std::tolower( *li, std::locale() );
+            const CharType rc = std::tolower( *ri, std::locale() );
+
+            ++li;
+            ++ri;
+
+            if ( lc < rc ) {
+                return true;
+            }
+            if ( lc > rc ) {
+                return false;
+            }
+            // the chars are "equal", so proceed to check the next pair
+        }
+
+        // we came to the end of either (or both) strings, left is "smaller" if it was shorter:
+        return li == lhs.end() && ri != rhs.end();
+    }
 }
 
 using MapsFileInfoList = std::vector<Maps::FileInfo>;

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -145,15 +145,6 @@ namespace Maps
 
         void Reset();
 
-        static bool sortByFileName( const FileInfo & lhs, const FileInfo & rhs );
-
-        static bool sortByMapName( const FileInfo & lhs, const FileInfo & rhs );
-        static bool sortByTimestamp( const FileInfo & lhs, const FileInfo & rhs )
-        {
-            // we want the latest timestamp first
-            return lhs.timestamp > rhs.timestamp;
-        }
-
         // Only Resurrection Maps contain supported language.
         std::optional<fheroes2::SupportedLanguage> getSupportedLanguage() const
         {
@@ -183,6 +174,40 @@ namespace Maps
             LOSS_TOWN = 1,
             LOSS_HERO = 2,
             LOSS_OUT_OF_TIME = 3
+        };
+
+        struct CompareByFileName
+        {
+            bool operator()( const FileInfo & lhs, const std::string & rhs ) const;
+
+            bool operator()( const FileInfo & lhs, const FileInfo & rhs ) const
+            {
+                return operator()( lhs, rhs.filename );
+            }
+        };
+
+        struct CompareByMapName
+        {
+            bool operator()( const FileInfo & lhs, const FileInfo & rhs ) const;
+        };
+
+        // This comparator will place the newer FileInfo instances (with a bigger timestamp) first
+        struct CompareByTimestamp
+        {
+            bool operator()( const FileInfo & lhs, const FileInfo & rhs )
+            {
+                return lhs.timestamp > rhs.timestamp;
+            }
+
+            bool operator()( const Maps::FileInfo & lhs, uint32_t rhs ) const
+            {
+                return lhs.timestamp > rhs;
+            }
+
+            bool operator()( uint32_t lhs, const Maps::FileInfo & rhs ) const
+            {
+                return lhs > rhs.timestamp;
+            }
         };
 
         std::string filename;

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -147,6 +147,7 @@ namespace Maps
         static bool sortByFileName( const FileInfo & lhs, const FileInfo & rhs );
 
         static bool sortByMapName( const FileInfo & lhs, const FileInfo & rhs );
+        static bool sortByTimestampDescending( const FileInfo & lhs, const FileInfo & rhs );
 
         // Only Resurrection Maps contain supported language.
         std::optional<fheroes2::SupportedLanguage> getSupportedLanguage() const

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -235,32 +235,6 @@ namespace Maps
 
     OStreamBase & operator<<( OStreamBase & stream, const FileInfo & fi );
     IStreamBase & operator>>( IStreamBase & stream, FileInfo & fi );
-
-    template <typename CharType>
-    bool CaseInsensitiveCompare( const std::basic_string<CharType> & lhs, const std::basic_string<CharType> & rhs )
-    {
-        typename std::basic_string<CharType>::const_iterator li = lhs.begin();
-        typename std::basic_string<CharType>::const_iterator ri = rhs.begin();
-
-        while ( li != lhs.end() && ri != rhs.end() ) {
-            const CharType lc = std::tolower( *li, std::locale() );
-            const CharType rc = std::tolower( *ri, std::locale() );
-
-            ++li;
-            ++ri;
-
-            if ( lc < rc ) {
-                return true;
-            }
-            if ( lc > rc ) {
-                return false;
-            }
-            // the chars are "equal", so proceed to check the next pair
-        }
-
-        // we came to the end of either (or both) strings, left is "smaller" if it was shorter:
-        return li == lhs.end() && ri != rhs.end();
-    }
 }
 
 using MapsFileInfoList = std::vector<Maps::FileInfo>;

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -147,7 +147,11 @@ namespace Maps
         static bool sortByFileName( const FileInfo & lhs, const FileInfo & rhs );
 
         static bool sortByMapName( const FileInfo & lhs, const FileInfo & rhs );
-        static bool sortByTimestampDescending( const FileInfo & lhs, const FileInfo & rhs );
+        static bool sortByTimestampDescending( const FileInfo & lhs, const FileInfo & rhs )
+        {
+            // we want the latest timestamp first
+            return lhs.timestamp > rhs.timestamp;
+        }
 
         // Only Resurrection Maps contain supported language.
         std::optional<fheroes2::SupportedLanguage> getSupportedLanguage() const

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -175,16 +175,15 @@ namespace Maps
             LOSS_OUT_OF_TIME = 3
         };
 
+        // This comparator performs the case-insensitive comparison
         struct CompareByFileName
         {
+            bool operator()( const FileInfo & lhs, const FileInfo & rhs ) const;
             bool operator()( const FileInfo & lhs, const std::string & rhs ) const;
-
-            bool operator()( const FileInfo & lhs, const FileInfo & rhs ) const
-            {
-                return operator()( lhs, rhs.filename );
-            }
+            bool operator()( const std::string & lhs, const FileInfo & rhs ) const;
         };
 
+        // This comparator performs the case-insensitive comparison
         struct CompareByMapName
         {
             bool operator()( const FileInfo & lhs, const FileInfo & rhs ) const;
@@ -198,12 +197,12 @@ namespace Maps
                 return lhs.timestamp > rhs.timestamp;
             }
 
-            bool operator()( const Maps::FileInfo & lhs, uint32_t rhs ) const
+            bool operator()( const FileInfo & lhs, uint32_t rhs ) const
             {
                 return lhs.timestamp > rhs;
             }
 
-            bool operator()( uint32_t lhs, const Maps::FileInfo & rhs ) const
+            bool operator()( uint32_t lhs, const FileInfo & rhs ) const
             {
                 return lhs > rhs.timestamp;
             }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -356,8 +356,8 @@ bool Settings::Read( const std::string & filePath )
         setEditorPassability( config.StrParams( "editor passability" ) == "on" );
     }
 
-    if ( config.Exists( "save load order" ) ) {
-        if ( config.StrParams( "save load order" ) == "date" ) {
+    if ( config.Exists( "save file sorting" ) ) {
+        if ( config.StrParams( "save file sorting" ) == "date" ) {
             _saveFileSortType = SaveFileSortingMethod::TIMESTAMP;
         }
         else {
@@ -530,7 +530,7 @@ std::string Settings::String() const
     os << "editor passability = " << ( _editorOptions.Modes( EDITOR_PASSABILITY ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# save files sorting method: name/date" << std::endl;
-    os << "save load order = " << ( _saveFileSortType == SaveFileSortingMethod::TIMESTAMP ? "date" : "name" ) << std::endl;
+    os << "save file sorting = " << ( _saveFileSortType == SaveFileSortingMethod::TIMESTAMP ? "date" : "name" ) << std::endl;
 
     return os.str();
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -602,16 +602,6 @@ void Settings::SetProgramPath( const char * path )
     _programPath = path;
 }
 
-SaveFileSortType Settings::GetSaveFileSortType() const
-{
-    return _saveFileSortType;
-}
-
-void Settings::CycleSaveFileSortType()
-{
-    _saveFileSortType = static_cast<SaveFileSortType>( ( static_cast<uint8_t>( _saveFileSortType ) + 1 ) % static_cast<uint8_t>( SaveFileSortType::VALUES_COUNT ) );
-}
-
 const std::vector<std::string> & Settings::GetRootDirs()
 {
     static const std::vector<std::string> rootDirs = []() {

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -607,6 +607,11 @@ SaveFileSortType Settings::GetSaveFileSortType() const
     return _saveFileSortType;
 }
 
+void Settings::CycleSaveFileSortType()
+{
+    _saveFileSortType = static_cast<SaveFileSortType>( ( static_cast<uint8_t>( _saveFileSortType ) + 1 ) % static_cast<uint8_t>( SaveFileSortType::VALUES_COUNT ) );
+}
+
 const std::vector<std::string> & Settings::GetRootDirs()
 {
     static const std::vector<std::string> rootDirs = []() {

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -101,6 +101,7 @@ std::string Settings::GetVersion()
 Settings::Settings()
     : _resolutionInfo( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT )
     , _gameDifficulty( Difficulty::NORMAL )
+    , _saveFileSortType( SaveFileSortType::FILENAME )
     , sound_volume( 6 )
     , music_volume( 6 )
     , _musicType( MUSIC_EXTERNAL )
@@ -355,6 +356,15 @@ bool Settings::Read( const std::string & filePath )
         setEditorPassability( config.StrParams( "editor passability" ) == "on" );
     }
 
+    if ( config.Exists( "save load order" ) ) {
+        if ( config.StrParams( "save load order" ) == "date" ) {
+            _saveFileSortType = SaveFileSortType::LATEST;
+        }
+        else {
+            _saveFileSortType = SaveFileSortType::FILENAME;
+        }
+    }
+
     return true;
 }
 
@@ -519,6 +529,9 @@ std::string Settings::String() const
     os << std::endl << "# display object passability in the Editor: on/off" << std::endl;
     os << "editor passability = " << ( _editorOptions.Modes( EDITOR_PASSABILITY ) ? "on" : "off" ) << std::endl;
 
+    os << std::endl << "# sort game saves when loading: name/date" << std::endl;
+    os << "save load order = " << ( _saveFileSortType == SaveFileSortType::LATEST ? "date" : "name" ) << std::endl;
+
     return os.str();
 }
 
@@ -587,6 +600,11 @@ void Settings::SetProgramPath( const char * path )
     }
 
     _programPath = path;
+}
+
+SaveFileSortType Settings::GetSaveFileSortType() const
+{
+    return _saveFileSortType;
 }
 
 const std::vector<std::string> & Settings::GetRootDirs()

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -358,7 +358,7 @@ bool Settings::Read( const std::string & filePath )
 
     if ( config.Exists( "save load order" ) ) {
         if ( config.StrParams( "save load order" ) == "date" ) {
-            _saveFileSortType = SaveFileSortType::LATEST;
+            _saveFileSortType = SaveFileSortType::TIMESTAMP;
         }
         else {
             _saveFileSortType = SaveFileSortType::FILENAME;
@@ -530,7 +530,7 @@ std::string Settings::String() const
     os << "editor passability = " << ( _editorOptions.Modes( EDITOR_PASSABILITY ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# sort game saves when loading: name/date" << std::endl;
-    os << "save load order = " << ( _saveFileSortType == SaveFileSortType::LATEST ? "date" : "name" ) << std::endl;
+    os << "save load order = " << ( _saveFileSortType == SaveFileSortType::TIMESTAMP ? "date" : "name" ) << std::endl;
 
     return os.str();
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -101,7 +101,7 @@ std::string Settings::GetVersion()
 Settings::Settings()
     : _resolutionInfo( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT )
     , _gameDifficulty( Difficulty::NORMAL )
-    , _saveFileSortType( SaveFileSortType::FILENAME )
+    , _saveFileSortType( SaveFileSortingMethod::FILENAME )
     , sound_volume( 6 )
     , music_volume( 6 )
     , _musicType( MUSIC_EXTERNAL )
@@ -358,10 +358,10 @@ bool Settings::Read( const std::string & filePath )
 
     if ( config.Exists( "save load order" ) ) {
         if ( config.StrParams( "save load order" ) == "date" ) {
-            _saveFileSortType = SaveFileSortType::TIMESTAMP;
+            _saveFileSortType = SaveFileSortingMethod::TIMESTAMP;
         }
         else {
-            _saveFileSortType = SaveFileSortType::FILENAME;
+            _saveFileSortType = SaveFileSortingMethod::FILENAME;
         }
     }
 
@@ -530,7 +530,7 @@ std::string Settings::String() const
     os << "editor passability = " << ( _editorOptions.Modes( EDITOR_PASSABILITY ) ? "on" : "off" ) << std::endl;
 
     os << std::endl << "# sort game saves when loading: name/date" << std::endl;
-    os << "save load order = " << ( _saveFileSortType == SaveFileSortType::TIMESTAMP ? "date" : "name" ) << std::endl;
+    os << "save load order = " << ( _saveFileSortType == SaveFileSortingMethod::TIMESTAMP ? "date" : "name" ) << std::endl;
 
     return os.str();
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -529,7 +529,7 @@ std::string Settings::String() const
     os << std::endl << "# display object passability in the Editor: on/off" << std::endl;
     os << "editor passability = " << ( _editorOptions.Modes( EDITOR_PASSABILITY ) ? "on" : "off" ) << std::endl;
 
-    os << std::endl << "# sort game saves when loading: name/date" << std::endl;
+    os << std::endl << "# save files sorting method: name/date" << std::endl;
     os << "save load order = " << ( _saveFileSortType == SaveFileSortingMethod::TIMESTAMP ? "date" : "name" ) << std::endl;
 
     return os.str();

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -73,7 +73,7 @@ enum class InterfaceType : uint8_t
     DYNAMIC = 2
 };
 
-enum class SaveFileSortType : uint8_t
+enum class SaveFileSortingMethod : uint8_t
 {
     FILENAME = 0,
     TIMESTAMP = 1,
@@ -360,18 +360,18 @@ public:
         _viewWorldZoomLevel = zoomLevel;
     }
 
-    SaveFileSortType GetSaveFileSortType() const
+    SaveFileSortingMethod GetSaveFileSortType() const
     {
         return _saveFileSortType;
     }
 
     void changeSaveFileSortingMethod()
     {
-        if ( _saveFileSortType == SaveFileSortType::FILENAME ) {
-            _saveFileSortType = SaveFileSortType::TIMESTAMP;
+        if ( _saveFileSortType == SaveFileSortingMethod::FILENAME ) {
+            _saveFileSortType = SaveFileSortingMethod::TIMESTAMP;
         }
         else {
-            _saveFileSortType = SaveFileSortType::FILENAME;
+            _saveFileSortType = SaveFileSortingMethod::FILENAME;
         }
     }
 
@@ -410,7 +410,7 @@ private:
 
     Maps::FileInfo _currentMapInfo;
 
-    SaveFileSortType _saveFileSortType;
+    SaveFileSortingMethod _saveFileSortType;
 
     int sound_volume;
     int music_volume;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -360,7 +360,7 @@ public:
         _viewWorldZoomLevel = zoomLevel;
     }
 
-    SaveFileSortingMethod GetSaveFileSortType() const
+    SaveFileSortingMethod GetSaveFileSortingMethod() const
     {
         return _saveFileSortType;
     }

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -365,14 +365,9 @@ public:
         return _saveFileSortType;
     }
 
-    void toggleSaveFileSortingMethod()
+    void setSaveFileSortingMethod( const SaveFileSortingMethod sortType )
     {
-        if ( _saveFileSortType == SaveFileSortingMethod::FILENAME ) {
-            _saveFileSortType = SaveFileSortingMethod::TIMESTAMP;
-        }
-        else {
-            _saveFileSortType = SaveFileSortingMethod::FILENAME;
-        }
+        _saveFileSortType = sortType;
     }
 
     void SetProgramPath( const char * path );

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -365,7 +365,7 @@ public:
         return _saveFileSortType;
     }
 
-    void CycleSaveFileSortType()
+    void changeSaveFileSortingMethod()
     {
         if ( _saveFileSortType == SaveFileSortType::FILENAME ) {
             _saveFileSortType = SaveFileSortType::TIMESTAMP;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -371,7 +371,12 @@ public:
 
     void CycleSaveFileSortType()
     {
-        _saveFileSortType = static_cast<SaveFileSortType>( ( static_cast<uint8_t>( _saveFileSortType ) + 1 ) % static_cast<uint8_t>( SaveFileSortType::VALUES_COUNT ) );
+        if ( _saveFileSortType == SaveFileSortType::FILENAME ) {
+            _saveFileSortType = SaveFileSortType::LATEST;
+        }
+        else {
+            _saveFileSortType = SaveFileSortType::FILENAME;
+        }
     }
 
     static std::string GetVersion();

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -364,8 +364,15 @@ public:
 
     void SetProgramPath( const char * path );
 
-    SaveFileSortType GetSaveFileSortType() const;
-    void CycleSaveFileSortType();
+    SaveFileSortType GetSaveFileSortType() const
+    {
+        return _saveFileSortType;
+    }
+
+    void CycleSaveFileSortType()
+    {
+        _saveFileSortType = static_cast<SaveFileSortType>( ( static_cast<uint8_t>( _saveFileSortType ) + 1 ) % static_cast<uint8_t>( SaveFileSortType::VALUES_COUNT ) );
+    }
 
     static std::string GetVersion();
 

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -76,7 +76,7 @@ enum class InterfaceType : uint8_t
 enum class SaveFileSortType : uint8_t
 {
     FILENAME = 0,
-    LATEST = 1,
+    TIMESTAMP = 1,
 
     VALUES_COUNT = 2,
 };
@@ -372,7 +372,7 @@ public:
     void CycleSaveFileSortType()
     {
         if ( _saveFileSortType == SaveFileSortType::FILENAME ) {
-            _saveFileSortType = SaveFileSortType::LATEST;
+            _saveFileSortType = SaveFileSortType::TIMESTAMP;
         }
         else {
             _saveFileSortType = SaveFileSortType::FILENAME;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -75,8 +75,8 @@ enum class InterfaceType : uint8_t
 
 enum class SaveFileSortingMethod : uint8_t
 {
-    FILENAME = 0,
-    TIMESTAMP = 1,
+    FILENAME,
+    TIMESTAMP,
 };
 
 class Settings

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -365,7 +365,7 @@ public:
         return _saveFileSortType;
     }
 
-    void changeSaveFileSortingMethod()
+    void toggleSaveFileSortingMethod()
     {
         if ( _saveFileSortType == SaveFileSortingMethod::FILENAME ) {
             _saveFileSortType = SaveFileSortingMethod::TIMESTAMP;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -77,6 +77,8 @@ enum class SaveFileSortType : uint8_t
 {
     FILENAME = 0,
     LATEST = 1,
+
+    VALUES_COUNT = 2,
 };
 
 class Settings
@@ -363,6 +365,7 @@ public:
     void SetProgramPath( const char * path );
 
     SaveFileSortType GetSaveFileSortType() const;
+    void CycleSaveFileSortType();
 
     static std::string GetVersion();
 

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -360,8 +360,6 @@ public:
         _viewWorldZoomLevel = zoomLevel;
     }
 
-    void SetProgramPath( const char * path );
-
     SaveFileSortType GetSaveFileSortType() const
     {
         return _saveFileSortType;
@@ -376,6 +374,8 @@ public:
             _saveFileSortType = SaveFileSortType::FILENAME;
         }
     }
+
+    void SetProgramPath( const char * path );
 
     static std::string GetVersion();
 

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -77,8 +77,6 @@ enum class SaveFileSortType : uint8_t
 {
     FILENAME = 0,
     TIMESTAMP = 1,
-
-    VALUES_COUNT = 2,
 };
 
 class Settings

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -73,6 +73,12 @@ enum class InterfaceType : uint8_t
     DYNAMIC = 2
 };
 
+enum class SaveFileSortType : uint8_t
+{
+    FILENAME = 0,
+    LATEST = 1,
+};
+
 class Settings
 {
 public:
@@ -356,6 +362,8 @@ public:
 
     void SetProgramPath( const char * path );
 
+    SaveFileSortType GetSaveFileSortType() const;
+
     static std::string GetVersion();
 
     static const std::vector<std::string> & GetRootDirs();
@@ -388,6 +396,8 @@ private:
     std::string _loadedFileLanguage;
 
     Maps::FileInfo _currentMapInfo;
+
+    SaveFileSortType _saveFileSortType;
 
     int sound_volume;
     int music_volume;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -360,7 +360,7 @@ public:
         _viewWorldZoomLevel = zoomLevel;
     }
 
-    SaveFileSortingMethod GetSaveFileSortingMethod() const
+    SaveFileSortingMethod getSaveFileSortingMethod() const
     {
         return _saveFileSortType;
     }


### PR DESCRIPTION
Solves #1211

Introduces a new configuration `save file sorting` that changes the way sorting works in the load dialog

✅ Allows sorting by timestamp rather than filename
✅ Doesn't change the default behavior
~~❌No UI improvements~~
✅ Awesome UI thanks to @zenseii 

