### PR TITLE
Fix Hero Dialog EXIT button flickering

### DIFF
--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -678,12 +678,6 @@ namespace fheroes2
     {
         LocalEvent & le = LocalEvent::Get();
 
-        for ( const auto & button : _button ) {
-            if ( button->isEnabled() ) {
-                button->drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( button->area() ) );
-            }
-        }
-
         const size_t buttonsCount = _button.size();
 
         assert( buttonsCount == _value.size() );
@@ -691,6 +685,12 @@ namespace fheroes2
         for ( size_t i = 0; i < buttonsCount; ++i ) {
             if ( _button[i]->isEnabled() && le.MouseClickLeft( _button[i]->area() ) ) {
                 return _value[i];
+            }
+        }
+
+        for ( const auto & button : _button ) {
+            if ( button->isEnabled() ) {
+                button->drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( button->area() ) );
             }
         }
 

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -678,6 +678,12 @@ namespace fheroes2
     {
         LocalEvent & le = LocalEvent::Get();
 
+        for ( const auto & button : _button ) {
+            if ( button->isEnabled() ) {
+                button->drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( button->area() ) );
+            }
+        }
+
         const size_t buttonsCount = _button.size();
 
         assert( buttonsCount == _value.size() );
@@ -685,12 +691,6 @@ namespace fheroes2
         for ( size_t i = 0; i < buttonsCount; ++i ) {
             if ( _button[i]->isEnabled() && le.MouseClickLeft( _button[i]->area() ) ) {
                 return _value[i];
-            }
-        }
-
-        for ( const auto & button : _button ) {
-            if ( button->isEnabled() ) {
-                button->drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( button->area() ) );
             }
         }
 

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -417,13 +417,12 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
     // dialog menu loop
     while ( le.HandleEvents() ) {
-        // Exit this dialog.
-        buttonExit.drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( buttonExit.area() ) );
-
         if ( le.MouseClickLeft( buttonExit.area() ) || Game::HotKeyCloseWindow() ) {
             // Exit the dialog handling loop to close it.
             break;
         }
+
+        buttonExit.drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( buttonExit.area() ) );
 
         // Manage hero's army.
         if ( le.isMouseCursorPosInArea( selectArmy.GetArea() ) && selectArmy.QueueEventProcessing( &message ) ) {


### PR DESCRIPTION
Buttons should be drawn after the state check.

relates to #10113