### PR TITLE
Fix the first editing of the hero while cancelling

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -2040,12 +2040,13 @@ namespace Interface
                     hero.SetColor( color );
                     hero.applyHeroMetadata( _mapFormat.heroMetadata[object.id], objectType == MP2::OBJ_JAIL, true );
 
-                    hero.OpenDialog( false, false, true, true, true, true, _mapFormat.mainLanguage );
-                    Maps::Map_Format::HeroMetadata heroNewMetadata = hero.getHeroMetadata();
-                    if ( heroNewMetadata != _mapFormat.heroMetadata[object.id] ) {
-                        fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::HERO_METADATA );
-                        _mapFormat.heroMetadata[object.id] = std::move( heroNewMetadata );
-                        action.commit();
+                    if ( hero.OpenDialog( false, false, true, true, true, true, _mapFormat.mainLanguage ) != Dialog::DISMISS ) {
+                        Maps::Map_Format::HeroMetadata heroNewMetadata = hero.getHeroMetadata();
+                        if ( heroNewMetadata != _mapFormat.heroMetadata[object.id] ) {
+                            fheroes2::ActionCreator action( _historyManager, _mapFormat, fheroes2::ActionCreator::ActionType::HERO_METADATA );
+                            _mapFormat.heroMetadata[object.id] = std::move( heroNewMetadata );
+                            action.commit();
+                        }
                     }
                 }
                 else if ( objectType == MP2::OBJ_CASTLE || objectType == MP2::OBJ_RANDOM_TOWN || objectType == MP2::OBJ_RANDOM_CASTLE ) {

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -792,9 +792,16 @@ Maps::Map_Format::HeroMetadata Heroes::getHeroMetadata() const
     const std::vector<Skill::Secondary> & skills = _secondarySkills.ToVector();
     const size_t skillsSize = skills.size();
     assert( heroMetadata.secondarySkill.size() == skillsSize && heroMetadata.secondarySkillLevel.size() == skillsSize );
+
+    size_t skillId{ 0 };
     for ( size_t i = 0; i < skillsSize; ++i ) {
-        heroMetadata.secondarySkill[i] = static_cast<int8_t>( skills[i].Skill() );
-        heroMetadata.secondarySkillLevel[i] = static_cast<uint8_t>( skills[i].Level() );
+        if ( !skills[i].isValid() ) {
+            continue;
+        }
+
+        heroMetadata.secondarySkill[skillId] = static_cast<int8_t>( skills[i].Skill() );
+        heroMetadata.secondarySkillLevel[skillId] = static_cast<uint8_t>( skills[i].Level() );
+        ++skillId;
     }
 
     // Hero's name.

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -814,7 +814,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         const auto currentMetadata = getHeroMetadata();
         if ( currentMetadata != *initialHeroMetadata ) {
             if ( fheroes2::showStandardTextMessage( GetName(), _( "Do you want to save the changes made?" ), Dialog::YES | Dialog::NO ) == Dialog::NO ) {
-                applyHeroMetadata( *initialHeroMetadata, Modes( JAIL ), true );
+                return Dialog::DISMISS;
             }
         }
     }

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -817,6 +817,11 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
                 return Dialog::DISMISS;
             }
         }
+        else {
+            // This could happen when we automatically change the location of certain items.
+            // For example, when pushing artifacts we put them to the first position.
+            return Dialog::DISMISS;
+        }
     }
 
     // Fade-out hero dialog.


### PR DESCRIPTION
relates to https://github.com/ihhub/fheroes2/pull/10688#issuecomment-4370225936

Plus fixed an issue when an action was created every time for hero opening dialog when secondary skills are not in order.

https://github.com/user-attachments/assets/b9167ffb-e4c5-4582-a47c-1fe317b2c56b

