### PR TITLE
Speed up game type switching in High Scores dialog

### DIFF
--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -256,8 +256,6 @@ namespace
         }
 #endif
 
-        
-
         // Try to load High Scores only once. If a player switches between modes we shouldn't reload the game file again and again.
         if ( !isInternalUpdate ) {
             const std::string highScoreDataPath = System::concatPath( Game::GetSaveDir(), highScoreFileName );


### PR DESCRIPTION
It was due the to the call of System::GetDataDirectory() function.

close #10486