### PR TITLE
Fix hero remove from the map in editor

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -457,6 +457,9 @@ namespace
                     assert( mapFormat.heroMetadata.find( objectIter->id ) != mapFormat.heroMetadata.end() );
                     mapFormat.heroMetadata.erase( objectIter->id );
 
+                    // Properly remove hero object from the `world` tile.
+                    world.getTile( static_cast<int32_t>( mapTileIndex ) ).setHero( nullptr );
+
                     objectIter = mapTile.objects.erase( objectIter );
                     needRedraw = true;
 


### PR DESCRIPTION
In the master build while removing a hero the sprite is removed properly from the `world` but the object stays because `_occupantHeroId` is not reset.

This PR fixes hero remove from the `world` tile by resetting the `_occupantHeroId` by calling `.setHero( nullptr )`
