### PR TITLE
Move scrollbar only to discrete positions corresponding to the list items

### DIFF
--- a/src/fheroes2/gui/ui_scrollbar.cpp
+++ b/src/fheroes2/gui/ui_scrollbar.cpp
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cmath>
 
 namespace
 {


### PR DESCRIPTION
Close #9371

This PS makes the scrollbar move only to the discrete positions corresponding to the given list, like by pressing next/previous buttons.
It makes the UI behavior more consistent: scrollbar positions are the same no matter you move it by mouse, by pressing buttons hot hotkeys.
It will also help player to see that the position is changed for the small amount of items.


https://github.com/user-attachments/assets/289469ad-870e-427a-bf4c-9e62d2cab401

