### PR TITLE
Keep hero sprite invisible after hero fade-out animation

### DIFF
--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -333,6 +333,9 @@ namespace
             Interface::AdventureMap::Get().getGameArea().SetCenter( hero.GetCenter() );
             hero.FadeIn( Game::AIHeroAnimSpeedMultiplier() );
         }
+        else {
+            hero.setAlphaValue( 255 );
+        }
 
         AI::Planner::Get().HeroesActionComplete( hero, targetIndex, hero.getObjectTypeUnderHero() );
 
@@ -1013,6 +1016,9 @@ namespace
             Interface::AdventureMap::Get().getGameArea().SetCenter( hero.GetCenter() );
             hero.FadeIn( Game::AIHeroAnimSpeedMultiplier() );
         }
+        else {
+            hero.setAlphaValue( 255 );
+        }
 
         hero.ActionNewPosition( false );
     }
@@ -1080,6 +1086,9 @@ namespace
         if ( AIIsShowAnimationForHero( hero, allianceColors ) ) {
             Interface::AdventureMap::Get().getGameArea().SetCenter( hero.GetCenter() );
             hero.FadeIn( Game::AIHeroAnimSpeedMultiplier() );
+        }
+        else {
+            hero.setAlphaValue( 255 );
         }
 
         hero.ActionNewPosition( false );
@@ -1813,6 +1822,7 @@ namespace
         hero.Move2Dest( dst_index );
         hero.ResetMovePoints();
         hero.GetPath().Reset();
+        hero.setAlphaValue( 255 );
 
         // Set the direction of the hero to the one of the boat as the boat does not move when boarding it
         hero.setDirection( boatDirection );
@@ -2428,6 +2438,9 @@ void AI::HeroesCastDimensionDoor( Heroes & hero, const int32_t targetIndex )
     if ( AIIsShowAnimationForHero( hero, allianceColors ) ) {
         Interface::AdventureMap::Get().getGameArea().SetCenter( hero.GetCenter() );
         hero.FadeIn( Game::AIHeroAnimSpeedMultiplier() );
+    }
+    else {
+        hero.setAlphaValue( 255 );
     }
 
     hero.ActionNewPosition( false );

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -1119,6 +1119,7 @@ bool Heroes::Recruit( const PlayerColor col, const fheroes2::Point & pt )
     ResetModes( JAIL );
 
     SetColor( col );
+    setAlphaValue( 255 );
 
     SetCenter( pt );
     setDirection( Direction::RIGHT );

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -700,6 +700,11 @@ public:
         return static_cast<uint8_t>( _alphaValue );
     }
 
+    void setAlphaValue( const uint8_t alphaValue )
+    {
+        _alphaValue = alphaValue;
+    }
+
     double getAIMinimumJoiningArmyStrength() const;
 
     uint32_t getDailyRestoredSpellPoints() const;

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -259,7 +259,7 @@ namespace
         // If there is a map bug the Object Animation destructor is not able to properly remove this object from the map.
         if ( actualObjectType != objectType && actualObjectType != MP2::OBJ_NONE ) {
             // Remove an object by its actual sprite type.
-            removeObjectFromTileByType( tile, actualObjectType );
+            Maps::removeObjectFromTileByType( tile, actualObjectType );
         }
 
         // Update radar in the place of the removed object.
@@ -684,6 +684,7 @@ namespace
         hero.Move2Dest( dst_index );
         hero.ResetMovePoints();
         hero.GetPath().Reset();
+        hero.setAlphaValue( 255 );
 
         // Update the radar map image before changing the direction of the hero.
         Interface::AdventureMap & I = Interface::AdventureMap::Get();

--- a/src/fheroes2/heroes/heroes_move.cpp
+++ b/src/fheroes2/heroes/heroes_move.cpp
@@ -548,8 +548,6 @@ void Heroes::FadeOut( const int animSpeedMultiplier, const fheroes2::Point & off
 
         display.render();
     }
-
-    _alphaValue = 255;
 }
 
 void Heroes::FadeIn( const int animSpeedMultiplier, const fheroes2::Point & offset /* = {} */ ) const


### PR DESCRIPTION
This PR is a part of https://github.com/ihhub/fheroes2/pull/10309

The fade-out animation gradually increases transparency (decreases `_alphaValue`) of the sprite from 255 (no transparency) to 0 (fully transparent).
In master build after performing this animation for hero the `_alphaValue` is restored to 255.
This PR removes this restoration from the `FadeOut()` method.
The `_alphaValue` can be now set using `setAlphaValue()` method if needed.