### PR TITLE
 Implement treasure placement logic

### DIFF
--- a/src/fheroes2/maps/map_random_generator.cpp
+++ b/src/fheroes2/maps/map_random_generator.cpp
@@ -73,7 +73,7 @@ namespace
 
     constexpr uint8_t directionCount{ 8 };
     const std::array<fheroes2::Point, directionCount> directionOffsets{ { { 0, -1 }, { 1, 0 }, { 0, 1 }, { -1, 0 }, { -1, -1 }, { 1, -1 }, { 1, 1 }, { -1, 1 } } };
-    static constexpr std::array<int, 4> secondaryResources = { Resource::CRYSTAL, Resource::SULFUR, Resource::GEMS, Resource::MERCURY };
+    constexpr std::array<int, 4> secondaryResources = { Resource::CRYSTAL, Resource::SULFUR, Resource::GEMS, Resource::MERCURY };
 
     // TODO: replace list of object indicies with a struct for a better variety
     const std::map<int, std::vector<int>> obstaclesPerGround = {


### PR DESCRIPTION
Relates to #10340.

Uses prefabs to put treasures and protection together.
Automatic detection of obstacle type based on ground terrain.
Rudimentary map economy value to make sure secondary resources evenly distributed.
More fixes for mine placements.