### PR TITLE
Fix two bad pixels on Jezebel's portrait

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3390,6 +3390,7 @@ namespace
             if ( !_icnVsSprite[id].empty() ) {
                 fheroes2::Sprite & original = _icnVsSprite[id][0];
                 if ( original.width() == 101 && original.height() == 93 ) {
+                    original._disableTransformLayer();
                     uint8_t * imageData = original.image();
                     imageData[6118] = 11;
                     imageData[6219] = 11;


### PR DESCRIPTION
The portrait of Jezebel unexpectedly has the transform layer and, as a result, two bad pixels on the tip of the nose.

Before:

<img width="128" height="120" alt="image" src="https://github.com/user-attachments/assets/fd7ca55a-76b3-409c-943b-9bd04662c8f7" />

After:

<img width="128" height="120" alt="image" src="https://github.com/user-attachments/assets/bd0c71ca-d2db-4ca3-81b9-88e06a4b59bf" />
