### PR TITLE
Fix "Ё" letter position for small font of CP-1251 code page

### DIFF
--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -1835,7 +1835,7 @@ namespace
             fheroes2::Copy( font[37], 0, 0, font[168 - 32], 0, 2, font[37].width(), font[37].height() );
             fheroes2::Copy( font[37], 3, 0, font[168 - 32], 3, 0, 1, 1 );
             fheroes2::Copy( font[37], 3, 0, font[168 - 32], 5, 0, 1, 1 );
-            font[168 - 32].setPosition( font[37].x(), font[37].y() );
+            font[168 - 32].setPosition( font[37].x(), font[37].y() - 2 );
             updateSmallFontLetterShadow( font[168 - 32] );
 
             font[161 - 32].resize( font[57 + offset].width(), font[57 + offset].height() + 2 );


### PR DESCRIPTION
relates to #10361

Before:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/db12c648-ef49-4715-9bf1-55aa92d58a60" />

After:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/b69dfe93-599c-49fc-af10-d52c56aa2b80" />
