### PR TITLE
Show map type explicitly as icons are too small to differentiate for some players

### DIFF
--- a/src/fheroes2/dialog/dialog_selectscenario.cpp
+++ b/src/fheroes2/dialog/dialog_selectscenario.cpp
@@ -29,6 +29,7 @@
 #include <optional>
 #include <ostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "agg_image.h"
@@ -43,6 +44,7 @@
 #include "screen.h"
 #include "settings.h"
 #include "system.h"
+#include "tools.h"
 #include "translations.h"
 #include "ui_button.h"
 #include "ui_constants.h"


### PR DESCRIPTION

https://github.com/user-attachments/assets/25988db4-ed98-445b-853e-f96c2fe189b2

