### PR TITLE
Fix AI not using Disrupting Ray spell when enemy defense value is 2

### DIFF
--- a/src/fheroes2/ai/ai_battle_spell.cpp
+++ b/src/fheroes2/ai/ai_battle_spell.cpp
@@ -115,7 +115,7 @@ namespace
             return unit.Modes( Battle::CAP_MIRROROWNER );
 
         case Spell::DISRUPTINGRAY:
-            return unit.GetDefense() < spell.ExtraValue();
+            return unit.GetDefense() <= 1;
 
         default:
             break;


### PR DESCRIPTION
Before the changes:

https://github.com/user-attachments/assets/b3c45fc9-c160-4344-90f3-828e47e1f260

After the changes:

https://github.com/user-attachments/assets/41ae1f80-eaa8-4c9e-bb4c-5e6d3bbe565f

