### PR TITLE
Fix passabilites update after map erasing an object in Editor

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -481,6 +481,11 @@ namespace
             assert( 0 );
         }
 
+        if ( needRedraw ) {
+            // Some object(s) is removed. Update the map passabilities.
+            world.updatePassabilities();
+        }
+
         return needRedraw;
     }
 

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -481,11 +481,6 @@ namespace
             assert( 0 );
         }
 
-        if ( needRedraw ) {
-            // Some object(s) is removed. Update the map passabilities.
-            world.updatePassabilities();
-        }
-
         return needRedraw;
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1444,7 +1444,7 @@ bool Maps::Tile::removeObjectPartsByUID( const uint32_t objectUID )
         updatePassability();
 
         // The remove of the object part may also affect on the passability on the tiles around.
-        for ( int32_t tileIndex : getAroundIndexes( _index, 1 ) ) {
+        for ( const int32_t tileIndex : getAroundIndexes( _index, 1 ) ) {
             Tile & tile = world.getTile( tileIndex );
             tile.setInitialPassability();
             tile.updatePassability();

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1443,6 +1443,13 @@ bool Maps::Tile::removeObjectPartsByUID( const uint32_t objectUID )
         setInitialPassability();
         updatePassability();
 
+        // The remove of the object part may also affect on the passability on the tiles around.
+        for ( int32_t tileIndex : getAroundIndexes( _index, 1 ) ) {
+            Tile & tile = world.getTile( tileIndex );
+            tile.setInitialPassability();
+            tile.updatePassability();
+        }
+
         if ( Heroes::isValidId( _occupantHeroId ) ) {
             Heroes * hero = world.GetHeroes( _occupantHeroId );
             if ( hero != nullptr ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1441,13 +1441,18 @@ bool Maps::Tile::removeObjectPartsByUID( const uint32_t objectUID )
         updateObjectType();
 
         setInitialPassability();
-        updatePassability();
 
         // The remove of the object part may also affect on the passability on the tiles around.
-        for ( const int32_t tileIndex : getAroundIndexes( _index, 1 ) ) {
-            Tile & tile = world.getTile( tileIndex );
-            tile.setInitialPassability();
-            tile.updatePassability();
+        // First set the initial passability for tiles.
+        const Indexes tilesAround = getAroundIndexes( _index, 1 );
+        for ( const int32_t tileIndex : tilesAround ) {
+            world.getTile( tileIndex ).setInitialPassability();
+        }
+
+        // Update passability based on initial passability.
+        updatePassability();
+        for ( const int32_t tileIndex : tilesAround ) {
+            world.getTile( tileIndex ).updatePassability();
         }
 
         if ( Heroes::isValidId( _occupantHeroId ) ) {


### PR DESCRIPTION
fix #9935 

When removing an object part from the tile we need to update passabilities not only in that tile but also in the tiles around.