### PR TITLE
Make AI heroes do not move around blindly if they are on patrol

### DIFF
--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -3089,7 +3089,7 @@ fheroes2::GameMode AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & curre
                 }
 
                 if ( hero->Modes( Heroes::PATROL ) && ( hero->GetPatrolCenter() == hero->GetCenter() ) ) {
-                    // Heroes on patrol are restricted for movement so it is assumed that they aren't blocking the way.
+                    // Heroes on patrol are restricted in movement so it is assumed that they aren't blocking the way.
                     // They actually could block the way but this is done deliberately by the map maker.
                     continue;
                 }


### PR DESCRIPTION
Otherwise, this leads to non-stop movement on heroes on patrol when they shouldn't do this. It is also annoying to see them going from one tile to another many tiles per AI turn.