### PR TITLE
Expand detail mode to support multiple brushes

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3324,7 +3324,7 @@ namespace
         }
         case ICN::EDITPANL:
             if ( _icnVsSprite[id].size() == 6 ) {
-                _icnVsSprite[id].resize( 22 );
+                _icnVsSprite[id].resize( 21 );
 
                 // Make empty buttons for object types.
                 _icnVsSprite[id][6]._disableTransformLayer();
@@ -3387,10 +3387,9 @@ namespace
                 Blit( fheroes2::AGG::GetICN( ICN::STREAM, 2 ), 0, 0, _icnVsSprite[id][17], 1, 8, 24, 11 );
 
                 // Make Detail mode images.
-                Blit( fheroes2::AGG::GetICN( ICN::ADVMCO, 0 ), 0, 0, _icnVsSprite[id][18], 6, 6, 15, 21 );
-                Blit( fheroes2::AGG::GetICN( ICN::CMSECO, 5 ), 0, 0, _icnVsSprite[id][19], 8, 4, 11, 18 );
-                Blit( fheroes2::AGG::GetICN( ICN::CMSECO, 2 ), 0, 0, _icnVsSprite[id][20], 3, 1, 21, 24 );
-                Blit( fheroes2::AGG::GetICN( ICN::ADVMCO, 8 ), 0, 0, _icnVsSprite[id][21], 6, 3, 15, 20 );
+                Blit( fheroes2::AGG::GetICN( ICN::CMSECO, 5 ), 0, 0, _icnVsSprite[id][18], 8, 4, 11, 18 );
+                Blit( fheroes2::AGG::GetICN( ICN::CMSECO, 2 ), 0, 0, _icnVsSprite[id][19], 3, 1, 21, 24 );
+                Blit( fheroes2::AGG::GetICN( ICN::ADVMCO, 8 ), 0, 0, _icnVsSprite[id][20], 6, 3, 15, 20 );
             }
             break;
         case ICN::TEXTBAR:

--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -3324,7 +3324,7 @@ namespace
         }
         case ICN::EDITPANL:
             if ( _icnVsSprite[id].size() == 6 ) {
-                _icnVsSprite[id].resize( 18 );
+                _icnVsSprite[id].resize( 22 );
 
                 // Make empty buttons for object types.
                 _icnVsSprite[id][6]._disableTransformLayer();
@@ -3385,6 +3385,12 @@ namespace
 
                 // Make erase Streams button image.
                 Blit( fheroes2::AGG::GetICN( ICN::STREAM, 2 ), 0, 0, _icnVsSprite[id][17], 1, 8, 24, 11 );
+
+                // Make Detail mode images.
+                Blit( fheroes2::AGG::GetICN( ICN::ADVMCO, 0 ), 0, 0, _icnVsSprite[id][18], 6, 6, 15, 21 );
+                Blit( fheroes2::AGG::GetICN( ICN::CMSECO, 5 ), 0, 0, _icnVsSprite[id][19], 8, 4, 11, 18 );
+                Blit( fheroes2::AGG::GetICN( ICN::CMSECO, 2 ), 0, 0, _icnVsSprite[id][20], 3, 1, 21, 24 );
+                Blit( fheroes2::AGG::GetICN( ICN::ADVMCO, 8 ), 0, 0, _icnVsSprite[id][21], 6, 3, 15, 20 );
             }
             break;
         case ICN::TEXTBAR:

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -2829,10 +2829,9 @@ namespace Interface
 
         Maps::Tile & tile = world.getTile( destinationTile );
         if ( _tryToPlaceObject( tile, movableObjectInfo.objectType, movableObjectInfo.groupType, false, action ) ) {
-            assert( action.get() != nullptr );
-
             copyMetadataToObjectClone( movableObjectInfo.objectUID, Maps::getLastObjectUID(), _mapFormat, destinationTile );
 
+            assert( action.get() != nullptr );
             action->commit();
         }
     }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1038,6 +1038,55 @@ namespace
         return true;
     }
 
+    template <typename T>
+    bool copyMetadataIfAvailable( const uint32_t originalObjectUID, const uint32_t newObjectUID, std::map<uint32_t, T> & metadata )
+    {
+        auto iter = metadata.find( originalObjectUID );
+        if ( iter == metadata.end() ) {
+            return false;
+        }
+
+        metadata[newObjectUID] = iter->second;
+        return true;
+    }
+
+    void copyMetadataToObjectClone( const uint32_t originalObjectUID, const uint32_t newObjectUID, Maps::Map_Format::MapFormat & mapFormat, const int32_t tileId )
+    {
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.castleMetadata ) ) {
+            return;
+        }
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.heroMetadata ) ) {
+            return;
+        }
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.sphinxMetadata ) ) {
+            return;
+        }
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.signMetadata ) ) {
+            return;
+        }
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.adventureMapEventMetadata ) ) {
+            return;
+        }
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.selectionObjectMetadata ) ) {
+            return;
+        }
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.capturableObjectsMetadata ) ) {
+            auto iter = mapFormat.capturableObjectsMetadata.find( newObjectUID );
+            if ( iter != mapFormat.capturableObjectsMetadata.end() ) {
+                world.CaptureObject( tileId, iter->second.ownerColor );
+            }
+            return;
+        }
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.monsterMetadata ) ) {
+            return;
+        }
+        if ( copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.artifactMetadata ) ) {
+            return;
+        }
+
+        copyMetadataIfAvailable( originalObjectUID, newObjectUID, mapFormat.resourceMetadata );
+    }
+
 #if defined( WITH_DEBUG )
     int32_t getObjectIndex( const Maps::Map_Format::MapFormat & mapFormat, const uint32_t uid, const Maps::ObjectGroup group )
     {
@@ -2781,6 +2830,9 @@ namespace Interface
         Maps::Tile & tile = world.getTile( destinationTile );
         if ( _tryToPlaceObject( tile, movableObjectInfo.objectType, movableObjectInfo.groupType, false, action ) ) {
             assert( action.get() != nullptr );
+
+            copyMetadataToObjectClone( movableObjectInfo.objectUID, Maps::getLastObjectUID(), _mapFormat, destinationTile );
+
             action->commit();
         }
     }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1230,7 +1230,7 @@ namespace Interface
                     const fheroes2::Point indices = getBrushAreaIndicies( brushSize, _tileUnderCursor );
 
                     assert( Maps::isValidAbsIndex( indices.x ) );
-                    const bool isActionObject = ( _editorPanel.isDetailEdit() && brushSize.width == 1 && brushSize.height == 1
+                    const bool isActionObject = ( _editorPanel.isObjectEditingMode() && brushSize.width == 1 && brushSize.height == 1
                                                   && MP2::isOffGameActionObject( world.getTile( indices.x ).getMainObjectType() ) );
 
                     _gameArea.renderTileAreaSelect( display, indices.x, indices.y, isActionObject );
@@ -1622,7 +1622,7 @@ namespace Interface
                             _brushTiles.clear();
                         }
                     }
-                    else if ( _editorPanel.isDetailEdit() ) {
+                    else if ( _editorPanel.isObjectMovingMode() || _editorPanel.isObjectCopyingMode() ) {
                         if ( le.isMouseLeftButtonPressed() ) {
                             if ( _brushTiles.count( _tileUnderCursor ) == 0 ) {
                                 if ( _brushTiles.empty() ) {
@@ -1645,7 +1645,12 @@ namespace Interface
                         }
                         else {
                             if ( le.isMouseLeftButtonReleased() ) {
-                                _tryToMoveObject( _movableObjectInfo, _tileUnderCursor );
+                                if ( _editorPanel.isObjectMovingMode() ) {
+                                    _tryToMoveObject( _movableObjectInfo, _tileUnderCursor );
+                                }
+                                else {
+                                    _tryToCopyObject( _movableObjectInfo, _tileUnderCursor );
+                                }
                             }
 
                             // Make sure to clear the action related information.
@@ -1916,7 +1921,7 @@ namespace Interface
 
         Maps::Tile & tile = world.getTile( tileIndex );
 
-        if ( _editorPanel.isDetailEdit() ) {
+        if ( _editorPanel.isObjectEditingMode() ) {
             // Trigger an action only when metadata has been changed to avoid expensive computations and bloated list of actions.
             // Comparing a metadata structure is much faster than restoring the whole map.
 
@@ -2754,6 +2759,30 @@ namespace Interface
         }
 
         Maps::setLastObjectUID( originalLastObjectUID );
+    }
+
+    void EditorInterface::_tryToCopyObject( const MovableObjectInfo & movableObjectInfo, const int32_t destinationTile )
+    {
+        assert( movableObjectInfo.tileIndex >= 0 );
+        assert( destinationTile >= 0 );
+
+        if ( movableObjectInfo.groupType == Maps::ObjectGroup::NONE ) {
+            // No object to move.
+            return;
+        }
+
+        if ( movableObjectInfo.tileIndex == destinationTile ) {
+            // Cannot copy to itself.
+            return;
+        }
+
+        auto action = std::make_unique<fheroes2::ActionCreator>( _historyManager, _mapFormat );
+
+        Maps::Tile & tile = world.getTile( destinationTile );
+        if ( _tryToPlaceObject( tile, movableObjectInfo.objectType, movableObjectInfo.groupType, false, action ) ) {
+            assert( action.get() != nullptr );
+            action->commit();
+        }
     }
 
     void EditorInterface::mouseCursorAreaPressRight( const int32_t tileIndex ) const

--- a/src/fheroes2/editor/editor_interface.h
+++ b/src/fheroes2/editor/editor_interface.h
@@ -176,6 +176,8 @@ namespace Interface
 
         void _tryToMoveObject( const MovableObjectInfo & movableObjectInfo, const int32_t destinationTile );
 
+        void _tryToCopyObject( const MovableObjectInfo & movableObjectInfo, const int32_t destinationTile );
+
         void _validateObjectsOnTerrainUpdate();
 
         // Returns true if an existing object was moved on top.

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -993,6 +993,10 @@ namespace Interface
                         _redraw();
                         handleObjectMouseClick( Dialog::selectMonsterType );
                     }
+                    else if ( _selectedInstrument == Instrument::DETAIL ) {
+                        // Reset to Detail Editing mode.
+                        _selectedDetailBrushType = DetailBrushType::EDITING;
+                    }
 
                     setRedraw();
 

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -525,7 +525,7 @@ namespace Interface
                 fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, i + 18 ), 0, 0, display, _detailModeButtonsRect[i] );
             }
 
-            updateObjectTypeSelection( _selectedDetailBrushType, _detailModeButtonsRect, _getDetailModeTypeName,
+            updateObjectTypeSelection( static_cast<int8_t>( _selectedDetailBrushType ), _detailModeButtonsRect, _getDetailModeTypeName,
                                        { _rectInstrumentPanel.x + 7, _rectInstrumentPanel.y + 80 }, display );
         }
         else if ( _selectedInstrument == Instrument::ADVENTURE_OBJECTS ) {
@@ -1140,8 +1140,8 @@ namespace Interface
         }
         else if ( _selectedInstrument == Instrument::DETAIL ) {
             for ( size_t i = 0; i < _detailModeButtonsRect.size(); ++i ) {
-                if ( ( _selectedDetailBrushType != static_cast<int8_t>( i ) ) && le.isMouseLeftButtonPressedInArea( _detailModeButtonsRect[i] ) ) {
-                    _selectedDetailBrushType = static_cast<int8_t>( i );
+                if ( ( _selectedDetailBrushType != static_cast<uint8_t>( i ) ) && le.isMouseLeftButtonPressedInArea( _detailModeButtonsRect[i] ) ) {
+                    _selectedDetailBrushType = static_cast<uint8_t>( i );
 
                     // Reset cursor updater since this UI element was clicked.
                     _setCursor();

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -415,6 +415,12 @@ namespace Interface
                                                offsetY + static_cast<int32_t>( i / 3 ) * buttonStepY, buttonWidth, buttonHeight };
         }
 
+        // Detail mode types.
+        for ( size_t i = 0; i < _detailModeButtonsRect.size(); ++i ) {
+            _detailModeButtonsRect[i] = { offsetX + static_cast<int32_t>( i % 2 ) * 2 * buttonStepX,
+                                          offsetY + static_cast<int32_t>( i / 2 ) * buttonStepY, buttonWidth, buttonHeight };
+        }
+
         // Adventure objects buttons position.
         for ( size_t i = 0; i < _adventureObjectButtonsRect.size(); ++i ) {
             _adventureObjectButtonsRect[i] = { offsetX + static_cast<int32_t>( i % 2 ) * buttonStepX + ( i < 4 ? buttonHalfStepX : ( i < 6 ? 0 : buttonStepX * 2 ) ),
@@ -511,6 +517,15 @@ namespace Interface
             }
 
             updateObjectTypeSelection( _selectedLandscapeObject, _landscapeObjectButtonsRect, _getLandscapeObjectTypeName,
+                                       { _rectInstrumentPanel.x + 7, _rectInstrumentPanel.y + 80 }, display );
+        }
+        else if ( _selectedInstrument == Instrument::DETAIL ) {
+            // Detail mode types.
+            for ( uint32_t i = 0; i < DetailBrushType::DETAIL_MODE_COUNT; ++i ) {
+                fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, i + 18 ), 0, 0, display, _detailModeButtonsRect[i] );
+            }
+
+            updateObjectTypeSelection( _selectedDetailBrushType, _detailModeButtonsRect, _getDetailModeTypeName,
                                        { _rectInstrumentPanel.x + 7, _rectInstrumentPanel.y + 80 }, display );
         }
         else if ( _selectedInstrument == Instrument::ADVENTURE_OBJECTS ) {
@@ -774,6 +789,24 @@ namespace Interface
         }
 
         return getObjectGroupName( _selectedLandscapeObjectGroup[brushId] );
+    }
+
+    const char * EditorPanel::_getDetailModeTypeName( const uint8_t brushId )
+    {
+        switch ( brushId ) {
+        case DetailBrushType::VIEWING:
+            return _( "editorDetailMode|View" );
+        case DetailBrushType::EDITING:
+            return _( "editorDetailMode|Edit" );
+        case DetailBrushType::MOVING:
+            return _( "editorDetailMode|Move" );
+        case DetailBrushType::COPYING:
+            return _( "editorDetailMode|Copy" );
+        default:
+            break;
+        }
+
+        return "Unknown detail mode";
     }
 
     const char * EditorPanel::_getAdventureObjectTypeName( const uint8_t brushId )
@@ -1103,6 +1136,42 @@ namespace Interface
             if ( le.MouseClickLeft( _landscapeObjectButtonsRect[LandscapeObjectBrush::LANDSCAPE_MISC] ) ) {
                 handleObjectMouseClick( Dialog::selectLandscapeMiscellaneousObjectType );
                 return res;
+            }
+        }
+        else if ( _selectedInstrument == Instrument::DETAIL ) {
+            for ( size_t i = 0; i < _detailModeButtonsRect.size(); ++i ) {
+                if ( ( _selectedDetailBrushType != static_cast<int8_t>( i ) ) && le.isMouseLeftButtonPressedInArea( _detailModeButtonsRect[i] ) ) {
+                    _selectedDetailBrushType = static_cast<int8_t>( i );
+
+                    // Reset cursor updater since this UI element was clicked.
+                    _setCursor();
+
+                    setRedraw();
+                    break;
+                }
+            }
+
+            for ( uint8_t brushId = DetailBrushType::VIEWING; brushId < DetailBrushType::DETAIL_MODE_COUNT; ++brushId ) {
+                if ( le.isMouseRightButtonPressedInArea( _detailModeButtonsRect[brushId] ) ) {
+                    switch ( brushId ) {
+                    case DetailBrushType::VIEWING:
+                        fheroes2::showStandardTextMessage( _getDetailModeTypeName( brushId ), _( "View objects on the Adventure Map." ), Dialog::ZERO );
+                        break;
+                    case DetailBrushType::EDITING:
+                        fheroes2::showStandardTextMessage( _getDetailModeTypeName( brushId ), _( "Edit objects on the Adventure Map." ), Dialog::ZERO );
+                        break;
+                    case DetailBrushType::MOVING:
+                        fheroes2::showStandardTextMessage( _getDetailModeTypeName( brushId ), _( "Move objects on the Adventure Map." ), Dialog::ZERO );
+                        break;
+                    case DetailBrushType::COPYING:
+                        fheroes2::showStandardTextMessage( _getDetailModeTypeName( brushId ), _( "Copy objects on the Adventure Map." ), Dialog::ZERO );
+                        break;
+                    default:
+                        assert( 0 );
+                        break;
+                    }
+                    break;
+                }
             }
         }
         else if ( _selectedInstrument == Instrument::ADVENTURE_OBJECTS ) {

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -581,10 +581,6 @@ namespace Interface
                 text.draw( _rectInstrumentPanel.x + 5, _rectInstrumentPanel.y + 95, _rectInstrumentPanel.width - 10, display );
             }
         }
-        else if ( _selectedInstrument == Instrument::DETAIL ) {
-            const fheroes2::Text instrumentName( _( "Click to edit\n\nor\n\nclick and hold to move" ), fheroes2::FontType::normalWhite() );
-            instrumentName.draw( _rectInstrumentPanel.x + 5, _rectInstrumentPanel.y + 8, _rectInstrumentPanel.width - 10, display );
-        }
         else if ( _selectedInstrument == Instrument::ROAD ) {
             const fheroes2::Text instrumentName( getObjectGroupName( Maps::ObjectGroup::ROADS ), fheroes2::FontType::normalWhite() );
             instrumentName.draw( _rectInstrumentPanel.x + ( _rectInstrumentPanel.width - instrumentName.width() ) / 2, _rectInstrumentPanel.y + 8, display );

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -417,8 +417,7 @@ namespace Interface
 
         // Detail mode types.
         for ( size_t i = 0; i < _detailModeButtonsRect.size(); ++i ) {
-            _detailModeButtonsRect[i]
-                = { offsetX + static_cast<int32_t>( i % 2 ) * 2 * buttonStepX, offsetY + static_cast<int32_t>( i / 2 ) * buttonStepY, buttonWidth, buttonHeight };
+            _detailModeButtonsRect[i] = { offsetX + static_cast<int32_t>( i ) * buttonStepX, offsetY, buttonWidth, buttonHeight };
         }
 
         // Adventure objects buttons position.
@@ -526,7 +525,7 @@ namespace Interface
             }
 
             updateObjectTypeSelection( static_cast<int8_t>( _selectedDetailBrushType ), _detailModeButtonsRect, _getDetailModeTypeName,
-                                       { _rectInstrumentPanel.x + 7, _rectInstrumentPanel.y + 80 }, display );
+                                       { _rectInstrumentPanel.x + 7, _rectInstrumentPanel.y + 48 }, display );
         }
         else if ( _selectedInstrument == Instrument::ADVENTURE_OBJECTS ) {
             // Adventure objects buttons.
@@ -790,8 +789,6 @@ namespace Interface
     const char * EditorPanel::_getDetailModeTypeName( const uint8_t brushId )
     {
         switch ( brushId ) {
-        case DetailBrushType::VIEWING:
-            return _( "editorDetailMode|View" );
         case DetailBrushType::EDITING:
             return _( "editorDetailMode|Edit" );
         case DetailBrushType::MOVING:
@@ -1151,12 +1148,9 @@ namespace Interface
                 }
             }
 
-            for ( uint8_t brushId = DetailBrushType::VIEWING; brushId < DetailBrushType::DETAIL_MODE_COUNT; ++brushId ) {
+            for ( uint8_t brushId = DetailBrushType::EDITING; brushId < DetailBrushType::DETAIL_MODE_COUNT; ++brushId ) {
                 if ( le.isMouseRightButtonPressedInArea( _detailModeButtonsRect[brushId] ) ) {
                     switch ( brushId ) {
-                    case DetailBrushType::VIEWING:
-                        fheroes2::showStandardTextMessage( _getDetailModeTypeName( brushId ), _( "View objects on the Adventure Map." ), Dialog::ZERO );
-                        break;
                     case DetailBrushType::EDITING:
                         fheroes2::showStandardTextMessage( _getDetailModeTypeName( brushId ), _( "Edit objects on the Adventure Map." ), Dialog::ZERO );
                         break;

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -417,8 +417,8 @@ namespace Interface
 
         // Detail mode types.
         for ( size_t i = 0; i < _detailModeButtonsRect.size(); ++i ) {
-            _detailModeButtonsRect[i] = { offsetX + static_cast<int32_t>( i % 2 ) * 2 * buttonStepX,
-                                          offsetY + static_cast<int32_t>( i / 2 ) * buttonStepY, buttonWidth, buttonHeight };
+            _detailModeButtonsRect[i]
+                = { offsetX + static_cast<int32_t>( i % 2 ) * 2 * buttonStepX, offsetY + static_cast<int32_t>( i / 2 ) * buttonStepY, buttonWidth, buttonHeight };
         }
 
         // Adventure objects buttons position.

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -330,8 +330,8 @@ namespace Interface
         int8_t _selectedAdventureObject{ -1 };
         int8_t _selectedKingdomObject{ -1 };
         uint8_t _selectedBrushSize{ BrushSize::MEDIUM };
-        uint32_t _eraseTypes{ ObjectErasureType::ERASE_ALL_OBJECTS };
         uint8_t _selectedDetailBrushType{ DetailBrushType::EDITING };
+        uint32_t _eraseTypes{ ObjectErasureType::ERASE_ALL_OBJECTS };
 
         std::array<int32_t, LandscapeObjectBrush::LANDSCAPE_COUNT> _selectedLandscapeObjectType;
         std::array<int32_t, AdventureObjectBrush::ADVENTURE_COUNT> _selectedAdventureObjectType;

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -101,7 +101,7 @@ namespace Interface
         bool showAreaSelectRect() const
         {
             return _selectedInstrument == Instrument::TERRAIN || _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD
-                   || _selectedInstrument == Instrument::ERASE || isObjectMode() || isObjectEditingMode() || isObjectMovingMode() || isObjectCopyingMode();
+                   || _selectedInstrument == Instrument::ERASE || isObjectMode() || _selectedInstrument == Instrument::DETAIL;
         }
 
         bool useMouseDragMovement() const

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -113,7 +113,7 @@ namespace Interface
             case Instrument::MONSTERS:
                 return true;
             case Instrument::DETAIL:
-                return ( _selectedDetailBrushType == DetailBrushType::EDITING ) || ( _selectedDetailBrushType == DetailBrushType::VIEWING );
+                return ( _selectedDetailBrushType == DetailBrushType::EDITING );
             default:
                 break;
             }
@@ -265,16 +265,14 @@ namespace Interface
 
         enum DetailBrushType : uint8_t
         {
-            // Viewing the map. No interaction can be done.
-            VIEWING = 0,
             // Edit objects and also can move the map view by dragging.
-            EDITING = 1,
+            EDITING = 0,
             // Moving existing object by dragging them.
-            MOVING = 2,
+            MOVING = 1,
             // Making a copy of an existing object by dragging it.
-            COPYING = 3,
+            COPYING = 2,
 
-            DETAIL_MODE_COUNT = 4,
+            DETAIL_MODE_COUNT = 3,
         };
 
         // This array represents the order of object-to-erase images on the erase tool panel (from left to right, from top to bottom).

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -60,9 +60,19 @@ namespace Interface
             return _selectedInstrument == Instrument::TERRAIN;
         }
 
-        bool isDetailEdit() const
+        bool isObjectEditingMode() const
         {
-            return _selectedInstrument == Instrument::DETAIL;
+            return ( _selectedInstrument == Instrument::DETAIL ) && ( _selectedDetailBrushType == DetailBrushType::EDITING );
+        }
+
+        bool isObjectMovingMode() const
+        {
+            return ( _selectedInstrument == Instrument::DETAIL ) && ( _selectedDetailBrushType == DetailBrushType::MOVING );
+        }
+
+        bool isObjectCopyingMode() const
+        {
+            return ( _selectedInstrument == Instrument::DETAIL ) && ( _selectedDetailBrushType == DetailBrushType::COPYING );
         }
 
         bool isRoadDraw() const
@@ -91,7 +101,7 @@ namespace Interface
         bool showAreaSelectRect() const
         {
             return _selectedInstrument == Instrument::TERRAIN || _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD
-                   || _selectedInstrument == Instrument::ERASE || isObjectMode() || _selectedInstrument == Instrument::DETAIL;
+                   || _selectedInstrument == Instrument::ERASE || isObjectMode() || isObjectEditingMode();
         }
 
         bool useMouseDragMovement() const
@@ -102,6 +112,8 @@ namespace Interface
             case Instrument::LANDSCAPE_OBJECTS:
             case Instrument::MONSTERS:
                 return true;
+            case Instrument::DETAIL:
+                return ( _selectedDetailBrushType == DetailBrushType::EDITING ) || ( _selectedDetailBrushType == DetailBrushType::VIEWING );
             default:
                 break;
             }
@@ -144,6 +156,7 @@ namespace Interface
         }
 
         static const char * _getLandscapeObjectTypeName( const uint8_t brushId );
+        static const char * _getDetailModeTypeName( const uint8_t brushId );
         static const char * _getAdventureObjectTypeName( const uint8_t brushId );
         static const char * _getKingdomObjectTypeName( const uint8_t brushId );
         static const char * _getEraseObjectTypeName( const uint32_t eraseObjectType );
@@ -250,6 +263,20 @@ namespace Interface
                                 | ERASE_MONSTERS | ERASE_HEROES | ERASE_STREAMS | ERASE_ROADS,
         };
 
+        enum DetailBrushType : uint8_t
+        {
+            // Viewing the map. No interaction can be done.
+            VIEWING = 0,
+            // Edit objects and also can move the map view by dragging.
+            EDITING = 1,
+            // Moving existing object by dragging them.
+            MOVING = 2,
+            // Making a copy of an existing object by dragging it.
+            COPYING = 3,
+
+            DETAIL_MODE_COUNT = 4,
+        };
+
         // This array represents the order of object-to-erase images on the erase tool panel (from left to right, from top to bottom).
         const std::array<uint32_t, 11> _eraseButtonObjectTypes{ ObjectErasureType::ERASE_MOUNTAINS,
                                                                 ObjectErasureType::ERASE_ROCKS,
@@ -291,6 +318,7 @@ namespace Interface
         std::array<fheroes2::Rect, Instrument::INSTRUMENTS_COUNT> _instrumentButtonsRect;
         std::array<fheroes2::Rect, TerrainBrush::TERRAIN_COUNT> _terrainButtonsRect;
         std::array<fheroes2::Rect, LandscapeObjectBrush::LANDSCAPE_COUNT> _landscapeObjectButtonsRect;
+        std::array<fheroes2::Rect, DetailBrushType::DETAIL_MODE_COUNT> _detailModeButtonsRect;
         std::array<fheroes2::Rect, AdventureObjectBrush::ADVENTURE_COUNT> _adventureObjectButtonsRect;
         std::array<fheroes2::Rect, KingdomObjectBrush::KINGDOM_OBJECTS_COUNT> _kingdomObjectButtonsRect;
         std::array<fheroes2::Rect, BrushSize::BRUSH_SIZE_COUNT> _brushSizeButtonsRect;
@@ -305,6 +333,7 @@ namespace Interface
         int8_t _selectedKingdomObject{ -1 };
         uint8_t _selectedBrushSize{ BrushSize::MEDIUM };
         uint32_t _eraseTypes{ ObjectErasureType::ERASE_ALL_OBJECTS };
+        uint8_t _selectedDetailBrushType{ DetailBrushType::EDITING };
 
         std::array<int32_t, LandscapeObjectBrush::LANDSCAPE_COUNT> _selectedLandscapeObjectType;
         std::array<int32_t, AdventureObjectBrush::ADVENTURE_COUNT> _selectedAdventureObjectType;

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -265,7 +265,7 @@ namespace Interface
 
         enum DetailBrushType : uint8_t
         {
-            // Edit objects and also can move the map view by dragging.
+            // Edit objects which can also move the map view by dragging.
             EDITING = 0,
             // Moving existing object by dragging them.
             MOVING = 1,

--- a/src/fheroes2/editor/editor_interface_panel.h
+++ b/src/fheroes2/editor/editor_interface_panel.h
@@ -101,7 +101,7 @@ namespace Interface
         bool showAreaSelectRect() const
         {
             return _selectedInstrument == Instrument::TERRAIN || _selectedInstrument == Instrument::STREAM || _selectedInstrument == Instrument::ROAD
-                   || _selectedInstrument == Instrument::ERASE || isObjectMode() || isObjectEditingMode();
+                   || _selectedInstrument == Instrument::ERASE || isObjectMode() || isObjectEditingMode() || isObjectMovingMode() || isObjectCopyingMode();
         }
 
         bool useMouseDragMovement() const


### PR DESCRIPTION
~~`Viewing` - simply view the map. No interaction can be done with objects.~~
`Editing` - as before: modify action objects. Also, can do drag to view map
`Moving` - the new object moving feature
`Copying` - drag to copy an existing object ~~(without metadata)~~

**Note**: upon reopening the same option `Editing` would be set back as a default selection. This is done to avoid accidental object movement or copying.

https://github.com/user-attachments/assets/9cfb4df6-0f9a-4300-9fa6-2244ca8de399


