### PR TITLE
Allow heroes to disembark on proper tiles even if they aren't marked as coast

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -2175,13 +2175,13 @@ void AI::HeroesAction( Heroes & hero, const int32_t dst_index )
         AIToBlackCatObject( hero, dst_index );
         break;
     default:
+        // AI should know what to do with this type of action object! Please add logic for it.
+        assert( !isActionObject );
+
         if ( world.getTile( dst_index ).isCoast() ) {
             AIToCoast( hero, dst_index );
         }
-        else {
-            // AI should know what to do with this type of action object! Please add logic for it.
-            assert( !isActionObject );
-        }
+
         break;
     }
 

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -2175,8 +2175,13 @@ void AI::HeroesAction( Heroes & hero, const int32_t dst_index )
         AIToBlackCatObject( hero, dst_index );
         break;
     default:
-        // AI should know what to do with this type of action object! Please add logic for it.
-        assert( !isActionObject );
+        if ( world.getTile( dst_index ).isCoast() ) {
+            AIToCoast( hero, dst_index );
+        }
+        else {
+            // AI should know what to do with this type of action object! Please add logic for it.
+            assert( !isActionObject );
+        }
         break;
     }
 

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -535,6 +535,9 @@ int Interface::AdventureMap::GetCursorFocusShipmaster( const Heroes & hero, cons
                 return Cursor::DistanceThemes( Cursor::CURSOR_HERO_BOAT, hero.getNumOfTravelDays( tile.GetIndex() ) );
             }
         }
+        else if ( tile.isCoast() ) {
+            return Cursor::DistanceThemes( Cursor::CURSOR_HERO_ANCHOR, hero.getNumOfTravelDays( tile.GetIndex() ) );
+        }
 
         break;
     }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -4081,6 +4081,9 @@ void Heroes::Action( int tileIndex )
         break;
 
     default:
+        if ( world.getTile( tileIndex ).isCoast() ) {
+            ActionToCoast( *this, tileIndex );
+        }
         break;
     }
 }

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -172,7 +172,7 @@ namespace
 
             return !hero.isFriends( castle->GetColor() ) && castle->GetActualArmy().isValid();
         }
-        if ( hero.isShipMaster() && next.getMainObjectType() == MP2::OBJ_COAST ) {
+        if ( hero.isShipMaster() && next.isCoast() ) {
             return true;
         }
         if ( !hero.isShipMaster() && next.getMainObjectType() == MP2::OBJ_SHIPWRECK ) {

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1125,9 +1125,23 @@ bool Maps::Tile::isCoast() const
         return false;
     }
 
-    if ( getTileIndependentPassability() != DIRECTION_ALL ) {
-        // The tile has something on it.
+    const auto isObjectPartPassable = []( const Maps::ObjectPart & part ) {
+        if ( part.icnType == MP2::OBJ_ICN_TYPE_ROAD || part.icnType == MP2::OBJ_ICN_TYPE_STREAM || part.icnType == MP2::OBJ_ICN_TYPE_FLAG32 ) {
+            // Rivers, streams and flags are completely passable.
+            return true;
+        }
+
+        return part.isPassabilityTransparent() || isObjectPartShadow( part );
+    };
+
+    if ( _mainObjectPart.icnType != MP2::OBJ_ICN_TYPE_UNKNOWN && !isObjectPartPassable( _mainObjectPart ) ) {
         return false;
+    }
+
+    for ( const auto & part : _groundObjectPart ) {
+        if ( !isObjectPartPassable( part ) ) {
+            return false;
+        }
     }
 
     return true;

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1124,7 +1124,7 @@ bool Maps::Tile::isCoast() const
         // Tiles with events are blocked for disembarkation (for now).
         return false;
     }
-    
+
     if ( getTileIndependentPassability() != DIRECTION_ALL ) {
         // The tile has something on it.
         return false;
@@ -1147,7 +1147,7 @@ bool Maps::Tile::isPassableFrom( const int direction, const bool fromWater, cons
             // Another boat is not passable for us.
             return false;
         }
-    
+
         if ( !tileIsWater && !isCoast() ) {
             return false;
         }

--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -167,6 +167,8 @@ namespace Maps
         // Checks whether it is possible to move into this tile from the specified direction under the specified conditions
         bool isPassableFrom( const int direction, const bool fromWater, const bool ignoreFog, const PlayerColor heroColor ) const;
 
+        bool isCoast() const;
+
         // Checks whether it is possible to exit this tile in the specified direction
         bool isPassableTo( const int direction ) const
         {

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -67,7 +67,7 @@ namespace
             return false;
         }
 
-        if ( fromWater && !toWater && objectType == MP2::OBJ_COAST ) {
+        if ( fromWater && !toWater && tile.isCoast() ) {
             return false;
         }
 
@@ -880,7 +880,7 @@ uint32_t AIWorldPathfinder::getMovementPenalty( const int from, const int to, co
         // AI-controlled hero may get from the shore to an empty water tile using the Summon Boat spell
         const bool isEmptyWaterTile = ( toTile.isWater() && toTile.getMainObjectType() == MP2::OBJ_NONE );
         const bool isComesOnBoard = ( !fromTile.isWater() && ( toTile.getMainObjectType() == MP2::OBJ_BOAT || isEmptyWaterTile ) );
-        const bool isDisembarks = ( fromTile.isWater() && toTile.getMainObjectType() == MP2::OBJ_COAST );
+        const bool isDisembarks = ( fromTile.isWater() && toTile.isCoast() );
 
         // When the hero gets into a boat or disembarks, he spends all remaining movement points.
         if ( isComesOnBoard || isDisembarks ) {


### PR DESCRIPTION
close #9152

This change requires heavy testing to make sure that we don't break any logic.