### PR TITLE
Add extra conditions on hiring AI heroes

### DIFF
--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -45,6 +45,7 @@
 #include "game_interface.h"
 #include "game_mode.h"
 #include "game_over.h"
+#include "game_static.h"
 #include "ground.h"
 #include "heroes.h"
 #include "heroes_recruits.h"
@@ -929,7 +930,18 @@ bool AI::Planner::purchaseNewHeroes( const std::vector<AICastle> & sortedCastleL
                                      const bool moreTasksForHeroes )
 {
     const bool isEarlyGameWithSingleCastle = world.CountDay() < 5 && sortedCastleList.size() == 1;
-    const int32_t heroLimit = isEarlyGameWithSingleCastle ? 2 : world.w() / Maps::SMALL + 2;
+    int32_t heroLimit = isEarlyGameWithSingleCastle ? 2 : world.w() / Maps::SMALL + 2;
+
+    if ( heroLimit < static_cast<int32_t>( sortedCastleList.size() ) ) {
+        // In most cases the number of heroes must at least be equal to the number of heroes.
+        heroLimit = static_cast<int32_t>( sortedCastleList.size() );
+    }
+
+    if ( heroLimit > static_cast<int32_t>( GameStatic::GetKingdomMaxHeroes() ) ) {
+        // Make sure we limit the number of heroes to the allowed number.
+        heroLimit = static_cast<int32_t>( GameStatic::GetKingdomMaxHeroes() );
+    }
+
 
     if ( availableHeroCount >= heroLimit ) {
         return false;


### PR DESCRIPTION
- if the number of castles is more than heroes than we might need to hire more heroes
- the number of heroes cannot be more than 8 as for humans