### PR TITLE
Sort maps in the Editor by filename, ignoring rest of filepath

### DIFF
--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -569,17 +569,17 @@ void Maps::FileInfo::FillUnions( const PlayerColorsSet side1Colors, const Player
 
 bool Maps::FileInfo::CompareByFileName::operator()( const FileInfo & lhs, const FileInfo & rhs ) const
 {
-    return fheroes2::compareStringsCaseInsensitively( lhs.filename, rhs.filename );
+    return fheroes2::compareStringsCaseInsensitively( System::GetFileName( lhs.filename ), System::GetFileName( rhs.filename ) );
 }
 
 bool Maps::FileInfo::CompareByFileName::operator()( const FileInfo & lhs, const std::string & rhs ) const
 {
-    return fheroes2::compareStringsCaseInsensitively( lhs.filename, rhs );
+    return fheroes2::compareStringsCaseInsensitively( System::GetFileName( lhs.filename ), System::GetFileName( rhs ) );
 }
 
 bool Maps::FileInfo::CompareByFileName::operator()( const std::string & lhs, const FileInfo & rhs ) const
 {
-    return fheroes2::compareStringsCaseInsensitively( lhs, rhs.filename );
+    return fheroes2::compareStringsCaseInsensitively( System::GetFileName( lhs ), System::GetFileName( rhs.filename ) );
 }
 
 bool Maps::FileInfo::CompareByMapName::operator()( const FileInfo & lhs, const FileInfo & rhs ) const


### PR DESCRIPTION
Close #10658 

<img width="500" height="966" alt="Screenshot from 2026-04-10 16-29-15" src="https://github.com/user-attachments/assets/74fd9c3b-4253-41c2-9f25-267b718055d1" />

<img width="500" src="https://github.com/user-attachments/assets/73d4d4e2-2741-4b60-8821-ff19e1d64a98"/> <img width="500" src="https://github.com/user-attachments/assets/dde8891d-4e7b-4a1e-9582-b39a3c3e28b0"/>
