### PR TITLE
Enable several hardware buttons for all Virtual Keyboards

### DIFF
--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -595,8 +595,7 @@ namespace
 
         switch ( layoutType ) {
         case LayoutType::LowerCase:
-            lastButtonRow.emplace_back( "|", fheroes2::Key::KEY_LEFT_SHIFT, defaultSpecialButtonSize, isEvilInterface,
-                                        []( const KeyboardRenderer & ) { return DialogAction::UpperCase; } );
+            lastButtonRow.emplace_back( "|", defaultSpecialButtonSize, isEvilInterface, []( const KeyboardRenderer & ) { return DialogAction::UpperCase; } );
 
             lastButtonRow.emplace_back( _( "Keyboard|123" ), defaultSpecialButtonSize, isEvilInterface,
                                         []( const KeyboardRenderer & ) { return DialogAction::AlphaNumeric; } );
@@ -617,8 +616,7 @@ namespace
             } );
             break;
         case LayoutType::UpperCase:
-            lastButtonRow.emplace_back( "|", fheroes2::Key::KEY_LEFT_SHIFT, defaultSpecialButtonSize, isEvilInterface,
-                                        []( const KeyboardRenderer & ) { return DialogAction::LowerCase; } );
+            lastButtonRow.emplace_back( "|", defaultSpecialButtonSize, isEvilInterface, []( const KeyboardRenderer & ) { return DialogAction::LowerCase; } );
             lastButtonRow.back().isInvertedRenderingLogic = true;
 
             lastButtonRow.emplace_back( _( "Keyboard|123" ), defaultSpecialButtonSize, isEvilInterface,


### PR DESCRIPTION
It is a bit annoying that it is not possible to do basic keyboard operations for any language except English. The following hotkeys are being added:
- Space
- ~~Shift to switch between upper and lower case letters~~
- Backspace to delete a character

It is understandable that Virtual Keyboard replaces UTF-8 input but basic operations like backspace should work since they also work on normal input text dialog.

This change should help mapmakers to suffer less with non-English text inputs.