### PR TITLE
Sort maps alphabetically by file name in the Editor

### DIFF
--- a/src/fheroes2/editor/editor_mainmenu.cpp
+++ b/src/fheroes2/editor/editor_mainmenu.cpp
@@ -389,7 +389,7 @@ namespace Editor
 
         fheroes2::validateFadeInAndRender();
 
-        MapsFileInfoList lists = Maps::getResurrectionMapFileInfos( true, 0 );
+        MapsFileInfoList lists = Maps::getEditorMapFileInfos();
         if ( lists.empty() ) {
             fheroes2::showStandardTextMessage( _( "Warning" ), _( "No maps available!" ), Dialog::OK );
             return fheroes2::GameMode::EDITOR_MAIN_MENU;

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -182,7 +182,7 @@ namespace Editor
     {
         const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-        MapsFileInfoList lists = Maps::getResurrectionMapFileInfos( true, 0 );
+        MapsFileInfoList lists = Maps::getEditorMapFileInfos();
 
         const int32_t listWidth = maxFileNameWidth + 9;
         const int32_t listHeightDeduction = 112 + 17;

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -508,7 +508,7 @@ fheroes2::GameMode Game::SelectScenario( const uint8_t humanPlayerCount )
 
     AudioManager::PlayMusicAsync( MUS::MAINMENU, Music::PlaybackMode::RESUME_AND_PLAY_INFINITE );
 
-    MapsFileInfoList maps = Maps::getAllMapFileInfos( false, humanPlayerCount );
+    MapsFileInfoList maps = Maps::getAllMapFileInfos( humanPlayerCount );
     if ( maps.empty() ) {
         fheroes2::showStandardTextMessage( _( "Warning" ), _( "No maps available!" ), Dialog::OK );
         return fheroes2::GameMode::MAIN_MENU;

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -779,7 +779,7 @@ MapsFileInfoList Maps::getEditorMapFileInfos()
             continue;
         }
 
-        sortedMaps.emplace( System::GetFileName( mapFile ), std::move( fi ) );
+        sortedMaps.emplace( StringLower( System::GetFileName( mapFile ) ), std::move( fi ) );
     }
 
     if ( sortedMaps.empty() ) {

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -736,7 +736,7 @@ IStreamBase & Maps::operator>>( IStreamBase & stream, FileInfo & fi )
     return stream;
 }
 
-MapsFileInfoList Maps::getAllMapFileInfos( const bool isForEditor, const uint8_t humanPlayerCount )
+MapsFileInfoList Maps::getAllMapFileInfos( const uint8_t humanPlayerCount )
 {
     ListFiles maps = Settings::FindFiles( "maps", ".mp2", false );
 
@@ -746,11 +746,11 @@ MapsFileInfoList Maps::getAllMapFileInfos( const bool isForEditor, const uint8_t
         maps.Append( Settings::FindFiles( "maps", ".mx2", false ) );
     }
 
-    MapsFileInfoList validMaps = getValidMaps( maps, humanPlayerCount, isForEditor, true );
+    MapsFileInfoList validMaps = getValidMaps( maps, humanPlayerCount, false, true );
 
     if ( isPOLSupported ) {
         const ListFiles resurrectionMaps = Settings::FindFiles( "maps", ".fh2m", false );
-        MapsFileInfoList validResurrectionMaps = getValidMaps( resurrectionMaps, humanPlayerCount, isForEditor, false );
+        MapsFileInfoList validResurrectionMaps = getValidMaps( resurrectionMaps, humanPlayerCount, false, false );
 
         validMaps.reserve( maps.size() + resurrectionMaps.size() );
 
@@ -759,17 +759,12 @@ MapsFileInfoList Maps::getAllMapFileInfos( const bool isForEditor, const uint8_t
         }
     }
 
-    if ( isForEditor ) {
-        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByFileName{} );
-    }
-    else {
-        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByMapName{} );
-    }
+    std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByMapName{} );
 
     return validMaps;
 }
 
-MapsFileInfoList Maps::getResurrectionMapFileInfos( const bool isForEditor, const uint8_t humanPlayerCount )
+MapsFileInfoList Maps::getEditorMapFileInfos()
 {
     if ( !Settings::Get().isPriceOfLoyaltySupported() ) {
         // Resurrection maps require POL resources presence.
@@ -777,16 +772,33 @@ MapsFileInfoList Maps::getResurrectionMapFileInfos( const bool isForEditor, cons
     }
 
     const ListFiles maps = Settings::FindFiles( "maps", ".fh2m", false );
-    MapsFileInfoList validMaps = getValidMaps( maps, humanPlayerCount, isForEditor, false );
-
-    if ( isForEditor ) {
-        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByFileName{} );
-    }
-    else {
-        std::sort( validMaps.begin(), validMaps.end(), Maps::FileInfo::CompareByMapName{} );
+    if ( maps.empty() ) {
+        // No files exist.
+        return {};
     }
 
-    return validMaps;
+    std::map<std::string, Maps::FileInfo, std::less<>> sortedMaps;
+
+    const auto currentLanguage = fheroes2::getCurrentLanguage();
+
+    for ( const std::string & mapFile : maps ) {
+        Maps::FileInfo fi;
+
+        if ( !fi.readResurrectionMap( mapFile, true, currentLanguage ) ) {
+            continue;
+        }
+
+        sortedMaps.try_emplace( System::GetFileName( mapFile ), std::move( fi ) );
+    }
+
+    MapsFileInfoList result;
+    result.reserve( sortedMaps.size() );
+
+    for ( auto & [name, info] : sortedMaps ) {
+        result.emplace_back( std::move( info ) );
+    }
+
+    return result;
 }
 
 bool Maps::tryGetMatchingFile( const std::string & fileName, std::string & matchingFilePath )

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -110,7 +110,7 @@ namespace
             }
 
             // Update French language-specific characters to match CP1252.
-            if ( fixSpecialFrenchCharacters ) {
+            if ( isOriginalMapFormat && fixSpecialFrenchCharacters ) {
                 fheroes2::fixFrenchCharactersForMP2Map( fi.name );
                 fheroes2::fixFrenchCharactersForMP2Map( fi.description );
             }

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -61,7 +61,7 @@ namespace
     const size_t mapDescriptionLength = 200;
 
     // This function returns an unsorted array. It is a caller responsibility to take care of sorting if needed.
-    MapsFileInfoList getValidMaps( const ListFiles & mapFiles, const uint8_t humanPlayerCount, const bool isForEditor, const bool isOriginalMapFormat )
+    MapsFileInfoList getValidMaps( const ListFiles & mapFiles, const uint8_t humanPlayerCount, const bool isOriginalMapFormat )
     {
         // create a list of unique maps (based on the map file name) and filter it by the preferred number of players
         std::map<std::string, Maps::FileInfo, std::less<>> uniqueMaps;
@@ -80,41 +80,39 @@ namespace
             Maps::FileInfo fi;
 
             if ( isOriginalMapFormat ) {
-                if ( !fi.readMP2Map( mapFile, isForEditor ) ) {
+                if ( !fi.readMP2Map( mapFile, false ) ) {
                     continue;
                 }
             }
             else {
-                if ( !fi.readResurrectionMap( mapFile, isForEditor, currentLanguage ) ) {
+                if ( !fi.readResurrectionMap( mapFile, false, currentLanguage ) ) {
                     continue;
                 }
             }
 
-            if ( !isForEditor ) {
-                assert( humanPlayerCount >= 1 );
+            assert( humanPlayerCount >= 1 );
 
-                const int humanOnlyColorsCount = Color::Count( fi.HumanOnlyColors() );
-                if ( humanOnlyColorsCount > humanPlayerCount ) {
-                    // This map requires more human-only players than needed.
-                    continue;
-                }
+            const int humanOnlyColorsCount = Color::Count( fi.HumanOnlyColors() );
+            if ( humanOnlyColorsCount > humanPlayerCount ) {
+                // This map requires more human-only players than needed.
+                continue;
+            }
 
-                const int computerHumanColorsCount = Color::Count( fi.AllowCompHumanColors() );
-                if ( humanPlayerCount > ( humanOnlyColorsCount + computerHumanColorsCount ) ) {
-                    // This map does not allow to be played by this number of human players.
-                    continue;
-                }
+            const int computerHumanColorsCount = Color::Count( fi.AllowCompHumanColors() );
+            if ( humanPlayerCount > ( humanOnlyColorsCount + computerHumanColorsCount ) ) {
+                // This map does not allow to be played by this number of human players.
+                continue;
+            }
 
-                if ( humanOnlyColorsCount == humanPlayerCount ) {
-                    // The map has the exact number of human-only players. Make sure that the user cannot select any other players.
-                    fi.removeHumanColors( fi.AllowCompHumanColors() );
-                }
+            if ( humanOnlyColorsCount == humanPlayerCount ) {
+                // The map has the exact number of human-only players. Make sure that the user cannot select any other players.
+                fi.removeHumanColors( fi.AllowCompHumanColors() );
+            }
 
-                // Update French language-specific characters to match CP1252.
-                if ( fixSpecialFrenchCharacters ) {
-                    fheroes2::fixFrenchCharactersForMP2Map( fi.name );
-                    fheroes2::fixFrenchCharactersForMP2Map( fi.description );
-                }
+            // Update French language-specific characters to match CP1252.
+            if ( fixSpecialFrenchCharacters ) {
+                fheroes2::fixFrenchCharactersForMP2Map( fi.name );
+                fheroes2::fixFrenchCharactersForMP2Map( fi.description );
             }
 
             uniqueMaps.try_emplace( System::GetFileName( mapFile ), std::move( fi ) );
@@ -746,11 +744,11 @@ MapsFileInfoList Maps::getAllMapFileInfos( const uint8_t humanPlayerCount )
         maps.Append( Settings::FindFiles( "maps", ".mx2", false ) );
     }
 
-    MapsFileInfoList validMaps = getValidMaps( maps, humanPlayerCount, false, true );
+    MapsFileInfoList validMaps = getValidMaps( maps, humanPlayerCount, true );
 
     if ( isPOLSupported ) {
         const ListFiles resurrectionMaps = Settings::FindFiles( "maps", ".fh2m", false );
-        MapsFileInfoList validResurrectionMaps = getValidMaps( resurrectionMaps, humanPlayerCount, false, false );
+        MapsFileInfoList validResurrectionMaps = getValidMaps( resurrectionMaps, humanPlayerCount, false );
 
         validMaps.reserve( maps.size() + resurrectionMaps.size() );
 

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -65,8 +65,8 @@ namespace
     {
         assert( humanPlayerCount >= 1 );
 
-        // create a list of unique maps (based on the map file name) and filter it by the preferred number of players
-        std::map<std::string, Maps::FileInfo, std::less<>> uniqueMaps;
+        MapsFileInfoList result;
+        result.reserve( mapFiles.size() );
 
         const auto currentLanguage = fheroes2::getCurrentLanguage();
 
@@ -115,14 +115,7 @@ namespace
                 fheroes2::fixFrenchCharactersForMP2Map( fi.description );
             }
 
-            uniqueMaps.try_emplace( System::GetFileName( mapFile ), std::move( fi ) );
-        }
-
-        MapsFileInfoList result;
-        result.reserve( uniqueMaps.size() );
-
-        for ( auto & [name, info] : uniqueMaps ) {
-            result.emplace_back( std::move( info ) );
+            result.emplace_back( std::move( fi ) );
         }
 
         return result;

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -778,7 +778,6 @@ MapsFileInfoList Maps::getEditorMapFileInfos()
     }
 
     std::map<std::string, Maps::FileInfo, std::less<>> sortedMaps;
-
     const auto currentLanguage = fheroes2::getCurrentLanguage();
 
     for ( const std::string & mapFile : maps ) {
@@ -789,6 +788,11 @@ MapsFileInfoList Maps::getEditorMapFileInfos()
         }
 
         sortedMaps.try_emplace( System::GetFileName( mapFile ), std::move( fi ) );
+    }
+
+    if ( sortedMaps.empty() ) {
+        // No valid maps.
+        return {};
     }
 
     MapsFileInfoList result;

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -775,7 +775,8 @@ MapsFileInfoList Maps::getEditorMapFileInfos()
         return {};
     }
 
-    std::map<std::string, Maps::FileInfo, std::less<>> sortedMaps;
+    // There could be different file locations but with the same filename.
+    std::multimap<std::string, Maps::FileInfo, std::less<>> sortedMaps;
     const auto currentLanguage = fheroes2::getCurrentLanguage();
 
     for ( const std::string & mapFile : maps ) {
@@ -785,7 +786,7 @@ MapsFileInfoList Maps::getEditorMapFileInfos()
             continue;
         }
 
-        sortedMaps.try_emplace( System::GetFileName( mapFile ), std::move( fi ) );
+        sortedMaps.emplace( System::GetFileName( mapFile ), std::move( fi ) );
     }
 
     if ( sortedMaps.empty() ) {

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -63,6 +63,8 @@ namespace
     // This function returns an unsorted array. It is a caller responsibility to take care of sorting if needed.
     MapsFileInfoList getValidMaps( const ListFiles & mapFiles, const uint8_t humanPlayerCount, const bool isOriginalMapFormat )
     {
+        assert( humanPlayerCount >= 1 );
+
         // create a list of unique maps (based on the map file name) and filter it by the preferred number of players
         std::map<std::string, Maps::FileInfo, std::less<>> uniqueMaps;
 
@@ -89,8 +91,6 @@ namespace
                     continue;
                 }
             }
-
-            assert( humanPlayerCount >= 1 );
 
             const int humanOnlyColorsCount = Color::Count( fi.HumanOnlyColors() );
             if ( humanOnlyColorsCount > humanPlayerCount ) {

--- a/src/fheroes2/maps/maps_fileinfo.h
+++ b/src/fheroes2/maps/maps_fileinfo.h
@@ -274,11 +274,11 @@ using MapsFileInfoList = std::vector<Maps::FileInfo>;
 
 namespace Maps
 {
-    // For all map files.
-    MapsFileInfoList getAllMapFileInfos( const bool isForEditor, const uint8_t humanPlayerCount );
+    // Get all map files.
+    MapsFileInfoList getAllMapFileInfos( const uint8_t humanPlayerCount );
 
-    // Only for RESURRECTION map files.
-    MapsFileInfoList getResurrectionMapFileInfos( const bool isForEditor, const uint8_t humanPlayerCount );
+    // Get all maps available for the Editor.
+    MapsFileInfoList getEditorMapFileInfos();
 
     bool tryGetMatchingFile( const std::string & fileName, std::string & matchingFilePath );
 }


### PR DESCRIPTION
close #10658

- display all maps, even duplicates for both the game and the Editor
- speed up some calculations while loading maps
- sort maps for the Editor by their filename

<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/4743f4d0-0b3f-4490-af38-204140ede9eb" />
