### PR TITLE
Add a popup dialog to confirm unsaved changes for hero in the Editor

### DIFF
--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -636,6 +636,9 @@ void Heroes::applyHeroMetadata( const Maps::Map_Format::HeroMetadata & heroMetad
         // Clear the initial spells and a possible spellBook.
         SpellBookDeactivate();
 
+        // Make sure that the Artifact Bag is empty.
+        GetBagArtifacts() = {};
+
         const size_t artifactCount = heroMetadata.artifact.size();
         assert( artifactCount == 14 );
         for ( size_t i = 0; i < artifactCount; ++i ) {

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -809,15 +809,13 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
             knowledge = -1;
         }
 
-        if ( isEditor ) {
-            assert( initialHeroMetadata.get() != nullptr );
+        assert( initialHeroMetadata.get() != nullptr );
 
-            const auto currentMetadata = getHeroMetadata();
-            if ( currentMetadata != *initialHeroMetadata ) {
-                if ( fheroes2::showStandardTextMessage( GetName(), _( "You have unsaved changes. Do you want to save them?" ), Dialog::YES | Dialog::NO )
-                     == Dialog::NO ) {
-                    applyHeroMetadata( *initialHeroMetadata, Modes( JAIL ), true );
-                }
+        const auto currentMetadata = getHeroMetadata();
+        if ( currentMetadata != *initialHeroMetadata ) {
+            if ( fheroes2::showStandardTextMessage( GetName(), _( "You have unsaved changes. Do you want to save them?" ), Dialog::YES | Dialog::NO )
+                 == Dialog::NO ) {
+                applyHeroMetadata( *initialHeroMetadata, Modes( JAIL ), true );
             }
         }
     }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -813,8 +813,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
         const auto currentMetadata = getHeroMetadata();
         if ( currentMetadata != *initialHeroMetadata ) {
-            if ( fheroes2::showStandardTextMessage( GetName(), _( "You have unsaved changes. Do you want to save them?" ), Dialog::YES | Dialog::NO )
-                 == Dialog::NO ) {
+            if ( fheroes2::showStandardTextMessage( GetName(), _( "You have unsaved changes. Do you want to save them?" ), Dialog::YES | Dialog::NO ) == Dialog::NO ) {
                 applyHeroMetadata( *initialHeroMetadata, Modes( JAIL ), true );
             }
         }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -813,7 +813,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
         const auto currentMetadata = getHeroMetadata();
         if ( currentMetadata != *initialHeroMetadata ) {
-            if ( fheroes2::showStandardTextMessage( GetName(), _( "You have unsaved changes. Do you want to save them?" ), Dialog::YES | Dialog::NO ) == Dialog::NO ) {
+            if ( fheroes2::showStandardTextMessage( GetName(), _( "Do you want to save the changes made?" ), Dialog::YES | Dialog::NO ) == Dialog::NO ) {
                 applyHeroMetadata( *initialHeroMetadata, Modes( JAIL ), true );
             }
         }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -86,6 +86,11 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     std::unique_ptr<fheroes2::StandardWindow> background;
     std::unique_ptr<fheroes2::ImageRestorer> restorer;
 
+    std::unique_ptr<Maps::Map_Format::HeroMetadata> initialHeroMetadata;
+    if ( isEditor ) {
+        initialHeroMetadata = std::make_unique<Maps::Map_Format::HeroMetadata>( getHeroMetadata() );
+    }
+
     if ( renderBackgroundDialog ) {
         background = std::make_unique<fheroes2::StandardWindow>( fheroes2::Display::DEFAULT_WIDTH, fheroes2::Display::DEFAULT_HEIGHT, false );
         dialogRoi = background->activeArea();
@@ -785,9 +790,6 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
     buttonExit.drawOnPress();
 
-    // Fade-out hero dialog.
-    fheroes2::fadeOutDisplay( dialogRoi, !isDefaultScreenSize );
-
     if ( isEditor ) {
         if ( useDefaultExperience ) {
             // Tell Editor that default experience value is set.
@@ -806,7 +808,22 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
             power = -1;
             knowledge = -1;
         }
+
+        if ( isEditor ) {
+            assert( initialHeroMetadata.get() != nullptr );
+
+            const auto currentMetadata = getHeroMetadata();
+            if ( currentMetadata != *initialHeroMetadata ) {
+                if ( fheroes2::showStandardTextMessage( GetName(), _( "You have unsaved changes. Do you want to save them?" ), Dialog::YES | Dialog::NO ) ==
+                    Dialog::NO ) {
+                    applyHeroMetadata( *initialHeroMetadata, Modes( JAIL ), true );
+                }
+            }
+        }
     }
+
+    // Fade-out hero dialog.
+    fheroes2::fadeOutDisplay( dialogRoi, !isDefaultScreenSize );
 
     return Dialog::CANCEL;
 }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -814,8 +814,8 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
             const auto currentMetadata = getHeroMetadata();
             if ( currentMetadata != *initialHeroMetadata ) {
-                if ( fheroes2::showStandardTextMessage( GetName(), _( "You have unsaved changes. Do you want to save them?" ), Dialog::YES | Dialog::NO ) ==
-                    Dialog::NO ) {
+                if ( fheroes2::showStandardTextMessage( GetName(), _( "You have unsaved changes. Do you want to save them?" ), Dialog::YES | Dialog::NO )
+                     == Dialog::NO ) {
                     applyHeroMetadata( *initialHeroMetadata, Modes( JAIL ), true );
                 }
             }


### PR DESCRIPTION
To make it clear whether a map maker wants to save them or ignore if they were made by mistake.

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/af5b52b5-a04d-4924-ae3c-613992e089f0" />
