### PR TITLE
Set proper object layer when placing a hole on the map after digging

### DIFF
--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -930,7 +930,7 @@ bool World::DiggingForUltimateArtifact( const fheroes2::Point & center )
         return false;
     }
 
-    tile.pushGroundObjectPart( Maps::ObjectPart( Maps::BACKGROUND_LAYER, Maps::getNewObjectUID(), objectIcnType, imageIndex ) );
+    tile.pushGroundObjectPart( Maps::ObjectPart( Maps::TERRAIN_LAYER, Maps::getNewObjectUID(), objectIcnType, imageIndex ) );
 
     if ( ultimate_artifact.isPosition( tile.GetIndex() ) && !ultimate_artifact.isFound() ) {
         ultimate_artifact.markAsFound();


### PR DESCRIPTION
fix #10042

After digging in `master` branch the hole object is places with `BACKGROUND_LAYER` set. When passabilities are updated (in example, after picking-up a nearby chest) the hole is considered as a one high high object.

This PR sets the `TERRAIN_LAYER` for the digging hole.
(The holes places in original and fheroes2 editors places holes to `TERRAIN_LAYER`).

This PR does not fix the saves that already have holes after digging, but fixes the new placed holes after digging.