### PR TITLE
Fix castle entrance road update on placing/erasing a castle and speed-up road updating

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -469,11 +469,8 @@ namespace
                     world.getTile( static_cast<int32_t>( mapTileIndex ) ).updateRoadFlag();
 
                     // There could be a road in front of the castle entrance.
-                    const size_t bottomTileIndex = mapTileIndex + mapFormat.width;
-                    assert( bottomTileIndex < mapFormat.tiles.size() );
-                    if ( Maps::doesContainRoad( mapFormat.tiles[bottomTileIndex] ) ) {
-                        Maps::setRoadOnTile( mapFormat, static_cast<int32_t>( bottomTileIndex ) );
-                    }
+                    const int32_t bottomTileIndex = static_cast<int32_t>( mapTileIndex ) + mapFormat.width;
+                    Maps::updateRoadOnTile( mapFormat, bottomTileIndex );
 
                     needRedraw = true;
                     updateMapPlayerInformation = true;
@@ -2743,6 +2740,16 @@ namespace Interface
                 world.CaptureObject( destinationTile, capturableObjectIter->second.ownerColor );
             }
 
+            if (movableObjectInfo.groupType == Maps::ObjectGroup::KINGDOM_TOWNS) {
+                // Update the castle entrance road.
+
+                const int32_t previousEntranceIndex = movableObjectInfo.tileIndex + _mapFormat.width;
+                Maps::updateRoadOnTile( _mapFormat, previousEntranceIndex );
+
+                const int32_t newEntranceIndex = destinationTile + _mapFormat.width;
+                Maps::updateRoadOnTile( _mapFormat, newEntranceIndex );
+            }
+
             action->commit();
         }
 
@@ -2987,9 +2994,9 @@ namespace Interface
 
         const int32_t bottomIndex = Maps::GetDirectionIndex( tile.GetIndex(), Direction::BOTTOM );
 
-        if ( Maps::isValidAbsIndex( bottomIndex ) && Maps::doesContainRoad( _mapFormat.tiles[bottomIndex] ) ) {
-            // Update road if there is one in front of the town/castle entrance.
-            Maps::setRoadOnTile( _mapFormat, bottomIndex );
+        if ( Maps::isValidAbsIndex( bottomIndex ) ) {
+            // Update road in front of the town/castle entrance.
+            Maps::updateRoadOnTile( _mapFormat, bottomIndex );
         }
 
         // By default use random (default) army for the neutral race town/castle.

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -2740,7 +2740,7 @@ namespace Interface
                 world.CaptureObject( destinationTile, capturableObjectIter->second.ownerColor );
             }
 
-            if (movableObjectInfo.groupType == Maps::ObjectGroup::KINGDOM_TOWNS) {
+            if ( movableObjectInfo.groupType == Maps::ObjectGroup::KINGDOM_TOWNS ) {
                 // Update the castle entrance road.
 
                 const int32_t previousEntranceIndex = movableObjectInfo.tileIndex + _mapFormat.width;

--- a/src/fheroes2/maps/map_format_helper.cpp
+++ b/src/fheroes2/maps/map_format_helper.cpp
@@ -902,57 +902,10 @@ namespace
         return true;
     }
 
-    bool updateRoadObjectOnTile( Maps::Map_Format::MapFormat & map, const int32_t tileIndex )
-    {
-        assert( static_cast<size_t>( tileIndex ) < map.tiles.size() );
-
-        auto & tile = map.tiles[tileIndex];
-
-        auto iter = std::find_if( tile.objects.begin(), tile.objects.end(), []( const auto & object ) { return object.group == Maps::ObjectGroup::ROADS; } );
-
-        if ( iter == tile.objects.end() ) {
-            return false;
-        }
-
-        const int roadObjectIndex = getRoadObjectIndex( map, tileIndex );
-
-        if ( iter->index == static_cast<uint32_t>( roadObjectIndex ) ) {
-            // Nothing to update here.
-            return false;
-        }
-
-        Maps::removeObjectFromMapByUID( tileIndex, iter->id );
-
-        // To replace the road on the `world` map we temporarily change the last object UID to the UID previous to the current road UID.
-        const uint32_t lastUid = Maps::getLastObjectUID();
-        Maps::setLastObjectUID( iter->id - 1 );
-
-        const auto & objectInfo = Maps::getObjectInfo( Maps::ObjectGroup::ROADS, roadObjectIndex );
-        if ( !setObjectOnTile( world.getTile( tileIndex ), objectInfo, false ) ) {
-            assert( 0 );
-            return false;
-        }
-
-        assert( Maps::getLastObjectUID() == iter->id );
-
-        // Restore the last object UID.
-        Maps::setLastObjectUID( lastUid );
-
-        // Just update the road direction index.
-        iter->index = static_cast<uint32_t>( roadObjectIndex );
-
-        return true;
-    }
-
     void updateRoadObjectsInAreaAround( Maps::Map_Format::MapFormat & map, const int32_t centerTileIndex, const int32_t centerToRectBorderDistance )
     {
         for ( const int32_t index : Maps::getAroundIndexes( centerTileIndex, centerToRectBorderDistance ) ) {
-            const auto & tile = map.tiles[index];
-            if ( !Maps::doesContainRoad( tile ) ) {
-                continue;
-            }
-
-            updateRoadObjectOnTile( map, index );
+            Maps::updateRoadOnTile( map, index );
         }
     }
 
@@ -1875,7 +1828,7 @@ namespace Maps
 
         auto & tile = map.tiles[tileIndex];
 
-        auto iter = std::find_if( tile.objects.cbegin(), tile.objects.cend(), []( const auto & object ) { return object.group == Maps::ObjectGroup::ROADS; } );
+        const auto iter = std::find_if( tile.objects.cbegin(), tile.objects.cend(), []( const auto & object ) { return object.group == Maps::ObjectGroup::ROADS; } );
 
         if ( iter == tile.objects.cend() ) {
             // Nothing to do here.
@@ -1891,15 +1844,54 @@ namespace Maps
         return true;
     }
 
+    bool updateRoadOnTile( Map_Format::MapFormat & map, const int32_t tileIndex )
+    {
+        assert( static_cast<size_t>( tileIndex ) < map.tiles.size() );
+
+        auto & tile = map.tiles[tileIndex];
+
+        const auto iter = std::find_if( tile.objects.begin(), tile.objects.end(), []( const auto & object ) { return object.group == Maps::ObjectGroup::ROADS; } );
+
+        if ( iter == tile.objects.end() ) {
+            // Nothing to do here.
+            return false;
+        }
+
+        const int roadObjectIndex = getRoadObjectIndex( map, tileIndex );
+
+        if ( iter->index == static_cast<uint32_t>( roadObjectIndex ) ) {
+            // Nothing to update here.
+            return false;
+        }
+
+        removeObjectFromMapByUID( tileIndex, iter->id );
+
+        // To replace the road on the `world` map we temporarily change the last object UID to the UID previous to the current road UID.
+        const uint32_t lastUid = Maps::getLastObjectUID();
+        setLastObjectUID( iter->id - 1 );
+
+        const auto & objectInfo = Maps::getObjectInfo( Maps::ObjectGroup::ROADS, roadObjectIndex );
+        if ( !setObjectOnTile( world.getTile( tileIndex ), objectInfo, false ) ) {
+            assert( 0 );
+            return false;
+        }
+
+        assert( Maps::getLastObjectUID() == iter->id );
+
+        // Restore the last object UID.
+        setLastObjectUID( lastUid );
+
+        // Just update the road direction index.
+        iter->index = static_cast<uint32_t>( roadObjectIndex );
+
+        return true;
+    }
+
     void updateAllRoads( Map_Format::MapFormat & map )
     {
         const int32_t size = map.width * map.width;
         for ( int32_t index = 0; index < size; ++index ) {
-            if ( !Maps::doesContainRoad( map.tiles[index] ) ) {
-                continue;
-            }
-
-            updateRoadObjectOnTile( map, index );
+            updateRoadOnTile( map, index );
         }
     }
 

--- a/src/fheroes2/maps/map_format_helper.h
+++ b/src/fheroes2/maps/map_format_helper.h
@@ -108,6 +108,9 @@ namespace Maps
     bool setRoadOnTile( Map_Format::MapFormat & map, const int32_t tileIndex );
     bool removeRoadFromTile( Map_Format::MapFormat & map, const int32_t tileIndex );
 
+    // Update road object on tile, if there is one, according to around tile objects.
+    bool updateRoadOnTile( Map_Format::MapFormat & map, const int32_t tileIndex );
+
     void updateAllRoads( Map_Format::MapFormat & map );
 
     bool doesContainRoad( const Map_Format::TileInfo & tile );


### PR DESCRIPTION
This PR moves the `updateRoadObjectOnTile()` function from anonymous namespace to `Maps::updateRoadOnTile()` to properly update road in front of castle entrance when placing/erasing a castle.

Also a redundaqnt `Maps::doesContainRoad()` check is removed before calling `Maps::updateRoadOnTile()` because this check is performed in this function.
`assert( bottomTileIndex < mapFormat.tiles.size() );` checks are also removed because they are performed in `Maps::updateRoadOnTile()`.