### PR TITLE
Compress fheroes2 assets data in h2d file

### DIFF
--- a/src/engine/h2d_file.cpp
+++ b/src/engine/h2d_file.cpp
@@ -153,7 +153,7 @@ namespace fheroes2
             return false;
         }
 
-        _fileData[name] = Compression::zipData( data.data(), data.size(), -1 );
+        _fileData[name] = Compression::zipData( data.data(), data.size() );
         return true;
     }
 

--- a/src/engine/zzlib.cpp
+++ b/src/engine/zzlib.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2026                                             *
+ *   Copyright (C) 2019 - 2024                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -100,15 +100,10 @@ std::vector<uint8_t> Compression::unzipData( const uint8_t * src, const size_t s
     return res;
 }
 
-std::vector<uint8_t> Compression::zipData( const uint8_t * src, const size_t srcSize, int compression )
+std::vector<uint8_t> Compression::zipData( const uint8_t * src, const size_t srcSize )
 {
     if ( src == nullptr || srcSize == 0 ) {
         return {};
-    }
-
-    if ( compression < Z_BEST_SPEED || compression > Z_BEST_COMPRESSION ) {
-        // Compression level is incorrect. Reset to default.
-        compression = Z_DEFAULT_COMPRESSION;
     }
 
     const uLong srcSizeULong = static_cast<uLong>( srcSize );
@@ -125,7 +120,7 @@ std::vector<uint8_t> Compression::zipData( const uint8_t * src, const size_t src
         return {};
     }
 
-    const int ret = compress2( res.data(), &dstSizeULong, src, srcSizeULong, compression );
+    const int ret = compress( res.data(), &dstSizeULong, src, srcSizeULong );
 
     if ( ret != Z_OK ) {
         ERROR_LOG( "zlib error: " << ret )

--- a/src/engine/zzlib.h
+++ b/src/engine/zzlib.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2026                                             *
+ *   Copyright (C) 2019 - 2025                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -42,8 +42,7 @@ namespace Compression
     std::vector<uint8_t> unzipData( const uint8_t * src, const size_t srcSize, size_t realSize = 0 );
 
     // Zips the input data and returns the compressed data or an empty vector in case of an error.
-    // Compression level: -1 - default, 1 - best speed, 9 - best compression.
-    std::vector<uint8_t> zipData( const uint8_t * src, const size_t srcSize, int compression = -1 );
+    std::vector<uint8_t> zipData( const uint8_t * src, const size_t srcSize );
 
     // Reads & unzips the zipped chunk from the given input stream and writes it to the given output
     // stream. Returns true on success or false on error.

--- a/src/fheroes2/maps/map_format_info.cpp
+++ b/src/fheroes2/maps/map_format_info.cpp
@@ -496,7 +496,7 @@ namespace
                    << map.adventureMapEventMetadata << map.selectionObjectMetadata << map.capturableObjectsMetadata << map.monsterMetadata << map.artifactMetadata
                    << map.resourceMetadata << map.translationInfo;
 
-        const std::vector<uint8_t> temp = Compression::zipData( compressed.data(), compressed.size(), 9 );
+        const std::vector<uint8_t> temp = Compression::zipData( compressed.data(), compressed.size() );
 
         stream.putRaw( temp.data(), temp.size() );
 


### PR DESCRIPTION
This PR:
- adds the compression to any data added to `resurrection.h2d` file;
- updates `zlib` handler to allow setting compression ratio;
- sets maximum compression for `fh2m` maps and `resurrection.h2d` data.