### PR TITLE
Tune the probability of the Good Luck and Bad Luck events

### DIFF
--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -318,7 +318,7 @@ void Battle::Unit::SetRandomMorale( Rand::DeterministicRandomGenerator & randomG
 void Battle::Unit::SetRandomLuck( Rand::DeterministicRandomGenerator & randomGenerator )
 {
     const int32_t luck = GetLuck();
-    const int32_t chance = static_cast<int32_t>( randomGenerator.Get( 1, 24 ) );
+    const int32_t chance = static_cast<int32_t>( randomGenerator.Get( 1, 12 ) );
 
     if ( luck > 0 && chance <= luck ) {
         SetModes( LUCK_GOOD );


### PR DESCRIPTION
close #9805

I did not find a specific formula for the probability of luck events for HoMM2, so I used the formula for HoMM1 from this description:

https://handbookhmm.ru/1-moral-luck-ppb

According to it, the probability of good luck event (if luck is positive) is `R % 12 < L`, where `R` is some random number and `L` is a luck of the unit. If `R` is always in range `[1..12]`, then it means than the probability is `L / 12`. The same probability is for a bad luck event (if `L` is negative): `-L / 12` (if we take the version of the formula with the OG bug fixed, see the original article).

In the `master` branch the probability is `L / 24` and `-L / 24` respectively. This PR changes the probabilities to `|L| / 12`, but honestly I'm not so sure that this is the correct probability. For some reason, it seems to me that at least bad luck event in HoMM2 is much less common.