### PR TITLE
Fix placing objects that overlaps the flag of already placed object and fix erasure of object by clicking on its flag

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -628,8 +628,8 @@ int Maps::Tile::getTileIndependentPassability() const
     int passability = DIRECTION_ALL;
 
     const auto getObjectPartPassability = []( const Maps::ObjectPart & part, bool & isActionObject ) {
-        if ( part.icnType == MP2::OBJ_ICN_TYPE_ROAD || part.icnType == MP2::OBJ_ICN_TYPE_STREAM ) {
-            // Rivers and stream are completely passable.
+        if ( part.icnType == MP2::OBJ_ICN_TYPE_ROAD || part.icnType == MP2::OBJ_ICN_TYPE_STREAM || part.icnType == MP2::OBJ_ICN_TYPE_FLAG32 ) {
+            // Rivers, streams and flags are completely passable.
             return DIRECTION_ALL;
         }
 
@@ -781,13 +781,13 @@ void Maps::Tile::updatePassability()
         return;
     }
 
-    // Count how many objects are there excluding shadows, roads and river streams.
+    // Count how many objects are there excluding shadows, roads, river streams and flags.
     const std::ptrdiff_t validBottomLayerObjects = std::count_if( _groundObjectPart.begin(), _groundObjectPart.end(), []( const auto & part ) {
         if ( isObjectPartShadow( part ) ) {
             return false;
         }
 
-        return part.icnType != MP2::OBJ_ICN_TYPE_ROAD && part.icnType != MP2::OBJ_ICN_TYPE_STREAM;
+        return part.icnType != MP2::OBJ_ICN_TYPE_ROAD && part.icnType != MP2::OBJ_ICN_TYPE_STREAM && part.icnType != MP2::OBJ_ICN_TYPE_FLAG32;
     } );
 
     const bool singleObjectTile = ( validBottomLayerObjects == 0 ) && _topObjectPart.empty() && ( bottomTile._mainObjectPart.icnType != _mainObjectPart.icnType );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -894,6 +894,18 @@ void Maps::Tile::sortObjectParts()
 
     if ( !_groundObjectPart.empty() ) {
         ObjectPart & highestPriorityPart = _groundObjectPart.back();
+
+        if ( highestPriorityPart.icnType == MP2::OBJ_ICN_TYPE_FLAG32 ) {
+            // Flags are not allowed to be the main object because they belong to other object.
+            if ( _groundObjectPart.size() == 1 ) {
+                return;
+            }
+
+            // Replace the last object (Flag) with the previous one.
+            ObjectPart & prevHighestPriorityPart = *std::next( _groundObjectPart.rbegin() );
+            std::swap( highestPriorityPart, prevHighestPriorityPart );
+        }
+
         std::swap( highestPriorityPart, _mainObjectPart );
 
         // If this assertion blows up then you are not storing correct values for layer type!

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -29,7 +29,6 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
-#include <iterator>
 #include <limits>
 #include <set>
 #include <sstream>

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -29,6 +29,7 @@
 #include <cassert>
 #include <cstdint>
 #include <cstdlib>
+#include <iterator>
 #include <limits>
 #include <set>
 #include <sstream>
@@ -903,6 +904,10 @@ void Maps::Tile::sortObjectParts()
 
             // Replace the last object (Flag) with the previous one.
             ObjectPart & prevHighestPriorityPart = *std::next( _groundObjectPart.rbegin() );
+
+            // There cannot be two flags on one tile.
+            assert( prevHighestPriorityPart.icnType != MP2::OBJ_ICN_TYPE_FLAG32 );
+
             std::swap( highestPriorityPart, prevHighestPriorityPart );
         }
 

--- a/src/fheroes2/maps/maps_tiles_helper.cpp
+++ b/src/fheroes2/maps/maps_tiles_helper.cpp
@@ -2314,7 +2314,7 @@ namespace Maps
                 }
 
                 for ( const auto & part : currentTile.getGroundObjectParts() ) {
-                    if ( part._uid != 0 && ( part.layerType != SHADOW_LAYER ) ) {
+                    if ( part._uid != 0 && ( part.layerType != SHADOW_LAYER ) && part.icnType != MP2::OBJ_ICN_TYPE_FLAG32 ) {
                         objectsUids.insert( part._uid );
                     }
                 }


### PR DESCRIPTION
The issue found by **Moucheron Quipet** on Discord:
"On the editor, trying to place a lighthouse next to a pre-flagged one cause this error to happen :
![img](https://github.com/user-attachments/assets/c995f289-0dfe-4f66-a9c4-3cbc501e57de) ![img](https://github.com/user-attachments/assets/38357b91-9dbb-49f3-9de4-7223deb3f6f6) "

This PR fixes the behavior of objects sorting on a tile (it is done when placing a new object).
Now if the Flag is found in the ground objects it will not be moved to the main object part.

This PR also fixes the incorrect erasure of an object (Lighthouse) if you click on a flag near it.