### PR TITLE
Add Timidity PAT files to PS Vita package

### DIFF
--- a/Makefile.vita
+++ b/Makefile.vita
@@ -1,6 +1,6 @@
 ###########################################################################
 #   fheroes2: https://github.com/ihhub/fheroes2                           #
-#   Copyright (C) 2021 - 2025                                             #
+#   Copyright (C) 2021 - 2026                                             #
 #                                                                         #
 #   This program is free software; you can redistribute it and/or modify  #
 #   it under the terms of the GNU General Public License as published by  #


### PR DESCRIPTION
On Vita3K emulator `midi` playback is only working if timidity PAT files are put to fheroes2 files folder.

This PR adds these files to `fheroes2.vpk` bundle increasing its size. :(

It should be tested on a real PS Vita hardware.