### PR TITLE
Nintendo Switch: add temporary workaround to fix the build

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -288,6 +288,9 @@ jobs:
     - uses: actions/checkout@v4
     - name: Install dependencies
       run: |
+        # TODO: remove this temporary workaround
+        sudo rm -f /etc/apt/sources.list.d/bullseye-backports.list
+        #
         sudo apt-get -y update
         sudo apt-get -y install gettext p7zip-full
     - name: Build


### PR DESCRIPTION
There is no corresponding directory on https://ftp.debian.org/debian/dists/ anymore.