### PR TITLE
Fix incorrect text are calculation for hot-key dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_hotkeys.cpp
+++ b/src/fheroes2/dialog/dialog_hotkeys.cpp
@@ -73,7 +73,7 @@ namespace
             text.add( fheroes2::Text{ _( "Hotkey: " ), fheroes2::FontType::normalYellow() } );
             text.add( fheroes2::Text{ StringUpper( KeySymGetName( _key ) ), fheroes2::FontType::normalWhite() } );
 
-            _restorer.update( offset.x, offset.y, fheroes2::boxAreaWidthPx, text.height() );
+            _restorer.update( offset.x, offset.y, fheroes2::boxAreaWidthPx, text.height( fheroes2::boxAreaWidthPx ) );
 
             text.draw( offset.x, offset.y, fheroes2::boxAreaWidthPx, output );
         }


### PR DESCRIPTION
close #10257

https://github.com/user-attachments/assets/6b1c6317-e422-4984-a39c-fc9649f09c46

