### PR TITLE
GitHub Actions: fix the SonarCloud workflow

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -63,14 +63,20 @@ jobs:
     - name: Prepare compile_commands.json
       run: |
         cmake -B build -DCMAKE_BUILD_TYPE=Debug -DCMAKE_COMPILE_WARNING_AS_ERROR=ON -DENABLE_IMAGE=ON -DENABLE_TOOLS=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+    - name: Prepare symlinks for SonarCloud sandbox
+      run: |
+        ln -s "$ANDROID_HOME" .sonar-android-sdk
+        ln -s ~/.sonar-cfamily-cache .sonar-cfamily-cache
+        # TODO: add ".sonar-gradle/caches/**/*.jar" to sonar.java.libraries as soon as Sonar fixes the comma-separated paths
+        ln -s ~/.gradle .sonar-gradle
     - uses: SonarSource/sonarqube-scan-action@v5
       with:
         args: >-
           -Dsonar.cfamily.compile-commands=build/compile_commands.json
           -Dsonar.cfamily.analysisCache.mode=fs
-          -Dsonar.cfamily.analysisCache.path="$HOME/.sonar-cfamily-cache"
+          -Dsonar.cfamily.analysisCache.path=.sonar-cfamily-cache
           -Dsonar.java.binaries="android/*/build/**/classes"
-          -Dsonar.java.libraries="$ANDROID_HOME/**/*.jar,$HOME/.gradle/**/*.jar"
+          -Dsonar.java.libraries=".sonar-android-sdk/platforms/**/*.jar"
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
fix #10135

It seems that there was some "vulnerability" in SonarCloud:

https://community.sonarsource.com/t/security-advisory-sonarqube-scanner-github-action/147696

It was "fixed" in such a way that:

* Environment variables can no longer be used in the scanner parameters.
* Only paths located inside the working directory now can be specified. Even if you specify the absolute path, it will be forcibly prepended by `/home/runner/fheroes2/fheroes2`, e.g. `/home/runner/fheroes2/fheroes2//usr/local/...`. Fortunately, this can still be circumvented by symlinks (in a way, not head-on).
* Comma operation in paths is broken, that is, now it is impossible to specify multiple paths separated by commas in one parameter, as before. I hope it gets fixed eventually, because this is a [documented behavior](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/languages/java/#analysis-and-bytecode), but until then I have to choose between specifying path to Android SDK or to packages downloaded by Gradle. This leads to the following warning from the scanner:
  ```
  12:46:41.825 WARN  Unresolved imports/types have been detected during analysis. Enable DEBUG mode to see them.
  ```
  So far I left the TODO comment regarding this.

In general, there is a suspicion that this "fix" from Sonar broke more than it fixed.