### PR TITLE
Show object index in editor popup

### DIFF
--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *


### PR DESCRIPTION
If there's no other info to display, show internal object index in the right click popup in the editor. It can be argued that the change is not necessary but I'm putting this PR out here because I use this locally for the map gen work. It's hard to determine where the object is otherwise. 

Before the change:
<img width="1602" height="1239" alt="image" src="https://github.com/user-attachments/assets/01cc23d1-2b27-43b8-b892-4c2b18c2b1b7" />

After the change:
<img width="1602" height="1239" alt="image" src="https://github.com/user-attachments/assets/8fd94dc1-7a03-48c0-8826-3ab22640903e" />
