### PR TITLE
Fix update of map and players info when restarting the map that was changed and saved in Editor

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -2097,7 +2097,12 @@ namespace Interface
             // Set the saved map as a default map for the new Standard Game.
             Maps::FileInfo fi;
             if ( fi.loadResurrectionMap( _mapFormat, fullPath ) ) {
-                Settings::Get().setCurrentMapInfo( std::move( fi ) );
+                // Update the default map info to allow to start this map without the need to select it from the all maps list.
+                Settings & conf = Settings::Get();
+                conf.setCurrentMapInfo( std::move( fi ) );
+
+                // Reset saved players parameters (including alliances) for starting a new game because they may have changed in editor.
+                Game::SavePlayers( "", Players{} );
             }
             else {
                 assert( 0 );

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -68,6 +68,7 @@
 #include "math_base.h"
 #include "monster.h"
 #include "mp2.h"
+#include "players.h"
 #include "puzzle.h"
 #include "race.h"
 #include "render_processor.h"

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -2103,7 +2103,7 @@ namespace Interface
                 conf.setCurrentMapInfo( std::move( fi ) );
 
                 // Reset saved players parameters (including alliances) for starting a new game because they may have changed in editor.
-                Game::SavePlayers( "", Players{} );
+                Game::SavePlayers( "", {} );
             }
             else {
                 assert( 0 );

--- a/src/fheroes2/game/game.cpp
+++ b/src/fheroes2/game/game.cpp
@@ -61,6 +61,8 @@
 namespace
 {
     std::string lastMapFileName;
+
+    // A vector to store player including their parameters to restore them in scenario info dialog when starting a new game.
     std::vector<Player> savedPlayers;
 
     bool updateSoundsOnFocusUpdate = true;
@@ -100,6 +102,7 @@ int Game::getDifficulty()
 void Game::LoadPlayers( const std::string & mapFileName, Players & players )
 {
     if ( lastMapFileName != mapFileName || savedPlayers.size() != players.size() ) {
+        // The map or human players count is changed - ignore previously set players parameters.
         return;
     }
 
@@ -141,15 +144,13 @@ void Game::SavePlayers( const std::string & mapFileName, const Players & players
     for ( const Player * p : players ) {
         assert( p != nullptr );
 
-        Player player( p->GetColor() );
+        Player & player = savedPlayers.emplace_back( p->GetColor() );
 
         player.SetRace( p->GetRace() );
         player.SetControl( p->GetControl() );
         player.SetFriends( p->GetFriends() );
         player.SetName( p->GetName() );
         player.setHandicapStatus( p->getHandicapStatus() );
-
-        savedPlayers.push_back( player );
     }
 }
 

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -231,9 +231,9 @@ namespace
         const int buttonCancelIcn = isEvilInterface ? ICN::BUTTON_SMALL_CANCEL_EVIL : ICN::BUTTON_SMALL_CANCEL_GOOD;
         background.renderButton( buttonCancel, buttonCancelIcn, 0, 1, buttonOffset, fheroes2::StandardWindow::Padding::BOTTOM_RIGHT );
 
-        Maps::FileInfo & currentMapInfo = conf.getCurrentMapInfo();
+        const Maps::FileInfo & mapInfo = [&lists, &conf = std::as_const( conf )]() {
+            const Maps::FileInfo & currentMapinfo = conf.getCurrentMapInfo();
 
-        const Maps::FileInfo & mapInfo = [&lists, &currentMapinfo = std::as_const( currentMapInfo )]() {
             if ( currentMapinfo.filename.empty() ) {
                 return lists.front();
             }
@@ -359,7 +359,7 @@ namespace
                 // The previous dialog might still have a pressed button event. We have to clean the state.
                 le.reset();
 
-                if ( fi && fi->filename != currentMapInfo.filename ) {
+                if ( fi && fi->filename != conf.getCurrentMapInfo().filename ) {
                     showCurrentlySelectedMapInfoInTextSupportMode( *fi );
 
                     // The map is changed. Update the map data and do default initialization of players.
@@ -393,7 +393,7 @@ namespace
             }
 
             if ( Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY ) || le.MouseClickLeft( buttonOk.area() ) ) {
-                DEBUG_LOG( DBG_GAME, DBG_INFO, "select maps: " << currentMapInfo.filename << ", difficulty: " << Difficulty::String( Game::getDifficulty() ) )
+                DEBUG_LOG( DBG_GAME, DBG_INFO, "select maps: " << conf.getCurrentMapInfo().filename << ", difficulty: " << Difficulty::String( Game::getDifficulty() ) )
                 result = fheroes2::GameMode::START_GAME;
 
                 // Fade-out screen before starting a scenario.
@@ -463,7 +463,7 @@ namespace
         }
 
         // Save the changes players parameters before closing this dialog.
-        Game::SavePlayers( currentMapInfo.filename, players );
+        Game::SavePlayers( conf.getCurrentMapInfo().filename, players );
 
         return result;
     }


### PR DESCRIPTION
Fix #9944

The issue happens if you star a map (or simply open a scenario info dialog when staring a new map and close it) then go to editor, change the players parameters, save the map and try to start a new game: the players parameters will be restored from the previous version of the map (now overwritten while saving).

This PR adds the reset of stored players' parameters to reload them when starting a new map.

It also removes redundant `Game::SavePlayers()` and `Game::LoadPlayers()` when changing the map because:
- there is no need to save players parameters from the previous map for the new different map, the parameters are always saved when leaving this dialog;
- the `Game::LoadPlayers()` immediately exits if the map name is different from the map name in ``Game::SavePlayers()` call and here they are always different.