### PR TITLE
macOS: use the macos-14-large (x86-64) runner for building the release version

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -103,7 +103,7 @@ jobs:
             FHEROES2_WITH_TSAN: ON
         - name: macOS SDL2
           on: [ 'pull_request', 'push' ]
-          os: macos-14
+          os: macos-14-large
           dependencies: sdl2 sdl2_mixer sdl2_image
           env:
             FHEROES2_STRICT_COMPILATION: ON


### PR DESCRIPTION
Related to https://github.com/ihhub/fheroes2/discussions/10060