### PR TITLE
Reduce resources usage for Object update actions in the Editor

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1951,7 +1951,7 @@ namespace Interface
                     hero.OpenDialog( false, false, true, true, true, true, _mapFormat.mainLanguage );
                     Maps::Map_Format::HeroMetadata heroNewMetadata = hero.getHeroMetadata();
                     if ( heroNewMetadata != _mapFormat.heroMetadata[object.id] ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::HERO_METADATA );
                         _mapFormat.heroMetadata[object.id] = std::move( heroNewMetadata );
                         action.commit();
                     }
@@ -1966,7 +1966,7 @@ namespace Interface
                     Maps::Map_Format::CastleMetadata newCastleMetadata = castleMetadata;
 
                     if ( Editor::castleDetailsDialog( newCastleMetadata, race, color, _mapFormat.mainLanguage ) && ( castleMetadata != newCastleMetadata ) ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::CASTLE_METADATA );
                         castleMetadata = std::move( newCastleMetadata );
                         action.commit();
                     }
@@ -1981,7 +1981,7 @@ namespace Interface
                     const fheroes2::Text body{ std::move( header ), fheroes2::FontType::normalWhite() };
                     if ( Dialog::inputString( fheroes2::Text{}, body, signText, Maps::Map_Format::messageCharLimit, true, _mapFormat.mainLanguage )
                          && originalMessage != signText ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::SIGN_METADATA );
                         originalMessage = std::move( signText );
                         action.commit();
                     }
@@ -1994,7 +1994,7 @@ namespace Interface
 
                     if ( Editor::eventDetailsDialog( newEventData, _mapFormat.humanPlayerColors, _mapFormat.computerPlayerColors, _mapFormat.mainLanguage )
                          && newEventData != eventMetadata ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::ADVENTURE_MAP_EVENT_METADATA );
                         eventMetadata = std::move( newEventData );
                         action.commit();
                     }
@@ -2027,7 +2027,7 @@ namespace Interface
 
                     if ( Dialog::SelectCount( std::move( str ), 0, 500000, monsterCount, 1, monsterUi.get(), selectionUi.get() )
                          && ( _mapFormat.monsterMetadata[object.id].count != monsterCount || ( selectionUi && selectedMonsters != selectionUi->getSelected() ) ) ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::MONSTER_METADATA );
                         _mapFormat.monsterMetadata[object.id].count = monsterCount;
 
                         if ( selectionUi ) {
@@ -2062,7 +2062,7 @@ namespace Interface
 
                     // We cannot support more than 6 digits in the dialog due to its UI element size.
                     if ( Dialog::SelectCount( std::move( str ), 0, 999999, resourceCount, 1, &resourceUI ) && resourceMetadata->second.count != resourceCount ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::RESOURCE_METADATA );
                         resourceMetadata->second.count = resourceCount;
                         action.commit();
                     }
@@ -2075,7 +2075,7 @@ namespace Interface
                         int32_t radius = originalRadius;
 
                         if ( Dialog::SelectCount( _( "Set Random Ultimate Artifact Radius:" ), 0, 100, radius ) && radius != originalRadius ) {
-                            fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                            fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::ARTIFACT_METADATA );
                             originalRadius = radius;
                             action.commit();
                         }
@@ -2095,7 +2095,7 @@ namespace Interface
                             return;
                         }
 
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::ARTIFACT_METADATA );
 
                         // As of now only one spell can be selected for Spell Scroll.
                         selected.clear();
@@ -2144,7 +2144,7 @@ namespace Interface
 
                         Dialog::multiSelectArtifact( allowed, temp );
                         if ( temp != selected ) {
-                            fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                            fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::ARTIFACT_METADATA );
                             selected = std::move( temp );
                             action.commit();
                         }
@@ -2165,7 +2165,7 @@ namespace Interface
                     Maps::Map_Format::SphinxMetadata newMetadata = originalMetadata;
 
                     if ( Editor::openSphinxWindow( newMetadata, _mapFormat.mainLanguage ) && newMetadata != originalMetadata ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::SPHINX_METADATA );
                         originalMetadata = std::move( newMetadata );
                         action.commit();
                     }
@@ -2196,7 +2196,7 @@ namespace Interface
                     std::string const title = std::string( MP2::StringObject( objectType ) ) + ':';
                     if ( Editor::openSpellSelectionWindow( title, spellLevel, newMetadata.selectedItems, false, 1, false )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::SELECTION_METADATA );
                         originalMetadata = std::move( newMetadata );
                         action.commit();
                     }
@@ -2229,7 +2229,7 @@ namespace Interface
                     std::string const title = std::string( MP2::StringObject( objectType ) ) + ':';
                     if ( Editor::openSpellSelectionWindow( title, spellLevel, newMetadata.selectedItems, false, 1, false )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::SELECTION_METADATA );
                         originalMetadata = std::move( newMetadata );
                         action.commit();
                     }
@@ -2253,7 +2253,7 @@ namespace Interface
                     const PlayerColor newColor = Dialog::selectPlayerColor( ownerColor, _mapFormat.availablePlayerColors );
 
                     if ( newColor != ownerColor ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::CAPTURABLE_OBJECT_METADATA );
 
                         if ( newColor == PlayerColor::NONE ) {
                             _mapFormat.capturableObjectsMetadata.erase( object.id );

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -2212,7 +2212,7 @@ namespace Interface
                     std::string const title = std::string( MP2::StringObject( objectType ) ) + ':';
                     if ( Editor::openSecondarySkillSelectionWindow( title, 1, newMetadata.selectedItems )
                          && originalMetadata.selectedItems != newMetadata.selectedItems ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::SELECTION_METADATA );
                         originalMetadata = std::move( newMetadata );
                         action.commit();
                     }

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -935,7 +935,7 @@ namespace
             return false;
         }
 
-        void getConditionMetadata( Maps::Map_Format::MapFormat & mapFormat ) const
+        void getConditionMetadata( Maps::Map_Format::BaseMapFormat & mapFormat ) const
         {
             assert( mapFormat.victoryConditionType == _conditionType );
 
@@ -1619,7 +1619,7 @@ namespace
             return false;
         }
 
-        void getConditionMetadata( Maps::Map_Format::MapFormat & mapFormat ) const
+        void getConditionMetadata( Maps::Map_Format::BaseMapFormat & mapFormat ) const
         {
             assert( _conditionType == mapFormat.lossConditionType );
 
@@ -1953,7 +1953,7 @@ namespace
         return selectedCondition;
     }
 
-    uint32_t getPlayerIcnIndex( const Maps::Map_Format::MapFormat & mapFormat, const PlayerColor currentColor )
+    uint32_t getPlayerIcnIndex( const Maps::Map_Format::BaseMapFormat & mapFormat, const PlayerColor currentColor )
     {
         if ( !( mapFormat.availablePlayerColors & currentColor ) ) {
             // This player is not available.

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -22,6 +22,7 @@
 
 #include <cassert>
 #include <cstdint>
+#include <map>
 
 #include "map_format_helper.h"
 #include "map_format_info.h"

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -129,7 +129,7 @@ namespace
             : _metadata( metadata )
             , _beforeMetadata( metadata )
         {
-           // Do nothing.
+            // Do nothing.
         }
 
         bool prepare() override

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2025                                             *
+ *   Copyright (C) 2023 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -30,13 +30,27 @@
 
 namespace
 {
+    class BaseMapAction : public fheroes2::Action
+    {
+    public:
+        BaseMapAction() = default;
+
+        ~BaseMapAction() override = default;
+
+        // Disable the copy and move (implicitly) constructors and assignment operators.
+        BaseMapAction( const BaseMapAction & ) = delete;
+        BaseMapAction & operator=( const BaseMapAction & ) = delete;
+
+        virtual bool prepare() = 0;
+    };
+
     // This class holds 2 copies of MapFormat objects in a compressed format:
     // - one copy before the action
     // - one copy after the action
-    class MapAction final : public fheroes2::Action
+    class GenericMapAction final : public BaseMapAction
     {
     public:
-        explicit MapAction( Maps::Map_Format::MapFormat & mapFormat )
+        explicit GenericMapAction( Maps::Map_Format::MapFormat & mapFormat )
             : _mapFormat( mapFormat )
             , _latestObjectUIDBefore( Maps::getLastObjectUID() )
         {
@@ -45,12 +59,7 @@ namespace
             }
         }
 
-        // Disable the copy and move (implicitly) constructors and assignment operators.
-        MapAction( const MapAction & ) = delete;
-        MapAction & operator=( const MapAction & ) = delete;
-        ~MapAction() override = default;
-
-        bool prepare()
+        bool prepare() override
         {
             if ( !Maps::Map_Format::saveMap( _afterMapFormat, _mapFormat ) ) {
                 assert( 0 );
@@ -111,19 +120,93 @@ namespace
         const uint32_t _latestObjectUIDBefore{ 0 };
         uint32_t _latestObjectUIDAfter{ 0 };
     };
+
+    template <typename T>
+    class MetadataMapAction : public BaseMapAction
+    {
+    public:
+        explicit MetadataMapAction( std::map<uint32_t, T> & metadata )
+            : _metadata( metadata )
+            , _beforeMetadata( metadata )
+        {
+           // Do nothing.
+        }
+
+        bool prepare() override
+        {
+            _afterMetadata = _metadata;
+            return true;
+        }
+
+        bool redo() override
+        {
+            _metadata = _afterMetadata;
+            return true;
+        }
+
+        bool undo() override
+        {
+            _metadata = _beforeMetadata;
+            return true;
+        }
+
+    private:
+        std::map<uint32_t, T> & _metadata;
+
+        const std::map<uint32_t, T> _beforeMetadata;
+        std::map<uint32_t, T> _afterMetadata;
+    };
 }
 
 namespace fheroes2
 {
-    ActionCreator::ActionCreator( HistoryManager & manager, Maps::Map_Format::MapFormat & mapFormat )
+    ActionCreator::ActionCreator( HistoryManager & manager, Maps::Map_Format::MapFormat & mapFormat, const ActionType type )
         : _manager( manager )
     {
-        _action = std::make_unique<MapAction>( mapFormat );
+        switch ( type ) {
+        case ActionType::GENERIC:
+            _action = std::make_unique<GenericMapAction>( mapFormat );
+            break;
+        case ActionType::HERO_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::HeroMetadata>>( mapFormat.heroMetadata );
+            break;
+        case ActionType::CASTLE_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::CastleMetadata>>( mapFormat.castleMetadata );
+            break;
+        case ActionType::SPHINX_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::SphinxMetadata>>( mapFormat.sphinxMetadata );
+            break;
+        case ActionType::SIGN_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::SignMetadata>>( mapFormat.signMetadata );
+            break;
+        case ActionType::ADVENTURE_MAP_EVENT_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::AdventureMapEventMetadata>>( mapFormat.adventureMapEventMetadata );
+            break;
+        case ActionType::SELECTION_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::SelectionObjectMetadata>>( mapFormat.selectionObjectMetadata );
+            break;
+        case ActionType::CAPTURABLE_OBJECT_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::CapturableObjectMetadata>>( mapFormat.capturableObjectsMetadata );
+            break;
+        case ActionType::MONSTER_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::MonsterMetadata>>( mapFormat.monsterMetadata );
+            break;
+        case ActionType::ARTIFACT_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::ArtifactMetadata>>( mapFormat.artifactMetadata );
+            break;
+        case ActionType::RESOURCE_METADATA:
+            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::ResourceMetadata>>( mapFormat.resourceMetadata );
+            break;
+        default:
+            // Did you add a new action type? Add the missing logic!
+            assert( 0 );
+            break;
+        }
     }
 
     void ActionCreator::commit()
     {
-        auto * action = dynamic_cast<MapAction *>( _action.get() );
+        auto * action = dynamic_cast<BaseMapAction *>( _action.get() );
         if ( action == nullptr ) {
             // How is it even possible? Did you call this method twice?
             assert( 0 );

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -23,6 +23,7 @@
 #include <algorithm>
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <deque>
 #include <functional>
 #include <memory>

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2025                                             *
+ *   Copyright (C) 2023 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -37,6 +37,7 @@ namespace fheroes2
 {
     class HistoryManager;
 
+    // A generic action class with basic functionality.
     class Action
     {
     public:
@@ -48,10 +49,28 @@ namespace fheroes2
     };
 
     // Remember the map state and create an action if the map has changed.
-    class ActionCreator
+    class ActionCreator final
     {
     public:
-        explicit ActionCreator( HistoryManager & manager, Maps::Map_Format::MapFormat & mapFormat );
+        enum class ActionType : uint8_t
+        {
+            // A generic map action type. It covers every possible map change scenario but it is the most resource demanding operation.
+            // Use it when you aren't sure what changes are done or the changes are too complex.
+            GENERIC,
+            // Metadata update for a single object type.
+            HERO_METADATA,
+            CASTLE_METADATA,
+            SPHINX_METADATA,
+            SIGN_METADATA,
+            ADVENTURE_MAP_EVENT_METADATA,
+            SELECTION_METADATA,
+            CAPTURABLE_OBJECT_METADATA,
+            MONSTER_METADATA,
+            ARTIFACT_METADATA,
+            RESOURCE_METADATA,
+        };
+
+        explicit ActionCreator( HistoryManager & manager, Maps::Map_Format::MapFormat & mapFormat, const ActionType type = ActionType::GENERIC );
 
         ~ActionCreator()
         {
@@ -73,7 +92,8 @@ namespace fheroes2
         std::unique_ptr<Action> _action;
     };
 
-    class HistoryManager
+    // Action history manager that stores and handles actions done in the past.
+    class HistoryManager final
     {
     public:
         void setStateCallback( std::function<void( const bool, const bool )> stateCallback )


### PR DESCRIPTION
Add new type of Action for History Manager - MetadataMapAction . This action stores only metadata information for a particular type of objects. Having this class allows up to utilize much less memory and CPU.

It is very noticeable when you try to edit any objects in a debug version of the engine.