### PR TITLE
Update Hungarian translations

### DIFF
--- a/files/lang/hu.po
+++ b/files/lang/hu.po
@@ -462,7 +462,7 @@ msgid "%{name} has turned on the auto combat"
 msgstr "%{name} bekapcsolta az automata csata módot"
 
 msgid "Spell failed!"
-msgstr "A varázslat nem sikerült!"
+msgstr "A varázslat meghiúsult!"
 
 msgid ""
 "The Sphere of Negation artifact is in effect for this battle, disabling all "
@@ -476,7 +476,7 @@ msgid "You have already cast a spell this round."
 msgstr "Már varázsoltál ebben a körben."
 
 msgid "That spell will have no effect!"
-msgstr "Ennek a varázslatnak nem lesz semmilyen hatása!"
+msgstr "Ez a varázslat nem hatásos senkire!"
 
 msgid "You may only summon one type of elemental per combat."
 msgstr "Csak egyféle elementált idézhetsz meg egy csatában."
@@ -689,7 +689,7 @@ msgid "Hero Screen"
 msgstr "Hős képernyő"
 
 msgid "Captain's Options"
-msgstr "Kapitány beállításai"
+msgstr "Kapitány beállítások"
 
 msgid "Hero's Options"
 msgstr "Hős beállításai"
@@ -2884,7 +2884,7 @@ msgid "Attack Skill"
 msgstr "Támadóerő"
 
 msgid "Defense Skill"
-msgstr "Védekezőerő"
+msgstr "Védőerő"
 
 msgid "Shots"
 msgstr "Lövések"
@@ -3372,7 +3372,7 @@ msgid "Attack:"
 msgstr "Támadóerő:"
 
 msgid "Defense:"
-msgstr "Védekezőerő:"
+msgstr "Védőerő:"
 
 msgid "Spell Power:"
 msgstr "Varázserő:"
@@ -5822,7 +5822,7 @@ msgid ""
 "They are triumphant."
 msgstr ""
 "Az ellenfél elfoglalta %{name} várat!\n"
-"Ővék a győzelem."
+"Ők győztek."
 
 msgid ""
 "The enemy has found the %{name}.\n"
@@ -5872,7 +5872,7 @@ msgstr ""
 "Az ellenfelek összes hősének legyőzése és várainak, városainak elpusztítása."
 
 msgid "Your side defeats the opposing side."
-msgstr "Az ellenfelet vagy te győzöd le, vagy a szövetségeseid."
+msgstr "Te vagy szövetségeseid legyőzik az ellenfeleket."
 
 msgid "Run out of time. (Fail to win by a certain point.)"
 msgstr "Az idő lejárt. (Nem sikerült nyernie adott idő alatt.)"


### PR DESCRIPTION
The fuzzy translations were corrected and missing entries in files/lang/hu.po were filled in.

Major Changes:

- Updated the “Select color” string to the correct Hungarian translation “Szín kiválasztása.”
- Added a translation for the message about ownership when no players exist on the map.
- Filled in “ABOUT” and “About” with “NÉVJEGY” and “Névjegy.”
- Translated the note-editing prompt from the map creator.
- Fixed the quest failure message when the enemy finds the artifact.
- Corrected the language name “Greek” to “görög.”
- Added missing text for the black cat encounter and the cat events.
- Overwrite some existing translation
