### PR TITLE
Use Generic map modification action for Capturable objects

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -2254,7 +2254,7 @@ namespace Interface
                     const PlayerColor newColor = Dialog::selectPlayerColor( ownerColor, _mapFormat.availablePlayerColors );
 
                     if ( newColor != ownerColor ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::CAPTURABLE_OBJECT_METADATA );
+                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::GENERIC );
 
                         if ( newColor == PlayerColor::NONE ) {
                             _mapFormat.capturableObjectsMetadata.erase( object.id );

--- a/src/fheroes2/editor/history_manager.cpp
+++ b/src/fheroes2/editor/history_manager.cpp
@@ -186,9 +186,6 @@ namespace fheroes2
         case ActionType::SELECTION_METADATA:
             _action = std::make_unique<MetadataMapAction<Maps::Map_Format::SelectionObjectMetadata>>( mapFormat.selectionObjectMetadata );
             break;
-        case ActionType::CAPTURABLE_OBJECT_METADATA:
-            _action = std::make_unique<MetadataMapAction<Maps::Map_Format::CapturableObjectMetadata>>( mapFormat.capturableObjectsMetadata );
-            break;
         case ActionType::MONSTER_METADATA:
             _action = std::make_unique<MetadataMapAction<Maps::Map_Format::MonsterMetadata>>( mapFormat.monsterMetadata );
             break;

--- a/src/fheroes2/editor/history_manager.h
+++ b/src/fheroes2/editor/history_manager.h
@@ -59,13 +59,13 @@ namespace fheroes2
             // Use it when you aren't sure what changes are done or the changes are too complex.
             GENERIC,
             // Metadata update for a single object type.
+            // An exception is capturable objects as they need to enforce map redrawing.
             HERO_METADATA,
             CASTLE_METADATA,
             SPHINX_METADATA,
             SIGN_METADATA,
             ADVENTURE_MAP_EVENT_METADATA,
             SELECTION_METADATA,
-            CAPTURABLE_OBJECT_METADATA,
             MONSTER_METADATA,
             ARTIFACT_METADATA,
             RESOURCE_METADATA,


### PR DESCRIPTION
Regression from #10700

This is because these objects require changes in `world` class and redrawing the map.