### PR TITLE
Improve video processing logic

### DIFF
--- a/.codechecker-review-status-config
+++ b/.codechecker-review-status-config
@@ -11,3 +11,18 @@ rules:
   actions:
     review_status: false_positive
     reason: "cetintrin.h:62:10: 1st function call argument is an uninitialized value"
+- filters:
+    report_hash: d071c5bf5e4d9f23cb32232823dc5f20
+  actions:
+    review_status: false_positive
+    reason: "https://github.com/llvm/llvm-project/issues/47814 https://godbolt.org/z/onxhTsqWa"
+- filters:
+    report_hash: f699c93e80136a0ef2a7837c8b01aee6
+  actions:
+    review_status: false_positive
+    reason: "https://github.com/llvm/llvm-project/issues/47814 https://godbolt.org/z/onxhTsqWa"
+- filters:
+    report_hash: 8f5f809c6c4c2746197c7d9434f936a0
+  actions:
+    review_status: false_positive
+    reason: "https://github.com/llvm/llvm-project/issues/47814 https://godbolt.org/z/onxhTsqWa"

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2024                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -82,13 +82,11 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     unsigned long height = 0;
     unsigned char scaledYMode = 1;
 
-    char returnValue = smk_info_all( _videoFile.get(), nullptr, &_frameCount, &_microsecondsPerFrame );
-    if ( returnValue < 0 ) {
+    if ( const signed char returnValue = smk_info_all( _videoFile.get(), nullptr, &_frameCount, &_microsecondsPerFrame ); returnValue < 0 ) {
         ERROR_LOG( "smk_info_all() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
-    returnValue = smk_info_video( _videoFile.get(), &width, &height, &scaledYMode );
-    if ( returnValue < 0 ) {
+    if ( const signed char returnValue = smk_info_video( _videoFile.get(), &width, &height, &scaledYMode ); returnValue < 0 ) {
         ERROR_LOG( "smk_info_video() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
@@ -106,8 +104,7 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     _width = static_cast<int32_t>( width );
     _height = static_cast<int32_t>( height ) * _heightScaleFactor;
 
-    returnValue = smk_info_audio( _videoFile.get(), &trackMask, channelsPerTrack, audioBitDepth, audioRate );
-    if ( returnValue < 0 ) {
+    if ( const signed char returnValue = smk_info_audio( _videoFile.get(), &trackMask, channelsPerTrack, audioBitDepth, audioRate ); returnValue < 0 ) {
         ERROR_LOG( "smk_info_audio() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
@@ -118,27 +115,24 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
 
     for ( uint8_t i = 0; i < audioChannelCount; ++i ) {
         if ( trackMask & ( 1 << i ) ) {
-            returnValue = smk_enable_audio( _videoFile.get(), i, 1 );
-            if ( returnValue < 0 ) {
+            if ( const signed char returnValue = smk_enable_audio( _videoFile.get(), i, 1 ); returnValue < 0 ) {
                 ERROR_LOG( "smk_enable_audio() failed with error code: " << static_cast<int>( returnValue ) )
             }
         }
     }
 
     // Disable video reading.
-    returnValue = smk_enable_video( _videoFile.get(), 0 );
-    if ( returnValue < 0 ) {
+    if ( const signed char returnValue = smk_enable_video( _videoFile.get(), 0 ); returnValue < 0 ) {
         ERROR_LOG( "smk_enable_video() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
-    returnValue = smk_first( _videoFile.get() );
-    if ( returnValue < 0 ) {
+    if ( const signed char returnValue = smk_first( _videoFile.get() ); returnValue < 0 ) {
         ERROR_LOG( "smk_first() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     unsigned long currentFrame = 0;
-    returnValue = smk_info_all( _videoFile.get(), &currentFrame, nullptr, nullptr );
-    if ( returnValue < 0 ) {
+
+    if ( const signed char returnValue = smk_info_all( _videoFile.get(), &currentFrame, nullptr, nullptr ); returnValue < 0 ) {
         ERROR_LOG( "smk_info_all() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
@@ -159,8 +153,7 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     }
 
     for ( currentFrame = 1; currentFrame < _frameCount; ++currentFrame ) {
-        returnValue = smk_next( _videoFile.get() );
-        if ( returnValue < 0 ) {
+        if ( const signed char returnValue = smk_next( _videoFile.get() ); returnValue < 0 ) {
             ERROR_LOG( "smk_next() failed with error code: " << static_cast<int>( returnValue ) )
         }
 
@@ -221,13 +214,11 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     }
 
     // Enable video reading.
-    returnValue = smk_enable_video( _videoFile.get(), 1 );
-    if ( returnValue < 0 ) {
+    if ( const signed char returnValue = smk_enable_video( _videoFile.get(), 1 ); returnValue < 0 ) {
         ERROR_LOG( "smk_enable_video() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
-    returnValue = smk_first( _videoFile.get() );
-    if ( returnValue < 0 ) {
+    if ( const signed char returnValue = smk_first( _videoFile.get() ); returnValue < 0 ) {
         ERROR_LOG( "smk_first() failed with error code: " << static_cast<int>( returnValue ) )
     }
 }
@@ -238,8 +229,7 @@ void SMKVideoSequence::resetFrame()
         return;
     }
 
-    const char returnValue = smk_first( _videoFile.get() );
-    if ( returnValue < 0 ) {
+    if ( const signed char returnValue = smk_first( _videoFile.get() ); returnValue < 0 ) {
         ERROR_LOG( "smk_first() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
@@ -314,8 +304,7 @@ void SMKVideoSequence::getNextFrame( fheroes2::Image & image, const int32_t x, c
 
     ++_currentFrameId;
     if ( _currentFrameId < _frameCount ) {
-        const char returnValue = smk_next( _videoFile.get() );
-        if ( returnValue < 0 ) {
+        if ( const signed char returnValue = smk_next( _videoFile.get() ); returnValue < 0 ) {
             ERROR_LOG( "smk_next() failed with error code: " << static_cast<int>( returnValue ) )
         }
     }

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -27,6 +27,7 @@
 #include <cstdio>
 #include <cstring>
 #include <memory>
+#include <ostream>
 
 #include "exception.h"
 #include "image.h"

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -64,13 +64,6 @@ namespace
 }
 
 SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
-    : _width( 0 )
-    , _height( 0 )
-    , _heightScaleFactor( 1 )
-    , _microsecondsPerFrame( 0 )
-    , _frameCount( 0 )
-    , _currentFrameId( 0 )
-    , _videoFile( nullptr )
 {
     verifyVideoFile( filePath );
 
@@ -91,14 +84,14 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     unsigned long height = 0;
     unsigned char scaledYMode = 1;
 
-    int returnValue = smk_info_all( _videoFile, nullptr, &_frameCount, &_microsecondsPerFrame );
+    char returnValue = smk_info_all( _videoFile, nullptr, &_frameCount, &_microsecondsPerFrame );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_info_all() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_info_all() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     returnValue = smk_info_video( _videoFile, &width, &height, &scaledYMode );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_info_video() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_info_video() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     _heightScaleFactor = scaledYMode;
@@ -117,7 +110,7 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
 
     returnValue = smk_info_audio( _videoFile, &trackMask, channelsPerTrack, audioBitDepth, audioRate );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_info_audio() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_info_audio() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     if ( _microsecondsPerFrame < 1 ) {
@@ -129,7 +122,7 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
         if ( trackMask & ( 1 << i ) ) {
             returnValue = smk_enable_audio( _videoFile, i, 1 );
             if ( returnValue < 0 ) {
-                ERROR_LOG( "smk_enable_audio() failed with error code: " << returnValue )
+                ERROR_LOG( "smk_enable_audio() failed with error code: " << static_cast<int>( returnValue ) )
             }
         }
     }
@@ -137,18 +130,18 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     // Disable video reading.
     returnValue = smk_enable_video( _videoFile, 0 );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_enable_video() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_enable_video() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     returnValue = smk_first( _videoFile );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_first() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_first() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     unsigned long currentFrame = 0;
     returnValue = smk_info_all( _videoFile, &currentFrame, nullptr, nullptr );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_info_all() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_info_all() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     for ( uint8_t i = 0; i < audioChannelCount; ++i ) {
@@ -170,7 +163,7 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     for ( currentFrame = 1; currentFrame < _frameCount; ++currentFrame ) {
         returnValue = smk_next( _videoFile );
         if ( returnValue < 0 ) {
-            ERROR_LOG( "smk_next() failed with error code: " << returnValue )
+            ERROR_LOG( "smk_next() failed with error code: " << static_cast<int>( returnValue ) )
         }
 
         for ( uint8_t i = 0; i < audioChannelCount; ++i ) {
@@ -232,12 +225,12 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
     // Enable video reading.
     returnValue = smk_enable_video( _videoFile, 1 );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_enable_video() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_enable_video() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     returnValue = smk_first( _videoFile );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_first() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_first() failed with error code: " << static_cast<int>( returnValue ) )
     }
 }
 
@@ -253,9 +246,9 @@ void SMKVideoSequence::resetFrame()
     if ( _videoFile == nullptr )
         return;
 
-    const int returnValue = smk_first( _videoFile );
+    const char returnValue = smk_first( _videoFile );
     if ( returnValue < 0 ) {
-        ERROR_LOG( "smk_first() failed with error code: " << returnValue )
+        ERROR_LOG( "smk_first() failed with error code: " << static_cast<int>( returnValue ) )
     }
 
     _currentFrameId = 0;
@@ -329,9 +322,9 @@ void SMKVideoSequence::getNextFrame( fheroes2::Image & image, const int32_t x, c
 
     ++_currentFrameId;
     if ( _currentFrameId < _frameCount ) {
-        const int returnValue = smk_next( _videoFile );
+        const char returnValue = smk_next( _videoFile );
         if ( returnValue < 0 ) {
-            ERROR_LOG( "smk_next() failed with error code: " << returnValue )
+            ERROR_LOG( "smk_next() failed with error code: " << static_cast<int>( returnValue ) )
         }
     }
 }

--- a/src/engine/smk_decoder.cpp
+++ b/src/engine/smk_decoder.cpp
@@ -115,7 +115,7 @@ SMKVideoSequence::SMKVideoSequence( const std::string & filePath )
 
     if ( _microsecondsPerFrame < 1 ) {
         // Since the value is not set let's set a default value for 15 FPS.
-        _microsecondsPerFrame = 1000000 / 15;
+        _microsecondsPerFrame = 1000000.0 / 15.0;
     }
 
     for ( uint8_t i = 0; i < audioChannelCount; ++i ) {

--- a/src/engine/smk_decoder.h
+++ b/src/engine/smk_decoder.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2023                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/engine/smk_decoder.h
+++ b/src/engine/smk_decoder.h
@@ -80,7 +80,7 @@ private:
     std::vector<std::vector<uint8_t>> _audioChannel;
     int32_t _width{ 0 };
     int32_t _height{ 0 };
-    int32_t _heightScaleFactor{ 0 };
+    int32_t _heightScaleFactor{ 1 };
     double _microsecondsPerFrame{ 0 };
     unsigned long _frameCount{ 0 };
     unsigned long _currentFrameId{ 0 };

--- a/src/engine/smk_decoder.h
+++ b/src/engine/smk_decoder.h
@@ -21,19 +21,22 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
+
+#include "smacker.h"
 
 namespace fheroes2
 {
     class Image;
 }
 
-class SMKVideoSequence
+class SMKVideoSequence final
 {
 public:
     explicit SMKVideoSequence( const std::string & filePath );
-    ~SMKVideoSequence();
+    ~SMKVideoSequence() = default;
 
     SMKVideoSequence( const SMKVideoSequence & ) = delete;
     SMKVideoSequence & operator=( const SMKVideoSequence & ) = delete;
@@ -85,5 +88,5 @@ private:
     unsigned long _frameCount{ 0 };
     unsigned long _currentFrameId{ 0 };
 
-    struct smk_t * _videoFile{ nullptr };
+    std::unique_ptr<smk_t, void ( * )( smk_t * )> _videoFile{ nullptr, smk_close };
 };

--- a/src/engine/smk_decoder.h
+++ b/src/engine/smk_decoder.h
@@ -46,12 +46,30 @@ public:
 
     std::vector<uint8_t> getCurrentPalette() const;
 
-    const std::vector<std::vector<uint8_t>> & getAudioChannels() const;
+    const std::vector<std::vector<uint8_t>> & getAudioChannels() const
+    {
+        return _audioChannel;
+    }
 
-    int32_t width() const;
-    int32_t height() const;
-    double fps() const;
-    unsigned long frameCount() const;
+    int32_t width() const
+    {
+        return _width;
+    }
+
+    int32_t height() const
+    {
+        return _height;
+    }
+
+    double microsecondsPerFrame() const
+    {
+        return _microsecondsPerFrame;
+    }
+
+    unsigned long frameCount() const
+    {
+        return _frameCount;
+    }
 
     unsigned long getCurrentFrame() const
     {
@@ -60,12 +78,12 @@ public:
 
 private:
     std::vector<std::vector<uint8_t>> _audioChannel;
-    int32_t _width;
-    int32_t _height;
-    int32_t _heightScaleFactor;
-    double _fps;
-    unsigned long _frameCount;
-    unsigned long _currentFrameId;
+    int32_t _width{ 0 };
+    int32_t _height{ 0 };
+    int32_t _heightScaleFactor{ 0 };
+    double _microsecondsPerFrame{ 0 };
+    unsigned long _frameCount{ 0 };
+    unsigned long _currentFrameId{ 0 };
 
-    struct smk_t * _videoFile;
+    struct smk_t * _videoFile{ nullptr };
 };

--- a/src/engine/smk_decoder.h
+++ b/src/engine/smk_decoder.h
@@ -88,5 +88,5 @@ private:
     unsigned long _frameCount{ 0 };
     unsigned long _currentFrameId{ 0 };
 
-    std::unique_ptr<smk_t, void ( * )( smk_t * )> _videoFile{ nullptr, smk_close };
+    std::unique_ptr<struct smk_t, void ( * )( struct smk_t * )> _videoFile{ nullptr, smk_close };
 };

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -208,7 +208,7 @@ fheroes2::GameMode Game::NewSuccessionWarsCampaign()
     const std::array<fheroes2::Rect, 2> campaignRoi{ fheroes2::Rect( 382 + roiOffset.x, 58 + roiOffset.y, 222, 298 ),
                                                      fheroes2::Rect( 30 + roiOffset.x, 59 + roiOffset.y, 224, 297 ) };
 
-    const uint64_t customDelay = static_cast<uint64_t>( std::lround( 1000.0 / video->fps() ) );
+    const uint64_t customDelay = static_cast<uint64_t>( std::lround( video->microsecondsPerFrame() / 1000 ) );
 
     outputNewSuccessionWarsCampaignInTextSupportMode();
 
@@ -368,7 +368,7 @@ fheroes2::GameMode Game::NewPriceOfLoyaltyCampaign()
         for ( size_t i = 0; i < activeCampaignArea.size(); ++i ) {
             if ( le.isMouseCursorPosInArea( activeCampaignArea[i] ) && videos[i] ) {
                 highlightCampaignId = i;
-                customDelay = static_cast<uint64_t>( std::lround( 1000.0 / videos[highlightCampaignId]->fps() ) );
+                customDelay = static_cast<uint64_t>( std::lround( videos[highlightCampaignId]->microsecondsPerFrame() / 1000 ) );
                 break;
             }
         }

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2024                                             *
+ *   Copyright (C) 2020 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -131,7 +131,8 @@ namespace Video
         uint32_t currentFrame = 0;
         fheroes2::Rect frameRoi( ( display.width() - video.width() ) / 2, ( display.height() - video.height() ) / 2, 0, 0 );
 
-        const uint32_t delay = static_cast<uint32_t>( 1000.0 / video.fps() + 0.5 ); // This might be not very accurate but it's the best we can have now
+        // This might be not very accurate but it's the best we can have now.
+        const uint32_t delay = static_cast<uint32_t>( video.microsecondsPerFrame() / 1000 + 0.5 );
 
         std::vector<uint8_t> palette;
         std::vector<uint8_t> prevPalette;

--- a/src/fheroes2/game/game_video.cpp
+++ b/src/fheroes2/game/game_video.cpp
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <array>
 #include <cassert>
+#include <cmath>
 #include <cstddef>
 #include <cstdint>
 #include <ostream>
@@ -132,7 +133,7 @@ namespace Video
         fheroes2::Rect frameRoi( ( display.width() - video.width() ) / 2, ( display.height() - video.height() ) / 2, 0, 0 );
 
         // This might be not very accurate but it's the best we can have now.
-        const uint32_t delay = static_cast<uint32_t>( video.microsecondsPerFrame() / 1000 + 0.5 );
+        const uint32_t delay = static_cast<uint32_t>( std::lround( video.microsecondsPerFrame() / 1000 ) );
 
         std::vector<uint8_t> palette;
         std::vector<uint8_t> prevPalette;


### PR DESCRIPTION
- add missing logging for video processing
- use micro-seconds per frame (usf) rather than doing double conversion from usf to fps and then to milli-seconds per frame as conversion between float values always adds some error