### PR TITLE
Rework application exiting logic

### DIFF
--- a/VisualStudio/fheroes2/sources.props
+++ b/VisualStudio/fheroes2/sources.props
@@ -132,6 +132,7 @@
     <ClCompile Include="src\fheroes2\game\game_campaign.cpp" />
     <ClCompile Include="src\fheroes2\game\game_credits.cpp" />
     <ClCompile Include="src\fheroes2\game\game_delays.cpp" />
+    <ClCompile Include="src\fheroes2\game\game_exit.cpp" />
     <ClCompile Include="src\fheroes2\game\game_highscores.cpp" />
     <ClCompile Include="src\fheroes2\game\game_hotkeys.cpp" />
     <ClCompile Include="src\fheroes2\game\game_interface.cpp" />
@@ -349,6 +350,7 @@
     <ClInclude Include="src\fheroes2\game\game.h" />
     <ClInclude Include="src\fheroes2\game\game_credits.h" />
     <ClInclude Include="src\fheroes2\game\game_delays.h" />
+    <ClInclude Include="src\fheroes2\game\game_exit.h" />
     <ClInclude Include="src\fheroes2\game\game_hotkeys.h" />
     <ClInclude Include="src\fheroes2\game\game_interface.h" />
     <ClInclude Include="src\fheroes2\game\game_io.h" />

--- a/src/fheroes2/dialog/dialog_file.cpp
+++ b/src/fheroes2/dialog/dialog_file.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -23,6 +23,7 @@
 
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_exit.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
 #include "game_io.h"
@@ -112,8 +113,8 @@ namespace
                 break;
             }
 
-            if ( le.MouseClickLeft( quitButton.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_QUIT ) ) {
-                if ( Interface::AdventureMap::EventExit() == fheroes2::GameMode::QUIT_GAME ) {
+            if ( le.MouseClickLeft( quitButton.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) ) {
+                if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                     result = fheroes2::GameMode::QUIT_GAME;
                     break;
                 }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -49,6 +49,7 @@
 #include "editor_sphinx_window.h"
 #include "game.h"
 #include "game_delays.h"
+#include "game_exit.h"
 #include "game_hotkeys.h"
 #include "game_static.h"
 #include "ground.h"
@@ -1140,7 +1141,7 @@ namespace Interface
 
         while ( res == fheroes2::GameMode::CANCEL ) {
             if ( !le.HandleEvents( Game::isDelayNeeded( delayTypes ), true ) ) {
-                if ( EventExit() == fheroes2::GameMode::QUIT_GAME ) {
+                if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                     res = fheroes2::GameMode::QUIT_GAME;
 
                     break;
@@ -1153,8 +1154,8 @@ namespace Interface
 
             // Hotkeys' press event processing.
             if ( le.isAnyKeyPressed() ) {
-                if ( HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_QUIT ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-                    res = EventExit();
+                if ( HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
+                    res = Game::processExitEvent();
                 }
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::EDITOR_NEW_MAP_MENU ) ) {
                     res = eventNewMap();
@@ -1597,8 +1598,8 @@ namespace Interface
                 return fheroes2::GameMode::CANCEL;
             }
 
-            if ( le.MouseClickLeft( buttonQuit.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_QUIT ) ) {
-                if ( EventExit() == fheroes2::GameMode::QUIT_GAME ) {
+            if ( le.MouseClickLeft( buttonQuit.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) ) {
+                if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                     return fheroes2::GameMode::QUIT_GAME;
                 }
             }

--- a/src/fheroes2/editor/editor_mainmenu.cpp
+++ b/src/fheroes2/editor/editor_mainmenu.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2025                                             *
+ *   Copyright (C) 2023 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_mainmenu.cpp
+++ b/src/fheroes2/editor/editor_mainmenu.cpp
@@ -33,6 +33,7 @@
 #include "dialog_selectscenario.h"
 #include "editor_interface.h"
 #include "game.h"
+#include "game_exit.h"
 #include "game_hotkeys.h"
 #include "game_mainmenu_ui.h"
 #include "game_mode.h"
@@ -221,7 +222,13 @@ namespace Editor
 
         bool generateRandomMap = false;
 
-        while ( le.HandleEvents() ) {
+        while ( true ) {
+            if ( !le.HandleEvents( true, true ) || HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) ) {
+                if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
+                    return fheroes2::GameMode::QUIT_GAME;
+                }
+            }
+
             if ( buttonNewMap.isEnabled() ) {
                 mainModeButtons.drawOnState( le );
                 buttonMainMenu.drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( buttonMainMenu.area() ) );

--- a/src/fheroes2/game/game_exit.cpp
+++ b/src/fheroes2/game/game_exit.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2026                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "game_exit.h"
+
+#include "dialog.h"
+#include "game_mode.h"
+#include "translations.h"
+#include "ui_dialog.h"
+
+namespace Game
+{
+    fheroes2::GameMode processExitEvent()
+    {
+#if defined( __IPHONEOS__ )
+        // iOS discourages to exit a running application.
+        fheroes2::showStandardTextMessage( _( "Quit" ), _( "To exit fheroes2, press the Home button or swipe up." ), Dialog::OK );
+#else
+        if ( Dialog::YES & fheroes2::showStandardTextMessage( _( "Quit" ), _( "Are you sure you want to quit?" ), Dialog::YES | Dialog::NO ) ) {
+            return fheroes2::GameMode::QUIT_GAME;
+        }
+#endif
+
+        return fheroes2::GameMode::CANCEL;
+    }
+}

--- a/src/fheroes2/game/game_exit.h
+++ b/src/fheroes2/game/game_exit.h
@@ -1,0 +1,29 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2026                                                    *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+namespace fheroes2
+{
+    enum class GameMode : int;
+}
+
+namespace Game
+{
+    fheroes2::GameMode processExitEvent();
+}

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -111,6 +111,8 @@ namespace
             = { Game::HotKeyCategory::GLOBAL, gettext_noop( "hotkey|toggle developer mode" ), fheroes2::Key::KEY_BACKQUOTE };
 #endif
 
+        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::GLOBAL_APP_QUIT )] = { Game::HotKeyCategory::GLOBAL, gettext_noop( "hotkey|quit" ), fheroes2::Key::KEY_Q };
+
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::MAIN_MENU_NEW_GAME )]
             = { Game::HotKeyCategory::MAIN_MENU, gettext_noop( "hotkey|new game" ), fheroes2::Key::KEY_N };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::MAIN_MENU_LOAD_GAME )]
@@ -127,7 +129,6 @@ namespace
             = { Game::HotKeyCategory::MAIN_MENU, gettext_noop( "hotkey|multi-player game" ), fheroes2::Key::KEY_M };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::MAIN_MENU_SETTINGS )]
             = { Game::HotKeyCategory::MAIN_MENU, gettext_noop( "hotkey|settings" ), fheroes2::Key::KEY_T };
-        hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::MAIN_MENU_QUIT )] = { Game::HotKeyCategory::MAIN_MENU, gettext_noop( "hotkey|quit" ), fheroes2::Key::KEY_Q };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::MAIN_MENU_SELECT_MAP )]
             = { Game::HotKeyCategory::MAIN_MENU, gettext_noop( "hotkey|select map" ), fheroes2::Key::KEY_S };
         hotKeyEventInfo[hotKeyEventToInt( Game::HotKeyEvent::MAIN_MENU_MAP_SIZE_SMALL )]

--- a/src/fheroes2/game/game_hotkeys.h
+++ b/src/fheroes2/game/game_hotkeys.h
@@ -51,6 +51,8 @@ namespace Game
         GLOBAL_TOGGLE_DEVELOPER_MODE,
 #endif
 
+        GLOBAL_APP_QUIT,
+
         MAIN_MENU_NEW_GAME,
         MAIN_MENU_LOAD_GAME,
         MAIN_MENU_HIGHSCORES,
@@ -59,7 +61,6 @@ namespace Game
         MAIN_MENU_CAMPAIGN,
         MAIN_MENU_MULTI,
         MAIN_MENU_SETTINGS,
-        MAIN_MENU_QUIT,
         MAIN_MENU_SELECT_MAP,
         MAIN_MENU_MAP_SIZE_SMALL,
         MAIN_MENU_MAP_SIZE_MEDIUM,

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -98,8 +98,8 @@ namespace
             COUT( "Press " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::EDITOR_MAIN_MENU ) << " to open Editor." )
         }
 
-        COUT( "Press " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::GLOBAL_APP_QUIT ) << " or " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::DEFAULT_CANCEL )
-                       << " to Quit the game." )
+        COUT( "Press " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::GLOBAL_APP_QUIT ) << " or "
+                       << Game::getHotKeyNameByEventId( Game::HotKeyEvent::DEFAULT_CANCEL ) << " to Quit the game." )
     }
 }
 

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -44,7 +44,6 @@
 #include "game_delays.h"
 #include "game_exit.h"
 #include "game_hotkeys.h"
-#include "game_interface.h"
 #include "game_mainmenu_ui.h"
 #include "game_mode.h"
 #include "icn.h"

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -42,6 +42,7 @@
 #include "editor_mainmenu.h"
 #include "game.h" // IWYU pragma: associated
 #include "game_delays.h"
+#include "game_exit.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
 #include "game_mainmenu_ui.h"
@@ -97,7 +98,7 @@ namespace
             COUT( "Press " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::EDITOR_MAIN_MENU ) << " to open Editor." )
         }
 
-        COUT( "Press " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::MAIN_MENU_QUIT ) << " or " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::DEFAULT_CANCEL )
+        COUT( "Press " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::GLOBAL_APP_QUIT ) << " or " << Game::getHotKeyNameByEventId( Game::HotKeyEvent::DEFAULT_CANCEL )
                        << " to Quit the game." )
     }
 }
@@ -314,7 +315,7 @@ fheroes2::GameMode Game::MainMenu( const bool isFirstGameRun )
 
     while ( true ) {
         if ( !le.HandleEvents( true, true ) ) {
-            if ( Interface::AdventureMap::EventExit() == fheroes2::GameMode::QUIT_GAME ) {
+            if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                 break;
             }
             else {
@@ -365,8 +366,8 @@ fheroes2::GameMode Game::MainMenu( const bool isFirstGameRun )
             return fheroes2::GameMode::CREDITS;
         }
 
-        if ( HotKeyPressEvent( HotKeyEvent::MAIN_MENU_QUIT ) || HotKeyPressEvent( HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( buttonQuit.area() ) ) {
-            if ( Interface::AdventureMap::EventExit() == fheroes2::GameMode::QUIT_GAME ) {
+        if ( HotKeyPressEvent( HotKeyEvent::GLOBAL_APP_QUIT ) || HotKeyPressEvent( HotKeyEvent::DEFAULT_CANCEL ) || le.MouseClickLeft( buttonQuit.area() ) ) {
+            if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                 return fheroes2::GameMode::QUIT_GAME;
             }
         }

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -40,7 +40,6 @@
 #include "game.h" // IWYU pragma: associated
 #include "game_exit.h"
 #include "game_hotkeys.h"
-#include "game_interface.h"
 #include "game_mainmenu_ui.h"
 #include "game_mode.h"
 #include "icn.h"

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -38,6 +38,7 @@
 #include "dialog_selectscenario.h"
 #include "difficulty.h"
 #include "game.h" // IWYU pragma: associated
+#include "game_exit.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
 #include "game_mainmenu_ui.h"
@@ -338,7 +339,7 @@ namespace
 
         while ( true ) {
             if ( !le.HandleEvents( true, true ) ) {
-                if ( Interface::AdventureMap::EventExit() == fheroes2::GameMode::QUIT_GAME ) {
+                if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                     fheroes2::fadeOutDisplay();
 
                     return fheroes2::GameMode::QUIT_GAME;

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -46,6 +46,7 @@
 #include "dialog.h"
 #include "direction.h"
 #include "game_delays.h"
+#include "game_exit.h"
 #include "game_hotkeys.h"
 #include "game_interface.h" // IWYU pragma: associated
 #include "game_io.h"
@@ -1069,7 +1070,7 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isLoadedFromSa
 
     while ( res == fheroes2::GameMode::CANCEL ) {
         if ( !le.HandleEvents( Game::isDelayNeeded( delayTypes ), true ) ) {
-            if ( EventExit() == fheroes2::GameMode::QUIT_GAME ) {
+            if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                 res = fheroes2::GameMode::QUIT_GAME;
 
                 break;
@@ -1106,8 +1107,8 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isLoadedFromSa
             // Hotkeys
             if ( le.isAnyKeyPressed() ) {
                 // Adventure map control
-                if ( HotKeyPressEvent( Game::HotKeyEvent::MAIN_MENU_QUIT ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-                    res = EventExit();
+                if ( HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
+                    res = Game::processExitEvent();
                 }
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::WORLD_END_TURN ) ) {
                     res = EventEndTurn();

--- a/src/fheroes2/gui/interface_base.h
+++ b/src/fheroes2/gui/interface_base.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -122,8 +122,6 @@ namespace Interface
         {
             return _radar;
         }
-
-        static fheroes2::GameMode EventExit();
 
         virtual bool useMouseDragMovement() const
         {

--- a/src/fheroes2/gui/interface_base.h
+++ b/src/fheroes2/gui/interface_base.h
@@ -22,7 +22,6 @@
 
 #include <cstdint>
 
-#include "game_mode.h"
 #include "interface_gamearea.h"
 #include "interface_radar.h"
 #include "math_base.h"

--- a/src/fheroes2/gui/interface_events.cpp
+++ b/src/fheroes2/gui/interface_events.cpp
@@ -299,20 +299,6 @@ void Interface::AdventureMap::EventSystemDialog() const
     fheroes2::showSystemOptionsDialog();
 }
 
-fheroes2::GameMode Interface::BaseInterface::EventExit()
-{
-#if defined( __IPHONEOS__ )
-    // iOS discourages to exit a running application.
-    fheroes2::showStandardTextMessage( _( "Quit" ), _( "To exit fheroes2, press the Home button or swipe up." ), Dialog::OK );
-#else
-    if ( Dialog::YES & fheroes2::showStandardTextMessage( _( "Quit" ), _( "Are you sure you want to quit?" ), Dialog::YES | Dialog::NO ) ) {
-        return fheroes2::GameMode::QUIT_GAME;
-    }
-#endif
-
-    return fheroes2::GameMode::CANCEL;
-}
-
 void Interface::AdventureMap::EventNextTown()
 {
     Kingdom & myKingdom = world.GetKingdom( Settings::Get().CurrentColor() );


### PR DESCRIPTION
- move application exiting windows out of Interface. It wasn't the correct place for it.
- rename hotkey to be a global key and move it to an appropriate hotkey group
- add application exiting logic for Main Menu in the Editor

relates to #3042