### PR TITLE
MSVC: copy the contents of the ANIM and MUSIC directories to the build directory

### DIFF
--- a/VisualStudio/SDL2.props
+++ b/VisualStudio/SDL2.props
@@ -10,8 +10,8 @@
       <AdditionalDependencies>SDL2main.lib;SDL2.lib;SDL2_mixer.lib;SDL2_image.lib;zlib.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
     <PostBuildEvent>
-      <Command>xcopy /Y /Q "$(MSBuildThisFileDirectory)packages\sdl2\lib\$(PlatformTarget)\*.dll" "$(OutDir)"
-xcopy /Y /Q "$(MSBuildThisFileDirectory)packages\sdl2\lib\$(PlatformTarget)\*.pdb" "$(OutDir)"
+      <Command>xcopy /D /Y /Q "$(MSBuildThisFileDirectory)packages\sdl2\lib\$(PlatformTarget)\*.dll" "$(OutDir)"
+xcopy /D /Y /Q "$(MSBuildThisFileDirectory)packages\sdl2\lib\$(PlatformTarget)\*.pdb" "$(OutDir)"
 %(Command)</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>

--- a/VisualStudio/fheroes2/common.props
+++ b/VisualStudio/fheroes2/common.props
@@ -13,21 +13,22 @@
       <PreprocessorDefinitions Condition="'$(FHEROES2_BUILD_NUMBER)'!=''">BUILD_VERSION=$(FHEROES2_BUILD_NUMBER);%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ResourceCompile>
     <PostBuildEvent>
-      <Command>if exist data (
-    if not exist "$(OutDir)data" (
-        xcopy /Y /S /Q data "$(OutDir)data\"
-    )
+      <Command>if exist anim (
+    xcopy /D /Y /S /Q anim "$(OutDir)anim\"
 )
-
+if exist data (
+    xcopy /D /Y /S /Q data "$(OutDir)data\"
+)
 if exist maps (
-    if not exist "$(OutDir)maps" (
-        xcopy /Y /S /Q maps "$(OutDir)maps\"
-    )
+    xcopy /D /Y /S /Q maps "$(OutDir)maps\"
+)
+if exist music (
+    xcopy /D /Y /S /Q music "$(OutDir)music\"
 )
 
-xcopy /Y /S /Q files\data "$(OutDir)files\data\"
-xcopy /Y /Q files\lang\*.mo "$(OutDir)files\lang\"
-xcopy /Y /S /Q files\timidity "$(OutDir)files\timidity\"
+xcopy /D /Y /S /Q files\data "$(OutDir)files\data\"
+xcopy /D /Y /Q files\lang\*.mo "$(OutDir)files\lang\"
+xcopy /D /Y /S /Q files\timidity "$(OutDir)files\timidity\"
 
 %(Command)</Command>
     </PostBuildEvent>


### PR DESCRIPTION
fix #9943

Currently, MSVC build scripts copy only the contents of the `DATA` and `MAPS` directories to the build directory.

Also, to speed up copying during build, the `/D` parameter has been added, with which only modified files (with a newer date) are copied.