### PR TITLE
Update French language-specific characters on map load

### DIFF
--- a/src/engine/tools.cpp
+++ b/src/engine/tools.cpp
@@ -152,6 +152,76 @@ namespace fheroes2
         output.replace( output.size() - originalEndingSize, originalEndingSize, correctedEnding, correctedEndingSize );
     }
 
+    void updateFrenchLanguageSpecificCharactersForMaps( std::string & str )
+    {
+        for ( char & c : str ) {
+            switch ( c ) {
+            case 9:
+                // Lowercase i with circumflex
+                c = static_cast<char>( 238 );
+                break;
+            case 35:
+                //  Lowercase o with circumflex
+                c = static_cast<char>( 244 );
+                break;
+            case 36:
+                // Lowercase u with circumflex
+                c = static_cast<char>( 251 );
+                break;
+            case 38:
+                // Lowercase u with grave accent
+                c = static_cast<char>( 249 );
+                break;
+            case 42:
+                // Lowercase a with circumflex
+                c = static_cast<char>( 226 );
+                break;
+            case 60:
+                // Lowercase i with diaeresis
+                c = static_cast<char>( 239 );
+                break;
+            case 62:
+                // Lowercase i with circumflex <- Confirmed used in the OG Succession wars.
+                c = static_cast<char>( 238 );
+                break;
+            case 64:
+                // Lowercase a with grave accent
+                c = static_cast<char>( 224 );
+                break;
+            case 94:
+                // Lowercase c with cedilla
+                c = static_cast<char>( 231 );
+                break;
+            case 96:
+                // Lowercase e with grave accent
+                c = static_cast<char>( 232 );
+                break;
+            case 123:
+                // Lowercase i with diaeresis
+                c = static_cast<char>( 239 );
+                break;
+            case 124:
+                // Lowercase e with circumflex
+                c = static_cast<char>( 234 );
+                break;
+            case 125:
+                // Lowercase i with circumflex
+                c = static_cast<char>( 239 );
+                break;
+            case 126:
+                // Lowercase e with acute
+                c = static_cast<char>( 233 );
+                break;
+            case 127:
+                // Lowercase i with circumflex
+                c = static_cast<char>( 239 );
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
     std::string abbreviateNumber( const int num )
     {
         if ( std::abs( num ) >= 1000000 ) {

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -100,6 +100,12 @@ namespace fheroes2
 
     void replaceStringEnding( std::string & output, const char * originalEnding, const char * correctedEnding );
 
+    // The original French version replaces several ASCII special characters with language-specific characters.
+    // In the engine we use CP1252 for the French translation.
+    // This function replaces the special ASCII characters with the language-specific characters from CP1252
+    // to properly display texts for maps from French assets.
+    void updateFrenchLanguageSpecificCharactersForMaps( std::string & str );
+
     std::string abbreviateNumber( const int num );
 
     // Appends the given modifier to the end of the given string (e.g. "Coliseum +2")

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -74,6 +74,7 @@
 #include "tools.h"
 #include "translations.h"
 #include "ui_dialog.h"
+#include "ui_language.h"
 #include "week.h"
 #include "world.h"
 
@@ -106,7 +107,7 @@ Castle::Castle( const int32_t posX, const int32_t posY, int race )
     // Do nothing.
 }
 
-void Castle::LoadFromMP2( const std::vector<uint8_t> & data )
+void Castle::LoadFromMP2( const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharactersInName )
 {
     assert( data.size() == MP2::MP2_CASTLE_STRUCTURE_SIZE );
 
@@ -345,6 +346,10 @@ void Castle::LoadFromMP2( const std::vector<uint8_t> & data )
     const bool isCustomTownNameSet = ( dataStream.get() != 0 );
     if ( isCustomTownNameSet ) {
         _name = dataStream.getString( 13 );
+
+        if ( updateFrenchLanguageSpecificCharactersInName ) {
+            fheroes2::updateFrenchLanguageSpecificCharactersForMaps( _name );
+        }
     }
     else {
         // Skip 13 bytes since the name is not set.

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -153,7 +153,7 @@ public:
 
     Castle & operator=( const Castle & ) = delete;
 
-    void LoadFromMP2( const std::vector<uint8_t> & data );
+    void LoadFromMP2( const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharactersInName );
 
     void loadFromResurrectionMap( const Maps::Map_Format::CastleMetadata & metadata );
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -74,6 +74,7 @@
 #include "ui_button.h"
 #include "ui_campaign.h"
 #include "ui_dialog.h"
+#include "ui_language.h"
 #include "ui_text.h"
 #include "ui_tool.h"
 #include "ui_window.h"
@@ -1573,6 +1574,13 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
             }
 
             Maps::FileInfo mapInfo = scenario.loadMap();
+
+            // Update French language-specific characters to match CP1252.
+            if ( fheroes2::getCurrentLanguage() == fheroes2::SupportedLanguage::French || fheroes2::getResourceLanguage() == fheroes2::SupportedLanguage::French ) {
+                fheroes2::updateFrenchLanguageSpecificCharactersForMaps( mapInfo.name );
+                fheroes2::updateFrenchLanguageSpecificCharactersForMaps( mapInfo.description );
+            }
+
             Campaign::CampaignData::updateScenarioGameplayConditions( currentScenarioInfoId, mapInfo );
 
             conf.setCurrentMapInfo( mapInfo );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1321,81 +1321,6 @@ namespace
             updateSmallFontLetterShadow( font[253 - 32] );
         }
     }
-    // The original French version replaces several ASCII special characters with language-specific characters.
-    // In the engine we use CP1252 for the French translation but we have to preserve the homegrown encoding
-    // for original map compatibility. The engine expects that letter indexes correspond to charcode - 0x20,
-    // but the original French Price of Loyalty maps use 0x09 for lowercase i with circumflex. This is currently
-    // not supported by the engine. See original maps' descriptions for Utopie and Sables du Temps.
-    void generateFrenchAlphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
-    {
-        // Normal font.
-        {
-            std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::FONT];
-
-            // Lowercase o with circumflex
-            font[35 - 32] = font[244 - 32];
-            // Lowercase u with circumflex
-            font[36 - 32] = font[251 - 32];
-            // Lowercase u with grave accent
-            font[38 - 32] = font[249 - 32];
-            // Lowercase a with circumflex
-            font[42 - 32] = font[226 - 32];
-            // Lowercase i with diaeresis
-            font[60 - 32] = font[239 - 32];
-            // Lowercase i with circumflex <- Confirmed used in the OG Succession wars.
-            font[62 - 32] = font[238 - 32];
-            // Lowercase a with grave accent
-            font[64 - 32] = font[224 - 32];
-            // Lowercase c with cedilla
-            font[94 - 32] = font[231 - 32];
-            // Lowercase e with grave accent
-            font[96 - 32] = font[232 - 32];
-            // Lowercase i with diaeresis
-            font[123 - 32] = font[239 - 32];
-            // Lowercase e with circumflex
-            font[124 - 32] = font[234 - 32];
-            // Lowercase i with circumflex
-            font[125 - 32] = font[239 - 32];
-            // Lowercase e with acute
-            font[126 - 32] = font[233 - 32];
-            // Lowercase i with circumflex
-            font[127 - 32] = font[239 - 32];
-        }
-
-        // Small font.
-        {
-            std::vector<fheroes2::Sprite> & font = icnVsSprite[ICN::SMALFONT];
-
-            // Lowercase o with circumflex
-            font[35 - 32] = font[244 - 32];
-            // Lowercase u with circumflex
-            font[36 - 32] = font[251 - 32];
-            // Lowercase u with grave accent
-            font[38 - 32] = font[249 - 32];
-            // Lowercase a with circumflex
-            font[42 - 32] = font[226 - 32];
-            // Lowercase i with diaeresis
-            font[60 - 32] = font[239 - 32];
-            // Lowercase i with circumflex
-            font[62 - 32] = font[238 - 32];
-            // Lowercase a with grave accent
-            font[64 - 32] = font[224 - 32];
-            // Lowercase c with cedilla
-            font[94 - 32] = font[231 - 32];
-            // Lowercase e with grave accent
-            font[96 - 32] = font[232 - 32];
-            // Lowercase i with diaeresis
-            font[123 - 32] = font[239 - 32];
-            // Lowercase e with circumflex
-            font[124 - 32] = font[234 - 32];
-            // Lowercase i with circumflex
-            font[125 - 32] = font[239 - 32];
-            // Lowercase e with acute
-            font[126 - 32] = font[233 - 32];
-            // Lowercase i with circumflex
-            font[127 - 32] = font[239 - 32];
-        }
-    }
 
     // CP-1251 supports Russian, Ukrainian, Belarussian, Bulgarian, Serbian Cyrillic, Macedonian and English.
     void generateCP1251Alphabet( std::vector<std::vector<fheroes2::Sprite>> & icnVsSprite )
@@ -5974,8 +5899,6 @@ namespace fheroes2
             break;
         case SupportedLanguage::French:
             generateCP1252Alphabet( icnVsSprite );
-            // This serves to make the font compatible with the original French custom encoding.
-            generateFrenchAlphabet( icnVsSprite );
             break;
         case SupportedLanguage::Turkish:
             generateCP1254Alphabet( icnVsSprite );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -320,7 +320,8 @@ Heroes::Heroes( int heroid, int rc )
     move_point = GetMaxMovePoints();
 }
 
-void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int raceType, const bool isInJail, const std::vector<uint8_t> & data )
+void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int raceType, const bool isInJail, const std::vector<uint8_t> & data,
+                          const bool updateFrenchLanguageSpecificCharactersInName )
 {
     assert( data.size() == MP2::MP2_HEROES_STRUCTURE_SIZE );
 
@@ -595,6 +596,10 @@ void Heroes::LoadFromMP2( const int32_t mapIndex, const int colorType, const int
         if ( !temp.empty() ) {
             SetModes( CUSTOM );
             name = std::move( temp );
+
+            if ( updateFrenchLanguageSpecificCharactersInName ) {
+                fheroes2::updateFrenchLanguageSpecificCharactersForMaps( name );
+            }
         }
     }
     else {

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -306,7 +306,8 @@ public:
     const Castle * inCastle() const override;
     Castle * inCastleMutable() const;
 
-    void LoadFromMP2( const int32_t mapIndex, const int colorType, const int raceType, const bool isInJail, const std::vector<uint8_t> & data );
+    void LoadFromMP2( const int32_t mapIndex, const int colorType, const int raceType, const bool isInJail, const std::vector<uint8_t> & data,
+                      const bool updateFrenchLanguageSpecificCharactersInName );
 
     void applyHeroMetadata( const Maps::Map_Format::HeroMetadata & heroMetadata, const bool isInJail, const bool isEditor );
     // Updates data in heroMetadata and returns true if it has changes.

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -52,6 +52,7 @@
 #include "settings.h"
 #include "system.h"
 #include "tools.h"
+#include "ui_language.h"
 
 namespace
 {
@@ -90,6 +91,11 @@ namespace
         // create a list of unique maps (based on the map file name) and filter it by the preferred number of players
         std::map<std::string, Maps::FileInfo, std::less<>> uniqueMaps;
 
+        // For the original French version we update the language-specific characters to match CP1252.
+        const bool updateFrenchLangugeSpecificCharacters
+            = isOriginalMapFormat
+              && ( fheroes2::getCurrentLanguage() == fheroes2::SupportedLanguage::French || fheroes2::getResourceLanguage() == fheroes2::SupportedLanguage::French );
+
         for ( const std::string & mapFile : mapFiles ) {
             Maps::FileInfo fi;
 
@@ -122,6 +128,12 @@ namespace
                 if ( humanOnlyColorsCount == humanPlayerCount ) {
                     // The map has the exact number of human-only players. Make sure that the user cannot select any other players.
                     fi.removeHumanColors( fi.AllowCompHumanColors() );
+                }
+
+                // Update French language-specific characters to match CP1252.
+                if ( updateFrenchLangugeSpecificCharacters ) {
+                    fheroes2::updateFrenchLanguageSpecificCharactersForMaps( fi.name );
+                    fheroes2::updateFrenchLanguageSpecificCharactersForMaps( fi.description );
                 }
             }
 

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -41,7 +41,7 @@
 #include "translations.h"
 #include "ui_language.h"
 
-void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & data )
+void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharacters )
 {
     assert( data.size() >= MP2::MP2_EVENT_STRUCTURE_MIN_SIZE );
 
@@ -158,12 +158,16 @@ void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & da
 
     message = dataStream.getString();
 
+    if ( updateFrenchLanguageSpecificCharacters ) {
+        fheroes2::updateFrenchLanguageSpecificCharactersForMaps( message );
+    }
+
     setUIDAndIndex( index );
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, "Ground event at tile " << index << " has event message: " << message )
 }
 
-void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t> & data )
+void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharacters )
 {
     assert( data.size() >= MP2::MP2_RIDDLE_STRUCTURE_MIN_SIZE );
 
@@ -249,11 +253,15 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
 
     // Get all possible answers.
     for ( uint32_t i = 0; i < 8; ++i ) {
-        const std::string answer = dataStream.getString( 13 );
+        std::string answer = dataStream.getString( 13 );
 
         if ( answerCount > 0 ) {
             --answerCount;
             if ( !answer.empty() ) {
+                if ( updateFrenchLanguageSpecificCharacters ) {
+                    fheroes2::updateFrenchLanguageSpecificCharactersForMaps( answer );
+                }
+
                 answers.push_back( StringLower( answer ) );
             }
         }
@@ -263,6 +271,9 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
     if ( riddle.empty() ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Sphinx at tile index " << tileIndex << " does not have questions. Marking it as visited." )
         return;
+    }
+    else if ( updateFrenchLanguageSpecificCharacters ) {
+        fheroes2::updateFrenchLanguageSpecificCharactersForMaps( riddle );
     }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, "Sphinx question is '" << riddle << "'." )
@@ -283,7 +294,7 @@ bool MapSphinx::isCorrectAnswer( std::string answer )
     return std::any_of( answers.begin(), answers.end(), checkAnswer );
 }
 
-void MapSign::LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & data )
+void MapSign::LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharacters )
 {
     assert( data.size() >= MP2::MP2_SIGN_STRUCTURE_MIN_SIZE );
     assert( data[0] == 0x1 );
@@ -305,6 +316,9 @@ void MapSign::LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & 
 
     if ( message.text.empty() ) {
         setDefaultMessage();
+    }
+    else if ( updateFrenchLanguageSpecificCharacters ) {
+        fheroes2::updateFrenchLanguageSpecificCharactersForMaps( message.text );
     }
 
     setUIDAndIndex( mapIndex );

--- a/src/fheroes2/maps/maps_objects.h
+++ b/src/fheroes2/maps/maps_objects.h
@@ -70,7 +70,7 @@ struct MapEvent final : public MapBaseObject
 {
     MapEvent() = default;
 
-    void LoadFromMP2( const int32_t index, const std::vector<uint8_t> & data );
+    void LoadFromMP2( const int32_t index, const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharacters );
 
     bool isAllow( const int color ) const
     {
@@ -99,7 +99,7 @@ struct MapSphinx final : public MapBaseObject
 {
     MapSphinx() = default;
 
-    void LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t> & data );
+    void LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharacters );
 
     bool isCorrectAnswer( std::string answer );
 
@@ -145,7 +145,7 @@ struct MapSign final : public MapBaseObject
 {
     MapSign() = default;
 
-    void LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & data );
+    void LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharacters );
 
     void setDefaultMessage();
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1624,7 +1624,7 @@ IStreamBase & operator>>( IStreamBase & stream, World & w )
     return stream;
 }
 
-void EventDate::LoadFromMP2( const std::vector<uint8_t> & data )
+void EventDate::LoadFromMP2( const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharacters )
 {
     assert( data.size() >= MP2::MP2_EVENT_STRUCTURE_MIN_SIZE );
 
@@ -1750,6 +1750,10 @@ void EventDate::LoadFromMP2( const std::vector<uint8_t> & data )
     }
 
     message = dataStream.getString();
+
+    if ( updateFrenchLanguageSpecificCharacters ) {
+        fheroes2::updateFrenchLanguageSpecificCharactersForMaps( message );
+    }
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, "A timed event which occurs at day " << firstOccurrenceDay << " contains a message: " << message )
 }

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -157,7 +157,7 @@ struct CapturedObjects : std::map<int32_t, CapturedObject>
 
 struct EventDate
 {
-    void LoadFromMP2( const std::vector<uint8_t> & data );
+    void LoadFromMP2( const std::vector<uint8_t> & data, const bool updateFrenchLanguageSpecificCharacters );
 
     bool isAllow( const int color, const uint32_t date ) const;
 


### PR DESCRIPTION
fix #9490

This PR also fixes inability to display `lowercase i with circumflex` from the French translated maps:
![изображение](https://github.com/user-attachments/assets/9802bf46-7ad5-477c-bb5f-62e430caf523)

https://github.com/user-attachments/assets/296ad9af-d286-4527-b28c-f3a7c2f6d8ac

TODO: update all texts from the save files with French language.

PS
I moved the "decoding" cases from `ui_font` to `tools` but while the comment differs with the character for the replacement (by it's comment).
The help of French-speaking players that have original assets is needed to check the correctness of characters update to the ones from [CP1252](https://www.ascii-code.com/).
