### PR TITLE
Update passabilities in `world` after random map generator has finished generating a map

### DIFF
--- a/src/fheroes2/maps/map_random_generator.cpp
+++ b/src/fheroes2/maps/map_random_generator.cpp
@@ -968,6 +968,7 @@ namespace Maps::Random_Generator
         }
 
         Maps::updateMapPlayers( mapFormat );
+        world.updatePassabilities();
 
         // Set random map name and description to be unique.
         mapFormat.name = "Random map " + std::to_string( generatorSeed );


### PR DESCRIPTION
In master build after generating a random map there are no passabilities for non-action objects:
<img src="https://github.com/user-attachments/assets/ccbce764-1fda-41e2-b366-00eb113b96f4" />

This PR add the `world.updatePassabilities()` at the end of map generation:
<img src="https://github.com/user-attachments/assets/64eeb47f-d221-47c4-b960-4e82ddf0db17" />
