### PR TITLE
German translation for dismissal of troops

### DIFF
--- a/files/lang/de.po
+++ b/files/lang/de.po
@@ -91,7 +91,7 @@ msgid "NO"
 msgstr "NEIN"
 
 msgid "DISMISS"
-msgstr "ABLEHNEN"
+msgstr "ENTLASSEN"
 
 msgid "UPGRADE"
 msgstr "AUFRÜSTEN"


### PR DESCRIPTION
Propose to change German translation for dismissal of troops: current "ABLEHNEN" translates to "decline" rather than to "dismiss". In context of troops, "ENTLASSEN" is better suited. For sources, see https://www.linguee.com/english-german/search?source=auto&query=Truppen+entlassen