### PR TITLE
Minor battlefield cell related code speed-up

### DIFF
--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -79,10 +79,19 @@ namespace Battle
 
         static std::string GetMoatInfo();
 
-        static Cell * GetCell( const int32_t position, const int dir = CENTER );
+        static Cell * GetCell( const int32_t position );
+        static Cell * GetCell( const int32_t position, const int dir );
 
-        static bool isNearIndexes( const int32_t index1, const int32_t index2 );
-        static bool isValidIndex( const int32_t index );
+        static bool isNearIndexes( const int32_t index1, const int32_t index2 )
+        {
+            return ( index1 != index2 ) && ( GetDirection( index1, index2 ) != UNKNOWN );
+        }
+
+        static bool isValidIndex( const int32_t index )
+        {
+            return ( index >= 0 ) && ( index < sizeInCells );
+        }
+
         // Returns true if the given index is considered to be inside the castle from the point of view of castle defense,
         // otherwise returns false. Indexes of destructible walls are considered to be located inside the castle.
         static bool isCastleIndex( const int32_t index );


### PR DESCRIPTION
This PR:
- inlines `isNearIndexes()` and `isValidIndex()` methods;
- adds `Battle::Board::GetCell( const int32_t position )` not to use `Battle::Cell * Battle::Board::GetCell( const int32_t position, const int dir = CENTER )` because for this case we don't need to check direction and to get index by direction;
- uses `operator[]` instead of `at()` in release version because the index is already checked in the upper lines;
- moves precalculations that are not needed for all `case`s.