### PR TITLE
Only run GitHub Pages workflow in the base repo

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -6,7 +6,7 @@ on:
 
 permissions:
   contents: write
-  id-token: write
+  id-token: write # To verify the deployment originates from an appropriate source
   pages: write
 
 concurrency:
@@ -25,25 +25,22 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: actions/configure-pages@v5
+      - name: Prepare directory structure
+        run: |
+          mkdir -p .pages/dist/play-online
       - uses: actions/jekyll-build-pages@v1
         with:
-          source: ./docs
-          destination: ./_site
-      - name: Download Emscripten release
+          source: docs
+          destination: .pages/dist
+      - name: Download and extract Emscripten release
+        run: |
+          gh release download fheroes2-emscripten-sdl2_dev -D .pages
+          unzip .pages/fheroes2_emscripten.zip -d .pages/dist/play-online
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          gh release download fheroes2-emscripten-sdl2_dev -D ./dist
-      - name: Extract and prepare website
-        working-directory: ./dist
-        run: |
-          mkdir -p ./site/play-online
-          unzip -q fheroes2_emscripten.zip -d site/play-online
-          cp -r ../_site/* ./site/
-          rm -f fheroes2_emscripten.zip
       - uses: actions/upload-pages-artifact@v3
         with:
-          path: ./dist/site
+          path: .pages/dist
   deploy:
     name: Deploy website
     if: ${{ github.repository == 'ihhub/fheroes2' && github.event_name == 'push' }}

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,7 @@ concurrency:
 jobs:
   build:
     name: Build website
+    if: ${{ github.repository == 'ihhub/fheroes2' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
     timeout-minutes: 10
     defaults:
@@ -45,6 +46,7 @@ jobs:
           path: ./dist/site
   deploy:
     name: Deploy website
+    if: ${{ github.repository == 'ihhub/fheroes2' && github.event_name == 'push' }}
     needs:
     - build
     runs-on: ubuntu-latest

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -10,8 +10,8 @@ concurrency:
 
 permissions:
   contents: write
-  id-token: write   # To verify the deployment originates from an appropriate source
-  pages: write      # To deploy to Pages
+  id-token: write
+  pages: write
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
Otherwise this workflow fails on forks (because GitHub Pages are usually not enabled/configured on them).

Also this PR simplifies the `pages.yml` workflow a bit by avoiding extra copy operations.