### PR TITLE
Android: use SHA512 hash instead of MD5 during the generateAssetsDigest build step to further minimize the likelihood of hash collisions

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -143,8 +143,8 @@ tasks.register('generateAssetsDigest') {
 
             final byte[] itBuf = Files.readAllBytes(itPath)
 
-            sb.append(String.format('%032x % 12d %s\n',
-                    new BigInteger(1, MessageDigest.getInstance('MD5').digest(itBuf)),
+            sb.append(String.format('%0128x % 12d %s\n',
+                    new BigInteger(1, MessageDigest.getInstance('SHA-512').digest(itBuf)),
                     itBuf.length, assetsDirPath.relativize(itPath)))
         }
 


### PR DESCRIPTION
The digest file is generated during the build, so the potential difference in hash function performance is not so important, and comparing digests during game startup will not suffer, because they are relatively small anyway.