### PR TITLE
MSVC workflow: migrate to the windows-2022 runner

### DIFF
--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -30,7 +30,7 @@ jobs:
           release_name: Windows x64 build with SDL2 (latest commit)
           release_tag: fheroes2-windows-x64-SDL2
     name: MSVC (${{ matrix.name }})
-    runs-on: windows-2019
+    runs-on: windows-2022
     timeout-minutes: 30
     defaults:
       run:

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -57,7 +57,7 @@ jobs:
         "%SIGNTOOL_DIR%\signtool.exe" verify /v /d /all /pa /r "Microsoft Root Certificate Authority" .vcredist\vcredist.exe
       shell: cmd
       env:
-        SIGNTOOL_DIR: C:\Program Files (x86)\Windows Kits\10\bin\x64
+        SIGNTOOL_DIR: C:\Program Files (x86)\Windows Kits\10\bin\10.0.19041.0\x64
     - name: Generate version information
       run: |
         echo "FHEROES2_APP_VERSION=$(cat version.txt)" >> "$GITHUB_ENV"

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -42,7 +42,7 @@ jobs:
         script/windows/install_packages.bat
     - name: Install MSYS2 tools
       run: |
-        C:\msys64\usr\bin\pacman.exe -S --noconfirm --noprogressbar gettext-devel
+        C:\msys64\usr\bin\pacman.exe -S --noconfirm --noprogressbar gettext-devel make
       shell: cmd
     - name: Download MSVC Redistributable package
       run: |


### PR DESCRIPTION
See https://github.com/actions/runner-images/issues/12045 for details.