### PR TITLE
Clean Editor-related code: remove the unused mine color property

### DIFF
--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -1446,8 +1446,6 @@ int32_t Dialog::selectMineType( const int32_t type )
     int32_t offsetY = area.y + 10;
     text.draw( area.x + ( area.width - text.width() ) / 2, offsetY, display );
 
-    // There can be up to 6 player colors plus none.
-
     // There are 7 resource types (WOOD, MERCURY, ORE, SULFUR, CRYSTAL, GEMS, GOLD) and abandoned mine.
     const uint32_t resourceCount{ 8 };
     const int32_t stepY = 35;

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -1435,7 +1435,7 @@ int Dialog::selectLandscapeMiscellaneousObjectType( const int objectType )
     return selectObjectType( objectType, objectInfo.size(), listbox );
 }
 
-void Dialog::selectMineType( int32_t & type, int32_t & color )
+int32_t Dialog::selectMineType( const int32_t type )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
     fheroes2::StandardWindow background( 380, 395, true, display );
@@ -1667,12 +1667,10 @@ void Dialog::selectMineType( int32_t & type, int32_t & color )
         bool needRedraw = listbox.QueueEventProcessing();
 
         if ( listbox.isDoubleClicked() || le.MouseClickLeft( buttonOk.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) ) {
-            type = objectInfoIndexes[listbox.getCurrentId()];
-            color = 0;
-            return;
+            return objectInfoIndexes[listbox.getCurrentId()];
         }
         if ( le.MouseClickLeft( buttonCancel.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-            return;
+            return type;
         }
 
         if ( le.isMouseRightButtonPressedInArea( buttonCancel.area() ) ) {
@@ -1720,6 +1718,8 @@ void Dialog::selectMineType( int32_t & type, int32_t & color )
         listbox.Redraw();
         display.render( area );
     }
+
+    return type;
 }
 
 int Dialog::selectMountainType( const int mountainType )

--- a/src/fheroes2/dialog/dialog_selectitems.h
+++ b/src/fheroes2/dialog/dialog_selectitems.h
@@ -138,7 +138,7 @@ namespace Dialog
 
     int selectLandscapeMiscellaneousObjectType( const int objectType );
 
-    void selectMineType( int32_t & type, int32_t & color );
+    int32_t selectMineType( const int32_t type );
 
     int selectMountainType( const int mountainType );
 

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1889,21 +1889,20 @@ namespace Interface
             }
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_MINES ) {
-            const int32_t type = _editorPanel.getMineObjectType();
-            if ( type < 0 ) {
+            if ( objectType < 0 ) {
                 // Check your logic!
                 assert( 0 );
                 return;
             }
 
-            if ( !verifyObjectPlacement( tilePos, groupType, type, errorMessage ) ) {
+            if ( !verifyObjectPlacement( tilePos, groupType, objectType, errorMessage ) ) {
                 _warningMessage.reset( std::move( errorMessage ) );
                 return;
             }
 
             fheroes2::ActionCreator action( _historyManager, _mapFormat );
 
-            if ( !_setObjectOnTile( tile, groupType, type ) ) {
+            if ( !_setObjectOnTile( tile, groupType, objectType ) ) {
                 return;
             }
 
@@ -2188,7 +2187,7 @@ namespace Interface
             objectIndex = type;
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_MINES ) {
-            const int32_t type = _editorPanel.getMineObjectType();
+            const int32_t type = _editorPanel.getSelectedObjectType();
 
             if ( type < 0 ) {
                 // Check your logic!

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1889,11 +1889,8 @@ namespace Interface
             }
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_MINES ) {
-            int32_t type = -1;
-            int32_t color = -1;
-
-            _editorPanel.getMineObjectProperties( type, color );
-            if ( type < 0 || color < 0 ) {
+            const int32_t type = _editorPanel.getMineObjectType();
+            if ( type < 0 ) {
                 // Check your logic!
                 assert( 0 );
                 return;
@@ -1910,7 +1907,6 @@ namespace Interface
                 return;
             }
 
-            // TODO: Place owner flag according to the color state.
             action.commit();
         }
         else if ( groupType == Maps::ObjectGroup::LANDSCAPE_MISCELLANEOUS ) {
@@ -2192,11 +2188,9 @@ namespace Interface
             objectIndex = type;
         }
         else if ( groupType == Maps::ObjectGroup::ADVENTURE_MINES ) {
-            int32_t type = -1;
-            int32_t color = -1;
+            const int32_t type = _editorPanel.getMineObjectType();
 
-            _editorPanel.getMineObjectProperties( type, color );
-            if ( type < 0 || color < 0 ) {
+            if ( type < 0 ) {
                 // Check your logic!
                 assert( 0 );
                 return false;

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -231,12 +231,7 @@ namespace Interface
             if ( objectType >= 0 ) {
                 const Maps::ObjectGroup objectGroup = getSelectedObjectGroup();
                 if ( objectGroup == Maps::ObjectGroup::ADVENTURE_MINES ) {
-                    // For mine we need to decode the objectType.
-                    int32_t type = -1;
-                    int32_t color = -1;
-                    getMineObjectProperties( type, color );
-
-                    return getObjectOccupiedArea( objectGroup, type );
+                    return getObjectOccupiedArea( objectGroup, getMineObjectType() );
                 }
 
                 return getObjectOccupiedArea( objectGroup, objectType );
@@ -826,11 +821,9 @@ namespace Interface
                 return;
             case AdventureObjectBrush::MINES:
                 _interface.setCursorUpdater( [this]( const int32_t /*tileIndex*/ ) {
-                    int32_t type = -1;
-                    int32_t color = -1;
-                    getMineObjectProperties( type, color );
+                    const int32_t type = getMineObjectType();
 
-                    if ( type == -1 || color == -1 ) {
+                    if ( type == -1 ) {
                         // The object type is not set. We show the POINTER cursor for this case.
                         Cursor::Get().SetThemes( Cursor::POINTER );
                         return;
@@ -838,7 +831,6 @@ namespace Interface
 
                     assert( Maps::getObjectsByGroup( Maps::ObjectGroup::ADVENTURE_MINES ).size() > static_cast<size_t>( type ) );
 
-                    // TODO: Implement a function to render also the owner flag after ownership selection is implemented.
                     const fheroes2::Sprite & image = getObjectImage( Maps::ObjectGroup::ADVENTURE_MINES, type );
 
                     Cursor::Get().setCustomImage( image, { image.x(), image.y() } );
@@ -1113,15 +1105,7 @@ namespace Interface
                 return res;
             }
             if ( le.MouseClickLeft( _adventureObjectButtonsRect[AdventureObjectBrush::MINES] ) ) {
-                handleObjectMouseClick( [this]( const int32_t /* type */ ) {
-                    int32_t type = -1;
-                    int32_t color = -1;
-
-                    getMineObjectProperties( type, color );
-                    Dialog::selectMineType( type, color );
-
-                    return _generateMineObjectProperties( type, color );
-                } );
+                handleObjectMouseClick( Dialog::selectMineType );
                 return res;
             }
             if ( le.MouseClickLeft( _adventureObjectButtonsRect[AdventureObjectBrush::DWELLINGS] ) ) {
@@ -1336,22 +1320,7 @@ namespace Interface
         return color * static_cast<int32_t>( townObjects.size() ) + type;
     }
 
-    void EditorPanel::getMineObjectProperties( int32_t & type, int32_t & color ) const
-    {
-        const auto & mineObjects = Maps::getObjectsByGroup( Maps::ObjectGroup::ADVENTURE_MINES );
-        if ( mineObjects.empty() ) {
-            // How is it even possible?
-            assert( 0 );
-            type = -1;
-            color = -1;
-            return;
-        }
-
-        type = _selectedAdventureObjectType[AdventureObjectBrush::MINES] % static_cast<int32_t>( mineObjects.size() );
-        color = _selectedAdventureObjectType[AdventureObjectBrush::MINES] / static_cast<int32_t>( mineObjects.size() );
-    }
-
-    int32_t EditorPanel::_generateMineObjectProperties( const int32_t type, const int32_t color )
+    int32_t EditorPanel::getMineObjectType() const
     {
         const auto & mineObjects = Maps::getObjectsByGroup( Maps::ObjectGroup::ADVENTURE_MINES );
         if ( mineObjects.empty() ) {
@@ -1360,7 +1329,6 @@ namespace Interface
             return -1;
         }
 
-        const int32_t objectType = ( color * static_cast<int32_t>( mineObjects.size() ) + type );
-        return ( objectType < 0 ) ? -1 : objectType;
+        return _selectedAdventureObjectType[AdventureObjectBrush::MINES] % static_cast<int32_t>( mineObjects.size() );
     }
 }

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -231,7 +231,7 @@ namespace Interface
             if ( objectType >= 0 ) {
                 const Maps::ObjectGroup objectGroup = getSelectedObjectGroup();
                 if ( objectGroup == Maps::ObjectGroup::ADVENTURE_MINES ) {
-                    return getObjectOccupiedArea( objectGroup, getMineObjectType() );
+                    return getObjectOccupiedArea( objectGroup, objectType );
                 }
 
                 return getObjectOccupiedArea( objectGroup, objectType );
@@ -820,9 +820,7 @@ namespace Interface
                     [type = getSelectedObjectType(), group = getSelectedObjectGroup()]( const int32_t /*tileIndex*/ ) { setCustomCursor( group, type ); } );
                 return;
             case AdventureObjectBrush::MINES:
-                _interface.setCursorUpdater( [this]( const int32_t /*tileIndex*/ ) {
-                    const int32_t type = getMineObjectType();
-
+                _interface.setCursorUpdater( [type = getSelectedObjectType()]( const int32_t /*tileIndex*/ ) {
                     if ( type == -1 ) {
                         // The object type is not set. We show the POINTER cursor for this case.
                         Cursor::Get().SetThemes( Cursor::POINTER );
@@ -1318,17 +1316,5 @@ namespace Interface
         }
 
         return color * static_cast<int32_t>( townObjects.size() ) + type;
-    }
-
-    int32_t EditorPanel::getMineObjectType() const
-    {
-        const auto & mineObjects = Maps::getObjectsByGroup( Maps::ObjectGroup::ADVENTURE_MINES );
-        if ( mineObjects.empty() ) {
-            // How is it even possible?
-            assert( 0 );
-            return -1;
-        }
-
-        return _selectedAdventureObjectType[AdventureObjectBrush::MINES] % static_cast<int32_t>( mineObjects.size() );
     }
 }

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -796,11 +796,11 @@ namespace Interface
             return;
         case Instrument::LANDSCAPE_OBJECTS:
             switch ( _selectedLandscapeObject ) {
+            case LandscapeObjectBrush::LANDSCAPE_MISC:
             case LandscapeObjectBrush::MOUNTAINS:
             case LandscapeObjectBrush::ROCKS:
             case LandscapeObjectBrush::TREES:
             case LandscapeObjectBrush::WATER_OBJECTS:
-            case LandscapeObjectBrush::LANDSCAPE_MISC:
                 _interface.setCursorUpdater(
                     [type = getSelectedObjectType(), group = getSelectedObjectGroup()]( const int32_t /*tileIndex*/ ) { setCustomCursor( group, type ); } );
                 return;
@@ -810,29 +810,15 @@ namespace Interface
             break;
         case Instrument::ADVENTURE_OBJECTS:
             switch ( _selectedAdventureObject ) {
+            case AdventureObjectBrush::ADVENTURE_MISC:
             case AdventureObjectBrush::ARTIFACTS:
             case AdventureObjectBrush::DWELLINGS:
+            case AdventureObjectBrush::MINES:
             case AdventureObjectBrush::POWER_UPS:
             case AdventureObjectBrush::TREASURES:
             case AdventureObjectBrush::WATER_ADVENTURE:
-            case AdventureObjectBrush::ADVENTURE_MISC:
                 _interface.setCursorUpdater(
                     [type = getSelectedObjectType(), group = getSelectedObjectGroup()]( const int32_t /*tileIndex*/ ) { setCustomCursor( group, type ); } );
-                return;
-            case AdventureObjectBrush::MINES:
-                _interface.setCursorUpdater( [type = getSelectedObjectType()]( const int32_t /*tileIndex*/ ) {
-                    if ( type == -1 ) {
-                        // The object type is not set. We show the POINTER cursor for this case.
-                        Cursor::Get().SetThemes( Cursor::POINTER );
-                        return;
-                    }
-
-                    assert( Maps::getObjectsByGroup( Maps::ObjectGroup::ADVENTURE_MINES ).size() > static_cast<size_t>( type ) );
-
-                    const fheroes2::Sprite & image = getObjectImage( Maps::ObjectGroup::ADVENTURE_MINES, type );
-
-                    Cursor::Get().setCustomImage( image, { image.x(), image.y() } );
-                } );
                 return;
             default:
                 break;

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -116,7 +116,7 @@ namespace Interface
         Maps::ObjectGroup getSelectedObjectGroup() const;
 
         void getTownObjectProperties( int32_t & type, int32_t & color ) const;
-        void getMineObjectProperties( int32_t & type, int32_t & color ) const;
+        int32_t getMineObjectType() const;
 
         static const char * getObjectGroupName( const Maps::ObjectGroup groupName );
 
@@ -136,7 +136,6 @@ namespace Interface
         static const char * _getEraseObjectTypeName( const uint32_t eraseObjectType );
 
         static int32_t _generateTownObjectProperties( const int32_t type, const int32_t color );
-        static int32_t _generateMineObjectProperties( const int32_t type, const int32_t color );
 
         void _setCursor();
 

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -116,7 +116,6 @@ namespace Interface
         Maps::ObjectGroup getSelectedObjectGroup() const;
 
         void getTownObjectProperties( int32_t & type, int32_t & color ) const;
-        int32_t getMineObjectType() const;
 
         static const char * getObjectGroupName( const Maps::ObjectGroup groupName );
 


### PR DESCRIPTION
Relates to #9766 

This PR removes the specially coded color for mines that assumed to have many map objects in the database for each player color.
The color for mines is now set in `CapturableObjectMetadata`.