### PR TITLE
Cache resource language calculations to improve the performance

### DIFF
--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -25,6 +25,7 @@
 #include <cstdint>
 #include <functional>
 #include <map>
+#include <optional>
 #include <set>
 #include <utility>
 

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -85,20 +85,28 @@ namespace fheroes2
 
     SupportedLanguage getResourceLanguage()
     {
+        static std::optional<SupportedLanguage> language;
+        if ( language.has_value() ) {
+            return *language;
+        }
+
         const std::vector<uint8_t> & data = ::AGG::getDataFromAggFile( ICN::getIcnFileName( ICN::FONT ), false );
         if ( data.empty() ) {
             // How is it possible to run the game without a font?
             assert( 0 );
-            return SupportedLanguage::English;
+            language = SupportedLanguage::English;
+            return *language;
         }
 
         const uint32_t crc32 = calculateCRC32( data.data(), data.size() );
         auto iter = languageCRC32.find( crc32 );
         if ( iter == languageCRC32.end() ) {
-            return SupportedLanguage::English;
+            language = SupportedLanguage::English;
+            return *language;
         }
 
-        return iter->second;
+        language = iter->second;
+        return *language;
     }
 
     std::vector<SupportedLanguage> getSupportedLanguages()


### PR DESCRIPTION
Reading resources from an AGG file and calculating CRC32 value from it is not an instance operation. Also, since we want to minimize I/O operations from file storage it is important to cache it. This should improve the startup time of the application as well as FPS value for the Select Game Language dialog.

Just small facts:
- the engine startup calls `getResourceLanguage()` function **5** times
- the Select Game Language dialog needs wooping **52** calls of the same function