### PR TITLE
Code clean in `spell_storage.h` and `.cpp`

### DIFF
--- a/src/fheroes2/spell/spell_storage.cpp
+++ b/src/fheroes2/spell/spell_storage.cpp
@@ -93,7 +93,7 @@ bool SpellStorage::removeSpell( const Spell & spell )
 
     auto foundSpell = std::find( cbegin(), cend(), spell );
 
-    if ( foundSpell == end() ) {
+    if ( foundSpell == cend() ) {
         return false;
     }
 

--- a/src/fheroes2/spell/spell_storage.cpp
+++ b/src/fheroes2/spell/spell_storage.cpp
@@ -70,8 +70,8 @@ std::string SpellStorage::String() const
 {
     std::string output;
 
-    for ( auto it = cbegin(); it != cend(); ++it ) {
-        output += it->GetName();
+    for ( const Spell & spell : *this ) {
+        output += spell.GetName();
         output += ", ";
     }
 

--- a/src/fheroes2/spell/spell_storage.cpp
+++ b/src/fheroes2/spell/spell_storage.cpp
@@ -27,46 +27,52 @@
 
 #include "artifact.h"
 
-SpellStorage::SpellStorage()
+SpellStorage SpellStorage::GetSpells( const int level /* = -1 */ ) const
 {
-    reserve( 67 );
-}
+    if ( level == -1 ) {
+        return *this;
+    }
 
-SpellStorage SpellStorage::GetSpells( int lvl ) const
-{
     SpellStorage result;
-    result.reserve( 20 );
-    for ( const_iterator it = begin(); it != end(); ++it )
-        if ( lvl == -1 || ( *it ).isLevel( lvl ) )
+
+    for ( auto it = cbegin(); it != cend(); ++it ) {
+        if ( it->isLevel( level ) ) {
             result.push_back( *it );
+        }
+    }
+
     return result;
 }
 
-void SpellStorage::Append( const Spell & sp )
+void SpellStorage::Append( const Spell & spell )
 {
-    if ( sp != Spell::NONE && end() == std::find( begin(), end(), sp ) )
-        push_back( sp );
-}
-
-void SpellStorage::Append( const SpellStorage & st )
-{
-    for ( const Spell & sp : st ) {
-        if ( std::find( begin(), end(), sp ) == end() ) {
-            push_back( sp );
-        }
+    if ( spell == Spell::NONE ) {
+        return;
     }
+
+    if ( isPresentSpell( spell ) ) {
+        return;
+    }
+
+    push_back( spell );
 }
 
-bool SpellStorage::isPresentSpell( const Spell & spell ) const
+void SpellStorage::Append( const SpellStorage & storage )
 {
-    return end() != std::find( begin(), end(), spell );
+    for ( const Spell & spell : storage ) {
+        if ( isPresentSpell( spell ) ) {
+            continue;
+        }
+
+        push_back( spell );
+    }
 }
 
 std::string SpellStorage::String() const
 {
     std::string output;
 
-    for ( const_iterator it = begin(); it != end(); ++it ) {
+    for ( auto it = cbegin(); it != cend(); ++it ) {
         output += it->GetName();
         output += ", ";
     }
@@ -76,13 +82,9 @@ std::string SpellStorage::String() const
 
 void SpellStorage::Append( const BagArtifacts & bag )
 {
-    for ( BagArtifacts::const_iterator it = bag.begin(); it != bag.end(); ++it )
-        Append( *it );
-}
-
-void SpellStorage::Append( const Artifact & art )
-{
-    Append( Spell( art.getSpellId() ) );
+    for ( const Artifact & artifact : bag ) {
+        Append( Spell( artifact.getSpellId() ) );
+    }
 }
 
 bool SpellStorage::removeSpell( const Spell & spell )
@@ -91,10 +93,13 @@ bool SpellStorage::removeSpell( const Spell & spell )
         return false;
     }
 
-    if ( auto foundSpell = std::find( begin(), end(), spell ); foundSpell != end() ) {
-        erase( foundSpell );
-        return true;
+    auto foundSpell = std::find( cbegin(), cend(), spell );
+
+    if ( foundSpell == end() ) {
+        return false;
     }
 
-    return false;
+    erase( foundSpell );
+
+    return true;
 }

--- a/src/fheroes2/spell/spell_storage.cpp
+++ b/src/fheroes2/spell/spell_storage.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -35,9 +35,9 @@ SpellStorage SpellStorage::GetSpells( const int level /* = -1 */ ) const
 
     SpellStorage result;
 
-    for ( auto it = cbegin(); it != cend(); ++it ) {
-        if ( it->isLevel( level ) ) {
-            result.push_back( *it );
+    for ( const Spell & spell : *this ) {
+        if ( spell.isLevel( level ) ) {
+            result.push_back( spell );
         }
     }
 
@@ -60,11 +60,9 @@ void SpellStorage::Append( const Spell & spell )
 void SpellStorage::Append( const SpellStorage & storage )
 {
     for ( const Spell & spell : storage ) {
-        if ( isPresentSpell( spell ) ) {
-            continue;
+        if ( std::find( cbegin(), cend(), spell ) == cend() ) {
+            push_back( spell );
         }
-
-        push_back( spell );
     }
 }
 
@@ -102,4 +100,9 @@ bool SpellStorage::removeSpell( const Spell & spell )
     erase( foundSpell );
 
     return true;
+}
+
+bool SpellStorage::isPresentSpell( const Spell & spell ) const
+{
+    return std::find( cbegin(), cend(), spell ) != cend();
 }

--- a/src/fheroes2/spell/spell_storage.h
+++ b/src/fheroes2/spell/spell_storage.h
@@ -28,7 +28,6 @@
 
 #include "spell.h"
 
-class Artifact;
 class BagArtifacts;
 
 class SpellStorage : public std::vector<Spell>

--- a/src/fheroes2/spell/spell_storage.h
+++ b/src/fheroes2/spell/spell_storage.h
@@ -40,10 +40,7 @@ public:
     void Append( const BagArtifacts & bag );
     bool removeSpell( const Spell & spell );
 
-    bool isPresentSpell( const Spell & spell ) const
-    {
-        return std::find( cbegin(), cend(), spell ) != cend();
-    }
+    bool isPresentSpell( const Spell & spell ) const;
 
     std::string String() const;
 };

--- a/src/fheroes2/spell/spell_storage.h
+++ b/src/fheroes2/spell/spell_storage.h
@@ -34,14 +34,16 @@ class BagArtifacts;
 class SpellStorage : public std::vector<Spell>
 {
 public:
-    SpellStorage();
-
-    SpellStorage GetSpells( int lvl = -1 ) const;
-    void Append( const SpellStorage & );
-    void Append( const Spell & );
-    void Append( const BagArtifacts & );
-    void Append( const Artifact & );
+    SpellStorage GetSpells( const int level = -1 ) const;
+    void Append( const SpellStorage & storage );
+    void Append( const Spell & spell );
+    void Append( const BagArtifacts & bag );
     bool removeSpell( const Spell & spell );
-    bool isPresentSpell( const Spell & ) const;
+
+    bool isPresentSpell( const Spell & spell ) const
+    {
+        return std::find( cbegin(), cend(), spell ) != cend();
+    }
+
     std::string String() const;
 };

--- a/src/fheroes2/spell/spell_storage.h
+++ b/src/fheroes2/spell/spell_storage.h
@@ -39,8 +39,6 @@ public:
     void Append( const Spell & spell );
     void Append( const BagArtifacts & bag );
     bool removeSpell( const Spell & spell );
-
     bool isPresentSpell( const Spell & spell ) const;
-
     std::string String() const;
 };


### PR DESCRIPTION
This PR does a code clean in `spell_storage.h` and `.cpp`:
- remove public unused `void Append( const Artifact & )` method (just do `Append( Spell( artifact.getSpellId() ) );`),
- do not `.reserve()` spell storage,
- return a copy of spell storage for `level == -1` instead of filling new spell storage by calling `push_pack()` in a loop for all items.