### PR TITLE
Remove or move to the nearest water the boats that are placed on the land in hacked maps

### DIFF
--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -1312,6 +1312,27 @@ bool World::ProcessNewMP2Map( const std::string & filename, const bool checkPoLO
             // You are trying to load a PoL map named as a MP2 file.
             return false;
         }
+
+        // On some hacked MP2 maps boats can present on the land.
+        if ( tile.getMainObjectType() == MP2::OBJ_BOAT && !tile.isWater() ) {
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid MP2 format: boat at tile index " << tile.GetIndex() << " is placed on the land! It is removed to avoid bugs." )
+
+            // Remove the "hacked" boat from the map.
+            removeMainObjectFromTile( tile );
+
+            // Search for the water around and move the boat there.
+            const Maps::Indexes tileIndices = Maps::getAroundIndexes( tile.GetIndex(), 1 );
+            for ( const int32_t tileIndex : tileIndices ) {
+                Maps::Tile & nearTile = world.getTile( tileIndex );
+                if ( nearTile.isWater() && nearTile.getMainObjectType() == MP2::OBJ_NONE ) {
+                    nearTile.setBoat( Direction::RIGHT, PlayerColor::NONE );
+
+                    DEBUG_LOG( DBG_GAME, DBG_WARN, "The boat is placed on water on the nearby tile index " << nearTile.GetIndex() << "." )
+
+                    break;
+                }
+            }
+        }
     }
 
     // add heroes to kingdoms

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -86,7 +86,6 @@ namespace
         assert( Color::allPlayerColors() & color );
 
         const Maps::Tile & tile = world.getTile( tileIndex );
-        const bool toWater = tile.isWater();
         const MP2::MapObjectType objectType = tile.getMainObjectType();
 
         const auto isTileAccessible = [color, armyStrength, minimalAdvantage, &tile]() {
@@ -105,6 +104,8 @@ namespace
 
         // Enemy heroes can be defeated and passed through
         if ( objectType == MP2::OBJ_HERO ) {
+            const bool toWater = tile.isWater();
+
             // Heroes on the water can be attacked from the nearby shore, but they cannot be passed through
             if ( fromWater != toWater ) {
                 assert( !fromWater && toWater );
@@ -199,7 +200,7 @@ namespace
 
         // AI can use boats to overcome water obstacles
         if ( objectType == MP2::OBJ_BOAT ) {
-            assert( !fromWater && toWater );
+            assert( !fromWater && tile.isWater() );
 
             return true;
         }


### PR DESCRIPTION
fix #9568

This PR tries to move the boat that is hacky placed on the land to the nearby empty water tile and if there is none than the boat is removed from the tile.

Also in pathfinder `tile.isWater()` is called only when it is needed: for `MP2::OBJ_HERO` and for assertion in `MP2::OBJ_BOAT` case.