### PR TITLE
Update hashes for Android & Windows dependency packages

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 plugins {
-    id 'com.android.application' version '8.10.0' apply false
-    id 'com.android.library' version '8.10.0' apply false
+    id 'com.android.application' version '8.10.1' apply false
+    id 'com.android.library' version '8.10.1' apply false
 }

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=09624282AEAA4C41A35E51A3A426E7E8CF469C64BC1003AE5E6BFE16DC395D5B
+set PKG_FILE_SHA256=FEA2A2CBA95F935217A21539C6BF456DE2634A7B25B7197084002FF7DD2D5EFD
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -23,7 +23,7 @@
 set -e -o pipefail
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="09624282aeaa4c41a35e51a3a426e7e8cf469c64bc1003ae5e6bfe16dc395d5b"
+PKG_FILE_SHA256="fea2a2cba95f935217a21539c6bf456de2634a7b25b7197084002ff7dd2d5efd"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=5024A2F8747D593BDC9035F1A0E94ADF228DBBC8EF4DDEE6BF62F0D1AEEAFB24
+set PKG_FILE_SHA256=0084C38FEE4700A09599A39B1FB1EDC9FFFF40AB886F03F00DC847ABFF26978A
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
See https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/63 for details.

Also this PR updates AGP to 8.10.1.