### PR TITLE
Fix showing one 1st level troop in hero's army diring hero fade-out animation after loosing the battle

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -346,12 +346,18 @@ double Troops::getReinforcementValue( const Troops & reinforcement ) const
 
 bool Troops::isValid() const
 {
-    return std::any_of( begin(), end(), []( const Troop * troop ) { return ( troop != nullptr ) && troop->isValid(); } );
+    return std::any_of( begin(), end(), []( const Troop * troop ) {
+        assert( troop != nullptr );
+        return troop->isValid();
+    } );
 }
 
 uint32_t Troops::GetOccupiedSlotCount() const
 {
-    return static_cast<uint32_t>( std::count_if( begin(), end(), []( const Troop * troop ) { return ( troop != nullptr ) && troop->isValid(); } ) );
+    return static_cast<uint32_t>( std::count_if( begin(), end(), []( const Troop * troop ) {
+        assert( troop != nullptr );
+        return troop->isValid();
+    } ) );
 }
 
 bool Troops::areAllTroopsUnique() const

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -346,21 +346,12 @@ double Troops::getReinforcementValue( const Troops & reinforcement ) const
 
 bool Troops::isValid() const
 {
-    for ( const_iterator it = begin(); it != end(); ++it ) {
-        if ( ( *it )->isValid() )
-            return true;
-    }
-    return false;
+    return std::any_of( begin(), end(), []( const Troop * troop ) { return ( troop != nullptr ) && troop->isValid(); } );
 }
 
 uint32_t Troops::GetOccupiedSlotCount() const
 {
-    uint32_t total = 0;
-    for ( const_iterator it = begin(); it != end(); ++it ) {
-        if ( ( *it )->isValid() )
-            ++total;
-    }
-    return total;
+    return static_cast<uint32_t>( std::count_if( begin(), end(), []( const Troop * troop ) { return ( troop != nullptr ) && troop->isValid(); } ) );
 }
 
 bool Troops::areAllTroopsUnique() const
@@ -1588,19 +1579,25 @@ void Army::drawMultipleMonsterLines( const Troops & troops, int32_t posX, int32_
                                      const bool isGarrisonView /* = false */, const uint32_t thievesGuildsCount /* = 0 */ )
 {
     const uint32_t count = troops.GetOccupiedSlotCount();
+
+    if ( count == 0 ) {
+        // There are no valid troops to render.
+        return;
+    }
+
     const int offsetX = lineWidth / 6;
     const int offsetY = isCompact ? 31 : 49;
 
-    fheroes2::Image & output = fheroes2::Display::instance();
-
     if ( count < 3 ) {
         fheroes2::drawMiniMonsters( troops, posX + offsetX, posY + offsetY / 2 + 1, lineWidth * 2 / 3, 0, 0, isCompact, isDetailedView, isGarrisonView,
-                                    thievesGuildsCount, output );
+                                    thievesGuildsCount, fheroes2::Display::instance() );
     }
     else {
-        const int firstLineTroopCount = 2;
-        const int secondLineTroopCount = count - firstLineTroopCount;
-        const int secondLineWidth = secondLineTroopCount == 2 ? lineWidth * 2 / 3 : lineWidth;
+        const uint32_t firstLineTroopCount = 2;
+        const uint32_t secondLineTroopCount = count - firstLineTroopCount;
+        const int32_t secondLineWidth = ( secondLineTroopCount == 2 ) ? lineWidth * 2 / 3 : lineWidth;
+
+        fheroes2::Image & output = fheroes2::Display::instance();
 
         fheroes2::drawMiniMonsters( troops, posX + offsetX, posY, lineWidth * 2 / 3, 0, firstLineTroopCount, isCompact, isDetailedView, isGarrisonView,
                                     thievesGuildsCount, output );

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -475,14 +475,6 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
     army1.resetInvalidMonsters();
     army2.resetInvalidMonsters();
 
-    // Reset the hero's army to the minimum army if the hero retreated or was defeated
-    if ( commander1 && commander1->isHeroes() && ( !army1.isValid() || ( result.army1 & RESULT_RETREAT ) ) ) {
-        army1.Reset( false );
-    }
-    if ( commander2 && commander2->isHeroes() && ( !army2.isValid() || ( result.army2 & RESULT_RETREAT ) ) ) {
-        army2.Reset( false );
-    }
-
     DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army1: " << ( result.army1 & RESULT_WINS ? "wins" : "loss" ) << ", army2: " << ( result.army2 & RESULT_WINS ? "wins" : "loss" ) )
 
     return result;

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -317,18 +317,18 @@ void Interface::StatusPanel::_drawResourceInfo( const int32_t offsetY ) const
 
 void Interface::StatusPanel::_drawArmyInfo( const int32_t offsetY ) const
 {
-    const Army * armies = nullptr;
+    const Army * armyTroops = nullptr;
 
     if ( const Heroes * focusedHero = GetFocusHeroes(); focusedHero != nullptr ) {
-        armies = &focusedHero->GetArmy();
+        armyTroops = &focusedHero->GetArmy();
     }
     else if ( const Castle * focusedCastle = GetFocusCastle(); focusedCastle != nullptr ) {
-        armies = &focusedCastle->GetArmy();
+        armyTroops = &focusedCastle->GetArmy();
     }
 
-    if ( armies ) {
+    if ( armyTroops ) {
         const fheroes2::Rect & pos = GetArea();
-        Army::drawMultipleMonsterLines( *armies, pos.x + 4, pos.y + 1 + offsetY, 138, true, true );
+        Army::drawMultipleMonsterLines( *armyTroops, pos.x + 4, pos.y + 1 + offsetY, 138, true, true );
     }
 }
 

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -319,11 +319,11 @@ void Interface::StatusPanel::_drawArmyInfo( const int32_t offsetY ) const
 {
     const Army * armies = nullptr;
 
-    if ( GetFocusHeroes() ) {
-        armies = &GetFocusHeroes()->GetArmy();
+    if ( const Heroes * focusedHero = GetFocusHeroes(); focusedHero != nullptr ) {
+        armies = &focusedHero->GetArmy();
     }
-    else if ( GetFocusCastle() ) {
-        armies = &GetFocusCastle()->GetArmy();
+    else if ( const Castle * focusedCastle = GetFocusCastle(); focusedCastle != nullptr ) {
+        armies = &focusedCastle->GetArmy();
     }
 
     if ( armies ) {

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -2011,7 +2011,7 @@ void Heroes::Dismiss( int reason )
         return;
     }
 
-    // if not surrendering, reset army
+    // Reset army to default state for hero's race if hero did not surrender in battle.
     if ( ( reason & Battle::RESULT_SURRENDER ) == 0 ) {
         army.Reset( true );
     }


### PR DESCRIPTION
fix #9869 

The incorrect 1st level troop is shown because before dismissing the defeated hero from the kingdom his army is always reset to one 1st level troop according to hero's race.
This PR removes the reset of the defeated army right after the battle because the reset is also done when dismissing the defeated hero from the kingdom right after the hero fade-out animation.

https://github.com/user-attachments/assets/9bc3e4ab-9dfa-4d69-833e-2ff86ec5f017

This PR also slightly updates the logic for `Troops::isValid()`, `Troops::GetOccupiedSlotCount()` and `Army::drawMultipleMonsterLines()`.
