### PR TITLE
Enable full zoom levels in adventure mode

### DIFF
--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -641,11 +641,7 @@ void ViewWorld::ViewWorldWindow( const PlayerColor color, const ViewWorldMode mo
         viewCenterInPixels.y = world.h() * fheroes2::tileWidthPx / 2;
     }
 
-#if defined( VIEWWORLD_DEBUG_ZOOM_LEVEL )
     const size_t zoomLevels = 4;
-#else
-    const size_t zoomLevels = interface.isEditor() ? 4 : 3;
-#endif
 
     ZoomROIs currentROI( zoomLevel, viewCenterInPixels, visibleScreenInPixels, zoomLevels );
 


### PR DESCRIPTION
### Summary

This change enables 4 zoom levels in Adventure Mode, previously limited to 3 unless in Editor mode.

### Motivation

- Several users in the community have noted that the 3-level zoom cap in Adventure Mode is restrictive, especially on high-resolution displays.
- Removing this limit improves map visibility and overall gameplay experience.

### Details

- Removed the conditional check that restricted zoom levels based on `interface.isEditor()`.
- Now sets `zoomLevels = 4` unconditionally.
