### PR TITLE
Make hero turning animation depend on the animation speed

### DIFF
--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -804,6 +804,9 @@ private:
 
     // This value should NOT be saved in save file as it's dynamically set during AI turn.
     Role _aiRole{ Role::HUNTER };
+
+    // Used to freeze the rotation animation for N frames to match the rotation animation with movement speed.
+    int32_t _rotationFrameHold{ 0 };
 };
 
 struct VecHeroes final : public std::vector<Heroes *>

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -806,7 +806,7 @@ private:
     Role _aiRole{ Role::HUNTER };
 
     // Used to freeze the rotation animation for N frames to match the rotation animation with movement speed.
-    int32_t _rotationFrameHold{ 0 };
+    int8_t _skippedFramesForAngleStep{ 0 };
 };
 
 struct VecHeroes final : public std::vector<Heroes *>

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -595,8 +595,14 @@ bool Heroes::Move( const bool jumpToNextTile /* = false */ )
         }
 
         if ( const int frontDirection = _path.GetFrontDirection(); GetDirection() != frontDirection ) {
-            // The hero is changing the direction of movement.
-            _angleStep( frontDirection );
+            // Hold rotation frame for N ticks to match the movement speed (similar to original game)
+            const int32_t freeze = std::clamp( 4 / Game::HumanHeroAnimSpeedMultiplier(), 1, 3 );
+            if ( ++_rotationFrameHold >= freeze ) {
+                _rotationFrameHold = 0;
+
+                // The hero is changing the direction of movement.
+                _angleStep( frontDirection );
+            }
         }
         else {
             // Set valid direction sprite in case of AI hero appearing from fog.

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -300,7 +300,7 @@ void Heroes::_angleStep( const int targetDirection )
     const int speedMultiplier = isControlHuman() ? Game::HumanHeroAnimSpeedMultiplier() : Game::AIHeroAnimSpeedMultiplier();
     assert( speedMultiplier > 0 );
     const int32_t framesToSkip = std::clamp( 4 / speedMultiplier, 1, 3 );
-    assert( _skippedFramesForAngleStep >= 0);
+    assert( _skippedFramesForAngleStep >= 0 );
 
     ++_skippedFramesForAngleStep;
     if ( _skippedFramesForAngleStep < framesToSkip ) {
@@ -612,6 +612,7 @@ bool Heroes::Move( const bool jumpToNextTile /* = false */ )
         }
 
         if ( const int frontDirection = _path.GetFrontDirection(); GetDirection() != frontDirection ) {
+            // The hero is changing the direction of movement.
             _angleStep( frontDirection );
         }
         else {

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -596,9 +596,12 @@ bool Heroes::Move( const bool jumpToNextTile /* = false */ )
 
         if ( const int frontDirection = _path.GetFrontDirection(); GetDirection() != frontDirection ) {
             // Hold rotation frame for N ticks to match the movement speed (similar to original game)
-            const int32_t freeze = std::clamp( 4 / Game::HumanHeroAnimSpeedMultiplier(), 1, 3 );
-            if ( ++_rotationFrameHold >= freeze ) {
-                _rotationFrameHold = 0;
+            const int speedMultiplier = isControlHuman() ? Game::HumanHeroAnimSpeedMultiplier() : Game::AIHeroAnimSpeedMultiplier();
+            const int32_t angleStepFramesToSkip = std::clamp( 4 / speedMultiplier, 1, 3 );
+            ++_skippedFramesForAngleStep;
+
+            if ( _skippedFramesForAngleStep >= angleStepFramesToSkip ) {
+                _skippedFramesForAngleStep = 0;
 
                 // The hero is changing the direction of movement.
                 _angleStep( frontDirection );

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -310,7 +310,7 @@ void Heroes::_angleStep( const int targetDirection )
 
     // Reset turning animation delay.
     _skippedFramesForAngleStep = 0;
-    
+
     const bool clockwise = Direction::ShortDistanceClockWise( _direction, targetDirection );
 
     // start index

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -294,6 +294,23 @@ bool Heroes::_moveStep( const bool jumpToNextTile )
 
 void Heroes::_angleStep( const int targetDirection )
 {
+    // Hero movement animation depends on the animation speed.
+    // To make the speed of the hero turning animation the same
+    // we need to skip certain frames.
+    const int speedMultiplier = isControlHuman() ? Game::HumanHeroAnimSpeedMultiplier() : Game::AIHeroAnimSpeedMultiplier();
+    assert( speedMultiplier > 0 );
+    const int32_t framesToSkip = std::clamp( 4 / speedMultiplier, 1, 3 );
+    assert( _skippedFramesForAngleStep >= 0);
+
+    ++_skippedFramesForAngleStep;
+    if ( _skippedFramesForAngleStep < framesToSkip ) {
+        // Skip the animation change for this frame.
+        return;
+    }
+
+    // Reset turning animation delay.
+    _skippedFramesForAngleStep = 0;
+    
     const bool clockwise = Direction::ShortDistanceClockWise( _direction, targetDirection );
 
     // start index
@@ -595,17 +612,7 @@ bool Heroes::Move( const bool jumpToNextTile /* = false */ )
         }
 
         if ( const int frontDirection = _path.GetFrontDirection(); GetDirection() != frontDirection ) {
-            // Hold rotation frame for N ticks to match the movement speed (similar to original game)
-            const int speedMultiplier = isControlHuman() ? Game::HumanHeroAnimSpeedMultiplier() : Game::AIHeroAnimSpeedMultiplier();
-            const int32_t angleStepFramesToSkip = std::clamp( 4 / speedMultiplier, 1, 3 );
-            ++_skippedFramesForAngleStep;
-
-            if ( _skippedFramesForAngleStep >= angleStepFramesToSkip ) {
-                _skippedFramesForAngleStep = 0;
-
-                // The hero is changing the direction of movement.
-                _angleStep( frontDirection );
-            }
+            _angleStep( frontDirection );
         }
         else {
             // Set valid direction sprite in case of AI hero appearing from fog.


### PR DESCRIPTION
- Hero turning animation respects movement speed by freezeing each animation frame by N ticks. Minimum 1, maximum 3

Fixes #2642 