### PR TITLE
Update hashes for Android & Windows dependency packages

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -92,7 +92,7 @@ dependencies {
 
     implementation group: 'commons-io', name: 'commons-io', version: '2.20.0'
 
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'com.google.android.material:material:1.13.0'
 }
 
 tasks.register('copyFH2M', Copy) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,4 @@
 plugins {
-    id 'com.android.application' version '8.12.0' apply false
-    id 'com.android.library' version '8.12.0' apply false
+    id 'com.android.application' version '8.13.0' apply false
+    id 'com.android.library' version '8.13.0' apply false
 }

--- a/script/android/install_packages.bat
+++ b/script/android/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\android
 
 set PKG_FILE=android.zip
-set PKG_FILE_SHA256=F3F3B31A6F8D402DFC88C3DCB9A9A6FAB9F500D58525AEAFF768F2786CA2E4E6
+set PKG_FILE_SHA256=5C8DB5488495CEB86FCFD48CC5F9C3D4123C6DD92F0B7FCC15B91C81E65EE142
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 

--- a/script/android/install_packages.sh
+++ b/script/android/install_packages.sh
@@ -23,7 +23,7 @@
 set -e -o pipefail
 
 PKG_FILE="android.zip"
-PKG_FILE_SHA256="f3f3b31a6f8d402dfc88c3dcb9a9a6fab9f500d58525aeaff768f2786ca2e4e6"
+PKG_FILE_SHA256="5c8db5488495ceb86fcfd48cc5f9c3d4123c6dd92f0b7fcc15b91c81e65ee142"
 PKG_URL="https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/android-deps/$PKG_FILE"
 
 TMP_DIR="$(mktemp -d)"

--- a/script/windows/install_packages.bat
+++ b/script/windows/install_packages.bat
@@ -23,7 +23,7 @@
 set DST_DIR=%~dp0\..\..\VisualStudio\packages
 
 set PKG_FILE=windows.zip
-set PKG_FILE_SHA256=410254CA4272C032866621718F99CB90BC77CC321F3FD498A268A0CF88C9436A
+set PKG_FILE_SHA256=617A9A31B7496227112318DC57D4A4F8A757F5B2401D781DE396303288AA89A0
 set PKG_URL=https://github.com/fheroes2/fheroes2-prebuilt-deps/releases/download/windows-deps/%PKG_FILE%
 set PKG_TLS=[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 


### PR DESCRIPTION
See https://github.com/fheroes2/fheroes2-prebuilt-deps/pull/69 for details.

Also this PR updates AGP and some of Android dependencies.