### PR TITLE
Detect doubled objects' UIDs in fh2m maps in debug build

### DIFF
--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -1213,14 +1213,65 @@ namespace Maps
         auto sortObjects = []( const IndexedObjectInfo & left, const IndexedObjectInfo & right ) { return left.info->id < right.info->id; };
         std::multiset<IndexedObjectInfo, decltype( sortObjects )> sortedObjects( sortObjects );
 
+#if defined( WITH_DEBUG )
+        std::map<uint32_t, IndexedObjectInfo> objectsUIDs;
+        std::multiset<IndexedObjectInfo, decltype( sortObjects )> incorrectObjects( sortObjects );
+#endif
+
         for ( size_t i = 0; i < tilesConut; ++i ) {
             for ( const auto & object : map.tiles[i].objects ) {
                 IndexedObjectInfo info;
                 info.tileIndex = static_cast<int32_t>( i );
                 info.info = &object;
                 sortedObjects.emplace( info );
+
+#if defined( WITH_DEBUG )
+                if ( object.group != Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS && object.group != Maps::ObjectGroup::LANDSCAPE_FLAGS ) {
+                    const auto [iter, inserted] = objectsUIDs.try_emplace( object.id, info );
+                    if ( !inserted ) {
+                        incorrectObjects.emplace( iter->second );
+                        incorrectObjects.emplace( info );
+                    }
+                }
+#endif
             }
         }
+
+#if defined( WITH_DEBUG )
+        uint32_t uid = 0;
+        for ( const IndexedObjectInfo & info : incorrectObjects ) {
+            if ( info.info->id != uid ) {
+                uid = info.info->id;
+                if ( map.standardMetadata.find( uid ) != map.standardMetadata.end() ) {
+                    VERBOSE_LOG( "`standardMetadata` belongs to many objects with same UID: " << uid )
+                }
+                if ( map.castleMetadata.find( uid ) != map.castleMetadata.end() ) {
+                    VERBOSE_LOG( "`castleMetadata` belongs to many objects with same UID: " << uid )
+                }
+                if ( map.heroMetadata.find( uid ) != map.heroMetadata.end() ) {
+                    VERBOSE_LOG( "`heroMetadata` belongs to many objects with same UID: " << uid )
+                }
+                if ( map.sphinxMetadata.find( uid ) != map.sphinxMetadata.end() ) {
+                    VERBOSE_LOG( "`sphinxMetadata` belongs to many objects with same UID: " << uid )
+                }
+                if ( map.signMetadata.find( uid ) != map.signMetadata.end() ) {
+                    VERBOSE_LOG( "`signMetadata` belongs to many objects with same UID: " << uid )
+                }
+                if ( map.adventureMapEventMetadata.find( uid ) != map.adventureMapEventMetadata.end() ) {
+                    VERBOSE_LOG( "`adventureMapEventMetadata` belongs to many objects with same UID: " << uid )
+                }
+                if ( map.selectionObjectMetadata.find( uid ) != map.selectionObjectMetadata.end() ) {
+                    VERBOSE_LOG( "`selectionObjectMetadata` belongs to many objects with same UID: " << uid )
+                }
+                if ( map.capturableObjectsMetadata.find( uid ) != map.capturableObjectsMetadata.end() ) {
+                    VERBOSE_LOG( "`capturableObjectsMetadata` belongs to many objects with same UID: " << uid )
+                }
+            }
+
+            VERBOSE_LOG( "Non-unique UID " << info.info->id << " at " << info.tileIndex << " (" << info.tileIndex % map.size << ", " << info.tileIndex / map.size
+                                           << ") tile for object type: " << MP2::StringObject( getObjectInfo( info.info->group, info.info->index ).objectType ) )
+        }
+#endif
 
         for ( const auto & info : sortedObjects ) {
             assert( info.info != nullptr );

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -736,8 +736,6 @@ bool World::loadResurrectionMap( const std::string & filename )
     std::set<uint32_t> signMetadataUIDs;
     std::set<uint32_t> adventureMapEventMetadataUIDs;
     std::set<uint32_t> selectionObjectMetadataUIDs;
-    std::map<uint32_t, size_t> objectsUIDs;
-    std::set<uint32_t> incorrectUIDs;
 #endif
 
     const auto areSpellsValid = []( const Maps::Map_Format::SelectionObjectMetadata & metadata, const int spellLevel ) {
@@ -758,16 +756,6 @@ bool World::loadResurrectionMap( const std::string & filename )
         const auto & tile = map.tiles[tileId];
 
         for ( const auto & object : tile.objects ) {
-#if defined( WITH_DEBUG )
-            if ( object.group != Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS && object.group != Maps::ObjectGroup::LANDSCAPE_FLAGS ) {
-                const auto [iter, inserted] = objectsUIDs.try_emplace( object.id, tileId );
-                if ( !inserted ) {
-                    incorrectUIDs.emplace( object.id );
-                    VERBOSE_LOG( "doubledID: " << object.id << " at " << tileId << ". First at " << iter->second )
-                }
-            }
-#endif
-
             if ( object.group == Maps::ObjectGroup::KINGDOM_TOWNS ) {
 #if defined( WITH_DEBUG )
                 castleMetadataUIDs.emplace( object.id );
@@ -1210,30 +1198,6 @@ bool World::loadResurrectionMap( const std::string & filename )
 
     for ( const uint32_t uid : selectionObjectMetadataUIDs ) {
         assert( map.selectionObjectMetadata.find( uid ) != map.selectionObjectMetadata.end() );
-    }
-
-    for ( const uint32_t uid : incorrectUIDs ) {
-        if ( map.standardMetadata.find( uid ) != map.standardMetadata.end() ) {
-            VERBOSE_LOG( "`standardMetadata` belongs to many objects with same UID = " << uid )
-        }
-        if ( map.castleMetadata.find( uid ) != map.castleMetadata.end() ) {
-            VERBOSE_LOG( "`castleMetadata` belongs to many objects with same UID = " << uid )
-        }
-        if ( map.heroMetadata.find( uid ) != map.heroMetadata.end() ) {
-            VERBOSE_LOG( "`heroMetadata` belongs to many objects with same UID = " << uid )
-        }
-        if ( map.sphinxMetadata.find( uid ) != map.sphinxMetadata.end() ) {
-            VERBOSE_LOG( "`sphinxMetadata` belongs to many objects with same UID = " << uid )
-        }
-        if ( map.signMetadata.find( uid ) != map.signMetadata.end() ) {
-            VERBOSE_LOG( "`signMetadata` belongs to many objects with same UID = " << uid )
-        }
-        if ( map.adventureMapEventMetadata.find( uid ) != map.adventureMapEventMetadata.end() ) {
-            VERBOSE_LOG( "`adventureMapEventMetadata` belongs to many objects with same UID = " << uid )
-        }
-        if ( map.selectionObjectMetadata.find( uid ) != map.selectionObjectMetadata.end() ) {
-            VERBOSE_LOG( "`selectionObjectMetadata` belongs to many objects with same UID = " << uid )
-        }
     }
 #endif
 

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -736,6 +736,8 @@ bool World::loadResurrectionMap( const std::string & filename )
     std::set<uint32_t> signMetadataUIDs;
     std::set<uint32_t> adventureMapEventMetadataUIDs;
     std::set<uint32_t> selectionObjectMetadataUIDs;
+    std::map<uint32_t, size_t> objectsUIDs;
+    std::set<uint32_t> incorrectUIDs;
 #endif
 
     const auto areSpellsValid = []( const Maps::Map_Format::SelectionObjectMetadata & metadata, const int spellLevel ) {
@@ -756,6 +758,16 @@ bool World::loadResurrectionMap( const std::string & filename )
         const auto & tile = map.tiles[tileId];
 
         for ( const auto & object : tile.objects ) {
+#if defined( WITH_DEBUG )
+            if ( object.group != Maps::ObjectGroup::LANDSCAPE_TOWN_BASEMENTS && object.group != Maps::ObjectGroup::LANDSCAPE_FLAGS ) {
+                const auto [iter, inserted] = objectsUIDs.try_emplace( object.id, tileId );
+                if ( !inserted ) {
+                    incorrectUIDs.emplace( object.id );
+                    VERBOSE_LOG( "doubledID: " << object.id << " at " << tileId << ". First at " << iter->second )
+                }
+            }
+#endif
+
             if ( object.group == Maps::ObjectGroup::KINGDOM_TOWNS ) {
 #if defined( WITH_DEBUG )
                 castleMetadataUIDs.emplace( object.id );
@@ -1198,6 +1210,30 @@ bool World::loadResurrectionMap( const std::string & filename )
 
     for ( const uint32_t uid : selectionObjectMetadataUIDs ) {
         assert( map.selectionObjectMetadata.find( uid ) != map.selectionObjectMetadata.end() );
+    }
+
+    for ( const uint32_t uid : incorrectUIDs ) {
+        if ( map.standardMetadata.find( uid ) != map.standardMetadata.end() ) {
+            VERBOSE_LOG( "`standardMetadata` belongs to many objects with same UID = " << uid )
+        }
+        if ( map.castleMetadata.find( uid ) != map.castleMetadata.end() ) {
+            VERBOSE_LOG( "`castleMetadata` belongs to many objects with same UID = " << uid )
+        }
+        if ( map.heroMetadata.find( uid ) != map.heroMetadata.end() ) {
+            VERBOSE_LOG( "`heroMetadata` belongs to many objects with same UID = " << uid )
+        }
+        if ( map.sphinxMetadata.find( uid ) != map.sphinxMetadata.end() ) {
+            VERBOSE_LOG( "`sphinxMetadata` belongs to many objects with same UID = " << uid )
+        }
+        if ( map.signMetadata.find( uid ) != map.signMetadata.end() ) {
+            VERBOSE_LOG( "`signMetadata` belongs to many objects with same UID = " << uid )
+        }
+        if ( map.adventureMapEventMetadata.find( uid ) != map.adventureMapEventMetadata.end() ) {
+            VERBOSE_LOG( "`adventureMapEventMetadata` belongs to many objects with same UID = " << uid )
+        }
+        if ( map.selectionObjectMetadata.find( uid ) != map.selectionObjectMetadata.end() ) {
+            VERBOSE_LOG( "`selectionObjectMetadata` belongs to many objects with same UID = " << uid )
+        }
     }
 #endif
 


### PR DESCRIPTION
This PR adds simple checks for repeat of objects' UIDs during `fh2m` map load.
If the repeats are detected the information about this will be output to the console and log file.
The shown information may help to fix the already made maps by the very first versions of editor and to check the editor correctness in the future while testing editor-related PRs.