### PR TITLE
Update battle_interface.cpp

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -7034,7 +7034,7 @@ void Battle::PopupDamageInfo::setSpellAttackInfo( const HeroBase * hero, const U
 
     // TODO: Currently, this functionality only supports a simple single-target spell case
     // We should refactor this to apply to all cases
-    if ( !spell.isSingleTarget() || !spell.isDamage() ) {
+    if ( !spell.isDamage() ) {
         return;
     }
 


### PR DESCRIPTION
Now ALL damage spells will show a DamageInfo dialog when tageting a _defender

<img width="368" height="387" alt="image" src="https://github.com/user-attachments/assets/5c6e1faa-4ce2-42fc-9565-a90890f3433c" />
