### PR TITLE
docs: add custom 404 error page for the project website

### DIFF
--- a/docs/404.html
+++ b/docs/404.html
@@ -1,0 +1,51 @@
+---
+layout: default
+title: "Page Not Found"
+permalink: /404.html
+---
+
+<style>
+  .error-container {
+    text-align: center;
+    padding: 3rem 1rem;
+  }
+
+  .error-code {
+    font-size: 6rem;
+    font-weight: bold;
+    margin: 0;
+    line-height: 1;
+  }
+
+  .error-message {
+    font-size: 1.5rem;
+    margin: 1rem 0 2rem;
+  }
+
+  .error-description {
+    font-size: 1.1rem;
+    margin-bottom: 2rem;
+    max-width: 500px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .error-home-link {
+    display: inline-block;
+    padding: 0.75rem 1.5rem;
+    font-size: 1rem;
+    text-decoration: none;
+    border: 2px solid;
+    border-radius: 4px;
+  }
+</style>
+
+<div class="error-container">
+  <p class="error-code">404</p>
+  <p class="error-message">Page Not Found</p>
+  <p class="error-description">
+    The page you are looking for might have been removed, had its name changed,
+    or is temporarily unavailable.
+  </p>
+  <a class="error-home-link" href="{{ site.baseurl }}/">Return to Home Page</a>
+</div>


### PR DESCRIPTION
## Summary

- Add a custom 404 error page (`docs/404.html`) for the GitHub Pages website
- Uses the existing `default` layout to maintain consistent site appearance
- Provides a clear error message and a link back to the home page

Closes #10563

## Test plan

- [ ] Verify the page renders correctly by visiting a non-existent URL on the project website
- [ ] Confirm the page inherits the site theme (including dark mode toggle)
- [ ] Confirm the "Return to Home Page" link navigates to the site root

Generated with [Claude Code](https://claude.com/claude-code)