### PR TITLE
Make boats are placed on the land in hacked maps non-action and unpassable that

### DIFF
--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -552,6 +552,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 continue;
             }
 
+            case MP2::OBJ_NON_ACTION_BOAT:
             case MP2::OBJ_BOAT: {
                 // Boats are 2 tiles high so we have to populate info for boat one tile lower than the fog.
                 const bool isUpperTileUnderFog = ( posY > 0 ) ? ( world.getTile( tileIndex - worldWidth ).getFogDirection() == DIRECTION_ALL ) : true;
@@ -561,7 +562,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                     continue;
                 }
 
-                const uint8_t alphaValue = getObjectAlphaValue( tileIndex, MP2::OBJ_BOAT );
+                const uint8_t alphaValue = getObjectAlphaValue( tileIndex, objectType );
 
                 auto spriteInfo = getBoatSpritesPerTile( tile );
                 auto spriteShadowInfo = getBoatShadowSpritesPerTile( tile );

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -607,6 +607,12 @@ int Maps::Tile::getTileIndependentPassability() const
     // In other words, we have to go through object parts in the reverse order as they are being rendered.
     //
     // Top object parts do not affect passability.
+
+    if ( _mainObjectType == MP2::OBJ_NON_ACTION_BOAT ) {
+        // On some hacked MP2 maps boats can present on the land. We make then non-action and unpassable.
+        return 0;
+    }
+
     int passability = DIRECTION_ALL;
 
     const auto getObjectPartPassability = []( const Maps::ObjectPart & part, bool & isActionObject ) {

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -1094,7 +1094,7 @@ namespace Maps
     std::vector<fheroes2::ObjectRenderingInfo> getBoatSpritesPerTile( const Tile & tile )
     {
         // TODO: combine both boat image generation for heroes and empty boats.
-        assert( tile.getMainObjectType() == MP2::OBJ_BOAT );
+        assert( tile.getMainObjectType() == MP2::OBJ_BOAT || tile.getMainObjectType() == MP2::OBJ_NON_ACTION_BOAT );
 
         const uint32_t spriteIndex = ( tile.getMainObjectPart().icnIndex == 255 ) ? 18 : tile.getMainObjectPart().icnIndex;
 
@@ -1124,7 +1124,7 @@ namespace Maps
 
     std::vector<fheroes2::ObjectRenderingInfo> getBoatShadowSpritesPerTile( const Tile & tile )
     {
-        assert( tile.getMainObjectType() == MP2::OBJ_BOAT );
+        assert( tile.getMainObjectType() == MP2::OBJ_BOAT || tile.getMainObjectType() == MP2::OBJ_NON_ACTION_BOAT );
 
         // TODO: boat shadow logic is more complex than this and it is not directly depend on spriteIndex. Find the proper logic and fix it!
         const uint32_t spriteIndex = ( tile.getMainObjectPart().icnIndex == 255 ) ? 18 : tile.getMainObjectPart().icnIndex;

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -1312,6 +1312,14 @@ bool World::ProcessNewMP2Map( const std::string & filename, const bool checkPoLO
             // You are trying to load a PoL map named as a MP2 file.
             return false;
         }
+
+        // On some hacked MP2 maps boats can present on the land.
+        if ( tile.getMainObjectType() == MP2::OBJ_BOAT && !tile.isWater() ) {
+            DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid MP2 format: boat at tile index " << tile.GetIndex() << " is placed on the land! It is made \"non-action\"." )
+
+            // Make the "hacked" boat non-action.
+            tile.setMainObjectType( MP2::OBJ_NON_ACTION_BOAT );
+        }
     }
 
     // add heroes to kingdoms


### PR DESCRIPTION
This is an alternative to #9967 solution to fix https://github.com/ihhub/fheroes2/issues/9568

This PR makes the boats that are placed on the land in hacked maps unpassable and non-action.

This PR keeps the map as it was "designed" my a map hacker. The non-action boats are the unpassable decoration objects that blocks one tile.