### PR TITLE
Truncate text within Monster Info dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -158,7 +158,7 @@ namespace
         text.set( ":", font );
         text.draw( middlePartPosX, textPos.y, display );
 
-        text.set(  _( "Defense Skill" ), font );
+        text.set( _( "Defense Skill" ), font );
         textPos.x = std::max( rightSidePosX - text.width(), minX );
         text.fitToOneRow( leftSideLength );
         text.draw( textPos.x, textPos.y, display );


### PR DESCRIPTION
relates to #10361

Not a perfect solution but way better than what we had.

Before:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/bd714f25-dfd2-4e78-bc87-2f46a74f0026" />

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/58625836-19ca-4aea-9a6a-f7b7445526f1" />

After:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/af759ce4-96f7-45da-899a-dacbc869c8ba" />

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/c5491506-0780-431a-9bba-89011143b5fc" />
