### PR TITLE
Do not double zip GitHub Actions artifacts

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -86,12 +86,14 @@ jobs:
       with:
         name: fheroes2_android.zip
         path: fheroes2_android.zip
+        archive: false
         if-no-files-found: error
     - uses: actions/upload-artifact@v7
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: fheroes2_android_aab.zip
         path: fheroes2_android_aab.zip
+        archive: false
         if-no-files-found: error
     - uses: ncipollo/release-action@v1
       if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -198,12 +198,14 @@ jobs:
       with:
         name: ${{ matrix.package_name }}
         path: ${{ matrix.package_name }}
+        archive: false
         if-no-files-found: error
     - uses: actions/upload-artifact@v7
       if: ${{ contains( matrix.on, github.event_name ) && github.event_name == 'pull_request' && matrix.tools_package_name != '' }}
       with:
         name: ${{ matrix.tools_package_name }}
         path: ${{ matrix.tools_package_name }}
+        archive: false
         if-no-files-found: error
     - uses: ncipollo/release-action@v1
       if: ${{ contains( matrix.on, github.event_name ) && github.event_name == 'push' }}
@@ -276,6 +278,7 @@ jobs:
       with:
         name: fheroes2_psv.zip
         path: fheroes2_psv.zip
+        archive: false
         if-no-files-found: error
     - uses: ncipollo/release-action@v1
       if: ${{ github.event_name == 'push' }}
@@ -324,6 +327,7 @@ jobs:
       with:
         name: fheroes2_switch.zip
         path: fheroes2_switch.zip
+        archive: false
         if-no-files-found: error
     - uses: ncipollo/release-action@v1
       if: ${{ github.event_name == 'push' }}
@@ -380,6 +384,7 @@ jobs:
       with:
         name: ${{ matrix.package_name }}
         path: ${{ matrix.package_name }}
+        archive: false
         if-no-files-found: error
     - uses: ncipollo/release-action@v1
       if: ${{ github.event_name == 'push' }}

--- a/.github/workflows/msvc.yml
+++ b/.github/workflows/msvc.yml
@@ -137,12 +137,14 @@ jobs:
       with:
         name: ${{ matrix.zip_package_name }}
         path: build/${{ matrix.platform }}/${{ matrix.build_config }}/${{ matrix.zip_package_name }}
+        archive: false
         if-no-files-found: error
     - uses: actions/upload-artifact@v7
       if: ${{ github.event_name == 'pull_request' }}
       with:
         name: ${{ matrix.tools_package_name }}
         path: build/${{ matrix.platform }}/${{ matrix.build_config }}/${{ matrix.tools_package_name }}
+        archive: false
         if-no-files-found: error
     - uses: ncipollo/release-action@v1
       if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
After update of `actions/upload-artifact` (https://github.com/ihhub/fheroes2/pull/10546) we can disable zipping of zip files while uploading artifacts to Actions summary page.
Windows installers (exe files) are kept zipping to slightly reduce their size.

