### PR TITLE
Make AI heroes on patrol return to their original position if nothing to do

### DIFF
--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2462,7 +2462,24 @@ int AI::Planner::getPriorityTarget( Heroes & hero, double & maxPriority )
     }
 
     if ( priorityTarget == -1 ) {
-        DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " can't find a meaningful tile to visit" )
+        if ( hero.Modes( Heroes::PATROL ) && hero.GetPatrolCenter() != hero.GetCenter() ) {
+            const int32_t patrolIndex = hero.GetPatrolCenter().x + hero.GetPatrolCenter().y * world.w();
+
+            auto [dist, useDimensionDoor] = getDistanceToTile( _pathfinder, patrolIndex );
+            if ( dist == 0 || MP2::isOffGameActionObject( world.getTile( patrolIndex ).getMainObjectType() ) ) {
+                DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " can't find a meaningful tile to visit and cannot return to the patrol position" )
+                return -1;
+            }
+
+            // This hero is on patrol. Since no tasks to perform go back to the original patrol position.
+            DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " can't find a meaningful tile to visit and returning back to the patrol position" )
+            priorityTarget = patrolIndex;
+            // Make the priority slightly higher than the limit.
+            maxPriority = -dangerousTaskPenalty + 1;
+        }
+        else {
+            DEBUG_LOG( DBG_AI, DBG_INFO, hero.GetName() << " can't find a meaningful tile to visit" )
+        }
     }
     else {
         DEBUG_LOG( DBG_AI, DBG_INFO,


### PR DESCRIPTION
close #2315

You can use this save file for tests:
[Colossal_Cavern_0001.zip](https://github.com/user-attachments/files/22745200/Colossal_Cavern_0001.zip)

Search for these heroes:

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/6115294b-8233-4977-bb2e-30afed96c726" />

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/5aae8590-2a15-4789-9c28-20783f7a5c60" />
