### PR TITLE
Battlefield. Fix Bad Luck animation to be closer to the original game

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4788,6 +4788,9 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
     StringReplaceWithLowercase( msg, "%{attacker}", unit.GetName() );
     setStatus( msg, true );
 
+    // Don't waste time waiting for Luck sound if the game sounds are turned off.
+    const bool soundOn = Settings::Get().SoundVolume() > 0;
+
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
     if ( isGoodLuck ) {
         // Reset the delay to wait till the next frame if is not already waiting.
@@ -4869,9 +4872,6 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
         // We set the constant animation time for all rainbows: rainbowLength/30 fits the rainbow sound duration on '1' speed.
         const double drawStep = static_cast<double>( rainbowLength ) / rainbowDrawSteps;
 
-        // Don't waste time waiting for Good Luck sound if the game sounds are turned off
-        const bool soundOn = Settings::Get().SoundVolume() > 0;
-
         if ( soundOn ) {
             AudioManager::PlaySound( M82::GOODLUCK );
         }
@@ -4918,10 +4918,6 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
         }
     }
     else {
-        // Reset the delay to wait till the next frame if is not already waiting.
-        if ( !Game::isDelayNeeded( { Game::DelayType::BATTLE_FRAME_DELAY } ) ) {
-            Game::AnimateResetDelay( Game::DelayType::BATTLE_FRAME_DELAY );
-        }
         const int32_t offsetX = pos.x + pos.width / 2;
         // Don't let the Bad Luck sprite clip outside the top of the battlefield.
         const int32_t offsetY = std::max( GetAbsoluteICNHeight( ICN::CLOUDLUK ), pos.y + pos.height + cellYOffset );
@@ -4929,14 +4925,12 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
         const uint32_t frameLimit = 8;
         uint32_t frameId = 0;
 
-        // Don't waste time waiting for Bad Luck sound if the game sounds are turned off.
-        const bool soundOn = Settings::Get().SoundVolume() > 0;
-
         if ( soundOn ) {
             // This sound lasts for about 2200 milliseconds.
             AudioManager::PlaySound( M82::BADLUCK );
         }
 
+        // Make the animation duration consistent with the played sound on the normal battle speed.
         const uint64_t animationDelay = Game::ApplyBattleSpeed( 2200 / frameLimit );
         // Immediately indicate that the delay has passed to render first frame immediately.
         Game::passCustomAnimationDelay( animationDelay );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -4793,7 +4793,7 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
 
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
     if ( isGoodLuck ) {
-        // Reset the delay to wait till the next frame if is not already waiting.
+        // Reset the delay to wait till the next frame if it's not already waiting.
         if ( !Game::isDelayNeeded( { Game::DelayType::BATTLE_MISSILE_DELAY } ) ) {
             Game::AnimateResetDelay( Game::DelayType::BATTLE_MISSILE_DELAY );
         }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -592,7 +592,9 @@ uint32_t Battle::Unit::GetDamage( const Unit & enemy, Rand::DeterministicRandomG
     if ( Modes( LUCK_GOOD ) ) {
         res *= 2;
     }
-    else if ( Modes( LUCK_BAD ) ) {
+    else if ( Modes( LUCK_BAD ) && res > 1 ) {
+        // We halves the damage in the case of Bad Luck.
+        // If the damage is less than 2 it is 1 and this is a minimal damage that should not be halved.
         res /= 2;
     }
 

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -592,9 +592,7 @@ uint32_t Battle::Unit::GetDamage( const Unit & enemy, Rand::DeterministicRandomG
     if ( Modes( LUCK_GOOD ) ) {
         res *= 2;
     }
-    else if ( Modes( LUCK_BAD ) && res > 1 ) {
-        // We halves the damage in the case of Bad Luck.
-        // If the damage is less than 2 it is 1 and this is a minimal damage that should not be halved.
+    else if ( Modes( LUCK_BAD ) ) {
         res /= 2;
     }
 


### PR DESCRIPTION
Relates to #9805

This PR only updates the Bag Luck animation to have animation delays closer to the OG.
The animation speed can be adjusted.

This PR:

https://github.com/user-attachments/assets/f34319a3-a173-493b-8b89-088e9ebbe140


Not done in this PR:
The ability to deal zero damage by Bad Luck halving or by other damage modifiers should be more investigated and discussed separately.

And talking about triggering Bad Luck more often: I found only the chances for HoMM3 (https://heroes.thelazy.net/index.php/Luck) where the chance of Bad Luck is 2 times higher than of Good Luck. The chance for Bad Luck in HoMM2 should be more investigated...