### PR TITLE
Fix an assertion hit when "Highlight monster area" option is enabled

### DIFF
--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3101,6 +3101,8 @@ void Battle::Interface::HumanTurn( const Unit & unit, Actions & actions )
             humanturn_redraw = true;
         }
 
+        _highlightUnitMovementArea = nullptr;
+
         if ( humanturn_spell.isValid() ) {
             HumanCastSpellTurn( unit, actions, msg );
         }
@@ -3135,6 +3137,7 @@ void Battle::Interface::HumanTurn( const Unit & unit, Actions & actions )
     popup.reset();
 
     _currentUnit = nullptr;
+    _highlightUnitMovementArea = nullptr;
 }
 
 void Battle::Interface::HumanBattleTurn( const Unit & unit, Actions & actions, std::string & msg )


### PR DESCRIPTION
close #10529

How to reproduce the assertion hit:
- change line
```cpp
monsterData[Monster::MEDUSA].battleStats.abilities.emplace_back( fheroes2::MonsterAbilityType::SPELL_CASTER, 20, Spell::PETRIFY );
```
into
```cpp
monsterData[Monster::MEDUSA].battleStats.abilities.emplace_back( fheroes2::MonsterAbilityType::SPELL_CASTER, 100, Spell::PETRIFY );
```
- load the [area_highlight_assertion.zip](https://github.com/user-attachments/files/25463724/area_highlight_assertion.zip) save
- follow the steps shown in the video below:


https://github.com/user-attachments/assets/b8aaa80c-475e-4523-a526-36acaab6140f

