### PR TITLE
Do not allow RMG to place more than one action object to a tile

### DIFF
--- a/src/fheroes2/maps/map_random_generator_helper.cpp
+++ b/src/fheroes2/maps/map_random_generator_helper.cpp
@@ -749,8 +749,21 @@ namespace Maps::Random_Generator
             return false;
         }
 
+        if ( MP2::isOffGameActionObject( objectInfo.objectType ) ) {
+            const auto & tileObjects = mapFormat.tiles[tile.GetIndex()].objects;
+            const bool tileHasActionObject = std::any_of( tileObjects.cbegin(), tileObjects.cend(), []( const Maps::Map_Format::TileObjectInfo & tileObjectinfo ) {
+                const auto & info = Maps::getObjectInfo( tileObjectinfo.group, static_cast<int32_t>( tileObjectinfo.index ) );
+                return MP2::isOffGameActionObject( info.objectType );
+            } );
+
+            if ( tileHasActionObject ) {
+                // Two action objects cannot be placed on one tile.
+                return false;
+            }
+        }
+
         // Maps::setObjectOnTile isn't idempotent, check if object was already placed
-        if ( MP2::isInGameActionObject( objectInfo.objectType ) && tile.getMainObjectType() == objectInfo.objectType ) {
+        if ( tile.getMainObjectType() == objectInfo.objectType && MP2::isInGameActionObject( objectInfo.objectType ) ) {
             return false;
         }
 


### PR DESCRIPTION
fix #10514

Currently the Random Map Generator can place more than one action object on a single tile:
<img src="https://github.com/user-attachments/assets/134605db-f565-4ed6-9b8a-b1b5ff1c4876" />

This PR adds a check to the `putObjectOnMap()` function that prevents placing an action object if there is already such an object on the tile.

Also to slightly speed-up the map generation the conditions of the next `if()` are swapped.