### PR TITLE
Fix some recently introduced code smells

### DIFF
--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -149,8 +149,8 @@ namespace fheroes2
     // Performs a checked conversion of a floating-point value of type From to an integer type To. Returns an empty std::optional<To>
     // if the source value does not fit into the target type.
     template <typename To, typename From,
-              std::enable_if_t<std::is_integral_v<To> && std::numeric_limits<To>::radix == 2 && std ::is_floating_point_v<From> && std::numeric_limits<From>::is_iec559
-                                   && std::numeric_limits<From>::radix == 2 && std::numeric_limits<From>::max_exponent >= std::numeric_limits<To>::digits,
+              std::enable_if_t<( std::is_integral_v<To> && std::numeric_limits<To>::radix == 2 && std ::is_floating_point_v<From> && std::numeric_limits<From>::is_iec559
+                                 && std::numeric_limits<From>::radix == 2 && std::numeric_limits<To>::digits < std::numeric_limits<From>::max_exponent ),
                                bool>
               = true>
     std::optional<To> checkedCast( const From from )

--- a/src/engine/tools.h
+++ b/src/engine/tools.h
@@ -116,8 +116,6 @@ namespace fheroes2
             if ( from < std::numeric_limits<To>::min() || from > std::numeric_limits<To>::max() ) {
                 return {};
             }
-
-            return static_cast<To>( from );
         }
         // From is signed, To is unsigned
         else if constexpr ( std::is_signed_v<From> ) {
@@ -129,8 +127,6 @@ namespace fheroes2
             if ( unsignedFrom > std::numeric_limits<To>::max() ) {
                 return {};
             }
-
-            return static_cast<To>( from );
         }
         // From is unsigned, To is signed
         else {
@@ -141,9 +137,9 @@ namespace fheroes2
             if ( from > unsignedMaxTo ) {
                 return {};
             }
-
-            return static_cast<To>( from );
         }
+
+        return static_cast<To>( from );
     }
 
     // Performs a checked conversion of a floating-point value of type From to an integer type To. Returns an empty std::optional<To>
@@ -175,8 +171,6 @@ namespace fheroes2
                  || from >= std::ldexp( static_cast<From>( 1.0 ), std::numeric_limits<To>::digits ) ) {
                 return {};
             }
-
-            return static_cast<To>( from );
         }
         else {
             // Value of 'from' should be not less than 0 and also it should be less than 2^N, where N is a number of significant bits
@@ -184,8 +178,8 @@ namespace fheroes2
             if ( from < 0 || from >= std::ldexp( static_cast<From>( 1.0 ), std::numeric_limits<To>::digits ) ) {
                 return {};
             }
-
-            return static_cast<To>( from );
         }
+
+        return static_cast<To>( from );
     }
 }

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1451,7 +1451,7 @@ void World::fixFrenchCharactersInStrings()
         fheroes2::fixFrenchCharactersForMP2Map( event.message );
     }
 
-    for ( auto & tile : vec_tiles ) {
+    for ( const auto & tile : vec_tiles ) {
         switch ( tile.getMainObjectType() ) {
         case MP2::OBJ_SIGN:
         case MP2::OBJ_BOTTLE: {

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -1228,14 +1228,12 @@ uint32_t World::CheckKingdomWins( const Kingdom & kingdom ) const
 
     const Settings & conf = Settings::Get();
 
-    if ( conf.isCampaignGameType() ) {
-        if ( Campaign::getCurrentScenarioVictoryCondition() == Campaign::ScenarioVictoryCondition::CAPTURE_DRAGON_CITY ) {
-            if ( kingdom.isVisited( MP2::OBJ_DRAGON_CITY ) ) {
-                return GameOver::WINS_SIDE;
-            }
-
-            return GameOver::COND_NONE;
+    if ( conf.isCampaignGameType() && Campaign::getCurrentScenarioVictoryCondition() == Campaign::ScenarioVictoryCondition::CAPTURE_DRAGON_CITY ) {
+        if ( kingdom.isVisited( MP2::OBJ_DRAGON_CITY ) ) {
+            return GameOver::WINS_SIDE;
         }
+
+        return GameOver::COND_NONE;
     }
 
     const std::array<uint32_t, 6> victoryConditions
@@ -1284,17 +1282,15 @@ uint32_t World::CheckKingdomLoss( const Kingdom & kingdom ) const
         }
     }
 
-    if ( conf.isCampaignGameType() ) {
-        if ( Campaign::getCurrentScenarioLossCondition() == Campaign::ScenarioLossCondition::LOSE_ALL_SORCERESS_VILLAGES ) {
-            const VecCastles & castles = kingdom.GetCastles();
+    if ( conf.isCampaignGameType() && Campaign::getCurrentScenarioLossCondition() == Campaign::ScenarioLossCondition::LOSE_ALL_SORCERESS_VILLAGES ) {
+        const VecCastles & castles = kingdom.GetCastles();
 
-            if ( std::none_of( castles.begin(), castles.end(), []( const Castle * castle ) {
-                     assert( castle != nullptr );
+        if ( std::none_of( castles.begin(), castles.end(), []( const Castle * castle ) {
+                 assert( castle != nullptr );
 
-                     return !castle->isCastle() && castle->GetRace() == Race::SORC;
-                 } ) ) {
-                return GameOver::LOSS_ALL;
-            }
+                 return !castle->isCastle() && castle->GetRace() == Race::SORC;
+             } ) ) {
+            return GameOver::LOSS_ALL;
         }
     }
 


### PR DESCRIPTION
* SFINAE: `std::numeric_limits<T>::max_exponent` is an [exclusive upper-bound](https://en.cppreference.com/w/cpp/types/numeric_limits/max_exponent) of the exponent and not an inclusive one (the maximum allowed exponent for a finite value is `max_exponent - 1` and not `max_exponent` itself);
* Deduplicated a few lines of code by simplification of the `if constexpr` in both `checkedCast()` implementations;
* Added `const` according to the Sonar hint;
* Merged a few `if` statements according to the Sonar hint.