### PR TITLE
Fix incorrect army pre-battle optimization for flying units

### DIFF
--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -134,7 +134,7 @@ void AI::OptimizeTroopsOrder( Army & army )
         }
 
         if ( left.isFlying() != right.isFlying() ) {
-            return right.isFlying();
+            return left.isFlying();
         }
 
         return left.GetStrength() < right.GetStrength();


### PR DESCRIPTION
close #5908

This is an invalid check that flying units with the same speed were put after non-fliers

Before:

https://github.com/user-attachments/assets/8468fae2-1a67-4dd7-a872-bf0d86b7bf70

After:

https://github.com/user-attachments/assets/136f195c-ba64-482b-abdc-125aa182773c