### PR TITLE
Remove redundant check for `MP2::OBJ_CASTLE` in `isRoad()` method

### DIFF
--- a/src/fheroes2/maps/maps_tiles.h
+++ b/src/fheroes2/maps/maps_tiles.h
@@ -183,7 +183,7 @@ namespace Maps
 
         bool isRoad() const
         {
-            return _isTileMarkedAsRoad || _mainObjectType == MP2::OBJ_CASTLE;
+            return _isTileMarkedAsRoad;
         }
 
         bool isStream() const;


### PR DESCRIPTION
This PR removes redundant check for `MP2::OBJ_CASTLE` in `isRoad()` method because the active tile is already marked as road (`_isTileMarkedAsRoad` == `true`) in `isSpriteRoad()` function:

https://github.com/ihhub/fheroes2/blob/e6b634925b3957200be87a973caf209f6ecdd84c/src/fheroes2/maps/maps_tiles.cpp#L356-L363