### PR TITLE
Optimize rendering and timers

### DIFF
--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -1199,18 +1199,8 @@ bool LocalEvent::HandleEvents( const bool sleepAfterEventProcessing /* = true */
     // We want to make sure that we do not slow down by going into sleep mode when it is not needed.
     const fheroes2::Time eventProcessingTimer;
 
-    // We can have more than one event which requires rendering. We must render only once and only when sleeping is excepted.
-    fheroes2::Rect renderRoi;
-
     // Mouse area must be updated only once so we will use only the latest area for rendering.
     _mouseCursorRenderArea = {};
-
-    fheroes2::Display & display = fheroes2::Display::instance();
-
-    if ( fheroes2::RenderProcessor::instance().isCyclingUpdateRequired() ) {
-        // To maintain color cycling animation we need to render the whole frame with an updated palette.
-        renderRoi = { 0, 0, display.width(), display.height() };
-    }
 
     // We shouldn't reset the MOUSE_PRESSED and KEY_HOLD here because these are "ongoing" states
     resetStates( KEY_PRESSED );
@@ -1229,15 +1219,22 @@ bool LocalEvent::HandleEvents( const bool sleepAfterEventProcessing /* = true */
         return false;
     }
 
-    if ( isDisplayRefreshRequired ) {
-        renderRoi = { 0, 0, display.width(), display.height() };
-    }
-
     if ( _engine->isControllerValid() ) {
         ProcessControllerAxisMotion();
     }
 
-    renderRoi = fheroes2::getBoundaryRect( renderRoi, _mouseCursorRenderArea );
+    // We can have more than one event which requires rendering. We must render only once and only when sleeping is expected.
+    fheroes2::Rect renderRoi;
+
+    fheroes2::Display & display = fheroes2::Display::instance();
+
+    // To maintain color cycling animation we need to render the whole frame with an updated palette.
+    if ( isDisplayRefreshRequired || fheroes2::RenderProcessor::instance().isCyclingUpdateRequired() ) {
+        renderRoi = { 0, 0, display.width(), display.height() };
+    }
+    else {
+        renderRoi = _mouseCursorRenderArea;
+    }
 
     static_assert( globalLoopSleepTime == 1, "Since you have changed the sleep time, make sure that the sleep does not last too long." );
 

--- a/src/engine/localevent.cpp
+++ b/src/engine/localevent.cpp
@@ -62,7 +62,6 @@
 #include "audio.h"
 #include "image.h"
 #include "logging.h"
-#include "math_tools.h"
 #include "render_processor.h"
 #include "screen.h"
 

--- a/src/engine/render_processor.cpp
+++ b/src/engine/render_processor.cpp
@@ -66,7 +66,7 @@ namespace fheroes2
         return true;
     }
 
-    void RenderProcessor::postRenderAction()
+    void RenderProcessor::postRenderAction() const
     {
         if ( _enableCycling && _enableRenderers && _postRenderer ) {
             _postRenderer();

--- a/src/engine/render_processor.cpp
+++ b/src/engine/render_processor.cpp
@@ -41,6 +41,11 @@ namespace fheroes2
 
     bool RenderProcessor::preRenderAction( std::vector<uint8_t> & palette )
     {
+        // We consider start of rendering is the time when we reset the timer for the next frame.
+        // This is because we have no control how long the whole rendering will need but
+        // a start of rendering is always a consistent time.
+        _lastRenderCall.reset();
+
         if ( !_enableCycling ) {
             return false;
         }
@@ -63,8 +68,6 @@ namespace fheroes2
 
     void RenderProcessor::postRenderAction()
     {
-        _lastRenderCall.reset();
-
         if ( _enableCycling && _enableRenderers && _postRenderer ) {
             _postRenderer();
         }

--- a/src/engine/render_processor.cpp
+++ b/src/engine/render_processor.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/render_processor.cpp
+++ b/src/engine/render_processor.cpp
@@ -41,9 +41,9 @@ namespace fheroes2
 
     bool RenderProcessor::preRenderAction( std::vector<uint8_t> & palette )
     {
-        // We consider start of rendering is the time when we reset the timer for the next frame.
-        // This is because we have no control how long the whole rendering will need but
-        // a start of rendering is always a consistent time.
+        // We consider the start of rendering to be the moment when we reset the timer for the next frame.
+        // This is because we have no control over how long the entire rendering process will take,
+        // but the start of rendering is always a consistent point in time.
         _lastRenderCall.reset();
 
         if ( !_enableCycling ) {

--- a/src/engine/render_processor.h
+++ b/src/engine/render_processor.h
@@ -66,7 +66,12 @@ namespace fheroes2
 
         void startColorCycling()
         {
-            _enableCycling = true;
+            if ( !_enableCycling ) {
+                _enableCycling = true;
+
+                // Since we are restarting cycling we have to reset cycling timer.
+                _cyclingTimer.reset();
+            }
         }
 
         void stopColorCycling()

--- a/src/engine/render_processor.h
+++ b/src/engine/render_processor.h
@@ -67,12 +67,14 @@ namespace fheroes2
 
         void startColorCycling()
         {
-            if ( !_enableCycling ) {
-                _enableCycling = true;
-
-                // Since we are restarting the cycling, we have to reset the timer.
-                _cyclingTimer.reset();
+            if ( _enableCycling ) {
+                return;
             }
+
+            _enableCycling = true;
+
+            // Since we are restarting the cycling, we have to reset the timer.
+            _cyclingTimer.reset();
         }
 
         void stopColorCycling()

--- a/src/engine/render_processor.h
+++ b/src/engine/render_processor.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023                                                    *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/render_processor.h
+++ b/src/engine/render_processor.h
@@ -62,7 +62,8 @@ namespace fheroes2
         }
 
         bool preRenderAction( std::vector<uint8_t> & palette );
-        void postRenderAction();
+
+        void postRenderAction() const;
 
         void startColorCycling()
         {

--- a/src/engine/render_processor.h
+++ b/src/engine/render_processor.h
@@ -69,7 +69,7 @@ namespace fheroes2
             if ( !_enableCycling ) {
                 _enableCycling = true;
 
-                // Since we are restarting cycling we have to reset cycling timer.
+                // Since we are restarting the cycling, we have to reset the timer.
                 _cyclingTimer.reset();
             }
         }

--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -24,59 +24,6 @@
 
 namespace fheroes2
 {
-    Time::Time()
-        : _startTime( std::chrono::steady_clock::now() )
-    {}
-
-    void Time::reset()
-    {
-        _startTime = std::chrono::steady_clock::now();
-    }
-
-    double Time::getS() const
-    {
-        const std::chrono::duration<double> time = std::chrono::steady_clock::now() - _startTime;
-        return time.count();
-    }
-
-    uint64_t Time::getMs() const
-    {
-        const auto time = std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() - _startTime );
-        return time.count();
-    }
-
-    TimeDelay::TimeDelay( const uint64_t delayMs )
-        : _prevTime( std::chrono::steady_clock::now() )
-        , _delayMs( delayMs )
-    {}
-
-    void TimeDelay::setDelay( const uint64_t delayMs )
-    {
-        _delayMs = delayMs;
-    }
-
-    bool TimeDelay::isPassed() const
-    {
-        return isPassed( _delayMs );
-    }
-
-    bool TimeDelay::isPassed( const uint64_t delayMs ) const
-    {
-        const auto time = std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() - _prevTime );
-        const uint64_t passedMs = time.count();
-        return passedMs >= delayMs;
-    }
-
-    void TimeDelay::reset()
-    {
-        _prevTime = std::chrono::steady_clock::now();
-    }
-
-    void TimeDelay::pass()
-    {
-        _prevTime = std::chrono::steady_clock::now() - std::chrono::milliseconds( 2 * _delayMs );
-    }
-
     void delayforMs( const uint32_t delayMs )
     {
         std::this_thread::sleep_for( std::chrono::milliseconds( delayMs ) );

--- a/src/engine/timing.cpp
+++ b/src/engine/timing.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/timing.h
+++ b/src/engine/timing.h
@@ -31,15 +31,29 @@ namespace fheroes2
     class Time
     {
     public:
-        Time();
+        Time()
+        {
+            reset();
+        }
 
-        void reset();
+        void reset()
+        {
+            _startTime = std::chrono::steady_clock::now();
+        }
 
         // Returns time in seconds.
-        double getS() const;
+        double getS() const
+        {
+            const std::chrono::duration<double> time = std::chrono::steady_clock::now() - _startTime;
+            return time.count();
+        }
 
         // Returns rounded time in milliseconds.
-        uint64_t getMs() const;
+        uint64_t getMs() const
+        {
+            const auto time = std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() - _startTime );
+            return time.count();
+        }
 
     private:
         std::chrono::time_point<std::chrono::steady_clock> _startTime;
@@ -50,23 +64,45 @@ namespace fheroes2
     public:
         TimeDelay() = delete;
 
-        explicit TimeDelay( const uint64_t delayMs );
+        explicit TimeDelay( const uint64_t delayMs )
+            : _delayMs( delayMs )
+        {
+            reset();
+        }
 
-        void setDelay( const uint64_t delayMs );
+        void setDelay( const uint64_t delayMs )
+        {
+            _delayMs = delayMs;
+        }
 
         uint64_t getDelay() const
         {
             return _delayMs;
         }
 
-        bool isPassed() const;
-        bool isPassed( const uint64_t delayMs ) const;
+        bool isPassed() const
+        {
+            return isPassed( _delayMs );
+        }
+
+        bool isPassed( const uint64_t delayMs ) const
+        {
+            const auto time = std::chrono::duration_cast<std::chrono::milliseconds>( std::chrono::steady_clock::now() - _prevTime );
+            const uint64_t passedMs = time.count();
+            return passedMs >= delayMs;
+        }
 
         // Reset delay by starting the count from the current time.
-        void reset();
+        void reset()
+        {
+            _prevTime = std::chrono::steady_clock::now();
+        }
 
         // Explicitly set delay to passed state. Can be used in cases when first call of isPassed() must return true.
-        void pass();
+        void pass()
+        {
+            _prevTime = std::chrono::steady_clock::now() - std::chrono::milliseconds( 2 * _delayMs );
+        }
 
     private:
         std::chrono::time_point<std::chrono::steady_clock> _prevTime;

--- a/src/engine/timing.h
+++ b/src/engine/timing.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2022                                             *
+ *   Copyright (C) 2021 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -192,13 +192,13 @@ bool Game::validateDisplayFadeIn()
 void Game::Init()
 {
     // set global events
-    LocalEvent & le = LocalEvent::Get();
-    le.setGlobalMouseMotionEventHook( Cursor::updateCursorPosition );
-    le.setGlobalKeyDownEventHook( Game::globalKeyDownEvent );
+    LocalEvent & eventHandler = LocalEvent::Get();
+    eventHandler.setGlobalMouseMotionEventHook( Cursor::updateCursorPosition );
+    eventHandler.setGlobalKeyDownEventHook( globalKeyDownEvent );
 
-    Game::AnimateDelaysInitialize();
+    AnimateDelaysInitialize();
 
-    Game::HotKeysLoad( Settings::GetLastFile( "", "fheroes2.key" ) );
+    HotKeysLoad( Settings::GetLastFile( "", "fheroes2.key" ) );
 }
 
 uint32_t Game::getAdventureMapAnimationIndex()

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -30,7 +30,7 @@
 
 namespace
 {
-    std::vector<fheroes2::TimeDelay> delays( Game::LAST_DELAY + 1, fheroes2::TimeDelay( 0 ) );
+    std::vector<fheroes2::TimeDelay> delays( Game::LAST_DELAY, fheroes2::TimeDelay( 0 ) );
 
     static_assert( ( defaultBattleSpeed >= 0 ) && ( defaultBattleSpeed < 10 ) );
 
@@ -108,8 +108,8 @@ void Game::AnimateDelaysInitialize()
     delays[BATTLE_DIALOG_DELAY].setDelay( 75 );
     delays[BATTLE_FRAME_DELAY].setDelay( 120 );
     delays[BATTLE_MISSILE_DELAY].setDelay( 40 );
-    delays[BATTLE_SPELL_DELAY].setDelay( 90 );
-    delays[BATTLE_DISRUPTING_DELAY].setDelay( 20 );
+    delays[BATTLE_SPELL_DELAY].setDelay( 75 );
+    delays[BATTLE_DISRUPTING_DELAY].setDelay( 25 );
     delays[BATTLE_CATAPULT_DELAY].setDelay( 90 );
     delays[BATTLE_CATAPULT_BOULDER_DELAY].setDelay( 40 );
     delays[BATTLE_CATAPULT_CLOUD_DELAY].setDelay( 40 );
@@ -124,11 +124,11 @@ void Game::AnimateDelaysInitialize()
     delays[CURRENT_HERO_DELAY].setDelay( 10 );
     delays[CURRENT_AI_DELAY].setDelay( 10 );
 
+    UpdateGameSpeed();
+
     for ( fheroes2::TimeDelay & delay : delays ) {
         delay.reset();
     }
-
-    UpdateGameSpeed();
 }
 
 void Game::AnimateResetDelay( const DelayType delayType )
@@ -216,7 +216,7 @@ int Game::AIHeroAnimSpeedMultiplier()
     return aiHeroMultiplier;
 }
 
-uint32_t Game::ApplyBattleSpeed( uint32_t delay )
+uint32_t Game::ApplyBattleSpeed( const uint32_t delay )
 {
     const uint32_t battleSpeed = static_cast<uint32_t>( battleSpeedAdjustment * ( 10 - Settings::Get().BattleSpeed() ) * delay );
     return battleSpeed == 0 ? 1 : battleSpeed;

--- a/src/fheroes2/game/game_delays.h
+++ b/src/fheroes2/game/game_delays.h
@@ -59,6 +59,8 @@ namespace Game
 
         CURRENT_HERO_DELAY,
         CURRENT_AI_DELAY,
+
+        // Never use the entry below directly in the code! Utilize helper functions for this matter.
         CUSTOM_DELAY,
 
         // IMPORTANT!!! All new entries must be put before this entry!
@@ -83,7 +85,7 @@ namespace Game
     void AnimateResetDelay( const DelayType delayType );
     void UpdateGameSpeed();
 
-    uint32_t ApplyBattleSpeed( uint32_t delay );
+    uint32_t ApplyBattleSpeed( const uint32_t delay );
 
     // Returns the animation speed multiplier for a human-controlled hero.
     int HumanHeroAnimSpeedMultiplier();


### PR DESCRIPTION
This pull requests contains multiple changes related to rendering coupled with timers:
- **timing.h|cpp** files: make all methods of classes inlined as they are tiny
- **localevent.cpp**: avoid calling `fheroes2::getBoundaryRect()` since no case exists that we need it. Also, check cycling readiness just at the very end before rendering
- **render_processor.cpp**: standartize time frame for each render call
- **render_processor.h**: we missed to reset the timer when enabling cycling
- **game_delays.cpp**: we had invalid default values for some times and also we were setting some timers after resetting them