### PR TITLE
AI: move the guardian spell cast logic from the AI planner to the anonymous namespace

### DIFF
--- a/src/fheroes2/ai/ai_planner.h
+++ b/src/fheroes2/ai/ai_planner.h
@@ -191,8 +191,6 @@ namespace AI
 
         static Skill::Secondary pickSecondarySkill( const Heroes & hero, const Skill::Secondary & left, const Skill::Secondary & right );
 
-        static void castAdventureSpellOnCapturedObject( Heroes & hero );
-
     private:
         Planner() = default;
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2071,36 +2071,6 @@ double AI::Planner::getObjectValue( const Heroes & hero, const int32_t index, co
     return 0;
 }
 
-void AI::Planner::castAdventureSpellOnCapturedObject( Heroes & hero )
-{
-    if ( !hero.HaveSpellBook() ) {
-        // The hero doesn't have a spell book.
-        return;
-    }
-
-    const MP2::MapObjectType objectType = hero.getObjectTypeUnderHero();
-    assert( world.getTile( hero.GetIndex() ).getMainObjectType( false ) == objectType );
-
-    if ( objectType == MP2::OBJ_MINE ) {
-        // For mines we can cast either a Guardian or Haunt spell.
-        // However, we have no idea where Haunt spell is going to be useful so we ignore it for now.
-        std::vector<Spell> spells = { Spell::SETAGUARDIAN, Spell::SETEGUARDIAN, Spell::SETFGUARDIAN, Spell::SETWGUARDIAN };
-        // Shuffle spells as all of them seem to be equal in power.
-        Rand::Shuffle( spells );
-
-        const int32_t spellMultiplier = Difficulty::getGuardianSpellMultiplier( Game::getDifficulty() );
-
-        for ( const Spell spell : spells ) {
-            if ( hero.CanCastSpell( spell ) && hero.GetSpellPoints() > spellMultiplier * spell.spellPoints( &hero ) ) {
-                // Looks like this hero knows the spell and casting it won't take too many spell points.
-                // So, let's do it!
-                hero.ActionSpellCast( spell );
-                return;
-            }
-        }
-    }
-}
-
 int AI::Planner::getCourierMainTarget( const Heroes & hero, const double lowestPossibleValue )
 {
     assert( hero.getAIRole() == Heroes::Role::COURIER );


### PR DESCRIPTION
`AI::Planner` class is not quite a suitable place for this logic, since this logic has nothing to do with _planning_ 🙂 and is not used somewhere outside of the AI code. Since it is used only by `ai_hero_action.cpp`, I moved the corresponding function to the anonymous namespace in that file.