### PR TITLE
Show water percentage limit in Random Generator

### DIFF
--- a/src/fheroes2/dialog/dialog_random_map_generator.cpp
+++ b/src/fheroes2/dialog/dialog_random_map_generator.cpp
@@ -261,7 +261,7 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
 
     HorizontalSlider waterSlider{ { inputPositionX, positionY }, 0, originalWaterPercentageLimit, configuration.waterPercentage };
     TextRestorer waterValue{ display, valuePositionX, positionY };
-    waterValue.render( std::to_string( configuration.waterPercentage ) + "/" + std::to_string( currentWaterPercentageLimit ) + "%", display );
+    waterValue.render( std::to_string( configuration.waterPercentage ) + '/' + std::to_string( currentWaterPercentageLimit ) + '%', display );
 
     positionY += ySpacing;
 
@@ -325,12 +325,12 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
             currentWaterPercentageLimit = newLimit;
 
             playerCountValue.render( std::to_string( configuration.playerCount ), display );
-            waterValue.render( std::to_string( configuration.waterPercentage ) + "/" + std::to_string( currentWaterPercentageLimit ) + "%", display );
+            waterValue.render( std::to_string( configuration.waterPercentage ) + '/' + std::to_string( currentWaterPercentageLimit ) + '%', display );
             display.render( window.activeArea() );
         }
         else if ( waterSlider.processEvents( le ) ) {
             configuration.waterPercentage = waterSlider.getCurrentValue();
-            waterValue.render( std::to_string( configuration.waterPercentage ) + "/" + std::to_string( currentWaterPercentageLimit ) + "%", display );
+            waterValue.render( std::to_string( configuration.waterPercentage ) + '/' + std::to_string( currentWaterPercentageLimit ) + '%', display );
             display.render( window.activeArea() );
         }
         else if ( monsterSlider.processEvents( le ) ) {


### PR DESCRIPTION
The limit depends on the number of players selected.  Without seeing the limit or knowing how it works, the behavior of the slider for the water percentage can look like a bug.

Before:

https://github.com/user-attachments/assets/6b813dff-d250-457e-af28-f55881de28c5

After:

https://github.com/user-attachments/assets/3453da53-951d-4d0f-ab99-158ff556e3e0

