### PR TITLE
feat: remember position of game window

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -971,10 +971,9 @@ namespace
             if ( _window == nullptr ) {
                 return { -1, -1 };
             }
-            int x = 0;
-            int y = 0;
-            SDL_GetWindowPosition( _window, &x, &y );
-            return { x, y };
+            fheroes2::Point result;
+            SDL_GetWindowPosition( _window, &result.x, &result.y );
+            return result;
         }
 
         void setWindowPos( fheroes2::Point pos ) override

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -960,6 +960,27 @@ namespace
             _toggleVSync();
         }
 
+        fheroes2::Point getWindowPos() const override
+        {
+            if ( _window == nullptr ) {
+                return { -1, -1 };
+            }
+            int x = 0;
+            int y = 0;
+            SDL_GetWindowPosition( _window, &x, &y );
+            return { x, y };
+        }
+
+        void setWindowPos( fheroes2::Point pos ) override
+        {
+            if ( pos == fheroes2::Point{ -1, -1 } ) {
+                _prevWindowPos = { SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED };
+            }
+            else {
+                _prevWindowPos = pos;
+            }
+        }
+
     private:
         SDL_Window * _window{ nullptr };
         SDL_Surface * _surface{ nullptr };
@@ -1361,6 +1382,11 @@ namespace fheroes2
         Image::reset();
 
         _screenSize = { info.screenWidth, info.screenHeight };
+    }
+
+    void Display::setWindowPos( Point point )
+    {
+        _engine->setWindowPos( point );
     }
 
     Display & Display::instance()

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -831,7 +831,7 @@ namespace
                 flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 #endif
 
-                // update the window position, in case we get queried for it
+                // Update the window position, in case we get queried for it
                 SDL_GetWindowPosition( _window, &_prevWindowPos.x, &_prevWindowPos.y );
 
                 // If the window size has been manually changed to one that does not match any of the resolutions supported by the display, then after switching

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -1139,15 +1139,9 @@ namespace
             }
 
             std::optional<bool> isInDisplay = isWindowInAnyDisplay( resolutionInfo, _prevWindowPos );
-            if ( !isInDisplay.has_value() ) {
-                ERROR_LOG( "Failed to check if the previous window position is within any display." )
 
-                clear();
-                return false;
-            }
-            const bool isInDisplayValue = *isInDisplay;
-            // check if the previous window position is within display
-            if ( !isInDisplayValue ) {
+            // check if the previous window position is within display or error occured
+            if ( !isInDisplay || !*isInDisplay ) {
                 // reset position if it is not within the bounds of any display
                 _prevWindowPos = { SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED };
             }

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -976,7 +976,7 @@ namespace
             return result;
         }
 
-        void setWindowPos( fheroes2::Point pos ) override
+        void setWindowPos( const fheroes2::Point pos ) override
         {
             if ( pos == fheroes2::Point{ -1, -1 } ) {
                 _prevWindowPos = { SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED };
@@ -1389,7 +1389,7 @@ namespace fheroes2
         _screenSize = { info.screenWidth, info.screenHeight };
     }
 
-    void Display::setWindowPos( Point point )
+    void Display::setWindowPos( const Point point )
     {
         _engine->setWindowPos( point );
     }

--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -831,6 +831,9 @@ namespace
                 flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
 #endif
 
+                // update the window position, in case we get queried for it
+                SDL_GetWindowPosition( _window, &_prevWindowPos.x, &_prevWindowPos.y );
+
                 // If the window size has been manually changed to one that does not match any of the resolutions supported by the display, then after switching
                 // to full-screen mode, the in-game display area may not occupy the entire screen, and black bars will remain on the sides of the screen. In this
                 // case, even if it is specified to use the SDL_WINDOW_FULLSCREEN, the SDL_WINDOW_FULLSCREEN_DESKTOP will still be used under the hood. To avoid
@@ -962,6 +965,9 @@ namespace
 
         fheroes2::Point getWindowPos() const override
         {
+            if ( isFullScreen() ) {
+                return _prevWindowPos;
+            }
             if ( _window == nullptr ) {
                 return { -1, -1 };
             }

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -144,7 +144,7 @@ namespace fheroes2
             return { -1, -1 };
         }
 
-        virtual void setWindowPos( Point pos )
+        virtual void setWindowPos( const Point pos )
         {
             (void)( pos );
             // Do nothing
@@ -234,7 +234,7 @@ namespace fheroes2
             return _engine->getWindowPos();
         }
 
-        void setWindowPos( Point point );
+        void setWindowPos( const Point point );
 
         // this function must return true if new palette has been generated
         using PreRenderProcessing = std::function<bool( std::vector<uint8_t> & )>;

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -139,6 +139,17 @@ namespace fheroes2
             return _nearestScaling;
         }
 
+        virtual Point getWindowPos() const
+        {
+            return { -1, -1 };
+        }
+
+        virtual void setWindowPos( Point pos )
+        {
+            (void)( pos );
+            // Do nothing
+        }
+
     protected:
         BaseRenderEngine()
             : _isFullScreen( false )
@@ -217,6 +228,13 @@ namespace fheroes2
         {
             return width() == DEFAULT_WIDTH && height() == DEFAULT_HEIGHT;
         }
+
+        Point getWindowPos() const
+        {
+            return _engine->getWindowPos();
+        }
+
+        void setWindowPos( Point point );
 
         // this function must return true if new palette has been generated
         using PreRenderProcessing = std::function<bool( std::vector<uint8_t> & )>;

--- a/src/engine/screen.h
+++ b/src/engine/screen.h
@@ -144,9 +144,8 @@ namespace fheroes2
             return { -1, -1 };
         }
 
-        virtual void setWindowPos( const Point pos )
+        virtual void setWindowPos( const Point /* pos */ )
         {
-            (void)( pos );
             // Do nothing
         }
 

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -72,6 +72,7 @@
 #include "image_palette.h"
 #include "localevent.h"
 #include "logging.h"
+#include "math_base.h"
 #include "render_processor.h"
 #include "screen.h"
 #include "settings.h"
@@ -369,7 +370,7 @@ int main( int argc, char ** argv )
             const fheroes2::Point pos = conf.getStarttWindowPos();
             Game::mainGameLoop( conf.isFirstGameRun(), isProbablyDemoVersion() );
             const fheroes2::Point currentPos = display.getWindowPos();
-            if ( !conf.FullScreen() && pos != currentPos ) {
+            if ( pos != currentPos ) {
                 conf.setStartWindowPos( currentPos );
                 conf.Save( Settings::configFileName );
             }

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -176,6 +176,7 @@ namespace
                 }
             }
 
+            display.setWindowPos( conf.getStarttWindowPos() );
             display.setResolution( bestResolution );
 
             fheroes2::engine().setTitle( GetCaption() );
@@ -343,7 +344,8 @@ int main( int argc, char ** argv )
 
         // Load palette.
         fheroes2::setGamePalette( AGG::getDataFromAggFile( "KB.PAL", false ) );
-        fheroes2::Display::instance().changePalette( nullptr, true );
+        const fheroes2::Display & display = fheroes2::Display::instance();
+        display.changePalette( nullptr, true );
 
         // Update the fonts according to the game language set in the configuration.
         // NOTICE: it must be done before initializing the engine to properly load all
@@ -364,8 +366,13 @@ int main( int argc, char ** argv )
 
         try {
             const CursorRestorer cursorRestorer( true, Cursor::POINTER );
-
+            const fheroes2::Point pos = conf.getStarttWindowPos();
             Game::mainGameLoop( conf.isFirstGameRun(), isProbablyDemoVersion() );
+            const fheroes2::Point currentPos = display.getWindowPos();
+            if ( !conf.FullScreen() && pos != currentPos ) {
+                conf.setStartWindowPos( currentPos );
+                conf.Save( Settings::configFileName );
+            }
         }
         catch ( const fheroes2::InvalidDataResources & ex ) {
             ERROR_LOG( ex.what() )

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -177,7 +177,7 @@ namespace
                 }
             }
 
-            display.setWindowPos( conf.getStarttWindowPos() );
+            display.setWindowPos( conf.getSavedWindowPos() );
             display.setResolution( bestResolution );
 
             fheroes2::engine().setTitle( GetCaption() );
@@ -367,7 +367,7 @@ int main( int argc, char ** argv )
 
         try {
             const CursorRestorer cursorRestorer( true, Cursor::POINTER );
-            const fheroes2::Point pos = conf.getStarttWindowPos();
+            const fheroes2::Point pos = conf.getSavedWindowPos();
             Game::mainGameLoop( conf.isFirstGameRun(), isProbablyDemoVersion() );
             const fheroes2::Point currentPos = display.getWindowPos();
             if ( pos != currentPos ) {

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -100,6 +100,7 @@ std::string Settings::GetVersion()
 
 Settings::Settings()
     : _resolutionInfo( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT )
+    , _windowPos( -1, -1 )
     , _gameDifficulty( Difficulty::NORMAL )
     , _saveFileSortType( SaveFileSortingMethod::FILENAME )
     , sound_volume( 6 )
@@ -280,6 +281,10 @@ bool Settings::Read( const std::string & filePath )
         _resolutionInfo = config.ResolutionParams( "videomode", { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } );
     }
 
+    if ( config.Exists( "main window position" ) ) {
+        _windowPos = config.PointParams( "main window position", { -1, -1 } );
+    }
+
     if ( config.Exists( "fullscreen" ) ) {
         setFullScreen( config.StrParams( "fullscreen" ) == "on" );
     }
@@ -407,6 +412,9 @@ std::string Settings::String() const
 
     os << std::endl << "# video mode: in-game width x in-game height : on-screen width x on-screen height" << std::endl;
     os << "videomode = " << display.width() << "x" << display.height() << ":" << display.screenSize().width << "x" << display.screenSize().height << std::endl;
+
+    os << std::endl << "# position of the main window" << std::endl;
+    os << "main window position = [ " << _windowPos.x << ", " << _windowPos.y << " ]" << std::endl;
 
     os << std::endl << "# music: original, expansion, external" << std::endl;
     os << "music = " << musicType << std::endl;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -281,8 +281,8 @@ bool Settings::Read( const std::string & filePath )
         _resolutionInfo = config.ResolutionParams( "videomode", { fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT } );
     }
 
-    if ( config.Exists( "main window position" ) ) {
-        _windowPos = config.PointParams( "main window position", { -1, -1 } );
+    if ( config.Exists( "game window position" ) ) {
+        _windowPos = config.PointParams( "game window position", { -1, -1 } );
     }
 
     if ( config.Exists( "fullscreen" ) ) {
@@ -414,7 +414,7 @@ std::string Settings::String() const
     os << "videomode = " << display.width() << "x" << display.height() << ":" << display.screenSize().width << "x" << display.screenSize().height << std::endl;
 
     os << std::endl << "# position of the game's window" << std::endl;
-    os << "main window position = [ " << _windowPos.x << ", " << _windowPos.y << " ]" << std::endl;
+    os << "game window position = [ " << _windowPos.x << ", " << _windowPos.y << " ]" << std::endl;
 
     os << std::endl << "# music: original, expansion, external" << std::endl;
     os << "music = " << musicType << std::endl;

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -413,7 +413,7 @@ std::string Settings::String() const
     os << std::endl << "# video mode: in-game width x in-game height : on-screen width x on-screen height" << std::endl;
     os << "videomode = " << display.width() << "x" << display.height() << ":" << display.screenSize().width << "x" << display.screenSize().height << std::endl;
 
-    os << std::endl << "# position of the main window" << std::endl;
+    os << std::endl << "# position of the game's window" << std::endl;
     os << "main window position = [ " << _windowPos.x << ", " << _windowPos.y << " ]" << std::endl;
 
     os << std::endl << "# music: original, expansion, external" << std::endl;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -243,6 +243,16 @@ public:
         return _resolutionInfo;
     }
 
+    fheroes2::Point getStarttWindowPos() const
+    {
+        return _windowPos;
+    }
+
+    void setStartWindowPos( fheroes2::Point pos )
+    {
+        _windowPos = pos;
+    }
+
     void EnablePriceOfLoyaltySupport( const bool set );
 
     void SetGameDifficulty( const int difficulty )
@@ -395,6 +405,8 @@ private:
     BitModes _editorOptions;
 
     fheroes2::ResolutionInfo _resolutionInfo;
+    fheroes2::Point _windowPos;
+
     int _gameDifficulty;
 
     std::string _programPath;

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -243,12 +243,12 @@ public:
         return _resolutionInfo;
     }
 
-    fheroes2::Point getStarttWindowPos() const
+    fheroes2::Point getStartWindowPos() const
     {
         return _windowPos;
     }
 
-    void setStartWindowPos( fheroes2::Point pos )
+    void setStartWindowPos( const fheroes2::Point pos )
     {
         _windowPos = pos;
     }

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -243,7 +243,7 @@ public:
         return _resolutionInfo;
     }
 
-    fheroes2::Point getStartWindowPos() const
+    fheroes2::Point getSavedWindowPos() const
     {
         return _windowPos;
     }


### PR DESCRIPTION
Solves #1228 

Saves the position of the window in fheroes2.conf.
The position is captured every time the window is moved, and saved to settings when the game exits.
It's possible to capture only when the game exits, but then we might not save the correct position if the user swaps to Fullscreen mode before quitting.