### PR TITLE
Install only needed packages when building PS Vita executable in GitHub Actions

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -260,7 +260,7 @@ jobs:
         EOF
         export PATH=$VITASDK/bin:$PATH
         ./bootstrap-vitasdk.sh
-        ./install-all.sh
+        ./vdpm flac libmikmod libmodplug libogg libvita2d libvorbis libxmp mpg123 opus opusfile sdl2 sdl2_mixer zlib
         rm -rf ~/.vitasdk-cache
       env:
         VITASDK: /usr/local/vitasdk


### PR DESCRIPTION
This PR makes the PS Vita build workflow to request installation only of packages that are needed to build and link fheroes2.
There is no need to download and install all available PS Vita packages (like boost, ffmpeg, imgui, unrar and others).