### PR TITLE
Fix assert in rand.h that always fails on 32bit systems

### DIFF
--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -58,7 +58,9 @@ namespace Rand
         const typename std::iterator_traits<Iter>::difference_type interval = last - first;
 
         // Our implementation doesn't work for intervals bigger than 2**32 - 1
-        assert( interval <= static_cast<typename std::iterator_traits<Iter>::difference_type>( std::numeric_limits<uint32_t>::max() ) );
+        if constexpr (sizeof(interval) > sizeof(uint32_t)) {
+            assert( interval <= static_cast<typename std::iterator_traits<Iter>::difference_type>( std::numeric_limits<uint32_t>::max() ) );
+        }
 
         uint32_t remainingSwaps = static_cast<uint32_t>( interval );
         while ( remainingSwaps > 0 ) {

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -58,7 +58,7 @@ namespace Rand
         const typename std::iterator_traits<Iter>::difference_type interval = last - first;
 
         // Our implementation doesn't work for intervals bigger than 2**32 - 1
-        if constexpr (sizeof(interval) > sizeof(uint32_t)) {
+        if constexpr ( sizeof( interval ) > sizeof( uint32_t ) ) {
             assert( interval <= static_cast<typename std::iterator_traits<Iter>::difference_type>( std::numeric_limits<uint32_t>::max() ) );
         }
 


### PR DESCRIPTION
On 32bit systems `static_cast<std::ptrdiff_t>(std::numeric_limits<uint32_t>)::max()` returns a negative number and this assert always fails.