### PR TITLE
Do not cast Curse and Mass Curse spells on monsters with no damage range

### DIFF
--- a/src/fheroes2/ai/ai_battle_spell.cpp
+++ b/src/fheroes2/ai/ai_battle_spell.cpp
@@ -418,6 +418,10 @@ double AI::BattlePlanner::spellEffectValue( const Spell & spell, const Battle::U
     }
     case Spell::CURSE:
     case Spell::MASSCURSE:
+        if ( target.GetDamageMax() == target.GetDamageMin() ) {
+            // It is useless to apply Curse spell as the monster already has minimal damage.
+            return 0;
+        }
         ratio = 0.15;
         break;
     case Spell::BERSERKER:
@@ -443,8 +447,10 @@ double AI::BattlePlanner::spellEffectValue( const Spell & spell, const Battle::U
         break;
     case Spell::BLESS:
     case Spell::MASSBLESS: {
-        if ( target.GetDamageMax() == target.GetDamageMin() )
+        if ( target.GetDamageMax() == target.GetDamageMin() ) {
+            // It is useless to apply Bless spell as the monster already has maximum damage.
             return 0.0;
+        }
         ratio = 0.15;
         break;
     }


### PR DESCRIPTION
So far it is only Peasants but who knows :)

Before the changes:

https://github.com/user-attachments/assets/e7009fc2-4b60-42d1-8d76-63de4545abb2

After the changes:

https://github.com/user-attachments/assets/f632e57e-ff00-4fc2-8f32-ad046faecfa6

