### PR TITLE
Battlefield. Fix rendering of high obstacles

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2244,7 +2244,7 @@ void Battle::Interface::_redrawBattleGround()
 
     // Ground obstacles.
     for ( int32_t cellId = 0; cellId < Board::sizeInCells; ++cellId ) {
-        _redrawLowObjects( cellId );
+        _redrawGroundObjects( cellId );
     }
 
     // Castle top wall.
@@ -2399,7 +2399,7 @@ void Battle::Interface::RedrawCastleMainTower( const Castle & castle )
     fheroes2::Blit( sprite, _mainSurface, sprite.x(), sprite.y() );
 }
 
-void Battle::Interface::_redrawLowObjects( const int32_t cellId )
+void Battle::Interface::_redrawGroundObjects( const int32_t cellId )
 {
     const Cell * cell = Board::GetCell( cellId );
     if ( cell == nullptr )

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2399,6 +2399,7 @@ void Battle::Interface::RedrawCastleMainTower( const Castle & castle )
     fheroes2::Blit( sprite, _mainSurface, sprite.x(), sprite.y() );
 }
 
+// Draws cracks and pools that are not higher than the ground level.
 void Battle::Interface::RedrawLowObjects( const int32_t cellId )
 {
     const Cell * cell = Board::GetCell( cellId );
@@ -2414,12 +2415,6 @@ void Battle::Interface::RedrawLowObjects( const int32_t cellId )
     int objectIcnId = 0;
 
     switch ( cellObjectId ) {
-    case 0x84:
-        objectIcnId = ICN::COBJ0004;
-        break;
-    case 0x87:
-        objectIcnId = ICN::COBJ0007;
-        break;
     case 0x90:
         objectIcnId = ICN::COBJ0016;
         break;
@@ -2438,6 +2433,7 @@ void Battle::Interface::RedrawLowObjects( const int32_t cellId )
     fheroes2::Blit( objectSprite, _battleGround, pt.x + pt.width / 2 + objectSprite.x(), pt.y + pt.height + objectSprite.y() + cellYOffset );
 }
 
+// Draws trees, rocks, bushes and other objects that are higher than the ground level.
 void Battle::Interface::RedrawHighObjects( const int32_t cellId )
 {
     const Cell * cell = Board::GetCell( cellId );
@@ -2465,11 +2461,17 @@ void Battle::Interface::RedrawHighObjects( const int32_t cellId )
     case 0x83:
         objectIcnId = ICN::COBJ0003;
         break;
+    case 0x84:
+        objectIcnId = ICN::COBJ0004;
+        break;
     case 0x85:
         objectIcnId = ICN::COBJ0005;
         break;
     case 0x86:
         objectIcnId = ICN::COBJ0006;
+        break;
+    case 0x87:
+        objectIcnId = ICN::COBJ0007;
         break;
     case 0x88:
         objectIcnId = ICN::COBJ0008;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1525,7 +1525,7 @@ void Battle::Interface::RedrawArmies()
         // Redraw objects.
         for ( int32_t cellColumnId = 0; cellColumnId < Board::widthInCells; ++cellColumnId ) {
             const int32_t cellId = cellRowId * Board::widthInCells + cellColumnId;
-            RedrawHighObjects( cellId );
+            _redrawHighObjects( cellId );
         }
 
         if ( castle != nullptr ) {
@@ -2244,7 +2244,7 @@ void Battle::Interface::_redrawBattleGround()
 
     // Ground obstacles.
     for ( int32_t cellId = 0; cellId < Board::sizeInCells; ++cellId ) {
-        RedrawLowObjects( cellId );
+        _redrawLowObjects( cellId );
     }
 
     // Castle top wall.
@@ -2399,8 +2399,7 @@ void Battle::Interface::RedrawCastleMainTower( const Castle & castle )
     fheroes2::Blit( sprite, _mainSurface, sprite.x(), sprite.y() );
 }
 
-// Draws cracks and pools that are not higher than the ground level.
-void Battle::Interface::RedrawLowObjects( const int32_t cellId )
+void Battle::Interface::_redrawLowObjects( const int32_t cellId )
 {
     const Cell * cell = Board::GetCell( cellId );
     if ( cell == nullptr )
@@ -2433,8 +2432,7 @@ void Battle::Interface::RedrawLowObjects( const int32_t cellId )
     fheroes2::Blit( objectSprite, _battleGround, pt.x + pt.width / 2 + objectSprite.x(), pt.y + pt.height + objectSprite.y() + cellYOffset );
 }
 
-// Draws trees, rocks, bushes and other objects that are higher than the ground level.
-void Battle::Interface::RedrawHighObjects( const int32_t cellId )
+void Battle::Interface::_redrawHighObjects( const int32_t cellId )
 {
     const Cell * cell = Board::GetCell( cellId );
     if ( cell == nullptr )

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -365,8 +365,13 @@ namespace Battle
         void RedrawCover();
         void _redrawBattleGround();
         void _redrawCoverStatic();
-        void RedrawLowObjects( const int32_t cellId );
-        void RedrawHighObjects( const int32_t cellId );
+
+        // Draws cracks and pools that are not higher than the ground level.
+        void _redrawLowObjects( const int32_t cellId );
+
+        // Draws trees, rocks, bushes and other objects that are higher than the ground level.
+        void _redrawHighObjects( const int32_t cellId );
+
         void RedrawCastle( const Castle & castle, const int32_t cellId );
         void RedrawCastleMainTower( const Castle & castle );
         void RedrawKilled();

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -367,7 +367,7 @@ namespace Battle
         void _redrawCoverStatic();
 
         // Draws cracks and pools that are not higher than the ground level.
-        void _redrawLowObjects( const int32_t cellId );
+        void _redrawGroundObjects( const int32_t cellId );
 
         // Draws trees, rocks, bushes and other objects that are higher than the ground level.
         void _redrawHighObjects( const int32_t cellId );


### PR DESCRIPTION
fix #7083 

This PR moves two "not flat" obstacles to the "high" obstacles rendering function.

This PR:
![img](https://github.com/user-attachments/assets/9cb736b1-3813-4dde-a41a-710d42ef799d)
