### PR TITLE
Polish translations: Map editor, hotkeys, cleanup

### DIFF
--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -1178,11 +1178,10 @@ msgstr "Kliknij, aby wybrać bohatera."
 msgid "Hero"
 msgstr "Bohater"
 
-#, fuzzy
 msgid ""
 "If this checkbox is checked, the defending hero is going be human-controlled."
 msgstr ""
-"Kliknij, aby ustawić tego bohatera jako kontrolowanego przez człowieka."
+"Po zaznaczeniu tego pola broniący się bohater będzie kontrolowany przez człowieka."
 
 msgid "%{race1} %{name1} vs %{race2} %{name2}"
 msgstr "%{race1} %{name1} kontra %{race2} %{name2}"
@@ -3259,9 +3258,8 @@ msgstr ""
 msgid "About"
 msgstr "Info"
 
-#, fuzzy
 msgid "Click to read notes from the map creator."
-msgstr "Kliknij, aby wrócić do głównego menu."
+msgstr "Kliknij, aby przeczytać notatki od autora mapy."
 
 msgid "Map Description"
 msgstr "Opis mapy"
@@ -4016,7 +4014,6 @@ msgstr "Nazwa aktualnie wybranej mapy."
 msgid "Selected Map Difficulty"
 msgstr "Trudność wybranej mapy"
 
-#, fuzzy
 msgid ""
 "The map difficulty of the currently selected map. The map difficulty is "
 "determined by the scenario designer. More difficult maps might include more "
@@ -4025,11 +4022,10 @@ msgid ""
 msgstr ""
 "Poziom trudności na aktualnie wybranej mapie, określony przez autora "
 "scenariusza. Na bardziej złożonych mapach mogą występować silniejsi "
-"przeciwnicy, mniej zasobów lub inne specjalne warunki utrudniające rozgrywkę."
+"przeciwnicy, mniej zasobów lub inne specjalne warunki utrudniające rozgrywkę graczowi."
 
-#, fuzzy
 msgid "Selected Map Description"
-msgstr "Wybrany opis"
+msgstr "Opis wybranej mapy"
 
 msgid "Jump"
 msgstr "Skok"
@@ -4044,7 +4040,7 @@ msgid "Enemy Speed"
 msgstr "Szybk. wroga"
 
 msgid "Auto Resolve"
-msgstr "Automatyczna"
+msgstr "Automatyczne"
 
 msgid "Auto, No Spells"
 msgstr "Auto, bez zaklęć"
@@ -4052,14 +4048,12 @@ msgstr "Auto, bez zaklęć"
 msgid "Battles"
 msgstr "Walki"
 
-#, fuzzy
 msgid "combatMode|Manual"
-msgstr "Ręczna"
+msgstr "Ręczne"
 
 msgid "Change the speed at which your heroes move on the main screen."
 msgstr "Zmień szybkość z jaką poruszają się twoi bohaterowie na ekranie."
 
-#, fuzzy
 msgid ""
 "Sets the speed that computer heroes move at. You can also elect not to view "
 "computer movement at all."
@@ -4193,9 +4187,8 @@ msgstr "Armia zamku"
 msgid "Town Army"
 msgstr "Armia miasta"
 
-#, fuzzy
 msgid "You have unsaved changes. Do you wish to proceed?"
-msgstr "Ile jednostek przenieść?"
+msgstr "Masz niezapisane zmiany. Czy chcesz kontynuować?"
 
 msgid "Click to change the Castle name."
 msgstr "Kliknij, aby zmienić nazwę zamku."
@@ -4379,31 +4372,26 @@ msgstr ""
 "przeciwnym wypadku zdarzenie zostanie aktywowane za każdym razem, gdy jeden "
 "z wybranych graczy wejdzie na pole zdarzenia."
 
-#, fuzzy
 msgid "Click to make selection."
-msgstr "Kliknij tutaj, aby wybrać scenariusz, który chcesz rozegrać."
+msgstr "Kliknij, aby dokonać wyboru."
 
-#, fuzzy
 msgid "%{objects} cannot be placed on water."
-msgstr "To zaklęcie nie może być rzucone z łodzi."
+msgstr "%{objects} nie mogą być umieszczone na wodzie."
 
-#, fuzzy
 msgid ""
 "The Ultimate Artifact can only be placed on terrain where digging is "
 "possible."
-msgstr "To zaklęcie nie może być rzucone z łodzi."
+msgstr "Najpotężniejszy artefakt można umieścić tylko na terenie "
+"umożliwiającym kopanie."
 
-#, fuzzy
 msgid "%{objects} must be placed on water."
-msgstr "To zaklęcie nie może być rzucone z łodzi."
+msgstr "%{objects} muszą być umieszczone na wodzie."
 
-#, fuzzy
 msgid "Action objects cannot be placed outside the map."
-msgstr "To zaklęcie nie może być rzucone z łodzi."
+msgstr "Obiekty nie mogą być umieszczone poza mapą."
 
-#, fuzzy
 msgid "Action objects must be placed on clear tiles."
-msgstr "To zaklęcie nie może być rzucone z łodzi."
+msgstr "Obiekty interaktywne muszą być umieszczone na pustych polach."
 
 msgid "A maximum of %{count} %{objects} can be placed on the map."
 msgstr "Na mapie można umieścić maksymalnie %{count} rodzaju '%{objects}'."
@@ -4515,15 +4503,14 @@ msgstr "Ustaw promień losowego najpotężniejszego artefaktu:"
 msgid "%{object} has no properties to change."
 msgstr "Obiekt '%{object}' nie posiada właściwości do zmiany."
 
-#, fuzzy
 msgid "This artifact"
-msgstr "z jednym artefaktem."
+msgstr "Ten artefakt"
 
 msgid "The total number of obelisks is %{count}."
 msgstr "Na mapie znajduje się %{count} obelisków."
 
 msgid "There are no players on the map, so no one can own this object."
-msgstr ""
+msgstr "Na mapie nie ma graczy, więc nikt nie może posiadać tego obiektu."
 
 msgid "Roads"
 msgstr "Drogi"
@@ -4531,31 +4518,28 @@ msgstr "Drogi"
 msgid "Streams"
 msgstr "Strumienie"
 
-#, fuzzy
 msgid ""
 "A maximum of %{count} heroes including jailed heroes can be placed on the "
 "map."
-msgstr "To zaklęcie nie może być rzucone z łodzi."
+msgstr "Na mapie można umieścić maksymalnie %{count} bohaterów, "
+"wliczając uwięzionych."
 
 msgid ""
 "A maximum of %{count} heroes of the same color can be placed on the map."
-msgstr ""
+msgstr "Na mapie można umieścić maksymalnie %{count} bohaterów tego samego koloru."
 
 msgid "Failed to update player information."
-msgstr ""
+msgstr "Nie udało się zaktualizować informacji o graczach."
 
-#, fuzzy
 msgid "Only one Random Ultimate Artifact can be placed on the map."
-msgstr "To zaklęcie nie może być rzucone z łodzi."
+msgstr "Na mapie można umieścić tylko jeden losowy najpotężniejszy artefakt."
 
 msgid "A maximum of %{count} obelisks can be placed on the map."
-msgstr ""
+msgstr "Na mapie można umieścić maksymalnie %{count} obelisków."
 
-#, fuzzy
 msgid "The same object exists on the tile."
-msgstr "Ten język już istnieje na liście."
+msgstr "Ten sam obiekt już istnieje na tym polu."
 
-#, fuzzy
 msgid "The map is corrupted."
 msgstr "Mapa jest uszkodzona."
 
@@ -4590,11 +4574,12 @@ msgstr ""
 "Kliknij tutaj aby\n"
 "wybrać potwora."
 
-#, fuzzy
 msgid ""
 "Click here to\n"
 "select another monster."
-msgstr "Wybierz innego bohatera."
+msgstr ""
+"Kliknij tutaj aby\n"
+"wybrać kolejnego potwora."
 
 msgid "Erase"
 msgstr "Usuwanie"
@@ -4636,14 +4621,13 @@ msgid "Towns"
 msgstr "Miasta"
 
 msgid "editorDetailMode|Edit"
-msgstr ""
+msgstr "Edytuj"
 
 msgid "editorDetailMode|Move"
-msgstr ""
+msgstr "Przenieś"
 
-#, fuzzy
 msgid "editorDetailMode|Copy"
-msgstr "ANULUJ"
+msgstr "Kopiuj"
 
 msgid "editorErasure|Mountains"
 msgstr "Góry"
@@ -4727,13 +4711,13 @@ msgid "No special modifiers."
 msgstr "Brak specjalnych modyfikatorów."
 
 msgid "Edit objects on the Adventure Map."
-msgstr ""
+msgstr "Zmień obiekty na mapie przygody."
 
 msgid "Move objects on the Adventure Map."
-msgstr ""
+msgstr "Przenieś obiekty na mapie przygody."
 
 msgid "Copy objects on the Adventure Map."
-msgstr ""
+msgstr "Kopiuj obiekty na mapie przygody."
 
 msgid "Toggle the erasure of %{type} objects."
 msgstr "Włącz/wyłącz wymazywanie obiektów - %{type}."
@@ -4883,15 +4867,15 @@ msgid "Delete an existing language."
 msgstr "Usuń istniejący język."
 
 msgid "Failed to generate a random map with given parameters."
-msgstr ""
+msgstr "Nie udało się wygenerować losowej mapy z podanymi parametrami."
 
 msgid ""
 "Create a new map, either from scratch or using the random map generator."
 msgstr ""
+"Stwórz nową mapę od podstaw, albo skorzystaj z generatora losowych map."
 
-#, fuzzy
 msgid "Exit the Editor and return to the game's Main Menu."
-msgstr "Kliknij, aby wrócić do głównego menu."
+msgstr "Wyjdź z edytora i wróć do głównego menu gry."
 
 msgid "From Scratch"
 msgstr "Od początku"
@@ -4906,23 +4890,21 @@ msgid "Random"
 msgstr "Losowa"
 
 msgid "Back"
-msgstr ""
+msgstr "Powrót"
 
-#, fuzzy
 msgid "Return to the Editor's main menu options."
-msgstr "Kliknij, aby wrócić do głównego menu."
+msgstr "Wróć do głównego menu edytora."
 
-#, fuzzy
 msgid ""
 "Generate a random map that is %{size} squares wide and %{size} squares high."
-msgstr "Utwórz mapę o długości %{size} i szerokości %{size}."
+msgstr ""
+"Wygeneruj mapę szeroką na %{size} pól i wysoką na %{size} pól."
 
 msgid "Create a map that is %{size} squares wide and %{size} squares high."
 msgstr "Utwórz mapę o długości %{size} i szerokości %{size}."
 
-#, fuzzy
 msgid "Return to the previous menu options."
-msgstr "Kliknij, aby wrócić do głównego menu."
+msgstr "Wróć do poprzednich opcji menu."
 
 msgid "No maps available!"
 msgstr "Mapy niedostępne!"
@@ -5105,15 +5087,15 @@ msgstr ""
 "występować silniejsi przeciwnicy, mniej zasobów lub inne specjalne warunki "
 "utrudniające rozgrywkę."
 
-#, fuzzy
 msgid ""
 "editor|%{object}\n"
 "(%{color} player)"
-msgstr "%{color} gracz"
+msgstr ""
+"%{object}\n"
+"(%{color} gracz)"
 
-#, fuzzy
 msgid "editor|%{count} %{resource}"
-msgstr "Wybierz ilość %{resource}:"
+msgstr "%{count} %{resource}"
 
 msgid "Animation"
 msgstr "Animacja"
@@ -5160,20 +5142,24 @@ msgstr "Usuń pogłoskę"
 msgid "Delete an existing rumor."
 msgstr "Usuń istniejącą pogłoskę."
 
-#, fuzzy
 msgid ""
 "\n"
 "\n"
 "Language:\n"
-msgstr "Język"
+msgstr ""
+"\n"
+"\n"
+"Język:\n"
 
 msgid ""
 "\n"
 "\n"
 "Size: "
 msgstr ""
+"\n"
+"\n"
+"Rozmiar: "
 
-#, fuzzy
 msgid ""
 "\n"
 "\n"
@@ -5181,7 +5167,7 @@ msgid ""
 msgstr ""
 "\n"
 "\n"
-"Położenie pliku: "
+"Opis: "
 
 msgid "Save Map:"
 msgstr "Zapisz mapę:"
@@ -5189,21 +5175,17 @@ msgstr "Zapisz mapę:"
 msgid "Click to save the current map."
 msgstr "Kliknij, aby zapisać bieżącą mapę."
 
-#, fuzzy
 msgid "Click to enable all secondary skills."
-msgstr "Kliknij tutaj, aby wybrać scenariusz, który chcesz rozegrać."
+msgstr "Kliknij, aby włączyć wszystkie umiejętności poboczne."
 
-#, fuzzy
 msgid "Enable All Secondary Skills"
-msgstr "Losowa"
+msgstr "Włącz wszystkie umiejętności poboczne"
 
-#, fuzzy
 msgid "Click to disable all secondary skills."
-msgstr "Użyj wskazanej rozdzielczości."
+msgstr "Kliknij, aby wyłączyć wszystkie umiejętności poboczne."
 
-#, fuzzy
 msgid "Disable All Secondary Skills"
-msgstr "Pokaż zaklęcia"
+msgstr "Wyłącz wszystkie umiejętności poboczne"
 
 msgid "Click to show only level %{level} spells."
 msgstr "Kliknij, aby pokazać tylko zaklęcia %{level}. poziomu."
@@ -5301,7 +5283,6 @@ msgstr "Trudna"
 msgid "Campaign Difficulty"
 msgstr "Stopień trudności kampanii"
 
-#, fuzzy
 msgid ""
 "Choose this difficulty to experience the game's story with less challenge. "
 "The AI will be weaker than at Normal difficulty."
@@ -5309,19 +5290,17 @@ msgstr ""
 "Wybierz tę opcję jeśli cenisz fabułę ponad wyzwanie. AI rozgrywa misje "
 "gorzej niż przy normalnym poziomie trudności."
 
-#, fuzzy
 msgid ""
 "Choose this difficulty to experience the campaign as per the original design."
 msgstr ""
 "Wybierz tę opcję by cieszyć się kampanią zgodnie z jej oryginalnymi "
 "założeniami."
 
-#, fuzzy
 msgid ""
 "Choose this difficulty if you want more challenge. The AI will be stronger "
 "than at Normal difficulty."
 msgstr ""
-"Wybierz tę opcję jeśli jesteś gotów na wyzwania. AI rozgrywa misje lepiej "
+"Wybierz tę opcję jeśli jesteś gotów na wyzwanie. AI rozgrywa misje lepiej "
 "niż przy normalnym poziomie trudności."
 
 msgid ""
@@ -5359,7 +5338,6 @@ msgstr "Rozpocznij wybrany scenariusz."
 msgid "View Intro"
 msgstr "Zobacz Wprowadzenie"
 
-#, fuzzy
 msgid "View the intro video for the current state of the campaign."
 msgstr "Zobacz filmy wprowadzające dla obecnego stanu kampanii."
 
@@ -5368,21 +5346,24 @@ msgid ""
 "campaign. However, the final score will be calculated based solely on the "
 "lowest difficulty of a completed scenario during the campaign."
 msgstr ""
+"Wybierz trudność kampanii. Można ją zmienić w dowolnym momencie. Jednak "
+"ostateczny wynik zostanie obliczony jedynie na podstawie najniższego "
+"poziomu trudności ukończonego scenariusza."
 
 msgid "Restart the current scenario."
 msgstr "Rozpocznij od nowa obecny scenariusz."
 
-#, fuzzy
 msgid "Difficulty"
-msgstr ""
-"Trudność\n"
-"mapy"
+msgstr "Trudność"
 
 msgid ""
 "You have changed the campaign difficulty. The final high score will be "
 "calculated based solely on the lowest difficulty level for a completed "
 "scenario during the campaign. Do you want to proceed?"
 msgstr ""
+"Trudność kampanii została zmieniona. Ostateczny wynik zostanie obliczony "
+"jedynie na podstawie najniższego poziomu trudności ukończonego scenariusza. "
+"Czy chcesz kontynuować?"
 
 msgid "Are you sure you want to restart this scenario?"
 msgstr "Czy na pewno chcesz rozpocząć od nowa obecny scenariusz?"
@@ -5399,9 +5380,8 @@ msgstr "Ilość dni"
 msgid "The number of days spent on this campaign."
 msgstr "Ilość dni spędzonych na tej kampanii."
 
-#, fuzzy
 msgid "Scenario Title"
-msgstr "Scenariusz"
+msgstr "Tytuł scenariusza"
 
 msgid "Project Coordination and Core Development"
 msgstr "Koordynacja projektu i development"
@@ -5419,10 +5399,10 @@ msgid "Dev and Support"
 msgstr "Development i wsparcie"
 
 msgid "Special Thanks to"
-msgstr "Specjalnie podziękowania dla"
+msgstr "Specjalne podziękowania dla"
 
 msgid "and all the people who have helped make the project possible!"
-msgstr ""
+msgstr "Oraz wszystkim, dzięki którym ten projekt mógł powstać!"
 
 msgid "Support us at"
 msgstr "Wesprzyj nas"
@@ -5557,7 +5537,7 @@ msgid "Package Design"
 msgstr "Projekt opakowania"
 
 msgid "To exit fheroes2, press the Home button or swipe up."
-msgstr ""
+msgstr "Aby wyjść z fheroes2, naciśnij przycisk Home lub przesuń palcem w górę."
 
 msgid "Are you sure you want to quit?"
 msgstr "Czy na pewno chcesz wyjść?"
@@ -5607,9 +5587,8 @@ msgstr "pełny ekran/okno"
 msgid "hotkey|toggle text support mode"
 msgstr "wł./wył. dodatkowe informacje"
 
-#, fuzzy
 msgid "hotkey|toggle developer mode"
-msgstr "wł./wył. dodatkowe informacje"
+msgstr "wł./wył. tryb dewelopera"
 
 msgid "hotkey|quit"
 msgstr "wyjdź"
@@ -5620,7 +5599,6 @@ msgstr "nowa gra"
 msgid "hotkey|load game"
 msgstr "wczytaj grę"
 
-#, fuzzy
 msgid "hotkey|high scores"
 msgstr "najlepsze wyniki"
 
@@ -5657,7 +5635,6 @@ msgstr "wybierz bardzo duże mapy"
 msgid "hotkey|select all map sizes"
 msgstr "wybierz wszystkie mapy"
 
-#, fuzzy
 msgid "hotkey|hot seat game"
 msgstr "zmiana miejsc"
 
@@ -5685,33 +5662,26 @@ msgstr "nowa mapa od początku"
 msgid "hotkey|new random map"
 msgstr "nowa losowa mapa"
 
-#, fuzzy
 msgid "hotkey|undo last action"
-msgstr "domyślna akcja"
+msgstr "cofnij ostatnią akcję"
 
-#, fuzzy
 msgid "hotkey|redo last action"
-msgstr "domyślna akcja"
+msgstr "powtórz ostatnią akcję"
 
-#, fuzzy
 msgid "hotkey|open game main menu"
-msgstr "nowa mapa"
+msgstr "otwórz główne menu gry"
 
-#, fuzzy
 msgid "hotkey|toggle passability"
-msgstr "pokaż/ukryj okno statusu"
+msgstr "pokaż/ukryj przejezdność"
 
-#, fuzzy
 msgid "hotkey|re-generate random map"
-msgstr "nowa losowa mapa"
+msgstr "zregeneruj losową mapę"
 
-#, fuzzy
 msgid "hotkey|re-configure random map"
-msgstr "nowa losowa mapa"
+msgstr "skonfiguruj losową mapę"
 
-#, fuzzy
 msgid "hotkey|output all text"
-msgstr "skroluj w lewo"
+msgstr "wyprowadź cały tekst"
 
 msgid "hotkey|roland campaign"
 msgstr "kampania Rolanda"
@@ -5719,7 +5689,6 @@ msgstr "kampania Rolanda"
 msgid "hotkey|archibald campaign"
 msgstr "kampania Archibalda"
 
-#, fuzzy
 msgid "hotkey|price of loyalty campaign"
 msgstr "kampania Cena Lojalności"
 
@@ -5777,23 +5746,20 @@ msgstr "porusz bohatera w dół w prawo"
 msgid "hotkey|save game"
 msgstr "zapisz grę"
 
-#, fuzzy
 msgid "hotkey|quick save"
-msgstr "wyjdź"
+msgstr "szybki zapis"
 
 msgid "hotkey|next hero"
 msgstr "pokaż następnego bohatera"
 
-#, fuzzy
 msgid "hotkey|change to hero under cursor"
-msgstr "pokaż następnego bohatera"
+msgstr "zmień na bohatera pod kursorem"
 
 msgid "hotkey|hold and left click to move hero portrait to top of list"
-msgstr ""
+msgstr "przytrzymaj i kliknij LPM, aby przenieść portret bohatera na początek listy"
 
-#, fuzzy
 msgid "hotkey|start hero movement"
-msgstr "kontynuuj ruch"
+msgstr "kontynuuj ruch bohatera"
 
 msgid "hotkey|cast adventure spell"
 msgstr "rzuć zaklęcie podróżne"
@@ -5873,13 +5839,11 @@ msgstr "ucieknij z walki"
 msgid "hotkey|surrender during battle"
 msgstr "poddaj walkę"
 
-#, fuzzy
 msgid "hotkey|toggle auto combat mode"
 msgstr "włącz/wyłącz automatyczny tryb walki"
 
-#, fuzzy
 msgid "hotkey|quick combat"
-msgstr "wyjdź"
+msgstr "szybka walka"
 
 msgid "hotkey|battle options"
 msgstr "opcje walki"
@@ -5890,9 +5854,8 @@ msgstr "pomiń turę w walce"
 msgid "hotkey|cast battle spell"
 msgstr "rzuć zaklęcie bojowe"
 
-#, fuzzy
 msgid "hotkey|toggle display of battle turn order"
-msgstr "włącz/wyłącz automatyczny tryb walki"
+msgstr "pokaż/ukryj kolejność tur walki"
 
 msgid "hotkey|dwelling level 1"
 msgstr "siedlisko poziom 1"
@@ -5936,13 +5899,11 @@ msgstr "ekran budowy zamku/miasta"
 msgid "hotkey|buy all monsters in well"
 msgstr "rekrutuj wszystkie stworzenia"
 
-#, fuzzy
 msgid "hotkey|merge troops with hero"
-msgstr "pokaż następnego bohatera"
+msgstr "połącz oddziały z bohaterem"
 
-#, fuzzy
 msgid "hotkey|merge troops with garrison"
-msgstr "domyślna akcja"
+msgstr "połącz oddziały z garnizonem"
 
 msgid "hotkey|split stack by half"
 msgstr "podziel jednostki na pół"
@@ -5959,9 +5920,8 @@ msgstr "ulepsz stworzenie"
 msgid "hotkey|dismiss hero or troop"
 msgstr "zwolnij bohatera lub stworzenie"
 
-#, fuzzy
 msgid "hotkey|exchange all troops"
-msgstr "ulepsz stworzenie"
+msgstr "zamień wszystkie oddziały"
 
 msgid ""
 "Do you want to regain control from AI? The effect will take place only on "
@@ -5976,26 +5936,23 @@ msgid ""
 msgstr ""
 "Czy chcesz przekazać AI kontrolę? Efekt zadziała tylko w następnej turze."
 
-#, fuzzy
 msgid "Default Actions"
-msgstr "domyślna akcja"
+msgstr "Domyślne akcje"
 
 msgid "Global Actions"
-msgstr ""
+msgstr "Globalne akcje"
 
 msgid "World Map"
 msgstr "Mapa świata"
 
-#, fuzzy
 msgid "Battle Screen"
-msgstr "Ekran bohatera"
+msgstr "Ekran bitwy"
 
-#, fuzzy
 msgid "Town Screen"
-msgstr "Ekran bohatera"
+msgstr "Ekran miasta"
 
 msgid "Army Actions"
-msgstr ""
+msgstr "Akcje armii"
 
 msgid "The save file is corrupted."
 msgstr "Plik z zapisaną grą jest uszkodzony."
@@ -6012,13 +5969,12 @@ msgstr "Ostatnia wspierana wersja: "
 msgid "This file contains a save with an invalid game type."
 msgstr "Ten plik zawiera zapis z nieprawidłowym typem gry."
 
-#, fuzzy
 msgid ""
 "This save file requires \"The Price of Loyalty\" game assets, but they have "
 "not been provided to the engine."
 msgstr ""
-"Ten plik jest zapisany w wersji gry \"Cena Lojalności\".\n"
-"Nie można wczytać pliku - do wczytania potrzebujesz \"Ceny Lojalności\"."
+"Ten plik wymaga zasobów dodatku \"Cena Lojalności\", "
+"które nie zostały dostarczone do silnika."
 
 msgid "This saved game is localized to '"
 msgstr "Zapisana gra jest w języku '"
@@ -6080,15 +6036,21 @@ msgid ""
 "anywhere else on the screen. While holding the second finger, you can remove "
 "the first one from the screen and keep viewing the information on the item."
 msgstr ""
+"\n"
+"\n"
+"Aby zasymulować kliknięcie PPM dotykiem i wyświetlić informacje o elementach, "
+"najpierw dotknij i przytrzymaj palec na wybranym elemencie, a następnie dotknij "
+"w innym miejscu ekranu. Trzymając drugi palec, możesz odsunąć pierwszy od ekranu "
+"i nadal widzieć informacje o elemencie."
 
-#, fuzzy
 msgid ""
 "\n"
 "\n"
 "Before starting the game, please select a game resolution."
 msgstr ""
-"Witamy w grze Heroes of Might and Magic II na silniku fheroes2! Przed "
-"rozpoczęciem wybierz rozdzielczość gry."
+"\n"
+"\n"
+"Przed rozpoczęciem wybierz rozdzielczość gry."
 
 msgid "Greetings!"
 msgstr "Witaj!"
@@ -6106,9 +6068,8 @@ msgstr "Obejrzyj autorów gry."
 msgid "View the high scores screen."
 msgstr "Obejrzyj najlepsze wyniki."
 
-#, fuzzy
 msgid "Create new or modify existing maps."
-msgstr "Wczytaj istniejącą mapę."
+msgstr "Stwórz nową lub zmień istniejącą mapę."
 
 msgid "Change language, resolution and settings of the game."
 msgstr "Wybierz język, rozdzielczość i ustawienia gry."
@@ -6116,7 +6077,6 @@ msgstr "Wybierz język, rozdzielczość i ustawienia gry."
 msgid "Game Settings"
 msgstr "Ustawienia gry"
 
-#, fuzzy
 msgid ""
 "The required video files for the campaign selection window are missing. "
 "Please make sure that all necessary files are present in the system."
@@ -6133,8 +6093,10 @@ msgid ""
 "Magic II for this purpose. Please note that only one scenario will be "
 "available in this setup."
 msgstr ""
+"Do działania fheroes2 wymaga plików danych z oryginalnej gry Heroes of Might "
+"and Magic II. Wygląda na to, że używasz w tym celu wersji demonstracyjnej. "
+"Pamiętaj, że w tej konfiguracji dostępny będzie tylko jeden scenariusz."
 
-#, fuzzy
 msgid ""
 "A multi-player game, with several human players competing against each other "
 "on a single map."
@@ -6204,7 +6166,6 @@ msgstr "Kampania z rozszerzenia"
 msgid "One of the four new campaigns from the Price of Loyalty expansion set."
 msgstr "Jedna z czterech kampani z rozszerzenia Cena Lojalności."
 
-#, fuzzy
 msgid ""
 "Play a Hot Seat game, where 2 to 6 players play on the same device, "
 "switching into the 'Hot Seat' when it is their turn."
@@ -6212,9 +6173,8 @@ msgstr ""
 "Graj wraz z 2-6 graczami na jednym komputerze, zamieniając się miejscami gdy "
 "przychodzi wasza kolej."
 
-#, fuzzy
 msgid "Dragon city has fallen! You are now the Master of the Dragons."
-msgstr "Smocze miasto upadło! Jesteś teraz Władcą Smoków."
+msgstr "Smocze miasto padło! Od tej chwili jesteś Władcą Smoków."
 
 msgid ""
 "You captured %{name}!\n"
@@ -6262,13 +6222,12 @@ msgid ""
 "They are triumphant."
 msgstr "Wróg zdobył miasto %{name} i odnosi zwycięstwo."
 
-#, fuzzy
 msgid ""
 "The enemy has found the %{name}.\n"
 "Your quest is a failure."
 msgstr ""
-"Odnajdujesz artefakt (%{name}).\n"
-"Twoja misja zakończyła się sukcesem."
+"Przeciwnik znalazł artefakt - %{name}.\n"
+"Twoja misja zakończyła się niepowodzeniem."
 
 msgid ""
 "The enemy has built up over %{count} gold in his treasury.\n"
@@ -6400,7 +6359,6 @@ msgstr "Scenariusz"
 msgid "Game Difficulty"
 msgstr "Trudność gry"
 
-#, fuzzy
 msgid ""
 "This lets you change the starting difficulty at which you will play. Higher "
 "difficulty levels start you off with fewer resources, and at the higher "
@@ -6426,9 +6384,8 @@ msgstr "Kliknij, aby użyć tych ustawień i rozpocząć nową grę."
 msgid "Click to return to the main menu."
 msgstr "Kliknij, aby wrócić do głównego menu."
 
-#, fuzzy
 msgid "The map is corrupted or doesn't exist."
-msgstr "Plik z zapisaną grą jest uszkodzony."
+msgstr "Mapa jest uszkodzona lub nie istnieje."
 
 msgid "Astrologers proclaim the Month of the %{name}."
 msgstr "Astrologowie ogłaszają, że symbolem tego miesiąca będzie %{name}."
@@ -6465,13 +6422,11 @@ msgstr[2] ""
 msgid "%{monster} growth +%{count}."
 msgstr "%{monster} zwiększają populację o +%{count}."
 
-#, fuzzy
 msgid "All populations are halved."
-msgstr " Ginie połowa populacji królestwa."
+msgstr "Ginie połowa populacji królestwa."
 
-#, fuzzy
 msgid "All dwellings increase population."
-msgstr " Populacja całego królestwa zwiększa się."
+msgstr "Populacja całego królestwa zwiększa się."
 
 msgid "Beware!"
 msgstr "Uwaga!"
@@ -6572,19 +6527,20 @@ msgstr "Następny bohater"
 msgid "Select the next Hero."
 msgstr "Wybierz następnego bohatera."
 
-#, fuzzy
 msgid "Hero Movement"
-msgstr "Cieniowanie pola"
+msgstr "Ruch bohatera"
 
 msgid ""
 "Start the Hero's movement along the current path or re-visit the object "
 "occupied by the Hero. Press and hold this button to reset the Hero's path."
 msgstr ""
+"Rozpocznij ruch bohatera po aktualnej trasie lub ponownie odwiedź obiekt, "
+"na którym stoi bohater. Naciśnij i przytrzymaj ten przycisk, aby wyczyścić "
+"trasę bohatera."
 
 msgid "Kingdom Summary"
 msgstr "Przegląd królestwa"
 
-#, fuzzy
 msgid "View a summary of your Kingdom."
 msgstr "Obejrzyj informacje na temat swego królestwa."
 
@@ -6594,7 +6550,6 @@ msgstr "Rzuć zaklęcie podróżne."
 msgid "End Turn"
 msgstr "Koniec tury"
 
-#, fuzzy
 msgid "End your turn and let the computer take its turn."
 msgstr "Zakończ swoją turę i pozwól ruszać się komputerowi."
 
@@ -6615,14 +6570,15 @@ msgid "Bring up the system options menu, allowing you to customize your game."
 msgstr ""
 "Pokazuje menu z opcjami systemowymi, pozwalając na zmianę ustawień gry."
 
-#, fuzzy
 msgid "Hero Movement Points"
-msgstr "Cieniowanie pola"
+msgstr "Punkty ruchu bohatera"
 
 msgid ""
 "The hero's army cannot move anymore today. The movement points will be "
 "refilled tomorrow after you end your turn."
 msgstr ""
+"Armia bohatera nie może się już dzisiaj poruszać. Punkty ruchu zostaną "
+"odnowione jutro, gdy skończysz swoją turę."
 
 msgid ""
 "One or more heroes may still move, are you sure you want to end your turn?"
@@ -6724,18 +6680,15 @@ msgstr ""
 msgid "Handicap"
 msgstr "Utrudnienie"
 
-#
-#, fuzzy
 msgid ""
 "This lets you change the handicap of a particular player. Only human players "
 "may have a handicap. Handicapped players start with fewer resources and earn "
 "15 or 30% fewer resources per turn for mild and severe handicaps, "
 "respectively."
 msgstr ""
-"Tutaj można ustawić utrudnienia dla poszczególnych graczy. Tylko gracze-"
-"ludzie mogą zostać obłożeni utrudnieniami. Taki gracz zaczyna z mniejszą "
-"ilością zasobów, a także otrzymuje 15% lub 30% mniej zasobów co turę, "
-"odpowiednio dla utrudnień niewielkich i znacznych."
+"Pozwala zmienić utrudnienia danego gracza. Tylko gracze-ludzie mogą mieć utrudnienia. "
+"Gracze z utrudnieniami zaczynają z mniejszą ilością zasobów oraz otrzymują o "
+"15% lub 30% mniej zasobów co turę, odpowiednio dla niewielkich i znacznych utrudnień."
 
 msgid "%{color} player"
 msgstr "%{color} gracz"
@@ -6743,29 +6696,25 @@ msgstr "%{color} gracz"
 msgid "No Handicap"
 msgstr "Brak utrudnień"
 
-#, fuzzy
 msgid ""
 "No special restrictions on starting resources and resource income per turn."
 msgstr ""
-"Żadnych ograniczeń w zasobach początkowych oraz otrzymywanych w każdej turze."
+"Brak specjalnych ograniczeń dotyczących zasobów początkowych oraz otrzymywanych "
+"w każdej turze."
 
 msgid "Mild Handicap"
 msgstr "Niewielkie utrudnienie"
 
-#
-#, fuzzy
 msgid ""
 "Players with mild handicap start with fewer resources and earn 15% fewer "
 "resources per turn."
 msgstr ""
 "Gracze z niewielkimi utrudnieniami zaczynają z mniejszą ilością zasobów oraz "
-"otrzymują 15% mniej zasobów co turę."
+"otrzymują o 15% mniej zasobów co turę."
 
 msgid "Severe Handicap"
 msgstr "Znaczne utrudnienia"
 
-#
-#, fuzzy
 msgid ""
 "Players with severe handicap start with fewer resources and earn 30% fewer "
 "resources per turn."
@@ -6784,7 +6733,7 @@ msgid "Set %{skill} Skill:"
 msgstr "Ustaw wartość - %{skill}:"
 
 msgid "Set %{skill} base value. Right-click to reset all skills to default."
-msgstr ""
+msgstr "Ustaw wartość - %{skill}. PPM, aby przywrócić wartości domyślne."
 
 msgid "View %{skill} Info"
 msgstr "Wyświetl informacje o %{skill}"
@@ -6800,65 +6749,59 @@ msgid "The available values range from %{min} to %{max}."
 msgstr "Dostępne wartości znajdują się w przedziale od %{min} do %{max}."
 
 msgid "Uppercase"
-msgstr ""
+msgstr "Wielkie litery"
 
-#, fuzzy
 msgid "Click to switch to uppercase letters."
-msgstr "Zapisz bieżącą grę."
+msgstr "Kliknij, aby włączyć wielkie litery."
 
 msgid "Keyboard|123"
 msgstr "123"
 
-#, fuzzy
 msgid "Keyboard type"
-msgstr "123"
+msgstr "Rodzaj klawiatury"
 
 msgid "Click to switch between keyboard types."
-msgstr ""
+msgstr "Kliknij, aby zmienić pomiędzy rodzajami klawiatur."
 
 msgid "Keyboard|SPACE"
 msgstr "SPACJA"
 
-#, fuzzy
 msgid "Change language"
-msgstr "Zmień język gry."
+msgstr "Zmień język"
 
-#, fuzzy
 msgid "Click to switch between languages."
-msgstr "Kliknij tutaj, aby ustawić wybrany język."
+msgstr "Kliknij, aby zmienić pomiędzy językami."
 
 msgid "Backspace"
-msgstr ""
+msgstr "Cofnij"
 
-#, fuzzy
 msgid "Click to remove characters."
-msgstr "Użyj wskazanej rozdzielczości."
+msgstr "Kliknij, aby usunąć znaki."
 
-#, fuzzy
 msgid "Lowercase"
-msgstr "Kwiaty"
+msgstr "Małe litery"
 
-#, fuzzy
 msgid "Click to switch to lowercase letters."
-msgstr "Zapisz bieżącą grę."
+msgstr "Kliknij, aby włączyć małe litery."
 
 msgid "Keyboard|ABC"
 msgstr "ABC"
 
-#, fuzzy
 msgid "Swap sign"
-msgstr "Projektanci Map"
+msgstr "Zamień znak"
 
 msgid "Click to switch between signed and unsigned numbers."
-msgstr ""
+msgstr "Kliknij, aby przełączyć pomiędzy liczbami ze znakiem a bez znaku."
 
 msgid "The entered value is invalid."
-msgstr ""
+msgstr "Wprowadzona wartość jest nieprawidłowa."
 
 msgid ""
 "The entered value is out of range.\n"
 "It should be not less than %{minValue} and not more than %{maxValue}."
 msgstr ""
+"Wprowadzona wartość jest poza zakresem.\n"
+"Powinna wynosić co najmniej %{minValue} i co najwyżej %{maxValue}."
 
 msgid "Kingdom Income"
 msgstr "Przychód"
@@ -6934,12 +6877,11 @@ msgstr "Słowacki"
 msgid "Vietnamese"
 msgstr "Wietnamski"
 
-#, fuzzy
 msgid "Greek"
-msgstr "Zielony"
+msgstr "Grecki"
 
 msgid "Esperanto"
-msgstr ""
+msgstr "Esperanto"
 
 msgid "Slow"
 msgstr "Wolno"
@@ -6951,7 +6893,7 @@ msgid "Very Fast"
 msgstr "Bardzo szybko"
 
 msgid "Dynamic"
-msgstr ""
+msgstr "Dynamiczny"
 
 msgid "Good"
 msgstr "Dobry"
@@ -7121,13 +7063,11 @@ msgstr "Jarkonas"
 msgid "Martine"
 msgstr "Martine"
 
-#, fuzzy
 msgid "shipAndGraveyard|%{object} robber"
-msgstr "Rabuś %{object}"
+msgstr "Rabuś: %{object}"
 
-#, fuzzy
 msgid "pyramid|%{object} raided"
-msgstr "Splądrowana %{object}"
+msgstr "Splądrowana: %{object}"
 
 msgid " gives you maximum morale"
 msgstr " zapewnia ci maksymalne morale"
@@ -7135,9 +7075,8 @@ msgstr " zapewnia ci maksymalne morale"
 msgid " gives you maximum luck"
 msgstr " zapewnia ci maksymalne szczęście"
 
-#, fuzzy
 msgid "You cannot have multiple spell books."
-msgstr "Nie można przenieść Księgi Zaklęć"
+msgstr "Nie możesz posiadać wielu ksiąg zaklęć."
 
 msgid "You cannot pick up this artifact, you already have a full load!"
 msgstr "Nie możesz podnieść tego artefaktu, twój plecak jest pełny!"
@@ -7184,6 +7123,8 @@ msgid ""
 "Your ship bumps into a barrel drifting at sea. Inside, you discover a stash "
 "of lost treasure."
 msgstr ""
+"Twój statek napotyka beczkę dryfującą po falach. W jej wnętrzu odnajdujesz "
+"skrytkę pełną zaginionych skarbów."
 
 msgid ""
 "The keeper of the mill announces:\n"
@@ -7414,7 +7355,6 @@ msgid "The mermaids silently entice you to return later and be blessed again."
 msgstr ""
 "Syreny w ciszy zachęcają cię, by wrócić do nich później po błogosławieństwo."
 
-#, fuzzy
 msgid ""
 "The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
 "Just for a moment, you forget your worries and bask in the beauty of the "
@@ -7423,7 +7363,7 @@ msgid ""
 msgstr ""
 "Magiczna uroda syren oczarowuje ciebie i twoją załogę.\n"
 "Zapominasz o wszystkich kłopotach ciesząc się chwilą.\n"
-"Na odchodne syreny błogosławią twoje wojska, co ma przynieść ci szczęście "
+"Na odchodne syreny błogosławią twoje wojska, co ma przynieść im szczęście "
 "podczas następnej bitwy."
 
 msgid ""
@@ -7737,27 +7677,26 @@ msgid ""
 msgstr ""
 "Rozsądek przeważa nad męstwem i uznajesz, że lepiej dziś uniknąć tej walki."
 
-#, fuzzy
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it, "
 "only to find it empty."
 msgstr ""
 "Spędziwszy wiele godzin na próbach wyłowienia skrzyni wciągasz ją w końcu na "
-"pokład i odkrywasz, iż znajduje się w niej %{gold} sztuk złota."
+"pokład i odkrywasz, że jest zupełnie pusta."
 
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold and the %{art}."
 msgstr ""
 "Spędziwszy wiele godzin na próbach wyłowienia skrzyni wciągasz ją w końcu na "
-"pokład i odkrywasz, iż znajduje się w niej %{gold} sztuk złota oraz %{art}."
+"pokład i odkrywasz, że znajduje się w niej %{gold} sztuk złota oraz %{art}."
 
 msgid ""
 "After spending hours trying to fish the chest out of the sea, you open it "
 "and find %{gold} gold pieces."
 msgstr ""
 "Spędziwszy wiele godzin na próbach wyłowienia skrzyni wciągasz ją w końcu na "
-"pokład i odkrywasz, iż znajduje się w niej %{gold} sztuk złota."
+"pokład i odkrywasz, że znajduje się w niej %{gold} sztuk złota."
 
 msgid ""
 "After scouring the area, you fall upon a hidden treasure cache. You may take "
@@ -8158,7 +8097,6 @@ msgstr ""
 "1000 sztuk złota oferuje ci morskie mapy, które wykonał w czasach młodości. "
 "Czy chcesz je kupić?"
 
-#, fuzzy
 msgid ""
 "The captain sighs. \"You don't have enough money, eh? You can't expect me to "
 "give my maps away for free!\""
@@ -8454,23 +8392,23 @@ msgstr ""
 "\"Mam dla ciebie zagadkę,\" mówi Sfinks. \"Jeśli odpowiesz dobrze, dam ci "
 "nagrodę. Jeśli odpowiesz źle, pożrę cię. Podejmujesz moje wyzwanie?\""
 
-#, fuzzy
 msgid ""
 "The Sphinx asks you the following riddle:\n"
 "\n"
 "'"
 msgstr ""
-"Sfinks zadaje ci następującą zagadkę: \n"
+"Sfinks zadaje ci następującą zagadkę:\n"
 "\n"
-"'%{riddle}'\n"
-"\n"
-" Twoja odpowiedź?"
+"'"
 
 msgid ""
 "sphinx|'\n"
 "\n"
 "Your answer?"
 msgstr ""
+"sphinx|'\n"
+"\n"
+"Twoja odpowiedź?"
 
 msgid ""
 "\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
@@ -8524,14 +8462,18 @@ msgid ""
 "distance from the intimidating cat until you have regained your courage in "
 "battle."
 msgstr ""
+"Ból z poprzedniego spotkania jeszcze nie minął, więc trzymasz się z daleka "
+"od groźnego kota, dopóki nie odzyskasz odwagi w walce."
 
 msgid ""
 "You come upon a great cat, purring as it rubs against your leg. Charmed, you "
 "reach down, but it bites you and flees. At least the laughter at your "
 "misfortune lifts your troops' spirits."
 msgstr ""
+"Napotykasz wielkiego kota, który mruczy ocierając się o twoją nogę. Oczarowany, "
+"pochylasz się, ale on gryzie cię i ucieka. Na szczęście śmiech z twojego "
+"niefortunnego losu poprawia morale twoich oddziałów."
 
-#, fuzzy
 msgid "No spell book is present."
 msgstr "Nie posiadasz Księgi Zaklęć."
 
@@ -8662,19 +8604,19 @@ msgid "Are you sure you want to dismiss this Hero?"
 msgstr "Czy na pewno chcesz zwolnić tego bohatera?"
 
 msgid "Set custom Experience value. Current value is default."
-msgstr ""
+msgstr "Ustaw niest. wartość doświadczenia. Obecna wartość jest domyślna."
 
 msgid "Change Experience value. Right-click to reset to default value."
-msgstr ""
+msgstr "Zmień wartość doświadczenia. PPM, aby przywrócić domyślną wartość."
 
 msgid "View Experience Info"
 msgstr "Doświadczenie - informacje"
 
 msgid "Set custom Spell Points value. Current value is default."
-msgstr ""
+msgstr "Ustaw niest. wartość pkt. magii. Obecna wartość jest domyślna."
 
 msgid "Change Spell Points value. Right-click to reset to default value."
-msgstr ""
+msgstr "Zmień wartość pkt. magii. PPM, aby przywrócić domyślną wartość."
 
 msgid "Set Spell Points value:"
 msgstr "Ustaw ilość Pkt. magii:"
@@ -8688,9 +8630,8 @@ msgstr "Ustaw promień patrolu w kwadratach:"
 msgid "Enter hero's name:"
 msgstr "Wpisz imię bohatera:"
 
-#, fuzzy
 msgid "Click to change class."
-msgstr "Kliknij aby przejść do następnego miasta."
+msgstr "Kliknij, aby zmienić klasę."
 
 msgid ""
 "'Spread' combat formation spreads the hero's units from the top to the "
@@ -8754,9 +8695,8 @@ msgstr ""
 msgid "Click to enable hero's patrol mode."
 msgstr "Kliknij, aby włączyć tryb patrolu dla bohatera."
 
-#, fuzzy
 msgid "Do you want to save the changes made?"
-msgstr "Kliknij aby przejść do następnego miasta."
+msgstr "Czy chcesz zapisać wprowadzone zmiany?"
 
 msgid "Blood Morale"
 msgstr "Krwi! morale"
@@ -8784,7 +8724,7 @@ msgstr ""
 " Następny poziom %{exp2}."
 
 msgid "million|M"
-msgstr ""
+msgstr "M"
 
 msgid "Level %{level}"
 msgstr "Poziom %{level}"
@@ -8803,35 +8743,32 @@ msgstr ""
 msgid "%{name1} meets %{name2}"
 msgstr "Spotkanie: %{name1} i %{name2}"
 
-#, fuzzy
 msgid "hero|Level %{level}"
 msgstr "Poziom %{level}"
 
 msgid "Move all artifacts from %{from_hero_name} to %{to_hero_name}."
-msgstr ""
+msgstr "Przekaż wszystkie artefakty od %{from_hero_name} do %{to_hero_name}."
 
-#, fuzzy
 msgid "Artifact Transfer"
-msgstr "Artefakty"
+msgstr "Przekazanie artefaktów"
 
-#, fuzzy
 msgid "Swap Artifacts"
-msgstr "Pokaż Artefakty"
+msgstr "Zamień artefakty"
 
 msgid "Swap all artifacts between heroes."
-msgstr ""
+msgstr "Zamień wszystkie artefakty pomiędzy bohaterami."
 
 msgid "Move army from %{from_hero_name} to %{to_hero_name}."
-msgstr ""
+msgstr "Przekaż armię od %{from_hero_name} do %{to_hero_name}."
 
 msgid "Army Transfer"
-msgstr ""
+msgstr "Przekazanie armii"
 
 msgid "Swap Armies"
-msgstr ""
+msgstr "Zamień armie"
 
 msgid "Swap armies between heroes."
-msgstr ""
+msgstr "Zamień armie pomiędzy bohaterami."
 
 msgid "Enemy heroes are now fully identifiable."
 msgstr "Można już w pełni zidentyfikować wrogich bohaterów."
@@ -9484,10 +9421,10 @@ msgid "speed|Instant"
 msgstr "Błyskawica"
 
 msgid "Click this button to adjust the level of zoom."
-msgstr ""
+msgstr "Kliknij ten przycisk, aby dostosować poziom powiększenia."
 
 msgid "Zoom"
-msgstr ""
+msgstr "Powiększenie"
 
 msgid "week|Squirrel"
 msgstr "Wiewiórka"
@@ -9595,19 +9532,19 @@ msgid "Ocean"
 msgstr "Ocean"
 
 msgid "map_layout|Mirrored"
-msgstr ""
+msgstr "Lustrzane"
 
 msgid "map_layout|Balanced"
-msgstr ""
+msgstr "Zrównoważone"
 
 msgid "map_layout|Islands"
-msgstr ""
+msgstr "Wyspy"
 
 msgid "map_layout|Pyramid"
-msgstr ""
+msgstr "Piramida"
 
 msgid "map_layout|Quest"
-msgstr ""
+msgstr "Misja"
 
 msgid "resource_density|Scarce"
 msgstr "Skąpe"
@@ -10039,22 +9976,22 @@ msgid "Barrel"
 msgstr "Beczka"
 
 msgid "randomRace|level 1 creatures"
-msgstr ""
+msgstr "Stworzenia 1. poz."
 
 msgid "randomRace|level 2 creatures"
-msgstr ""
+msgstr "Stworzenia 2. poz."
 
 msgid "randomRace|level 3 creatures"
-msgstr ""
+msgstr "Stworzenia 3. poz."
 
 msgid "randomRace|level 4 creatures"
-msgstr ""
+msgstr "Stworzenia 4. poz."
 
 msgid "randomRace|level 5 creatures"
-msgstr ""
+msgstr "Stworzenia 5. poz."
 
 msgid "randomRace|level 6 creatures"
-msgstr ""
+msgstr "Stworzenia 6. poz."
 
 msgid "Unknown Monsters"
 msgstr "Nieznane potwory"
@@ -10548,9 +10485,8 @@ msgstr "Atakuje dwa pola"
 msgid "Flyer"
 msgstr "Latający"
 
-#, fuzzy
 msgid "Unlimited retaliation"
-msgstr "Powstrzymuje kontratak"
+msgstr "Zawsze kontratakuje"
 
 msgid "Attacks all adjacent enemies"
 msgstr "Atakuje wszystkich przyległych przeciwników"
@@ -10588,45 +10524,35 @@ msgstr "Żywiołak"
 msgid "No Morale"
 msgstr "Neutralne morale"
 
-#, fuzzy
 msgid "Earth creature"
-msgstr "Rekrutuj stworzenia"
+msgstr "Stworzenie ziemi"
 
-#, fuzzy
 msgid "Air creature"
-msgstr "Rekrutuj stworzenia"
+msgstr "Stworzenie powietrza"
 
-#, fuzzy
 msgid "Fire creature"
-msgstr "Rekrutuj stworzenia"
+msgstr "Stworzenie ognia"
 
-#, fuzzy
 msgid "Water creature"
-msgstr "Jezioro"
+msgstr "Stworzenie wody"
 
-#, fuzzy
 msgid "Double damage from Fire spells"
-msgstr "200% obrażeń od czarów ognia"
+msgstr "Podwójne obrażenia od zaklęć ognia"
 
-#, fuzzy
 msgid "Double damage from Cold spells"
-msgstr "200% obrażeń od czarów zimna"
+msgstr "Podwójne obrażenia od zaklęć zimna"
 
-#, fuzzy
 msgid "Double damage from Earth creatures"
-msgstr "Przerywa działanie wszelkich zaklęć rzuconych na wszystkie jednostki."
+msgstr "Podwójne obrażenia od stworzeń ziemi"
 
-#, fuzzy
 msgid "Double damage from Air creatures"
-msgstr "Podwójne obrażenia nieumarłym"
+msgstr "Podwójne obrażenia od stworzeń powietrza"
 
-#, fuzzy
 msgid "Double damage from Fire creatures"
-msgstr "200% obrażeń od czarów ognia"
+msgstr "Podwójne obrażenia od stworzeń ognia"
 
-#, fuzzy
 msgid "Double damage from Water creatures"
-msgstr "Przerywa działanie wszelkich zaklęć rzuconych na wszystkie jednostki."
+msgstr "Podwójne obrażenia od stworzeń wody"
 
 msgid "Lightning"
 msgstr "błyskawic"
@@ -10833,14 +10759,12 @@ msgstr "Pancerne Rękawice Ochrony"
 msgid "The %{name} increase the hero's defense skill by %{count}."
 msgstr "%{name} zwiększa obronę bohatera o %{count}."
 
-#, fuzzy
 msgid ""
 "You encounter the infamous Black Knight! After a grueling duel ending in a "
 "draw, the Knight, out of respect, offers you a pair of armored gauntlets."
 msgstr ""
-"Na swej drodze napotykasz niesławnego Czarnego Rycerza! Po wyczerpującej "
-"walce, zakończonej remisem, Rycerz, chcąc okazać ci swój szacunek, "
-"ofiarowuje ci parę pancernych rękawic."
+"Spotykasz niesławnego Czarnego Rycerza! Po zaciętym pojedynku zakończonym "
+"remisem, rycerz w dowód szacunku wręcza ci parę pancernych rękawic."
 
 msgid "Defender Helm of Protection"
 msgstr "Wzmocniony Hełm Ochrony"
@@ -11741,18 +11665,16 @@ msgstr ""
 msgid "Endless Pouch of Crystal"
 msgstr "Bezdenna Sakiewka Kryształów"
 
-#, fuzzy
 msgid ""
 "Taking shelter from a storm in a small cave, you notice a small patch of "
 "crystal in one corner. Curious, you break a piece off and notice that the "
 "original crystal grows the lost piece back. You decide to stuff the entire "
 "patch into a pouch and take it with you."
 msgstr ""
-"Chroniąc się przed burzą w małej jaskini, dostrzegasz niewielką formację "
-"kryształów w jednym z zakamarków pieczary. Wiedziony ciekawością, odłamujesz "
-"kawałek i zauważasz, że brakujący fragment minerału odrasta na nowo. "
-"Decydujesz się na zapakowanie całego kryształu do sakiewki i zabierasz go ze "
-"sobą."
+"Chroniąc się przed nagłym deszczem w przypadkowo napotkanej jaskini "
+"zauważasz w kącie kilka kryształów. Odłamujesz kawałek i zauważasz, że z "
+"kryształu na nowo odrasta ułamany fragment. Wsadzasz cały kryształ do "
+"sakiewki i zabierasz go z sobą."
 
 msgid "The %{name} provides %{count} unit of crystal per day."
 msgstr "%{name} zapewnia %{count} jednostkę kryształów dziennie."
@@ -11822,6 +11744,11 @@ msgid ""
 "here is it!\" he says eagerly, \"The Printing Press.\" And before you get to "
 "say a word, he hands you a Magic Book."
 msgstr ""
+"Podchodzi do ciebie młody mężczyzna: \"Mój panie, pozwól mi pokazać ci mój "
+"najnowszy wynalazek służący szerzeniu wiedzy!\" Podążasz za nim do jego "
+"warsztatu i od razu dostrzegasz wielkie urządzenie z dźwigniami i korbami. "
+"\"Oto i ono!\" mówi z entuzjazmem, \"Prasa drukarska.\" I zanim zdążysz "
+"powiedzieć słowo, wręcza ci Księgę Zaklęć."
 
 msgid "Victory can be achieved by finding any Ultimate Artifact."
 msgstr "Zwycięstwo można osiągnąć, znajdując dowolny najpotężniejszy artefakt."
@@ -11990,7 +11917,6 @@ msgstr ""
 "%{name} zapewnia %{count}-procentową ochronę przed zimnem, ale podwaja "
 "uszkodzenia otrzymywane od ognia."
 
-#, fuzzy
 msgid ""
 "Suddenly, a biting coldness engulfs your body. You seize up, falling from "
 "your horse. The pain subsides, but you still feel as if your chest is "
@@ -12020,7 +11946,6 @@ msgstr ""
 msgid "Holy Hammer"
 msgstr "Święty Młot"
 
-#, fuzzy
 msgid ""
 "You come upon a battle where a Paladin has been mortally wounded by a group "
 "of Zombies. He asks you to take his hammer and finish what he started. As "
@@ -12029,8 +11954,8 @@ msgid ""
 msgstr ""
 "Na polu bitwy znajdujesz paladyna, śmiertelnie zranionego przez grupę "
 "zombie. Prosi cię o wzięcie jego młota i dokończenie tego, co zaczął. Gdy "
-"podnosisz młot, rozbrzmiewa dziwnym dźwiękiem, a po chwili wszystko "
-"rozmazuje ci się przed oczami. Zombie leżą martwe, a z młota kapie krew."
+"podnosisz młot, rozbrzmiewa dziwnym dźwiękiem, a po chwili wszystko zamazuje "
+"ci się przed oczami. Zombie leżą martwe, a z młota kapie krew."
 
 msgid "Legendary Scepter"
 msgstr "Legendarne Berło"
@@ -12683,7 +12608,7 @@ msgid "Random Spell"
 msgstr "Losowe zaklęcie"
 
 msgid "Randomly selected spell of any level."
-msgstr ""
+msgstr "Losowo wybrane zaklęcie dowolnego poziomu."
 
 msgid "Random 1st Level Spell"
 msgstr "Losowe zaklęcie 1. poz."
@@ -12731,9 +12656,8 @@ msgstr "Nie posiadasz Księgi Zaklęć, więc nie możesz rzucić zaklęcia."
 msgid "No spell to cast."
 msgstr "Brak zaklęć."
 
-#, fuzzy
 msgid "Your hero has %{sp} spell points remaining out of %{max}."
-msgstr "Twój bohater ma jeszcze %{point} pkt. magii."
+msgstr "Twój bohater ma jeszcze %{sp} z %{max} pkt. magii."
 
 msgid "View Adventure Spells"
 msgstr "Obejrzyj zaklęcia podróżne"

--- a/files/lang/pl.po
+++ b/files/lang/pl.po
@@ -8406,7 +8406,7 @@ msgid ""
 "\n"
 "Your answer?"
 msgstr ""
-"sphinx|'\n"
+"'\n"
 "\n"
 "Twoja odpowiedź?"
 


### PR DESCRIPTION
- Game is now 100% translated
- ~119 fuzzy translations resolved
- ~50 new translations

- Translation areas:
  - Map editor: various screens, dialogs and messages (town, hero, adventure map edit)
  - Settings and hotkey descriptions
  - Various strings (e.g. campaign difficulty, fluff text, creature abilities, morale, etc.)