### PR TITLE
Improvement(Random): replace mt19937 with PCG32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,4 +102,3 @@ fheroes2.data
 fheroes2.js
 fheroes2.wasm
 fheroes2.wasm.map
-/.cache/clangd/index

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,4 @@ fheroes2.data
 fheroes2.js
 fheroes2.wasm
 fheroes2.wasm.map
+/.cache/clangd/index

--- a/src/engine/rand.cpp
+++ b/src/engine/rand.cpp
@@ -24,6 +24,7 @@
 #include "rand.h"
 
 #include <numeric>
+#include <random>
 
 namespace
 {

--- a/src/engine/rand.cpp
+++ b/src/engine/rand.cpp
@@ -29,12 +29,12 @@ namespace
 {
     // Implementation of Fast Random Integer Generation in an Interval (https://arxiv.org/abs/1805.10941)
     // NOTE: we can't use std::uniform_int_distribution here because it behaves differently on different platforms
-    uint32_t uniformIntInInterval( const uint32_t range, std::mt19937 & gen )
+    uint32_t uniformIntInInterval( const uint32_t range, Rand::PCG32 & gen )
     {
         assert( range > 0 );
 
         // Our implementation assumes our RNG can use the entire range of uint32_t
-        static_assert( std::mt19937::min() == 0 && std::mt19937::max() == std::numeric_limits<uint32_t>::max() );
+        static_assert( Rand::PCG32::min() == 0 && Rand::PCG32::max() == std::numeric_limits<uint32_t>::max() );
 
         uint32_t generated = gen();
         uint64_t mult = ( static_cast<uint64_t>( generated ) * range );
@@ -63,7 +63,7 @@ namespace
     }
 }
 
-uint32_t Rand::uniformIntDistribution( const uint32_t from, const uint32_t to, std::mt19937 & gen )
+uint32_t Rand::uniformIntDistribution( const uint32_t from, const uint32_t to, PCG32 & gen )
 {
     if ( from == to ) {
         return from;
@@ -73,7 +73,7 @@ uint32_t Rand::uniformIntDistribution( const uint32_t from, const uint32_t to, s
     const uint32_t rangeExclusive = to - from;
     // If the range is the entire uint32_t (from 0 to 2**32-1), we can just return a random number
     if ( rangeExclusive == std::numeric_limits<uint32_t>::max() ) {
-        static_assert( std::mt19937::min() == 0 && std::mt19937::max() == std::numeric_limits<uint32_t>::max() );
+        static_assert( PCG32::min() == 0 && PCG32::max() == std::numeric_limits<uint32_t>::max() );
 
         return gen();
     }
@@ -81,10 +81,10 @@ uint32_t Rand::uniformIntDistribution( const uint32_t from, const uint32_t to, s
     return from + uniformIntInInterval( rangeExclusive + 1, gen );
 }
 
-std::mt19937 & Rand::CurrentThreadRandomDevice()
+Rand::PCG32 & Rand::CurrentThreadRandomDevice()
 {
     thread_local std::random_device rd;
-    thread_local std::mt19937 gen( rd() );
+    thread_local PCG32 gen( rd );
 
     return gen;
 }
@@ -104,11 +104,11 @@ uint32_t Rand::GetWithSeed( uint32_t from, uint32_t to, uint32_t seed )
         std::swap( from, to );
     }
 
-    std::mt19937 seededGen( seed );
+    PCG32 seededGen( seed );
     return uniformIntDistribution( from, to, seededGen );
 }
 
-uint32_t Rand::GetWithGen( uint32_t from, uint32_t to, std::mt19937 & gen )
+uint32_t Rand::GetWithGen( uint32_t from, uint32_t to, PCG32 & gen )
 {
     if ( from > to ) {
         std::swap( from, to );

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -41,6 +41,7 @@ namespace Rand
 {
     class PCG32
     {
+    private:
         static constexpr uint64_t multiplier = 6364136223846793005ULL;
         static constexpr uint64_t defaultStream = 54ULL;
         static constexpr uint64_t defaultSeed = 42ULL;

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -33,7 +33,6 @@
 #include <functional>
 #include <iterator>
 #include <limits>
-#include <random>
 #include <type_traits>
 #include <utility>
 #include <vector>

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -113,10 +113,12 @@ namespace Rand
         uint64_t _increment;
     };
 
+    uint32_t uniformIntDistribution( const uint32_t from, const uint32_t to, PCG32 & gen );
+
     // Fisher-Yates shuffle AKA Knuth shuffle, probably the same as std::shuffle.
     // NOTE: we can't use std::shuffle here because it uses std::uniform_int_distribution which behaves differently on different platforms.
     template <class Iter>
-    void shuffle( Iter first, Iter last, std::mt19937 & gen )
+    void shuffle( Iter first, Iter last, PCG32 & gen )
     {
         if ( first == last ) {
             return;
@@ -142,7 +144,7 @@ namespace Rand
         }
     }
 
-    std::mt19937 & CurrentThreadRandomDevice();
+    PCG32 & CurrentThreadRandomDevice();
 
     uint32_t Get( uint32_t from, uint32_t to = 0 );
 
@@ -160,7 +162,7 @@ namespace Rand
         return static_cast<T>( GetWithSeed( static_cast<uint32_t>( from ), static_cast<uint32_t>( to ), seed ) );
     }
 
-    uint32_t GetWithGen( uint32_t from, uint32_t to, std::mt19937 & gen );
+    uint32_t GetWithGen( uint32_t from, uint32_t to, PCG32 & gen );
 
     template <typename T>
     void Shuffle( std::vector<T> & vec )
@@ -169,7 +171,7 @@ namespace Rand
     }
 
     template <typename T>
-    void ShuffleWithGen( std::vector<T> & vec, std::mt19937 & gen )
+    void ShuffleWithGen( std::vector<T> & vec, PCG32 & gen )
     {
         Rand::shuffle( vec.begin(), vec.end(), gen );
     }
@@ -184,7 +186,7 @@ namespace Rand
     }
 
     template <typename T>
-    const T & GetWithGen( const std::vector<T> & vec, std::mt19937 & gen )
+    const T & GetWithGen( const std::vector<T> & vec, PCG32 & gen )
     {
         assert( !vec.empty() );
 
@@ -248,7 +250,7 @@ namespace Rand
         const T & Get( const std::vector<T> & vec )
         {
             ++_currentSeed;
-            std::mt19937 seededGen( _currentSeed );
+            PCG32 seededGen( _currentSeed );
             return Rand::GetWithGen( vec, seededGen );
         }
 

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -93,6 +93,8 @@ namespace Rand
             : _state( 0 )
             , _increment( ( stream << 1U ) | 1U )
         {
+            // _increment must be odd
+            assert( _increment % 2 == 1 );
             advanceState();
             _state += seed;
             advanceState();

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -50,6 +50,11 @@ namespace Rand
             return ( value >> rotations ) | ( value << ( ( ~( rotations - 1 ) ) & 31 ) );
         }
 
+        // Defines a new templated false value to be used in static_assert
+        // See https://devblogs.microsoft.com/oldnewthing/20200311-00/?p=103553
+        template <typename T>
+        static constexpr bool alwaysFalseValue = false;
+
         template <typename Random>
         static uint64_t generateUInt64( Random & gen )
         {
@@ -61,8 +66,8 @@ namespace Rand
                 return gen();
             }
             else {
-                // Using !sizeof because static_assert( false ) is ill-formed in c++17
-                static_assert( !sizeof( Random ), "Unsupported random generator type" );
+                // Using alwaysFalseValue because static_assert( false ) is ill-formed in c++17
+                static_assert( alwaysFalseValue<Random>, "Unsupported random generator type" );
             }
         }
 

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -41,42 +41,6 @@ namespace Rand
 {
     class PCG32
     {
-    private:
-        static constexpr uint64_t multiplier = 6364136223846793005ULL;
-        static constexpr uint64_t defaultStream = 54ULL;
-        static constexpr uint64_t defaultSeed = 42ULL;
-
-        static constexpr uint32_t rotateRight( const uint32_t value, const uint32_t rotations )
-        {
-            return ( value >> rotations ) | ( value << ( ( ~( rotations - 1 ) ) & 31 ) );
-        }
-
-        // Defines a new templated false value to be used in static_assert
-        // See https://devblogs.microsoft.com/oldnewthing/20200311-00/?p=103553
-        template <typename T>
-        static constexpr bool alwaysFalseValue = false;
-
-        template <typename Random>
-        static uint64_t generateUInt64( Random & gen )
-        {
-            static_assert( Random::min() == std::numeric_limits<uint32_t>::min() );
-            if constexpr ( Random::max() == std::numeric_limits<uint32_t>::max() ) {
-                return static_cast<uint64_t>( gen() ) << 32 | static_cast<uint64_t>( gen() );
-            }
-            else if constexpr ( Random::max() == std::numeric_limits<uint64_t>::max() ) {
-                return gen();
-            }
-            else {
-                // Using alwaysFalseValue because static_assert( false ) is ill-formed in c++17
-                static_assert( alwaysFalseValue<Random>, "Unsupported random generator type" );
-            }
-        }
-
-        constexpr void advanceState()
-        {
-            _state = _state * multiplier + ( _increment | 1 );
-        }
-
     public:
         using result_type = uint32_t;
 
@@ -117,6 +81,41 @@ namespace Rand
         }
 
     private:
+        static constexpr uint64_t multiplier = 6364136223846793005ULL;
+        static constexpr uint64_t defaultStream = 54ULL;
+        static constexpr uint64_t defaultSeed = 42ULL;
+
+        static constexpr uint32_t rotateRight( const uint32_t value, const uint32_t rotations )
+        {
+            return ( value >> rotations ) | ( value << ( ( ~( rotations - 1 ) ) & 31 ) );
+        }
+
+        // Defines a new templated false value to be used in static_assert
+        // See https://devblogs.microsoft.com/oldnewthing/20200311-00/?p=103553
+        template <typename T>
+        static constexpr bool alwaysFalseValue = false;
+
+        template <typename Random>
+        static uint64_t generateUInt64( Random & gen )
+        {
+            static_assert( Random::min() == std::numeric_limits<uint32_t>::min() );
+            if constexpr ( Random::max() == std::numeric_limits<uint32_t>::max() ) {
+                return static_cast<uint64_t>( gen() ) << 32 | static_cast<uint64_t>( gen() );
+            }
+            else if constexpr ( Random::max() == std::numeric_limits<uint64_t>::max() ) {
+                return gen();
+            }
+            else {
+                // Using alwaysFalseValue because static_assert( false ) is ill-formed in c++17
+                static_assert( alwaysFalseValue<Random>, "Unsupported random generator type" );
+            }
+        }
+
+        constexpr void advanceState()
+        {
+            _state = _state * multiplier + ( _increment | 1 );
+        }
+
         uint64_t _state;
         uint64_t _increment;
     };

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -42,8 +42,6 @@ namespace Rand
     class PCG32
     {
     public:
-        using result_type = uint32_t;
-
         static constexpr uint32_t min()
         {
             return std::numeric_limits<uint32_t>::min();

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -61,7 +61,8 @@ namespace Rand
                 return gen();
             }
             else {
-                static_assert( false, "Unsupported random generator type" );
+                // Using !sizeof because static_assert( false ) is ill-formed in c++17
+                static_assert( !sizeof( Random ), "Unsupported random generator type" );
             }
         }
 

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -28,7 +28,6 @@
 #include <initializer_list>
 #include <map>
 #include <numeric>
-#include <random>
 #include <set>
 #include <stdexcept>
 #include <string>
@@ -221,7 +220,7 @@ namespace
     }
 
     void fillRandomPixelsFromImage( const fheroes2::Image & original, const fheroes2::Rect & originalRoi, fheroes2::Image & output, const fheroes2::Rect & outputRoi,
-                                    std::mt19937 & seededGen )
+                                    Rand::PCG32 & seededGen )
     {
         for ( int x = outputRoi.x; x < outputRoi.x + outputRoi.width; ++x ) {
             for ( int y = outputRoi.y; y < outputRoi.y + outputRoi.height; ++y ) {
@@ -4126,7 +4125,7 @@ namespace
                 Copy( image, 52, 100, image, 57, 100, 2, 1 );
 
                 // Generate programmatically the left part of the building.
-                std::mt19937 seededGen( 751 ); // 751 is and ID of this sprite. To keep the changes constant we need to hardcode this value.
+                Rand::PCG32 seededGen( 751 ); // 751 is and ID of this sprite. To keep the changes constant we need to hardcode this value.
 
                 fillRandomPixelsFromImage( image, { 33, 105, 4, 7 }, image, { 33, 117, 4, 39 }, seededGen );
                 fillRandomPixelsFromImage( image, { 41, 105, 5, 9 }, image, { 41, 121, 5, 36 }, seededGen );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -28,7 +28,6 @@
 #include <cmath>
 #include <map>
 #include <numeric>
-#include <random>
 #include <set>
 #include <sstream>
 #include <utility>
@@ -1923,7 +1922,7 @@ void Army::ArrangeForBattle( const Monster & monster, const uint32_t monstersCou
         stacksCount = maximumTroopCount;
     }
     else {
-        std::mt19937 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tileIndex ) );
+        Rand::PCG32 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tileIndex ) );
 
         stacksCount = Rand::GetWithGen( 3, 5, seededGen );
     }
@@ -1938,7 +1937,7 @@ void Army::ArrangeForBattle( const Monster & monster, const uint32_t monstersCou
         assert( troopToUpgrade != nullptr );
 
         if ( troopToUpgrade->isValid() && troopToUpgrade->isAllowUpgrade() ) {
-            std::mt19937 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tileIndex ) + static_cast<uint32_t>( monster.GetID() ) );
+            Rand::PCG32 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tileIndex ) + static_cast<uint32_t>( monster.GetID() ) );
 
             // 50% chance to get an upgraded stack
             if ( Rand::GetWithGen( 0, 1, seededGen ) == 1 ) {

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -31,7 +31,6 @@
 #include <map>
 #include <numeric>
 #include <ostream>
-#include <random>
 #include <type_traits>
 #include <utility>
 
@@ -118,7 +117,7 @@ namespace
         return *iter;
     }
 
-    int GetCovr( int ground, std::mt19937 & gen )
+    int GetCovr( int ground, Rand::PCG32 & gen )
     {
         std::vector<int> covrs;
         covrs.reserve( 6 );
@@ -425,7 +424,7 @@ Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const
     else
     // set obstacles
     {
-        std::mt19937 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tileIndex ) );
+        Rand::PCG32 seededGen( world.GetMapSeed() + static_cast<uint32_t>( tileIndex ) );
 
         _covrIcnId = Rand::GetWithGen( 0, 99, seededGen ) < 40 ? GetCovr( world.getTile( tileIndex ).GetGround(), seededGen ) : ICN::UNKNOWN;
 

--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -46,7 +46,7 @@
 
 namespace
 {
-    uint32_t GetRandomObstaclePosition( std::mt19937 & gen )
+    uint32_t GetRandomObstaclePosition( Rand::PCG32 & gen )
     {
         return Rand::GetWithGen( 2, 8, gen ) + ( 11 * Rand::GetWithGen( 0, 8, gen ) );
     }
@@ -378,7 +378,7 @@ bool Battle::Board::isMoatIndex( const int32_t index, const Unit & unit )
     return false;
 }
 
-void Battle::Board::SetCobjObjects( const Maps::Tile & tile, std::mt19937 & gen )
+void Battle::Board::SetCobjObjects( const Maps::Tile & tile, Rand::PCG32 & gen )
 {
     std::vector<int> objs;
 

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -30,11 +30,15 @@
 
 #include "battle_cell.h"
 #include "math_base.h"
-#include "rand.h"
 
 namespace Maps
 {
     class Tile;
+}
+
+namespace Rand
+{
+    class PCG32;
 }
 
 namespace Battle

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -30,7 +30,7 @@
 
 #include "battle_cell.h"
 #include "math_base.h"
-#include <rand.h>
+#include "rand.h"
 
 namespace Maps
 {

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -25,12 +25,12 @@
 
 #include <algorithm>
 #include <cstdint>
-#include <random>
 #include <string>
 #include <vector>
 
 #include "battle_cell.h"
 #include "math_base.h"
+#include <rand.h>
 
 namespace Maps
 {
@@ -74,7 +74,7 @@ namespace Battle
         int32_t GetIndexAbsPosition( const fheroes2::Point & ) const;
         std::vector<Unit *> GetNearestTroops( const Unit * startUnit, const std::vector<Unit *> & blackList );
 
-        void SetCobjObjects( const Maps::Tile & tile, std::mt19937 & gen );
+        void SetCobjObjects( const Maps::Tile & tile, Rand::PCG32 & gen );
         void SetCovrObjects( int icn );
 
         static std::string GetMoatInfo();

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -29,7 +29,6 @@
 #include <limits>
 #include <optional>
 #include <ostream>
-#include <random>
 #include <set>
 #include <tuple>
 
@@ -75,7 +74,7 @@ namespace
         return std::any_of( indexes.cbegin(), indexes.cend(), [&excludeTiles]( const int32_t indexId ) { return excludeTiles.count( indexId ) > 0; } );
     }
 
-    int32_t findSuitableNeighbouringTile( const std::vector<Maps::Tile> & mapTiles, const int32_t tileId, const bool allDirections, std::mt19937 & gen )
+    int32_t findSuitableNeighbouringTile( const std::vector<Maps::Tile> & mapTiles, const int32_t tileId, const bool allDirections, Rand::PCG32 & gen )
     {
         std::vector<int32_t> suitableIds;
 
@@ -558,7 +557,7 @@ void World::_monthOfMonstersAction( const Monster & mons )
 
     std::set<int32_t> excludeTiles;
 
-    std::mt19937 seededGen( _seed + month );
+    Rand::PCG32 seededGen( _seed + month );
 
     // First we scan for Heroes, Castles and Monsters to exclude these from tiles and nearby tiles.
     // We must do this prior to checking the possibility for a monster to spawn in order to properly perform the check on nearby tiles.


### PR DESCRIPTION
Addresses performance issues raised in #9867 

- implements PCG32 random engine
- replaces mt19937 with PCG32 random engine

Doesn't address other performance issues (Not reusing random engine)

✅ No external dependencies
✅ Fixes seeding issues of mt19937 (only 2<sup>32</sup> possible seeds out of only 2<sup>19937</sup>)
✅ State reduced from 5000 bytes to 16 bytes
❔ Possible speed boost (haven't measured)

Note:
There is some performance to be gained by further optimizing `PCG32::rotateRight` but I'm not sure it's worth the hassle.
The operation should be compiled to a `rotr` instruction but compilers don't seem to agree with me.
c++20 has builtin std::rotr which should be faster but not available in c++17.

Possibilities:
- use _rotr instrinsic on MSVC. This may require either giving up on constexpr, or using a small hack to implement is_consteval_evaluated (available only in c++20).
- use inline assembly in gcc x64 builds. Fairly straightforward as I have a reference. May need to giveup on constexpr or use the internal __builtin_constant_p.
- Not sure if I know how to optimize on CLANG or on ARM targets