### PR TITLE
Update the GetEuclideanLine() code and use it also instead of GetLinePoints() function

### DIFF
--- a/src/engine/math_tools.h
+++ b/src/engine/math_tools.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2024                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -28,8 +28,7 @@
 namespace fheroes2
 {
     double GetAngle( const Point & start, const Point & target );
-    std::vector<Point> GetEuclideanLine( const Point & pt1, const Point & pt2, const uint32_t step );
-    std::vector<Point> GetLinePoints( const Point & pt1, const Point & pt2, const int32_t step );
+    std::vector<Point> getLinePoints( const Point & pt1, const Point & pt2, const uint32_t step );
     std::vector<Point> GetArcPoints( const Point & from, const Point & to, const int32_t arcHeight, const int32_t step );
     int32_t GetRectIndex( const std::vector<Rect> & rects, const Point & pt );
     Rect getBoundaryRect( const Rect & rt1, const Rect & rt2 );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -1388,7 +1388,7 @@ bool Battle::Arena::IsShootingPenalty( const Unit & attacker, const Unit & defen
     }
 
     // penalty does not apply if the target unit is exposed due to the broken castle wall
-    const std::vector<fheroes2::Point> points = GetLinePoints( attacker.GetBackPoint(), defender.GetBackPoint(), Cell::widthPx / 3 );
+    const std::vector<fheroes2::Point> points = getLinePoints( attacker.GetBackPoint(), defender.GetBackPoint(), Cell::widthPx / 3 );
 
     for ( std::vector<fheroes2::Point>::const_iterator it = points.begin(); it != points.end(); ++it ) {
         if ( ( 0 == board[CASTLE_FIRST_TOP_WALL_POS].GetObject() && ( board[CASTLE_FIRST_TOP_WALL_POS].GetPos() & *it ) )

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3565,7 +3565,7 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
     }
 
     // Lich/Power lich has projectile speed of 25
-    const std::vector<fheroes2::Point> points = GetEuclideanLine( startPos, endPos + endPosShift, isMage ? 50 : std::max( missile.width(), 25 ) );
+    const std::vector<fheroes2::Point> points = getLinePoints( startPos, endPos + endPosShift, isMage ? 50 : std::max( missile.width(), 25 ) );
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
     // For most shooting creatures we do not render the first missile position to better imitate start position change depending on shooting angle.
@@ -4282,7 +4282,7 @@ void Battle::Interface::RedrawActionFly( Unit & unit, const Position & pos )
     unit.SwitchAnimation( Monster_Info::MOVING );
     Game::setCustomUnitMovementDelay( frameDelay / unit.animation.animationLength() );
 
-    const std::vector<fheroes2::Point> points = GetEuclideanLine( destPos, targetPos, step );
+    const std::vector<fheroes2::Point> points = getLinePoints( destPos, targetPos, step );
     std::vector<fheroes2::Point>::const_iterator currentPoint = points.begin();
 
     Bridge * bridge = Arena::GetBridge();
@@ -5325,7 +5325,7 @@ void Battle::Interface::RedrawActionMirrorImageSpell( const Unit & target, const
     const fheroes2::Rect & rt1 = target.GetRectPosition();
     const fheroes2::Rect & rt2 = pos.GetRect();
 
-    const std::vector<fheroes2::Point> points = GetLinePoints( rt1.getPosition(), rt2.getPosition(), 5 );
+    const std::vector<fheroes2::Point> points = getLinePoints( rt1.getPosition(), rt2.getPosition(), 5 );
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
@@ -5633,7 +5633,7 @@ void Battle::Interface::RedrawRaySpell( const Unit & target, const int spellICN,
     const fheroes2::Point startingPos = arena.GetCurrentCommander() == _opponent1->GetHero() ? _opponent1->GetCastPosition() : _opponent2->GetCastPosition();
     const fheroes2::Point targetPos = target.GetCenterPoint();
 
-    const std::vector<fheroes2::Point> path = GetEuclideanLine( startingPos, targetPos, size );
+    const std::vector<fheroes2::Point> path = getLinePoints( startingPos, targetPos, size );
     const uint32_t spriteCount = fheroes2::AGG::GetICNCount( spellICN );
 
     cursor.SetThemes( Cursor::WAR_POINTER );


### PR DESCRIPTION
This PR updates the `GetEuclideanLine()` function to make it a bit clearer and to slishtly speed-up calculations.

`GetEuclideanLine()` and `GetLinePoints()` functions were done to get the same results: points on line between two given points with a given step. But `GetEuclideanLine()` calculates about 8 times faster (tested on release build with about 250 points to calculate)and gives more accurate result.
So the `GetLinePoints()` is removed in favor to `GetEuclideanLine()` which is now named `getLinePoints()` because this name more clearly tells whet the function is doing.