### PR TITLE
Add Danish language to virtual keyboard

### DIFF
--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -5844,6 +5844,12 @@ namespace
         fheroes2::SetPixel( released[214 - 32], offset + 3, offset + 0, buttonGoodReleasedColor );
         fheroes2::SetPixel( released[214 - 32], offset + 6, offset + 0, buttonGoodReleasedColor );
 
+         // O with slash.
+        released[216 - 32].resize( released[79 - 32].width(), released[79 - 32].height() );
+        released[216 - 32].reset();
+        fheroes2::Copy( released[79 - 32], 0, 0, released[216 - 32], 0, 0, released[79 - 32].width(), released[79 - 32].height() );
+        fheroes2::DrawLine( released[216 - 32], { released[216 - 32].width(), 0 }, { 0, released[216 - 32].height() }, buttonGoodReleasedColor );
+
         // U with grave.
         released[217 - 32].resize( released[85 - 32].width(), released[85 - 32].height() + 3 );
         released[217 - 32].reset();
@@ -6072,6 +6078,8 @@ namespace fheroes2
 
         updateButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED], icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED], icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED],
                           icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] );
+
+        //fheroes2::Save( icnVsSprite[216 - 32], "oWithDiagonalBar.png", 96 );
     }
 
     void modifyBaseNormalFont( std::vector<fheroes2::Sprite> & icnVsSprite )

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -5844,7 +5844,7 @@ namespace
         fheroes2::SetPixel( released[214 - 32], offset + 3, offset + 0, buttonGoodReleasedColor );
         fheroes2::SetPixel( released[214 - 32], offset + 6, offset + 0, buttonGoodReleasedColor );
 
-         // O with slash.
+        // O with slash.
         released[216 - 32].resize( released[79 - 32].width(), released[79 - 32].height() );
         released[216 - 32].reset();
         fheroes2::Copy( released[79 - 32], 0, 0, released[216 - 32], 0, 0, released[79 - 32].width(), released[79 - 32].height() );
@@ -6078,8 +6078,6 @@ namespace fheroes2
 
         updateButtonFont( icnVsSprite[ICN::BUTTON_GOOD_FONT_RELEASED], icnVsSprite[ICN::BUTTON_GOOD_FONT_PRESSED], icnVsSprite[ICN::BUTTON_EVIL_FONT_RELEASED],
                           icnVsSprite[ICN::BUTTON_EVIL_FONT_PRESSED] );
-
-        //fheroes2::Save( icnVsSprite[216 - 32], "oWithDiagonalBar.png", 96 );
     }
 
     void modifyBaseNormalFont( std::vector<fheroes2::Sprite> & icnVsSprite )

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -5678,6 +5678,10 @@ namespace
             released[charCode - 32].setPosition( buttonFontOffset.x, buttonFontOffset.y - 2 );
         }
 
+        for ( const int & charCode : { 216 } ) {
+            released[charCode - 32].setPosition( buttonFontOffset.x, buttonFontOffset.y - 1 );
+        }
+
         // Offset A-related letters to have less space to neighboring letters. Keep the y-offset change from earlier.
         for ( const int & charCode : { 65, 192, 193, 194, 195, 196, 197, 198 } ) {
             released[charCode - 32].setPosition( buttonFontOffset.x - 2, released[charCode - 32].y() );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -5845,10 +5845,10 @@ namespace
         fheroes2::SetPixel( released[214 - 32], offset + 6, offset + 0, buttonGoodReleasedColor );
 
         // O with slash.
-        released[216 - 32].resize( released[79 - 32].width(), released[79 - 32].height() );
+        released[216 - 32].resize( released[79 - 32].width() + 2, released[79 - 32].height() + 2 );
         released[216 - 32].reset();
-        fheroes2::Copy( released[79 - 32], 0, 0, released[216 - 32], 0, 0, released[79 - 32].width(), released[79 - 32].height() );
-        fheroes2::DrawLine( released[216 - 32], { released[216 - 32].width(), 0 }, { 0, released[216 - 32].height() }, buttonGoodReleasedColor );
+        fheroes2::Copy( released[79 - 32], 0, 0, released[216 - 32], 1, 1, released[79 - 32].width(), released[79 - 32].height() );
+        fheroes2::DrawLine( released[216 - 32], { released[79 - 32].width() - 1, 2 }, { 2, released[79 - 32].height() - 1 }, buttonGoodReleasedColor );
 
         // U with grave.
         released[217 - 32].resize( released[85 - 32].width(), released[85 - 32].height() + 3 );

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -5678,9 +5678,7 @@ namespace
             released[charCode - 32].setPosition( buttonFontOffset.x, buttonFontOffset.y - 2 );
         }
 
-        for ( const int & charCode : { 216 } ) {
-            released[charCode - 32].setPosition( buttonFontOffset.x, buttonFontOffset.y - 1 );
-        }
+        released[216 - 32].setPosition( buttonFontOffset.x, buttonFontOffset.y - 1 );
 
         // Offset A-related letters to have less space to neighboring letters. Keep the y-offset change from earlier.
         for ( const int & charCode : { 65, 192, 193, 194, 195, 196, 197, 198 } ) {

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -389,6 +389,7 @@ namespace
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
+        case fheroes2::SupportedLanguage::Danish:
             return { "1234567890", "-:;()_+=", "[].,!'?" };
         default:
             // Did you add a new layout type? Add the logic above!

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -74,15 +74,15 @@ namespace
         case fheroes2::SupportedLanguage::English:
             // English is a default language so it is not considered as an extra language.
             return false;
-        case fheroes2::SupportedLanguage::German:
         case fheroes2::SupportedLanguage::Belarusian:
         case fheroes2::SupportedLanguage::Czech:
+        case fheroes2::SupportedLanguage::Danish:
         case fheroes2::SupportedLanguage::French:
+        case fheroes2::SupportedLanguage::German:
         case fheroes2::SupportedLanguage::Polish:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
-        case fheroes2::SupportedLanguage::Danish:
             return true;
         default:
             break;
@@ -382,6 +382,7 @@ namespace
         switch ( language ) {
         case fheroes2::SupportedLanguage::Belarusian:
         case fheroes2::SupportedLanguage::Czech:
+        case fheroes2::SupportedLanguage::Danish:
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::French:
         case fheroes2::SupportedLanguage::German:
@@ -389,7 +390,6 @@ namespace
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
-        case fheroes2::SupportedLanguage::Danish:
             return { "1234567890", "-:;()_+=", "[].,!'?" };
         default:
             // Did you add a new layout type? Add the logic above!
@@ -412,6 +412,8 @@ namespace
             return { "\xC9\xD6\xD3\xCA\xC5\xCD\xC3\xD8\xA1\xC7\xD5\x92", "\xD4\xDB\xC2\xC0\xCF\xD0\xCE\xCB\xC4\xC6\xDD", "\xDF\xD7\xD1\xCC\xB2\xD2\xDC\xC1\xDE\xA8" };
         case fheroes2::SupportedLanguage::Czech:
             return { "\xCC\x8A\xC8\xD8\x8E\xDD\xC1\xCD\xC9", "QWERTZUIOP\xDA", "ASDFGHJKL\xD9", "YXCVBNM" };
+        case fheroes2::SupportedLanguage::Danish:
+            return { "QWERTYUIOP\xC5", "ASDFGHJKL\xC6\xD8", "ZXCVBNM" };
         case fheroes2::SupportedLanguage::English:
             return { "QWERTYUIOP", "ASDFGHJKL", "ZXCVBNM" };
         case fheroes2::SupportedLanguage::French:
@@ -426,8 +428,6 @@ namespace
             return { "\xCF\xBC\x8A\xC8\x8D\x8E\xDD\xC1\xCD\xC9\xD3", "QWERTZUIOP\xDA", "ASDFGHJKL\xD4\xD2", "\xC4YXCVBNM\xC5\xC0" };
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "\xC9\xD6\xD3\xCA\xC5\xCD\xC3\xD8\xD9\xC7\xD5\xAF", "\xD4\xB2\xC2\xC0\xCF\xD0\xCE\xCB\xC4\xC6\xAA", "\xDF\xD7\xD1\xCC\xC8\xD2\xDC\xC1\xDE\xA5" };
-        case fheroes2::SupportedLanguage::Danish:
-            return { "QWERTYUIOP\xC5", "ASDFGHJKL\xC6\xD8", "ZXCVBNM" };
         default:
             // Did you add a new layout type? Add the logic above!
             assert( 0 );
@@ -444,6 +444,8 @@ namespace
             return { "\xE9\xF6\xF3\xEA\xE5\xED\xE3\xF8\xA2\xE7\xF5\x92", "\xF4\xFB\xE2\xE0\xEF\xF0\xEE\xEB\xE4\xE6\xFD", "\xFF\xF7\xF1\xEC\xB3\xF2\xFC\xE1\xFE\xB8" };
         case fheroes2::SupportedLanguage::Czech:
             return { "\xEC\x9A\xE8\xF8\xBE\xFD\xE1\xED\xE9", "qwertzuiop\xFA", "asdfghjkl\xF9", "yxcvbnm" };
+        case fheroes2::SupportedLanguage::Danish:
+            return { "qwertyuiop\xE5", "asdfghjkl\xE6\xF8", "zxcvbnm" };
         case fheroes2::SupportedLanguage::English:
             return { "qwertyuiop", "asdfghjkl", "zxcvbnm" };
         case fheroes2::SupportedLanguage::French:
@@ -458,8 +460,6 @@ namespace
             return { "\xEF\xBE\x9A\xE8\x9D\x9E\xFD\xE1\xED\xE9\xF3", "qwertzuiop\xFA", "asdfghjkl\xF4\xF2", "\xE4yxcvbnm\xE5\xE0" };
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "\xE9\xF6\xF3\xEA\xE5\xED\xE3\xF8\xF9\xE7\xF5\xBF", "\xF4\xB3\xE2\xE0\xEF\xF0\xEE\xEB\xE4\xE6\xBA", "\xFF\xF7\xF1\xEC\xE8\xF2\xFC\xE1\xFE\xB4" };
-        case fheroes2::SupportedLanguage::Danish:
-            return { "qwertyuiop\xE5", "asdfghjkl\xE6\xF8", "zxcvbnm" };
         default:
             // Did you add a new layout type? Add the logic above!
             assert( 0 );
@@ -507,12 +507,12 @@ namespace
         case fheroes2::SupportedLanguage::Polish:
             return { 30, defaultButtonHeight };
         case fheroes2::SupportedLanguage::Belarusian:
+        case fheroes2::SupportedLanguage::Danish:
         case fheroes2::SupportedLanguage::German:
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::French:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
-        case fheroes2::SupportedLanguage::Danish:
             return { 24, defaultButtonHeight };
         default:
             // Did you add a new supported language? Add the value above!
@@ -717,6 +717,7 @@ namespace
         switch ( language ) {
         case fheroes2::SupportedLanguage::Belarusian:
         case fheroes2::SupportedLanguage::Czech:
+        case fheroes2::SupportedLanguage::Danish:
         case fheroes2::SupportedLanguage::English:
         case fheroes2::SupportedLanguage::French:
         case fheroes2::SupportedLanguage::German:
@@ -724,7 +725,6 @@ namespace
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
-        case fheroes2::SupportedLanguage::Danish:
             addExtraStandardButtons( buttons, layoutType, isEvilInterface, isExtraLanguageSupported );
             break;
         default:

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -82,6 +82,7 @@ namespace
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
+        case fheroes2::SupportedLanguage::Danish:
             return true;
         default:
             break;
@@ -424,6 +425,8 @@ namespace
             return { "\xCF\xBC\x8A\xC8\x8D\x8E\xDD\xC1\xCD\xC9\xD3", "QWERTZUIOP\xDA", "ASDFGHJKL\xD4\xD2", "\xC4YXCVBNM\xC5\xC0" };
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "\xC9\xD6\xD3\xCA\xC5\xCD\xC3\xD8\xD9\xC7\xD5\xAF", "\xD4\xB2\xC2\xC0\xCF\xD0\xCE\xCB\xC4\xC6\xAA", "\xDF\xD7\xD1\xCC\xC8\xD2\xDC\xC1\xDE\xA5" };
+        case fheroes2::SupportedLanguage::Danish:
+            return { "QWERTYUIOP\xC5", "ASDFGHJKL\xC6\xD8", "ZXCVBNM" };
         default:
             // Did you add a new layout type? Add the logic above!
             assert( 0 );
@@ -454,6 +457,8 @@ namespace
             return { "\xEF\xBE\x9A\xE8\x9D\x9E\xFD\xE1\xED\xE9\xF3", "qwertzuiop\xFA", "asdfghjkl\xF4\xF2", "\xE4yxcvbnm\xE5\xE0" };
         case fheroes2::SupportedLanguage::Ukrainian:
             return { "\xE9\xF6\xF3\xEA\xE5\xED\xE3\xF8\xF9\xE7\xF5\xBF", "\xF4\xB3\xE2\xE0\xEF\xF0\xEE\xEB\xE4\xE6\xBA", "\xFF\xF7\xF1\xEC\xE8\xF2\xFC\xE1\xFE\xB4" };
+        case fheroes2::SupportedLanguage::Danish:
+            return { "qwertyuiop\xE5", "asdfghjkl\xE6\xF8", "zxcvbnm" };
         default:
             // Did you add a new layout type? Add the logic above!
             assert( 0 );
@@ -506,6 +511,7 @@ namespace
         case fheroes2::SupportedLanguage::French:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
+        case fheroes2::SupportedLanguage::Danish:
             return { 24, defaultButtonHeight };
         default:
             // Did you add a new supported language? Add the value above!
@@ -717,6 +723,7 @@ namespace
         case fheroes2::SupportedLanguage::Russian:
         case fheroes2::SupportedLanguage::Slovak:
         case fheroes2::SupportedLanguage::Ukrainian:
+        case fheroes2::SupportedLanguage::Danish:
             addExtraStandardButtons( buttons, layoutType, isEvilInterface, isExtraLanguageSupported );
             break;
         default:


### PR DESCRIPTION
Part of #8826 
Added Danish keyboard:
![image](https://github.com/user-attachments/assets/140587e2-1b3a-4839-b0c0-8a7df5a17411)

Added Ø to font:
![oWithDiagonalBar](https://github.com/user-attachments/assets/90df4ef2-2539-4308-89ee-ac4ef8f7ec88)
