### PR TITLE
Update calculation display of hero's remaining spell points in the spell point bar

### DIFF
--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -529,8 +529,8 @@ void Battle::Only::copyHero( const Heroes & in, Heroes & out )
     out._secondarySkills.ToVector() = in._secondarySkills.ToVector();
     out._army.Assign( in._army );
 
-    out.bag_artifacts = in.bag_artifacts;
-    out.spell_book = in.spell_book;
+    out._bagArtifacts = in._bagArtifacts;
+    out._spellBook = in._spellBook;
 
     out.SetSpellPoints( out.GetMaxSpellPoints() );
 }

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -123,7 +123,7 @@ int Captain::GetMorale() const
     result += GetMoraleModificator( nullptr );
 
     // A special artifact ability presence must be the last check.
-    const Artifact maxMoraleArtifact = bag_artifacts.getFirstArtifactWithBonus( fheroes2::ArtifactBonusType::MAXIMUM_MORALE );
+    const Artifact maxMoraleArtifact = _bagArtifacts.getFirstArtifactWithBonus( fheroes2::ArtifactBonusType::MAXIMUM_MORALE );
     if ( maxMoraleArtifact.isValid() ) {
         result = Morale::BLOOD;
     }
@@ -139,7 +139,7 @@ int Captain::GetLuck() const
     result += GetLuckModificator( nullptr );
 
     // A special artifact ability presence must be the last check.
-    const Artifact maxLuckArtifact = bag_artifacts.getFirstArtifactWithBonus( fheroes2::ArtifactBonusType::MAXIMUM_LUCK );
+    const Artifact maxLuckArtifact = _bagArtifacts.getFirstArtifactWithBonus( fheroes2::ArtifactBonusType::MAXIMUM_LUCK );
     if ( maxLuckArtifact.isValid() ) {
         result = Luck::IRISH;
     }
@@ -189,7 +189,7 @@ void Captain::ActionAfterBattle()
 
 void Captain::ActionPreBattle()
 {
-    spell_book.resetState();
+    _spellBook.resetState();
 }
 
 const Castle * Captain::inCastle() const
@@ -252,7 +252,7 @@ void Captain::PortraitRedraw( const int32_t px, const int32_t py, const Portrait
         return;
     }
 
-    const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, GetManaIndexSprite() );
+    const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, getManaIndexSprite() );
 
     const int iconWidth = Interface::IconsBar::getItemWidth();
     const int iconHeight = Interface::IconsBar::getItemHeight();
@@ -271,12 +271,4 @@ void Captain::PortraitRedraw( const int32_t px, const int32_t py, const Portrait
     // spell points
     fheroes2::Fill( dstsf, px + barWidth + port.width() + 2, py, barWidth, iconHeight, blueColor );
     fheroes2::Blit( mana, dstsf, px + barWidth + port.width() + 2, py + mana.y() );
-}
-
-int Captain::GetManaIndexSprite() const
-{
-    // valid range (0 - 25)
-    const int r = GetMaxSpellPoints() / 5;
-
-    return 25 >= r ? r : 25;
 }

--- a/src/fheroes2/castle/captain.h
+++ b/src/fheroes2/castle/captain.h
@@ -86,7 +86,5 @@ public:
     fheroes2::Sprite GetPortrait( const PortraitType type ) const;
 
 private:
-    int GetManaIndexSprite() const;
-
     Castle & home;
 };

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -440,19 +440,19 @@ public:
 
     uint32_t GetMovePoints() const
     {
-        return move_point;
+        return _movePoints;
     }
 
     void IncreaseMovePoints( const uint32_t point )
     {
-        move_point += point;
+        _movePoints += point;
     }
 
     bool MayStillMove( const bool ignorePath, const bool ignoreSleeper ) const;
 
     void ResetMovePoints()
     {
-        move_point = 0;
+        _movePoints = 0;
     }
 
     bool HasSecondarySkill( const int skill ) const;
@@ -470,23 +470,20 @@ public:
 
     bool HasUltimateArtifact() const
     {
-        return bag_artifacts.ContainUltimateArtifact();
+        return _bagArtifacts.ContainUltimateArtifact();
     }
 
     uint32_t GetCountArtifacts() const
     {
-        return bag_artifacts.CountArtifacts();
+        return _bagArtifacts.CountArtifacts();
     }
 
     bool IsFullBagArtifacts() const
     {
-        return bag_artifacts.isFull();
+        return _bagArtifacts.isFull();
     }
 
     uint32_t GetMobilityIndexSprite() const;
-
-    // Returns the relative height of mana column near hero's portrait in heroes panel. Returned value will be in range [0; 25].
-    uint32_t GetManaIndexSprite() const;
 
     int OpenDialog( const bool readonly, const bool fade, const bool disableDismiss, const bool disableSwitch, const bool renderBackgroundDialog, const bool isEditor,
                     const fheroes2::SupportedLanguage language );

--- a/src/fheroes2/heroes/heroes_base.h
+++ b/src/fheroes2/heroes/heroes_base.h
@@ -72,7 +72,7 @@ class HeroBase : public Skill::Primary, public MapPosition, public BitModes, pub
 {
 public:
     HeroBase( const int type, const int race );
-    HeroBase();
+    HeroBase() = default;
 
     ~HeroBase() override = default;
 
@@ -117,8 +117,11 @@ public:
 
     uint32_t GetSpellPoints() const
     {
-        return magic_point;
+        return _spellPoints;
     }
+
+    // Returns the relative height of mana column near hero's portrait in heroes panel. Returned value will be in range [0; 25].
+    uint32_t getManaIndexSprite() const;
 
     bool HaveSpellPoints( const Spell & spell ) const;
     bool haveMovePoints( const Spell & spell ) const;
@@ -127,7 +130,7 @@ public:
     void SpellCasted( const Spell & spell );
     void SetSpellPoints( const uint32_t points )
     {
-        magic_point = points;
+        _spellPoints = points;
     }
 
     bool isPotentSpellcaster() const;
@@ -137,7 +140,7 @@ public:
 
     const SpellStorage & getMagicBookSpells() const
     {
-        return spell_book;
+        return _spellBook;
     }
 
     void EditSpellBook();
@@ -149,9 +152,9 @@ public:
         return hasArtifact( Artifact::MAGIC_BOOK );
     }
 
-    bool HaveSpell( const Spell & spell, const bool skip_bag = false ) const;
-    void AppendSpellToBook( const Spell &, const bool without_wisdom = false );
-    void AppendSpellsToBook( const SpellStorage &, const bool without_wisdom = false );
+    bool HaveSpell( const Spell & spell, const bool skipBag = false ) const;
+    void AppendSpellToBook( const Spell &, const bool withoutWisdom = false );
+    void AppendSpellsToBook( const SpellStorage &, const bool withoutWisdom = false );
 
     // Adds the spell book to the artifact bag if it is not already there. Returns true if the spell book was actually added to the artifact bag, otherwise returns false.
     bool SpellBookActivate();
@@ -160,12 +163,12 @@ public:
 
     BagArtifacts & GetBagArtifacts()
     {
-        return bag_artifacts;
+        return _bagArtifacts;
     }
 
     const BagArtifacts & GetBagArtifacts() const
     {
-        return bag_artifacts;
+        return _bagArtifacts;
     }
 
     bool hasArtifact( const Artifact & art ) const;
@@ -176,11 +179,11 @@ protected:
     friend OStreamBase & operator<<( OStreamBase & stream, const HeroBase & hero );
     friend IStreamBase & operator>>( IStreamBase & stream, HeroBase & hero );
 
-    uint32_t magic_point;
-    uint32_t move_point;
+    uint32_t _spellPoints{ 0 };
+    uint32_t _movePoints{ 0 };
 
-    SpellBook spell_book;
-    BagArtifacts bag_artifacts;
+    SpellBook _spellBook;
+    BagArtifacts _bagArtifacts;
 };
 
 OStreamBase & operator<<( OStreamBase & stream, const HeroBase & hero );

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -494,7 +494,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     // This dialog currently does not have borders so its ROI is the same as fade ROI.
     fheroes2::fadeInDisplay( fadeRoi, !isDefaultScreenSize );
 
-    const int32_t hero1ScoutAreaBonus = bag_artifacts.getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE );
+    const int32_t hero1ScoutAreaBonus = _bagArtifacts.getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE );
     const int32_t hero2ScoutAreaBonus = otherHero.GetBagArtifacts().getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE );
 
     LocalEvent & le = LocalEvent::Get();
@@ -571,8 +571,8 @@ void Heroes::MeetingDialog( Heroes & otherHero )
             else if ( selectArmy2.isSelected() )
                 selectArmy2.ResetSelected();
 
-            std::set<ArtifactSetData> assembledArtifacts = bag_artifacts.assembleArtifactSetIfPossible();
-            std::set<ArtifactSetData> otherHeroAssembledArtifacts = otherHero.bag_artifacts.assembleArtifactSetIfPossible();
+            std::set<ArtifactSetData> assembledArtifacts = _bagArtifacts.assembleArtifactSetIfPossible();
+            std::set<ArtifactSetData> otherHeroAssembledArtifacts = otherHero._bagArtifacts.assembleArtifactSetIfPossible();
 
             // MSVC 2017 fails to use the std::set<...>::merge( std::set<...> && ) overload here, so we have to use a temporary variable
             assembledArtifacts.merge( otherHeroAssembledArtifacts );
@@ -849,7 +849,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     restorer.restore();
 
     // If the scout area bonus is increased with the new artifact we reveal the fog and update the radar.
-    if ( hero1ScoutAreaBonus < bag_artifacts.getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) {
+    if ( hero1ScoutAreaBonus < _bagArtifacts.getTotalArtifactEffectValue( fheroes2::ArtifactBonusType::AREA_REVEAL_DISTANCE ) ) {
         Scout( GetIndex() );
         ScoutRadar();
     }

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -450,13 +450,13 @@ void Heroes::_angleStep( const int targetDirection )
 
 void Heroes::_applyMovementPenalty( const uint32_t penalty )
 {
-    if ( penalty > move_point ) {
-        move_point = 0;
+    if ( penalty > _movePoints ) {
+        _movePoints = 0;
 
         return;
     }
 
-    move_point -= penalty;
+    _movePoints -= penalty;
 }
 
 fheroes2::Point Heroes::getCurrentPixelOffset() const


### PR DESCRIPTION
Fix #9520

The method `getManaIndexSprite()` is moved to `HeroBase` class to avoid duplicated code for hero and for captain.

In this PR all `HeroBase` private members are also renamed according to the code style along with other minor code clean in `hero_base.cpp`.