### PR TITLE
Improve adventure map spells messages order

### DIFF
--- a/src/fheroes2/heroes/heroes_base.cpp
+++ b/src/fheroes2/heroes/heroes_base.cpp
@@ -476,6 +476,13 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
 
         if ( spell == Spell::TOWNGATE ) {
             const Castle * castle = fheroes2::getNearestCastleTownGate( *hero );
+            if ( castle == nullptr ) {
+                if ( res != nullptr ) {
+                    *res = _( "You do not own any town or castle that is not currently occupied by a hero. This spell will have no effect." );
+                }
+                return false;
+            }
+
             assert( castle != nullptr );
 
             if ( castle->GetIndex() == hero->GetIndex() ) {
@@ -496,7 +503,7 @@ bool HeroBase::CanCastSpell( const Spell & spell, std::string * res /* = nullptr
             }
         }
 
-        if ( spell == Spell::TOWNGATE || spell == Spell::TOWNPORTAL ) {
+        if ( spell == Spell::TOWNPORTAL ) {
             const VecCastles & castles = hero->GetKingdom().GetCastles();
             const bool hasCastles = std::any_of( castles.begin(), castles.end(), []( const Castle * castle ) { return castle && castle->GetHero() == nullptr; } );
             if ( !hasCastles ) {


### PR DESCRIPTION
Closes #7027.

Additionally, for Town Gate and situation where player all castles and towns are occupied by heroes, show "This town is occupied..." instead of "You do not own any town or castle that is not occupied,,,". It makes more sense and is in line with original game.