### PR TITLE
Changing 'penalty: {cost} to 'move points cost: {cost}' in ground right clicking

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -428,7 +428,7 @@ namespace
             const uint32_t cost = isRoad ? Maps::Ground::roadPenalty : Maps::Ground::GetPenalty( tile, hero->GetLevelSkill( Skill::Secondary::PATHFINDING ) );
             if ( cost > 0 ) {
                 str += '\n';
-                str.append( _( "penalty: %{cost}" ) );
+                str.append( _( "move points cost: %{cost}" ) );
                 StringReplace( str, "%{cost}", static_cast<int32_t>( cost ) );
             }
         }


### PR DESCRIPTION
Changed to call it for what it really is: "move points cost: 100". This is a much more user-friendly term.

![image](https://github.com/user-attachments/assets/dcc31284-e430-4fcb-9934-8dffcaecca59)

![image](https://github.com/user-attachments/assets/111a29d3-35a2-4a71-9345-6287a1832247)
