### PR TITLE
Change 'exchange all troops' default hotkey to 'X'

### DIFF
--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -336,7 +336,7 @@ namespace
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::ARMY_DISMISS )]
             = { Game::HotKeyCategory::ARMY, gettext_noop( "hotkey|dismiss hero or troop" ), fheroes2::Key::KEY_D };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::ARMY_SWAP )]
-            = { Game::HotKeyCategory::ARMY, gettext_noop( "hotkey|exchange all troops" ), fheroes2::Key::KEY_S };
+            = { Game::HotKeyCategory::ARMY, gettext_noop( "hotkey|exchange all troops" ), fheroes2::Key::KEY_X };
     }
 
     std::string getHotKeyFileContent()


### PR DESCRIPTION
In town screen, hotkey `S` opens the Mage Guild. But since `exchange all troops` has the same hotkey by default, now pressing `S` opens Mage Guild and also exchanges troops if a hero is present. To avoid this, let's change the default hotkey for troop exchange to `X` (as in eXchange).