### PR TITLE
Adjust vertical positioning of header and body text in dialog panels

### DIFF
--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -57,7 +57,9 @@ class HeroBase;
 
 namespace
 {
-    const int32_t textOffsetY = 10;
+    const int32_t textOffsetY = 2;
+
+    const int32_t headerBodySpacing = 5;
 
     const int32_t elementOffsetX = 10;
 
@@ -170,7 +172,7 @@ namespace fheroes2
 
         Display & display = Display::instance();
         header.draw( pos.x, pos.y + textOffsetY, fheroes2::boxAreaWidthPx, display );
-        body.draw( pos.x, pos.y + textOffsetY + headerHeight, fheroes2::boxAreaWidthPx, display );
+        body.draw( pos.x, pos.y + headerHeight + headerBodySpacing, fheroes2::boxAreaWidthPx, display );
 
         elementHeight = overallTextHeight + textOffsetY;
         if ( bodyTextHeight > 0 ) {


### PR DESCRIPTION
Fix [#1260](https://github.com/ihhub/fheroes2/issues/1260)

This PR introduces a new constant headerBodySpacing and adjusts the Y positions of the header and body text elements in dialog panels. The changes improve vertical alignment and better reflect the original game’s layout, where the space below the text is slightly larger than the space above.

These updates aim to resolve the visual imbalance noted in issue [#1260](https://github.com/ihhub/fheroes2/issues/1260), where the body text appeared too close to the header and the top of the text was too far from the window’s upper edge.