### PR TITLE
Replace DeterministicRandomGenerator with PCG32

### DIFF
--- a/src/engine/rand.cpp
+++ b/src/engine/rand.cpp
@@ -142,23 +142,3 @@ int32_t Rand::Queue::Get( const std::function<uint32_t( uint32_t )> & randomFunc
 
     return 0;
 }
-
-Rand::DeterministicRandomGenerator::DeterministicRandomGenerator( const uint32_t initialSeed )
-    : _currentSeed( initialSeed )
-{}
-
-uint32_t Rand::DeterministicRandomGenerator::GetSeed() const
-{
-    return _currentSeed;
-}
-
-void Rand::DeterministicRandomGenerator::UpdateSeed( const uint32_t seed )
-{
-    _currentSeed = seed;
-}
-
-uint32_t Rand::DeterministicRandomGenerator::Get( const uint32_t from, const uint32_t to /* = 0 */ )
-{
-    ++_currentSeed;
-    return Rand::GetWithSeed( from, to, _currentSeed );
-}

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -256,30 +256,4 @@ namespace Rand
     private:
         int32_t Get( const std::function<uint32_t( uint32_t )> & randomFunc ) const;
     };
-
-    // Specific random generator that keeps and update its state
-    class DeterministicRandomGenerator
-    {
-    public:
-        explicit DeterministicRandomGenerator( const uint32_t initialSeed );
-        DeterministicRandomGenerator( const DeterministicRandomGenerator & ) = delete;
-
-        DeterministicRandomGenerator & operator=( const DeterministicRandomGenerator & ) = delete;
-
-        uint32_t GetSeed() const;
-        void UpdateSeed( const uint32_t seed );
-
-        uint32_t Get( const uint32_t from, const uint32_t to = 0 );
-
-        template <typename T>
-        const T & Get( const std::vector<T> & vec )
-        {
-            ++_currentSeed;
-            PCG32 seededGen( _currentSeed );
-            return Rand::GetWithGen( vec, seededGen );
-        }
-
-    private:
-        uint32_t _currentSeed;
-    };
 }

--- a/src/engine/rand.h
+++ b/src/engine/rand.h
@@ -37,6 +37,14 @@
 #include <utility>
 #include <vector>
 
+namespace
+{
+    constexpr uint64_t makeOdd( const uint64_t value )
+    {
+        return ( value << 1U ) | 1U;
+    }
+}
+
 namespace Rand
 {
     class PCG32
@@ -59,7 +67,7 @@ namespace Rand
 
         explicit constexpr PCG32( const uint64_t seed = defaultSeed, const uint64_t stream = defaultStream )
             : _state( 0 )
-            , _increment( ( stream << 1U ) | 1U )
+            , _increment( makeOdd( stream ) )
         {
             // _increment must be odd
             assert( _increment % 2 == 1 );
@@ -76,6 +84,16 @@ namespace Rand
             const uint32_t xorShifted = static_cast<uint32_t>( ( ( prevState >> 18U ) ^ prevState ) >> 27U );
             const uint32_t rotations = prevState >> 59U;
             return rotateRight( xorShifted, rotations );
+        }
+
+        constexpr uint64_t getStream() const
+        {
+            return _increment;
+        }
+
+        constexpr void setStream( const uint64_t stream )
+        {
+            _increment = makeOdd( stream );
         }
 
     private:

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -258,7 +258,7 @@ void Battle::Arena::BattleProcess( Unit & attacker, Unit & defender, int32_t tgt
             // The built-in spell can only be applied to one target. If there are multiple
             // targets eligible for this spell, then we should randomly select only one.
             if ( spellTargets.size() > 1 ) {
-                const Unit * selectedUnit = _randomGenerator.Get( spellTargets ).defender;
+                const Unit * selectedUnit = Rand::GetWithGen( spellTargets, _randomGenerator ).defender;
 
                 spellTargets.erase( std::remove_if( spellTargets.begin(), spellTargets.end(),
                                                     [selectedUnit]( const TargetInfo & v ) { return v.defender != selectedUnit; } ),
@@ -908,7 +908,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForDamage( const Unit & attacker, U
         if ( const auto abilityIter = std::find( attackerAbilities.begin(), attackerAbilities.end(), fheroes2::MonsterAbilityType::ENEMY_HALVING );
              abilityIter != attackerAbilities.end() ) {
             const uint32_t halvingDamage = ( defender.GetCount() / 2 + defender.GetCount() % 2 ) * defender.Monster::GetHitPoints();
-            if ( halvingDamage > res.damage && _randomGenerator.Get( 1, 100 ) <= abilityIter->percentage ) {
+            if ( halvingDamage > res.damage && Rand::GetWithGen( 1, 100, _randomGenerator ) <= abilityIter->percentage ) {
                 // Replaces damage, not adds extra damage
                 res.damage = std::min( defender.GetHitPoints(), halvingDamage );
 
@@ -1008,7 +1008,7 @@ std::vector<Battle::Unit *> Battle::Arena::FindChainLightningTargetIndexes( cons
             const uint32_t resist = foundTroops[i]->GetMagicResist( Spell::CHAINLIGHTNING, hero );
             assert( resist < 100 );
 
-            if ( !applyRandomMagicResistance || resist < _randomGenerator.Get( 1, 100 ) ) {
+            if ( !applyRandomMagicResistance || resist < Rand::GetWithGen( 1, 100, _randomGenerator ) ) {
                 ignoredTroops.push_back( foundTroops[i] );
                 result.push_back( foundTroops[i] );
                 foundTroops.erase( foundTroops.begin() + i );
@@ -1044,7 +1044,7 @@ Battle::TargetsInfo Battle::Arena::TargetsForChainLightning( const HeroBase * he
 
     const uint32_t firstUnitResist = unit->GetMagicResist( Spell::CHAINLIGHTNING, hero );
 
-    if ( firstUnitResist >= 100 || ( applyRandomMagicResistance && firstUnitResist >= _randomGenerator.Get( 1, 100 ) ) ) {
+    if ( firstUnitResist >= 100 || ( applyRandomMagicResistance && firstUnitResist >= Rand::GetWithGen( 1, 100, _randomGenerator ) ) ) {
         targets.emplace_back();
         TargetInfo & res = targets.back();
         res.defender = unit;
@@ -1190,7 +1190,7 @@ Battle::TargetsInfo Battle::Arena::GetTargetsForSpell( const HeroBase * hero, co
         const uint32_t resist = tgt.defender->GetMagicResist( spell, hero );
         assert( resist < 100 );
 
-        if ( applyRandomMagicResistance && resist >= _randomGenerator.Get( 1, 100 ) ) {
+        if ( applyRandomMagicResistance && resist >= Rand::GetWithGen( 1, 100, _randomGenerator ) ) {
             tgt.resist = true;
         }
     }
@@ -1561,11 +1561,11 @@ void Battle::Arena::_applyActionSpellEarthquake()
             // Reduce the chance of bridge demolition by an extra 50% chance to "miss" it by the Earthquake spell.
             // It is done to be closer to the original game behavior where bridge demolition by this spell
             // is more rare than the demolition of the other structures.
-            if ( target == CastleDefenseStructure::BRIDGE && _randomGenerator.Get( 0, 1 ) == 0 ) {
+            if ( target == CastleDefenseStructure::BRIDGE && Rand::GetWithGen( 0, 1, _randomGenerator ) == 0 ) {
                 return 0;
             }
 
-            return static_cast<int>( _randomGenerator.Get( minDmg, maxDmg ) );
+            return static_cast<int>( Rand::GetWithGen( minDmg, maxDmg, _randomGenerator ) );
         }();
         assert( damage >= 0 );
 

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <iterator>
 #include <limits>
 #include <map>
@@ -343,7 +344,7 @@ bool Battle::Arena::isAnyTowerPresent()
     return std::any_of( arena->_towers.begin(), arena->_towers.end(), []( const auto & twr ) { return twr && twr->isValid(); } );
 }
 
-Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const bool isShowInterface, Rand::DeterministicRandomGenerator & randomGenerator )
+Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const bool isShowInterface, Rand::PCG32 & randomGenerator )
     : castle( world.getCastleEntrance( Maps::GetPoint( tileIndex ) ) )
     , _isTown( castle != nullptr )
     , _randomGenerator( randomGenerator )
@@ -514,9 +515,9 @@ void Battle::Arena::UnitTurn( const Units & orderHistory )
             }
         }
 
-        const uint32_t newSeed = std::accumulate( actions.cbegin(), actions.cend(), _randomGenerator.GetSeed(),
+        const uint32_t newSeed = std::accumulate( actions.cbegin(), actions.cend(), static_cast<uint32_t>( _randomGenerator.getStream() ),
                                                   []( const uint32_t seed, const Command & cmd ) { return cmd.updateSeed( seed ); } );
-        _randomGenerator.UpdateSeed( newSeed );
+        _randomGenerator.setStream( newSeed );
 
         while ( !actions.empty() ) {
             ApplyAction( actions.front() );

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -48,7 +48,7 @@ class HeroBase;
 
 namespace Rand
 {
-    class DeterministicRandomGenerator;
+    class PCG32;
 }
 
 namespace Battle
@@ -93,7 +93,7 @@ namespace Battle
     class Arena
     {
     public:
-        Arena( Army & army1, Army & army2, const int32_t tileIndex, const bool isShowInterface, Rand::DeterministicRandomGenerator & randomGenerator );
+        Arena( Army & army1, Army & army2, const int32_t tileIndex, const bool isShowInterface, Rand::PCG32 & randomGenerator );
         Arena( const Arena & ) = delete;
         Arena( Arena && ) = delete;
 
@@ -363,7 +363,7 @@ namespace Battle
         // places (for example, in code that performs situation assessment or AI decision-making) because in this
         // case the battles performed by AI will not be reproducible by a human player when performing exactly the
         // same actions.
-        Rand::DeterministicRandomGenerator & _randomGenerator;
+        Rand::PCG32 & _randomGenerator;
 
         TroopsUidGenerator _uidGenerator;
 

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -66,9 +66,9 @@ Battle::Catapult::Catapult( const HeroBase & hero )
     catShots += hero.GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::EXTRA_CATAPULT_SHOTS );
 }
 
-int Battle::Catapult::GetDamage( Rand::DeterministicRandomGenerator & randomGenerator ) const
+int Battle::Catapult::GetDamage( Rand::PCG32 & randomGenerator ) const
 {
-    if ( doubleDamageChance == 100 || doubleDamageChance >= randomGenerator.Get( 1, 100 ) ) {
+    if ( doubleDamageChance == 100 || doubleDamageChance >= Rand::GetWithGen( 1, 100, randomGenerator ) ) {
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "Catapult dealt double damage! (" << doubleDamageChance << "% chance)" )
         return 2;
     }
@@ -114,8 +114,7 @@ fheroes2::Point Battle::Catapult::GetTargetPosition( const CastleDefenseStructur
     return {};
 }
 
-Battle::CastleDefenseStructure Battle::Catapult::GetTarget( const std::map<CastleDefenseStructure, int> & stateOfCatapultTargets,
-                                                            Rand::DeterministicRandomGenerator & randomGenerator )
+Battle::CastleDefenseStructure Battle::Catapult::GetTarget( const std::map<CastleDefenseStructure, int> & stateOfCatapultTargets, Rand::PCG32 & randomGenerator )
 {
     const auto checkTargetState = [&stateOfCatapultTargets]( const CastleDefenseStructure target ) {
         const auto iter = stateOfCatapultTargets.find( target );
@@ -166,7 +165,7 @@ Battle::CastleDefenseStructure Battle::Catapult::GetTarget( const std::map<Castl
     }
 
     if ( !targets.empty() ) {
-        return randomGenerator.Get( targets );
+        return Rand::GetWithGen( targets, randomGenerator );
     }
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "no target was found" )
@@ -174,8 +173,8 @@ Battle::CastleDefenseStructure Battle::Catapult::GetTarget( const std::map<Castl
     return CastleDefenseStructure::NONE;
 }
 
-bool Battle::Catapult::IsNextShotHit( Rand::DeterministicRandomGenerator & randomGenerator ) const
+bool Battle::Catapult::IsNextShotHit( Rand::PCG32 & randomGenerator ) const
 {
     // Miss chance is 25%
-    return !( canMiss && randomGenerator.Get( 1, 20 ) < 6 );
+    return !( canMiss && Rand::GetWithGen( 1, 20, randomGenerator ) < 6 );
 }

--- a/src/fheroes2/battle/battle_catapult.cpp
+++ b/src/fheroes2/battle/battle_catapult.cpp
@@ -176,5 +176,5 @@ Battle::CastleDefenseStructure Battle::Catapult::GetTarget( const std::map<Castl
 bool Battle::Catapult::IsNextShotHit( Rand::PCG32 & randomGenerator ) const
 {
     // Miss chance is 25%
-    return !( canMiss && Rand::GetWithGen( 1, 20, randomGenerator ) < 6 );
+    return !canMiss || Rand::GetWithGen( 1, 20, randomGenerator ) >= 6;
 }

--- a/src/fheroes2/battle/battle_catapult.h
+++ b/src/fheroes2/battle/battle_catapult.h
@@ -34,7 +34,7 @@ class HeroBase;
 
 namespace Rand
 {
-    class DeterministicRandomGenerator;
+    class PCG32;
 }
 
 namespace Battle
@@ -48,8 +48,7 @@ namespace Battle
         Catapult & operator=( const Catapult & ) = delete;
 
         static const std::vector<CastleDefenseStructure> & getAllowedTargets();
-        static CastleDefenseStructure GetTarget( const std::map<CastleDefenseStructure, int> & stateOfCatapultTargets,
-                                                 Rand::DeterministicRandomGenerator & randomGenerator );
+        static CastleDefenseStructure GetTarget( const std::map<CastleDefenseStructure, int> & stateOfCatapultTargets, Rand::PCG32 & randomGenerator );
         static fheroes2::Point GetTargetPosition( const CastleDefenseStructure target, const bool hit );
 
         uint32_t GetShots() const
@@ -57,8 +56,8 @@ namespace Battle
             return catShots;
         }
 
-        int GetDamage( Rand::DeterministicRandomGenerator & randomGenerator ) const;
-        bool IsNextShotHit( Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        int GetDamage( Rand::PCG32 & randomGenerator ) const;
+        bool IsNextShotHit( Rand::PCG32 & randomGenerator ) const;
 
     private:
         uint32_t catShots;

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -174,7 +174,7 @@ namespace
         return 0;
     }
 
-    void eagleEyeSkillAction( HeroBase & hero, const SpellStorage & spells, bool local, Rand::DeterministicRandomGenerator & randomGenerator )
+    void eagleEyeSkillAction( HeroBase & hero, const SpellStorage & spells, bool local, Rand::PCG32 & randomGenerator )
     {
         if ( spells.empty() || !hero.HaveSpellBook() )
             return;
@@ -193,17 +193,17 @@ namespace
             switch ( eagleeye.Level() ) {
             case Skill::Level::BASIC:
                 // 20%
-                if ( 3 > sp.Level() && eagleeye.GetValue() >= randomGenerator.Get( 1, 100 ) )
+                if ( 3 > sp.Level() && eagleeye.GetValue() >= Rand::GetWithGen( 1, 100, randomGenerator ) )
                     new_spells.push_back( sp );
                 break;
             case Skill::Level::ADVANCED:
                 // 30%
-                if ( 4 > sp.Level() && eagleeye.GetValue() >= randomGenerator.Get( 1, 100 ) )
+                if ( 4 > sp.Level() && eagleeye.GetValue() >= Rand::GetWithGen( 1, 100, randomGenerator ) )
                     new_spells.push_back( sp );
                 break;
             case Skill::Level::EXPERT:
                 // 40%
-                if ( 5 > sp.Level() && eagleeye.GetValue() >= randomGenerator.Get( 1, 100 ) )
+                if ( 5 > sp.Level() && eagleeye.GetValue() >= Rand::GetWithGen( 1, 100, randomGenerator ) )
                     new_spells.push_back( sp );
                 break;
             default:
@@ -380,7 +380,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
     const uint32_t battleSeed = computeBattleSeed( mapsindex, world.GetMapSeed(), army1, army2 );
 
     while ( true ) {
-        Rand::DeterministicRandomGenerator randomGenerator( battleSeed );
+        Rand::PCG32 randomGenerator( battleSeed );
         Arena arena( army1, army2, mapsindex, showBattle, randomGenerator );
 
         DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army1 " << army1.String() )

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -305,11 +305,8 @@ void Battle::Unit::SetRandomMorale( Rand::PCG32 & randomGenerator )
         SetModes( MORALE_GOOD );
     }
     else if ( morale < 0 && static_cast<int>( Rand::GetWithGen( 1, 12, randomGenerator ) ) <= -morale ) {
-        if ( isControlHuman() ) {
-            SetModes( MORALE_BAD );
-        }
         // AI is given a cheeky 25% chance to avoid it - because they build armies from random troops
-        else if ( Rand::GetWithGen( 1, 4, randomGenerator ) != 1 ) {
+        if ( isControlHuman() || ( Rand::GetWithGen( 1, 4, randomGenerator ) != 1 ) ) {
             SetModes( MORALE_BAD );
         }
     }

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -297,28 +297,28 @@ int32_t Battle::Unit::GetTailIndex() const
     return _position.GetTail() ? _position.GetTail()->GetIndex() : -1;
 }
 
-void Battle::Unit::SetRandomMorale( Rand::DeterministicRandomGenerator & randomGenerator )
+void Battle::Unit::SetRandomMorale( Rand::PCG32 & randomGenerator )
 {
     const int morale = GetMorale();
 
-    if ( morale > 0 && static_cast<int>( randomGenerator.Get( 1, 24 ) ) <= morale ) {
+    if ( morale > 0 && static_cast<int>( Rand::GetWithGen( 1, 24, randomGenerator ) ) <= morale ) {
         SetModes( MORALE_GOOD );
     }
-    else if ( morale < 0 && static_cast<int>( randomGenerator.Get( 1, 12 ) ) <= -morale ) {
+    else if ( morale < 0 && static_cast<int>( Rand::GetWithGen( 1, 12, randomGenerator ) ) <= -morale ) {
         if ( isControlHuman() ) {
             SetModes( MORALE_BAD );
         }
         // AI is given a cheeky 25% chance to avoid it - because they build armies from random troops
-        else if ( randomGenerator.Get( 1, 4 ) != 1 ) {
+        else if ( Rand::GetWithGen( 1, 4, randomGenerator ) != 1 ) {
             SetModes( MORALE_BAD );
         }
     }
 }
 
-void Battle::Unit::SetRandomLuck( Rand::DeterministicRandomGenerator & randomGenerator )
+void Battle::Unit::SetRandomLuck( Rand::PCG32 & randomGenerator )
 {
     const int32_t luck = GetLuck();
-    const int32_t chance = static_cast<int32_t>( randomGenerator.Get( 1, 24 ) );
+    const int32_t chance = static_cast<int32_t>( Rand::GetWithGen( 1, 24, randomGenerator ) );
 
     if ( luck > 0 && chance <= luck ) {
         SetModes( LUCK_GOOD );
@@ -576,7 +576,7 @@ uint32_t Battle::Unit::CalculateDamageUnit( const Unit & enemy, double dmg ) con
     return std::max( fheroes2::checkedCast<uint32_t>( dmg ).value(), 1U );
 }
 
-uint32_t Battle::Unit::GetDamage( const Unit & enemy, Rand::DeterministicRandomGenerator & randomGenerator ) const
+uint32_t Battle::Unit::GetDamage( const Unit & enemy, Rand::PCG32 & randomGenerator ) const
 {
     uint32_t res = 0;
 
@@ -587,7 +587,7 @@ uint32_t Battle::Unit::GetDamage( const Unit & enemy, Rand::DeterministicRandomG
         res = CalculateMinDamage( enemy );
     }
     else {
-        res = randomGenerator.Get( CalculateMinDamage( enemy ), CalculateMaxDamage( enemy ) );
+        res = Rand::GetWithGen( CalculateMinDamage( enemy ), CalculateMaxDamage( enemy ), randomGenerator );
     }
 
     if ( Modes( LUCK_GOOD ) ) {
@@ -1533,7 +1533,7 @@ uint32_t Battle::Unit::GetMagicResist( const Spell & spell, const HeroBase * app
     return fheroes2::getSpellResistance( id, spell.GetID() );
 }
 
-Spell Battle::Unit::GetSpellMagic( Rand::DeterministicRandomGenerator & randomGenerator ) const
+Spell Battle::Unit::GetSpellMagic( Rand::PCG32 & randomGenerator ) const
 {
     const std::vector<fheroes2::MonsterAbility> & abilities = fheroes2::getMonsterData( GetID() ).battleStats.abilities;
 
@@ -1543,7 +1543,7 @@ Spell Battle::Unit::GetSpellMagic( Rand::DeterministicRandomGenerator & randomGe
         return Spell::NONE;
     }
 
-    if ( randomGenerator.Get( 1, 100 ) > abilityIter->percentage ) {
+    if ( Rand::GetWithGen( 1, 100, randomGenerator ) > abilityIter->percentage ) {
         // No luck to cast the spell.
         return Spell::NONE;
     }

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -44,7 +44,7 @@ enum class PlayerColor : uint8_t;
 
 namespace Rand
 {
-    class DeterministicRandomGenerator;
+    class PCG32;
 }
 
 namespace Battle
@@ -123,8 +123,8 @@ namespace Battle
             _mirrorUnit = ptr;
         }
 
-        void SetRandomMorale( Rand::DeterministicRandomGenerator & randomGenerator );
-        void SetRandomLuck( Rand::DeterministicRandomGenerator & randomGenerator );
+        void SetRandomMorale( Rand::PCG32 & randomGenerator );
+        void SetRandomLuck( Rand::PCG32 & randomGenerator );
         void NewTurn();
 
         bool isFlying() const;
@@ -192,7 +192,7 @@ namespace Battle
         // is set to true, then the value of 'skipMovedCheck' doesn't matter.
         uint32_t GetSpeed( const bool skipStandingCheck, const bool skipMovedCheck ) const;
 
-        uint32_t GetDamage( const Unit & enemy, Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        uint32_t GetDamage( const Unit & enemy, Rand::PCG32 & randomGenerator ) const;
 
         // Returns the threat level of this unit, calculated as if it attacked the 'defender' unit. See
         // the implementation for details.
@@ -306,7 +306,7 @@ namespace Battle
         void PostKilledAction();
 
         uint32_t GetMagicResist( const Spell & spell, const HeroBase * applyingHero ) const;
-        Spell GetSpellMagic( Rand::DeterministicRandomGenerator & randomGenerator ) const;
+        Spell GetSpellMagic( Rand::PCG32 & randomGenerator ) const;
 
         const HeroBase * GetCommander() const;
         // If the color of the current unit is valid (i.e. this unit is not under the influence of a Berserker spell), then returns the commander of the army with the


### PR DESCRIPTION
Removes DeterministicRandomGenerator as described [here](https://github.com/ihhub/fheroes2/issues/9867#issuecomment-2996474468l)

✅ Less one-off uses of PCG32
✅ Mechanism for scambling the RNG based on user actions still works
✅ More code deleted than introduced