### PR TITLE
Save days spent value for each scenario of campaign

### DIFF
--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -91,18 +91,19 @@ namespace Campaign
 
     void CampaignSaveData::addDaysPassed( const uint32_t days )
     {
-        _daysPassed += days;
+        _daysPassed.emplace_back( days );
+        assert( _daysPassed.size() == _finishedMaps.size() );
     }
 
     void CampaignSaveData::reset()
     {
         _finishedMaps.clear();
+        _daysPassed.clear();
         _bonusesForFinishedMaps.clear();
         _obtainedCampaignAwards.clear();
         _carryOverTroops.clear();
         _currentScenarioInfoId = { -1, -1 };
         _currentScenarioBonusId = -1;
-        _daysPassed = 0;
         _difficulty = CampaignDifficulty::Normal;
         _minDifficulty = CampaignDifficulty::Normal;
     }
@@ -176,7 +177,19 @@ namespace Campaign
         // Make sure that the number of elements in the vector of map bonuses matches the number of elements in the vector of finished maps
         data._bonusesForFinishedMaps.resize( data._finishedMaps.size(), -1 );
 
-        stream >> data._daysPassed >> data._obtainedCampaignAwards >> data._carryOverTroops >> data._difficulty;
+        static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1111_RELEASE, "Remove the logic below." );
+        if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1111_RELEASE ) {
+            uint32_t daysPassed{ 0 };
+            stream >> daysPassed;
+
+            data._daysPassed.clear();
+            data._daysPassed.resize( data._finishedMaps.size(), daysPassed );
+        }
+        else {
+            stream >> data._daysPassed;
+        }
+
+        stream >> data._obtainedCampaignAwards >> data._carryOverTroops >> data._difficulty;
 
         static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_PRE1_1108_RELEASE, "Remove the logic below." );
         if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_PRE1_1108_RELEASE ) {

--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -182,11 +182,18 @@ namespace Campaign
             uint32_t daysPassed{ 0 };
             stream >> daysPassed;
 
-            data._daysPassed.clear();
-            data._daysPassed.resize( data._finishedMaps.size(), daysPassed );
+            data._daysPassed.assign( data._finishedMaps.size(), 1 );
+
+            if ( !data._daysPassed.empty() && daysPassed > data._daysPassed.size() ) {
+                data._daysPassed.back() += static_cast<uint32_t>( daysPassed - data._daysPassed.size() );
+            }
         }
         else {
             stream >> data._daysPassed;
+
+            // Make sure that the number of elements in the vector of the number of days spent completing individual maps matches the number of elements in the vector of
+            // finished maps
+            data._daysPassed.resize( data._finishedMaps.size(), 1 );
         }
 
         stream >> data._obtainedCampaignAwards >> data._carryOverTroops >> data._difficulty;

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -22,6 +22,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <numeric>
 #include <optional>
 #include <vector>
 
@@ -82,7 +83,7 @@ namespace Campaign
 
         uint32_t getDaysPassed() const
         {
-            return _daysPassed;
+            return std::accumulate( _daysPassed.cbegin(), _daysPassed.cend(), 0 );
         }
 
         int32_t getDifficulty() const
@@ -135,6 +136,7 @@ namespace Campaign
         CampaignSaveData() = default;
 
         std::vector<ScenarioInfoId> _finishedMaps;
+        std::vector<uint32_t> _daysPassed;
         std::vector<int32_t> _bonusesForFinishedMaps;
         std::vector<int> _obtainedCampaignAwards;
         std::vector<Troop> _carryOverTroops;
@@ -142,7 +144,6 @@ namespace Campaign
         ScenarioInfoId _currentScenarioInfoId;
         int32_t _currentScenarioBonusId{ -1 };
 
-        uint32_t _daysPassed{ 0 };
         int32_t _difficulty{ CampaignDifficulty::Normal };
         int32_t _minDifficulty{ CampaignDifficulty::Normal };
     };

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -83,7 +83,7 @@ namespace Campaign
 
         uint32_t getDaysPassed() const
         {
-            return std::accumulate( _daysPassed.cbegin(), _daysPassed.cend(), 0 );
+            return std::accumulate( _daysPassed.cbegin(), _daysPassed.cend(), 0U );
         }
 
         int32_t getDifficulty() const

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -83,7 +83,7 @@ namespace Campaign
 
         uint32_t getDaysPassed() const
         {
-            return std::accumulate( _daysPassed.cbegin(), _daysPassed.cend(), 0U );
+            return std::accumulate( _daysPassed.cbegin(), _daysPassed.cend(), static_cast<uint32_t>( 0 ) );
         }
 
         int32_t getDifficulty() const

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -27,6 +27,7 @@ enum SaveFileFormat : uint16_t
     // !!! IMPORTANT !!!
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
+    FORMAT_VERSION_1111_RELEASE = 10032,
     FORMAT_VERSION_1109_RELEASE = 10031,
     FORMAT_VERSION_1108_RELEASE = 10030,
     FORMAT_VERSION_PRE1_1108_RELEASE = 10029,
@@ -52,5 +53,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_1005_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1109_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1111_RELEASE
 };


### PR DESCRIPTION
We are still missing a feature to review completed scenarios in a campaign. In the original game it is possible to do and for each scenario it displays the number of days spent in relation to the scenario. This change saves the same information to be used in the future UI updates.

relates to #4381