### PR TITLE
Retry other spells from the guaranteed list if the chosen spell was not added

### DIFF
--- a/src/fheroes2/castle/mageguild.cpp
+++ b/src/fheroes2/castle/mageguild.cpp
@@ -23,6 +23,7 @@
 
 #include "mageguild.h"
 
+#include <algorithm>
 #include <array>
 #include <cassert>
 #include <cstddef>


### PR DESCRIPTION
Relates to https://github.com/ihhub/fheroes2/pull/10161

This PR makes the engine during map initialization to try other spells from the "guaranteed" list if the randomly selected spell from this list was not added because of no space for this spell or if it is in ban list.