### PR TITLE
Update the main object part of the tile after erasing an object

### DIFF
--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1453,6 +1453,10 @@ bool Maps::Tile::removeObjectPartsByUID( const uint32_t objectUID )
     if ( _mainObjectPart._uid == objectUID ) {
         _mainObjectPart = {};
 
+        // We need to sort main and ground object parts if the main part was removed
+        // to properly place the object with the highest priority to the `_mainObjectPart`.
+        sortObjectParts();
+
         isObjectPartRemoved = true;
     }
 

--- a/src/fheroes2/maps/maps_tiles.cpp
+++ b/src/fheroes2/maps/maps_tiles.cpp
@@ -1450,15 +1450,6 @@ void Maps::Tile::fixMP2MapTileObjectType( Tile & tile )
 bool Maps::Tile::removeObjectPartsByUID( const uint32_t objectUID )
 {
     bool isObjectPartRemoved = false;
-    if ( _mainObjectPart._uid == objectUID ) {
-        _mainObjectPart = {};
-
-        // We need to sort main and ground object parts if the main part was removed
-        // to properly place the object with the highest priority to the `_mainObjectPart`.
-        sortObjectParts();
-
-        isObjectPartRemoved = true;
-    }
 
     size_t partCountBefore = _groundObjectPart.size();
     _groundObjectPart.remove_if( [objectUID]( const auto & v ) { return v._uid == objectUID; } );
@@ -1469,6 +1460,16 @@ bool Maps::Tile::removeObjectPartsByUID( const uint32_t objectUID )
     partCountBefore = _topObjectPart.size();
     _topObjectPart.remove_if( [objectUID]( const auto & v ) { return v._uid == objectUID; } );
     if ( partCountBefore != _topObjectPart.size() ) {
+        isObjectPartRemoved = true;
+    }
+
+    if ( _mainObjectPart._uid == objectUID ) {
+        _mainObjectPart = {};
+
+        // We need to sort main and ground object parts if the main part was removed
+        // to properly place the object with the highest priority to the `_mainObjectPart`.
+        sortObjectParts();
+
         isObjectPartRemoved = true;
     }
 


### PR DESCRIPTION
Close https://github.com/ihhub/fheroes2/issues/10739

This is an alternative solution (to #10741) of bugs after moving (erase + place) objects in editor.
It fixes the erase operation from the `world` tile by updating the main object part if it was cleared with one of the objects from the ground object parts. This fixes the passabilities of the tile avoiding issues with placing a new object to this tile.