### PR TITLE
Use the double-precision floating-point values for unit threat evaluation

### DIFF
--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -23,11 +23,11 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
-#include <cfloat>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <functional>
+#include <limits>
 #include <map>
 #include <numeric>
 #include <optional>

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -252,7 +252,8 @@ namespace
                     // If attacker is able to attack all adjacent cells, then the values of all units in adjacent cells (including archers) have already been taken into
                     // account
                     if ( attacker.isAllAdjacentCellsAttack() ) {
-                        assert( iter->second == attackValue );
+                        // Silence the -Wfloat-equal, since the values here should be literally equal
+                        assert( std::make_tuple( iter->second ) == std::make_tuple( attackValue ) );
                     }
                     else if ( enemyUnit->isArchers() ) {
                         iter->second += attackValue;

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -73,8 +73,8 @@ namespace
     struct MeleeAttackOutcome
     {
         int32_t fromIndex{ -1 };
-        double attackValue{ DBL_MIN };
-        double positionValue{ DBL_MIN };
+        double attackValue{ std::numeric_limits<double>::lowest() };
+        double positionValue{ std::numeric_limits<double>::lowest() };
         bool canAttackImmediately{ false };
     };
 
@@ -1430,7 +1430,7 @@ Battle::Actions AI::BattlePlanner::archerDecision( Battle::Arena & arena, const 
     // Archers are able to shoot
     else {
         BattleTargetPair target;
-        double highestPriority = DBL_MIN;
+        double highestPriority = std::numeric_limits<double>::lowest();
 
         for ( const Battle::Unit * enemy : enemies ) {
             assert( enemy != nullptr );
@@ -1546,7 +1546,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitOffense( Battle::Arena & arena,
     // 2. For units that don't have a target within reach, choose a target depending on distance-based priority
     {
         const auto chooseDistantTarget = [this, &arena, &currentUnit, &target, &enemies]( const auto enemyPredicate ) {
-            double maxPriority = DBL_MIN;
+            double maxPriority = std::numeric_limits<double>::lowest();
 
             for ( const Battle::Unit * enemy : enemies ) {
                 assert( enemy != nullptr );
@@ -1710,7 +1710,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitDefense( Battle::Arena & arena,
         // covered.
         const double defenseDistanceModifier = _myRangedUnitsOnly / 15.0;
 
-        double bestArcherValue = DBL_MIN;
+        double bestArcherValue = std::numeric_limits<double>::lowest();
 
         for ( const Battle::Unit * frnd : friendly ) {
             assert( frnd != nullptr );

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cfloat>
 #include <cmath>
 #include <cstddef>
 #include <cstdint>

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -118,7 +118,7 @@ namespace
         const std::array<const Battle::Cell *, 2> targetCells = { targetPos.GetHead(), targetPos.GetTail() };
 
         std::pair<int32_t, int> bestAttackVector{ -1, Battle::UNKNOWN };
-        double bestAttackValue{ 0.0 };
+        double bestAttackValue = 0.0;
 
         for ( const Battle::Cell * attackCell : attackCells ) {
             if ( attackCell == nullptr ) {
@@ -1386,7 +1386,7 @@ Battle::Actions AI::BattlePlanner::archerDecision( Battle::Arena & arena, const 
     // Archers are blocked and there is nowhere to retreat, they are fighting in melee
     else if ( currentUnit.isHandFighting() ) {
         BattleTargetPair target;
-        int32_t bestOutcome{ INT32_MIN };
+        int32_t bestOutcome = INT32_MIN;
 
         for ( const Battle::Unit * enemy : enemies ) {
             assert( enemy != nullptr );
@@ -1430,7 +1430,7 @@ Battle::Actions AI::BattlePlanner::archerDecision( Battle::Arena & arena, const 
     // Archers are able to shoot
     else {
         BattleTargetPair target;
-        double highestPriority{ DBL_MIN };
+        double highestPriority = DBL_MIN;
 
         for ( const Battle::Unit * enemy : enemies ) {
             assert( enemy != nullptr );
@@ -1546,7 +1546,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitOffense( Battle::Arena & arena,
     // 2. For units that don't have a target within reach, choose a target depending on distance-based priority
     {
         const auto chooseDistantTarget = [this, &arena, &currentUnit, &target, &enemies]( const auto enemyPredicate ) {
-            double maxPriority{ DBL_MIN };
+            double maxPriority = DBL_MIN;
 
             for ( const Battle::Unit * enemy : enemies ) {
                 assert( enemy != nullptr );
@@ -1638,7 +1638,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitOffense( Battle::Arena & arena,
 
     // 3. Try to get closer to the castle walls during the siege
     if ( _attackingCastle ) {
-        uint32_t shortestDist{ UINT32_MAX };
+        uint32_t shortestDist = UINT32_MAX;
 
         for ( const int32_t cellIdx : cellsUnderWallsIndexes ) {
             const Battle::Position pos = Battle::Position::GetPosition( currentUnit, cellIdx );
@@ -1710,7 +1710,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitDefense( Battle::Arena & arena,
         // covered.
         const double defenseDistanceModifier = _myRangedUnitsOnly / 15.0;
 
-        double bestArcherValue{ DBL_MIN };
+        double bestArcherValue = DBL_MIN;
 
         for ( const Battle::Unit * frnd : friendly ) {
             assert( frnd != nullptr );
@@ -1950,7 +1950,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitDefense( Battle::Arena & arena,
 
             // If the decision is made to attack one of the neighboring enemy units (if any) while covering the archer, then we should choose the best target
             {
-                double bestAttackValue{ 0.0 };
+                double bestAttackValue = 0.0;
 
                 for ( const Battle::Unit * enemy : enemies ) {
                     assert( enemy != nullptr );

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -117,7 +117,7 @@ namespace
         const std::array<const Battle::Cell *, 2> targetCells = { targetPos.GetHead(), targetPos.GetTail() };
 
         std::pair<int32_t, int> bestAttackVector{ -1, Battle::UNKNOWN };
-        double bestAttackValue = 0.0;
+        double bestAttackValue{ 0.0 };
 
         for ( const Battle::Cell * attackCell : attackCells ) {
             if ( attackCell == nullptr ) {

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -72,10 +72,10 @@ namespace
 
     struct MeleeAttackOutcome
     {
-        int32_t fromIndex = -1;
-        double attackValue = INT32_MIN;
-        double positionValue = INT32_MIN;
-        bool canAttackImmediately = false;
+        int32_t fromIndex{ -1 };
+        double attackValue{ DBL_MIN };
+        double positionValue{ DBL_MIN };
+        bool canAttackImmediately{ false };
     };
 
     bool ValueHasImproved( double primary, double primaryMax, double secondary, double secondaryMax )
@@ -94,7 +94,7 @@ namespace
                     && ValueHasImproved( newOutcome.positionValue, previous.positionValue, newOutcome.attackValue, previous.attackValue ) );
     }
 
-    int32_t doubleCellAttackValue( const Battle::Unit & attacker, const Battle::Unit & target, const int32_t from, const int32_t targetCell )
+    double doubleCellAttackValue( const Battle::Unit & attacker, const Battle::Unit & target, const int32_t from, const int32_t targetCell )
     {
         const Battle::Cell * behind = Battle::Board::GetCell( targetCell, Battle::Board::GetDirection( from, targetCell ) );
         const Battle::Unit * secondaryTarget = ( behind != nullptr ) ? behind->GetUnit() : nullptr;
@@ -103,7 +103,7 @@ namespace
             return secondaryTarget->evaluateThreatForUnit( attacker );
         }
 
-        return 0;
+        return 0.0;
     }
 
     std::pair<int32_t, int> optimalAttackVector( const Battle::Unit & attacker, const Battle::Unit & target, const Battle::Position & attackPos )
@@ -156,7 +156,7 @@ namespace
         return bestAttackVector;
     }
 
-    int32_t optimalAttackValue( const Battle::Unit & attacker, const Battle::Unit & target, const Battle::Position & attackPos )
+    double optimalAttackValue( const Battle::Unit & attacker, const Battle::Unit & target, const Battle::Position & attackPos )
     {
         assert( attackPos.isValidForUnit( attacker ) );
 
@@ -176,11 +176,11 @@ namespace
                 unitsUnderAttack.insert( unit );
             }
 
-            return std::accumulate( unitsUnderAttack.begin(), unitsUnderAttack.end(), static_cast<int32_t>( 0 ),
-                                    [&attacker]( const int32_t total, const Battle::Unit * unit ) { return total + unit->evaluateThreatForUnit( attacker ); } );
+            return std::accumulate( unitsUnderAttack.begin(), unitsUnderAttack.end(), static_cast<double>( 0.0 ),
+                                    [&attacker]( const double total, const Battle::Unit * unit ) { return total + unit->evaluateThreatForUnit( attacker ); } );
         }
 
-        int32_t attackValue = target.evaluateThreatForUnit( attacker );
+        double attackValue = target.evaluateThreatForUnit( attacker );
 
         // A double cell attack should only be considered if the attacker is actually able to attack the target from the given attack position. Otherwise, the attacker
         // can at least block the target if the target is a shooter, so this position can be valuable in any case.
@@ -196,7 +196,7 @@ namespace
         return attackValue;
     }
 
-    using PositionValues = std::map<Battle::Position, int32_t>;
+    using PositionValues = std::map<Battle::Position, double>;
 
     PositionValues evaluatePotentialAttackPositions( Battle::Arena & arena, const Battle::Unit & attacker )
     {
@@ -245,7 +245,7 @@ namespace
                     continue;
                 }
 
-                const int32_t attackValue = optimalAttackValue( attacker, *enemyUnit, pos );
+                const double attackValue = optimalAttackValue( attacker, *enemyUnit, pos );
 
                 if ( const auto [iter, inserted] = result.try_emplace( pos, attackValue ); !inserted ) {
                     // If attacker is able to attack all adjacent cells, then the values of all units in adjacent cells (including archers) have already been taken into
@@ -420,8 +420,8 @@ namespace
 
     struct CellDistanceInfo
     {
-        int32_t idx = -1;
-        uint32_t dist = UINT32_MAX;
+        int32_t idx{ -1 };
+        uint32_t dist{ UINT32_MAX };
     };
 
     CellDistanceInfo findNearestCellNextToUnit( Battle::Arena & arena, const Battle::Unit & currentUnit, const Battle::Unit & target )
@@ -1385,7 +1385,7 @@ Battle::Actions AI::BattlePlanner::archerDecision( Battle::Arena & arena, const 
     // Archers are blocked and there is nowhere to retreat, they are fighting in melee
     else if ( currentUnit.isHandFighting() ) {
         BattleTargetPair target;
-        int32_t bestOutcome = INT32_MIN;
+        int32_t bestOutcome{ INT32_MIN };
 
         for ( const Battle::Unit * enemy : enemies ) {
             assert( enemy != nullptr );
@@ -1429,7 +1429,7 @@ Battle::Actions AI::BattlePlanner::archerDecision( Battle::Arena & arena, const 
     // Archers are able to shoot
     else {
         BattleTargetPair target;
-        double highestPriority = INT32_MIN;
+        double highestPriority{ DBL_MIN };
 
         for ( const Battle::Unit * enemy : enemies ) {
             assert( enemy != nullptr );
@@ -1545,7 +1545,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitOffense( Battle::Arena & arena,
     // 2. For units that don't have a target within reach, choose a target depending on distance-based priority
     {
         const auto chooseDistantTarget = [this, &arena, &currentUnit, &target, &enemies]( const auto enemyPredicate ) {
-            double maxPriority = std::numeric_limits<double>::lowest();
+            double maxPriority{ DBL_MIN };
 
             for ( const Battle::Unit * enemy : enemies ) {
                 assert( enemy != nullptr );
@@ -1562,7 +1562,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitOffense( Battle::Arena & arena,
                 // If this distance was zero, it would mean that this enemy unit would have already been attacked by the current unit
                 assert( nearestCellInfo.dist > 0 );
 
-                const double priority = static_cast<double>( enemy->evaluateThreatForUnit( currentUnit ) ) / nearestCellInfo.dist;
+                const double priority = enemy->evaluateThreatForUnit( currentUnit ) / nearestCellInfo.dist;
                 if ( priority < maxPriority ) {
                     continue;
                 }
@@ -1637,7 +1637,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitOffense( Battle::Arena & arena,
 
     // 3. Try to get closer to the castle walls during the siege
     if ( _attackingCastle ) {
-        uint32_t shortestDist = UINT32_MAX;
+        uint32_t shortestDist{ UINT32_MAX };
 
         for ( const int32_t cellIdx : cellsUnderWallsIndexes ) {
             const Battle::Position pos = Battle::Position::GetPosition( currentUnit, cellIdx );
@@ -1709,7 +1709,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitDefense( Battle::Arena & arena,
         // covered.
         const double defenseDistanceModifier = _myRangedUnitsOnly / 15.0;
 
-        double bestArcherValue = std::numeric_limits<double>::lowest();
+        double bestArcherValue{ DBL_MIN };
 
         for ( const Battle::Unit * frnd : friendly ) {
             assert( frnd != nullptr );
@@ -1949,7 +1949,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitDefense( Battle::Arena & arena,
 
             // If the decision is made to attack one of the neighboring enemy units (if any) while covering the archer, then we should choose the best target
             {
-                int32_t bestAttackValue = 0;
+                double bestAttackValue{ 0.0 };
 
                 for ( const Battle::Unit * enemy : enemies ) {
                     assert( enemy != nullptr );
@@ -1961,7 +1961,7 @@ AI::BattleTargetPair AI::BattlePlanner::meleeUnitDefense( Battle::Arena & arena,
                     const Battle::Position pos = Battle::Position::GetReachable( currentUnit, target.cell );
                     assert( pos.isValidForUnit( currentUnit ) );
 
-                    const int32_t attackValue = optimalAttackValue( currentUnit, *enemy, pos );
+                    const double attackValue = optimalAttackValue( currentUnit, *enemy, pos );
                     if ( bestAttackValue < attackValue ) {
                         bestAttackValue = attackValue;
 

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -28,7 +28,6 @@
 #include <cstddef>
 #include <cstdint>
 #include <functional>
-#include <limits>
 #include <map>
 #include <numeric>
 #include <optional>

--- a/src/fheroes2/ai/ai_battle.h
+++ b/src/fheroes2/ai/ai_battle.h
@@ -40,21 +40,21 @@ namespace AI
 {
     struct BattleTargetPair
     {
-        int cell = -1;
-        const Battle::Unit * unit = nullptr;
+        int cell{ -1 };
+        const Battle::Unit * unit{ nullptr };
     };
 
     struct SpellSelection
     {
-        int spellID = -1;
-        int32_t cell = -1;
-        double value = 0.0;
+        int spellID{ -1 };
+        int32_t cell{ -1 };
+        double value{ 0.0 };
     };
 
     struct SpellcastOutcome
     {
-        int32_t cell = -1;
-        double value = 0.0;
+        int32_t cell{ -1 };
+        double value{ 0.0 };
 
         void updateOutcome( const double potentialValue, const int32_t targetCell, const bool isMassEffect = false )
         {
@@ -114,31 +114,31 @@ namespace AI
 
         // When this limit of turns without deaths is exceeded for an attacking AI-controlled hero,
         // the auto combat should be interrupted (one way or another)
-        static const uint32_t MAX_TURNS_WITHOUT_DEATHS = 50;
+        static const uint32_t MAX_TURNS_WITHOUT_DEATHS{ 50 };
 
         // Member variables related to the logic of checking the limit of the number of turns
-        uint32_t _currentTurnNumber = 0;
-        uint32_t _numberOfRemainingTurnsWithoutDeaths = MAX_TURNS_WITHOUT_DEATHS;
-        uint32_t _attackerForceNumberOfDead = 0;
-        uint32_t _defenderForceNumberOfDead = 0;
+        uint32_t _currentTurnNumber{ 0 };
+        uint32_t _numberOfRemainingTurnsWithoutDeaths{ MAX_TURNS_WITHOUT_DEATHS };
+        uint32_t _attackerForceNumberOfDead{ 0 };
+        uint32_t _defenderForceNumberOfDead{ 0 };
 
         // Member variables with a lifetime in one turn
-        const HeroBase * _commander = nullptr;
-        int _myColor = Color::NONE;
-        double _myArmyStrength = 0;
-        double _enemyArmyStrength = 0;
-        double _myShootersStrength = 0;
-        double _enemyShootersStrength = 0;
-        double _myRangedUnitsOnly = 0;
-        double _enemyRangedUnitsOnly = 0;
-        double _myArmyAverageSpeed = 0;
-        double _enemyAverageSpeed = 0;
-        double _enemySpellStrength = 0;
-        bool _attackingCastle = false;
-        bool _defendingCastle = false;
-        bool _considerRetreat = false;
-        bool _defensiveTactics = false;
-        bool _cautiousOffensive = false;
-        bool _avoidStackingUnits = false;
+        const HeroBase * _commander{ nullptr };
+        int _myColor{ Color::NONE };
+        double _myArmyStrength{ 0.0 };
+        double _enemyArmyStrength{ 0.0 };
+        double _myShootersStrength{ 0.0 };
+        double _enemyShootersStrength{ 0.0 };
+        double _myRangedUnitsOnly{ 0.0 };
+        double _enemyRangedUnitsOnly{ 0.0 };
+        double _myArmyAverageSpeed{ 0.0 };
+        double _enemyAverageSpeed{ 0.0 };
+        double _enemySpellStrength{ 0.0 };
+        bool _attackingCastle{ false };
+        bool _defendingCastle{ false };
+        bool _considerRetreat{ false };
+        bool _defensiveTactics{ false };
+        bool _cautiousOffensive{ false };
+        bool _avoidStackingUnits{ false };
     };
 }

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <cfloat>
 #include <cstddef>
 #include <iterator>
 #include <map>

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -687,7 +687,7 @@ void Battle::Arena::TowerAction( const Tower & twr )
     assert( std::all_of( board.begin(), board.end(), []( const Cell & cell ) { return ( cell.GetUnit() == nullptr || cell.GetUnit()->isValid() ); } ) );
 
     // Target unit and its threat level
-    std::pair<const Unit *, int32_t> targetInfo{ nullptr, INT32_MIN };
+    std::pair<const Unit *, double> targetInfo{ nullptr, DBL_MIN };
 
     for ( const Cell & cell : board ) {
         const Unit * unit = cell.GetUnit();
@@ -696,7 +696,7 @@ void Battle::Arena::TowerAction( const Tower & twr )
             continue;
         }
 
-        const int32_t unitThreatLevel = unit->evaluateThreatForUnit( twr );
+        const double unitThreatLevel = unit->evaluateThreatForUnit( twr );
 
         if ( targetInfo.first == nullptr || targetInfo.second < unitThreatLevel ) {
             targetInfo = { unit, unitThreatLevel };

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -25,9 +25,9 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cfloat>
 #include <cstddef>
 #include <iterator>
+#include <limits>
 #include <map>
 #include <numeric>
 #include <ostream>

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -688,7 +688,7 @@ void Battle::Arena::TowerAction( const Tower & twr )
     assert( std::all_of( board.begin(), board.end(), []( const Cell & cell ) { return ( cell.GetUnit() == nullptr || cell.GetUnit()->isValid() ); } ) );
 
     // Target unit and its threat level
-    std::pair<const Unit *, double> targetInfo{ nullptr, DBL_MIN };
+    std::pair<const Unit *, double> targetInfo{ nullptr, std::numeric_limits<double>::lowest() };
 
     for ( const Cell & cell : board ) {
         const Unit * unit = cell.GetUnit();

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -993,7 +993,7 @@ uint32_t Battle::Unit::GetDefense() const
     return res;
 }
 
-int32_t Battle::Unit::evaluateThreatForUnit( const Unit & defender ) const
+double Battle::Unit::evaluateThreatForUnit( const Unit & defender ) const
 {
     const Unit & attacker = *this;
 
@@ -1157,7 +1157,7 @@ int32_t Battle::Unit::evaluateThreatForUnit( const Unit & defender ) const
         attackerThreat /= 1.25;
     }
 
-    return fheroes2::checkedCast<int32_t>( attackerThreat * 100 ).value();
+    return attackerThreat;
 }
 
 Funds Battle::Unit::GetSurrenderCost() const

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -194,7 +194,7 @@ namespace Battle
 
         // Returns the threat level of this unit, calculated as if it attacked the 'defender' unit. See
         // the implementation for details.
-        int32_t evaluateThreatForUnit( const Unit & defender ) const;
+        double evaluateThreatForUnit( const Unit & defender ) const;
 
         uint32_t GetInitialCount() const
         {


### PR DESCRIPTION
After implementing the `checkedCast()` for floating-point -> integer conversions in #9819 it became obvious that unit threat evaluation logic with conversions from `double` to `int32_t` wasn't a good idea. For instance, although this battle works just fine in this PR:

https://github.com/user-attachments/assets/28f835a3-3441-4ab2-a67a-969e3e7f5705

it crashes in the `master` branch due to `std::bad_optional_access` exception here:

https://github.com/ihhub/fheroes2/blob/4d3b56f8bde4d54335cfb2febfa9c6444ea85a17/src/fheroes2/battle/battle_troop.cpp#L1160

since the result of the `attackerThreat * 100` expression doesn't fit into `int32_t`, so in this PR I decided to remove all these extra `double` -> `int32_t` -> `double` conversions (since most of the threat evaluation code in the `AI::BattlePlanner` already works with `double` values), and just use `double` everywhere.