### PR TITLE
Do not allow to dismiss a monster by mouse right-clicking

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -406,7 +406,8 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
 {
     if ( isSelected() ) {
         if ( read_only ) {
-            return false; // reset cursor
+            // reset cursor
+            return false;
         }
 
         ArmyTroop * selectedTroop = GetSelectedItem();
@@ -439,9 +440,11 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
                 Army::SwapTroops( troop, *selectedTroop );
         }
 
-        return false; // reset cursor
+        // reset cursor
+        return false;
     }
-    else if ( troop.isValid() ) {
+
+    if ( troop.isValid() ) {
         if ( !read_only ) // select
         {
             if ( IsSplitHotkeyUsed( troop, _army ) )
@@ -551,7 +554,8 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & destTroop, ArmyTroop & 
         }
     }
 
-    return false; // reset cursor
+    // reset cursor
+    return false;
 }
 
 bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
@@ -567,8 +571,10 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
     if ( &troop == troop2 ) {
         int flags = Dialog::BUTTONS;
 
+        const bool keepLastTroop = _saveLastTroop && _army->SaveLastTroop();
+
         if ( !read_only ) {
-            if ( !_saveLastTroop || !_army->SaveLastTroop() ) {
+            if ( !keepLastTroop ) {
                 flags |= Dialog::DISMISS;
             }
 
@@ -583,6 +589,11 @@ bool ArmyBar::ActionBarLeftMouseDoubleClick( ArmyTroop & troop )
                     }
                 }
             }
+        }
+
+        if ( can_change && keepLastTroop ) {
+            // This is an editing mode. We allow to dismiss monsters.
+            flags |= Dialog::DISMISS;
         }
 
         switch ( Dialog::ArmyInfo( troop, flags, false, _troopWindowOffsetY ) ) {
@@ -669,12 +680,7 @@ bool ArmyBar::ActionBarRightMouseHold( ArmyTroop & troop )
     if ( troop.isValid() ) {
         ResetSelected();
 
-        if ( can_change && ( !_saveLastTroop || !_army->SaveLastTroop() ) ) {
-            troop.Reset();
-        }
-        else {
-            Dialog::ArmyInfo( troop, Dialog::ZERO, false, _troopWindowOffsetY );
-        }
+        Dialog::ArmyInfo( troop, Dialog::ZERO, false, _troopWindowOffsetY );
     }
 
     return true;

--- a/src/fheroes2/resource/artifact_info.cpp
+++ b/src/fheroes2/resource/artifact_info.cpp
@@ -1040,7 +1040,7 @@ namespace fheroes2
                     os << "Add " << bonus.value << " to hero's Attack Skill" << std::endl;
                     break;
                 case ArtifactBonusType::DEFENCE_SKILL:
-                    os << "Add " << bonus.value << " to hero's Defence Skill" << std::endl;
+                    os << "Add " << bonus.value << " to hero's Defense Skill" << std::endl;
                     break;
                 case ArtifactBonusType::SPELL_POWER_SKILL:
                     os << "Add " << bonus.value << " to hero's Spell Power Skill" << std::endl;


### PR DESCRIPTION
This is against the whole concept of using mouse right-click for gathering information. DISMISS button in the monster dialog is the correct way of doing things.

This affects Battle Only and the Editor.

close #9991