### PR TITLE
Show Turn Order dialog above the arena if there is enough space

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1271,7 +1271,7 @@ void Battle::TurnOrder::redraw( const Unit * current, const uint8_t currentUnitC
     }
 
     auto & display = fheroes2::Display::instance();
-    _isInsideBattleField = display.height() < dialogRoi.height + turnOrderMonsterIconSize;
+    _isInsideBattleField = ( dialogRoi.y <= turnOrderMonsterIconSize );
 
     const int32_t unitsToDraw = std::min( _battleRoi.width / turnOrderMonsterIconSize, validUnitCount );
 
@@ -1283,7 +1283,7 @@ void Battle::TurnOrder::redraw( const Unit * current, const uint8_t currentUnitC
         int32_t offsetX = ( _battleRoi.width - _renderingRoi.width ) / 2;
 
         if ( !_isInsideBattleField ) {
-            offsetX += ( display.width() - dialogRoi.width ) / 2;
+            offsetX += dialogRoi.x;
         }
 
         if ( _isInsideBattleField ) {

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -1189,7 +1189,7 @@ bool Battle::TurnOrder::queueEventProcessing( Interface & interface, std::string
     for ( const auto & [unit, unitPos] : _rects ) {
         assert( unit != nullptr );
 
-        const fheroes2::Rect unitRoi = unitPos + offset;
+        const fheroes2::Rect unitRoi = _isInsideBattleField ? ( unitPos + offset ) : unitPos;
         if ( le.isMouseCursorPosInArea( unitRoi ) ) {
             msg = _( "View %{monster} info" );
             StringReplaceWithLowercase( msg, "%{monster}", unit->GetName() );
@@ -1246,8 +1246,13 @@ void Battle::TurnOrder::_redrawUnit( const fheroes2::Rect & pos, const Battle::U
     }
 }
 
-void Battle::TurnOrder::redraw( const Unit * current, const uint8_t currentUnitColor, const Unit * underCursor, fheroes2::Image & output )
+void Battle::TurnOrder::redraw( const Unit * current, const uint8_t currentUnitColor, const Unit * underCursor, fheroes2::Image & output,
+                                const fheroes2::Rect & dialogRoi )
 {
+    if ( _restorer ) {
+        _restorer->restore();
+    }
+
     if ( _orderOfUnits.expired() ) {
         // Nothing to show.
         return;
@@ -1260,18 +1265,37 @@ void Battle::TurnOrder::redraw( const Unit * current, const uint8_t currentUnitC
         return unit->isValid();
     } ) );
 
-    const int32_t unitsToDraw = std::min( _area.width / turnOrderMonsterIconSize, validUnitCount );
+    if ( validUnitCount == 0 ) {
+        // Nothing to draw.
+        return;
+    }
+
+    auto & display = fheroes2::Display::instance();
+    _isInsideBattleField = display.height() < dialogRoi.height + turnOrderMonsterIconSize;
+
+    const int32_t unitsToDraw = std::min( _battleRoi.width / turnOrderMonsterIconSize, validUnitCount );
 
     if ( _rects.size() != static_cast<size_t>( unitsToDraw ) ) {
         // Update units icons positions.
 
-        width = turnOrderMonsterIconSize * unitsToDraw;
+        _renderingRoi.width = turnOrderMonsterIconSize * unitsToDraw;
 
-        int32_t offsetX = ( _area.width - width ) / 2;
+        int32_t offsetX = ( _battleRoi.width - _renderingRoi.width ) / 2;
 
-        x = _area.x + offsetX;
-        y = _area.y;
-        height = turnOrderMonsterIconSize;
+        if ( !_isInsideBattleField ) {
+            offsetX += ( display.width() - dialogRoi.width ) / 2;
+        }
+
+        if ( _isInsideBattleField ) {
+            _renderingRoi.x = _battleRoi.x + offsetX;
+            _renderingRoi.y = _battleRoi.y;
+        }
+        else {
+            _renderingRoi.x = offsetX;
+            _renderingRoi.y = dialogRoi.y - turnOrderMonsterIconSize;
+        }
+
+        _renderingRoi.height = turnOrderMonsterIconSize;
 
         _rects.clear();
         _rects.reserve( unitsToDraw );
@@ -1279,9 +1303,18 @@ void Battle::TurnOrder::redraw( const Unit * current, const uint8_t currentUnitC
         for ( int32_t index = 0; index < unitsToDraw; ++index ) {
             // Just for now place 'nullptr' instead of a pointer to unit.
             // These pointers will be updated in the next loop.
-            _rects.emplace_back( nullptr, fheroes2::Rect( offsetX, 0, turnOrderMonsterIconSize, turnOrderMonsterIconSize ) );
+            if ( _isInsideBattleField ) {
+                _rects.emplace_back( nullptr, fheroes2::Rect( offsetX, 0, turnOrderMonsterIconSize, turnOrderMonsterIconSize ) );
+            }
+            else {
+                _rects.emplace_back( nullptr, fheroes2::Rect( offsetX, _renderingRoi.y, turnOrderMonsterIconSize, turnOrderMonsterIconSize ) );
+            }
 
             offsetX += turnOrderMonsterIconSize;
+        }
+
+        if ( !_isInsideBattleField ) {
+            _restorer = std::make_unique<fheroes2::ImageRestorer>( display, _renderingRoi.x, _renderingRoi.y, _renderingRoi.width, _renderingRoi.height );
         }
     }
 
@@ -1310,7 +1343,7 @@ void Battle::TurnOrder::redraw( const Unit * current, const uint8_t currentUnitC
             unitColor = currentUnitColor;
         }
 
-        _redrawUnit( _rects[unitRectIndex].second, *unit, unit->GetColor() == _opponentColor, unitColor, output );
+        _redrawUnit( _rects[unitRectIndex].second, *unit, unit->GetColor() == _opponentColor, unitColor, _isInsideBattleField ? output : display );
 
         ++unitRectIndex;
         ++unitsProcessed;
@@ -1445,6 +1478,10 @@ Battle::Interface::~Interface()
 {
     AudioManager::ResetAudio();
 
+    // Turn order dialog can be outside the battlefield area.
+    // We need to restore the original background before doing extra animation.
+    _turnOrder.restore();
+
     // Fade-out battlefield.
     const bool isDefaultScreenSize = fheroes2::Display::instance().isDefaultSize();
 
@@ -1525,7 +1562,7 @@ void Battle::Interface::fullRedraw()
     // Fade-in battlefield.
     if ( !isDefaultScreenSize ) {
         // We need to expand the ROI for the next render to properly render window borders and shadow.
-        display.updateNextRenderRoi( _background->totalArea() );
+        display.updateNextRenderRoi( fheroes2::getBoundaryRect( _background->totalArea(), _turnOrder.getRenderingRoi() ) );
     }
 
     fheroes2::fadeInDisplay( _background->activeArea(), !isDefaultScreenSize );
@@ -1560,7 +1597,8 @@ void Battle::Interface::RedrawPartialFinish()
 {
     redrawPreRender();
 
-    fheroes2::Display::instance().render( _interfacePosition );
+    auto & display = fheroes2::Display::instance();
+    display.render( fheroes2::getBoundaryRect( _interfacePosition, _turnOrder.getRenderingRoi() ) );
 }
 
 void Battle::Interface::redrawPreRender()
@@ -1571,7 +1609,7 @@ void Battle::Interface::redrawPreRender()
         if ( cell != nullptr ) {
             unit = cell->GetUnit();
         }
-        _turnOrder.redraw( _currentUnit, _contourColor, unit, _mainSurface );
+        _turnOrder.redraw( _currentUnit, _contourColor, unit, _mainSurface, border.GetRect() );
     }
 
 #ifdef WITH_DEBUG
@@ -3018,7 +3056,7 @@ void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, s
             fheroes2::showStandardTextMessage( _( "Ballista" ), ballistaMessage, le.isMouseRightButtonPressed() ? Dialog::ZERO : Dialog::OK );
         }
     }
-    else if ( conf.BattleShowTurnOrder() && le.isMouseCursorPosInArea( _turnOrder ) ) {
+    else if ( conf.BattleShowTurnOrder() && le.isMouseCursorPosInArea( _turnOrder.getRenderingRoi() ) ) {
         cursor.SetThemes( Cursor::POINTER );
         if ( _turnOrder.queueEventProcessing( *this, msg, _interfacePosition.getPosition() ) ) {
             humanturn_redraw = true;

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -225,7 +225,7 @@ namespace Battle
         StatusListBox * _battleStatusLog{ nullptr };
     };
 
-    class TurnOrder final : public fheroes2::Rect
+    class TurnOrder final
     {
     public:
         TurnOrder() = default;
@@ -236,13 +236,26 @@ namespace Battle
 
         void set( const fheroes2::Rect & roi, const std::shared_ptr<const Units> & units, const PlayerColor opponentColor )
         {
-            _area = roi;
+            _battleRoi = roi;
             _orderOfUnits = units;
             _opponentColor = opponentColor;
         }
 
-        void redraw( const Unit * current, const uint8_t currentUnitColor, const Unit * underCursor, fheroes2::Image & output );
+        void redraw( const Unit * current, const uint8_t currentUnitColor, const Unit * underCursor, fheroes2::Image & output, const fheroes2::Rect & dialogRoi );
+
         bool queueEventProcessing( Interface & interface, std::string & msg, const fheroes2::Point & offset ) const;
+
+        const fheroes2::Rect & getRenderingRoi() const
+        {
+            return _renderingRoi;
+        }
+
+        void restore()
+        {
+            if ( _restorer ) {
+                _restorer->restore();
+            }
+        }
 
     private:
         using UnitPos = std::pair<const Unit *, fheroes2::Rect>;
@@ -251,8 +264,12 @@ namespace Battle
 
         std::weak_ptr<const Units> _orderOfUnits;
         PlayerColor _opponentColor{ PlayerColor::NONE };
-        fheroes2::Rect _area;
+        fheroes2::Rect _renderingRoi;
+        fheroes2::Rect _battleRoi;
         std::vector<UnitPos> _rects;
+
+        std::unique_ptr<fheroes2::ImageRestorer> _restorer;
+        bool _isInsideBattleField{ false };
     };
 
     class PopupDamageInfo : public Dialog::FrameBorder


### PR DESCRIPTION
We have a plenty of space on the screen for high resolutions. So, no need to overlap an already small battlefield.

The turn order will stay the same if the display high is not enough to put the dialog above the battlefield.

<img width="1024" height="768" alt="image" src="https://github.com/user-attachments/assets/c0b64e26-9ba3-4d4d-b8b7-e0e54e4ff2a1" />

<img width="720" height="480" alt="image" src="https://github.com/user-attachments/assets/62154985-6e49-4962-8026-3a887d44cad6" />

close #6522