### PR TITLE
Fix player count for non-symmetrical maps

### DIFF
--- a/src/fheroes2/maps/map_random_generator.cpp
+++ b/src/fheroes2/maps/map_random_generator.cpp
@@ -394,6 +394,7 @@ namespace Maps::Random_Generator
             }
         }
 
+        // If this assertion blows up it means that the code above wasn't capable to place all players on the map.
         assert( placedPlayers == config.playerCount );
 
         // Step 3. Grow all regions one step at the time so they would compete for space.


### PR DESCRIPTION
There were cases with certain water percentage that generated maps with invalid player count. Adding an assertion to catch it in the future.