### PR TITLE
Avoid terrain extra objects under the road objects in random map generator

### DIFF
--- a/src/fheroes2/maps/map_random_generator_helper.cpp
+++ b/src/fheroes2/maps/map_random_generator_helper.cpp
@@ -724,7 +724,8 @@ namespace Maps::Random_Generator
     // Wouldn't render correctly but will speed up placement
     void forceTempRoadOnTile( Map_Format::MapFormat & mapFormat, const int32_t tileIndex )
     {
-        if ( Maps::doesContainRoad( mapFormat.tiles[tileIndex] ) ) {
+        auto & tile = mapFormat.tiles[tileIndex];
+        if ( Maps::doesContainRoad( tile ) ) {
             return;
         }
 
@@ -732,6 +733,13 @@ namespace Maps::Random_Generator
         if ( objectInfo.empty() ) {
             assert( 0 );
             return;
+        }
+
+        if ( Ground::doesTerrainImageIndexContainEmbeddedObjects( tile.terrainIndex ) ) {
+            // Set terrain image without extra objects under the road.
+            const int32_t groundType = Ground::getGroundByImageIndex( tile.terrainIndex );
+            tile.terrainIndex = Ground::getRandomTerrainImageIndex( groundType, false );
+            world.getTile( tileIndex ).setTerrain( tile.terrainIndex, tile.terrainFlags );
         }
 
         // We just increase the UID counter to use the last UID in `Maps::addObjectToMap()`.


### PR DESCRIPTION
Currently RMG may place roads over the extra terrain objects (bushes, flowers, cracks, rocks):
<img src="https://github.com/user-attachments/assets/72d9ba4c-dbd4-4e2e-bae9-47b9cc80bb6c" />

This PR adds a check for such objects when placing "temp" road in RMG that makes a clean terrain under this road object.