### PR TITLE
Fix generating buttons font when using non-English assets

### DIFF
--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -198,6 +198,10 @@ void Game::Init()
 
     AnimateDelaysInitialize();
 
+    // Update the fonts according to the game language set in the configuration.
+    Settings & conf = Settings::Get();
+    conf.setGameLanguage( conf.getGameLanguage() );
+
     HotKeysLoad( Settings::GetLastFile( "", "fheroes2.key" ) );
 }
 


### PR DESCRIPTION
When starting the fheroes2 engine it switches sometimes to English to properly load configuration data. And English is always considered as `original` because English characters are present in any other font and we don't need to reload them.
But if non-English assets are present the first set language after the engine was started is English: to load hotkeys configuration.
And switching back to non-English language that is equal to assets language will not force load of the button fonts because the engine has already load the `original` fonts.

This PR adds an extra `Settings::Get().setGameLanguage()` to set the currently set language and generate its fonts.

The added extra call should not slow down the game start because now (see #9798) we we do not re-generate fonts for the `original` language in `Settings::Get().setGameLanguage()` calls. And `original` language is English + language of the assets.