### PR TITLE
Fix castles handling in Editor

### DIFF
--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2338,6 +2338,37 @@ Castle * AllCastles::Get( const fheroes2::Point & position ) const
     return _castles[iter->second].get();
 }
 
+void AllCastles::removeCastle( const fheroes2::Point & position )
+{
+    auto iter = _castleTiles.find( position );
+    if ( iter == _castleTiles.end() ) {
+        return;
+    }
+
+    const size_t castleId = iter->second;
+
+    _castles.erase( _castles.begin() + castleId );
+
+    _castleTiles.erase( iter );
+
+    // Castle is represented by more than 1 tile on the radar - remove the other tiles.
+    for ( auto it = _castleTiles.begin(); it != _castleTiles.end(); ) {
+        if ( it->second == castleId ) {
+            it = _castleTiles.erase( it );
+        }
+        else {
+            ++it;
+        }
+    }
+
+    // After the castle is removed we need to decrease the indices of the castles with "id" more than `castleId`.
+    for ( auto it = _castleTiles.begin(); it != _castleTiles.end(); ++it ) {
+        if ( it->second > castleId ) {
+            --it->second;
+        }
+    }
+}
+
 void AllCastles::Scout( const PlayerColorsSet colors ) const
 {
     for ( const Castle * castle : *this ) {

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -2362,9 +2362,9 @@ void AllCastles::removeCastle( const fheroes2::Point & position )
     }
 
     // After the castle is removed we need to decrease the indices of the castles with "id" more than `castleId`.
-    for ( auto it = _castleTiles.begin(); it != _castleTiles.end(); ++it ) {
-        if ( it->second > castleId ) {
-            --it->second;
+    for ( auto & [pos, id] : _castleTiles ) {
+        if ( id > castleId ) {
+            --id;
         }
     }
 }

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -560,6 +560,8 @@ public:
 
     Castle * Get( const fheroes2::Point & position ) const;
 
+    void removeCastle( const fheroes2::Point & position );
+
     void Scout( const PlayerColorsSet colors ) const;
 
     void NewDay() const;

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -345,6 +345,12 @@ namespace
                         Maps::updateRoadOnTile( mapFormat, static_cast<int32_t>( bottomTileIndex ), false );
                     }
 
+                    // The castle entrance is marked as road. Update this tile to remove the mark.
+                    Maps::updateRoadSpriteOnTile( mapFormat, static_cast<int32_t>( mapTileIndex ), false );
+
+                    // Remove the castle from `world` castles vector.
+                    world.removeCastle( Maps::GetPoint( static_cast<int32_t>( mapTileIndex ) ) );
+
                     needRedraw = true;
                     updateMapPlayerInformation = true;
                 }
@@ -641,6 +647,14 @@ namespace
             break;
         }
         case Maps::ObjectGroup::KINGDOM_TOWNS: {
+            // TODO: Allow castles with custom names to exceed the 72 random castle names limit.
+            // To do this we'll need also to check that the custom name is not present in random names.
+            if ( world.getCastleCount() > 71 ) {
+                errorMessage = _( "A maximum of 72 %{objects} can be placed on the map." );
+                StringReplace( errorMessage, "%{objects}", Interface::EditorPanel::getObjectGroupName( groupType ) );
+                return false;
+            }
+
             const Maps::Tile & tile = world.getTile( tilePos.x, tilePos.y );
 
             if ( tile.isWater() ) {

--- a/src/fheroes2/world/world.h
+++ b/src/fheroes2/world/world.h
@@ -296,6 +296,16 @@ public:
         return vec_castles.Get( tilePosition );
     }
 
+    size_t getCastleCount() const
+    {
+        return vec_castles.Size();
+    }
+
+    void removeCastle( const fheroes2::Point & tilePosition )
+    {
+        vec_castles.removeCastle( tilePosition );
+    }
+
     // Get castle based on its entrance tile. If the tile is not castle's entrance return nullptr.
     const Castle * getCastleEntrance( const fheroes2::Point & tilePosition ) const;
     Castle * getCastleEntrance( const fheroes2::Point & tilePosition );


### PR DESCRIPTION
This PR fixes:
- a crash when giving a random castle a name of 72 random names: currently the castle count is limited to 72, but a TODO is left to allow custom named castles to be excludeв from  this limit;
- a bug after removing the castle: the castle data was not removed from `vec_castles`.