### PR TITLE
If an application becomes busy then cycling animation goes wild

### DIFF
--- a/src/engine/render_processor.cpp
+++ b/src/engine/render_processor.cpp
@@ -24,6 +24,13 @@
 
 #include "pal.h"
 
+namespace
+{
+    // The maximum FPS the engine can handle is 125.
+    // This means that a frame should be generated only every 8 ms.
+    const uint64_t frameHalfInterval{ 4 };
+}
+
 namespace fheroes2
 {
     RenderProcessor & RenderProcessor::instance()
@@ -47,13 +54,10 @@ namespace fheroes2
             _preRenderer();
         }
 
-        const uint64_t cylingTime = _previousCyclingInterval + _cyclingTimer.getMs();
-        if ( cylingTime < ( _cyclingInterval * 2 - _frameHalfInterval ) ) {
+        if ( _cyclingTimer.getMs() < ( _cyclingInterval - frameHalfInterval ) ) {
             // If the current timer is less than cycling internal minus half of the frame generation then nothing is needed.
             return false;
         }
-
-        _previousCyclingInterval = cylingTime - _cyclingInterval;
 
         // TODO: here we need to deduct possible time difference from the current time to have consistent FPS.
         _cyclingTimer.reset();

--- a/src/engine/render_processor.h
+++ b/src/engine/render_processor.h
@@ -84,7 +84,7 @@ namespace fheroes2
 
         bool isCyclingUpdateRequired() const
         {
-            return _enableCycling && _cyclingTimer.getMs() + _previousCyclingInterval >= 2 * _cyclingInterval && _lastRenderCall.getMs() > _frameHalfInterval;
+            return _enableCycling && _lastRenderCall.getMs() >= _cyclingInterval;
         }
 
     private:
@@ -96,18 +96,11 @@ namespace fheroes2
         fheroes2::Time _cyclingTimer;
         fheroes2::Time _lastRenderCall;
 
-        // This variable represents the inaccuracy of the previous color cycling rendering to be taken into account in the next one.
-        uint64_t _previousCyclingInterval{ _cyclingInterval };
-
         uint32_t _cyclingCounter{ 0 };
 
         bool _enableRenderers{ false };
         bool _enableCycling{ false };
 
         static const uint64_t _cyclingInterval{ 220 };
-
-        // Lets assume that the desynchronization of one frame is not noticeable on 60 FPS.
-        // To reduce the render calls we may do color cycling update 8 ms earlier or later.
-        static constexpr uint64_t _frameHalfInterval{ 8 };
     };
 }


### PR DESCRIPTION
regression from #10298

This is how it looks in the master branch (I deliberately break all in debug mode for few seconds to reproduce the issue):

https://github.com/user-attachments/assets/09255e80-ef42-4630-a074-139c41063c8b

The same approach after the fix:

https://github.com/user-attachments/assets/ab2bad68-7d5d-40f7-b4f6-ba80f59745b7

