### PR TITLE
Use the macos-14 runner instead of the macos-13

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -103,7 +103,7 @@ jobs:
             FHEROES2_WITH_TSAN: ON
         - name: macOS SDL2
           on: [ 'pull_request', 'push' ]
-          os: macos-13
+          os: macos-14
           dependencies: sdl2 sdl2_mixer sdl2_image
           env:
             FHEROES2_STRICT_COMPILATION: ON


### PR DESCRIPTION
`macos-13` runner is [closing down](https://github.blog/changelog/2025-07-11-upcoming-changes-to-macos-hosted-runners-macos-latest-migration-and-xcode-support-policy-updates/) and won't be available soon.