### PR TITLE
Combat / Castle Siege: render moat water effect for troops

### DIFF
--- a/src/fheroes2/battle/battle_board.cpp
+++ b/src/fheroes2/battle/battle_board.cpp
@@ -1140,7 +1140,7 @@ std::pair<const Battle::Cell *, const Battle::Cell *> Battle::Board::GetMoatCell
     // Check if unit is on bridge, and bridge is down
     if ( result.first || result.second ) {
         const Bridge * bridge = Arena::GetBridge();
-        if ( bridge && ( ( result.first && result.first->GetIndex() == 49 ) || ( result.second && result.second->GetIndex() == 49 ) ) ) {
+        if ( bridge && bridge->isDown() && ( ( result.first && result.first->GetIndex() == 49 ) || ( result.second && result.second->GetIndex() == 49 ) ) ) {
             return { nullptr, nullptr };
         }
     }

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -26,6 +26,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "battle_cell.h"
@@ -91,6 +92,8 @@ namespace Battle
         void SetCovrObjects( int icn );
 
         static std::string GetMoatInfo();
+        static fheroes2::Rect GetMoatCellMask( const Cell & cell );
+        static std::pair<const Cell *, const Cell *> GetMoatCellsForUnit( const Unit & unit, const CellDirection movementDirection );
 
         static Cell * GetCell( const int32_t position );
         static Cell * GetCell( const int32_t position, const CellDirection dir );
@@ -113,6 +116,7 @@ namespace Battle
 
         static CellDirection GetReflectDirection( const CellDirection dir );
         static Battle::CellDirection GetDirection( const int32_t index1, const int32_t index2 );
+        static Battle::CellDirection GetDirectionFromDelta( const fheroes2::Point & movementDelta );
 
         // Returns the distance to the cell with the given index from the given edge of the battlefield along the X axis. The
         // distance from the edges of the battlefield to the cells closest to them is counted as one.

--- a/src/fheroes2/battle/battle_board.h
+++ b/src/fheroes2/battle/battle_board.h
@@ -93,6 +93,13 @@ namespace Battle
 
         static std::string GetMoatInfo();
         static fheroes2::Rect GetMoatCellMask( const Cell & cell );
+
+        // Check the unit's current and next cells following the movement direction
+        // Return pair of Cell pointers if any of the cells are valid moat cells:
+        // { nullptr, nullptr } => unit is not on moat tile nor moving to moat tile
+        // { Cell * , nullptr } => unit is entering a moat tile
+        // { nullptr, Cell *  } => unit is leaving a moat tile
+        // { Cell * , Cell *  } => unit is either standing in the moat, or moving from one moat tile to another
         static std::pair<const Cell *, const Cell *> GetMoatCellsForUnit( const Unit & unit, const CellDirection movementDirection );
 
         static Cell * GetCell( const int32_t position );
@@ -116,7 +123,7 @@ namespace Battle
 
         static CellDirection GetReflectDirection( const CellDirection dir );
         static Battle::CellDirection GetDirection( const int32_t index1, const int32_t index2 );
-        static Battle::CellDirection GetDirectionFromDelta( const fheroes2::Point & movementDelta );
+        static Battle::CellDirection GetDirectionFromDelta( const int32_t moveX, const int32_t moveY );
 
         // Returns the distance to the cell with the given index from the given edge of the battlefield along the X axis. The
         // distance from the edges of the battlefield to the cells closest to them is counted as one.

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2135,7 +2135,6 @@ bool Battle::Interface::_drawTroopSpriteWithMoatMask( const Unit & unit, const f
         mask.x -= movementDelta.x;
         mask.y += movementDelta.y;
     }
-    fheroes2::DrawRect( _mainSurface, mask, 133 );
 
     const fheroes2::Rect spriteRect{ offset.x, offset.y, sprite.width(), sprite.height() };
     const fheroes2::Rect intersection = spriteRect ^ mask;

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2152,12 +2152,11 @@ bool Battle::Interface::_drawTroopSpriteWithMoatMask( const Unit & unit, const f
     // around the mask.
 
     // Top
-    fheroes2::AlphaBlit( sprite, spriteRect.x - spriteRect.x, spriteRect.y - spriteRect.y, _mainSurface, spriteRect.x, spriteRect.y, spriteRect.width,
-                         intersection.y - spriteRect.y, alpha, isReflect );
+    fheroes2::AlphaBlit( sprite, 0, 0, _mainSurface, spriteRect.x, spriteRect.y, spriteRect.width, intersection.y - spriteRect.y, alpha, isReflect );
 
     // Left
-    fheroes2::AlphaBlit( sprite, spriteRect.x - spriteRect.x, intersection.y - spriteRect.y, _mainSurface, spriteRect.x, intersection.y, intersection.x - spriteRect.x,
-                         intersection.height, alpha, isReflect );
+    fheroes2::AlphaBlit( sprite, 0, intersection.y - spriteRect.y, _mainSurface, spriteRect.x, intersection.y, intersection.x - spriteRect.x, intersection.height, alpha,
+                         isReflect );
 
     // Right
     fheroes2::AlphaBlit( sprite, ( intersection.x + intersection.width ) - spriteRect.x, intersection.y - spriteRect.y, _mainSurface, intersection.x + intersection.width,

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -2029,6 +2029,8 @@ fheroes2::Point Battle::Interface::_drawTroopSprite( const Unit & unit, const fh
 {
     // Get the sprite rendering offset.
     fheroes2::Point offset = GetTroopPosition( unit, troopSprite );
+    fheroes2::Point movementDelta{ 0, 0 };
+    CellDirection movementDirection = CellDirection::CENTER;
 
     if ( _movingUnit == &unit ) {
         // Monster is moving.
@@ -2042,6 +2044,7 @@ fheroes2::Point Battle::Interface::_drawTroopSprite( const Unit & unit, const fh
             const fheroes2::Rect & unitPosition = unit.GetRectPosition();
             const int32_t moveX = _movingPos.x - unitPosition.x;
             const int32_t moveY = _movingPos.y - unitPosition.y;
+            movementDirection = Board::GetDirectionFromDelta( { moveX, moveY } );
 
             // If it is a slowed flying creature, then it should smoothly move horizontally.
             if ( _movingUnit->isAbilityPresent( fheroes2::MonsterAbilityType::FLYING ) ) {
@@ -2051,8 +2054,11 @@ fheroes2::Point Battle::Interface::_drawTroopSprite( const Unit & unit, const fh
             }
             // If the creature has to move diagonally.
             else if ( moveY != 0 ) {
-                offset.x -= Sign( moveX ) * ( _movingUnit->animation.getCurrentFrameXOffset() ) / 2;
-                offset.y += static_cast<int32_t>( _movingUnit->animation.movementProgress() * moveY );
+                movementDelta.x -= Sign( moveX ) * ( _movingUnit->animation.getCurrentFrameXOffset() ) / 2;
+                movementDelta.y = static_cast<int32_t>( _movingUnit->animation.movementProgress() * moveY );
+
+                offset.x += movementDelta.x;
+                offset.y += movementDelta.y;
             }
         }
     }
@@ -2069,9 +2075,102 @@ fheroes2::Point Battle::Interface::_drawTroopSprite( const Unit & unit, const fh
         offset.y += moveY + static_cast<int32_t>( ( _movingPos.y - _flyingPos.y ) * movementProgress );
     }
 
+    if ( _drawTroopSpriteWithMoatMask( unit, troopSprite, offset, movementDelta, movementDirection ) ) {
+        return offset;
+    }
+
     fheroes2::AlphaBlit( troopSprite, _mainSurface, offset.x, offset.y, unit.GetCustomAlpha(), unit.isReflect() );
 
     return offset;
+}
+
+bool Battle::Interface::_drawTroopSpriteWithMoatMask( const Unit & unit, const fheroes2::Sprite & sprite, const fheroes2::Point & offset,
+                                                      const fheroes2::Point & movementDelta, const CellDirection movementDirection )
+{
+    if ( _flyingUnit == &unit ) {
+        return false;
+    }
+
+    const Castle * castle = Arena::GetCastle();
+    if ( castle == nullptr || !castle->isBuild( BUILD_MOAT ) ) {
+        return false;
+    }
+
+    const auto moatCells = Board::GetMoatCellsForUnit( unit, movementDirection );
+    if ( moatCells.first == nullptr && moatCells.second == nullptr ) {
+        return false;
+    }
+
+    const bool isDiagonal = movementDirection == CellDirection::TOP_LEFT || movementDirection == CellDirection::TOP_RIGHT
+                            || movementDirection == CellDirection::BOTTOM_LEFT || movementDirection == CellDirection::BOTTOM_RIGHT;
+
+    const bool isEntering = ( moatCells.first == nullptr && moatCells.second != nullptr );
+    const bool isExiting = ( moatCells.first != nullptr && moatCells.second == nullptr );
+    const bool isInside = ( moatCells.first != nullptr && moatCells.second != nullptr );
+
+    // Diagonal movement rules:
+    //
+    // - Diagonal + isEntering = Apply mask, don't move mask
+    // - Diagonal + isEntering + movement:TOP_RIGHT = Don't apply mask (it can clip some sprites)
+    // - Diagonal + isExiting = Don't apply mask (it can clip some sprites)
+    // - Diagonal + isInside  = Apply and move mask
+    //
+
+    if ( ( isDiagonal && isExiting ) || ( isDiagonal && isEntering && movementDirection == CellDirection::TOP_RIGHT ) ) {
+        return false;
+    }
+
+    const Cell * maskCell = moatCells.first;
+    if ( isEntering ) {
+        maskCell = moatCells.second;
+    }
+
+    if ( maskCell == nullptr ) {
+        return false;
+    }
+
+    fheroes2::Rect mask = Board::GetMoatCellMask( *maskCell );
+
+    if ( isInside || !isDiagonal ) {
+        mask.x -= movementDelta.x;
+        mask.y += movementDelta.y;
+    }
+    fheroes2::DrawRect( _mainSurface, mask, 133 );
+
+    const fheroes2::Rect spriteRect{ offset.x, offset.y, sprite.width(), sprite.height() };
+    const fheroes2::Rect intersection = spriteRect ^ mask;
+
+    if ( intersection.width == 0 || intersection.height == 0 ) {
+        return false;
+    }
+
+    // Account for short sprites (e.g. vampire dead sprite)
+    constexpr int32_t minVisibleHeight = 10;
+    if ( sprite.height() - mask.height < minVisibleHeight ) {
+        return false;
+    }
+
+    const uint8_t alpha = unit.GetCustomAlpha();
+    const bool isReflect = unit.isReflect();
+
+    // The mask is a rectangle which means that worst-case is it's in the middle
+    // of the sprite and we will need to make 4 calls to AlphaBlit to render the sprite
+    // around the mask.
+    auto blit = [&]( const fheroes2::Rect & dst ) {
+        if ( dst.width > 0 && dst.height > 0 ) {
+            fheroes2::AlphaBlit( sprite, dst.x - spriteRect.x, dst.y - spriteRect.y, _mainSurface, dst.x, dst.y, dst.width, dst.height, alpha, isReflect );
+        }
+    };
+
+    // Top
+    blit( { spriteRect.x, spriteRect.y, spriteRect.width, intersection.y - spriteRect.y } );
+
+    // Left
+    blit( { spriteRect.x, intersection.y, intersection.x - spriteRect.x, intersection.height } );
+
+    // Right
+    blit( { intersection.x + intersection.width, intersection.y, ( spriteRect.x + spriteRect.width ) - ( intersection.x + intersection.width ), intersection.height } );
+    return true;
 }
 
 void Battle::Interface::RedrawTroopCount( const Unit & unit )

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -69,6 +69,7 @@ namespace Battle
     struct TargetsInfo;
 
     enum class CastleDefenseStructure : int;
+    enum class CellDirection;
 
     void DialogBattleSettings();
     bool DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdom & kingdom );
@@ -412,6 +413,9 @@ namespace Battle
         fheroes2::Point _drawTroopSprite( const Unit & unit, const fheroes2::Sprite & troopSprite );
 
         void RedrawTroopCount( const Unit & unit );
+
+        bool _drawTroopSpriteWithMoatMask( const Unit & unit, const fheroes2::Sprite & sprite, const fheroes2::Point & offset, const fheroes2::Point & movementDelta,
+                                           const CellDirection movementDirection );
 
         void _redrawActionArmageddonSpell();
         void _redrawActionArrowSpell( const Unit & target );


### PR DESCRIPTION
- Mimics the original game’s effect where creatures appear partially submerged in water while in the moat.
- The original game renders a separate water sprite on top of the troop sprites. This implementation uses a masking approach to prevent drawing the submerged portion of the troop sprite.

Fixes #1954 