### PR TITLE
Fix placing "Month of" monsters on the map to avoid Events removing

### DIFF
--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -68,27 +68,11 @@
 
 namespace
 {
-    bool isTileBlockedForSettingMonster( const std::vector<Maps::Tile> & mapTiles, const int32_t tileId, const int32_t radius, const std::set<int32_t> & excludeTiles )
+    bool isTileBlockedForSettingMonster( const int32_t tileId, const int32_t radius, const std::set<int32_t> & excludeTiles )
     {
         const MapsIndexes & indexes = Maps::getAroundIndexes( tileId, radius );
 
-        for ( const int32_t indexId : indexes ) {
-            if ( excludeTiles.count( indexId ) > 0 ) {
-                return true;
-            }
-
-            const Maps::Tile & indexedTile = mapTiles[indexId];
-            if ( indexedTile.isWater() ) {
-                continue;
-            }
-
-            const MP2::MapObjectType objectType = indexedTile.getMainObjectType( true );
-            if ( objectType == MP2::OBJ_CASTLE || objectType == MP2::OBJ_HERO || objectType == MP2::OBJ_MONSTER ) {
-                return true;
-            }
-        }
-
-        return false;
+        return std::any_of( indexes.cbegin(), indexes.cend(), [&excludeTiles]( const int32_t indexId ) { return excludeTiles.count( indexId ) > 0; } );
     }
 
     int32_t findSuitableNeighbouringTile( const std::vector<Maps::Tile> & mapTiles, const int32_t tileId, const bool allDirections, std::mt19937 & gen )
@@ -109,8 +93,18 @@ namespace
                 continue;
             }
 
+            const MP2::MapObjectType objectType = indexedTile.getMainObjectType( true );
+
+            if ( objectType == MP2::OBJ_EVENT ) {
+                // Event is not considered as in-game action object to avoid confusion with visible action objects.
+                // We skip the tile with event because there cannot be two action objects (monster and event) on one tile.
+                // And we don't need to leave space between event and spawned monster so we don't add tile to `excludeTiles`.
+
+                continue;
+            }
+
             // If the candidate tile is a coast tile, it is suitable only if there are other coast tiles nearby
-            if ( indexedTile.getMainObjectType( false ) == MP2::OBJ_COAST ) {
+            if ( objectType == MP2::OBJ_COAST ) {
                 const MapsIndexes coastTiles = Maps::ScanAroundObject( indexId, MP2::OBJ_COAST );
 
                 if ( coastTiles.empty() ) {
@@ -542,11 +536,11 @@ void World::NewWeek()
 void World::NewMonth()
 {
     if ( month > 1 && GetWeekType().GetType() == WeekName::MONSTERS ) {
-        MonthOfMonstersAction( Monster( GetWeekType().GetMonster() ) );
+        _monthOfMonstersAction( Monster( GetWeekType().GetMonster() ) );
     }
 }
 
-void World::MonthOfMonstersAction( const Monster & mons )
+void World::_monthOfMonstersAction( const Monster & mons )
 {
     if ( !mons.isValid() ) {
         return;
@@ -565,6 +559,15 @@ void World::MonthOfMonstersAction( const Monster & mons )
 
     std::mt19937 seededGen( _seed + month );
 
+    // First we scan for Heroes, Castles and Monsters to exclude that tiles and tiles around.
+    // We must do it prior to checking ability for monster spawning to properly do check for around tiles.
+    std::for_each( vec_tiles.cbegin(), vec_tiles.cend(), [&excludeTiles]( const Maps::Tile & tile ) {
+        const MP2::MapObjectType objectType = tile.getMainObjectType( true );
+        if ( objectType == MP2::OBJ_CASTLE || objectType == MP2::OBJ_HERO || objectType == MP2::OBJ_MONSTER ) {
+            excludeTiles.emplace( tile.GetIndex() );
+        }
+    } );
+
     for ( const Maps::Tile & tile : vec_tiles ) {
         if ( tile.isWater() ) {
             // Monsters are not placed on water.
@@ -572,15 +575,15 @@ void World::MonthOfMonstersAction( const Monster & mons )
         }
 
         const int32_t tileId = tile.GetIndex();
-        const MP2::MapObjectType objectType = tile.getMainObjectType( true );
 
-        if ( objectType == MP2::OBJ_CASTLE || objectType == MP2::OBJ_HERO || objectType == MP2::OBJ_MONSTER ) {
-            excludeTiles.emplace( tileId );
+        if ( excludeTiles.count( tileId ) > 0 ) {
             continue;
         }
 
+        const MP2::MapObjectType objectType = tile.getMainObjectType( true );
+
         if ( MP2::isInGameActionObject( objectType ) ) {
-            if ( isTileBlockedForSettingMonster( vec_tiles, tileId, 3, excludeTiles ) ) {
+            if ( isTileBlockedForSettingMonster( tileId, 3, excludeTiles ) ) {
                 continue;
             }
 
@@ -591,7 +594,7 @@ void World::MonthOfMonstersAction( const Monster & mons )
             }
         }
         else if ( tile.isRoad() ) {
-            if ( isTileBlockedForSettingMonster( vec_tiles, tileId, 4, excludeTiles ) ) {
+            if ( isTileBlockedForSettingMonster( tileId, 4, excludeTiles ) ) {
                 continue;
             }
 
@@ -606,7 +609,7 @@ void World::MonthOfMonstersAction( const Monster & mons )
             }
         }
         else if ( isClearGround( tile ) ) {
-            if ( isTileBlockedForSettingMonster( vec_tiles, tileId, 4, excludeTiles ) ) {
+            if ( isTileBlockedForSettingMonster( tileId, 4, excludeTiles ) ) {
                 continue;
             }
 

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -445,7 +445,7 @@ private:
 
     void Defaults();
     void Reset();
-    void MonthOfMonstersAction( const Monster & mons );
+    void _monthOfMonstersAction( const Monster & mons );
     bool ProcessNewMP2Map( const std::string & filename, const bool checkPoLObjects );
     void PostLoad( const bool setTilePassabilities, const bool updateUidCounterToMaximum );
 


### PR DESCRIPTION
The issue is posted by @zenseii  here https://github.com/ihhub/fheroes2/pull/9888#pullrequestreview-2913306004 and here https://github.com/ihhub/fheroes2/pull/9888#issuecomment-2959143434

This PR make the "spawning" algorithm to skip tiles with event so the monster will not "overwrite" it.

It also updates initialization of `excludeTiles` set for Heroes, Castles and Monsters to exclude extra checks in `isTileBlockedForSettingMonster()`. It was done to avoid placing monster right near the hero when `findSuitableNeighbouringTile()` checks the bottom and left tiles (that were not previously checked to place them in `excludeTiles`).

Now all the map is checked for Heroes, Castles and Monsters first and only then the suitable tiles are found in the next loop.
