### PR TITLE
Bring the logic of calculating experience and losses in line with the logic of the original game

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -288,6 +288,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
+        # TODO: remove this temporary workaround
+        sudo rm -f /etc/apt/sources.list.d/bullseye-backports.list
+        #
         sudo apt-get -y update
         sudo apt-get -y install gettext p7zip-full
     - name: Build

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -642,7 +642,8 @@ bool AI::BattlePlanner::isLimitOfTurnsExceeded( const Battle::Arena & arena, Bat
     // This is the beginning of a new turn and we still haven't gone beyond the limit on the number of turns without deaths
     if ( currentTurnNumber > _currentTurnNumber && _numberOfRemainingTurnsWithoutDeaths > 0 ) {
         auto prevNumbersOfDeadUnits = std::tie( _attackerForceTotalNumberOfDeadUnits, _defenderForceTotalNumberOfDeadUnits );
-        const auto currNumbersOfDeadUnits = std::make_tuple( arena.getAttackingForce().getTotalNumberOfDeadUnits(), arena.getDefendingForce().getTotalNumberOfDeadUnits() );
+        const auto currNumbersOfDeadUnits
+            = std::make_tuple( arena.getAttackingForce().getTotalNumberOfDeadUnits(), arena.getDefendingForce().getTotalNumberOfDeadUnits() );
 
         // Either we don't have numbers of dead units from the previous turn, or there were changes in these numbers compared
         // to the previous turn, reset the counter

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -612,8 +612,8 @@ void AI::BattlePlanner::battleBegins()
 {
     _currentTurnNumber = 0;
     _numberOfRemainingTurnsWithoutDeaths = MAX_TURNS_WITHOUT_DEATHS;
-    _attackerForceNumberOfDead = 0;
-    _defenderForceNumberOfDead = 0;
+    _attackerForceTotalNumberOfDeadUnits = 0;
+    _defenderForceTotalNumberOfDeadUnits = 0;
 }
 
 void AI::BattlePlanner::BattleTurn( Battle::Arena & arena, const Battle::Unit & currentUnit, Battle::Actions & actions )
@@ -641,13 +641,13 @@ bool AI::BattlePlanner::isLimitOfTurnsExceeded( const Battle::Arena & arena, Bat
 
     // This is the beginning of a new turn and we still haven't gone beyond the limit on the number of turns without deaths
     if ( currentTurnNumber > _currentTurnNumber && _numberOfRemainingTurnsWithoutDeaths > 0 ) {
-        auto prevNumbersOfDead = std::tie( _attackerForceNumberOfDead, _defenderForceNumberOfDead );
-        const auto currNumbersOfDead = std::make_tuple( arena.GetForce1().getTotalNumberOfDeadUnits(), arena.GetForce2().getTotalNumberOfDeadUnits() );
+        auto prevNumbersOfDeadUnits = std::tie( _attackerForceTotalNumberOfDeadUnits, _defenderForceTotalNumberOfDeadUnits );
+        const auto currNumbersOfDeadUnits = std::make_tuple( arena.GetForce1().getTotalNumberOfDeadUnits(), arena.GetForce2().getTotalNumberOfDeadUnits() );
 
         // Either we don't have numbers of dead units from the previous turn, or there were changes in these numbers compared
         // to the previous turn, reset the counter
-        if ( _currentTurnNumber == 0 || currentTurnNumber - _currentTurnNumber != 1 || prevNumbersOfDead != currNumbersOfDead ) {
-            prevNumbersOfDead = currNumbersOfDead;
+        if ( _currentTurnNumber == 0 || currentTurnNumber - _currentTurnNumber != 1 || prevNumbersOfDeadUnits != currNumbersOfDeadUnits ) {
+            prevNumbersOfDeadUnits = currNumbersOfDeadUnits;
 
             _numberOfRemainingTurnsWithoutDeaths = MAX_TURNS_WITHOUT_DEATHS;
         }

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -642,7 +642,7 @@ bool AI::BattlePlanner::isLimitOfTurnsExceeded( const Battle::Arena & arena, Bat
     // This is the beginning of a new turn and we still haven't gone beyond the limit on the number of turns without deaths
     if ( currentTurnNumber > _currentTurnNumber && _numberOfRemainingTurnsWithoutDeaths > 0 ) {
         auto prevNumbersOfDead = std::tie( _attackerForceNumberOfDead, _defenderForceNumberOfDead );
-        const auto currNumbersOfDead = std::make_tuple( arena.GetForce1().GetDeadCounts(), arena.GetForce2().GetDeadCounts() );
+        const auto currNumbersOfDead = std::make_tuple( arena.GetForce1().getTotalNumberOfDeadUnits(), arena.GetForce2().getTotalNumberOfDeadUnits() );
 
         // Either we don't have numbers of dead units from the previous turn, or there were changes in these numbers compared
         // to the previous turn, reset the counter

--- a/src/fheroes2/ai/ai_battle.cpp
+++ b/src/fheroes2/ai/ai_battle.cpp
@@ -632,7 +632,7 @@ bool AI::BattlePlanner::isLimitOfTurnsExceeded( const Battle::Arena & arena, Bat
     const PlayerColor currentColor = arena.GetCurrentColor();
 
     // Not the attacker's turn, no further checks
-    if ( currentColor != arena.GetArmy1Color() ) {
+    if ( currentColor != arena.getAttackingArmyColor() ) {
         return false;
     }
 
@@ -642,7 +642,7 @@ bool AI::BattlePlanner::isLimitOfTurnsExceeded( const Battle::Arena & arena, Bat
     // This is the beginning of a new turn and we still haven't gone beyond the limit on the number of turns without deaths
     if ( currentTurnNumber > _currentTurnNumber && _numberOfRemainingTurnsWithoutDeaths > 0 ) {
         auto prevNumbersOfDeadUnits = std::tie( _attackerForceTotalNumberOfDeadUnits, _defenderForceTotalNumberOfDeadUnits );
-        const auto currNumbersOfDeadUnits = std::make_tuple( arena.GetForce1().getTotalNumberOfDeadUnits(), arena.GetForce2().getTotalNumberOfDeadUnits() );
+        const auto currNumbersOfDeadUnits = std::make_tuple( arena.getAttackingForce().getTotalNumberOfDeadUnits(), arena.getDefendingForce().getTotalNumberOfDeadUnits() );
 
         // Either we don't have numbers of dead units from the previous turn, or there were changes in these numbers compared
         // to the previous turn, reset the counter
@@ -1051,7 +1051,7 @@ void AI::BattlePlanner::analyzeBattleState( const Battle::Arena & arena, const B
     // Mark as castle siege only if any tower is present. If no towers present then nothing to defend and most likely all walls are destroyed as well.
     if ( castle && Battle::Arena::isAnyTowerPresent() ) {
         const bool attackerIgnoresCover = [&arena]() {
-            const HeroBase * commander = arena.GetForce1().GetCommander();
+            const HeroBase * commander = arena.getAttackingForce().GetCommander();
             assert( commander != nullptr );
 
             if ( commander->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::NO_SHOOTING_PENALTY ) ) {

--- a/src/fheroes2/ai/ai_battle.h
+++ b/src/fheroes2/ai/ai_battle.h
@@ -119,8 +119,8 @@ namespace AI
         // Member variables related to the logic of checking the limit of the number of turns
         uint32_t _currentTurnNumber{ 0 };
         uint32_t _numberOfRemainingTurnsWithoutDeaths{ MAX_TURNS_WITHOUT_DEATHS };
-        uint32_t _attackerForceNumberOfDead{ 0 };
-        uint32_t _defenderForceNumberOfDead{ 0 };
+        uint32_t _attackerForceTotalNumberOfDeadUnits{ 0 };
+        uint32_t _defenderForceTotalNumberOfDeadUnits{ 0 };
 
         // Member variables with a lifetime in one turn
         const HeroBase * _commander{ nullptr };

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -320,7 +320,7 @@ namespace
 
     void AIBattleLose( Heroes & hero, const Battle::Result & res, bool attacker, const fheroes2::Point * centerOn = nullptr, const bool playSound = false )
     {
-        const uint32_t reason = attacker ? res.AttackerResult() : res.DefenderResult();
+        const uint32_t reason = attacker ? res.getAttackerResult() : res.getDefenderResult();
 
         if ( AIIsShowAnimationForHero( hero, AIGetAllianceColors() ) ) {
             if ( centerOn != nullptr ) {
@@ -441,10 +441,10 @@ namespace
             // Human controlled castle or hero in this castle was in the battle. Update icons.
             Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_ICONS );
 
-            castle->ActionAfterBattle( res.AttackerWins() );
+            castle->ActionAfterBattle( res.isAttackerWin() );
 
             // The defender was defeated
-            if ( !res.DefenderWins() ) {
+            if ( !res.isDefenderWin() ) {
                 if ( defender ) {
                     AIBattleLose( *defender, res, false, nullptr, isDefenderHuman );
                 }
@@ -456,19 +456,19 @@ namespace
             }
 
             // The attacker was defeated
-            if ( !res.AttackerWins() ) {
+            if ( !res.isAttackerWin() ) {
                 AIBattleLose( hero, res, true, &( castle->GetCenter() ), isDefenderHuman );
             }
 
             // The attacker won
-            if ( res.AttackerWins() ) {
+            if ( res.isAttackerWin() ) {
                 captureCastle();
 
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+                hero.IncreaseExperience( res.getAttackerExperience() );
             }
             // The defender won
-            else if ( res.DefenderWins() && defender ) {
-                defender->IncreaseExperience( res.GetExperienceDefender() );
+            else if ( res.isDefenderWin() && defender ) {
+                defender->IncreaseExperience( res.getDefenderExperience() );
             }
 
             return;
@@ -531,7 +531,7 @@ namespace
         Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES );
 
         // The defender was defeated
-        if ( !res.DefenderWins() ) {
+        if ( !res.isDefenderWin() ) {
             AIBattleLose( *otherHero, res, false, nullptr, isDefenderHuman );
 
             if ( isDefenderHuman ) {
@@ -541,17 +541,17 @@ namespace
         }
 
         // The attacker was defeated
-        if ( !res.AttackerWins() ) {
+        if ( !res.isAttackerWin() ) {
             AIBattleLose( hero, res, true, ( otherHero->isActive() ? &( otherHero->GetCenter() ) : nullptr ), isDefenderHuman );
         }
 
         // The attacker won
-        if ( res.AttackerWins() ) {
-            hero.IncreaseExperience( res.GetExperienceAttacker() );
+        if ( res.isAttackerWin() ) {
+            hero.IncreaseExperience( res.getAttackerExperience() );
         }
         // The defender won
-        else if ( res.DefenderWins() ) {
-            otherHero->IncreaseExperience( res.GetExperienceDefender() );
+        else if ( res.isDefenderWin() ) {
+            otherHero->IncreaseExperience( res.getDefenderExperience() );
         }
     }
 
@@ -616,8 +616,8 @@ namespace
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
 
                 destroy = true;
             }
@@ -816,8 +816,8 @@ namespace
 
                 const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
-                if ( result.AttackerWins() ) {
-                    hero.IncreaseExperience( result.GetExperienceAttacker() );
+                if ( result.isAttackerWin() ) {
+                    hero.IncreaseExperience( result.getAttackerExperience() );
 
                     captureObject();
                 }
@@ -1353,8 +1353,8 @@ namespace
             Army army( tile );
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
                 complete = true;
 
                 Artifact art;
@@ -1405,8 +1405,8 @@ namespace
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
 
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
 
                 // check magic book
                 if ( hero.HaveSpellBook() &&
@@ -1483,8 +1483,8 @@ namespace
             Army army( tile );
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
                 // Daemon Cave always gives 2500 Gold after a battle
                 hero.GetKingdom().AddFundsResource( Funds( Resource::GOLD, 2500 ) );
             }
@@ -1593,8 +1593,8 @@ namespace
             Army army( tile );
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, tileIndex );
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
 
                 // Set ownership of the dwelling to a Neutral (gray) player so that any player can recruit troops without a fight.
                 setColorOnTile( tile, PlayerColor::UNUSED );
@@ -1649,8 +1649,8 @@ namespace
 
         const Battle::Result result = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
-        if ( result.AttackerWins() ) {
-            hero.IncreaseExperience( result.GetExperienceAttacker() );
+        if ( result.isAttackerWin() ) {
+            hero.IncreaseExperience( result.getAttackerExperience() );
 
             Maps::restoreAbandonedMine( tile, Resource::GOLD );
             hero.setObjectTypeUnderHero( MP2::OBJ_MINE );
@@ -1738,8 +1738,8 @@ namespace
             Army army( tile );
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dst_index );
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
                 result = true;
             }
             else {

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -50,10 +50,19 @@ namespace Battle
 
         bool isAttackerWin() const;
         bool isDefenderWin() const;
+
         uint32_t getAttackerResult() const;
         uint32_t getDefenderResult() const;
-        uint32_t getAttackerExperience() const;
-        uint32_t getDefenderExperience() const;
+
+        uint32_t getAttackerExperience() const
+        {
+            return attackerExperience;
+        }
+
+        uint32_t getDefenderExperience() const
+        {
+            return defenderExperience;
+        }
     };
 
     Result Loader( Army & attackingArmy, Army & defendingArmy, const int32_t tileIndex );

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -56,7 +56,7 @@ namespace Battle
         uint32_t getDefenderExperience() const;
     };
 
-    Result Loader( Army &, Army &, int32_t );
+    Result Loader( Army & attackingArmy, Army & defendingArmy, const int32_t tileIndex );
 
     struct TargetInfo
     {

--- a/src/fheroes2/battle/battle.h
+++ b/src/fheroes2/battle/battle.h
@@ -42,18 +42,18 @@ namespace Battle
 
     struct Result
     {
-        uint32_t army1{ 0 };
-        uint32_t army2{ 0 };
-        uint32_t exp1{ 0 };
-        uint32_t exp2{ 0 };
-        uint32_t killed{ 0 };
+        uint32_t attacker{ 0 };
+        uint32_t defender{ 0 };
+        uint32_t attackerExperience{ 0 };
+        uint32_t defenderExperience{ 0 };
+        uint32_t numOfDeadUnitsForNecromancy{ 0 };
 
-        bool AttackerWins() const;
-        bool DefenderWins() const;
-        uint32_t AttackerResult() const;
-        uint32_t DefenderResult() const;
-        uint32_t GetExperienceAttacker() const;
-        uint32_t GetExperienceDefender() const;
+        bool isAttackerWin() const;
+        bool isDefenderWin() const;
+        uint32_t getAttackerResult() const;
+        uint32_t getDefenderResult() const;
+        uint32_t getAttackerExperience() const;
+        uint32_t getDefenderExperience() const;
     };
 
     Result Loader( Army &, Army &, int32_t );

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -795,10 +795,10 @@ void Battle::Arena::ApplyActionRetreat( const Command & /* cmd */ )
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( currentColor ) )
 
-    if ( _army1->GetColor() == currentColor ) {
+    if ( _attackingArmy->GetColor() == currentColor ) {
         _battleResult.attacker = RESULT_RETREAT;
     }
-    else if ( _army2->GetColor() == currentColor ) {
+    else if ( _defendingArmy->GetColor() == currentColor ) {
         _battleResult.defender = RESULT_RETREAT;
     }
     else {
@@ -825,10 +825,10 @@ void Battle::Arena::ApplyActionSurrender( const Command & /* cmd */ )
 
     const PlayerColor currentColor = GetCurrentColor();
 
-    if ( _army1->GetColor() == currentColor ) {
+    if ( _attackingArmy->GetColor() == currentColor ) {
         Funds cost;
 
-        cost.gold = _army1->GetSurrenderCost();
+        cost.gold = _attackingArmy->GetSurrenderCost();
 
         if ( !checkPreconditions( cost ) ) {
             ERROR_LOG( "Preconditions were not met" )
@@ -842,15 +842,15 @@ void Battle::Arena::ApplyActionSurrender( const Command & /* cmd */ )
 
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( currentColor ) )
 
-        world.GetKingdom( _army1->GetColor() ).OddFundsResource( cost );
-        world.GetKingdom( _army2->GetColor() ).AddFundsResource( cost );
+        world.GetKingdom( _attackingArmy->GetColor() ).OddFundsResource( cost );
+        world.GetKingdom( _defendingArmy->GetColor() ).AddFundsResource( cost );
 
         _battleResult.attacker = RESULT_SURRENDER;
     }
-    else if ( _army2->GetColor() == currentColor ) {
+    else if ( _defendingArmy->GetColor() == currentColor ) {
         Funds cost;
 
-        cost.gold = _army2->GetSurrenderCost();
+        cost.gold = _defendingArmy->GetSurrenderCost();
 
         if ( !checkPreconditions( cost ) ) {
             ERROR_LOG( "Preconditions were not met" )
@@ -864,8 +864,8 @@ void Battle::Arena::ApplyActionSurrender( const Command & /* cmd */ )
 
         DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( currentColor ) )
 
-        world.GetKingdom( _army2->GetColor() ).OddFundsResource( cost );
-        world.GetKingdom( _army1->GetColor() ).AddFundsResource( cost );
+        world.GetKingdom( _defendingArmy->GetColor() ).OddFundsResource( cost );
+        world.GetKingdom( _attackingArmy->GetColor() ).AddFundsResource( cost );
 
         _battleResult.defender = RESULT_SURRENDER;
     }
@@ -1321,7 +1321,7 @@ void Battle::Arena::ApplyActionToggleAutoCombat( Command & cmd )
         const Arena * arena = GetArena();
         assert( arena != nullptr );
 
-        if ( color != arena->GetArmy1Color() && color != arena->GetArmy2Color() ) {
+        if ( color != arena->getAttackingArmyColor() && color != arena->getDefendingArmyColor() ) {
             return false;
         }
 
@@ -1362,10 +1362,10 @@ void Battle::Arena::ApplyActionToggleAutoCombat( Command & cmd )
 
 void Battle::Arena::ApplyActionQuickCombat( const Command & /* cmd */ )
 {
-    const int army1Control = GetForce1().GetControl();
-    const int army2Control = GetForce2().GetControl();
+    const int attackingArmyControl = getAttackingForce().GetControl();
+    const int defendingArmyControl = getDefendingForce().GetControl();
 
-    if ( !( army1Control & CONTROL_HUMAN ) && !( army2Control & CONTROL_HUMAN ) ) {
+    if ( !( attackingArmyControl & CONTROL_HUMAN ) && !( defendingArmyControl & CONTROL_HUMAN ) ) {
         ERROR_LOG( "Preconditions were not met" )
 
 #ifdef WITH_DEBUG
@@ -1377,14 +1377,14 @@ void Battle::Arena::ApplyActionQuickCombat( const Command & /* cmd */ )
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "finishing the battle" )
 
-    const PlayerColor army1Color = GetArmy1Color();
-    const PlayerColor army2Color = GetArmy2Color();
+    const PlayerColor attackingArmyColor = getAttackingArmyColor();
+    const PlayerColor defendingArmyColor = getDefendingArmyColor();
 
-    if ( army1Control & CONTROL_HUMAN ) {
-        _autoCombatColors |= army1Color;
+    if ( attackingArmyControl & CONTROL_HUMAN ) {
+        _autoCombatColors |= attackingArmyColor;
     }
-    if ( army2Control & CONTROL_HUMAN ) {
-        _autoCombatColors |= army2Color;
+    if ( defendingArmyControl & CONTROL_HUMAN ) {
+        _autoCombatColors |= defendingArmyColor;
     }
 
     _interface.reset();

--- a/src/fheroes2/battle/battle_action.cpp
+++ b/src/fheroes2/battle/battle_action.cpp
@@ -796,10 +796,10 @@ void Battle::Arena::ApplyActionRetreat( const Command & /* cmd */ )
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, "color: " << Color::String( currentColor ) )
 
     if ( _army1->GetColor() == currentColor ) {
-        result_game.army1 = RESULT_RETREAT;
+        _battleResult.attacker = RESULT_RETREAT;
     }
     else if ( _army2->GetColor() == currentColor ) {
-        result_game.army2 = RESULT_RETREAT;
+        _battleResult.defender = RESULT_RETREAT;
     }
     else {
         assert( 0 );
@@ -845,7 +845,7 @@ void Battle::Arena::ApplyActionSurrender( const Command & /* cmd */ )
         world.GetKingdom( _army1->GetColor() ).OddFundsResource( cost );
         world.GetKingdom( _army2->GetColor() ).AddFundsResource( cost );
 
-        result_game.army1 = RESULT_SURRENDER;
+        _battleResult.attacker = RESULT_SURRENDER;
     }
     else if ( _army2->GetColor() == currentColor ) {
         Funds cost;
@@ -867,7 +867,7 @@ void Battle::Arena::ApplyActionSurrender( const Command & /* cmd */ )
         world.GetKingdom( _army2->GetColor() ).OddFundsResource( cost );
         world.GetKingdom( _army1->GetColor() ).AddFundsResource( cost );
 
-        result_game.army2 = RESULT_SURRENDER;
+        _battleResult.defender = RESULT_SURRENDER;
     }
     else {
         assert( 0 );

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -167,51 +167,51 @@ namespace
         return covrs.empty() ? ICN::UNKNOWN : Rand::GetWithGen( covrs, gen );
     }
 
-    Battle::Unit * GetCurrentUnit( Battle::Units & units1, Battle::Units & units2, const bool units1GoFirst, const bool ordersMode )
+    Battle::Unit * GetCurrentUnit( Battle::Units & attackingUnits, Battle::Units & defendingUnits, const bool attackingUnitsGoFirst, const bool ordersMode )
     {
         Battle::Unit * result = nullptr;
 
         const auto unitFilter = []( const Battle::Unit * unit ) { return unit->GetSpeed() > Speed::STANDING; };
 
-        Battle::Units::iterator it1 = std::find_if( units1.begin(), units1.end(), unitFilter );
-        Battle::Units::iterator it2 = std::find_if( units2.begin(), units2.end(), unitFilter );
+        const Battle::Units::iterator attackingUnitsIter = std::find_if( attackingUnits.begin(), attackingUnits.end(), unitFilter );
+        const Battle::Units::iterator defendingUnitsIter = std::find_if( defendingUnits.begin(), defendingUnits.end(), unitFilter );
 
-        if ( it1 != units1.end() && it2 != units2.end() ) {
-            if ( ( *it1 )->GetSpeed() == ( *it2 )->GetSpeed() ) {
-                result = units1GoFirst ? *it1 : *it2;
+        if ( attackingUnitsIter != attackingUnits.end() && defendingUnitsIter != defendingUnits.end() ) {
+            if ( ( *attackingUnitsIter )->GetSpeed() == ( *defendingUnitsIter )->GetSpeed() ) {
+                result = attackingUnitsGoFirst ? *attackingUnitsIter : *defendingUnitsIter;
             }
             else {
-                result = ( ( *it1 )->GetSpeed() > ( *it2 )->GetSpeed() ) ? *it1 : *it2;
+                result = ( ( *attackingUnitsIter )->GetSpeed() > ( *defendingUnitsIter )->GetSpeed() ) ? *attackingUnitsIter : *defendingUnitsIter;
             }
         }
-        else if ( it1 != units1.end() ) {
-            result = *it1;
+        else if ( attackingUnitsIter != attackingUnits.end() ) {
+            result = *attackingUnitsIter;
         }
-        else if ( it2 != units2.end() ) {
-            result = *it2;
+        else if ( defendingUnitsIter != defendingUnits.end() ) {
+            result = *defendingUnitsIter;
         }
 
         if ( result && ordersMode ) {
-            if ( it1 != units1.end() && result == *it1 ) {
-                units1.erase( it1 );
+            if ( attackingUnitsIter != attackingUnits.end() && result == *attackingUnitsIter ) {
+                attackingUnits.erase( attackingUnitsIter );
             }
-            else if ( it2 != units2.end() && result == *it2 ) {
-                units2.erase( it2 );
+            else if ( defendingUnitsIter != defendingUnits.end() && result == *defendingUnitsIter ) {
+                defendingUnits.erase( defendingUnitsIter );
             }
         }
 
         return result;
     }
 
-    Battle::Unit * GetCurrentUnit( const Battle::Force & army1, const Battle::Force & army2, const PlayerColor preferredColor )
+    Battle::Unit * GetCurrentUnit( const Battle::Force & attackingArmy, const Battle::Force & defendingArmy, const PlayerColor preferredColor )
     {
-        Battle::Units units1( army1.getUnits(), Battle::Units::REMOVE_INVALID_UNITS );
-        Battle::Units units2( army2.getUnits(), Battle::Units::REMOVE_INVALID_UNITS );
+        Battle::Units attackingUnits( attackingArmy.getUnits(), Battle::Units::REMOVE_INVALID_UNITS );
+        Battle::Units defendingUnits( defendingArmy.getUnits(), Battle::Units::REMOVE_INVALID_UNITS );
 
-        units1.SortFastest();
-        units2.SortFastest();
+        attackingUnits.SortFastest();
+        defendingUnits.SortFastest();
 
-        Battle::Unit * result = GetCurrentUnit( units1, units2, preferredColor != army2.GetColor(), false );
+        Battle::Unit * result = GetCurrentUnit( attackingUnits, defendingUnits, preferredColor != defendingArmy.GetColor(), false );
         if ( result == nullptr ) {
             return result;
         }
@@ -221,19 +221,19 @@ namespace
         return result;
     }
 
-    void UpdateOrderOfUnits( const Battle::Force & army1, const Battle::Force & army2, const Battle::Unit * currentUnit, PlayerColor preferredColor,
+    void UpdateOrderOfUnits( const Battle::Force & attackingArmy, const Battle::Force & defendingArmy, const Battle::Unit * currentUnit, PlayerColor preferredColor,
                              const Battle::Units & orderHistory, Battle::Units & orderOfUnits )
     {
         orderOfUnits.assign( orderHistory.begin(), orderHistory.end() );
 
-        Battle::Units units1( army1.getUnits(), Battle::Units::REMOVE_INVALID_UNITS );
-        Battle::Units units2( army2.getUnits(), Battle::Units::REMOVE_INVALID_UNITS );
+        Battle::Units attackingUnits( attackingArmy.getUnits(), Battle::Units::REMOVE_INVALID_UNITS );
+        Battle::Units defendingUnits( defendingArmy.getUnits(), Battle::Units::REMOVE_INVALID_UNITS );
 
-        units1.SortFastest();
-        units2.SortFastest();
+        attackingUnits.SortFastest();
+        defendingUnits.SortFastest();
 
         while ( true ) {
-            Battle::Unit * unit = GetCurrentUnit( units1, units2, preferredColor != army2.GetColor(), true );
+            Battle::Unit * unit = GetCurrentUnit( attackingUnits, defendingUnits, preferredColor != defendingArmy.GetColor(), true );
             if ( unit == nullptr ) {
                 break;
             }
@@ -244,7 +244,7 @@ namespace
                 continue;
             }
 
-            preferredColor = ( unit->GetArmyColor() == army1.GetColor() ) ? army2.GetColor() : army1.GetColor();
+            preferredColor = ( unit->GetArmyColor() == attackingArmy.GetColor() ) ? defendingArmy.GetColor() : attackingArmy.GetColor();
 
             orderOfUnits.push_back( unit );
         }
@@ -344,7 +344,7 @@ bool Battle::Arena::isAnyTowerPresent()
     return std::any_of( arena->_towers.begin(), arena->_towers.end(), []( const auto & twr ) { return twr && twr->isValid(); } );
 }
 
-Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const bool isShowInterface, Rand::PCG32 & randomGenerator )
+Battle::Arena::Arena( Army & attackingArmy, Army & defendingArmy, const int32_t tileIndex, const bool isShowInterface, Rand::PCG32 & randomGenerator )
     : castle( world.getCastleEntrance( Maps::GetPoint( tileIndex ) ) )
     , _isTown( castle != nullptr )
     , _randomGenerator( randomGenerator )
@@ -354,8 +354,8 @@ Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const
     assert( arena == nullptr );
     arena = this;
 
-    _army1 = std::make_unique<Force>( army1, false, _uidGenerator );
-    _army2 = std::make_unique<Force>( army2, true, _uidGenerator );
+    _attackingArmy = std::make_unique<Force>( attackingArmy, false, _uidGenerator );
+    _defendingArmy = std::make_unique<Force>( defendingArmy, true, _uidGenerator );
 
     // If this is a siege of a town, then there is in fact no castle
     if ( castle && !castle->isCastle() ) {
@@ -372,11 +372,11 @@ Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const
     }
     else {
         // There is no interface - force the auto combat mode for the human player
-        if ( army1.isControlHuman() ) {
-            _autoCombatColors |= army1.GetColor();
+        if ( attackingArmy.isControlHuman() ) {
+            _autoCombatColors |= attackingArmy.GetColor();
         }
-        if ( army2.isControlHuman() ) {
-            _autoCombatColors |= army2.GetColor();
+        if ( defendingArmy.isControlHuman() ) {
+            _autoCombatColors |= defendingArmy.GetColor();
         }
     }
 
@@ -391,8 +391,8 @@ Battle::Arena::Arena( Army & army1, Army & army2, const int32_t tileIndex, const
             _towers[2] = std::make_unique<Tower>( *castle, TowerType::TWR_RIGHT, _uidGenerator.GetUnique() );
         }
 
-        if ( _army1->GetCommander() ) {
-            _catapult = std::make_unique<Catapult>( *_army1->GetCommander() );
+        if ( _attackingArmy->GetCommander() ) {
+            _catapult = std::make_unique<Catapult>( *_attackingArmy->GetCommander() );
         }
 
         _bridge = std::make_unique<Bridge>();
@@ -527,7 +527,7 @@ void Battle::Arena::UnitTurn( const Units & orderHistory )
 
             if ( _orderOfUnits ) {
                 // Applied action could kill someone or affect the speed of some unit, update the order of units
-                UpdateOrderOfUnits( *_army1, *_army2, _currentUnit, GetOppositeColor( _currentUnit->GetArmyColor() ), orderHistory, *_orderOfUnits );
+                UpdateOrderOfUnits( *_attackingArmy, *_defendingArmy, _currentUnit, GetOppositeColor( _currentUnit->GetArmyColor() ), orderHistory, *_orderOfUnits );
             }
 
             if ( !BattleValid() ) {
@@ -547,7 +547,7 @@ void Battle::Arena::UnitTurn( const Units & orderHistory )
 
 bool Battle::Arena::BattleValid() const
 {
-    return _army1->isValid() && _army2->isValid() && 0 == _battleResult.attacker && 0 == _battleResult.defender;
+    return _attackingArmy->isValid() && _defendingArmy->isValid() && 0 == _battleResult.attacker && 0 == _battleResult.defender;
 }
 
 void Battle::Arena::Turns()
@@ -560,8 +560,8 @@ void Battle::Arena::Turns()
         _interface->RedrawActionNewTurn();
     }
 
-    _army1->NewTurn();
-    _army2->NewTurn();
+    _attackingArmy->NewTurn();
+    _defendingArmy->NewTurn();
 
     // History of unit order on the current turn
     Units orderHistory;
@@ -570,7 +570,7 @@ void Battle::Arena::Turns()
         orderHistory.reserve( 25 );
 
         // Build the initial order of units
-        UpdateOrderOfUnits( *_army1, *_army2, nullptr, GetOppositeColor( _lastActiveUnitArmyColor ), orderHistory, *_orderOfUnits );
+        UpdateOrderOfUnits( *_attackingArmy, *_defendingArmy, nullptr, GetOppositeColor( _lastActiveUnitArmyColor ), orderHistory, *_orderOfUnits );
     }
 
     {
@@ -579,7 +579,7 @@ void Battle::Arena::Turns()
 
         while ( BattleValid() ) {
             // We can get the nullptr here if there are no units left waiting for their turn
-            _currentUnit = GetCurrentUnit( *_army1, *_army2, GetOppositeColor( _lastActiveUnitArmyColor ) );
+            _currentUnit = GetCurrentUnit( *_attackingArmy, *_defendingArmy, GetOppositeColor( _lastActiveUnitArmyColor ) );
 
             if ( _orderOfUnits ) {
                 // Add unit to the history
@@ -588,14 +588,14 @@ void Battle::Arena::Turns()
                 }
 
                 // Update the order of units
-                UpdateOrderOfUnits( *_army1, *_army2, _currentUnit, GetOppositeColor( _currentUnit ? _currentUnit->GetArmyColor() : _lastActiveUnitArmyColor ),
-                                    orderHistory, *_orderOfUnits );
+                UpdateOrderOfUnits( *_attackingArmy, *_defendingArmy, _currentUnit,
+                                    GetOppositeColor( _currentUnit ? _currentUnit->GetArmyColor() : _lastActiveUnitArmyColor ), orderHistory, *_orderOfUnits );
             }
 
             if ( castle ) {
                 // Catapult acts either during the turn of the first unit from the attacking army, or at the end of the
                 // turn if none of the units from the attacking army are able to act (for example, all are blinded)
-                if ( !catapultActed && ( _currentUnit == nullptr || _currentUnit->GetColor() == _army1->GetColor() ) ) {
+                if ( !catapultActed && ( _currentUnit == nullptr || _currentUnit->GetColor() == _attackingArmy->GetColor() ) ) {
                     CatapultAction();
 
                     catapultActed = true;
@@ -603,7 +603,7 @@ void Battle::Arena::Turns()
 
                 // Castle towers act either during the turn of the first unit from the defending army, or at the end of
                 // the turn if none of the units from the defending army are able to act (for example, all are blinded)
-                if ( !towersActed && ( _currentUnit == nullptr || _currentUnit->GetColor() == _army2->GetColor() ) ) {
+                if ( !towersActed && ( _currentUnit == nullptr || _currentUnit->GetColor() == _defendingArmy->GetColor() ) ) {
                     const auto towerAction = [this, &orderHistory]( const size_t idx ) {
                         assert( idx < std::size( _towers ) );
 
@@ -615,7 +615,7 @@ void Battle::Arena::Turns()
 
                         if ( _orderOfUnits ) {
                             // Tower could kill someone, update the order of units
-                            UpdateOrderOfUnits( *_army1, *_army2, _currentUnit,
+                            UpdateOrderOfUnits( *_attackingArmy, *_defendingArmy, _currentUnit,
                                                 GetOppositeColor( _currentUnit ? _currentUnit->GetArmyColor() : _lastActiveUnitArmyColor ), orderHistory,
                                                 *_orderOfUnits );
                         }
@@ -644,30 +644,30 @@ void Battle::Arena::Turns()
     }
 
     // Check if the battle is over
-    if ( !_army1->isValid() || ( _battleResult.attacker & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+    if ( !_attackingArmy->isValid() || ( _battleResult.attacker & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
         _battleResult.attacker |= RESULT_LOSS;
-        // Check if any of the original troops in the army2 are still alive
-        _battleResult.defender = _army2->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
+        // Check if any of the original troops in the defending army are still alive
+        _battleResult.defender = _defendingArmy->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
     }
-    else if ( !_army2->isValid() || ( _battleResult.defender & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+    else if ( !_defendingArmy->isValid() || ( _battleResult.defender & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
         _battleResult.defender |= RESULT_LOSS;
-        // Check if any of the original troops in the army1 are still alive
-        _battleResult.attacker = _army1->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
+        // Check if any of the original troops in the attacking army are still alive
+        _battleResult.attacker = _attackingArmy->isValid( false ) ? RESULT_WINS : RESULT_LOSS;
     }
 
     // If the battle is over, calculate the experience and the number of units killed
     if ( _battleResult.attacker || _battleResult.defender ) {
-        _battleResult.attackerExperience = _army2->calculateExperienceBasedOnLosses();
-        _battleResult.defenderExperience = _army1->calculateExperienceBasedOnLosses();
+        _battleResult.attackerExperience = _defendingArmy->calculateExperienceBasedOnLosses();
+        _battleResult.defenderExperience = _attackingArmy->calculateExperienceBasedOnLosses();
 
-        const HeroBase * army1Commander = _army1->GetCommander();
-        const HeroBase * army2Commander = _army2->GetCommander();
+        const HeroBase * attackingArmyCommander = _attackingArmy->GetCommander();
+        const HeroBase * defendingArmyCommander = _defendingArmy->GetCommander();
 
         // Attacker (or defender) gets an experience bonus if the enemy army was under the command of a hero who was defeated (i.e. did not retreat or surrender)
-        if ( army1Commander && army1Commander->isHeroes() && !( _battleResult.attacker & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+        if ( attackingArmyCommander && attackingArmyCommander->isHeroes() && !( _battleResult.attacker & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             _battleResult.defenderExperience += 500;
         }
-        if ( army2Commander && army2Commander->isHeroes() && !( _battleResult.defender & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
+        if ( defendingArmyCommander && defendingArmyCommander->isHeroes() && !( _battleResult.defender & ( RESULT_RETREAT | RESULT_SURRENDER ) ) ) {
             _battleResult.attackerExperience += 500;
         }
 
@@ -676,8 +676,9 @@ void Battle::Arena::Turns()
             _battleResult.attackerExperience += 500;
         }
 
-        const Force * army_loss = ( _battleResult.attacker & RESULT_LOSS ? _army1.get() : ( _battleResult.defender & RESULT_LOSS ? _army2.get() : nullptr ) );
-        _battleResult.numOfDeadUnitsForNecromancy = army_loss ? army_loss->calculateNumberOfDeadUnitsForNecromancy() : 0;
+        const Force * losingArmy
+            = ( _battleResult.attacker & RESULT_LOSS ? _attackingArmy.get() : ( _battleResult.defender & RESULT_LOSS ? _defendingArmy.get() : nullptr ) );
+        _battleResult.numOfDeadUnitsForNecromancy = losingArmy ? losingArmy->calculateNumberOfDeadUnitsForNecromancy() : 0;
     }
 }
 
@@ -788,24 +789,24 @@ const Battle::Unit * Battle::Arena::GetTroopBoard( int32_t index ) const
     return Board::isValidIndex( index ) ? board[index].GetUnit() : nullptr;
 }
 
-HeroBase * Battle::Arena::GetCommander1() const
+HeroBase * Battle::Arena::getAttackingArmyCommander() const
 {
-    return _army1->GetCommander();
+    return _attackingArmy->GetCommander();
 }
 
-HeroBase * Battle::Arena::GetCommander2() const
+HeroBase * Battle::Arena::getDefendingArmyCommander() const
 {
-    return _army2->GetCommander();
+    return _defendingArmy->GetCommander();
 }
 
-PlayerColor Battle::Arena::GetArmy1Color() const
+PlayerColor Battle::Arena::getAttackingArmyColor() const
 {
-    return _army1->GetColor();
+    return _attackingArmy->GetColor();
 }
 
-PlayerColor Battle::Arena::GetArmy2Color() const
+PlayerColor Battle::Arena::getDefendingArmyColor() const
 {
-    return _army2->GetColor();
+    return _defendingArmy->GetColor();
 }
 
 PlayerColor Battle::Arena::GetCurrentColor() const
@@ -821,16 +822,18 @@ PlayerColor Battle::Arena::GetCurrentColor() const
 
 PlayerColor Battle::Arena::GetOppositeColor( const PlayerColor col ) const
 {
-    return col == GetArmy1Color() ? GetArmy2Color() : GetArmy1Color();
+    return col == getAttackingArmyColor() ? getDefendingArmyColor() : getAttackingArmyColor();
 }
 
 Battle::Unit * Battle::Arena::GetTroopUID( uint32_t uid )
 {
-    if ( const auto iter = std::find_if( _army1->begin(), _army1->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } ); iter != _army1->end() ) {
+    if ( const auto iter = std::find_if( _attackingArmy->begin(), _attackingArmy->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
+         iter != _attackingArmy->end() ) {
         return *iter;
     }
 
-    if ( const auto iter = std::find_if( _army2->begin(), _army2->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } ); iter != _army2->end() ) {
+    if ( const auto iter = std::find_if( _defendingArmy->begin(), _defendingArmy->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
+         iter != _defendingArmy->end() ) {
         return *iter;
     }
 
@@ -839,11 +842,13 @@ Battle::Unit * Battle::Arena::GetTroopUID( uint32_t uid )
 
 const Battle::Unit * Battle::Arena::GetTroopUID( uint32_t uid ) const
 {
-    if ( const auto iter = std::find_if( _army1->begin(), _army1->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } ); iter != _army1->end() ) {
+    if ( const auto iter = std::find_if( _attackingArmy->begin(), _attackingArmy->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
+         iter != _attackingArmy->end() ) {
         return *iter;
     }
 
-    if ( const auto iter = std::find_if( _army2->begin(), _army2->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } ); iter != _army2->end() ) {
+    if ( const auto iter = std::find_if( _defendingArmy->begin(), _defendingArmy->end(), [uid]( const Unit * unit ) { return unit->isUID( uid ); } );
+         iter != _defendingArmy->end() ) {
         return *iter;
     }
 
@@ -867,10 +872,10 @@ const SpellStorage & Battle::Arena::GetUsedSpells() const
 int32_t Battle::Arena::GetFreePositionNearHero( const PlayerColor heroColor ) const
 {
     std::vector<int> cellIds;
-    if ( _army1->GetColor() == heroColor ) {
+    if ( _attackingArmy->GetColor() == heroColor ) {
         cellIds = { 11, 22, 33 };
     }
-    else if ( _army2->GetColor() == heroColor ) {
+    else if ( _defendingArmy->GetColor() == heroColor ) {
         cellIds = { 21, 32, 43 };
     }
     else {
@@ -902,18 +907,18 @@ bool Battle::Arena::CanSurrenderOpponent( PlayerColor color ) const
 bool Battle::Arena::CanRetreatOpponent( const PlayerColor color ) const
 {
     const HeroBase * hero = getCommander( color );
-    return hero && hero->isHeroes() && ( color == _army1->GetColor() || hero->inCastle() == nullptr );
+    return hero && hero->isHeroes() && ( color == _attackingArmy->GetColor() || hero->inCastle() == nullptr );
 }
 
 bool Battle::Arena::isSpellcastDisabled() const
 {
-    const HeroBase * hero1 = _army1->GetCommander();
-    if ( hero1 != nullptr && hero1->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::DISABLE_ALL_SPELL_COMBAT_CASTING ) ) {
+    const HeroBase * attackingHero = _attackingArmy->GetCommander();
+    if ( attackingHero != nullptr && attackingHero->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::DISABLE_ALL_SPELL_COMBAT_CASTING ) ) {
         return true;
     }
 
-    const HeroBase * hero2 = _army2->GetCommander();
-    if ( hero2 != nullptr && hero2->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::DISABLE_ALL_SPELL_COMBAT_CASTING ) ) {
+    const HeroBase * defendingHero = _defendingArmy->GetCommander();
+    if ( defendingHero != nullptr && defendingHero->GetBagArtifacts().isArtifactBonusPresent( fheroes2::ArtifactBonusType::DISABLE_ALL_SPELL_COMBAT_CASTING ) ) {
         return true;
     }
 
@@ -1290,12 +1295,12 @@ int Battle::Arena::getCastleDefenseStructureCondition( const CastleDefenseStruct
 
 const HeroBase * Battle::Arena::getCommander( const PlayerColor color ) const
 {
-    return ( _army1->GetColor() == color ) ? _army1->GetCommander() : _army2->GetCommander();
+    return ( _attackingArmy->GetColor() == color ) ? _attackingArmy->GetCommander() : _defendingArmy->GetCommander();
 }
 
 const HeroBase * Battle::Arena::getEnemyCommander( const PlayerColor color ) const
 {
-    return ( _army1->GetColor() == color ) ? _army2->GetCommander() : _army1->GetCommander();
+    return ( _attackingArmy->GetColor() == color ) ? _defendingArmy->GetCommander() : _attackingArmy->GetCommander();
 }
 
 const HeroBase * Battle::Arena::GetCurrentCommander() const
@@ -1319,7 +1324,7 @@ Battle::Unit * Battle::Arena::CreateElemental( const Spell & spell )
 
     DEBUG_LOG( DBG_BATTLE, DBG_TRACE, mons.GetName() << ", position: " << idx )
 
-    const bool reflect = ( hero == _army2->GetCommander() );
+    const bool reflect = ( hero == _defendingArmy->GetCommander() );
     const uint32_t count = fheroes2::getSummonMonsterCount( spell, hero->GetPower(), hero );
 
     Position pos;
@@ -1403,12 +1408,12 @@ bool Battle::Arena::IsShootingPenalty( const Unit & attacker, const Unit & defen
 
 Battle::Force & Battle::Arena::getForce( const PlayerColor color ) const
 {
-    return ( _army1->GetColor() == color ) ? *_army1 : *_army2;
+    return ( _attackingArmy->GetColor() == color ) ? *_attackingArmy : *_defendingArmy;
 }
 
 Battle::Force & Battle::Arena::getEnemyForce( const PlayerColor color ) const
 {
-    return ( _army1->GetColor() == color ) ? *_army2 : *_army1;
+    return ( _attackingArmy->GetColor() == color ) ? *_defendingArmy : *_attackingArmy;
 }
 
 Battle::Force & Battle::Arena::GetCurrentForce() const

--- a/src/fheroes2/battle/battle_arena.cpp
+++ b/src/fheroes2/battle/battle_arena.cpp
@@ -657,8 +657,8 @@ void Battle::Arena::Turns()
 
     // If the battle is over, calculate the experience and the number of units killed
     if ( result_game.army1 || result_game.army2 ) {
-        result_game.exp1 = _army2->GetDeadHitPoints();
-        result_game.exp2 = _army1->GetDeadHitPoints();
+        result_game.exp1 = _army2->calculateExperienceBasedOnLosses();
+        result_game.exp2 = _army1->calculateExperienceBasedOnLosses();
 
         const HeroBase * army1Commander = _army1->GetCommander();
         const HeroBase * army2Commander = _army2->GetCommander();
@@ -677,7 +677,7 @@ void Battle::Arena::Turns()
         }
 
         const Force * army_loss = ( result_game.army1 & RESULT_LOSS ? _army1.get() : ( result_game.army2 & RESULT_LOSS ? _army2.get() : nullptr ) );
-        result_game.killed = army_loss ? army_loss->GetDeadCounts() : 0;
+        result_game.killed = army_loss ? army_loss->getTotalNumberOfDeadUnitsInOriginalArmy() : 0;
     }
 }
 

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -116,7 +116,7 @@ namespace Battle
 
         Result & GetResult()
         {
-            return result_game;
+            return _battleResult;
         }
 
         HeroBase * GetCommander1() const;
@@ -345,7 +345,7 @@ namespace Battle
         std::unique_ptr<Bridge> _bridge;
 
         std::unique_ptr<Interface> _interface;
-        Result result_game;
+        Result _battleResult;
 
         Graveyard _graveyard;
         SpellStorage _usedSpells;

--- a/src/fheroes2/battle/battle_arena.h
+++ b/src/fheroes2/battle/battle_arena.h
@@ -93,7 +93,7 @@ namespace Battle
     class Arena
     {
     public:
-        Arena( Army & army1, Army & army2, const int32_t tileIndex, const bool isShowInterface, Rand::PCG32 & randomGenerator );
+        Arena( Army & attackingArmy, Army & defendingArmy, const int32_t tileIndex, const bool isShowInterface, Rand::PCG32 & randomGenerator );
         Arena( const Arena & ) = delete;
         Arena( Arena && ) = delete;
 
@@ -119,29 +119,29 @@ namespace Battle
             return _battleResult;
         }
 
-        HeroBase * GetCommander1() const;
-        HeroBase * GetCommander2() const;
+        HeroBase * getAttackingArmyCommander() const;
+        HeroBase * getDefendingArmyCommander() const;
 
         const HeroBase * getCommander( const PlayerColor color ) const;
         const HeroBase * getEnemyCommander( const PlayerColor color ) const;
         const HeroBase * GetCurrentCommander() const;
 
-        Force & GetForce1() const
+        Force & getAttackingForce() const
         {
-            return *_army1;
+            return *_attackingArmy;
         }
 
-        Force & GetForce2() const
+        Force & getDefendingForce() const
         {
-            return *_army2;
+            return *_defendingArmy;
         }
 
         Force & getForce( const PlayerColor color ) const;
         Force & getEnemyForce( const PlayerColor color ) const;
         Force & GetCurrentForce() const;
 
-        PlayerColor GetArmy1Color() const;
-        PlayerColor GetArmy2Color() const;
+        PlayerColor getAttackingArmyColor() const;
+        PlayerColor getDefendingArmyColor() const;
         PlayerColor GetCurrentColor() const;
         // Returns the color of the army opposite to the army of the given color. If there is no army of the given color,
         // returns the color of the attacking army.
@@ -325,8 +325,8 @@ namespace Battle
         // position, which should be updated separately.
         Unit * CreateMirrorImage( Unit & unit );
 
-        std::unique_ptr<Force> _army1;
-        std::unique_ptr<Force> _army2;
+        std::unique_ptr<Force> _attackingArmy;
+        std::unique_ptr<Force> _defendingArmy;
         std::shared_ptr<Units> _orderOfUnits;
 
         // The unit that is currently active. Please note that some battle actions (e.g. catapult or castle tower shots) can be performed without an active unit.

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -282,36 +282,19 @@ uint32_t Battle::Force::getTotalNumberOfDeadUnits() const
 
 uint32_t Battle::Force::calculateNumberOfDeadUnitsForNecromancy() const
 {
-    uint32_t result = 0;
+    return std::accumulate( begin(), end(), static_cast<uint32_t>( 0 ), []( const uint32_t total, const Battle::Unit * unit ) {
+        assert( unit != nullptr );
 
-    applyActionToTroopsOfOriginalArmy( [&result]( const Troop & troop, const Unit & unit ) {
-        const uint32_t initialCount = troop.GetCount();
-        const uint32_t currentCount = unit.GetDead() > unit.GetInitialCount() ? 0 : unit.GetInitialCount() - unit.GetDead();
-
-        if ( currentCount > initialCount ) {
-            return;
-        }
-
-        result += initialCount - currentCount;
+        return total + std::min( unit->GetInitialCount(), unit->GetDead() );
     } );
-
-    return result;
 }
 
 uint32_t Battle::Force::calculateExperienceBasedOnLosses() const
 {
     uint32_t result = 0;
 
-    applyActionToTroopsOfOriginalArmy( [&result]( const Troop & troop, const Unit & unit ) {
-        const uint32_t initialCount = troop.GetCount();
-        const uint32_t currentCount = unit.GetDead() > unit.GetInitialCount() ? 0 : unit.GetInitialCount() - unit.GetDead();
-
-        if ( currentCount > initialCount ) {
-            return;
-        }
-
-        result += troop.Monster::GetHitPoints() * ( initialCount - currentCount );
-    } );
+    applyActionToTroopsOfOriginalArmy(
+        [&result]( const Troop &, const Unit & unit ) { result += unit.Monster::GetHitPoints() * std::min( unit.GetInitialCount(), unit.GetDead() ); } );
 
     return result;
 }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -280,7 +280,7 @@ uint32_t Battle::Force::getTotalNumberOfDeadUnits() const
     } );
 }
 
-uint32_t Battle::Force::getTotalNumberOfDeadUnitsInOriginalArmy() const
+uint32_t Battle::Force::calculateNumberOfDeadUnitsForNecromancy() const
 {
     uint32_t result = 0;
 

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -319,7 +319,6 @@ uint32_t Battle::Force::calculateExperienceBasedOnLosses() const
 
 void Battle::Force::syncOriginalArmy() const
 {
-    applyActionToTroopsOfOriginalArmy( []( Troop & troop, const Unit & unit ) {
-        troop.SetCount( unit.GetDead() > unit.GetInitialCount() ? 0 : unit.GetInitialCount() - unit.GetDead() );
-    } );
+    applyActionToTroopsOfOriginalArmy(
+        []( Troop & troop, const Unit & unit ) { troop.SetCount( unit.GetDead() > unit.GetInitialCount() ? 0 : unit.GetInitialCount() - unit.GetDead() ); } );
 }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -293,7 +293,7 @@ uint32_t Battle::Force::calculateExperienceBasedOnLosses() const
 {
     uint32_t result = 0;
 
-    applyActionToTroopsFromOriginalArmy(
+    _applyActionToTroopsFromOriginalArmy(
         [&result]( const Troop &, const Unit & unit ) { result += unit.Monster::GetHitPoints() * std::min( unit.GetInitialCount(), unit.GetDead() ); } );
 
     return result;
@@ -301,6 +301,6 @@ uint32_t Battle::Force::calculateExperienceBasedOnLosses() const
 
 void Battle::Force::syncOriginalArmy() const
 {
-    applyActionToTroopsFromOriginalArmy(
+    _applyActionToTroopsFromOriginalArmy(
         []( Troop & troop, const Unit & unit ) { troop.SetCount( unit.GetDead() > unit.GetMaxCount() ? 0 : unit.GetMaxCount() - unit.GetDead() ); } );
 }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -302,5 +302,5 @@ uint32_t Battle::Force::calculateExperienceBasedOnLosses() const
 void Battle::Force::syncOriginalArmy() const
 {
     _applyActionToTroopsFromOriginalArmy(
-        []( Troop & troop, const Unit & unit ) { troop.SetCount( unit.GetDead() > unit.GetMaxCount() ? 0 : unit.GetMaxCount() - unit.GetDead() ); } );
+        []( Troop & troop, const Unit & unit ) { troop.SetCount( unit.GetDead() >= unit.GetMaxCount() ? 0 : unit.GetMaxCount() - unit.GetDead() ); } );
 }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -27,7 +27,6 @@
 #include <cstddef>
 #include <numeric>
 
-#include "army_troop.h"
 #include "artifact.h"
 #include "artifact_info.h"
 #include "battle_arena.h"

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -293,7 +293,7 @@ uint32_t Battle::Force::calculateExperienceBasedOnLosses() const
 {
     uint32_t result = 0;
 
-    applyActionToTroopsOfOriginalArmy(
+    applyActionToTroopsFromOriginalArmy(
         [&result]( const Troop &, const Unit & unit ) { result += unit.Monster::GetHitPoints() * std::min( unit.GetInitialCount(), unit.GetDead() ); } );
 
     return result;
@@ -301,6 +301,6 @@ uint32_t Battle::Force::calculateExperienceBasedOnLosses() const
 
 void Battle::Force::syncOriginalArmy() const
 {
-    applyActionToTroopsOfOriginalArmy(
+    applyActionToTroopsFromOriginalArmy(
         []( Troop & troop, const Unit & unit ) { troop.SetCount( unit.GetDead() > unit.GetMaxCount() ? 0 : unit.GetMaxCount() - unit.GetDead() ); } );
 }

--- a/src/fheroes2/battle/battle_army.cpp
+++ b/src/fheroes2/battle/battle_army.cpp
@@ -152,7 +152,7 @@ bool Battle::Force::isValid( const bool considerBattlefieldArmy /* = true */ ) c
         }
 
         const Unit * unit = FindUID( uids.at( index ) );
-        if ( unit == nullptr || unit->GetDead() >= unit->GetInitialCount() ) {
+        if ( unit == nullptr || unit->GetDead() >= unit->GetMaxCount() ) {
             continue;
         }
 
@@ -319,5 +319,5 @@ uint32_t Battle::Force::calculateExperienceBasedOnLosses() const
 void Battle::Force::syncOriginalArmy() const
 {
     applyActionToTroopsOfOriginalArmy(
-        []( Troop & troop, const Unit & unit ) { troop.SetCount( unit.GetDead() > unit.GetInitialCount() ? 0 : unit.GetInitialCount() - unit.GetDead() ); } );
+        []( Troop & troop, const Unit & unit ) { troop.SetCount( unit.GetDead() > unit.GetMaxCount() ? 0 : unit.GetMaxCount() - unit.GetDead() ); } );
 }

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -136,7 +136,8 @@ namespace Battle
         bool HasMonster( const Monster & ) const;
 
         uint32_t getTotalNumberOfDeadUnits() const;
-        uint32_t getTotalNumberOfDeadUnitsInOriginalArmy() const;
+
+        uint32_t calculateNumberOfDeadUnitsForNecromancy() const;
         uint32_t calculateExperienceBasedOnLosses() const;
 
         PlayerColor GetColor() const;

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -157,7 +157,7 @@ namespace Battle
 
     private:
         template <typename T>
-        void applyActionToTroopsOfOriginalArmy( const T & action ) const
+        void applyActionToTroopsFromOriginalArmy( const T & action ) const
         {
             for ( uint32_t index = 0; index < army.Size(); ++index ) {
                 Troop * troop = army.GetTroop( index );

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -134,8 +134,9 @@ namespace Battle
         bool isValid( const bool considerBattlefieldArmy = true ) const;
         bool HasMonster( const Monster & ) const;
 
-        uint32_t GetDeadHitPoints() const;
-        uint32_t GetDeadCounts() const;
+        uint32_t getTotalNumberOfDeadUnits() const;
+        uint32_t getTotalNumberOfDeadUnitsInOriginalArmy() const;
+        uint32_t calculateExperienceBasedOnLosses() const;
 
         PlayerColor GetColor() const;
         int GetControl() const;
@@ -149,9 +150,28 @@ namespace Battle
         void resetIdleAnimation() const;
 
         void NewTurn();
-        void SyncArmyCount();
+
+        void syncOriginalArmy() const;
 
     private:
+        template <typename T>
+        void applyActionToTroopsOfOriginalArmy( const T & action ) const
+        {
+            for ( uint32_t index = 0; index < army.Size(); ++index ) {
+                Troop * troop = army.GetTroop( index );
+                if ( troop == nullptr || !troop->isValid() ) {
+                    continue;
+                }
+
+                const Unit * unit = FindUID( uids.at( index ) );
+                if ( unit == nullptr ) {
+                    continue;
+                }
+
+                action( *troop, *unit );
+            }
+        }
+
         Army & army;
         std::vector<uint32_t> uids;
     };

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -31,6 +31,7 @@
 #include <vector>
 
 #include "army.h"
+#include "army_troop.h"
 #include "battle_troop.h"
 #include "bitmodes.h"
 #include "monster.h"

--- a/src/fheroes2/battle/battle_army.h
+++ b/src/fheroes2/battle/battle_army.h
@@ -157,7 +157,7 @@ namespace Battle
 
     private:
         template <typename T>
-        void applyActionToTroopsFromOriginalArmy( const T & action ) const
+        void _applyActionToTroopsFromOriginalArmy( const T & action ) const
         {
             for ( uint32_t index = 0; index < army.Size(); ++index ) {
                 Troop * troop = army.GetTroop( index );

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -511,8 +511,8 @@ void Battle::GetSummaryParams( const uint32_t res1, const uint32_t res2, const H
 // Returns true if player wants to restart the battle
 bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<Artifact> & artifacts, const bool allowToRestart ) const
 {
-    const bool attackerIsHuman = _army1->GetControl() & CONTROL_HUMAN;
-    const bool defenderIsHuman = _army2->GetControl() & CONTROL_HUMAN;
+    const bool attackerIsHuman = _attackingArmy->GetControl() & CONTROL_HUMAN;
+    const bool defenderIsHuman = _defendingArmy->GetControl() & CONTROL_HUMAN;
 
     if ( !attackerIsHuman && !defenderIsHuman ) {
         // AI vs AI battle, this dialog should not be shown
@@ -544,23 +544,23 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
     fheroes2::FontType summaryTitleFont = fheroes2::FontType::normalWhite();
     if ( ( res.attacker & RESULT_WINS ) && attackerIsHuman ) {
-        GetSummaryParams( res.attacker, res.defender, _army1->GetCommander(), res.attackerExperience, _army2->GetSurrenderCost(), sequence, title, surrenderText,
-                          outcomeText );
+        GetSummaryParams( res.attacker, res.defender, _attackingArmy->GetCommander(), res.attackerExperience, _defendingArmy->GetSurrenderCost(), sequence, title,
+                          surrenderText, outcomeText );
         summaryTitleFont = fheroes2::FontType::normalYellow();
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( ( res.defender & RESULT_WINS ) && defenderIsHuman ) {
-        GetSummaryParams( res.defender, res.attacker, _army2->GetCommander(), res.defenderExperience, _army1->GetSurrenderCost(), sequence, title, surrenderText,
-                          outcomeText );
+        GetSummaryParams( res.defender, res.attacker, _defendingArmy->GetCommander(), res.defenderExperience, _attackingArmy->GetSurrenderCost(), sequence, title,
+                          surrenderText, outcomeText );
         summaryTitleFont = fheroes2::FontType::normalYellow();
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( attackerIsHuman ) {
-        GetSummaryParams( res.attacker, res.defender, _army1->GetCommander(), res.attackerExperience, 0, sequence, title, surrenderText, outcomeText );
+        GetSummaryParams( res.attacker, res.defender, _attackingArmy->GetCommander(), res.attackerExperience, 0, sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( defenderIsHuman ) {
-        GetSummaryParams( res.defender, res.attacker, _army2->GetCommander(), res.defenderExperience, 0, sequence, title, surrenderText, outcomeText );
+        GetSummaryParams( res.defender, res.attacker, _defendingArmy->GetCommander(), res.defenderExperience, 0, sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
 
@@ -622,11 +622,11 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     text.set( _( "Attacker" ), casualtiesFont );
     text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY + 15, display );
 
-    const Troops killed1 = _army1->GetKilledTroops();
-    const Troops killed2 = _army2->GetKilledTroops();
+    const Troops killedInAttackingArmy = _attackingArmy->GetKilledTroops();
+    const Troops killedInDefendingArmy = _defendingArmy->GetKilledTroops();
 
-    if ( killed1.isValid() ) {
-        Army::drawSingleDetailedMonsterLine( killed1, summaryRoi.x + 13, casualtiesOffsetY + 36, roi.width - 47 );
+    if ( killedInAttackingArmy.isValid() ) {
+        Army::drawSingleDetailedMonsterLine( killedInAttackingArmy, summaryRoi.x + 13, casualtiesOffsetY + 36, roi.width - 47 );
     }
     else {
         text.set( _( "None" ), casualtiesFont );
@@ -637,8 +637,8 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     text.set( _( "Defender" ), casualtiesFont );
     text.draw( summaryRoi.x + ( summaryRoi.width - text.width() ) / 2, casualtiesOffsetY + 75, display );
 
-    if ( killed2.isValid() ) {
-        Army::drawSingleDetailedMonsterLine( killed2, summaryRoi.x + 13, casualtiesOffsetY + 96, roi.width - 47 );
+    if ( killedInDefendingArmy.isValid() ) {
+        Army::drawSingleDetailedMonsterLine( killedInDefendingArmy, summaryRoi.x + 13, casualtiesOffsetY + 96, roi.width - 47 );
     }
     else {
         text.set( _( "None" ), casualtiesFont );
@@ -706,8 +706,10 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     }
 
     if ( !artifacts.empty() ) {
-        const HeroBase * winner = ( res.attacker & RESULT_WINS ? _army1->GetCommander() : ( res.defender & RESULT_WINS ? _army2->GetCommander() : nullptr ) );
-        const HeroBase * loser = ( res.attacker & RESULT_LOSS ? _army1->GetCommander() : ( res.defender & RESULT_LOSS ? _army2->GetCommander() : nullptr ) );
+        const HeroBase * winner
+            = ( res.attacker & RESULT_WINS ? _attackingArmy->GetCommander() : ( res.defender & RESULT_WINS ? _defendingArmy->GetCommander() : nullptr ) );
+        const HeroBase * loser
+            = ( res.attacker & RESULT_LOSS ? _attackingArmy->GetCommander() : ( res.defender & RESULT_LOSS ? _defendingArmy->GetCommander() : nullptr ) );
 
         // Cannot transfer artifacts
         if ( winner == nullptr || loser == nullptr ) {

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -543,22 +543,24 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     LoopedAnimationSequence sequence;
 
     fheroes2::FontType summaryTitleFont = fheroes2::FontType::normalWhite();
-    if ( ( res.army1 & RESULT_WINS ) && attackerIsHuman ) {
-        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, _army2->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
+    if ( ( res.attacker & RESULT_WINS ) && attackerIsHuman ) {
+        GetSummaryParams( res.attacker, res.defender, _army1->GetCommander(), res.attackerExperience, _army2->GetSurrenderCost(), sequence, title, surrenderText,
+                          outcomeText );
         summaryTitleFont = fheroes2::FontType::normalYellow();
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
-    else if ( ( res.army2 & RESULT_WINS ) && defenderIsHuman ) {
-        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, _army1->GetSurrenderCost(), sequence, title, surrenderText, outcomeText );
+    else if ( ( res.defender & RESULT_WINS ) && defenderIsHuman ) {
+        GetSummaryParams( res.defender, res.attacker, _army2->GetCommander(), res.defenderExperience, _army1->GetSurrenderCost(), sequence, title, surrenderText,
+                          outcomeText );
         summaryTitleFont = fheroes2::FontType::normalYellow();
         AudioManager::PlayMusic( MUS::BATTLEWIN, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( attackerIsHuman ) {
-        GetSummaryParams( res.army1, res.army2, _army1->GetCommander(), res.exp1, 0, sequence, title, surrenderText, outcomeText );
+        GetSummaryParams( res.attacker, res.defender, _army1->GetCommander(), res.attackerExperience, 0, sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
     else if ( defenderIsHuman ) {
-        GetSummaryParams( res.army2, res.army1, _army2->GetCommander(), res.exp2, 0, sequence, title, surrenderText, outcomeText );
+        GetSummaryParams( res.defender, res.attacker, _army2->GetCommander(), res.defenderExperience, 0, sequence, title, surrenderText, outcomeText );
         AudioManager::PlayMusic( MUS::BATTLELOSE, Music::PlaybackMode::PLAY_ONCE );
     }
 
@@ -704,8 +706,8 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
     }
 
     if ( !artifacts.empty() ) {
-        const HeroBase * winner = ( res.army1 & RESULT_WINS ? _army1->GetCommander() : ( res.army2 & RESULT_WINS ? _army2->GetCommander() : nullptr ) );
-        const HeroBase * loser = ( res.army1 & RESULT_LOSS ? _army1->GetCommander() : ( res.army2 & RESULT_LOSS ? _army2->GetCommander() : nullptr ) );
+        const HeroBase * winner = ( res.attacker & RESULT_WINS ? _army1->GetCommander() : ( res.defender & RESULT_WINS ? _army2->GetCommander() : nullptr ) );
+        const HeroBase * loser = ( res.attacker & RESULT_LOSS ? _army1->GetCommander() : ( res.defender & RESULT_LOSS ? _army2->GetCommander() : nullptr ) );
 
         // Cannot transfer artifacts
         if ( winner == nullptr || loser == nullptr ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1396,11 +1396,11 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     _buttonSettings.setICNInfo( ICN::TEXTBAR, 6, 7 );
 
     // opponents
-    if ( HeroBase * opponent = arena.GetCommander1(); opponent != nullptr ) {
-        _opponent1 = std::make_unique<OpponentSprite>( _surfaceInnerArea, opponent, false );
+    if ( HeroBase * opponent = arena.getAttackingArmyCommander(); opponent != nullptr ) {
+        _attackingOpponent = std::make_unique<OpponentSprite>( _surfaceInnerArea, opponent, false );
     }
-    if ( HeroBase * opponent = arena.GetCommander2(); opponent != nullptr ) {
-        _opponent2 = std::make_unique<OpponentSprite>( _surfaceInnerArea, opponent, true );
+    if ( HeroBase * opponent = arena.getDefendingArmyCommander(); opponent != nullptr ) {
+        _defendingOpponent = std::make_unique<OpponentSprite>( _surfaceInnerArea, opponent, true );
     }
 
     if ( Arena::GetCastle() ) {
@@ -1461,7 +1461,7 @@ Battle::Interface::~Interface()
 
 void Battle::Interface::SetOrderOfUnits( const std::shared_ptr<const Units> & units )
 {
-    _turnOrder.set( _interfacePosition, units, arena.GetArmy2Color() );
+    _turnOrder.set( _interfacePosition, units, arena.getDefendingArmyColor() );
 }
 
 fheroes2::Point Battle::Interface::getRelativeMouseCursorPos() const
@@ -1888,10 +1888,10 @@ void Battle::Interface::RedrawArmies()
 
 void Battle::Interface::RedrawOpponents()
 {
-    if ( _opponent1 )
-        _opponent1->Redraw( _mainSurface );
-    if ( _opponent2 )
-        _opponent2->Redraw( _mainSurface );
+    if ( _attackingOpponent )
+        _attackingOpponent->Redraw( _mainSurface );
+    if ( _defendingOpponent )
+        _defendingOpponent->Redraw( _mainSurface );
 
     RedrawOpponentsFlags();
 }
@@ -1918,18 +1918,19 @@ void Battle::Interface::RedrawOpponentsFlags()
         return ICN::HEROFL06;
     };
 
-    if ( _opponent1 ) {
-        const int icn = getFlagIcn( arena.GetForce1().GetColor() );
+    if ( _attackingOpponent ) {
+        const int icn = getFlagIcn( arena.getAttackingForce().GetColor() );
         const fheroes2::Sprite & flag = fheroes2::AGG::GetICN( icn, ICN::getAnimatedIcnIndex( icn, 0, animation_flags_frame ) );
-        fheroes2::Blit( flag, _mainSurface, _opponent1->Offset().x + OpponentSprite::LEFT_HERO_X_OFFSET + flag.x(),
-                        _opponent1->Offset().y + OpponentSprite::LEFT_HERO_Y_OFFSET + flag.y() );
+        fheroes2::Blit( flag, _mainSurface, _attackingOpponent->Offset().x + OpponentSprite::LEFT_HERO_X_OFFSET + flag.x(),
+                        _attackingOpponent->Offset().y + OpponentSprite::LEFT_HERO_Y_OFFSET + flag.y() );
     }
 
-    if ( _opponent2 ) {
-        const int icn = getFlagIcn( arena.GetForce2().GetColor() );
+    if ( _defendingOpponent ) {
+        const int icn = getFlagIcn( arena.getDefendingForce().GetColor() );
         const fheroes2::Sprite & flag = fheroes2::AGG::GetICN( icn, ICN::getAnimatedIcnIndex( icn, 0, animation_flags_frame ) );
-        fheroes2::Blit( flag, _mainSurface, _opponent2->Offset().x + fheroes2::Display::DEFAULT_WIDTH - OpponentSprite::RIGHT_HERO_X_OFFSET - ( flag.x() + flag.width() ),
-                        _opponent2->Offset().y + OpponentSprite::RIGHT_HERO_Y_OFFSET + flag.y(), true );
+        fheroes2::Blit( flag, _mainSurface,
+                        _defendingOpponent->Offset().x + fheroes2::Display::DEFAULT_WIDTH - OpponentSprite::RIGHT_HERO_X_OFFSET - ( flag.x() + flag.width() ),
+                        _defendingOpponent->Offset().y + OpponentSprite::RIGHT_HERO_Y_OFFSET + flag.y(), true );
     }
 }
 
@@ -3055,10 +3056,10 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
                                                Dialog::ZERO );
         }
     }
-    else if ( _opponent1 && le.isMouseCursorPosInArea( _opponent1->GetArea() + _interfacePosition.getPosition() ) ) {
-        const fheroes2::Rect opponent1Area = _opponent1->GetArea() + _interfacePosition.getPosition();
-        if ( arena.GetCurrentColor() == arena.GetArmy1Color() ) {
-            if ( _opponent1->GetHero()->isCaptain() ) {
+    else if ( _attackingOpponent && le.isMouseCursorPosInArea( _attackingOpponent->GetArea() + _interfacePosition.getPosition() ) ) {
+        const fheroes2::Rect attackingOpponentArea = _attackingOpponent->GetArea() + _interfacePosition.getPosition();
+        if ( arena.GetCurrentColor() == arena.getAttackingArmyColor() ) {
+            if ( _attackingOpponent->GetHero()->isCaptain() ) {
                 msg = _( "View Captain's options" );
             }
             else {
@@ -3066,13 +3067,13 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             }
             cursor.SetThemes( Cursor::WAR_HERO );
 
-            if ( le.MouseClickLeft( opponent1Area ) ) {
-                ProcessingHeroDialogResult( arena.DialogBattleHero( *_opponent1->GetHero(), true, status ), actions );
+            if ( le.MouseClickLeft( attackingOpponentArea ) ) {
+                ProcessingHeroDialogResult( arena.DialogBattleHero( *_attackingOpponent->GetHero(), true, status ), actions );
                 humanturn_redraw = true;
             }
         }
         else {
-            if ( _opponent1->GetHero()->isCaptain() ) {
+            if ( _attackingOpponent->GetHero()->isCaptain() ) {
                 msg = _( "View opposing Captain" );
             }
             else {
@@ -3080,21 +3081,21 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             }
             cursor.SetThemes( Cursor::WAR_INFO );
 
-            if ( le.MouseClickLeft( opponent1Area ) ) {
-                arena.DialogBattleHero( *_opponent1->GetHero(), true, status );
+            if ( le.MouseClickLeft( attackingOpponentArea ) ) {
+                arena.DialogBattleHero( *_attackingOpponent->GetHero(), true, status );
                 humanturn_redraw = true;
             }
         }
 
-        if ( le.isMouseRightButtonPressedInArea( opponent1Area ) ) {
-            arena.DialogBattleHero( *_opponent1->GetHero(), false, status );
+        if ( le.isMouseRightButtonPressedInArea( attackingOpponentArea ) ) {
+            arena.DialogBattleHero( *_attackingOpponent->GetHero(), false, status );
             humanturn_redraw = true;
         }
     }
-    else if ( _opponent2 && le.isMouseCursorPosInArea( _opponent2->GetArea() + _interfacePosition.getPosition() ) ) {
-        const fheroes2::Rect opponent2Area = _opponent2->GetArea() + _interfacePosition.getPosition();
-        if ( arena.GetCurrentColor() == arena.GetForce2().GetColor() ) {
-            if ( _opponent2->GetHero()->isCaptain() ) {
+    else if ( _defendingOpponent && le.isMouseCursorPosInArea( _defendingOpponent->GetArea() + _interfacePosition.getPosition() ) ) {
+        const fheroes2::Rect defendingOpponentArea = _defendingOpponent->GetArea() + _interfacePosition.getPosition();
+        if ( arena.GetCurrentColor() == arena.getDefendingForce().GetColor() ) {
+            if ( _defendingOpponent->GetHero()->isCaptain() ) {
                 msg = _( "View Captain's options" );
             }
             else {
@@ -3103,13 +3104,13 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
             cursor.SetThemes( Cursor::WAR_HERO );
 
-            if ( le.MouseClickLeft( opponent2Area ) ) {
-                ProcessingHeroDialogResult( arena.DialogBattleHero( *_opponent2->GetHero(), true, status ), actions );
+            if ( le.MouseClickLeft( defendingOpponentArea ) ) {
+                ProcessingHeroDialogResult( arena.DialogBattleHero( *_defendingOpponent->GetHero(), true, status ), actions );
                 humanturn_redraw = true;
             }
         }
         else {
-            if ( _opponent2->GetHero()->isCaptain() ) {
+            if ( _defendingOpponent->GetHero()->isCaptain() ) {
                 msg = _( "View opposing Captain" );
             }
             else {
@@ -3118,14 +3119,14 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
 
             cursor.SetThemes( Cursor::WAR_INFO );
 
-            if ( le.MouseClickLeft( opponent2Area ) ) {
-                arena.DialogBattleHero( *_opponent2->GetHero(), true, status );
+            if ( le.MouseClickLeft( defendingOpponentArea ) ) {
+                arena.DialogBattleHero( *_defendingOpponent->GetHero(), true, status );
                 humanturn_redraw = true;
             }
         }
 
-        if ( le.isMouseRightButtonPressedInArea( opponent2Area ) ) {
-            arena.DialogBattleHero( *_opponent2->GetHero(), false, status );
+        if ( le.isMouseRightButtonPressedInArea( defendingOpponentArea ) ) {
+            arena.DialogBattleHero( *_defendingOpponent->GetHero(), false, status );
             humanturn_redraw = true;
         }
     }
@@ -4120,9 +4121,9 @@ void Battle::Interface::SetHeroAnimationReactionToTroopDeath( const PlayerColor 
         return;
     }
 
-    const bool attackersTurn = ( deathColor == arena.GetArmy2Color() );
-    OpponentSprite * attackingHero = attackersTurn ? _opponent1.get() : _opponent2.get();
-    OpponentSprite * defendingHero = attackersTurn ? _opponent2.get() : _opponent1.get();
+    const bool attackersTurn = ( deathColor == arena.getDefendingArmyColor() );
+    OpponentSprite * attackingHero = attackersTurn ? _attackingOpponent.get() : _defendingOpponent.get();
+    OpponentSprite * defendingHero = attackersTurn ? _defendingOpponent.get() : _attackingOpponent.get();
     // 60% of joyful animation
     if ( attackingHero && Rand::Get( 1, 5 ) < 4 ) {
         attackingHero->SetAnimation( OP_JOY );
@@ -4562,8 +4563,8 @@ void Battle::Interface::redrawActionSpellCastPart1( const Spell & spell, int32_t
 
     // set spell cast animation
     if ( caster ) {
-        const bool isLeftOpponent = ( caster->GetColor() == arena.GetArmy1Color() );
-        opponent = isLeftOpponent ? _opponent1.get() : _opponent2.get();
+        const bool isLeftOpponent = ( caster->GetColor() == arena.getAttackingArmyColor() );
+        opponent = isLeftOpponent ? _attackingOpponent.get() : _defendingOpponent.get();
         if ( opponent != nullptr ) {
             if ( isMassSpell ) {
                 opponent->SetAnimation( OP_CAST_MASS );
@@ -4934,8 +4935,8 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
 
         // Set the rainbow animation direction to match the army side.
         // Also, if the creature is under effect of the Berserker spell (or similar), then check its original color.
-        bool isRainbowFromRight
-            = ( unit.GetCurrentColor() == PlayerColor::UNUSED ) ? ( unit.GetColor() == arena.GetArmy2Color() ) : ( unit.GetCurrentColor() == arena.GetArmy2Color() );
+        bool isRainbowFromRight = ( unit.GetCurrentColor() == PlayerColor::UNUSED ) ? ( unit.GetColor() == arena.getDefendingArmyColor() )
+                                                                                    : ( unit.GetCurrentColor() == arena.getDefendingArmyColor() );
 
         // The distance from the right or left battlefield border to the 'lucky' creature in the direction from the beginning of the animation to its end.
         const int32_t borderDistance = isRainbowFromRight ? battleArea.width - rainbowDescendPoint.x : rainbowDescendPoint.x;
@@ -5326,7 +5327,7 @@ void Battle::Interface::_redrawActionArrowSpell( const Unit & target )
     const HeroBase * caster = arena.GetCurrentCommander();
 
     if ( caster ) {
-        const fheroes2::Point missileStart = caster == _opponent1->GetHero() ? _opponent1->GetCastPosition() : _opponent2->GetCastPosition();
+        const fheroes2::Point missileStart = caster == _attackingOpponent->GetHero() ? _attackingOpponent->GetCastPosition() : _defendingOpponent->GetCastPosition();
 
         const fheroes2::Point targetPos = target.GetCenterPoint();
         const double angle = GetAngle( missileStart, targetPos );
@@ -5498,10 +5499,10 @@ void Battle::Interface::redrawActionMirrorImageSpell( const HeroBase & caster, c
     }
 
     // Animate casting.
-    const bool isLeftOpponent = ( caster.GetColor() == arena.GetArmy1Color() );
+    const bool isLeftOpponent = ( caster.GetColor() == arena.getAttackingArmyColor() );
     const bool isCastDown = isHeroCastDown( targetCell, isLeftOpponent );
 
-    OpponentSprite * opponent = isLeftOpponent ? _opponent1.get() : _opponent2.get();
+    OpponentSprite * opponent = isLeftOpponent ? _attackingOpponent.get() : _defendingOpponent.get();
     assert( opponent != nullptr );
 
     opponent->SetAnimation( isCastDown ? OP_CAST_DOWN : OP_CAST_UP );
@@ -5669,7 +5670,8 @@ void Battle::Interface::_redrawActionLightningBoltSpell( const Unit & target )
 {
     _currentUnit = nullptr;
 
-    const fheroes2::Point startingPos = arena.GetCurrentCommander() == _opponent1->GetHero() ? _opponent1->GetCastPosition() : _opponent2->GetCastPosition();
+    const fheroes2::Point startingPos
+        = arena.GetCurrentCommander() == _attackingOpponent->GetHero() ? _attackingOpponent->GetCastPosition() : _defendingOpponent->GetCastPosition();
     const fheroes2::Rect & pos = target.GetRectPosition();
     const fheroes2::Point endPos( pos.x + pos.width / 2, pos.y );
 
@@ -5680,7 +5682,8 @@ void Battle::Interface::_redrawActionLightningBoltSpell( const Unit & target )
 
 void Battle::Interface::_redrawActionChainLightningSpell( const TargetsInfo & targets )
 {
-    const fheroes2::Point startingPos = arena.GetCurrentCommander() == _opponent1->GetHero() ? _opponent1->GetCastPosition() : _opponent2->GetCastPosition();
+    const fheroes2::Point startingPos
+        = arena.GetCurrentCommander() == _attackingOpponent->GetHero() ? _attackingOpponent->GetCastPosition() : _defendingOpponent->GetCastPosition();
     std::vector<fheroes2::Point> points;
     points.reserve( size( targets ) + 1 );
     points.push_back( startingPos );
@@ -5832,7 +5835,8 @@ void Battle::Interface::_redrawRaySpell( const Unit & target, const int spellICN
     LocalEvent & le = LocalEvent::Get();
 
     // Casting hero position
-    const fheroes2::Point startingPos = arena.GetCurrentCommander() == _opponent1->GetHero() ? _opponent1->GetCastPosition() : _opponent2->GetCastPosition();
+    const fheroes2::Point startingPos
+        = arena.GetCurrentCommander() == _attackingOpponent->GetHero() ? _attackingOpponent->GetCastPosition() : _defendingOpponent->GetCastPosition();
     const fheroes2::Point targetPos = target.GetCenterPoint();
 
     const std::vector<fheroes2::Point> path = getLinePoints( startingPos, targetPos, size );
@@ -6264,8 +6268,8 @@ void Battle::Interface::redrawActionEarthquakeSpellPart1( const HeroBase & caste
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
 
     // Animate casting.
-    const bool isLeftOpponent = ( caster.GetColor() == arena.GetArmy1Color() );
-    OpponentSprite * opponent = isLeftOpponent ? _opponent1.get() : _opponent2.get();
+    const bool isLeftOpponent = ( caster.GetColor() == arena.getAttackingArmyColor() );
+    OpponentSprite * opponent = isLeftOpponent ? _attackingOpponent.get() : _defendingOpponent.get();
     assert( opponent != nullptr );
 
     opponent->SetAnimation( OP_CAST_MASS );
@@ -6773,8 +6777,8 @@ void Battle::Interface::RedrawBridgeAnimation( const bool bridgeDownAnimation )
 bool Battle::Interface::IdleTroopsAnimation() const
 {
     if ( Game::validateAnimationDelay( Game::BATTLE_IDLE_DELAY ) ) {
-        const bool redrawNeeded = arena.GetForce1().animateIdleUnits();
-        return arena.GetForce2().animateIdleUnits() || redrawNeeded;
+        const bool redrawNeeded = arena.getAttackingForce().animateIdleUnits();
+        return arena.getDefendingForce().animateIdleUnits() || redrawNeeded;
     }
 
     return false;
@@ -6782,18 +6786,18 @@ bool Battle::Interface::IdleTroopsAnimation() const
 
 void Battle::Interface::ResetIdleTroopAnimation() const
 {
-    arena.GetForce1().resetIdleAnimation();
-    arena.GetForce2().resetIdleAnimation();
+    arena.getAttackingForce().resetIdleAnimation();
+    arena.getDefendingForce().resetIdleAnimation();
 }
 
 void Battle::Interface::SwitchAllUnitsAnimation( const int32_t animationState ) const
 {
-    for ( Battle::Unit * unit : arena.GetForce1() ) {
+    for ( Battle::Unit * unit : arena.getAttackingForce() ) {
         if ( unit->isValid() ) {
             unit->SwitchAnimation( animationState );
         }
     }
-    for ( Battle::Unit * unit : arena.GetForce2() ) {
+    for ( Battle::Unit * unit : arena.getDefendingForce() ) {
         if ( unit->isValid() ) {
             unit->SwitchAnimation( animationState );
         }
@@ -6814,11 +6818,11 @@ void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
 
         // Perform heroes idle animation only if heroes are not performing any other animation (e.g. spell casting).
         if ( Game::hasEveryDelayPassed( { Game::BATTLE_OPPONENTS_DELAY } ) ) {
-            if ( _opponent1 && _opponent1->updateAnimationState() ) {
+            if ( _attackingOpponent && _attackingOpponent->updateAnimationState() ) {
                 humanturn_redraw = true;
             }
 
-            if ( _opponent2 && _opponent2->updateAnimationState() ) {
+            if ( _defendingOpponent && _defendingOpponent->updateAnimationState() ) {
                 humanturn_redraw = true;
             }
         }

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -457,8 +457,8 @@ namespace Battle
         fheroes2::Button _buttonSkip;
         Status status;
 
-        std::unique_ptr<OpponentSprite> _opponent1;
-        std::unique_ptr<OpponentSprite> _opponent2;
+        std::unique_ptr<OpponentSprite> _attackingOpponent;
+        std::unique_ptr<OpponentSprite> _defendingOpponent;
 
         Spell humanturn_spell{ Spell::NONE };
         bool humanturn_exit{ true };

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -495,16 +495,6 @@ uint32_t Battle::Result::getDefenderResult() const
     return getBattleResult( defender );
 }
 
-uint32_t Battle::Result::getAttackerExperience() const
-{
-    return attackerExperience;
-}
-
-uint32_t Battle::Result::getDefenderExperience() const
-{
-    return defenderExperience;
-}
-
 bool Battle::Result::isAttackerWin() const
 {
     return ( attacker & RESULT_WINS ) != 0;

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -448,8 +448,8 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
             }
         }
 
-        arena.GetForce1().SyncArmyCount();
-        arena.GetForce2().SyncArmyCount();
+        arena.GetForce1().syncOriginalArmy();
+        arena.GetForce2().syncOriginalArmy();
 
         if ( commander1 ) {
             commander1->ActionAfterBattle();

--- a/src/fheroes2/battle/battle_main.cpp
+++ b/src/fheroes2/battle/battle_main.cpp
@@ -131,12 +131,12 @@ namespace
         }
     }
 
-    uint32_t computeBattleSeed( const int32_t mapIndex, const uint32_t mapSeed, const Army & army1, const Army & army2 )
+    uint32_t computeBattleSeed( const int32_t mapIndex, const uint32_t mapSeed, const Army & attackingArmy, const Army & defendingArmy )
     {
         uint32_t seed = static_cast<uint32_t>( mapIndex ) + mapSeed;
 
-        for ( size_t i = 0; i < army1.Size(); ++i ) {
-            const Troop * troop = army1.GetTroop( i );
+        for ( size_t i = 0; i < attackingArmy.Size(); ++i ) {
+            const Troop * troop = attackingArmy.GetTroop( i );
             if ( troop->isValid() ) {
                 fheroes2::hashCombine( seed, troop->GetID() );
                 fheroes2::hashCombine( seed, troop->GetCount() );
@@ -146,8 +146,8 @@ namespace
             }
         }
 
-        for ( size_t i = 0; i < army2.Size(); ++i ) {
-            const Troop * troop = army2.GetTroop( i );
+        for ( size_t i = 0; i < defendingArmy.Size(); ++i ) {
+            const Troop * troop = defendingArmy.GetTroop( i );
             if ( troop->isValid() ) {
                 fheroes2::hashCombine( seed, troop->GetID() );
                 fheroes2::hashCombine( seed, troop->GetCount() );
@@ -288,43 +288,43 @@ namespace
     }
 }
 
-Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
+Battle::Result Battle::Loader( Army & attackingArmy, Army & defendingArmy, const int32_t tileIndex )
 {
     Result result;
 
     // Validate the arguments - check if battle should even load
-    if ( !army1.isValid() || !army2.isValid() ) {
+    if ( !attackingArmy.isValid() || !defendingArmy.isValid() ) {
         // Check second army first so attacker would win by default
-        if ( !army2.isValid() ) {
+        if ( !defendingArmy.isValid() ) {
             result.attacker = RESULT_WINS;
-            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Invalid battle detected! Index " << mapsindex << ", Army: " << army2.String() )
+            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Invalid battle detected! Index " << tileIndex << ", Army: " << defendingArmy.String() )
         }
         else {
             result.defender = RESULT_WINS;
-            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Invalid battle detected! Index " << mapsindex << ", Army: " << army1.String() )
+            DEBUG_LOG( DBG_BATTLE, DBG_WARN, "Invalid battle detected! Index " << tileIndex << ", Army: " << attackingArmy.String() )
         }
         return result;
     }
 
-    HeroBase * commander1 = army1.GetCommander();
-    if ( commander1 ) {
-        commander1->ActionPreBattle();
+    HeroBase * attackingArmyCommander = attackingArmy.GetCommander();
+    if ( attackingArmyCommander ) {
+        attackingArmyCommander->ActionPreBattle();
 
-        if ( army1.isControlAI() ) {
-            AI::Planner::HeroesPreBattle( *commander1, true );
+        if ( attackingArmy.isControlAI() ) {
+            AI::Planner::HeroesPreBattle( *attackingArmyCommander, true );
         }
     }
 
-    const uint32_t initialSpellPoints1 = [commander1]() -> uint32_t {
-        if ( commander1 == nullptr ) {
+    const uint32_t attackingArmyCommanderInitialSpellPoints = [attackingArmyCommander]() -> uint32_t {
+        if ( attackingArmyCommander == nullptr ) {
             return 0;
         }
 
-        return commander1->GetSpellPoints();
+        return attackingArmyCommander->GetSpellPoints();
     }();
 
-    const Funds initialFunds1 = [commander1]() -> Funds {
-        const Kingdom * kingdom = getKingdomOfCommander( commander1 );
+    const Funds attackingKingdomInitialFunds = [attackingArmyCommander]() -> Funds {
+        const Kingdom * kingdom = getKingdomOfCommander( attackingArmyCommander );
         if ( kingdom == nullptr ) {
             return {};
         }
@@ -332,25 +332,25 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
         return kingdom->GetFunds();
     }();
 
-    HeroBase * commander2 = army2.GetCommander();
-    if ( commander2 ) {
-        commander2->ActionPreBattle();
+    HeroBase * defendingArmyCommander = defendingArmy.GetCommander();
+    if ( defendingArmyCommander ) {
+        defendingArmyCommander->ActionPreBattle();
 
-        if ( army2.isControlAI() ) {
-            AI::Planner::HeroesPreBattle( *commander2, false );
+        if ( defendingArmy.isControlAI() ) {
+            AI::Planner::HeroesPreBattle( *defendingArmyCommander, false );
         }
     }
 
-    const uint32_t initialSpellPoints2 = [commander2]() -> uint32_t {
-        if ( commander2 == nullptr ) {
+    const uint32_t defendingArmyCommanderInitialSpellPoints = [defendingArmyCommander]() -> uint32_t {
+        if ( defendingArmyCommander == nullptr ) {
             return 0;
         }
 
-        return commander2->GetSpellPoints();
+        return defendingArmyCommander->GetSpellPoints();
     }();
 
-    const Funds initialFunds2 = [commander2]() -> Funds {
-        const Kingdom * kingdom = getKingdomOfCommander( commander2 );
+    const Funds defendingKingdomInitialFunds = [defendingArmyCommander]() -> Funds {
+        const Kingdom * kingdom = getKingdomOfCommander( defendingArmyCommander );
         if ( kingdom == nullptr ) {
             return {};
         }
@@ -358,7 +358,7 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
         return kingdom->GetFunds();
     }();
 
-    const bool isHumanBattle = army1.isControlHuman() || army2.isControlHuman();
+    const bool isHumanBattle = attackingArmy.isControlHuman() || defendingArmy.isControlHuman();
 
     const Settings & conf = Settings::Get();
     bool showBattle = !conf.BattleAutoResolve() && isHumanBattle;
@@ -371,32 +371,32 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
         }
         // ... or when any of the participating human players are controlled by AI
         else {
-            const Player * player1 = Players::Get( army1.GetColor() );
-            const Player * player2 = Players::Get( army2.GetColor() );
+            const Player * attackingPlayer = Players::Get( attackingArmy.GetColor() );
+            const Player * defendingPlayer = Players::Get( defendingArmy.GetColor() );
 
-            if ( ( player1 != nullptr && player1->isAIAutoControlMode() ) || ( player2 != nullptr && player2->isAIAutoControlMode() ) ) {
+            if ( ( attackingPlayer != nullptr && attackingPlayer->isAIAutoControlMode() ) || ( defendingPlayer != nullptr && defendingPlayer->isAIAutoControlMode() ) ) {
                 showBattle = true;
             }
         }
     }
 #endif
 
-    const uint32_t battleSeed = computeBattleSeed( mapsindex, world.GetMapSeed(), army1, army2 );
+    const uint32_t battleSeed = computeBattleSeed( tileIndex, world.GetMapSeed(), attackingArmy, defendingArmy );
 
     while ( true ) {
         Rand::PCG32 randomGenerator( battleSeed );
-        Arena arena( army1, army2, mapsindex, showBattle, randomGenerator );
+        Arena arena( attackingArmy, defendingArmy, tileIndex, showBattle, randomGenerator );
 
-        DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army1 " << army1.String() )
-        DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army2 " << army2.String() )
+        DEBUG_LOG( DBG_BATTLE, DBG_INFO, "attacking army: " << attackingArmy.String() )
+        DEBUG_LOG( DBG_BATTLE, DBG_INFO, "defending army: " << defendingArmy.String() )
 
         while ( arena.BattleValid() ) {
             arena.Turns();
         }
         result = arena.GetResult();
 
-        HeroBase * const winnerHero = ( result.attacker & RESULT_WINS ? commander1 : ( result.defender & RESULT_WINS ? commander2 : nullptr ) );
-        HeroBase * const loserHero = ( result.attacker & RESULT_LOSS ? commander1 : ( result.defender & RESULT_LOSS ? commander2 : nullptr ) );
+        HeroBase * const winnerHero = ( result.attacker & RESULT_WINS ? attackingArmyCommander : ( result.defender & RESULT_WINS ? defendingArmyCommander : nullptr ) );
+        HeroBase * const loserHero = ( result.attacker & RESULT_LOSS ? attackingArmyCommander : ( result.defender & RESULT_LOSS ? defendingArmyCommander : nullptr ) );
 
         const bool isLoserHeroAbandoned = !( ( result.attacker & RESULT_LOSS ? result.attacker : result.defender ) & ( RESULT_RETREAT | RESULT_SURRENDER ) );
         const bool shouldTransferArtifacts = ( winnerHero != nullptr && loserHero != nullptr && winnerHero->isHeroes() && loserHero->isHeroes() && isLoserHeroAbandoned );
@@ -416,15 +416,15 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
 
             // Reset the state of army commanders and the state of their kingdoms' finances (one of them could spend gold to surrender, and the other could accept this
             // gold). Please note that heroes can also surrender to castle captains.
-            if ( commander1 ) {
-                commander1->SetSpellPoints( initialSpellPoints1 );
+            if ( attackingArmyCommander ) {
+                attackingArmyCommander->SetSpellPoints( attackingArmyCommanderInitialSpellPoints );
 
-                restoreFundsOfCommandersKingdom( commander1, initialFunds1 );
+                restoreFundsOfCommandersKingdom( attackingArmyCommander, attackingKingdomInitialFunds );
             }
-            if ( commander2 ) {
-                commander2->SetSpellPoints( initialSpellPoints2 );
+            if ( defendingArmyCommander ) {
+                defendingArmyCommander->SetSpellPoints( defendingArmyCommanderInitialSpellPoints );
 
-                restoreFundsOfCommandersKingdom( commander2, initialFunds2 );
+                restoreFundsOfCommandersKingdom( defendingArmyCommander, defendingKingdomInitialFunds );
             }
 
             continue;
@@ -452,14 +452,14 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
             }
         }
 
-        arena.GetForce1().syncOriginalArmy();
-        arena.GetForce2().syncOriginalArmy();
+        arena.getAttackingForce().syncOriginalArmy();
+        arena.getDefendingForce().syncOriginalArmy();
 
-        if ( commander1 ) {
-            commander1->ActionAfterBattle();
+        if ( attackingArmyCommander ) {
+            attackingArmyCommander->ActionAfterBattle();
         }
-        if ( commander2 ) {
-            commander2->ActionAfterBattle();
+        if ( defendingArmyCommander ) {
+            defendingArmyCommander->ActionAfterBattle();
         }
 
         if ( winnerHero && loserHero && winnerHero->GetLevelSkill( Skill::Secondary::EAGLE_EYE ) && loserHero->isHeroes() ) {
@@ -473,11 +473,11 @@ Battle::Result Battle::Loader( Army & army1, Army & army2, int32_t mapsindex )
         break;
     }
 
-    DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army1 " << army1.String() )
-    DEBUG_LOG( DBG_BATTLE, DBG_INFO, "army2 " << army2.String() )
+    DEBUG_LOG( DBG_BATTLE, DBG_INFO, "attacking army: " << attackingArmy.String() )
+    DEBUG_LOG( DBG_BATTLE, DBG_INFO, "defending army: " << defendingArmy.String() )
 
-    army1.resetInvalidMonsters();
-    army2.resetInvalidMonsters();
+    attackingArmy.resetInvalidMonsters();
+    defendingArmy.resetInvalidMonsters();
 
     DEBUG_LOG( DBG_BATTLE, DBG_INFO,
                "attacker: " << ( result.attacker & RESULT_WINS ? "wins" : "loss" ) << ", defender: " << ( result.defender & RESULT_WINS ? "wins" : "loss" ) )

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -444,9 +444,9 @@ void Battle::Only::redrawOpponents( const fheroes2::Point & top ) const
 
     for ( const size_t idx : { 0, 1 } ) {
         if ( armyInfo[idx].hero ) {
-            const fheroes2::Sprite & port1 = armyInfo[idx].hero->GetPortrait( PORT_BIG );
-            if ( !port1.empty() ) {
-                fheroes2::Copy( port1, 0, 0, display, armyInfo[idx].portraitRoi );
+            const fheroes2::Sprite & port = armyInfo[idx].hero->GetPortrait( PORT_BIG );
+            if ( !port.empty() ) {
+                fheroes2::Copy( port, 0, 0, display, armyInfo[idx].portraitRoi );
             }
         }
         else {

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -203,7 +203,7 @@ void Battle::Unit::UpdateDirection()
     const Arena * arena = GetArena();
     assert( arena != nullptr );
 
-    SetReflection( arena->GetArmy1Color() != GetArmyColor() );
+    SetReflection( arena->getAttackingArmyColor() != GetArmyColor() );
 }
 
 bool Battle::Unit::UpdateDirection( const fheroes2::Rect & pos )

--- a/src/fheroes2/battle/battle_troop.h
+++ b/src/fheroes2/battle/battle_troop.h
@@ -203,6 +203,11 @@ namespace Battle
             return _initialCount;
         }
 
+        uint32_t GetMaxCount() const
+        {
+            return _maxCount;
+        }
+
         uint32_t GetDead() const
         {
             return _deadCount;
@@ -337,7 +342,7 @@ namespace Battle
     private:
         // Returns the count of killed troops.
         uint32_t _applyDamage( const uint32_t dmg );
-        uint32_t _resurrect( const uint32_t points, const bool allowToExceedInitialCount, const bool isTemporary );
+        uint32_t _resurrect( const uint32_t points, const bool allowToExceedMaxCount, const bool isTemporary );
 
         // Applies a damage-causing spell to this unit.
         void _spellApplyDamage( const Spell & spell, const uint32_t spellPower, const HeroBase * applyingHero, TargetInfo & target );
@@ -355,7 +360,8 @@ namespace Battle
 
         const uint32_t _uid{ 0 };
         uint32_t _hitPoints{ 0 };
-        uint32_t _initialCount{ 0 };
+        const uint32_t _initialCount{ 0 };
+        uint32_t _maxCount{ 0 };
         uint32_t _deadCount{ 0 };
         uint32_t _shotsLeft{ 0 };
         uint32_t _disruptingRaysNum{ 0 };

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -205,7 +205,7 @@ namespace
 
     void BattleLose( Heroes & hero, const Battle::Result & res, bool attacker )
     {
-        const uint32_t reason = attacker ? res.AttackerResult() : res.DefenderResult();
+        const uint32_t reason = attacker ? res.getAttackerResult() : res.getDefenderResult();
 
         AudioManager::PlaySound( M82::KILLFADE );
 
@@ -444,8 +444,8 @@ namespace
             // Hero' spell points and army could have changed. Update heroes icons and status area.
             I.renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
 
                 destroy = true;
             }
@@ -560,30 +560,30 @@ namespace
 
             const Battle::Result res = Battle::Loader( hero.GetArmy(), army, dstIndex );
 
-            castle->ActionAfterBattle( res.AttackerWins() );
+            castle->ActionAfterBattle( res.isAttackerWin() );
 
             // Hero' spell points and army could have changed. Update heroes icons and status area.
             Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
             // The defender was defeated
-            if ( !res.DefenderWins() && defender ) {
+            if ( !res.isDefenderWin() && defender ) {
                 BattleLose( *defender, res, false );
             }
 
             // The attacker was defeated
-            if ( !res.AttackerWins() ) {
+            if ( !res.isAttackerWin() ) {
                 BattleLose( hero, res, true );
             }
 
             // The attacker won
-            if ( res.AttackerWins() ) {
+            if ( res.isAttackerWin() ) {
                 captureCastle();
 
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+                hero.IncreaseExperience( res.getAttackerExperience() );
             }
             // The defender won
-            else if ( res.DefenderWins() && defender ) {
-                defender->IncreaseExperience( res.GetExperienceDefender() );
+            else if ( res.isDefenderWin() && defender ) {
+                defender->IncreaseExperience( res.getDefenderExperience() );
             }
 
             return;
@@ -643,22 +643,22 @@ namespace
         // TODO: make fading animation of both heroes together.
 
         // The defender was defeated
-        if ( !res.DefenderWins() ) {
+        if ( !res.isDefenderWin() ) {
             BattleLose( *otherHero, res, false );
         }
 
         // The attacker was defeated
-        if ( !res.AttackerWins() ) {
+        if ( !res.isAttackerWin() ) {
             BattleLose( hero, res, true );
         }
 
         // The attacker won
-        if ( res.AttackerWins() ) {
-            hero.IncreaseExperience( res.GetExperienceAttacker() );
+        if ( res.isAttackerWin() ) {
+            hero.IncreaseExperience( res.getAttackerExperience() );
         }
         // The defender won
-        else if ( res.DefenderWins() ) {
-            otherHero->IncreaseExperience( res.GetExperienceDefender() );
+        else if ( res.isDefenderWin() ) {
+            otherHero->IncreaseExperience( res.getDefenderExperience() );
         }
     }
 
@@ -1182,8 +1182,8 @@ namespace
                 // Hero' spell points and army could have changed. Update heroes icons and status area.
                 Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
-                if ( res.AttackerWins() ) {
-                    hero.IncreaseExperience( res.GetExperienceAttacker() );
+                if ( res.isAttackerWin() ) {
+                    hero.IncreaseExperience( res.getAttackerExperience() );
                     bool valid = false;
 
                     std::string msg = _( "Upon defeating the monsters, you decipher an ancient glyph on the wall, telling the secret of the spell - '" );
@@ -1399,8 +1399,8 @@ namespace
             // Hero' spell points could have changed. Update heroes icons.
             Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS );
 
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
 
                 complete = true;
 
@@ -1740,8 +1740,8 @@ namespace
                 // Hero' spell points and army could have changed. Update heroes icons and status area.
                 Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
-                if ( res.AttackerWins() ) {
-                    hero.IncreaseExperience( res.GetExperienceAttacker() );
+                if ( res.isAttackerWin() ) {
+                    hero.IncreaseExperience( res.getAttackerExperience() );
                     result = true;
                     msg = _( "Victorious, you take your prize, the %{art}." );
                     StringReplace( msg, "%{art}", art.GetName() );
@@ -2150,8 +2150,8 @@ namespace
                 // Hero' spell points and army could have changed. Update heroes icons and status area.
                 Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
-                if ( result.AttackerWins() ) {
-                    hero.IncreaseExperience( result.GetExperienceAttacker() );
+                if ( result.isAttackerWin() ) {
+                    hero.IncreaseExperience( result.getAttackerExperience() );
 
                     captureObject();
                 }
@@ -2203,8 +2203,8 @@ namespace
             // Hero' spell points and army could have changed. Update heroes icons and status area.
             Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
-            if ( result.AttackerWins() ) {
-                hero.IncreaseExperience( result.GetExperienceAttacker() );
+            if ( result.isAttackerWin() ) {
+                hero.IncreaseExperience( result.getAttackerExperience() );
 
                 Maps::restoreAbandonedMine( tile, Resource::GOLD );
                 hero.setObjectTypeUnderHero( MP2::OBJ_MINE );
@@ -2487,8 +2487,8 @@ namespace
             // Hero' spell points and army could have changed. Update heroes icons and status area.
             Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
-            if ( res.AttackerWins() ) {
-                hero.IncreaseExperience( res.GetExperienceAttacker() );
+            if ( res.isAttackerWin() ) {
+                hero.IncreaseExperience( res.getAttackerExperience() );
 
                 // Set ownership of the dwelling to a Neutral (gray) player so that any player can recruit troops without a fight.
                 setColorOnTile( tile, PlayerColor::UNUSED );
@@ -3185,8 +3185,8 @@ namespace
                     // Hero' spell points and army could have changed. Update heroes icons and status area.
                     Interface::AdventureMap::Get().renderWithFadeInOrPlanRender( Interface::REDRAW_HEROES | Interface::REDRAW_BUTTONS | Interface::REDRAW_STATUS );
 
-                    if ( res.AttackerWins() ) {
-                        hero.IncreaseExperience( res.GetExperienceAttacker() );
+                    if ( res.isAttackerWin() ) {
+                        hero.IncreaseExperience( res.getAttackerExperience() );
 
                         // Daemon Cave always gives 2500 Gold after a battle.
                         const uint32_t gold = 2500;
@@ -3231,7 +3231,7 @@ namespace
                 }
                 case Outcome::Death: {
                     Battle::Result res;
-                    res.army1 = Battle::RESULT_LOSS;
+                    res.attacker = Battle::RESULT_LOSS;
 
                     BattleLose( hero, res, true );
 
@@ -3631,7 +3631,7 @@ namespace
         }
         case Outcome::IncorrectAnswer: {
             Battle::Result result;
-            result.army1 = Battle::RESULT_LOSS;
+            result.attacker = Battle::RESULT_LOSS;
 
             BattleLose( hero, result, true );
 


### PR DESCRIPTION
fix #10020

<details>
<summary>1. Ghosts: losses, experience and Necromancy</summary>

`master` branch:

https://github.com/user-attachments/assets/ef61be86-03a6-4eb2-aa7d-94129a6405dd

OG behavior:

https://github.com/user-attachments/assets/68929300-155e-47bb-859a-a0c660105eb4

This PR:

https://github.com/user-attachments/assets/ddacfae2-3ebc-42a6-b79a-080d0210a3db
</details>

<details>
<summary>2. Resurrect spell and Necromancy</summary>

`master` branch:

https://github.com/user-attachments/assets/07105b60-e6b6-4d1d-92b9-7e1aeaae30fe

OG behavior:

https://github.com/user-attachments/assets/a1b68a3e-cba7-497c-8f80-fd1fbf8aca78

This PR:

https://github.com/user-attachments/assets/dc227a9a-4a06-4409-8b47-a962a5902880
</details>

So far, these are all the differences with the original game that I have found (and fixed). If there are any more, please let me know.

Also, as part of this PR, I renamed some variables and functions in a more understandable (from my point of view) way.