### PR TITLE
Fix the regressing that forced a crash after saving a map in editor and loading another map

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -903,7 +903,7 @@ namespace Interface
                                                              Dialog::YES | Dialog::NO );
 
                     if ( returnValue == Dialog::YES ) {
-                        return fheroes2::GameMode::MAIN_MENU;
+                        res = fheroes2::GameMode::MAIN_MENU;
                     }
                 }
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::EDITOR_TOGGLE_PASSABILITY ) ) {
@@ -1123,6 +1123,11 @@ namespace Interface
                 validateFadeInAndRender();
             }
         }
+
+        // When exiting the editor we must reset the players data to properly load the new maps.
+        conf.GetPlayers().clear();
+        // And reset the players configuration for the selected map to properly initialize it when starting a new map.
+        Game::SavePlayers( "", {} );
 
         Game::setDisplayFadeIn();
 
@@ -2098,11 +2103,7 @@ namespace Interface
             Maps::FileInfo fi;
             if ( fi.loadResurrectionMap( _mapFormat, fullPath ) ) {
                 // Update the default map info to allow to start this map without the need to select it from the all maps list.
-                Settings & conf = Settings::Get();
-                conf.setCurrentMapInfo( std::move( fi ) );
-
-                // Reset saved players parameters (including alliances) for starting a new game because they may have changed in editor.
-                Game::SavePlayers( "", {} );
+                Settings::Get().setCurrentMapInfo( std::move( fi ) );
             }
             else {
                 assert( 0 );


### PR DESCRIPTION
This PR fixes a regression after #9948 (fond by **Moucheron Quipet** on Discord) that made the engine crash if you save a map in editor and then try to load a different map in editor:

<img alt="img" src="https://github.com/user-attachments/assets/15c71db5-c0d7-4553-9731-d85e256b51b6" />

The issue was present always but it did no harm while "saved" players and `Settings::Get().GetPlayers()` operate with the same data.

This PR resets the players vector as well as the "saved" players data data when exiting editor. And there is no need to reset the "saved" players data when saving a map.

This OR also make the exit from editor to the engine main menu act the same the the exit to editor's main menu - with fade in/out and with resetting the data.