### PR TITLE
Adjust castle image and castle name in Town's dialog

### DIFF
--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1323,7 +1323,6 @@ bool Castle::BuyBuilding( const uint32_t buildingType )
     return true;
 }
 
-/* draw image castle to position */
 void Castle::DrawImageCastle( const fheroes2::Point & pt ) const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
@@ -1363,16 +1362,16 @@ void Castle::DrawImageCastle( const fheroes2::Point & pt ) const
         return;
     }
 
-    for ( uint32_t ii = 0; ii < 5; ++ii ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTWBA, index + ii );
-        dst_pt.x = pt.x + ii * 32 + sprite.x();
+    for ( uint32_t i = 0; i < 5; ++i ) {
+        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTWBA, index + i );
+        dst_pt.x = pt.x + i * 32 + sprite.x();
         dst_pt.y = pt.y + 3 * 32 + sprite.y();
         fheroes2::Blit( sprite, display, dst_pt.x, dst_pt.y );
     }
 
-    for ( uint32_t ii = 0; ii < 5; ++ii ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTWBA, index + 5 + ii );
-        dst_pt.x = pt.x + ii * 32 + sprite.x();
+    for ( uint32_t i = 0; i < 5; ++i ) {
+        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTWBA, index + 5 + i );
+        dst_pt.x = pt.x + i * 32 + sprite.x();
         dst_pt.y = pt.y + 4 * 32 + sprite.y();
         fheroes2::Blit( sprite, display, dst_pt.x, dst_pt.y );
     }

--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -288,6 +288,7 @@ public:
     void ActionPreBattle();
     void ActionAfterBattle( const bool attackerWins );
 
+    // Draw image castle to position.
     void DrawImageCastle( const fheroes2::Point & pt ) const;
 
     CastleDialogReturnValue OpenDialog( const bool openConstructionWindow, const bool openMageGuildWindow, const bool fade, const bool renderBackgroundDialog );

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -208,12 +208,12 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
 
     // draw castle sprite
     dst_pt.x = cur_pt.x + 459;
-    dst_pt.y = cur_pt.y + 5;
+    dst_pt.y = cur_pt.y + 6;
     DrawImageCastle( dst_pt );
 
     // castle name
     const fheroes2::Text castleName( GetName(), fheroes2::FontType::smallWhite() );
-    castleName.draw( cur_pt.x + 538 - castleName.width() / 2, cur_pt.y + 3, display );
+    castleName.draw( cur_pt.x + 538 - castleName.width() / 2, cur_pt.y + 2, display );
 
     dst_pt.y = cur_pt.y + 2;
 


### PR DESCRIPTION
close #1756

Before:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/b2c800e5-afae-4fe7-a6e9-66c4e80d73ba" />

After:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/378c18db-78de-4b5d-8315-f90706e8e4e0" />


The text now is on the same level as building windows. The castle rendering image is shifted by 1 pixel. Overall, we have 2 pixels difference compare to the original solution which is enough to avoid the overlap.