### PR TITLE
Add Play Online Feature to Website

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -318,7 +318,6 @@ jobs:
         artifactErrorsFailBuild: true
         prerelease: true
         replacesArtifacts: true
-
   make-emscripten:
     strategy:
       matrix:

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -326,15 +326,15 @@ jobs:
           env:
             FHEROES2_STRICT_COMPILATION: ON
           package_name: fheroes2_emscripten.zip
-          release_tag: fheroes2-emscripten-sdl2_dev
           release_name: Emscripten build (latest commit)
+          release_tag: fheroes2-emscripten-sdl2_dev
         - name: Emscripten Multithreaded
           env:
             FHEROES2_STRICT_COMPILATION: ON
             FHEROES2_WITH_THREADS: ON
           package_name: fheroes2_emscripten_mt.zip
-          release_tag: fheroes2-emscripten-sdl2-mt_dev
           release_name: Emscripten Multithreaded build (latest commit)
+          release_tag: fheroes2-emscripten-sdl2-mt_dev
     name: Make (${{ matrix.name }})
     runs-on: ubuntu-latest
     container: emscripten/emsdk:latest

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -318,21 +318,26 @@ jobs:
         artifactErrorsFailBuild: true
         prerelease: true
         replacesArtifacts: true
+
   make-emscripten:
     strategy:
       matrix:
         include:
         - name: Emscripten
-          on: [ 'pull_request' ]
+          on: [ 'pull_request', 'push' ]
           env:
             FHEROES2_STRICT_COMPILATION: ON
           package_name: fheroes2_emscripten.zip
+          release_tag: fheroes2-emscripten-sdl2_dev
+          release_name: Emscripten build (latest commit)
         - name: Emscripten Multithreaded
-          on: [ 'pull_request' ]
+          on: [ 'pull_request', 'push' ]
           env:
             FHEROES2_STRICT_COMPILATION: ON
             FHEROES2_WITH_THREADS: ON
           package_name: fheroes2_emscripten_mt.zip
+          release_tag: fheroes2-emscripten-sdl2-mt_dev
+          release_name: Emscripten Multithreaded build (latest commit)
     name: Make (${{ matrix.name }})
     runs-on: ubuntu-latest
     container: emscripten/emsdk:latest
@@ -364,3 +369,15 @@ jobs:
         name: ${{ matrix.package_name }}
         path: ${{ matrix.package_name }}
         if-no-files-found: error
+    - uses: ncipollo/release-action@v1
+      if: ${{ github.event_name == 'push' }}
+      with:
+        artifacts: ${{ matrix.package_name }}
+        body: ${{ github.event.head_commit.message }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        name: ${{ matrix.release_name }}
+        tag: ${{ matrix.release_tag }}
+        allowUpdates: true
+        artifactErrorsFailBuild: true
+        prerelease: true
+        replacesArtifacts: true

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -323,14 +323,12 @@ jobs:
       matrix:
         include:
         - name: Emscripten
-          on: [ 'pull_request', 'push' ]
           env:
             FHEROES2_STRICT_COMPILATION: ON
           package_name: fheroes2_emscripten.zip
           release_tag: fheroes2-emscripten-sdl2_dev
           release_name: Emscripten build (latest commit)
         - name: Emscripten Multithreaded
-          on: [ 'pull_request', 'push' ]
           env:
             FHEROES2_STRICT_COMPILATION: ON
             FHEROES2_WITH_THREADS: ON
@@ -346,24 +344,20 @@ jobs:
         shell: bash
     steps:
     - uses: actions/checkout@v4
-      if: ${{ contains( matrix.on, github.event_name ) }}
     - name: Install dependencies
-      if: ${{ contains( matrix.on, github.event_name ) }}
       run: |
         sudo apt-get -y update
         sudo apt-get -y install gettext p7zip-full
     - name: Build
-      if: ${{ contains( matrix.on, github.event_name ) }}
       run: |
         emmake make -f Makefile.emscripten -j "$(nproc)"
       env: ${{ matrix.env }}
     - name: Create package
-      if: ${{ contains( matrix.on, github.event_name ) }}
       run: |
         # Translations and H2D files are already included in fheroes2.data
         7z a -bb1 -tzip -- ${{ matrix.package_name }} LICENSE changelog.txt fheroes2.data fheroes2.js fheroes2.wasm ./docs/README.txt ./files/emscripten/*
     - uses: actions/upload-artifact@v4
-      if: ${{ contains( matrix.on, github.event_name ) }}
+      if: ${{ github.event_name == 'pull_request' }}
       with:
         name: ${{ matrix.package_name }}
         path: ${{ matrix.package_name }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,62 @@
+name: Build and deploy website
+
+on:
+  push:
+    branches: [ master ]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        id: pages
+        uses: actions/configure-pages@v5
+
+      - name: Build with Jekyll
+        uses: actions/jekyll-build-pages@v1
+        with:
+          source: ./docs
+          destination: ./_site
+
+      - name: Download Emscripten release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release download fheroes2-emscripten-sdl2_dev -D ./dist
+
+      - name: Extract and prepare site
+        working-directory: ./dist
+        run: |
+          mkdir -p ./site/play-online
+          unzip -q fheroes2_emscripten.zip -d site/play-online
+          cp -r ../_site/* ./site/
+          rm -f fheroes2_emscripten.zip
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./dist/site"
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash
@@ -45,6 +46,7 @@ jobs:
     needs:
     - build
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     defaults:
       run:
         shell: bash

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,8 +6,8 @@ on:
 
 permissions:
   contents: write
-  pages: write
   id-token: write
+  pages: write
 
 concurrency:
   group: "pages"
@@ -19,23 +19,19 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v5
-
       - name: Build with Jekyll
         uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
-
       - name: Download Emscripten release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release download fheroes2-emscripten-sdl2_dev -D ./dist
-
       - name: Extract and prepare site
         working-directory: ./dist
         run: |
@@ -43,12 +39,10 @@ jobs:
           unzip -q fheroes2_emscripten.zip -d site/play-online
           cp -r ../_site/* ./site/
           rm -f fheroes2_emscripten.zip
-
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:
           path: "./dist/site"
-
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -15,6 +15,7 @@ concurrency:
 
 jobs:
   build:
+    name: Build website
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -43,6 +44,7 @@ jobs:
         with:
           path: ./dist/site
   deploy:
+    name: Deploy website
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -40,7 +40,7 @@ jobs:
           rm -f fheroes2_emscripten.zip
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: "./dist/site"
+          path: ./dist/site
   deploy:
     needs:
     - build

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -10,20 +10,19 @@ permissions:
   pages: write
 
 concurrency:
-  group: "pages"
+  group: pages
   cancel-in-progress: false
 
 jobs:
   build:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      - name: Setup Pages
-        id: pages
-        uses: actions/configure-pages@v5
-      - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+      - uses: actions/checkout@v4
+      - uses: actions/configure-pages@v5
+      - uses: actions/jekyll-build-pages@v1
         with:
           source: ./docs
           destination: ./_site
@@ -32,24 +31,25 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           gh release download fheroes2-emscripten-sdl2_dev -D ./dist
-      - name: Extract and prepare site
+      - name: Extract and prepare website
         working-directory: ./dist
         run: |
           mkdir -p ./site/play-online
           unzip -q fheroes2_emscripten.zip -d site/play-online
           cp -r ../_site/* ./site/
           rm -f fheroes2_emscripten.zip
-      - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v3
         with:
           path: "./dist/site"
   deploy:
+    needs:
+    - build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        shell: bash
     environment:
       name: github-pages
-      url: ${{steps.deployment.outputs.page_url}}
-    runs-on: ubuntu-latest
-    needs: build
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - name: Deploy to GitHub Pages
-        id: deployment
-        uses: actions/deploy-pages@v4
+      - uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,10 +1,7 @@
 name: Build and deploy website
 
 on:
-  workflow_run:
-    workflows: ["Push"]
-    types:
-      - completed
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,8 +1,10 @@
 name: Build and deploy website
 
 on:
-  push:
-    branches: [ master ]
+  workflow_run:
+    workflows: ["Push"]
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,9 +10,9 @@ concurrency:
 
 permissions:
   contents: write
+  id-token: write   # To verify the deployment originates from an appropriate source
+  pages: write      # To deploy to Pages
   pull-requests: write
-  pages: write      # to deploy to Pages
-  id-token: write   # to verify the deployment originates from an appropriate source
 
 jobs:
   android:
@@ -33,6 +33,11 @@ jobs:
     uses: ./.github/workflows/sonarcloud.yml
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+  pages:
+    name: Pages
+    needs:
+    - make
+    uses: ./.github/workflows/pages.yml
   translation:
     name: Translation update
     needs:
@@ -40,9 +45,3 @@ jobs:
     - make
     - msvc
     uses: ./.github/workflows/translation_update.yml
-
-  pages:
-    name: Pages
-    needs:
-    - make
-    uses: ./.github/workflows/pages.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -34,7 +34,7 @@ jobs:
     secrets:
       SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   pages:
-    name: Pages
+    name: Build and deploy website
     needs:
     - make
     uses: ./.github/workflows/pages.yml

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -11,6 +11,8 @@ concurrency:
 permissions:
   contents: write
   pull-requests: write
+  pages: write      # to deploy to Pages
+  id-token: write   # to verify the deployment originates from an appropriate source
 
 jobs:
   android:
@@ -38,3 +40,9 @@ jobs:
     - make
     - msvc
     uses: ./.github/workflows/translation_update.yml
+
+  pages:
+    name: Pages
+    needs:
+    - make
+    uses: ./.github/workflows/pages.yml

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -38,7 +38,7 @@ sequenceDiagram
 ### Trigger
 
 * Deployment is triggered **when a new Git commit is pushed**.
-* A GitHub Action workflow listens via `workflow_run` to wait for the build-and-release process.
+* A GitHub Action workflow waits for the completion of the build-and-release process (`build.yml` workflow).
 
 ### Build Process (Upstream)
 
@@ -62,7 +62,7 @@ sequenceDiagram
 
 ### pages.yml
 
-* Triggered on `workflow_run` completion of `push.yml`
+* Triggered on completion of `build.yml`
 * Builds Jekyll site
 * Downloads release
 * Deploys to Github Pages

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -38,7 +38,7 @@ sequenceDiagram
 ### Trigger
 
 * Deployment is triggered **when a new Git commit is pushed**.
-* A GitHub Action workflow waits for the completion of the build-and-release process (`build.yml` workflow).
+* A GitHub Action workflow waits for the completion of the build-and-release process (`make.yml` workflow).
 
 ### Build Process (Upstream)
 

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -1,4 +1,4 @@
-# Website Duild and Deployment
+# Website Build and Deployment
 
 This document describes the end-to-end deployment strategy for the fheroes2 site deployment.
 We target Github Pages for hosting and leverage GitHub Actions for automation.
@@ -80,4 +80,4 @@ C4Context
 ## Future Considerations
 
 * Hook up a custom domain if needed
-* Allow better devex around pages/emscripten process for local builds
+* Allow better developer experience around pages/emscripten process for local builds

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -1,12 +1,13 @@
-# FHeroes2 WebAssembly Deployment Process
+# Website Duild and Deployment
 
-This document describes the end-to-end deployment strategy for the FHeroes2 WebAssembly build,
-targeting Github Pages for hosting and leveraging GitHub Actions for automation.
+This document describes the end-to-end deployment strategy for the fheroes2 site deployment.
+We target Github Pages for hosting and leverage GitHub Actions for automation.
 
-## Goals
-
-* Allow end users to click a link and launch the game via the web.
-* Automatically deploy the WebAssembly build to Github Pages on push.
+## Functionality
+* Builds the documentation site for the fheroes2 project
+* Deploys the site, along with WebAssembly build, to Github Pages on push.
+* Allows end users to view the documentation via the web.
+* Allows end users to click a link and launch the game via the web.
 
 ## Infrastructure Diagram
 

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -4,6 +4,7 @@ This document describes the end-to-end deployment strategy for the fheroes2 site
 We target Github Pages for hosting and leverage GitHub Actions for automation.
 
 ## Functionality
+
 * Builds the documentation site for the fheroes2 project
 * Deploys the site, along with WebAssembly build, to Github Pages on push.
 * Allows end users to view the documentation via the web.

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -10,37 +10,27 @@ We target Github Pages for hosting and leverage GitHub Actions for automation.
 * Allows end users to view the documentation via the web.
 * Allows end users to click a link and launch the game via the web.
 
-## Infrastructure Diagram
+## Build and Deployment Diagram
 
 ```mermaid
-C4Context
-    title FHeroes2 WebAssembly Infrastructure
-    Person(user, "End User", "Plays the game via web browser")
-    Person(committer, "Engineer", "Engineer who commits into master")
+sequenceDiagram
+    actor EndUser
+    actor Engineer
+    participant GitHubRepo
+    participant PushAction
+    participant MakeAction
+    participant GitHubReleases
+    participant PagesAction
+    participant GitHubPages
 
-    System_Boundary(github-pages, "GitHub Pages") {
-        System(site, "Website", "Github pages hosted website")
-    }
-    System_Boundary(github, "GitHub") {
-        System(repo, "GitHub Repository", "Source code and infrastructure")
-    }
-    System_Boundary(github-releases, "GitHub Releases") {
-        System(releases, "GitHub Releases", "Stores build artifacts")
-    }
-    System_Boundary(github_actions, "GitHub Actions") {
-        System(push_action, "Push Action ", "Triggers the build of the application")
-        System(make_action, "Make Action ", "Builds the releases including emscripten release")
-        System(pages_action, "Pages Action", "Builds and deploys the pages site")
-    }
-
-    Rel(committer, repo, "Pushes change into master")
-    Rel(repo, push_action, "Triggers workflows", "On push")
-    Rel(push_action, make_action, "Builds Applicaion", "workflow_call")
-    Rel(make_action, releases, "Uploads Releases", "latest commit")
-    Rel(push_action, pages_action, "Builds site", "workflow_run")
-    Rel(releases, pages_action, "Downloads release")
-    Rel(pages_action, site, "Deploys Site")
-    Rel(user, site, "Plays game", "HTTPS")
+    Engineer->>GitHubRepo: Pushes change to master
+    GitHubRepo->>PushAction: Triggers workflow
+    PushAction->>MakeAction: Calls workflow
+    MakeAction->>GitHubReleases: Uploads release artifacts
+    PushAction->>PagesAction: Triggers workflow
+    PagesAction->>GitHubReleases: Downloads latest release
+    PagesAction->>GitHubPages: Deploys site
+    EndUser->>GitHubPages: Plays game via browser
 ```
 
 ## Deployment Pipeline Overview

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -1,0 +1,81 @@
+# FHeroes2 WebAssembly Deployment Process
+
+This document describes the end-to-end deployment strategy for the FHeroes2 WebAssembly build,
+targeting Github Pages for hosting and leveraging GitHub Actions for automation.
+
+## Goals
+
+* Allow end users to click a link and launch the game via the web.
+* Automatically deploy the WebAssembly build to Github Pages on push.
+
+## Infrastructure Diagram
+
+```mermaid
+C4Context
+    title FHeroes2 WebAssembly Infrastructure
+    Person(user, "End User", "Plays the game via web browser")
+    Person(committer, "Engineer", "Engineer who commits into master")
+
+    System_Boundary(github-pages, "GitHub Pages") {
+        System(site, "Website", "Github pages hosted website")
+    }
+    System_Boundary(github, "GitHub") {
+        System(repo, "GitHub Repository", "Source code and infrastructure")
+    }
+    System_Boundary(github-releases, "GitHub Releases") {
+        System(releases, "GitHub Releases", "Stores build artifacts")
+    }
+    System_Boundary(github_actions, "GitHub Actions") {
+        System(push_action, "Push Action ", "Triggers the build of the application")
+        System(make_action, "Make Action ", "Builds the releases including emscripten release")
+        System(pages_action, "Pages Action", "Builds and deploys the pages site")
+    }
+
+    Rel(committer, repo, "Pushes change into master")
+    Rel(repo, push_action, "Triggers workflows", "On push")
+    Rel(push_action, make_action, "Builds Applicaion", "workflow_call")
+    Rel(make_action, releases, "Uploads Releases", "latest commit")
+    Rel(push_action, pages_action, "Builds site", "workflow_run")
+    Rel(releases, pages_action, "Downloads release")
+    Rel(pages_action, site, "Deploys Site")
+    Rel(user, site, "Plays game", "HTTPS")
+```
+
+## Deployment Pipeline Overview
+
+### Trigger
+
+* Deployment is triggered **when a new Git commit is pushed**.
+* A GitHub Action workflow listens via `workflow_run` to wait for the build-and-release process.
+
+### Build Process (Upstream)
+
+* Compiles the FHeroes2 WebAssembly bundle using Emscripten.
+* Packages assets and build artifacts into a ZIP file.
+* Publishes the ZIP as a GitHub Release asset using `ncipollo/release-action`.
+
+### Deploy Process (Downstream)
+
+* Listens for completion of the upstream `Make` workflow.
+* Pulls the latest GitHub Release and extracts the ZIP bundle.
+* Builds and Deploys the Github Pages with the bundle.
+
+## GitHub Workflows Summary
+
+### make.yml
+
+* Triggered on `push` to branch
+* Builds the application
+* Publishes release assets
+
+### pages.yml
+
+* Triggered on `workflow_run` completion of `push.yml`
+* Builds Jekyll site
+* Downloads release
+* Deploys to Github Pages
+
+## Future Considerations
+
+* Hook up a custom domain if needed
+* Allow better devex around pages/emscripten process for local builds

--- a/docs/deployments/WEB_DEPLOYMENT.md
+++ b/docs/deployments/WEB_DEPLOYMENT.md
@@ -62,7 +62,7 @@ sequenceDiagram
 
 ### pages.yml
 
-* Triggered on completion of `build.yml`
+* Triggered on completion of `make.yml`
 * Builds Jekyll site
 * Downloads release
 * Deploys to Github Pages


### PR DESCRIPTION
## Overview
This PR introduces a new "Play Online" feature to our website, allowing users to play fheroes2 directly in their browser. This is implemented through Emscripten integration and requires changes to our site deployment process to support it.

> [!IMPORTANT]
> Try and [play online](https://justinbburris.github.io/fheroes2/play-online)! 

## Core Changes
- Added new `/play-online` section to the website
- Integrated Emscripten build into the site structure
- Upload Emscripten builds into latest-commit releases
- Created GitHub Actions workflow to automate the build and deployment process

## Technical Implementation
The implementation required changes to our deployment process to support the Emscripten build:
- New GitHub Actions workflow (`.github/workflows/pages.yml`) that:
  - Builds the Jekyll site
  - Downloads and integrates the latest Emscripten release
  - Deploys the combined site to GitHub Pages

## Required Repository Changes
To enable this new deployment method, the following changes are needed in the repository settings:

1. Go to Settings > Pages
2. Under "Build and deployment":
   - Source: Select "GitHub Actions"
   - Branch: This will be handled by the workflow

## Testing
The play-online feature has been tested with:
- Latest Emscripten build integration
- Proper site structure and navigation
- Automatic deployment process

## Migration Steps
1. Update repository settings as described above
2. Merge this PR
3. Monitor the first automatic deployment
4. Verify the play-online feature is accessible at https://ihhub.github.io/fheroes2/play-online/

## Notes
- The pages site build is automatically updated with each push to master
- The workflow includes proper concurrency handling to prevent deployment conflicts
- All necessary permissions are explicitly defined in the workflow

## Testing
- Tested successfully on macOS Chrome
- Tested semi-successfully on iPhone
  - Game plays but no audio. 🤔