### PR TITLE
Limit resolutions only in software rendering mode

### DIFF
--- a/src/engine/screen.cpp
+++ b/src/engine/screen.cpp
@@ -941,6 +941,12 @@ namespace
                 return std::vector<fheroes2::ResolutionInfo>{ resolutionSet.rbegin(), resolutionSet.rend() };
             }
 
+            if ( !fheroes2::cursor().isSoftwareEmulation() ) {
+                // If software emulation is not enabled it means that we need to use resolutions supported
+                // by the hardware.
+                return std::vector<fheroes2::ResolutionInfo>{ resolutionSet.rbegin(), resolutionSet.rend() };
+            }
+
             // We should limit all available resolutions to the one which is currently chosen on the system
             // to avoid ending up having application window which is bigger than the screen resolution.
             SDL_DisplayMode maxDisplayMode{};


### PR DESCRIPTION
With the current implementation if software rendering is off and a user goes to a full-screen mode, selects lower resolution (for example, 640x480) there is no way to select a higher resolution after. This is because the operating system resolution is set to it and since we limit all resolution to the system we have no way to change it.

This pull request limits the original logic only for software rendering mode.