### PR TITLE
Map Editor - fix inconsistency in window titles

### DIFF
--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -477,7 +477,7 @@ bool ArmyBar::ActionBarLeftMouseSingleClick( ArmyTroop & troop )
             const Monster mons = Dialog::selectMonster( cur );
 
             if ( mons.isValid() ) {
-                std::string str = _( "Set %{monster} Count" );
+                std::string str = _( "Set %{monster} Count:" );
                 StringReplace( str, "%{monster}", mons.GetName() );
 
                 int32_t count = 1;

--- a/src/fheroes2/dialog/dialog_random_map_generator.cpp
+++ b/src/fheroes2/dialog/dialog_random_map_generator.cpp
@@ -221,7 +221,7 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
     int32_t positionY = activeArea.y + 70;
 
     // Map configuration options.
-    text.set( _( "rmg|Player count" ), FontType::normalWhite() );
+    text.set( _( "rmg|Player count:" ), FontType::normalWhite() );
     text.draw( positionX + ( settingDescriptionWidth - text.width() ) / 2, positionY, display );
     HorizontalSlider playerCountSlider{ { inputPositionX, positionY }, 2, 6, configuration.playerCount };
     TextRestorer playerCountValue{ display, valuePositionX, positionY };
@@ -229,7 +229,7 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
 
     positionY += ySpacing;
 
-    text.set( _( "rmg|Map layout" ), FontType::normalWhite() );
+    text.set( _( "rmg|Map layout:" ), FontType::normalWhite() );
     text.draw( positionX + ( settingDescriptionWidth - text.width() ) / 2, positionY, display );
 
     // Dropdown with map layout selection.
@@ -256,7 +256,7 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
 
     positionY += ySpacing;
 
-    text.set( _( "rmg|Water percentage" ), FontType::normalWhite() );
+    text.set( _( "rmg|Water percentage:" ), FontType::normalWhite() );
     text.draw( positionX + ( settingDescriptionWidth - text.width() ) / 2, positionY, display );
 
     HorizontalSlider waterSlider{ { inputPositionX, positionY }, 0, originalWaterPercentageLimit, configuration.waterPercentage };
@@ -265,7 +265,7 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
 
     positionY += ySpacing;
 
-    text.set( _( "rmg|Monster strength" ), FontType::normalWhite() );
+    text.set( _( "rmg|Monster strength:" ), FontType::normalWhite() );
     text.draw( positionX + ( settingDescriptionWidth - text.width() ) / 2, positionY, display );
     HorizontalSlider monsterSlider{ { inputPositionX, positionY }, 0, 3, static_cast<int>( configuration.monsterStrength ) };
     TextRestorer monsterValue{ display, valuePositionX, positionY };
@@ -273,7 +273,7 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
 
     positionY += ySpacing;
 
-    text.set( _( "rmg|Resource availability" ), FontType::normalWhite() );
+    text.set( _( "rmg|Resource availability:" ), FontType::normalWhite() );
     text.draw( positionX + ( settingDescriptionWidth - text.width() ) / 2, positionY, display );
     HorizontalSlider resourceSlider{ { inputPositionX, positionY }, 0, 2, static_cast<int>( configuration.resourceDensity ) };
     TextRestorer resourceValue{ display, valuePositionX, positionY };
@@ -281,7 +281,7 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
 
     positionY += ySpacing + 10;
 
-    text.set( _( "rmg|Map seed" ), FontType::normalWhite() );
+    text.set( _( "rmg|Map seed:" ), FontType::normalWhite() );
     text.draw( positionX + ( settingDescriptionWidth - text.width() ) / 2, positionY, display );
 
     ValueSelectionDialogElement mapSeedSelection{ 0, 999999, configuration.seed, 1, { positionX + settingDescriptionWidth + 4, positionY - 5 } };

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -1404,7 +1404,7 @@ void Dialog::selectTownType( int32_t & type, int32_t & color )
 
     const fheroes2::Rect & area = background.activeArea();
 
-    fheroes2::Text text( _( "Castle/town placing" ), fheroes2::FontType::normalYellow() );
+    fheroes2::Text text( _( "Castle/town placing:" ), fheroes2::FontType::normalYellow() );
     text.draw( area.x + ( area.width - text.width() ) / 2, area.y + 10, display );
 
     // Render color and race selection sprites.
@@ -1672,7 +1672,7 @@ int32_t Dialog::selectMineType( const int32_t type )
 
     const fheroes2::Rect & area = background.activeArea();
 
-    fheroes2::Text text( _( "Mine placing" ), fheroes2::FontType::normalYellow() );
+    fheroes2::Text text( _( "Mine placing:" ), fheroes2::FontType::normalYellow() );
     int32_t offsetY = area.y + 10;
     text.draw( area.x + ( area.width - text.width() ) / 2, offsetY, display );
 
@@ -2013,7 +2013,7 @@ PlayerColor Dialog::selectPlayerColor( const PlayerColor color, const uint8_t av
 
     const fheroes2::Rect & area = background.activeArea();
 
-    fheroes2::Text text( _( "Select color" ), fheroes2::FontType::normalYellow() );
+    fheroes2::Text text( _( "Select color:" ), fheroes2::FontType::normalYellow() );
     text.draw( area.x + ( area.width - text.width() ) / 2, area.y + 10, display );
 
     // Render color selection sprites.

--- a/src/fheroes2/editor/editor_castle_details_window.cpp
+++ b/src/fheroes2/editor/editor_castle_details_window.cpp
@@ -512,7 +512,8 @@ namespace
                 };
 
                 int32_t selectedLevel = currentBannedSpellsLevel;
-                while ( Editor::openSpellSelectionWindow( getMageGuildTitle( selectedLevel ), selectedLevel, bannedSpellsContainer[selectedLevel - 1], true,
+                while ( Editor::openSpellSelectionWindow( std::string( getMageGuildTitle( selectedLevel ) ) + ':', selectedLevel,
+                                                          bannedSpellsContainer[selectedLevel - 1], true,
                                                           MageGuild::getMaxSpellsCount( selectedLevel, hasLibraryCapability ), true ) ) {
                     if ( selectedLevel == currentBannedSpellsLevel ) {
                         // The banned spells dialog was closed with confirmation of changes.
@@ -835,7 +836,7 @@ namespace Editor
                 if ( le.MouseClickLeft( nameArea ) ) {
                     std::string res = castleMetadata.customName;
 
-                    const fheroes2::Text body{ _( "Enter Castle name" ), fheroes2::FontType::normalWhite() };
+                    const fheroes2::Text body{ _( "Enter Castle name:" ), fheroes2::FontType::normalWhite() };
                     if ( Dialog::inputString( fheroes2::Text{}, body, res, Maps::Map_Format::nameCharLimit, false, language ) && !res.empty() ) {
                         castleMetadata.customName = std::move( res );
                         redrawName = true;

--- a/src/fheroes2/editor/editor_daily_event_spec_window.cpp
+++ b/src/fheroes2/editor/editor_daily_event_spec_window.cpp
@@ -84,7 +84,7 @@ namespace Editor
 
         int32_t offsetY = dialogRoi.y + elementOffset;
 
-        const fheroes2::Text title( MP2::StringObject( MP2::OBJ_EVENT ), fheroes2::FontType::normalYellow() );
+        const fheroes2::Text title( std::string( MP2::StringObject( MP2::OBJ_EVENT ) ) + ':', fheroes2::FontType::normalYellow() );
         title.draw( dialogRoi.x + ( dialogRoi.width - title.width() ) / 2, offsetY, display );
 
         offsetY += title.height() + elementOffset;
@@ -313,7 +313,7 @@ namespace Editor
 
                     const fheroes2::ResourceDialogElement resourceUI( resourceType, {} );
 
-                    std::string message = _( "Set %{resource-type} Count" );
+                    std::string message = _( "Set %{resource-type} Count:" );
                     StringReplace( message, "%{resource-type}", Resource::String( resourceType ) );
 
                     if ( Dialog::SelectCount( std::move( message ), -99999, 999999, temp, 1, &resourceUI ) ) {

--- a/src/fheroes2/editor/editor_daily_events_window.cpp
+++ b/src/fheroes2/editor/editor_daily_events_window.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_daily_events_window.cpp
+++ b/src/fheroes2/editor/editor_daily_events_window.cpp
@@ -169,7 +169,7 @@ namespace Editor
 
         int32_t offsetY = windowArea.y + elementOffset;
 
-        const fheroes2::Text title( _( "Daily Events" ), fheroes2::FontType::normalYellow() );
+        const fheroes2::Text title( _( "Daily events:" ), fheroes2::FontType::normalYellow() );
         title.draw( windowArea.x + ( windowArea.width - title.width() ) / 2, offsetY, display );
 
         offsetY += title.height() + elementOffset;

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -92,7 +92,7 @@ namespace Editor
 
         int32_t offsetY = dialogRoi.y + elementOffset;
 
-        const fheroes2::Text title( MP2::StringObject( MP2::OBJ_EVENT ), fheroes2::FontType::normalYellow() );
+        const fheroes2::Text title( std::string( MP2::StringObject( MP2::OBJ_EVENT ) ) + ':', fheroes2::FontType::normalYellow() );
         title.draw( dialogRoi.x + ( dialogRoi.width - title.width() ) / 2, offsetY, display );
 
         offsetY += title.height() + elementOffset;
@@ -327,7 +327,7 @@ namespace Editor
 
                     const fheroes2::ResourceDialogElement resourceUI( resourceType, {} );
 
-                    std::string message = _( "Set %{resource-type} Count" );
+                    std::string message = _( "Set %{resource-type} Count:" );
                     StringReplace( message, "%{resource-type}", Resource::String( resourceType ) );
 
                     if ( Dialog::SelectCount( std::move( message ), -99999, 999999, temp, 1, &resourceUI ) ) {
@@ -423,7 +423,7 @@ namespace Editor
                 const fheroes2::ExperienceDialogElement tempExperienceUI{ 0 };
                 int32_t tempValue{ eventMetadata.experience };
 
-                if ( Dialog::SelectCount( _( "Set Experience value" ), 0, static_cast<int32_t>( Heroes::getExperienceMaxValue() ), tempValue, 1, &tempExperienceUI ) ) {
+                if ( Dialog::SelectCount( _( "Set Experience value:" ), 0, static_cast<int32_t>( Heroes::getExperienceMaxValue() ), tempValue, 1, &tempExperienceUI ) ) {
                     eventMetadata.experience = tempValue;
 
                     experienceRoiRestorer.restore();

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1731,7 +1731,7 @@ namespace Interface
                     }
                 }
                 else if ( objectType == MP2::OBJ_SIGN || objectType == MP2::OBJ_BOTTLE ) {
-                    std::string header = _( "Input %{object} text" );
+                    std::string header = _( "Input %{object} text:" );
                     StringReplace( header, "%{object}", MP2::StringObject( objectType ) );
 
                     auto & originalMessage = _mapFormat.signMetadata[object.id].message;
@@ -1767,7 +1767,7 @@ namespace Interface
 
                     const Monster tempMonster( static_cast<int>( object.index ) + 1 );
 
-                    std::string str = _( "Set %{monster} Count" );
+                    std::string str = _( "Set %{monster} Count:" );
                     StringReplace( str, "%{monster}", tempMonster.GetName() );
 
                     std::unique_ptr<const fheroes2::MonsterDialogElement> monsterUi = nullptr;
@@ -1816,7 +1816,7 @@ namespace Interface
 
                     const fheroes2::ResourceDialogElement resourceUI( resourceType, {} );
 
-                    std::string str = _( "Set %{resource-type} Count" );
+                    std::string str = _( "Set %{resource-type} Count:" );
                     StringReplace( str, "%{resource-type}", Resource::String( resourceType ) );
 
                     // We cannot support more than 6 digits in the dialog due to its UI element size.
@@ -1833,7 +1833,7 @@ namespace Interface
                         auto & originalRadius = _mapFormat.artifactMetadata[object.id].radius;
                         int32_t radius = originalRadius;
 
-                        if ( Dialog::SelectCount( _( "Set Random Ultimate Artifact Radius" ), 0, 100, radius ) && radius != originalRadius ) {
+                        if ( Dialog::SelectCount( _( "Set Random Ultimate Artifact Radius:" ), 0, 100, radius ) && radius != originalRadius ) {
                             fheroes2::ActionCreator action( _historyManager, _mapFormat );
                             originalRadius = radius;
                             action.commit();
@@ -1908,7 +1908,8 @@ namespace Interface
                         spellLevel = 1;
                     }
 
-                    if ( Editor::openSpellSelectionWindow( MP2::StringObject( objectType ), spellLevel, newMetadata.selectedItems, false, 1, false )
+                    std::string title = std::string( MP2::StringObject( objectType ) ) + ':';
+                    if ( Editor::openSpellSelectionWindow( title, spellLevel, newMetadata.selectedItems, false, 1, false )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
                         originalMetadata = std::move( newMetadata );
@@ -1923,7 +1924,8 @@ namespace Interface
                     auto & originalMetadata = _mapFormat.selectionObjectMetadata[object.id];
                     auto newMetadata = originalMetadata;
 
-                    if ( Editor::openSecondarySkillSelectionWindow( MP2::StringObject( objectType ), 1, newMetadata.selectedItems )
+                    std::string title = std::string( MP2::StringObject( objectType ) ) + ':';
+                    if ( Editor::openSecondarySkillSelectionWindow( title, 1, newMetadata.selectedItems )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
                         originalMetadata = std::move( newMetadata );
@@ -1939,7 +1941,8 @@ namespace Interface
                     auto newMetadata = originalMetadata;
 
                     int32_t spellLevel = 5;
-                    if ( Editor::openSpellSelectionWindow( MP2::StringObject( objectType ), spellLevel, newMetadata.selectedItems, false, 1, false )
+                    std::string title = std::string( MP2::StringObject( objectType ) ) + ':';
+                    if ( Editor::openSpellSelectionWindow( title, spellLevel, newMetadata.selectedItems, false, 1, false )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
                         originalMetadata = std::move( newMetadata );

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1908,7 +1908,7 @@ namespace Interface
                         spellLevel = 1;
                     }
 
-                    std::string title = std::string( MP2::StringObject( objectType ) ) + ':';
+                    std::string const title = std::string( MP2::StringObject( objectType ) ) + ':';
                     if ( Editor::openSpellSelectionWindow( title, spellLevel, newMetadata.selectedItems, false, 1, false )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
@@ -1924,7 +1924,7 @@ namespace Interface
                     auto & originalMetadata = _mapFormat.selectionObjectMetadata[object.id];
                     auto newMetadata = originalMetadata;
 
-                    std::string title = std::string( MP2::StringObject( objectType ) ) + ':';
+                    std::string const title = std::string( MP2::StringObject( objectType ) ) + ':';
                     if ( Editor::openSecondarySkillSelectionWindow( title, 1, newMetadata.selectedItems )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );
@@ -1941,7 +1941,7 @@ namespace Interface
                     auto newMetadata = originalMetadata;
 
                     int32_t spellLevel = 5;
-                    std::string title = std::string( MP2::StringObject( objectType ) ) + ':';
+                    std::string const title = std::string( MP2::StringObject( objectType ) ) + ':';
                     if ( Editor::openSpellSelectionWindow( title, spellLevel, newMetadata.selectedItems, false, 1, false )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
                         fheroes2::ActionCreator action( _historyManager, _mapFormat );

--- a/src/fheroes2/editor/editor_language_window.cpp
+++ b/src/fheroes2/editor/editor_language_window.cpp
@@ -141,7 +141,7 @@ namespace Editor
 
         int32_t offsetY = windowArea.y + elementOffset;
 
-        const fheroes2::Text title( _( "Supported languages" ), fheroes2::FontType::normalYellow() );
+        const fheroes2::Text title( _( "Supported languages:" ), fheroes2::FontType::normalYellow() );
         title.draw( windowArea.x + ( windowArea.width - title.width() ) / 2, offsetY, display );
 
         offsetY += title.height() + elementOffset;

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -2099,7 +2099,7 @@ namespace Editor
         offsetX = activeArea.x + 15;
         offsetY = scenarioBoxRoi.y + scenarioBoxRoi.height + 65;
 
-        text.set( _( "Map Difficulty" ), fheroes2::FontType::normalWhite() );
+        text.set( std::string( _( "Map Difficulty" ) ) + ':', fheroes2::FontType::normalWhite() );
         text.draw( offsetX + ( difficultyStepX * 4 - text.width() ) / 2, scenarioBoxRoi.y + scenarioBoxRoi.height + 65, display );
 
         std::array<fheroes2::Rect, 4> difficultyRects;
@@ -2136,7 +2136,7 @@ namespace Editor
         offsetX = activeArea.x + activeArea.width - descriptionBoxWidth - 15;
         offsetY -= 23;
 
-        text.set( _( "Map Description" ), fheroes2::FontType::normalWhite() );
+        text.set( std::string( _( "Map Description" ) ) + ':', fheroes2::FontType::normalWhite() );
         text.draw( offsetX + ( descriptionBoxWidth - text.width() ) / 2, offsetY, display );
 
         offsetY += 25;
@@ -2151,7 +2151,7 @@ namespace Editor
         // Victory conditions.
         offsetY += descriptionTextRoi.height + 20;
 
-        text.set( _( "Special Victory Condition" ), fheroes2::FontType::normalWhite() );
+        text.set( std::string( _( "Special Victory Condition" ) ) + ':', fheroes2::FontType::normalWhite() );
         text.draw( activeArea.x + activeArea.width / 4 - text.width() / 2, offsetY, display );
 
         offsetY += 20;
@@ -2185,7 +2185,7 @@ namespace Editor
         // Loss conditions.
         offsetY = descriptionTextRoi.y + descriptionTextRoi.height + 20;
 
-        text.set( _( "Special Loss Condition" ), fheroes2::FontType::normalWhite() );
+        text.set( std::string( _( "Special Loss Condition" ) ) + ':', fheroes2::FontType::normalWhite() );
         text.draw( activeArea.x + 3 * activeArea.width / 4 - text.width() / 2, offsetY, display );
 
         offsetY += 20;
@@ -2230,7 +2230,7 @@ namespace Editor
                                                   fheroes2::StandardWindow::Padding::BOTTOM_LEFT );
 
         fheroes2::ButtonSprite buttonAbout;
-        translatedText = fheroes2::getSupportedText( gettext_noop( "ABOUT" ), fheroes2::FontType::buttonReleasedWhite() );
+        translatedText = fheroes2::getSupportedText( gettext_noop( "map|ABOUT" ), fheroes2::FontType::buttonReleasedWhite() );
         background.renderTextAdaptedButtonSprite( buttonAbout, translatedText, { 21, 12 }, fheroes2::StandardWindow::Padding::TOP_RIGHT );
 
         auto renderMapName = [&text, &mapFormat, &display, &scenarioBox, &mapNameRoi, &scenarioBoxRoi]() {
@@ -2307,7 +2307,7 @@ namespace Editor
 
                 std::string editableMapName = mapFormat.name;
 
-                const fheroes2::Text body{ _( "Change Map Name" ), fheroes2::FontType::normalWhite() };
+                const fheroes2::Text body{ _( "Change Map Name:" ), fheroes2::FontType::normalWhite() };
                 if ( Dialog::inputString( fheroes2::Text{}, body, editableMapName, maxMapNameLength, false, mapFormat.mainLanguage ) ) {
                     mapFormat.name = std::move( editableMapName );
 
@@ -2318,7 +2318,7 @@ namespace Editor
             else if ( le.MouseClickLeft( descriptionTextRoi ) ) {
                 std::string descripton = mapFormat.description;
 
-                const fheroes2::Text body{ _( "Change Map Description" ), fheroes2::FontType::normalWhite() };
+                const fheroes2::Text body{ _( "Change Map Description:" ), fheroes2::FontType::normalWhite() };
                 if ( Dialog::inputString( fheroes2::Text{}, body, descripton, Maps::Map_Format::messageCharLimit, true, mapFormat.mainLanguage ) ) {
                     mapFormat.description = std::move( descripton );
 
@@ -2363,7 +2363,7 @@ namespace Editor
             else if ( le.MouseClickLeft( buttonAbout.area() ) ) {
                 std::string notes = mapFormat.creatorNotes;
 
-                const fheroes2::Text body{ _( "About" ), fheroes2::FontType::normalWhite() };
+                const fheroes2::Text body{ std::string( _( "map|About" ) ) + ':', fheroes2::FontType::normalWhite() };
                 if ( Dialog::inputString( fheroes2::Text{}, body, notes, Maps::Map_Format::messageCharLimit, true, mapFormat.mainLanguage ) ) {
                     mapFormat.creatorNotes = std::move( notes );
                 }
@@ -2384,7 +2384,7 @@ namespace Editor
                 fheroes2::showStandardTextMessage( _( "Language" ), _( "Click to change the language of the map." ), Dialog::ZERO );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonAbout.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "About" ),
+                fheroes2::showStandardTextMessage( _( "map|About" ),
                                                    _( "Click to edit notes from the map creator. These notes are optional and do not appear during gameplay." ),
                                                    Dialog::ZERO );
             }

--- a/src/fheroes2/editor/editor_rumor_window.cpp
+++ b/src/fheroes2/editor/editor_rumor_window.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_rumor_window.cpp
+++ b/src/fheroes2/editor/editor_rumor_window.cpp
@@ -148,7 +148,7 @@ namespace Editor
 
         int32_t offsetY = windowArea.y + elementOffset;
 
-        const fheroes2::Text title( _( "Rumors" ), fheroes2::FontType::normalYellow() );
+        const fheroes2::Text title( _( "Rumors:" ), fheroes2::FontType::normalYellow() );
         title.draw( windowArea.x + ( windowArea.width - title.width() ) / 2, offsetY, display );
 
         offsetY += title.height() + elementOffset;

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -362,7 +362,7 @@ namespace Editor
             }
             else if ( le.MouseClickLeft( mapNameRoi ) ) {
                 std::string editableMapName = mapName;
-                const fheroes2::Text body{ _( "Change Map Name" ), fheroes2::FontType::normalWhite() };
+                const fheroes2::Text body{ _( "Change Map Name:" ), fheroes2::FontType::normalWhite() };
                 if ( Dialog::inputString( fheroes2::Text{}, body, editableMapName, maxMapNameLength, false, language ) ) {
                     if ( editableMapName.empty() ) {
                         // Map should have a non empty name.

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -159,7 +159,7 @@ namespace Editor
 
         int32_t offsetY = windowArea.y + elementOffset;
 
-        const fheroes2::Text title( MP2::StringObject( MP2::OBJ_SPHINX ), fheroes2::FontType::normalYellow() );
+        const fheroes2::Text title( std::string( MP2::StringObject( MP2::OBJ_SPHINX ) ) + ':', fheroes2::FontType::normalYellow() );
         title.draw( windowArea.x + ( windowArea.width - title.width() ) / 2, offsetY, display );
 
         offsetY += title.height() + elementOffset;
@@ -295,7 +295,7 @@ namespace Editor
 
                     const fheroes2::ResourceDialogElement resourceUI( resourceType, {} );
 
-                    std::string str = _( "Set %{resource-type} Count" );
+                    std::string str = _( "Set %{resource-type} Count:" );
                     StringReplace( str, "%{resource-type}", Resource::String( resourceType ) );
 
                     if ( Dialog::SelectCount( std::move( str ), 0, 1000000, temp, 1, &resourceUI ) ) {

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2025                                             *
+ *   Copyright (C) 2020 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -206,7 +206,7 @@ bool PrimarySkillsBar::ActionBarLeftMouseSingleClick( int & skill )
 
     // The case when we are in Editor mode.
     auto primarySkillEditDialog = [skill]( int32_t & skillValue ) {
-        std::string header = _( "Set %{skill} Skill" );
+        std::string header = _( "Set %{skill} Skill:" );
         StringReplace( header, "%{skill}", Skill::Primary::String( skill ) );
 
         const auto [min, max] = Skill::Primary::getSkillValueRange( skill );

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -515,7 +515,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
                     const fheroes2::ExperienceDialogElement tempExperienceUI{ 0 };
                     int32_t value = static_cast<int32_t>( _experience );
 
-                    if ( Dialog::SelectCount( _( "Set Experience value" ), 0, static_cast<int32_t>( Heroes::getExperienceMaxValue() ), value, 1, &tempExperienceUI ) ) {
+                    if ( Dialog::SelectCount( _( "Set Experience value:" ), 0, static_cast<int32_t>( Heroes::getExperienceMaxValue() ), value, 1, &tempExperienceUI ) ) {
                         useDefaultExperience = false;
                         _experience = static_cast<uint32_t>( value );
                         experienceInfo.setDefaultState( useDefaultExperience );
@@ -545,7 +545,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
                 if ( le.MouseClickLeft() ) {
                     int32_t value = static_cast<int32_t>( GetSpellPoints() );
-                    if ( Dialog::SelectCount( _( "Set Spell Points value" ), 0, std::max( spellPointsMaxValue, value ), value ) ) {
+                    if ( Dialog::SelectCount( _( "Set Spell Points value:" ), 0, std::max( spellPointsMaxValue, value ), value ) ) {
                         useDefaultSpellPoints = false;
                         SetSpellPoints( static_cast<uint32_t>( value ) );
                         spellPointsInfo.setDefaultState( useDefaultSpellPoints );
@@ -621,7 +621,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
             if ( le.isMouseLeftButtonPressed() && buttonPatrol->isReleased() && !Modes( PATROL ) ) {
                 buttonPatrol->drawOnPress();
                 int32_t value = static_cast<int32_t>( _patrolDistance );
-                if ( Dialog::SelectCount( _( "Set patrol radius in tiles" ), 0, 255, value ) ) {
+                if ( Dialog::SelectCount( _( "Set patrol radius in tiles:" ), 0, 255, value ) ) {
                     SetModes( PATROL );
                     _patrolDistance = static_cast<uint32_t>( value );
                 }
@@ -640,7 +640,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         else if ( isEditor ) {
             if ( le.MouseClickLeft( titleRoi ) ) {
                 std::string res = _name;
-                const fheroes2::Text body{ _( "Enter hero's name" ), fheroes2::FontType::normalWhite() };
+                const fheroes2::Text body{ _( "Enter hero's name:" ), fheroes2::FontType::normalWhite() };
 
                 if ( Dialog::inputString( fheroes2::Text{}, body, res, Maps::Map_Format::nameCharLimit, false, language ) && !res.empty() ) {
                     _name = std::move( res );


### PR DESCRIPTION
Relates to #8589 - fix inconsistency with window titles: some have : at the end while others don't

I see FHeroes2 uses colons in multiple window / option labels, so I chose to add missing colons.

The idea is: if label indicates some possible action for user - add colon at end of label. Label is for "read-only" entity, like artifact description - no colon at end of label.
<img width="593" height="639" alt="Screenshot from 2026-04-04 14-16-30" src="https://github.com/user-attachments/assets/9f4a80e4-bc32-40d9-a0a1-82c5f363d045" />

<img width="877" height="263" alt="Screenshot from 2026-04-04 14-16-36" src="https://github.com/user-attachments/assets/bb9874b9-2be0-4c0e-a991-fe3613fcd19b" />

<img width="1273" height="566" alt="Screenshot from 2026-04-04 14-16-56" src="https://github.com/user-attachments/assets/6b2f07c3-4f41-40e7-b433-5aac849c9a5a" />

<img width="596" height="610" alt="Screenshot from 2026-04-04 14-16-49" src="https://github.com/user-attachments/assets/e0538d76-622c-452e-8617-f2e914d2465c" />

<img width="1274" height="694" alt="Screenshot from 2026-04-04 13-46-37" src="https://github.com/user-attachments/assets/432da355-76f0-4b50-ab08-c9d42b9abab8" />
