### PR TITLE
Do not show cell selection frame when no monster is selected for a brush in the Editor

### DIFF
--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -223,12 +223,13 @@ namespace Interface
         // If not selected monsters, frame don't draw.
         if ( _selectedInstrument == Instrument::MONSTERS ) {
             const int32_t objectType = getSelectedObjectType();
-                if ( objectType >= 0 ) {
-                    return { 0, 0, 1, 1 };
-                } 
+            if ( objectType >= 0 ) {
+                return { 0, 0, 1, 1 };
+            }
 
-                return {};
+            return {};
         }
+
         // Roads and streams are placed using only 1x1 brush.
         if ( _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD || _selectedInstrument == Instrument::DETAIL ) {
             return { 0, 0, 1, 1 };

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -220,7 +220,11 @@ namespace Interface
 
     fheroes2::Rect EditorPanel::getBrushArea() const
     {
-        // If not selected monsters, frame don't draw.
+        // Roads and streams are placed using only 1x1 brush.
+        if ( _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD || _selectedInstrument == Instrument::DETAIL ) {
+            return { 0, 0, 1, 1 };
+        }
+
         if ( _selectedInstrument == Instrument::MONSTERS ) {
             const int32_t objectType = getSelectedObjectType();
             if ( objectType >= 0 ) {
@@ -228,11 +232,6 @@ namespace Interface
             }
 
             return {};
-        }
-
-        // Roads and streams are placed using only 1x1 brush.
-        if ( _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD || _selectedInstrument == Instrument::DETAIL ) {
-            return { 0, 0, 1, 1 };
         }
 
         if ( _selectedInstrument == Instrument::LANDSCAPE_OBJECTS || _selectedInstrument == Instrument::ADVENTURE_OBJECTS

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -227,7 +227,7 @@ namespace Interface
                     return { 0, 0, 1, 1 };
                 } 
 
-		return {};
+                return {};
         }
         // Roads and streams are placed using only 1x1 brush.
         if ( _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD || _selectedInstrument == Instrument::DETAIL ) {

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -220,9 +220,17 @@ namespace Interface
 
     fheroes2::Rect EditorPanel::getBrushArea() const
     {
+        // If not selected monsters, frame don't draw.
+        if ( _selectedInstrument == Instrument::MONSTERS ) {
+            const int32_t objectType = getSelectedObjectType();
+                if ( objectType >= 0 ) {
+                    return { 0, 0, 1, 1 };
+                } 
+
+		return {};
+        }
         // Roads and streams are placed using only 1x1 brush.
-        if ( _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD || _selectedInstrument == Instrument::DETAIL
-             || _selectedInstrument == Instrument::MONSTERS ) {
+        if ( _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD || _selectedInstrument == Instrument::DETAIL ) {
             return { 0, 0, 1, 1 };
         }
 


### PR DESCRIPTION
close #10118 