### PR TITLE
Add an optional field for map creator's notes

### DIFF
--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -2262,6 +2262,10 @@ namespace Editor
         background.renderTextAdaptedButtonSprite( buttonLanguage, translatedText, { 20 + buttonRumors.area().width + buttonEvents.area().width + 2 * 10, 6 },
                                                   fheroes2::StandardWindow::Padding::BOTTOM_LEFT );
 
+        fheroes2::ButtonSprite buttonCreatorNotes;
+        translatedText = fheroes2::getSupportedText( gettext_noop( "INFO" ), fheroes2::FontType::buttonReleasedWhite() );
+        background.renderTextAdaptedButtonSprite( buttonCreatorNotes, translatedText, { 21, 12 }, fheroes2::StandardWindow::Padding::TOP_RIGHT );
+
         auto renderMapName = [&text, &mapFormat, &display, &scenarioBox, &mapNameRoi, &scenarioBoxRoi]() {
             text.set( mapFormat.name, fheroes2::FontType::normalWhite(), mapFormat.mainLanguage );
             fheroes2::Copy( scenarioBox, 0, 0, display, scenarioBoxRoi );
@@ -2301,6 +2305,7 @@ namespace Editor
             buttonLanguage.drawOnState( le.isMouseLeftButtonPressedInArea( buttonLanguage.area() ) );
             victoryDroplistButton.drawOnState( le.isMouseLeftButtonPressedInArea( victoryDroplistButtonRoi ) );
             lossDroplistButton.drawOnState( le.isMouseLeftButtonPressedInArea( lossDroplistButtonRoi ) );
+            buttonCreatorNotes.drawOnState( le.isMouseLeftButtonPressedInArea( buttonCreatorNotes.area() ) );
 
             if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( buttonCancel.area() ) ) {
                 return false;
@@ -2414,6 +2419,14 @@ namespace Editor
 
                 display.render( fheroes2::getBoundaryRect( lossTextRoi, lossConditionUIRoi ) );
             }
+            else if ( le.MouseClickLeft( buttonCreatorNotes.area() ) ) {
+                std::string notes = mapFormat.creatorNotes;
+
+                const fheroes2::Text body{ _( "Creator's Notes" ), fheroes2::FontType::normalWhite() };
+                if ( Dialog::inputString( fheroes2::Text{}, body, notes, 150, true, mapFormat.mainLanguage ) ) {
+                    mapFormat.creatorNotes = std::move( notes );
+                }
+            }
             else if ( le.isMouseRightButtonPressedInArea( buttonCancel.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Cancel" ), _( "Exit this menu without doing anything." ), Dialog::ZERO );
             }
@@ -2428,6 +2441,9 @@ namespace Editor
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonLanguage.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Language" ), _( "Click to change the language of the map." ), Dialog::ZERO );
+            }
+            else if ( le.isMouseRightButtonPressedInArea( buttonCreatorNotes.area() ) ) {
+                fheroes2::showStandardTextMessage( _( "Creator's Notes" ), _( "Click to change notes from map creator." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( mapNameRoi ) ) {
                 fheroes2::MultiFontText message;

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -2443,7 +2443,9 @@ namespace Editor
                 fheroes2::showStandardTextMessage( _( "Language" ), _( "Click to change the language of the map." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonCreatorNotes.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "Creator's Notes" ), _( "Click to change notes from map creator." ), Dialog::ZERO );
+                fheroes2::showStandardTextMessage( _( "Creator's Notes" ),
+                                                   _( "Click to edit notes from the map creator. These notes are optional and do not appear during gameplay." ),
+                                                   Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( mapNameRoi ) ) {
                 fheroes2::MultiFontText message;

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -2263,7 +2263,7 @@ namespace Editor
                                                   fheroes2::StandardWindow::Padding::BOTTOM_LEFT );
 
         fheroes2::ButtonSprite buttonCreatorNotes;
-        translatedText = fheroes2::getSupportedText( gettext_noop( "INFO" ), fheroes2::FontType::buttonReleasedWhite() );
+        translatedText = fheroes2::getSupportedText( gettext_noop( "ABOUT" ), fheroes2::FontType::buttonReleasedWhite() );
         background.renderTextAdaptedButtonSprite( buttonCreatorNotes, translatedText, { 21, 12 }, fheroes2::StandardWindow::Padding::TOP_RIGHT );
 
         auto renderMapName = [&text, &mapFormat, &display, &scenarioBox, &mapNameRoi, &scenarioBoxRoi]() {

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -2262,9 +2262,9 @@ namespace Editor
         background.renderTextAdaptedButtonSprite( buttonLanguage, translatedText, { 20 + buttonRumors.area().width + buttonEvents.area().width + 2 * 10, 6 },
                                                   fheroes2::StandardWindow::Padding::BOTTOM_LEFT );
 
-        fheroes2::ButtonSprite buttonCreatorNotes;
+        fheroes2::ButtonSprite buttonAbout;
         translatedText = fheroes2::getSupportedText( gettext_noop( "ABOUT" ), fheroes2::FontType::buttonReleasedWhite() );
-        background.renderTextAdaptedButtonSprite( buttonCreatorNotes, translatedText, { 21, 12 }, fheroes2::StandardWindow::Padding::TOP_RIGHT );
+        background.renderTextAdaptedButtonSprite( buttonAbout, translatedText, { 21, 12 }, fheroes2::StandardWindow::Padding::TOP_RIGHT );
 
         auto renderMapName = [&text, &mapFormat, &display, &scenarioBox, &mapNameRoi, &scenarioBoxRoi]() {
             text.set( mapFormat.name, fheroes2::FontType::normalWhite(), mapFormat.mainLanguage );
@@ -2305,7 +2305,7 @@ namespace Editor
             buttonLanguage.drawOnState( le.isMouseLeftButtonPressedInArea( buttonLanguage.area() ) );
             victoryDroplistButton.drawOnState( le.isMouseLeftButtonPressedInArea( victoryDroplistButtonRoi ) );
             lossDroplistButton.drawOnState( le.isMouseLeftButtonPressedInArea( lossDroplistButtonRoi ) );
-            buttonCreatorNotes.drawOnState( le.isMouseLeftButtonPressedInArea( buttonCreatorNotes.area() ) );
+            buttonAbout.drawOnState( le.isMouseLeftButtonPressedInArea( buttonAbout.area() ) );
 
             if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( buttonCancel.area() ) ) {
                 return false;
@@ -2419,10 +2419,10 @@ namespace Editor
 
                 display.render( fheroes2::getBoundaryRect( lossTextRoi, lossConditionUIRoi ) );
             }
-            else if ( le.MouseClickLeft( buttonCreatorNotes.area() ) ) {
+            else if ( le.MouseClickLeft( buttonAbout.area() ) ) {
                 std::string notes = mapFormat.creatorNotes;
 
-                const fheroes2::Text body{ _( "Creator's Notes" ), fheroes2::FontType::normalWhite() };
+                const fheroes2::Text body{ _( "About" ), fheroes2::FontType::normalWhite() };
                 if ( Dialog::inputString( fheroes2::Text{}, body, notes, 150, true, mapFormat.mainLanguage ) ) {
                     mapFormat.creatorNotes = std::move( notes );
                 }
@@ -2442,8 +2442,8 @@ namespace Editor
             else if ( le.isMouseRightButtonPressedInArea( buttonLanguage.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "Language" ), _( "Click to change the language of the map." ), Dialog::ZERO );
             }
-            else if ( le.isMouseRightButtonPressedInArea( buttonCreatorNotes.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "Creator's Notes" ),
+            else if ( le.isMouseRightButtonPressedInArea( buttonAbout.area() ) ) {
+                fheroes2::showStandardTextMessage( _( "About" ),
                                                    _( "Click to edit notes from the map creator. These notes are optional and do not appear during gameplay." ),
                                                    Dialog::ZERO );
             }

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2024                                             *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -22,6 +22,7 @@
 
 #include <array>
 #include <cstddef>
+#include <initializer_list>
 
 #include "serialize.h"
 #include "zzlib.h"

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -72,7 +72,7 @@ namespace
     constexpr uint16_t minimumSupportedVersion{ 2 };
 
     // Change the version when there is a need to expand map format functionality.
-    constexpr uint16_t currentSupportedVersion{ 8 };
+    constexpr uint16_t currentSupportedVersion{ 9 };
 
     void convertFromV2ToV3( Maps::Map_Format::MapFormat & map )
     {
@@ -218,7 +218,8 @@ namespace
     {
         stream << currentSupportedVersion << map.isCampaign << map.difficulty << map.availablePlayerColors << map.humanPlayerColors << map.computerPlayerColors
                << map.alliances << map.playerRace << map.victoryConditionType << map.isVictoryConditionApplicableForAI << map.allowNormalVictory
-               << map.victoryConditionMetadata << map.lossConditionType << map.lossConditionMetadata << map.size << map.mainLanguage << map.name << map.description;
+               << map.victoryConditionMetadata << map.lossConditionType << map.lossConditionMetadata << map.size << map.mainLanguage << map.name << map.description
+               << map.creatorNotes;
 
         return !stream.fail();
     }
@@ -240,6 +241,13 @@ namespace
         }
 
         stream >> map.mainLanguage >> map.name >> map.description;
+
+        if ( map.version < 9 ) {
+            map.creatorNotes = {};
+        }
+        else {
+            stream >> map.creatorNotes;
+        }
 
         return !stream.fail();
     }

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -306,8 +306,7 @@ namespace Maps::Map_Format
 
         // This is an optional parameter where a map maker can leave their contact details.
         // This parameter is only visible within the Editor, it doesn't affect the gameplay in any way.
-        // The parameter is mandatory to be filled by map makers who want to include their creations
-        // into the engine's bundle.
+        // The parameter is mandatory to fill out by map makers who want to have their creations bundled with the engine.
         std::string creatorNotes;
     };
 

--- a/src/fheroes2/maps/map_format_info.h
+++ b/src/fheroes2/maps/map_format_info.h
@@ -303,6 +303,12 @@ namespace Maps::Map_Format
 
         std::string name;
         std::string description;
+
+        // This is an optional parameter where a map maker can leave their contact details.
+        // This parameter is only visible within the Editor, it doesn't affect the gameplay in any way.
+        // The parameter is mandatory to be filled by map makers who want to include their creations
+        // into the engine's bundle.
+        std::string creatorNotes;
     };
 
     struct MapFormat : public BaseMapFormat


### PR DESCRIPTION
This field is optional and requires to be filled for map makers providing maps to be a part of the fheroes2 bundle. This is a much more elegant solution rather than proving contact details in the description of the map or in a separate file.

![image](https://github.com/user-attachments/assets/6aa7ee1f-78eb-4222-afa7-a37d529b9f8b)