### PR TITLE
Fix mini monsters vertical offset

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -2974,6 +2974,7 @@ namespace
                         modified = std::move( temp );
                     }
 
+                    // Original images' Y offset is not needed for rendering. Set it to 0 to align all images vertically.
                     modified.setPosition( modified.x(), 0 );
                 }
             }


### PR DESCRIPTION
relates to #5258 

https://github.com/user-attachments/assets/1a73c085-1e65-4468-8a40-90283f0afbf8

https://github.com/user-attachments/assets/1ac8f62e-5174-46f5-b5b4-d3f7cb200a43

Check this out yourself: [testmaps.zip](https://github.com/user-attachments/files/25581550/testmaps.zip)
+ also fixes "compact" view vertical offsets.

Monsters vertical positions which come from *.icn are not needed for positioning portraits in this engine and vertical fix is an easy win.

Horizontal positions are also reduntant, but there comes perceived centre of portrait, for example Elves have huge bow - this will be another PR.