### PR TITLE
Fix a crash after saving a map when victory condition was "One side defeats another" and then the players were removed from map

### DIFF
--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -1732,10 +1732,15 @@ namespace Maps
         }
         else {
             // No colors are set so no alliances should exist.
-            map.alliances = { 0 };
+            map.alliances.clear();
 
             // No races are set.
             map.playerRace = { 0 };
+        }
+
+        if ( map.alliances.empty() && map.victoryConditionType == FileInfo::VictoryCondition::VICTORY_DEFEAT_OTHER_SIDE ) {
+            // When there are no alliances there are no sides. Reset the victory condition to the default.
+            map.victoryConditionType = FileInfo::VictoryCondition::VICTORY_DEFEAT_EVERYONE;
         }
 
         // Update events according to the possible changes in human and/or AI player colors.


### PR DESCRIPTION
This PR fixes the next bug:

1. Make a new map (or open a map), add 2 or more players and set the Special Victory Condition to "One side defeats another".
2. Remove the players (or leave only 1 player on the map).
3. Save the map.
4. You'll get a crash!

Then it will appear every time you try to open the maps list (until you remove the map from your hard drive):
`Assertion failed: map.alliances.size() == 2, file D:\h2\git\src\fheroes2\maps\maps_fileinfo.cpp, line 492`

<img alt="img" src="https://github.com/user-attachments/assets/44a7bac3-85c3-4d35-ba31-e27b2bc60817" />
