### PR TITLE
Make the Toolset activities compatible with Android 15 edge-to-edge enforcements

### DIFF
--- a/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024                                                    *
+ *   Copyright (C) 2024 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
@@ -292,9 +292,10 @@ public final class MapFileManagerActivity extends AppCompatActivity
     @Override
     protected void onCreate( final Bundle savedInstanceState )
     {
-        EdgeToEdge.enable( this );
-
         super.onCreate( savedInstanceState );
+
+        // TODO: use WindowCompat.enableEdgeToEdge() instead, as soon as androidx.core 1.17 becomes generally available
+        EdgeToEdge.enable( this );
 
         setContentView( R.layout.activity_map_file_manager );
 

--- a/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
@@ -43,9 +43,13 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
@@ -288,9 +292,19 @@ public final class MapFileManagerActivity extends AppCompatActivity
     @Override
     protected void onCreate( final Bundle savedInstanceState )
     {
+        EdgeToEdge.enable( this );
+
         super.onCreate( savedInstanceState );
 
         setContentView( R.layout.activity_map_file_manager );
+
+        ViewCompat.setOnApplyWindowInsetsListener( findViewById( android.R.id.content ).getRootView(), ( v, insets ) -> {
+            final Insets paddingInsets = insets.getInsets( WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout() );
+
+            v.setPadding( paddingInsets.left, paddingInsets.top, paddingInsets.right, paddingInsets.bottom );
+
+            return WindowInsetsCompat.CONSUMED;
+        } );
 
         mapFileDir = new File( getExternalFilesDir( null ), "maps" );
 

--- a/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/MapFileManagerActivity.java
@@ -43,7 +43,6 @@ import android.widget.ListView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
@@ -294,12 +293,9 @@ public final class MapFileManagerActivity extends AppCompatActivity
     {
         super.onCreate( savedInstanceState );
 
-        // TODO: use WindowCompat.enableEdgeToEdge() instead, as soon as androidx.core 1.17 becomes generally available
-        EdgeToEdge.enable( this );
-
         setContentView( R.layout.activity_map_file_manager );
 
-        ViewCompat.setOnApplyWindowInsetsListener( findViewById( android.R.id.content ).getRootView(), ( v, insets ) -> {
+        ViewCompat.setOnApplyWindowInsetsListener( findViewById( R.id.activity_map_file_manager_root_rl ), ( v, insets ) -> {
             final Insets paddingInsets = insets.getInsets( WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout() );
 
             v.setPadding( paddingInsets.left, paddingInsets.top, paddingInsets.right, paddingInsets.bottom );

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2024                                             *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -43,7 +43,6 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.ToggleButton;
 
-import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
@@ -293,12 +292,9 @@ public final class SaveFileManagerActivity extends AppCompatActivity
     {
         super.onCreate( savedInstanceState );
 
-        // TODO: use WindowCompat.enableEdgeToEdge() instead, as soon as androidx.core 1.17 becomes generally available
-        EdgeToEdge.enable( this );
-
         setContentView( R.layout.activity_save_file_manager );
 
-        ViewCompat.setOnApplyWindowInsetsListener( findViewById( android.R.id.content ).getRootView(), ( v, insets ) -> {
+        ViewCompat.setOnApplyWindowInsetsListener( findViewById( R.id.activity_save_file_manager_root_rl ), ( v, insets ) -> {
             final Insets paddingInsets = insets.getInsets( WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout() );
 
             v.setPadding( paddingInsets.left, paddingInsets.top, paddingInsets.right, paddingInsets.bottom );

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -291,9 +291,10 @@ public final class SaveFileManagerActivity extends AppCompatActivity
     @Override
     protected void onCreate( final Bundle savedInstanceState )
     {
-        EdgeToEdge.enable( this );
-
         super.onCreate( savedInstanceState );
+
+        // TODO: use WindowCompat.enableEdgeToEdge() instead, as soon as androidx.core 1.17 becomes generally available
+        EdgeToEdge.enable( this );
 
         setContentView( R.layout.activity_save_file_manager );
 

--- a/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
+++ b/android/app/src/main/java/org/fheroes2/SaveFileManagerActivity.java
@@ -43,9 +43,13 @@ import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.ToggleButton;
 
+import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
@@ -287,9 +291,19 @@ public final class SaveFileManagerActivity extends AppCompatActivity
     @Override
     protected void onCreate( final Bundle savedInstanceState )
     {
+        EdgeToEdge.enable( this );
+
         super.onCreate( savedInstanceState );
 
         setContentView( R.layout.activity_save_file_manager );
+
+        ViewCompat.setOnApplyWindowInsetsListener( findViewById( android.R.id.content ).getRootView(), ( v, insets ) -> {
+            final Insets paddingInsets = insets.getInsets( WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout() );
+
+            v.setPadding( paddingInsets.left, paddingInsets.top, paddingInsets.right, paddingInsets.bottom );
+
+            return WindowInsetsCompat.CONSUMED;
+        } );
 
         saveFileDir = new File( getExternalFilesDir( null ), "files" + File.separator + "save" );
 

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2024                                             *
+ *   Copyright (C) 2023 - 2025                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -35,7 +35,6 @@ import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
-import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
@@ -146,12 +145,9 @@ public final class ToolsetActivity extends AppCompatActivity
     {
         super.onCreate( savedInstanceState );
 
-        // TODO: use WindowCompat.enableEdgeToEdge() instead, as soon as androidx.core 1.17 becomes generally available
-        EdgeToEdge.enable( this );
-
         setContentView( R.layout.activity_toolset );
 
-        ViewCompat.setOnApplyWindowInsetsListener( findViewById( android.R.id.content ).getRootView(), ( v, insets ) -> {
+        ViewCompat.setOnApplyWindowInsetsListener( findViewById( R.id.activity_toolset_root_sv ), ( v, insets ) -> {
             final Insets paddingInsets = insets.getInsets( WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout() );
 
             v.setPadding( paddingInsets.left, paddingInsets.top, paddingInsets.right, paddingInsets.bottom );

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -35,9 +35,13 @@ import android.widget.Button;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 
+import androidx.activity.EdgeToEdge;
 import androidx.activity.result.ActivityResultLauncher;
 import androidx.activity.result.contract.ActivityResultContracts;
 import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 import androidx.lifecycle.ViewModelProvider;
@@ -140,9 +144,19 @@ public final class ToolsetActivity extends AppCompatActivity
     @Override
     protected void onCreate( final Bundle savedInstanceState )
     {
+        EdgeToEdge.enable( this );
+
         super.onCreate( savedInstanceState );
 
         setContentView( R.layout.activity_toolset );
+
+        ViewCompat.setOnApplyWindowInsetsListener( findViewById( android.R.id.content ).getRootView(), ( v, insets ) -> {
+            final Insets paddingInsets = insets.getInsets( WindowInsetsCompat.Type.systemBars() | WindowInsetsCompat.Type.displayCutout() );
+
+            v.setPadding( paddingInsets.left, paddingInsets.top, paddingInsets.right, paddingInsets.bottom );
+
+            return WindowInsetsCompat.CONSUMED;
+        } );
 
         viewModel = new ViewModelProvider( this ).get( ToolsetActivityViewModel.class );
         viewModel.liveStatus.observe( this, this::updateUI );

--- a/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
+++ b/android/app/src/main/java/org/fheroes2/ToolsetActivity.java
@@ -144,9 +144,10 @@ public final class ToolsetActivity extends AppCompatActivity
     @Override
     protected void onCreate( final Bundle savedInstanceState )
     {
-        EdgeToEdge.enable( this );
-
         super.onCreate( savedInstanceState );
+
+        // TODO: use WindowCompat.enableEdgeToEdge() instead, as soon as androidx.core 1.17 becomes generally available
+        EdgeToEdge.enable( this );
 
         setContentView( R.layout.activity_toolset );
 

--- a/android/app/src/main/res/layout/activity_map_file_manager.xml
+++ b/android/app/src/main/res/layout/activity_map_file_manager.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/activity_map_file_manager_root_rl"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/android/app/src/main/res/layout/activity_save_file_manager.xml
+++ b/android/app/src/main/res/layout/activity_save_file_manager.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/activity_save_file_manager_root_rl"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 

--- a/android/app/src/main/res/layout/activity_toolset.xml
+++ b/android/app/src/main/res/layout/activity_toolset.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <ScrollView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/activity_toolset_root_sv"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fillViewport="true">


### PR DESCRIPTION
Without this, some parts of Toolset activities UI (e.g. toolbars) may overlap with the system bars (navigation bar or status bar) on Android 15. Tested on Android 14 and Android 15 devices with both buttons-based and gesture-based navigation bars.

See https://developer.android.com/about/versions/15/behavior-changes-15?hl=en#window-insets for details.