### PR TITLE
Add OS version for iOS builds

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -31,6 +31,6 @@ jobs:
         cd ios
         xcodebuild -project fheroes2.xcodeproj \
           -scheme fheroes2 \
-          -destination 'platform=iOS Simulator,OS:18.6,name:iPhone 16' \
+          -destination 'platform=iOS Simulator,OS=18.6,name=iPhone 16' \
           build
     # TODO: add signing stage.


### PR DESCRIPTION
Without the changes iOS builds fail. See this - https://github.com/ihhub/fheroes2/actions/runs/20270923260/job/58206782866?pr=10437

relates to #10205