### PR TITLE
Polish some Battlefield animation delays and make `enum class` DelayType

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -2266,7 +2266,7 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
     const bool hideAIMovements = ( conf.AIMoveSpeed() == 0 );
     const bool noMovementAnimation = ( conf.AIMoveSpeed() == 10 );
 
-    const std::vector<Game::DelayType> delayTypes = { Game::CURRENT_AI_DELAY, Game::MAPS_DELAY };
+    const std::vector<Game::DelayType> delayTypes = { Game::DelayType::CURRENT_AI_DELAY, Game::DelayType::MAPS_DELAY };
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -2297,7 +2297,7 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
             }
 
             // Render a frame only if there is a need to show one.
-            if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+            if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
                 // Update Adventure Map objects' animation.
                 Game::updateAdventureMapAnimationIndex();
 
@@ -2309,7 +2309,7 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
                 display.render();
             }
         }
-        else if ( Game::validateAnimationDelay( Game::CURRENT_AI_DELAY ) ) {
+        else if ( Game::validateAnimationDelay( Game::DelayType::CURRENT_AI_DELAY ) ) {
             // re-center in case hero appears from the fog
             if ( recenterNeeded ) {
                 gameArea.SetCenter( hero.GetCenter() );
@@ -2379,7 +2379,7 @@ fheroes2::GameMode AI::HeroesMove( Heroes & hero )
                 }
             }
 
-            if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+            if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
                 // Update Adventure Map objects' animation.
                 Game::updateAdventureMapAnimationIndex();
 

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -189,7 +189,7 @@ namespace
 
     void updateAnimation( fheroes2::Display & display, int & lastSequence, LoopedAnimationSequence & sequence, const fheroes2::Rect & animationRoi )
     {
-        if ( Game::validateAnimationDelay( Game::BATTLE_DIALOG_DELAY ) && !sequence.nextFrame() ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_DIALOG_DELAY ) && !sequence.nextFrame() ) {
             if ( lastSequence != sequence.id() ) {
                 lastSequence = sequence.id();
                 const fheroes2::Sprite & base = fheroes2::AGG::GetICN( lastSequence, 0 );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -53,7 +53,6 @@
 #include "bin_info.h"
 #include "castle.h"
 #include "game.h"
-#include "game_delays.h"
 #include "game_hotkeys.h"
 #include "ground.h"
 #include "heroes_base.h"
@@ -410,17 +409,17 @@ namespace
         return Battle::KNIGHT;
     }
 
-    const std::vector<int> & getHeroAnimation( const HeroBase * hero, int animation )
+    const std::vector<int> & getHeroAnimation( const HeroBase * hero, const Battle::HeroAnimation animation )
     {
         static const std::vector<int> staticAnim{ 1 };
 
-        if ( !hero || animation == Battle::OP_STATIC ) {
+        if ( !hero || animation == Battle::HeroAnimation::OP_STATIC ) {
             return staticAnim;
         }
 
         const int heroType = matchHeroType( hero );
 
-        if ( animation == Battle::OP_SORROW ) {
+        if ( animation == Battle::HeroAnimation::OP_SORROW ) {
             static const std::vector<int> sorrowAnim{ 2, 3, 4, 5, 4, 5, 4, 3, 2 };
             return ( heroType == Battle::CAPTAIN ) ? staticAnim : sorrowAnim;
         }
@@ -436,7 +435,7 @@ namespace
             { { 1 }, { 2, 3, 4 }, { 3, 2 }, { 5, 6 }, { 5 }, { 5, 7 }, { 5 }, { 8, 9 }, { 10 } } // CAPTAIN
         };
 
-        return heroTypeAnim[heroType][animation];
+        return heroTypeAnim[heroType][static_cast<size_t>( animation )];
     }
 
     bool CursorAttack( uint32_t theme )
@@ -987,9 +986,9 @@ bool Battle::TargetInfo::isFinishAnimFrame( const TargetInfo & info )
 
 Battle::OpponentSprite::OpponentSprite( const fheroes2::Rect & area, HeroBase * hero, const bool isReflect )
     : _heroBase( hero )
-    , _currentAnim( getHeroAnimation( hero, OP_STATIC ) )
-    , _isFlippedHorizontally( isReflect )
+    , _currentAnim( getHeroAnimation( hero, Battle::HeroAnimation::OP_STATIC ) )
     , _offset( area.x, area.y )
+    , _isFlippedHorizontally( isReflect )
 {
     const bool isCaptain = hero->isCaptain();
     switch ( hero->GetRace() ) {
@@ -1048,7 +1047,7 @@ void Battle::OpponentSprite::IncreaseAnimFrame()
     _currentAnim.playAnimation( false );
 }
 
-void Battle::OpponentSprite::SetAnimation( const int rule )
+void Battle::OpponentSprite::SetAnimation( const Battle::HeroAnimation rule )
 {
     _animationType = rule;
     _currentAnim = getHeroAnimation( _heroBase, rule );
@@ -1117,14 +1116,15 @@ void Battle::OpponentSprite::Redraw( fheroes2::Image & dst ) const
 bool Battle::OpponentSprite::updateAnimationState()
 {
     if ( _currentAnim.isLastFrame() ) {
-        if ( _animationType != OP_STATIC ) {
-            if ( _animationType != OP_CAST_MASS && _animationType != OP_CAST_UP && _animationType != OP_CAST_DOWN ) {
-                SetAnimation( OP_STATIC );
+        if ( _animationType != Battle::HeroAnimation::OP_STATIC ) {
+            if ( _animationType != Battle::HeroAnimation::OP_CAST_MASS && _animationType != Battle::HeroAnimation::OP_CAST_UP
+                 && _animationType != Battle::HeroAnimation::OP_CAST_DOWN ) {
+                SetAnimation( Battle::HeroAnimation::OP_STATIC );
                 return true;
             }
         }
         else if ( _idleTimer.checkDelay() ) {
-            SetAnimation( ( Rand::Get( 1, 3 ) < 2 ) ? OP_IDLE2 : OP_IDLE );
+            SetAnimation( ( Rand::Get( 1, 3 ) < 2 ) ? Battle::HeroAnimation::OP_IDLE2 : Battle::HeroAnimation::OP_IDLE );
             return true;
         }
 
@@ -1449,6 +1449,10 @@ Battle::Interface::Interface( Arena & battleArena, const int32_t tileIndex )
     default:
         break;
     }
+
+    // Setup delay types for all common battlefield animations rendering.
+    _commonAnimationsDelays = { Game::DelayType::BATTLE_FLAGS_DELAY, Game::DelayType::BATTLE_OPPONENTS_DELAY, Game::DelayType::BATTLE_SELECTED_UNIT_DELAY,
+                                Game::DelayType::BATTLE_IDLE_DELAY };
 
     // hexagon
     _hexagonGrid = DrawHexagon( fheroes2::GetColorId( 0x68, 0x8C, 0x04 ) );
@@ -3105,15 +3109,12 @@ void Battle::Interface::HumanTurn( const Unit & unit, Actions & actions )
     Redraw();
 
     std::string msg;
-
-    // TODO: update delay types within the loop to avoid rendering slowdown.
-    const std::vector<Game::DelayType> delayTypes{ Game::BATTLE_FLAGS_DELAY };
     _flagAnimationFrameIndex = 0;
 
     const Board * board = Arena::GetBoard();
     LocalEvent & le = LocalEvent::Get();
 
-    while ( !humanturn_exit && le.HandleEvents( Game::isDelayNeeded( delayTypes ) ) ) {
+    while ( !humanturn_exit && le.HandleEvents( Game::isDelayNeeded( _commonAnimationsDelays ) ) ) {
         // move cursor
         int32_t indexNew = -1;
         if ( le.isMouseCursorPosInArea( { _interfacePosition.x, _interfacePosition.y, _interfacePosition.width, _interfacePosition.height - status.height } ) ) {
@@ -3144,7 +3145,7 @@ void Battle::Interface::HumanTurn( const Unit & unit, Actions & actions )
             _needRedraw = true;
         }
 
-        CheckGlobalEvents( le );
+        _checkGlobalEvents( le );
 
         // redraw arena
         if ( _needRedraw ) {
@@ -3617,6 +3618,13 @@ void Battle::Interface::_quickCombat( Actions & actions )
     humanturn_exit = true;
 }
 
+std::vector<Game::DelayType> Battle::Interface::_mergeWithCommonAnimationsDelays( std::vector<Game::DelayType> otherDelays ) const
+{
+    otherDelays.reserve( otherDelays.size() + _commonAnimationsDelays.size() );
+    otherDelays.insert( otherDelays.end(), _commonAnimationsDelays.cbegin(), _commonAnimationsDelays.cend() );
+    return otherDelays;
+}
+
 void Battle::Interface::OpenAutoModeDialog( const Unit & unit, Actions & actions )
 {
     Cursor::Get().SetThemes( Cursor::POINTER );
@@ -3842,9 +3850,16 @@ void Battle::Interface::WaitForAllActionDelays()
                                                    Game::DelayType::BATTLE_BRIDGE_DELAY,
                                                    Game::DelayType::CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY };
 
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( unitDelays );
+
     // Wait for the delay after previous render and only after it render a new frame and proceed to the rest of this function.
-    while ( le.HandleEvents( Game::isDelayNeeded( unitDelays ) ) ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) ) {
+        _checkGlobalEvents( le );
+
+        if ( _needRedraw ) {
+            Redraw();
+            _needRedraw = false;
+        }
 
         if ( Game::hasEveryDelayPassed( unitDelays ) ) {
             break;
@@ -3861,9 +3876,11 @@ void Battle::Interface::AnimateUnitWithDelay( Unit & unit, const bool skipLastFr
 
     LocalEvent & le = LocalEvent::Get();
 
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY } );
+
     // In the loop below we wait for the delay and then display the next frame.
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::DelayType::CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY } ) ) ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) ) {
+        _checkGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::DelayType::CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY ) ) {
             Redraw();
@@ -3898,23 +3915,20 @@ void Battle::Interface::_animateOpponents( OpponentSprite * hero )
     // We need to wait this delay before rendering the first frame of hero animation.
     Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
 
-    // 'BATTLE_OPPONENTS_DELAY' is different than 'BATTLE_IDLE_DELAY', so we handle the idle animation separately in this loop.
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_OPPONENTS_DELAY, Game::BATTLE_IDLE_DELAY } ) ) ) {
-        // Animate the idling units.
-        if ( IdleTroopsAnimation() ) {
-            Redraw();
+    while ( le.HandleEvents( Game::isDelayNeeded( _commonAnimationsDelays ) ) ) {
+        // We should check BATTLE_OPPONENTS_DELAY prior to _checkGlobalEvents() call because _checkGlobalEvents() resets this delay.
+        if ( Game::hasEveryDelayPassed( { Game::DelayType::BATTLE_OPPONENTS_DELAY } ) && hero->isFinishFrame() ) {
+            // We have reached the end of animation.
+            break;
         }
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_OPPONENTS_DELAY ) ) {
-            if ( hero->isFinishFrame() ) {
-                // We have reached the end of animation.
-                break;
-            }
+        _checkGlobalEvents( le );
 
-            hero->IncreaseAnimFrame();
+        _needRedraw |= IdleTroopsAnimation();
 
-            // Render the next frame and then wait a delay before checking if it is the last frame in the animation.
+        if ( _needRedraw ) {
             Redraw();
+            _needRedraw = false;
         }
     }
 }
@@ -3926,11 +3940,13 @@ void Battle::Interface::RedrawTroopDefaultDelay( Unit & unit )
         return;
     }
 
-    LocalEvent & le = LocalEvent::Get();
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_FRAME_DELAY } ) ) ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_FRAME_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_FRAME_DELAY ) ) {
+    LocalEvent & le = LocalEvent::Get();
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_FRAME_DELAY ) ) {
             Redraw();
 
             if ( unit.isFinishAnimFrame() ) {
@@ -3989,11 +4005,13 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
     // Wait for previously set and not passed delays before rendering a new frame.
     WaitForAllActionDelays();
 
-    // convert the following code into a function/event service
-    while ( le.HandleEvents( false ) && pnt != points.end() ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_MISSILE_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_MISSILE_DELAY ) ) {
+    // convert the following code into a function/event service
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && pnt != points.end() ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_MISSILE_DELAY ) ) {
             RedrawPartialStart();
             if ( isMage ) {
                 fheroes2::DrawLine( _mainSurface, { startPos.x, startPos.y - 2 }, { pnt->x, pnt->y - 2 }, 0x77 );
@@ -4281,10 +4299,12 @@ void Battle::Interface::_redrawActionWincesKills( const TargetsInfo & targets, U
         AudioManager::PlaySound( attacker->M82Expl() );
     }
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_FRAME_DELAY } ) ) ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_FRAME_DELAY } );
 
-        if ( !Game::validateAnimationDelay( Game::BATTLE_FRAME_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) ) {
+        _checkGlobalEvents( le );
+
+        if ( !Game::validateAnimationDelay( Game::DelayType::BATTLE_FRAME_DELAY ) ) {
             continue;
         }
 
@@ -4386,11 +4406,11 @@ void Battle::Interface::SetHeroAnimationReactionToTroopDeath( const PlayerColor 
     OpponentSprite * defendingHero = attackersTurn ? _defendingOpponent.get() : _attackingOpponent.get();
     // 60% of joyful animation
     if ( attackingHero && Rand::Get( 1, 5 ) < 4 ) {
-        attackingHero->SetAnimation( OP_JOY );
+        attackingHero->SetAnimation( Battle::HeroAnimation::OP_JOY );
     }
     // 80% of sorrow animation otherwise
     else if ( defendingHero && Rand::Get( 1, 5 ) < 5 ) {
-        defendingHero->SetAnimation( OP_SORROW );
+        defendingHero->SetAnimation( Battle::HeroAnimation::OP_SORROW );
     }
 }
 
@@ -4827,12 +4847,12 @@ void Battle::Interface::redrawActionSpellCastPart1( const Spell & spell, int32_t
         opponent = isLeftOpponent ? _attackingOpponent.get() : _defendingOpponent.get();
         if ( opponent != nullptr ) {
             if ( isMassSpell ) {
-                opponent->SetAnimation( OP_CAST_MASS );
+                opponent->SetAnimation( Battle::HeroAnimation::OP_CAST_MASS );
             }
             else {
                 isCastDown = isHeroCastDown( dst, isLeftOpponent );
 
-                opponent->SetAnimation( isCastDown ? OP_CAST_DOWN : OP_CAST_UP );
+                opponent->SetAnimation( isCastDown ? Battle::HeroAnimation::OP_CAST_DOWN : Battle::HeroAnimation::OP_CAST_UP );
             }
 
             _animateOpponents( opponent );
@@ -4995,15 +5015,15 @@ void Battle::Interface::redrawActionSpellCastPart1( const Spell & spell, int32_t
 
     if ( opponent != nullptr ) {
         if ( isMassSpell ) {
-            opponent->SetAnimation( OP_CAST_MASS_RETURN );
+            opponent->SetAnimation( Battle::HeroAnimation::OP_CAST_MASS_RETURN );
         }
         else {
-            opponent->SetAnimation( isCastDown ? OP_CAST_DOWN_RETURN : OP_CAST_UP_RETURN );
+            opponent->SetAnimation( isCastDown ? Battle::HeroAnimation::OP_CAST_DOWN_RETURN : Battle::HeroAnimation::OP_CAST_UP_RETURN );
         }
         _animateOpponents( opponent );
 
         // Return to the static animation of hero.
-        opponent->SetAnimation( OP_STATIC );
+        opponent->SetAnimation( Battle::HeroAnimation::OP_STATIC );
     }
 }
 
@@ -5266,15 +5286,16 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
             AudioManager::PlaySound( M82::GOODLUCK );
         }
 
+        const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_MISSILE_DELAY } );
+
         // If sound is turned off we still wait for the GOODLUCK sound to over but no more the twice the rainbow animation time.
         // So we start counting steps from '-rainbowDrawSteps' to 'rainbowDrawSteps'.
         int32_t step = -rainbowDrawSteps;
         double x = 0;
-        while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_MISSILE_DELAY } ) )
-                && ( ( ( soundOn || step < rainbowDrawSteps ) && Mixer::isPlaying( -1 ) ) || x < rainbowLength ) ) {
-            CheckGlobalEvents( le );
+        while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && ( ( ( soundOn || step < rainbowDrawSteps ) && Mixer::isPlaying( -1 ) ) || x < rainbowLength ) ) {
+            _checkGlobalEvents( le );
 
-            if ( Game::validateAnimationDelay( Game::BATTLE_MISSILE_DELAY ) ) {
+            if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_MISSILE_DELAY ) ) {
                 // Reset all units idle animation delay during rainbow animation not to start new idle animations.
                 // This does not affect Zombies, Genies, Medusas and Ghosts as they have permanent idle animations.
                 ResetIdleTroopAnimation();
@@ -5327,8 +5348,9 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
         // Make sure that the first run is passed immediately.
         assert( !Game::isCustomDelayNeeded( animationDelay ) );
 
-        while ( le.HandleEvents( Game::isCustomDelayNeeded( animationDelay ) ) && ( frameId < frameLimit || ( soundOn && Mixer::isPlaying( -1 ) ) ) ) {
-            CheckGlobalEvents( le );
+        while ( le.HandleEvents( Game::isCustomDelayNeeded( animationDelay ) || Game::isDelayNeeded( _commonAnimationsDelays ) )
+                && ( frameId < frameLimit || ( soundOn && Mixer::isPlaying( -1 ) ) ) ) {
+            _checkGlobalEvents( le );
 
             if ( Game::validateCustomAnimationDelay( animationDelay ) ) {
                 RedrawPartialStart();
@@ -5420,11 +5442,13 @@ void Battle::Interface::RedrawActionCatapultPart1( const CastleDefenseStructure 
 
     AudioManager::PlaySound( M82::CATSND00 );
 
-    // catapult animation
-    while ( le.HandleEvents( false ) && catapult_frame < 5 ) {
-        CheckGlobalEvents( le );
+    std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_CATAPULT_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_CATAPULT_DELAY ) ) {
+    // catapult animation
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && catapult_frame < 5 ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_CATAPULT_DELAY ) ) {
             Redraw();
             ++catapult_frame;
         }
@@ -5476,10 +5500,12 @@ void Battle::Interface::RedrawActionCatapultPart1( const CastleDefenseStructure 
     uint32_t boulderFrameId = 0;
     const uint32_t boulderFramesCount = fheroes2::AGG::GetICNCount( ICN::BOULDER );
 
-    while ( le.HandleEvents( false ) && pnt != points.end() ) {
-        CheckGlobalEvents( le );
+    allDelays.front() = Game::DelayType::BATTLE_CATAPULT_BOULDER_DELAY;
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_CATAPULT_BOULDER_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && pnt != points.end() ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_CATAPULT_BOULDER_DELAY ) ) {
             if ( catapult_frame < 9 )
                 ++catapult_frame;
 
@@ -5512,10 +5538,12 @@ void Battle::Interface::RedrawActionCatapultPart1( const CastleDefenseStructure 
 
     AudioManager::PlaySound( M82::CATSND02 );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_CATAPULT_CLOUD_DELAY } ) ) && frame < maxFrame ) {
-        CheckGlobalEvents( le );
+    allDelays.front() = Game::DelayType::BATTLE_CATAPULT_CLOUD_DELAY;
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_CATAPULT_CLOUD_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < maxFrame ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_CATAPULT_CLOUD_DELAY ) ) {
             RedrawPartialStart();
             // Start animation of the second smoke cloud only for the bridge and after 2 frames of the first smoke cloud.
             if ( isBridgeDestroyed && frame >= bridgeDestroySmokeDelay ) {
@@ -5557,12 +5585,14 @@ void Battle::Interface::RedrawActionCatapultPart2( const CastleDefenseStructure 
         frame = bridgeDestroyFrame;
     }
 
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_CATAPULT_CLOUD_DELAY } );
+
     LocalEvent & le = LocalEvent::Get();
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_CATAPULT_CLOUD_DELAY } ) ) && frame < maxAnimationFrame ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < maxAnimationFrame ) {
+        _checkGlobalEvents( le );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_CATAPULT_CLOUD_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_CATAPULT_CLOUD_DELAY ) ) {
             RedrawPartialStart();
             // Draw animation of the second smoke cloud only for the bridge.
             if ( isBridgeDestroyed ) {
@@ -5640,14 +5670,25 @@ void Battle::Interface::_redrawActionTeleportSpell( Unit & target, const int32_t
     const double phaseCoeff = 0.6;
     const int32_t wavePeriod = 60;
 
-    Game::passAnimationDelay( Game::BATTLE_DISRUPTING_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_DISRUPTING_DELAY } );
+
+    Game::passAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY );
 
     // Animate first teleportation phase: disappearing.
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && ( frame <= frameLimit || ( soundOn && Mixer::isPlaying( -1 ) ) ) ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && ( frame < frameLimit || ( soundOn && Mixer::isPlaying( -1 ) ) ) ) {
+        _checkGlobalEvents( le );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
-            if ( frame >= frameLimit ) {
+        // To smoothly render the software mouse cursor by `le.HandleEvents()` we need to reset all passed delays in `allDelays`.
+        const bool needSpellAnimation = Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY );
+        if ( frame > frameLimit ) {
+            if ( _needRedraw ) {
+                // Avoid making the game to freeze while sound is still being played.
+                Redraw();
+                _needRedraw = false;
+            }
+        }
+        else if ( needSpellAnimation ) {
+            if ( frame == frameLimit ) {
                 // Render battlefield without this unit.
                 rippleSprite.clear();
             }
@@ -5664,6 +5705,7 @@ void Battle::Interface::_redrawActionTeleportSpell( Unit & target, const int32_t
             ++frame;
 
             Redraw();
+            _needRedraw = false;
         }
     }
 
@@ -5674,10 +5716,19 @@ void Battle::Interface::_redrawActionTeleportSpell( Unit & target, const int32_t
 
     frame = 1;
     // Animate second teleportation phase: appearing.
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && ( frame < frameLimit || ( soundOn && Mixer::isPlaying( -1 ) ) ) ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && ( frame < frameLimit || ( soundOn && Mixer::isPlaying( -1 ) ) ) ) {
+        _checkGlobalEvents( le );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
+        // To smoothly render the software mouse cursor by `le.HandleEvents()` we need to reset all passed delays in `allDelays`.
+        const bool needSpellAnimation = Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY );
+        if ( frame > frameLimit ) {
+            if ( _needRedraw ) {
+                // Avoid making the game to freeze while sound is still being played.
+                Redraw();
+                _needRedraw = false;
+            }
+        }
+        else if ( needSpellAnimation ) {
             if ( frame == frameLimit ) {
                 // Render battlefield with this unit.
                 _spriteInsteadCurrentUnit = &unitSprite;
@@ -5690,11 +5741,12 @@ void Battle::Interface::_redrawActionTeleportSpell( Unit & target, const int32_t
                     // Animate appearing from bottom to top by making the top part transparent.
                     fheroes2::FillTransform( rippleSprite, 0, 0, rippleSprite.width(), spriteHeight * ( imageCutFrames - frame ) / imageCutFrames, 1 );
                 }
-
-                ++frame;
             }
 
+            ++frame;
+
             Redraw();
+            _needRedraw = false;
         }
     }
 
@@ -5718,12 +5770,14 @@ void Battle::Interface::_redrawActionSummonElementalSpell( Unit & target )
 
     AudioManager::PlaySound( M82::SUMNELM );
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && currentAlpha <= ( 255 - alphaStep ) ) {
-        CheckGlobalEvents( le );
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && currentAlpha <= ( 255 - alphaStep ) ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             currentAlpha += alphaStep;
             target.SetCustomAlpha( currentAlpha );
             Redraw();
@@ -5765,7 +5819,7 @@ void Battle::Interface::redrawActionMirrorImageSpell( const HeroBase & caster, c
     OpponentSprite * opponent = isLeftOpponent ? _attackingOpponent.get() : _defendingOpponent.get();
     assert( opponent != nullptr );
 
-    opponent->SetAnimation( isCastDown ? OP_CAST_DOWN : OP_CAST_UP );
+    opponent->SetAnimation( isCastDown ? Battle::HeroAnimation::OP_CAST_DOWN : Battle::HeroAnimation::OP_CAST_UP );
     _animateOpponents( opponent );
 
     const fheroes2::Point & unitPos = originalUnit.GetRectPosition().getPosition();
@@ -5783,12 +5837,14 @@ void Battle::Interface::redrawActionMirrorImageSpell( const HeroBase & caster, c
 
     LocalEvent & le = LocalEvent::Get();
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && pnt != points.cend() ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && pnt != points.cend() ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             mirrorUnitSprite.setPosition( pnt->x, pnt->y );
             RedrawPartialStart();
             RedrawPartialFinish();
@@ -5798,9 +5854,9 @@ void Battle::Interface::redrawActionMirrorImageSpell( const HeroBase & caster, c
     }
 
     // Run caster's "cast return" animation.
-    opponent->SetAnimation( isCastDown ? OP_CAST_DOWN_RETURN : OP_CAST_UP_RETURN );
+    opponent->SetAnimation( isCastDown ? Battle::HeroAnimation::OP_CAST_DOWN_RETURN : Battle::HeroAnimation::OP_CAST_UP_RETURN );
     _animateOpponents( opponent );
-    opponent->SetAnimation( OP_STATIC );
+    opponent->SetAnimation( Battle::HeroAnimation::OP_STATIC );
 
     // Restore the initial state.
     mirrorUnit.SwitchAnimation( Monster_Info::STATIC );
@@ -5825,6 +5881,8 @@ void Battle::Interface::_redrawLightningOnTargets( const std::vector<fheroes2::P
     cursor.SetThemes( Cursor::WAR_POINTER );
 
     AudioManager::PlaySound( points.size() > 2 ? M82::CHAINLTE : M82::LIGHTBLT );
+
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_DISRUPTING_DELAY } );
 
     for ( size_t i = 1; i < points.size(); ++i ) {
         const fheroes2::Point & startingPos = points[i - 1];
@@ -5859,9 +5917,11 @@ void Battle::Interface::_redrawLightningOnTargets( const std::vector<fheroes2::P
             }
         }
 
-        while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) )
+        while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) )
                 && ( ( isHorizontalBolt && roi.width < drawRoi.width ) || ( !isHorizontalBolt && roi.height < drawRoi.height ) ) ) {
-            if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
+            _checkGlobalEvents( le );
+
+            if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY ) ) {
                 if ( isHorizontalBolt ) {
                     if ( isForwardDirection ) {
                         roi.width += animationStep;
@@ -5906,10 +5966,10 @@ void Battle::Interface::_redrawLightningOnTargets( const std::vector<fheroes2::P
     fheroes2::delayforMs( 100 );
 
     uint32_t frame = 0;
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && frame < fheroes2::AGG::GetICNCount( ICN::SPARKS ) ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < fheroes2::AGG::GetICNCount( ICN::SPARKS ) ) {
+        _checkGlobalEvents( le );
 
-        if ( ( frame == 0 ) || Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
+        if ( ( frame == 0 ) || Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY ) ) {
             RedrawPartialStart();
 
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::SPARKS, frame );
@@ -5984,16 +6044,26 @@ void Battle::Interface::_redrawActionBloodLustSpell( const Unit & target )
     // Make sure that the first run is passed immediately.
     assert( !Game::isCustomDelayNeeded( bloodlustDelay ) );
 
-    while ( le.HandleEvents( Game::isCustomDelayNeeded( bloodlustDelay ) ) && Mixer::isPlaying( -1 ) ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isCustomDelayNeeded( bloodlustDelay ) || Game::isDelayNeeded( _commonAnimationsDelays ) ) && Mixer::isPlaying( -1 ) ) {
+        _checkGlobalEvents( le );
 
-        if ( frame < 20 && Game::validateCustomAnimationDelay( bloodlustDelay ) ) {
-            mixSprite = unitSprite;
-            fheroes2::AlphaBlit( bloodlustEffect, mixSprite, alpha );
+        // To smoothly render the software mouse cursor by `le.HandleEvents()` we need to reset all passed delays.
+        const bool needSpellAnimation = Game::validateCustomAnimationDelay( bloodlustDelay );
+        if ( frame < 20 ) {
+            if ( needSpellAnimation ) {
+                mixSprite = unitSprite;
+                fheroes2::AlphaBlit( bloodlustEffect, mixSprite, alpha );
+                Redraw();
+                _needRedraw = false;
+
+                alpha += ( frame < 10 ) ? 20 : -20;
+                ++frame;
+            }
+        }
+        else if ( _needRedraw ) {
+            // Avoid making the game to freeze while sound is still being played.
             Redraw();
-
-            alpha += ( frame < 10 ) ? 20 : -20;
-            ++frame;
+            _needRedraw = false;
         }
     }
 
@@ -6029,24 +6099,30 @@ void Battle::Interface::_redrawActionStoneSpell( const Unit & target )
 
     AudioManager::PlaySound( M82::PARALIZE );
 
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
+
     uint8_t alpha = 0;
     uint32_t frame = 0;
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && Mixer::isPlaying( -1 ) ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && Mixer::isPlaying( -1 ) ) {
+        _checkGlobalEvents( le );
 
-        if ( Game::validateCustomAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
-            if ( frame < 25 ) {
+        // To smoothly render the software mouse cursor by `le.HandleEvents()` we need to reset all passed delays in `allDelays`.
+        const bool needSpellAnimation = Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
+        if ( frame < 25 ) {
+            if ( needSpellAnimation ) {
                 mixSprite = unitSprite;
                 fheroes2::AlphaBlit( stoneEffect, mixSprite, alpha );
                 Redraw();
+                _needRedraw = false;
 
                 alpha += 10;
                 ++frame;
             }
-            else {
-                // Avoid making the game to freeze while sound is still being played.
-                Redraw();
-            }
+        }
+        else if ( _needRedraw ) {
+            // Avoid making the game to freeze while sound is still being played.
+            Redraw();
+            _needRedraw = false;
         }
     }
 
@@ -6073,13 +6149,15 @@ void Battle::Interface::_redrawActionResurrectSpell( Unit & target, const Spell 
         Redraw();
         target.IncreaseAnimFrame();
 
-        Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+        const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
+
+        Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
         LocalEvent & le = LocalEvent::Get();
-        while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) ) {
-            CheckGlobalEvents( le );
+        while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) ) {
+            _checkGlobalEvents( le );
 
-            if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+            if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
                 if ( target.isFinishAnimFrame() ) {
                     // We have reached the end of animation.
                     break;
@@ -6118,11 +6196,14 @@ void Battle::Interface::_redrawRaySpell( const Unit & target, const int spellICN
     cursor.SetThemes( Cursor::WAR_POINTER );
     AudioManager::PlaySound( spellSound );
 
-    size_t i = 0;
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && i < path.size() ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_DISRUPTING_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
+    size_t i = 0;
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && i < path.size() ) {
+        _checkGlobalEvents( le );
+        // TODO: Render the background opponents and flags animation.
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY ) ) {
             const uint32_t frame = static_cast<uint32_t>( i * spriteCount / path.size() ); // it's safe to do such as i <= path.size()
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( spellICN, frame );
             fheroes2::Blit( sprite, _mainSurface, path[i].x - sprite.width() / 2, path[i].y - sprite.height() / 2 );
@@ -6163,12 +6244,14 @@ void Battle::Interface::_redrawActionDisruptingRaySpell( Unit & target )
     const int32_t frameLimit = 60;
     const int32_t maxAmplitude = 3;
 
-    Game::passAnimationDelay( Game::BATTLE_DISRUPTING_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_DISRUPTING_DELAY } );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && frame < frameLimit ) {
-        CheckGlobalEvents( le );
+    Game::passAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < frameLimit ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY ) ) {
             const int32_t amplitude = std::min( std::min( frame, ( frameLimit - frame ) ) / 3, maxAmplitude );
             rippleSprite = fheroes2::createRippleEffect( unitSprite, amplitude, -0.4 * frame, 60 );
 
@@ -6239,10 +6322,10 @@ void Battle::Interface::_redrawActionDeathWaveSpell( const int32_t strength )
 
     AudioManager::PlaySound( M82::MNRDEATH );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_DISRUPTING_DELAY } ) ) && position < area.width + waveLength ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_DISRUPTING_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_DISRUPTING_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && position < area.width + waveLength ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY ) ) {
             const int32_t wavePositionX = ( area.x + position < 0 ) ? 0 : ( area.x + position );
             const int32_t waveWidth = position > waveLength ? ( position > area.width ? ( waveLength - position + area.width ) : waveLength ) : position;
             const int32_t restorePositionX = ( wavePositionX < waveStep ) ? 0 : ( wavePositionX - waveStep );
@@ -6288,12 +6371,14 @@ void Battle::Interface::_redrawActionColdRingSpell( const int32_t dst, const Tar
 
     AudioManager::PlaySound( m82 );
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && frame < fheroes2::AGG::GetICNCount( icn ) ) {
-        CheckGlobalEvents( le );
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < fheroes2::AGG::GetICNCount( icn ) ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             RedrawPartialStart();
 
             const fheroes2::Sprite & sprite1 = fheroes2::AGG::GetICN( icn, frame );
@@ -6379,9 +6464,7 @@ void Battle::Interface::_redrawActionHolyShoutSpell( const uint8_t strength )
 
     AudioManager::PlaySound( M82::MASSCURS );
 
-    while ( le.HandleEvents( Game::isCustomDelayNeeded( spellcastDelay ) ) && frame < maxFrame ) {
-        CheckGlobalEvents( le );
-
+    while ( le.HandleEvents( Game::isCustomDelayNeeded( spellcastDelay ) || Game::isDelayNeeded( _commonAnimationsDelays ) ) && frame < maxFrame ) {
         if ( Game::validateCustomAnimationDelay( spellcastDelay ) ) {
             // Display the maximum spell effect for 1 more 'spellcastDelay' without rendering a frame.
             if ( frame != halfMaxFrame ) {
@@ -6428,13 +6511,15 @@ void Battle::Interface::_redrawActionElementalStormSpell( const TargetsInfo & ta
 
     AudioManager::PlaySound( m82 );
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
+
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
     uint32_t frame = 0;
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && frame < 60 ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < 60 ) {
+        _checkGlobalEvents( le );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             RedrawPartialStart();
 
             if ( icnCount > 0 ) {
@@ -6505,12 +6590,12 @@ void Battle::Interface::_redrawActionArmageddonSpell()
     AudioManager::PlaySound( M82::ARMGEDN );
     uint32_t alpha = 10;
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && alpha < 100 ) {
-        CheckGlobalEvents( le );
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && alpha < 100 ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             fheroes2::ApplyPalette( spriteWhitening, 9 );
             fheroes2::Copy( spriteWhitening, 0, 0, _mainSurface, area.x, area.y, area.width, area.height );
             RedrawPartialFinish();
@@ -6521,10 +6606,8 @@ void Battle::Interface::_redrawActionArmageddonSpell()
 
     fheroes2::Copy( spriteReddish, 0, 0, _mainSurface, area.x, area.y, area.width, area.height );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && Mixer::isPlaying( -1 ) ) {
-        CheckGlobalEvents( le );
-
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && Mixer::isPlaying( -1 ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             const int32_t offsetX = static_cast<int32_t>( Rand::Get( 0, 28 ) ) - 14;
             const int32_t offsetY = static_cast<int32_t>( Rand::Get( 0, 22 ) ) - 11;
 
@@ -6545,7 +6628,7 @@ void Battle::Interface::redrawActionEarthquakeSpellPart1( const HeroBase & caste
     OpponentSprite * opponent = isLeftOpponent ? _attackingOpponent.get() : _defendingOpponent.get();
     assert( opponent != nullptr );
 
-    opponent->SetAnimation( OP_CAST_MASS );
+    opponent->SetAnimation( Battle::HeroAnimation::OP_CAST_MASS );
     _animateOpponents( opponent );
 
     fheroes2::Rect area = GetArea();
@@ -6578,13 +6661,13 @@ void Battle::Interface::redrawActionEarthquakeSpellPart1( const HeroBase & caste
     LocalEvent & le = LocalEvent::Get();
     uint32_t frame = 0;
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
+
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
     // Draw earth quake animation.
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && frame < 18 ) {
-        CheckGlobalEvents( le );
-
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < 18 ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             const int32_t offsetX = static_cast<int32_t>( Rand::Get( 0, 28 ) ) - 14;
             const int32_t offsetY = static_cast<int32_t>( Rand::Get( 0, 22 ) ) - 11;
 
@@ -6598,7 +6681,7 @@ void Battle::Interface::redrawActionEarthquakeSpellPart1( const HeroBase & caste
     }
 
     // Set end of casting animation. The animation will be done by `CheckGlobalEvents()`.
-    opponent->SetAnimation( OP_CAST_MASS_RETURN );
+    opponent->SetAnimation( Battle::HeroAnimation::OP_CAST_MASS_RETURN );
 
     // Draw buildings demolition clouds.
     const int icn = ICN::LICHCLOD;
@@ -6607,17 +6690,19 @@ void Battle::Interface::redrawActionEarthquakeSpellPart1( const HeroBase & caste
 
     AudioManager::PlaySound( M82::CATSND02 );
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
     // We need to wait this delay before rendering the first frame of hero animation.
     Game::AnimateResetDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY, Game::BATTLE_OPPONENTS_DELAY } ) ) && frame < maxFrame ) {
-        CheckGlobalEvents( le );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < maxFrame ) {
+        _checkGlobalEvents( le );
 
-        const bool isNeedSpellAnimationUpdate = Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY );
+        const bool isNeedSpellAnimationUpdate = Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
-        if ( isNeedSpellAnimationUpdate || Game::validateAnimationDelay( Game::BATTLE_OPPONENTS_DELAY ) ) {
+        if ( isNeedSpellAnimationUpdate || _needRedraw ) {
+            _needRedraw = false;
+
             RedrawPartialStart();
 
             for ( const CastleDefenseStructure target : targets ) {
@@ -6657,14 +6742,18 @@ void Battle::Interface::redrawActionEarthquakeSpellPart2( const std::vector<Cast
         maxFrame += bridgeDestroySmokeDelay - 1;
     }
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY, Game::BATTLE_OPPONENTS_DELAY } ) ) && frame < maxFrame ) {
-        CheckGlobalEvents( le );
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
-        const bool isNeedSpellAnimationUpdate = Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < maxFrame ) {
+        _checkGlobalEvents( le );
 
-        if ( isNeedSpellAnimationUpdate || Game::validateAnimationDelay( Game::BATTLE_OPPONENTS_DELAY ) ) {
+        const bool isNeedSpellAnimationUpdate = Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
+
+        if ( isNeedSpellAnimationUpdate || _needRedraw ) {
+            _needRedraw = false;
+
             RedrawPartialStart();
 
             for ( const CastleDefenseStructure target : targets ) {
@@ -6704,10 +6793,12 @@ void Battle::Interface::RedrawActionRemoveMirrorImage( const std::vector<Unit *>
     uint8_t frameId = 10;
     const uint8_t alphaStep = 25;
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_FRAME_DELAY } ) ) && frameId > 0 ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_FRAME_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_FRAME_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frameId > 0 ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_FRAME_DELAY ) ) {
             const uint8_t alpha = frameId * alphaStep;
             for ( Unit * unit : mirrorImages ) {
                 if ( unit != nullptr ) {
@@ -6743,12 +6834,14 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const int32_t dst, cons
 
     uint32_t frameCount = fheroes2::AGG::GetICNCount( icn );
 
-    Game::passAnimationDelay( Game::BATTLE_SPELL_DELAY );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && frame < frameCount ) {
-        CheckGlobalEvents( le );
+    Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < frameCount ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             RedrawPartialStart();
 
             const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, frame );
@@ -6859,10 +6952,12 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const TargetsInfo & tar
 
     AudioManager::PlaySound( m82 );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && ( frame < maxFrame || isDefenderAnimating ) ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && ( frame < maxFrame || isDefenderAnimating ) ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             if ( frame < maxFrame ) {
                 std::vector<Battle::UnitSpellEffectInfo>::iterator overlaySpriteIter = overlaySpriteBegin;
                 const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( icn, frame );
@@ -6964,10 +7059,12 @@ void Battle::Interface::RedrawTroopWithFrameAnimation( Unit & unit, const int ic
 
     AudioManager::PlaySound( m82 );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_SPELL_DELAY } ) ) && ( frame < maxICNFrame || unit.GetAnimationState() == Monster_Info::WNCE_DOWN ) ) {
-        CheckGlobalEvents( le );
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_SPELL_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && ( frame < maxICNFrame || unit.GetAnimationState() == Monster_Info::WNCE_DOWN ) ) {
+        _checkGlobalEvents( le );
+
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             if ( frame < maxICNFrame ) {
                 _unitSpellEffectInfos.back().position = CalculateSpellPosition( unit, icn, fheroes2::AGG::GetICN( icn, frame ) );
                 _unitSpellEffectInfos.back().icnIndex = frame;
@@ -7015,7 +7112,9 @@ void Battle::Interface::RedrawBridgeAnimation( const bool bridgeDownAnimation )
         AudioManager::PlaySound( M82::DRAWBRG );
     }
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::BATTLE_BRIDGE_DELAY } ) ) ) {
+    const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_BRIDGE_DELAY } );
+
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) ) {
         if ( bridgeDownAnimation ) {
             if ( _bridgeAnimation.currentFrameId < BridgeMovementAnimation::DOWN_POSITION ) {
                 break;
@@ -7027,9 +7126,9 @@ void Battle::Interface::RedrawBridgeAnimation( const bool bridgeDownAnimation )
             }
         }
 
-        CheckGlobalEvents( le );
+        _checkGlobalEvents( le );
 
-        if ( Game::validateAnimationDelay( Game::BATTLE_BRIDGE_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_BRIDGE_DELAY ) ) {
             Redraw();
 
             if ( bridgeDownAnimation ) {
@@ -7050,7 +7149,7 @@ void Battle::Interface::RedrawBridgeAnimation( const bool bridgeDownAnimation )
 
 bool Battle::Interface::IdleTroopsAnimation() const
 {
-    if ( Game::validateAnimationDelay( Game::BATTLE_IDLE_DELAY ) ) {
+    if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_IDLE_DELAY ) ) {
         const bool redrawNeeded = arena.getAttackingForce().animateIdleUnits();
         return arena.getDefendingForce().animateIdleUnits() || redrawNeeded;
     }
@@ -7078,28 +7177,29 @@ void Battle::Interface::SwitchAllUnitsAnimation( const int32_t animationState ) 
     }
 }
 
-void Battle::Interface::CheckGlobalEvents( LocalEvent & le )
+void Battle::Interface::_checkGlobalEvents( LocalEvent & le )
 {
-    // Animation of the currently active unit's contour
-    if ( Game::validateAnimationDelay( Game::BATTLE_SELECTED_UNIT_DELAY ) ) {
+    // Animation of the currently active unit's contour.
+    // Notice: to smoothly render the software mouse cursor we need to reset all passed common delays (even if `_currentUnit` is `nullptr`).
+    if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SELECTED_UNIT_DELAY ) && _currentUnit != nullptr ) {
         UpdateContourColor();
         _needRedraw = true;
     }
 
     // Animation of flags and heroes idle.
-    if ( Game::validateAnimationDelay( Game::BATTLE_FLAGS_DELAY ) ) {
+    if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_FLAGS_DELAY ) ) {
         ++_flagAnimationFrameIndex;
         _needRedraw = true;
+    }
 
-        // Perform heroes idle animation only if heroes are not performing any other animation (e.g. spell casting).
-        if ( Game::hasEveryDelayPassed( { Game::BATTLE_OPPONENTS_DELAY } ) ) {
-            if ( _attackingOpponent && _attackingOpponent->updateAnimationState() ) {
-                _needRedraw = true;
-            }
+    // Perform heroes idle animation only if heroes are not performing any other animation (e.g. spell casting).
+    if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_OPPONENTS_DELAY ) ) {
+        if ( _attackingOpponent && _attackingOpponent->updateAnimationState() ) {
+            _needRedraw = true;
+        }
 
-            if ( _defendingOpponent && _defendingOpponent->updateAnimationState() ) {
-                _needRedraw = true;
-            }
+        if ( _defendingOpponent && _defendingOpponent->updateAnimationState() ) {
+            _needRedraw = true;
         }
     }
 
@@ -7251,13 +7351,13 @@ bool Battle::PopupDamageInfo::_setDamageInfoBase( const Unit * defender )
 
     // When pop-up is hidden: _cell is nullptr. Before showing pop-up
     if ( _needDelay ) {
-        Game::AnimateResetDelay( Game::BATTLE_POPUP_DELAY );
+        Game::AnimateResetDelay( Game::DelayType::BATTLE_POPUP_DELAY );
         _needDelay = false;
 
         return false;
     }
 
-    if ( !Game::hasEveryDelayPassed( { Game::BATTLE_POPUP_DELAY } ) ) {
+    if ( !Game::hasEveryDelayPassed( { Game::DelayType::BATTLE_POPUP_DELAY } ) ) {
         return false;
     }
 

--- a/src/fheroes2/battle/battle_interface.h
+++ b/src/fheroes2/battle/battle_interface.h
@@ -36,6 +36,7 @@
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_delays.h"
 #include "icn.h"
 #include "image.h"
 #include "math_base.h"
@@ -74,7 +75,7 @@ namespace Battle
     void DialogBattleSettings( const bool isTurnOrderInsideWindow );
     bool DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdom & kingdom );
 
-    enum HeroAnimation : uint32_t
+    enum class HeroAnimation : uint32_t
     {
         OP_JOY,
         OP_CAST_MASS,
@@ -134,6 +135,8 @@ namespace Battle
         OpponentSprite( const fheroes2::Rect & area, HeroBase * hero, const bool isReflect );
         OpponentSprite( const OpponentSprite & ) = delete;
 
+        ~OpponentSprite() = default;
+
         OpponentSprite & operator=( const OpponentSprite & ) = delete;
 
         const fheroes2::Rect & GetArea() const
@@ -147,7 +150,7 @@ namespace Battle
         // Return true is animation state was changed.
         bool updateAnimationState();
 
-        void SetAnimation( const int rule );
+        void SetAnimation( const Battle::HeroAnimation rule );
         void IncreaseAnimFrame();
 
         bool isFinishFrame() const
@@ -178,13 +181,15 @@ namespace Battle
     private:
         HeroBase * _heroBase{ nullptr };
         AnimationSequence _currentAnim;
-        int _animationType{ OP_STATIC };
         RandomizedDelay _idleTimer{ 8000 };
 
-        int _heroIcnId{ ICN::UNKNOWN };
-        bool _isFlippedHorizontally{ false };
         fheroes2::Rect _area;
         fheroes2::Point _offset;
+
+        Battle::HeroAnimation _animationType{ Battle::HeroAnimation::OP_STATIC };
+        int _heroIcnId{ ICN::UNKNOWN };
+
+        bool _isFlippedHorizontally{ false };
     };
 
     class Status final : public fheroes2::Rect
@@ -461,7 +466,9 @@ namespace Battle
         void ResetIdleTroopAnimation() const;
         void SwitchAllUnitsAnimation( const int32_t animationState ) const;
         void UpdateContourColor();
-        void CheckGlobalEvents( LocalEvent & );
+
+        // Warning: This method checks and resets the next delays: BATTLE_SELECTED_UNIT_DELAY, BATTLE_FLAGS_DELAY, BATTLE_OPPONENTS_DELAY.
+        void _checkGlobalEvents( LocalEvent & le );
         void InterruptAutoCombatIfRequested( LocalEvent & le );
         void SetHeroAnimationReactionToTroopDeath( const PlayerColor deathColor ) const;
 
@@ -478,6 +485,8 @@ namespace Battle
 
         void _startAutoCombat( const Unit & unit, Actions & actions );
         void _quickCombat( Actions & actions );
+
+        std::vector<Game::DelayType> _mergeWithCommonAnimationsDelays( std::vector<Game::DelayType> otherDelays ) const;
 
         Arena & arena;
         Dialog::FrameBorder border;
@@ -503,21 +512,25 @@ namespace Battle
         std::unique_ptr<OpponentSprite> _attackingOpponent;
         std::unique_ptr<OpponentSprite> _defendingOpponent;
 
+        std::vector<Game::DelayType> _commonAnimationsDelays;
+
         Spell humanturn_spell{ Spell::NONE };
         bool humanturn_exit{ true };
         bool _needRedraw{ true };
+
+        // True if background is bright. It is done to determine current unit contour cycling colors.
+        bool _brightLandType{ false };
+
         uint32_t _flagAnimationFrameIndex{ 0 };
         int catapult_frame{ 0 };
-
-        PlayerColor _interruptAutoCombatForColor{ PlayerColor::NONE };
 
         // The Channel ID of pre-battle sound. Used to check it is over to start the battle music.
         std::optional<int> _preBattleSoundChannelId{ -1 };
 
         uint8_t _contourColor{ 110 };
 
-        // True if background is bright. It is done to determine current unit contour cycling colors.
-        bool _brightLandType{ false };
+        PlayerColor _interruptAutoCombatForColor{ PlayerColor::NONE };
+
         uint32_t _contourCycle{ 0 };
 
         const Unit * _currentUnit{ nullptr };

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -478,7 +478,7 @@ CastleDialog::BuildingsRenderQueue::BuildingsRenderQueue( const Castle & castle,
 
 bool CastleDialog::FadeBuilding::updateFadeAlpha()
 {
-    if ( _alpha < 255 && Game::validateAnimationDelay( Game::CASTLE_BUILD_DELAY ) ) {
+    if ( _alpha < 255 && Game::validateAnimationDelay( Game::DelayType::CASTLE_BUILD_DELAY ) ) {
         if ( _alpha < 255 - 15 ) {
             _alpha += 15;
         }

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -488,7 +488,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     // This variable must be declared out of the loop for performance reasons.
     uint32_t castleAnimationIndex = 1;
 
-    Game::passAnimationDelay( Game::CASTLE_AROUND_DELAY );
+    Game::passAnimationDelay( Game::DelayType::CASTLE_AROUND_DELAY );
 
     while ( le.HandleEvents() && result == CastleDialogReturnValue::DoNothing ) {
         bool needRedraw = false;
@@ -780,7 +780,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             break;
         }
 
-        if ( alphaHero < 255 && Game::validateAnimationDelay( Game::CASTLE_BUYHERO_DELAY ) ) {
+        if ( alphaHero < 255 && Game::validateAnimationDelay( Game::DelayType::CASTLE_BUYHERO_DELAY ) ) {
             alphaHero += 10;
             if ( alphaHero >= 255 ) {
                 alphaHero = 255;
@@ -842,7 +842,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         }
 
         // Castle dialog animation.
-        if ( Game::validateAnimationDelay( Game::CASTLE_AROUND_DELAY ) || needRedraw ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::CASTLE_AROUND_DELAY ) || needRedraw ) {
             CastleDialog::redrawAllBuildings( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
 
             display.render( dialogRoi );

--- a/src/fheroes2/castle/castle_tavern.cpp
+++ b/src/fheroes2/castle/castle_tavern.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -47,7 +47,7 @@ void Castle::_openTavern() const
     text->add( fheroes2::Text{ std::move( body ), fheroes2::FontType::normalWhite() } );
     text->add( fheroes2::Text{ std::move( rumor.text ), fheroes2::FontType::normalWhite(), rumor.language } );
 
-    const fheroes2::AnimationDialogElement imageUI( ICN::TAVWIN, { 0, 1 }, 0, Game::getAnimationDelayValue( Game::CASTLE_TAVERN_DELAY ) );
+    const fheroes2::AnimationDialogElement imageUI( ICN::TAVWIN, { 0, 1 }, 0, Game::getAnimationDelayValue( Game::DelayType::CASTLE_TAVERN_DELAY ) );
     const fheroes2::TextDialogElement textBodyUI( text );
 
     fheroes2::showStandardTextMessage( GetStringBuilding( BUILD_TAVERN ), {}, Dialog::OK, { &imageUI, &textBodyUI } );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -242,9 +242,9 @@ void Castle::_openWell()
 
     LocalEvent & le = LocalEvent::Get();
 
-    Game::passAnimationDelay( Game::CASTLE_UNIT_DELAY );
+    Game::passAnimationDelay( Game::DelayType::CASTLE_UNIT_DELAY );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::CASTLE_UNIT_DELAY } ) ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::DelayType::CASTLE_UNIT_DELAY } ) ) ) {
         buttonExit.drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( buttonExit.area() ) );
 
         buttonMax.drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( buttonMax.area() ) );
@@ -284,7 +284,7 @@ void Castle::_openWell()
             }
         }
 
-        if ( Game::validateAnimationDelay( Game::CASTLE_UNIT_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::CASTLE_UNIT_DELAY ) ) {
             fheroes2::Copy( background, 0, 0, display, roi.x, roi.y, roi.width, roi.height );
 
             _wellRedrawMonsterAnimation( roi, monsterAnimInfo );

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -621,7 +621,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
 
     display.render( restorer.rect() );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::CASTLE_UNIT_DELAY } ) ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::DelayType::CASTLE_UNIT_DELAY } ) ) ) {
         if ( buttonUpgrade ) {
             buttonUpgrade->drawOnState( le.isMouseLeftButtonPressedAndHeldInArea( buttonUpgrade->area() ) );
         }
@@ -682,7 +682,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
             }
         }
 
-        if ( Game::validateAnimationDelay( Game::CASTLE_UNIT_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::CASTLE_UNIT_DELAY ) ) {
             // TODO: Only redraw the half of the window containing the creature. Note that fire-breathing creatures spew fire into the other half,
             // so the animation has to be changed to only walking animation. Also their walking animation overlaps with the creature name.
             fheroes2::Blit( sprite_dialog, display, dialogOffset.x, dialogOffset.y );

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1306,7 +1306,7 @@ namespace Interface
         int32_t fastScrollRepeatCount = 0;
         const int32_t fastScrollStartThreshold = 2;
 
-        const std::vector<Game::DelayType> delayTypes = { Game::MAPS_DELAY };
+        const std::vector<Game::DelayType> delayTypes = { Game::DelayType::MAPS_DELAY };
 
         LocalEvent & le = LocalEvent::Get();
         Cursor & cursor = Cursor::Get();
@@ -1463,7 +1463,7 @@ namespace Interface
                     }
 
                     if ( scrollDirection != SCROLL_NONE && _gameArea.isFastScrollEnabled() ) {
-                        if ( Game::validateAnimationDelay( Game::SCROLL_START_DELAY ) && fastScrollRepeatCount < fastScrollStartThreshold ) {
+                        if ( Game::validateAnimationDelay( Game::DelayType::SCROLL_START_DELAY ) && fastScrollRepeatCount < fastScrollStartThreshold ) {
                             ++fastScrollRepeatCount;
                         }
 
@@ -1706,7 +1706,7 @@ namespace Interface
             }
 
             // Scrolling the game area
-            if ( _gameArea.NeedScroll() && Game::validateAnimationDelay( Game::SCROLL_DELAY ) ) {
+            if ( _gameArea.NeedScroll() && Game::validateAnimationDelay( Game::DelayType::SCROLL_DELAY ) ) {
                 assert( !_gameArea.isDragScroll() );
 
                 if ( isScrollLeft( le.getMouseCursorPos() ) || isScrollRight( le.getMouseCursorPos() ) || isScrollTop( le.getMouseCursorPos() )
@@ -1725,7 +1725,7 @@ namespace Interface
             assert( res == fheroes2::GameMode::CANCEL );
 
             // Map objects animation
-            if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+            if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
                 if ( conf.isEditorAnimationEnabled() ) {
                     Game::updateAdventureMapAnimationIndex();
                 }

--- a/src/fheroes2/game/game_delays.cpp
+++ b/src/fheroes2/game/game_delays.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2010 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -24,13 +24,14 @@
 #include "game_delays.h"
 
 #include <cassert>
+#include <cstddef>
 
 #include "settings.h"
 #include "timing.h"
 
 namespace
 {
-    std::vector<fheroes2::TimeDelay> delays( Game::LAST_DELAY, fheroes2::TimeDelay( 0 ) );
+    std::vector<fheroes2::TimeDelay> delays( static_cast<size_t>( Game::DelayType::LAST_DELAY ), fheroes2::TimeDelay( 0 ) );
 
     static_assert( ( defaultBattleSpeed >= 0 ) && ( defaultBattleSpeed < 10 ) );
 
@@ -83,6 +84,11 @@ namespace
             multiplier = 4;
         }
     }
+
+    inline void setDelay( Game::DelayType type, const uint64_t delayMs )
+    {
+        delays[static_cast<size_t>( type )].setDelay( delayMs );
+    }
 }
 
 namespace Game
@@ -92,37 +98,37 @@ namespace Game
 
 void Game::AnimateDelaysInitialize()
 {
-    delays[SCROLL_DELAY].setDelay( 20 );
-    delays[SCROLL_START_DELAY].setDelay( 20 );
-    delays[CURSOR_BLINK_DELAY].setDelay( 440 );
-    delays[MAIN_MENU_DELAY].setDelay( 250 );
-    delays[MAPS_DELAY].setDelay( 250 );
-    delays[CASTLE_TAVERN_DELAY].setDelay( 75 );
-    delays[CASTLE_AROUND_DELAY].setDelay( 200 );
-    delays[CASTLE_BUYHERO_DELAY].setDelay( 130 );
-    delays[CASTLE_BUILD_DELAY].setDelay( 130 );
-    delays[CASTLE_UNIT_DELAY].setDelay( 150 );
-    delays[HEROES_FADE_DELAY].setDelay( 32 );
-    delays[HEROES_PICKUP_DELAY].setDelay( 40 );
-    delays[PUZZLE_FADE_DELAY].setDelay( 50 );
-    delays[BATTLE_DIALOG_DELAY].setDelay( 75 );
-    delays[BATTLE_FRAME_DELAY].setDelay( 120 );
-    delays[BATTLE_MISSILE_DELAY].setDelay( 40 );
-    delays[BATTLE_SPELL_DELAY].setDelay( 75 );
-    delays[BATTLE_DISRUPTING_DELAY].setDelay( 25 );
-    delays[BATTLE_CATAPULT_DELAY].setDelay( 90 );
-    delays[BATTLE_CATAPULT_BOULDER_DELAY].setDelay( 40 );
-    delays[BATTLE_CATAPULT_CLOUD_DELAY].setDelay( 40 );
-    delays[BATTLE_BRIDGE_DELAY].setDelay( 90 );
-    delays[BATTLE_IDLE_DELAY].setDelay( 150 );
-    delays[BATTLE_OPPONENTS_DELAY].setDelay( 75 );
-    delays[BATTLE_FLAGS_DELAY].setDelay( 250 );
-    delays[BATTLE_POPUP_DELAY].setDelay( 800 );
-    delays[BATTLE_COLOR_CYCLE_DELAY].setDelay( 220 );
-    delays[BATTLE_SELECTED_UNIT_DELAY].setDelay( 160 );
-    delays[CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY].setDelay( 10 );
-    delays[CURRENT_HERO_DELAY].setDelay( 10 );
-    delays[CURRENT_AI_DELAY].setDelay( 10 );
+    setDelay( DelayType::SCROLL_DELAY, 20 );
+    setDelay( DelayType::SCROLL_START_DELAY, 20 );
+    setDelay( DelayType::CURSOR_BLINK_DELAY, 440 );
+    setDelay( DelayType::MAIN_MENU_DELAY, 250 );
+    setDelay( DelayType::MAPS_DELAY, 250 );
+    setDelay( DelayType::CASTLE_TAVERN_DELAY, 75 );
+    setDelay( DelayType::CASTLE_AROUND_DELAY, 200 );
+    setDelay( DelayType::CASTLE_BUYHERO_DELAY, 130 );
+    setDelay( DelayType::CASTLE_BUILD_DELAY, 130 );
+    setDelay( DelayType::CASTLE_UNIT_DELAY, 150 );
+    setDelay( DelayType::HEROES_FADE_DELAY, 32 );
+    setDelay( DelayType::HEROES_PICKUP_DELAY, 40 );
+    setDelay( DelayType::PUZZLE_FADE_DELAY, 50 );
+    setDelay( DelayType::BATTLE_DIALOG_DELAY, 75 );
+    setDelay( DelayType::BATTLE_FRAME_DELAY, 120 );
+    setDelay( DelayType::BATTLE_MISSILE_DELAY, 40 );
+    setDelay( DelayType::BATTLE_SPELL_DELAY, 75 );
+    setDelay( DelayType::BATTLE_DISRUPTING_DELAY, 25 );
+    setDelay( DelayType::BATTLE_CATAPULT_DELAY, 90 );
+    setDelay( DelayType::BATTLE_CATAPULT_BOULDER_DELAY, 40 );
+    setDelay( DelayType::BATTLE_CATAPULT_CLOUD_DELAY, 40 );
+    setDelay( DelayType::BATTLE_BRIDGE_DELAY, 90 );
+    setDelay( DelayType::BATTLE_IDLE_DELAY, 150 );
+    setDelay( DelayType::BATTLE_OPPONENTS_DELAY, 75 );
+    setDelay( DelayType::BATTLE_FLAGS_DELAY, 250 );
+    setDelay( DelayType::BATTLE_POPUP_DELAY, 800 );
+    setDelay( DelayType::BATTLE_COLOR_CYCLE_DELAY, 220 );
+    setDelay( DelayType::BATTLE_SELECTED_UNIT_DELAY, 160 );
+    setDelay( DelayType::CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY, 10 );
+    setDelay( DelayType::CURRENT_HERO_DELAY, 10 );
+    setDelay( DelayType::CURRENT_AI_DELAY, 10 );
 
     UpdateGameSpeed();
 
@@ -133,13 +139,13 @@ void Game::AnimateDelaysInitialize()
 
 void Game::AnimateResetDelay( const DelayType delayType )
 {
-    delays[delayType].reset();
+    delays[static_cast<size_t>( delayType )].reset();
 }
 
 bool Game::validateCustomAnimationDelay( const uint64_t delayMs )
 {
-    if ( delays[Game::DelayType::CUSTOM_DELAY].isPassed( delayMs ) ) {
-        delays[Game::DelayType::CUSTOM_DELAY].reset();
+    if ( delays[static_cast<size_t>( DelayType::CUSTOM_DELAY )].isPassed( delayMs ) ) {
+        delays[static_cast<size_t>( DelayType::CUSTOM_DELAY )].reset();
         return true;
     }
 
@@ -148,10 +154,10 @@ bool Game::validateCustomAnimationDelay( const uint64_t delayMs )
 
 bool Game::validateAnimationDelay( const DelayType delayType )
 {
-    assert( delayType != Game::DelayType::CUSTOM_DELAY );
+    assert( delayType != DelayType::CUSTOM_DELAY );
 
-    if ( delays[delayType].isPassed() ) {
-        delays[delayType].reset();
+    if ( delays[static_cast<size_t>( delayType )].isPassed() ) {
+        delays[static_cast<size_t>( delayType )].reset();
         return true;
     }
 
@@ -160,28 +166,28 @@ bool Game::validateAnimationDelay( const DelayType delayType )
 
 void Game::passAnimationDelay( const DelayType delayType )
 {
-    assert( delayType != Game::DelayType::CUSTOM_DELAY );
+    assert( delayType != DelayType::CUSTOM_DELAY );
 
-    delays[delayType].pass();
+    delays[static_cast<size_t>( delayType )].pass();
 }
 
 void Game::passCustomAnimationDelay( const uint64_t delayMs )
 {
-    delays[Game::DelayType::CUSTOM_DELAY].setDelay( delayMs );
-    delays[Game::DelayType::CUSTOM_DELAY].pass();
+    setDelay( DelayType::CUSTOM_DELAY, delayMs );
+    delays[static_cast<size_t>( DelayType::CUSTOM_DELAY )].pass();
 }
 
 void Game::setCustomUnitMovementDelay( const uint64_t delayMs )
 {
-    delays[Game::DelayType::CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY].setDelay( delayMs > 0 ? delayMs : 1 );
+    setDelay( DelayType::CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY, delayMs > 0 ? delayMs : 1 );
 }
 
 void Game::UpdateGameSpeed()
 {
     const Settings & conf = Settings::Get();
 
-    SetupHeroMovement( conf.HeroesMoveSpeed(), delays[CURRENT_HERO_DELAY], humanHeroMultiplier );
-    SetupHeroMovement( conf.AIMoveSpeed(), delays[CURRENT_AI_DELAY], aiHeroMultiplier );
+    SetupHeroMovement( conf.HeroesMoveSpeed(), delays[static_cast<size_t>( DelayType::CURRENT_HERO_DELAY )], humanHeroMultiplier );
+    SetupHeroMovement( conf.AIMoveSpeed(), delays[static_cast<size_t>( DelayType::CURRENT_AI_DELAY )], aiHeroMultiplier );
 
     const int32_t battleSpeed = conf.BattleSpeed();
     // For the battle speed = 10 avoid the zero delay and set animation speed to the 1/3 of battleSpeedAdjustment step.
@@ -189,17 +195,17 @@ void Game::UpdateGameSpeed()
     // Reduce the Idle animation adjustment interval to: 1.2 for speed 1 ... 0.8 for speed 10.
     const double adjustedIdleAnimationSpeed = ( 28 - battleSpeed ) / 22.5;
 
-    delays[BATTLE_FRAME_DELAY].setDelay( static_cast<uint64_t>( 120 * adjustedBattleSpeed ) );
-    delays[BATTLE_MISSILE_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
-    delays[BATTLE_SPELL_DELAY].setDelay( static_cast<uint64_t>( 75 * adjustedBattleSpeed ) );
-    delays[BATTLE_DISRUPTING_DELAY].setDelay( static_cast<uint64_t>( 25 * adjustedBattleSpeed ) );
-    delays[BATTLE_CATAPULT_DELAY].setDelay( static_cast<uint64_t>( 90 * adjustedBattleSpeed ) );
-    delays[BATTLE_CATAPULT_BOULDER_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
-    delays[BATTLE_CATAPULT_CLOUD_DELAY].setDelay( static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
-    delays[BATTLE_BRIDGE_DELAY].setDelay( static_cast<uint64_t>( 90 * adjustedBattleSpeed ) );
-    delays[BATTLE_IDLE_DELAY].setDelay( static_cast<uint64_t>( 150 * adjustedIdleAnimationSpeed ) );
-    delays[BATTLE_OPPONENTS_DELAY].setDelay( static_cast<uint64_t>( 75 * adjustedIdleAnimationSpeed ) );
-    delays[BATTLE_FLAGS_DELAY].setDelay( static_cast<uint64_t>( 250 * adjustedIdleAnimationSpeed ) );
+    setDelay( DelayType::BATTLE_FRAME_DELAY, static_cast<uint64_t>( 120 * adjustedBattleSpeed ) );
+    setDelay( DelayType::BATTLE_MISSILE_DELAY, static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
+    setDelay( DelayType::BATTLE_SPELL_DELAY, static_cast<uint64_t>( 75 * adjustedBattleSpeed ) );
+    setDelay( DelayType::BATTLE_DISRUPTING_DELAY, static_cast<uint64_t>( 25 * adjustedBattleSpeed ) );
+    setDelay( DelayType::BATTLE_CATAPULT_DELAY, static_cast<uint64_t>( 90 * adjustedBattleSpeed ) );
+    setDelay( DelayType::BATTLE_CATAPULT_BOULDER_DELAY, static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
+    setDelay( DelayType::BATTLE_CATAPULT_CLOUD_DELAY, static_cast<uint64_t>( 40 * adjustedBattleSpeed ) );
+    setDelay( DelayType::BATTLE_BRIDGE_DELAY, static_cast<uint64_t>( 90 * adjustedBattleSpeed ) );
+    setDelay( DelayType::BATTLE_IDLE_DELAY, static_cast<uint64_t>( 150 * adjustedIdleAnimationSpeed ) );
+    setDelay( DelayType::BATTLE_OPPONENTS_DELAY, static_cast<uint64_t>( 75 * adjustedIdleAnimationSpeed ) );
+    setDelay( DelayType::BATTLE_FLAGS_DELAY, static_cast<uint64_t>( 250 * adjustedIdleAnimationSpeed ) );
 }
 
 int Game::HumanHeroAnimSpeedMultiplier()
@@ -222,10 +228,10 @@ uint32_t Game::ApplyBattleSpeed( const uint32_t delay )
     return battleSpeed == 0 ? 1 : battleSpeed;
 }
 
-bool Game::hasEveryDelayPassed( const std::vector<Game::DelayType> & delayTypes )
+bool Game::hasEveryDelayPassed( const std::vector<DelayType> & delayTypes )
 {
-    for ( const Game::DelayType type : delayTypes ) {
-        if ( !delays[type].isPassed() ) {
+    for ( const DelayType type : delayTypes ) {
+        if ( !delays[static_cast<size_t>( type )].isPassed() ) {
             return false;
         }
     }
@@ -233,12 +239,12 @@ bool Game::hasEveryDelayPassed( const std::vector<Game::DelayType> & delayTypes 
     return true;
 }
 
-bool Game::isDelayNeeded( const std::vector<Game::DelayType> & delayTypes )
+bool Game::isDelayNeeded( const std::vector<DelayType> & delayTypes )
 {
-    for ( const Game::DelayType type : delayTypes ) {
-        assert( type != Game::DelayType::CUSTOM_DELAY );
+    for ( const DelayType type : delayTypes ) {
+        assert( type != DelayType::CUSTOM_DELAY );
 
-        if ( delays[type].isPassed() ) {
+        if ( delays[static_cast<size_t>( type )].isPassed() ) {
             return false;
         }
     }
@@ -248,11 +254,11 @@ bool Game::isDelayNeeded( const std::vector<Game::DelayType> & delayTypes )
 
 bool Game::isCustomDelayNeeded( const uint64_t delayMs )
 {
-    return !delays[Game::DelayType::CUSTOM_DELAY].isPassed( delayMs );
+    return !delays[static_cast<size_t>( DelayType::CUSTOM_DELAY )].isPassed( delayMs );
 }
 
 uint64_t Game::getAnimationDelayValue( const DelayType delayType )
 {
-    assert( delayType != Game::DelayType::CUSTOM_DELAY );
-    return delays[delayType].getDelay();
+    assert( delayType != DelayType::CUSTOM_DELAY );
+    return delays[static_cast<size_t>( delayType )].getDelay();
 }

--- a/src/fheroes2/game/game_delays.h
+++ b/src/fheroes2/game/game_delays.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2025                                             *
+ *   Copyright (C) 2020 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -25,7 +25,7 @@
 
 namespace Game
 {
-    enum DelayType : int
+    enum class DelayType : uint8_t
     {
         SCROLL_DELAY = 0,
         SCROLL_START_DELAY,

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -435,7 +435,7 @@ namespace
                 }
             }
 
-            if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+            if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
                 // Restore background with static monster animation part.
                 backgroundCopy.restore();
 

--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -248,7 +248,7 @@ int32_t Interface::AdventureMap::GetDimensionDoorDestination( const int32_t from
     LocalEvent & le = LocalEvent::Get();
     int32_t returnValue = -1;
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::MAPS_DELAY } ) ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::DelayType::MAPS_DELAY } ) ) ) {
         const fheroes2::Point & mp = le.getMouseCursorPos();
 
         if ( radarRect & mp ) {
@@ -283,7 +283,7 @@ int32_t Interface::AdventureMap::GetDimensionDoorDestination( const int32_t from
             cursor.SetThemes( Cursor::POINTER );
         }
 
-        if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
             Game::updateAdventureMapAnimationIndex();
 
             redraw( REDRAW_GAMEAREA );

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -405,7 +405,7 @@ fheroes2::GameMode Game::MainMenu( const bool isFirstGameRun )
             fheroes2::showStandardTextMessage( _( "Game Settings" ), _( "Change language, resolution and settings of the game." ), Dialog::ZERO );
         }
 
-        if ( validateAnimationDelay( MAIN_MENU_DELAY ) ) {
+        if ( validateAnimationDelay( DelayType::MAIN_MENU_DELAY ) ) {
             const fheroes2::Sprite & lantern12 = fheroes2::AGG::GetICN( ICN::SHNGANIM, ICN::getAnimatedIcnIndex( ICN::SHNGANIM, 0, lantern_frame ) );
             ++lantern_frame;
             fheroes2::Blit( lantern12, display, lantern12.x(), lantern12.y() );

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -1046,7 +1046,7 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isLoadedFromSa
     fheroes2::Point heroAnimationOffset;
     int heroAnimationSpriteId = 0;
 
-    const std::vector<Game::DelayType> delayTypes = { Game::CURRENT_HERO_DELAY, Game::MAPS_DELAY };
+    const std::vector<Game::DelayType> delayTypes = { Game::DelayType::CURRENT_HERO_DELAY, Game::DelayType::MAPS_DELAY };
 
     LocalEvent & le = LocalEvent::Get();
     Cursor & cursor = Cursor::Get();
@@ -1308,7 +1308,7 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isLoadedFromSa
                     }
 
                     if ( scrollDirection != SCROLL_NONE && _gameArea.isFastScrollEnabled() ) {
-                        if ( Game::validateAnimationDelay( Game::SCROLL_START_DELAY ) && fastScrollRepeatCount < fastScrollStartThreshold ) {
+                        if ( Game::validateAnimationDelay( Game::DelayType::SCROLL_START_DELAY ) && fastScrollRepeatCount < fastScrollStartThreshold ) {
                             ++fastScrollRepeatCount;
                         }
 
@@ -1377,7 +1377,7 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isLoadedFromSa
         }
 
         // Animation of the hero's movement
-        if ( Game::validateAnimationDelay( Game::CURRENT_HERO_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::CURRENT_HERO_DELAY ) ) {
             Heroes * hero = GetFocusHeroes();
 
             if ( hero ) {
@@ -1504,7 +1504,7 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isLoadedFromSa
 
         // Scrolling the game area
         if ( !isHeroMoving ) {
-            if ( _gameArea.NeedScroll() && Game::validateAnimationDelay( Game::SCROLL_DELAY ) ) {
+            if ( _gameArea.NeedScroll() && Game::validateAnimationDelay( Game::DelayType::SCROLL_DELAY ) ) {
                 assert( !_gameArea.isDragScroll() );
 
                 if ( isScrollLeft( le.getMouseCursorPos() ) || isScrollRight( le.getMouseCursorPos() ) || isScrollTop( le.getMouseCursorPos() )
@@ -1532,7 +1532,7 @@ fheroes2::GameMode Interface::AdventureMap::HumanTurn( const bool isLoadedFromSa
         }
 
         // Map objects animation
-        if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
             Game::updateAdventureMapAnimationIndex();
 
             _gameArea.SetRedraw();

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -1208,8 +1208,8 @@ void Interface::GameArea::runSingleObjectAnimation( const std::shared_ptr<BaseOb
     fheroes2::Display & display = fheroes2::Display::instance();
     Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::HEROES_PICKUP_DELAY } ) ) && !info->isAnimationCompleted() ) {
-        if ( Game::validateAnimationDelay( Game::HEROES_PICKUP_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::DelayType::HEROES_PICKUP_DELAY } ) ) && !info->isAnimationCompleted() ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::HEROES_PICKUP_DELAY ) ) {
             adventureMapInterface.redraw( Interface::REDRAW_GAMEAREA );
             display.render();
         }

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -495,7 +495,7 @@ void Interface::StatusPanel::drawAITurnProgress( const uint32_t progressValue )
     LocalEvent::Get().HandleEvents( false );
 
     const bool updateProgress = ( progressValue != _aiTurnProgress );
-    const bool isMapAnimation = Game::validateAnimationDelay( Game::MAPS_DELAY );
+    const bool isMapAnimation = Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY );
 
     if ( !updateProgress && !isMapAnimation ) {
         return;

--- a/src/fheroes2/gui/ui_kingdom.cpp
+++ b/src/fheroes2/gui/ui_kingdom.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2024                                             *
+ *   Copyright (C) 2022 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -82,7 +82,7 @@ namespace fheroes2
         const CustomAnimationDialogElement lighthouseCustomDynamicImageElement( ICN::OBJNMUL2, combined,
                                                                                 { fheroes2::tileWidthPx * 2 + lighthouseLight.x(),
                                                                                   fheroes2::tileWidthPx + lighthouseLight.y() - topOffset },
-                                                                                61, getAnimationDelayValue( Game::MAPS_DELAY ) );
+                                                                                61, getAnimationDelayValue( Game::DelayType::MAPS_DELAY ) );
 
         // StringObject on OBJ_LIGHTHOUSE with count 2 for the plural of lighthouse
         showStandardTextMessage( StringObject( MP2::OBJ_LIGHTHOUSE, 2 ), _( "For every lighthouse controlled, your ships will move further each day." ), buttons,

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -3476,13 +3476,13 @@ namespace
                     LocalEvent & le = LocalEvent::Get();
                     size_t delay = 0;
 
-                    while ( delay < maxDelay && le.HandleEvents( Game::isDelayNeeded( { Game::MAPS_DELAY } ) ) ) {
+                    while ( delay < maxDelay && le.HandleEvents( Game::isDelayNeeded( { Game::DelayType::MAPS_DELAY } ) ) ) {
                         if ( le.isAnyKeyPressed() || le.MouseClickLeft() || le.MouseClickMiddle() || le.MouseClickRight() ) {
                             skipAnimation = true;
                             break;
                         }
 
-                        if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+                        if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
                             ++delay;
                             Game::updateAdventureMapAnimationIndex();
                             I.redraw( Interface::REDRAW_GAMEAREA );

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -525,8 +525,8 @@ void Heroes::FadeOut( const int animSpeedMultiplier, const fheroes2::Point & off
 
     _alphaValue = 255;
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::HEROES_FADE_DELAY } ) ) && _alphaValue > 0 ) {
-        if ( !Game::validateAnimationDelay( Game::HEROES_FADE_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::DelayType::HEROES_FADE_DELAY } ) ) && _alphaValue > 0 ) {
+        if ( !Game::validateAnimationDelay( Game::DelayType::HEROES_FADE_DELAY ) ) {
             continue;
         }
 
@@ -534,7 +534,7 @@ void Heroes::FadeOut( const int animSpeedMultiplier, const fheroes2::Point & off
             gamearea.ShiftCenter( offset );
         }
 
-        if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
             Game::updateAdventureMapAnimationIndex();
             if ( isControlAI() ) {
                 // Draw hourglass sand grains animation.
@@ -568,8 +568,8 @@ void Heroes::FadeIn( const int animSpeedMultiplier, const fheroes2::Point & offs
 
     _alphaValue = 0;
 
-    while ( le.HandleEvents( Game::isDelayNeeded( { Game::HEROES_FADE_DELAY } ) ) && _alphaValue < 255 ) {
-        if ( !Game::validateAnimationDelay( Game::HEROES_FADE_DELAY ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( { Game::DelayType::HEROES_FADE_DELAY } ) ) && _alphaValue < 255 ) {
+        if ( !Game::validateAnimationDelay( Game::DelayType::HEROES_FADE_DELAY ) ) {
             continue;
         }
 
@@ -577,7 +577,7 @@ void Heroes::FadeIn( const int animSpeedMultiplier, const fheroes2::Point & offs
             gamearea.ShiftCenter( offset );
         }
 
-        if ( Game::validateAnimationDelay( Game::MAPS_DELAY ) ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::MAPS_DELAY ) ) {
             Game::updateAdventureMapAnimationIndex();
             if ( isControlAI() ) {
                 // Draw hourglass sand grains animation.

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -116,8 +116,8 @@ namespace
         fheroes2::Display & display = fheroes2::Display::instance();
         LocalEvent & le = LocalEvent::Get();
 
-        const std::vector<Game::DelayType> delayTypes = { Game::PUZZLE_FADE_DELAY };
-        Game::passAnimationDelay( Game::PUZZLE_FADE_DELAY );
+        const std::vector<Game::DelayType> delayTypes = { Game::DelayType::PUZZLE_FADE_DELAY };
+        Game::passAnimationDelay( Game::DelayType::PUZZLE_FADE_DELAY );
 
         int alpha = 250;
 
@@ -132,7 +132,7 @@ namespace
                 fheroes2::showStandardTextMessage( _( "Exit" ), _( "Exit this menu." ), 0 );
             }
 
-            if ( Game::validateAnimationDelay( Game::PUZZLE_FADE_DELAY ) ) {
+            if ( Game::validateAnimationDelay( Game::DelayType::PUZZLE_FADE_DELAY ) ) {
                 fheroes2::Copy( sf, 0, 0, display, dstx, dsty, sf.width(), sf.height() );
 
                 for ( size_t i = 0; i < pzl.size(); ++i ) {


### PR DESCRIPTION
This PR is a part of https://github.com/ihhub/fheroes2/pull/10309

This PR:
- converts `Game::DelayType` from `enum` to `enum class`;
- converts `Battle::HeroAnimation` from `enum` to `enum class`;
- tries to make the background animations on the Battlefield (heroes reactions, flags) more smooth while performing other animations.

In future we should polish every animation render loop for proper use of `_checkGlobalEvents( le );` method.
This method makes the `_needRedraw` variable `true` if any background animation is needed to render and it makes this animation (increases the animation index). And it should be called only when performing full battlefield redraw.
So I removed calls to this method where only `RedrawPartialFinish()` is called without `RedrawPartialStart()`, and also in animations like "Earthquake" and "Death Ripple" where there is no animation, but only effects are applied to a static image.