### PR TITLE
Render hero's "current / max" Spell Points in two lines if they don't fit in one line

### DIFF
--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -74,11 +74,6 @@ HeroesIndicator::HeroesIndicator( const Heroes * hero )
     assert( _hero != nullptr );
 }
 
-const fheroes2::Rect & HeroesIndicator::GetArea() const
-{
-    return _area;
-}
-
 void HeroesIndicator::SetPos( const fheroes2::Point & pt )
 {
     _area.x = pt.x;
@@ -234,16 +229,21 @@ void ExperienceIndicator::Redraw() const
         fheroes2::Text text{ std::move( experienceString ), fheroes2::FontType::smallWhite() };
         if ( text.width() > renderRoi.width + 1 ) {
             // The experience string is much longer than the rendering area. We want to avoid too long strings.
-            const uint32_t millions = experienceValue / 1000000;
+            constexpr uint32_t millionValue = 1000000;
+            const uint32_t millions = experienceValue / millionValue;
 
-            if ( experienceValue < 10000000 ) {
-                experienceString = std::to_string( millions ) + "." + std::to_string( ( experienceValue - millions * 1000000 ) / 10000 ) + _( "million|M" );
+            if ( experienceValue < 10 * millionValue ) {
+                // Show two digits after the point ("x.xxM").
+                experienceString
+                    = std::to_string( millions ) + "." + std::to_string( ( experienceValue - millions * millionValue ) / ( millionValue / 100 ) ) + _( "million|M" );
             }
             else {
-                experienceString = std::to_string( millions ) + "." + std::to_string( ( experienceValue - millions * 1000000 ) / 100000 ) + _( "million|M" );
+                // Show one digit after the point ("xx.xM").
+                experienceString
+                    = std::to_string( millions ) + "." + std::to_string( ( experienceValue - millions * millionValue ) / ( millionValue / 10 ) ) + _( "million|M" );
             }
 
-            text.set( experienceString, fheroes2::FontType::smallWhite() );
+            text.set( std::move( experienceString ), fheroes2::FontType::smallWhite() );
             text.drawInRoi( renderRoi.x + ( experienceImage.width() - text.width() ) / 2 - widthReduction, _area.y + 25, display, renderRoi );
         }
 
@@ -278,17 +278,49 @@ SpellPointsIndicator::SpellPointsIndicator( const Heroes * hero )
     StringReplace( _description, "%{max}", _hero->GetMaxSpellPoints() );
 }
 
-void SpellPointsIndicator::Redraw() const
+void SpellPointsIndicator::Redraw()
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
     const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::HSICONS, 8 );
+
+    const fheroes2::Rect renderRoi{ _area.x + 1, _area.y + 22, 33, 9 };
+
+    fheroes2::Text text;
+    if ( _isDefault ) {
+        text.set( std::to_string( _hero->GetMaxSpellPoints() ), fheroes2::FontType::smallWhite() );
+    }
+    else {
+        text.set( std::to_string( _hero->GetSpellPoints() ) + "/" + std::to_string( _hero->GetMaxSpellPoints() ), fheroes2::FontType::smallWhite() );
+    }
+
+    const bool drawOneLinedText = _isDefault || ( text.width() <= renderRoi.width );
+    if ( drawOneLinedText && _needBackgroundRestore ) {
+        _needBackgroundRestore = false;
+        redrawOnlyBackground();
+    }
+
+    // Draw the SpellPoints indicator sprite.
     fheroes2::Blit( sprite, display, _area.x, _area.y );
 
-    const fheroes2::Text text( _isDefault ? std::to_string( _hero->GetMaxSpellPoints() )
-                                          : std::to_string( _hero->GetSpellPoints() ) + "/" + std::to_string( _hero->GetMaxSpellPoints() ),
-                               fheroes2::FontType::smallWhite() );
-    text.draw( _area.x + sprite.width() / 2 - text.width() / 2, _area.y + 23, display );
+    if ( drawOneLinedText ) {
+        text.drawInRoi( _area.x + sprite.width() / 2 - text.width() / 2, _area.y + 23, display, renderRoi );
+    }
+    else {
+        // The spell points do not fit the render area. Expand the area to the top.
+        fheroes2::Copy( sprite, 0, 21, display, renderRoi.x - 1, renderRoi.y - renderRoi.height - 1, renderRoi.width + 2, renderRoi.height + 1 );
+
+        // Render the current Spell Points value at the top line.
+        text.set( std::to_string( _hero->GetSpellPoints() ) + "/", fheroes2::FontType::smallWhite() );
+        text.drawInRoi( renderRoi.x, renderRoi.y - renderRoi.height + 1, display, { renderRoi.x, renderRoi.y - renderRoi.height, renderRoi.width, renderRoi.height } );
+
+        // Render the maximum Spell Points value in the bottom line.
+        text.set( std::to_string( _hero->GetMaxSpellPoints() ), fheroes2::FontType::smallWhite() );
+        text.drawInRoi( renderRoi.x + renderRoi.width - text.width() - 1, renderRoi.y + 1, display, renderRoi );
+
+        // The background of the two-lined text should be restored if the one-lined variant is going to be rendered.
+        _needBackgroundRestore = true;
+    }
 }
 
 void SpellPointsIndicator::QueueEventProcessing() const

--- a/src/fheroes2/heroes/heroes_indicator.h
+++ b/src/fheroes2/heroes/heroes_indicator.h
@@ -43,9 +43,18 @@ class HeroesIndicator
 public:
     explicit HeroesIndicator( const Heroes * hero );
 
-    const fheroes2::Rect & GetArea() const;
+    const fheroes2::Rect & GetArea() const
+    {
+        return _area;
+    }
 
     void SetPos( const fheroes2::Point & pt );
+
+    // Restores the background under this indicator. The indicator itself is not drawn.
+    void redrawOnlyBackground()
+    {
+        _back.restore();
+    }
 
 protected:
     const Heroes * _hero;
@@ -54,7 +63,7 @@ protected:
     std::string _description;
 };
 
-class LuckIndicator : public HeroesIndicator
+class LuckIndicator final : public HeroesIndicator
 {
 public:
     explicit LuckIndicator( const Heroes * hero )
@@ -66,19 +75,13 @@ public:
 
     void Redraw();
 
-    // Redraws only the background under this indicator, but not the indicator itself
-    void redrawOnlyBackground()
-    {
-        _back.restore();
-    }
-
     static void QueueEventProcessing( const LuckIndicator & indicator );
 
 private:
     int _luck{ Luck::NORMAL };
 };
 
-class MoraleIndicator : public HeroesIndicator
+class MoraleIndicator final : public HeroesIndicator
 {
 public:
     explicit MoraleIndicator( const Heroes * hero )
@@ -90,19 +93,13 @@ public:
 
     void Redraw();
 
-    // Redraws only the background under this indicator, but not the indicator itself
-    void redrawOnlyBackground()
-    {
-        _back.restore();
-    }
-
     static void QueueEventProcessing( const MoraleIndicator & indicator );
 
 private:
     int _morale{ Morale::NORMAL };
 };
 
-class ExperienceIndicator : public HeroesIndicator
+class ExperienceIndicator final : public HeroesIndicator
 {
 public:
     explicit ExperienceIndicator( const Heroes * hero );
@@ -121,12 +118,12 @@ private:
     bool _isDefault{ false };
 };
 
-class SpellPointsIndicator : public HeroesIndicator
+class SpellPointsIndicator final : public HeroesIndicator
 {
 public:
     explicit SpellPointsIndicator( const Heroes * hero );
 
-    void Redraw() const;
+    void Redraw();
     void QueueEventProcessing() const;
 
     // Set if default value is used. Use this method only in Editor!
@@ -138,4 +135,5 @@ public:
 private:
     // This state is used in Editor to show that default value is used.
     bool _isDefault{ false };
+    bool _needBackgroundRestore{ false };
 };


### PR DESCRIPTION
fix #9433 

This PR does rendering of "long" Spell Points values in two lines to fully and properly show them in the output field. The field for this case is expanded to the top.
![img](https://github.com/user-attachments/assets/6b364450-da9e-488c-81ae-f4c6ea8514ec) ![ing](https://github.com/user-attachments/assets/c7e9f60a-bb2f-43d9-8f42-52637b6a55f2)

The introducing of thousands (e.g. "1K" for 1000-1999) will not fix the issue because not all three-digit values already fit:
![img](https://github.com/user-attachments/assets/bb7693dd-cc2a-4240-a765-a82b2d0df1db), while others do: ![img](https://github.com/user-attachments/assets/01f53768-b0c1-4636-8876-5fc4437799e6)
