### PR TITLE
Bugfix: Force CMake to use v142 toolchain

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -73,6 +73,9 @@ jobs:
       run: |
         vcpkg.exe --triplet x64-windows install sdl2 sdl2-mixer sdl2-image zlib
     - name: Build
+      env:
+        CMAKE_GENERATOR: Visual Studio 17 2022
+        CMAKE_GENERATOR_TOOLSET: v142
       run: |
         cmake.exe -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_IMAGE=ON \
                            -DENABLE_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT\\scripts\\buildsystems\\vcpkg.cmake" \


### PR DESCRIPTION
There's an automated github action to build fheroes2 in debug mode using CMake on windows.
That build uses the v143 toolchain (Visual Studio 17 2022), whereas all other builds use the V142 toolchain (Visual Studio 16 2019).
An excert from the build log an arbitrary PR:
```shell
  cmake.exe -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_IMAGE=ON \
                     -DENABLE_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT\\scripts\\buildsystems\\vcpkg.cmake" \
                     -DVCPKG_TARGET_TRIPLET=x64-windows
  cmake.exe --build build --config Debug
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
-- Building for: Visual Studio 17 2022
-- The C compiler identification is MSVC 19.43.34808.0
-- The CXX compiler identification is MSVC 19.43.34808.0
```

This is because the windows runner on github has Visual Studio 17 2022 which uses v143 by default.
This PR specifies the v142 toolchain directly.

After the change:
```shell
cmake.exe -B build -DCMAKE_VERBOSE_MAKEFILE=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_IMAGE=ON \
                     -DENABLE_TOOLS=ON -DCMAKE_TOOLCHAIN_FILE="$VCPKG_INSTALLATION_ROOT\\scripts\\buildsystems\\vcpkg.cmake" \
                     -DVCPKG_TARGET_TRIPLET=x64-windows
  cmake.exe --build build --config Debug
  shell: C:\Program Files\Git\bin\bash.EXE --noprofile --norc -e -o pipefail {0}
  env:
    CMAKE_GENERATOR: Visual Studio 17 2022
    CMAKE_GENERATOR_TOOLSET: v142
-- Building for: Visual Studio 17 2022
-- The C compiler identification is MSVC 19.29.30158.0
-- The CXX compiler identification is MSVC 19.29.30158.0
```

Note: We still have to use VS 17 2022 because the runner doesn't have VS 16 2019. But the toolchain is what matters.