### PR TITLE
Do not place roads under the obstacles in Random Map Generator

### DIFF
--- a/src/fheroes2/maps/map_object_info.h
+++ b/src/fheroes2/maps/map_object_info.h
@@ -67,7 +67,7 @@ namespace Maps
         uint8_t animationFrames{ 0 };
     };
 
-    struct LayeredObjectPartInfo : public ObjectPartInfo
+    struct LayeredObjectPartInfo final : public ObjectPartInfo
     {
         LayeredObjectPartInfo( const MP2::ObjectIcnType icn, const uint32_t index, const fheroes2::Point & offset, const MP2::MapObjectType type,
                                const ObjectLayerType layer )

--- a/src/fheroes2/maps/map_random_generator.cpp
+++ b/src/fheroes2/maps/map_random_generator.cpp
@@ -846,12 +846,12 @@ namespace Maps::Random_Generator
                 continue;
             }
 
+            // Connect regions only after placing mines and castles to avoid
             for ( const auto & [regionId, tileIndex] : region.connections ) {
                 mapState.getNodeToUpdate( tileIndex ).type = NodeType::PATH;
                 const auto & path = findPathToNearestRoad( mapState, width, region.id, tileIndex );
                 for ( const auto & step : path ) {
-                    mapState.getNodeToUpdate( step ).type = NodeType::PATH;
-                    forceTempRoadOnTile( mapFormat, step );
+                    forceTempRoadOnTile( mapState, mapFormat, step );
                 }
             }
 

--- a/src/fheroes2/maps/map_random_generator.cpp
+++ b/src/fheroes2/maps/map_random_generator.cpp
@@ -846,15 +846,6 @@ namespace Maps::Random_Generator
                 continue;
             }
 
-            // Connect regions only after placing mines and castles to avoid
-            for ( const auto & [regionId, tileIndex] : region.connections ) {
-                mapState.getNodeToUpdate( tileIndex ).type = NodeType::PATH;
-                const auto & path = findPathToNearestRoad( mapState, width, region.id, tileIndex );
-                for ( const auto & step : path ) {
-                    forceTempRoadOnTile( mapState, mapFormat, step );
-                }
-            }
-
             const auto & mineInfo = Maps::getObjectInfo( ObjectGroup::ADVENTURE_MINES, fheroes2::getMineObjectInfoId( Resource::GOLD, Ground::GRASS ) );
             std::vector<int32_t> options = findTilesForPlacement( mapState, width, region.id, findTilesByType( region, NodeType::OPEN ), mineInfo );
             if ( options.empty() ) {
@@ -876,6 +867,15 @@ namespace Maps::Random_Generator
             if ( regionSizeLimit > regionSizeForGoldMine ) {
                 for ( size_t idx = 0; idx < regionConfiguration.goldMineCount; ++idx ) {
                     placeMine( mapFormat, mapState, mapEconomy, options, Resource::GOLD, config.monsterStrength );
+                }
+            }
+
+            // Connect regions only after placing mines and castles to avoid roads under these objects.
+            for ( const auto & [regionId, tileIndex] : region.connections ) {
+                mapState.getNodeToUpdate( tileIndex ).type = NodeType::PATH;
+                const auto & path = findPathToNearestRoad( mapState, width, region.id, tileIndex );
+                for ( const auto & step : path ) {
+                    forceTempRoadOnTile( mapState, mapFormat, step );
                 }
             }
         }

--- a/src/fheroes2/maps/map_random_generator_helper.cpp
+++ b/src/fheroes2/maps/map_random_generator_helper.cpp
@@ -221,8 +221,10 @@ namespace
     void markNodeIndexAsType( Maps::Random_Generator::MapStateManager & data, const int32_t index, const Maps::Random_Generator::NodeType type )
     {
         auto & node = data.getNodeToUpdate( index );
-        // Never override border types (no assert needed; can happen when placing overlapping obstacles)
-        if ( node.type != Maps::Random_Generator::NodeType::BORDER && node.type != Maps::Random_Generator::NodeType::ACTION ) {
+        // Never override border types (no assert needed; can happen when placing overlapping obstacles),
+        // action types and do not put path though an obstacle.
+        if ( node.type != Maps::Random_Generator::NodeType::BORDER && node.type != Maps::Random_Generator::NodeType::ACTION
+             && ( type != Maps::Random_Generator::NodeType::PATH || node.type != Maps::Random_Generator::NodeType::OBSTACLE ) ) {
             node.type = type;
         }
     }
@@ -722,8 +724,15 @@ namespace Maps::Random_Generator
     }
 
     // Wouldn't render correctly but will speed up placement
-    void forceTempRoadOnTile( Map_Format::MapFormat & mapFormat, const int32_t tileIndex )
+    void forceTempRoadOnTile( Maps::Random_Generator::MapStateManager & data, Map_Format::MapFormat & mapFormat, const int32_t tileIndex )
     {
+        if ( data.getNode( tileIndex ).type == NodeType::OBSTACLE ) {
+            // Roads should not be placed under the obstacles.
+            return;
+        }
+
+        markNodeIndexAsType( data, tileIndex, NodeType::PATH );
+
         auto & tile = mapFormat.tiles[tileIndex];
         if ( Maps::doesContainRoad( tile ) ) {
             return;
@@ -802,8 +811,7 @@ namespace Maps::Random_Generator
 
             if ( putObjectOnMap( mapFormat, tile, groupType, type ) ) {
                 for ( const auto & step : roadToObject ) {
-                    markNodeIndexAsType( data, step, NodeType::PATH );
-                    forceTempRoadOnTile( mapFormat, step );
+                    forceTempRoadOnTile( data, mapFormat, step );
                 }
                 transaction.commit();
                 return true;
@@ -879,9 +887,8 @@ namespace Maps::Random_Generator
         // Force roads coming from the castle
         const int32_t nextIndex = Maps::GetDirectionIndex( bottomIndex, Direction::BOTTOM );
         if ( Maps::isValidAbsIndex( nextIndex ) ) {
-            markNodeIndexAsType( data, bottomIndex, NodeType::PATH );
-            forceTempRoadOnTile( mapFormat, bottomIndex );
-            forceTempRoadOnTile( mapFormat, nextIndex );
+            forceTempRoadOnTile( data, mapFormat, bottomIndex );
+            forceTempRoadOnTile( data, mapFormat, nextIndex );
         }
 
         return true;
@@ -1134,8 +1141,7 @@ namespace Maps::Random_Generator
                 }
 
                 for ( const auto & step : routeToGroup ) {
-                    markNodeIndexAsType( data, step, NodeType::PATH );
-                    forceTempRoadOnTile( mapFormat, step );
+                    forceTempRoadOnTile( data, mapFormat, step );
                 }
                 transaction.commit();
 
@@ -1169,7 +1175,7 @@ namespace Maps::Random_Generator
         }
     }
 
-    void placeDecorations( Map_Format::MapFormat & mapFormat, MapStateManager & data, Region & region, const std::vector<DecorationSet> & decorations,
+    void placeDecorations( Map_Format::MapFormat & mapFormat, MapStateManager & data, const Region & region, const std::vector<DecorationSet> & decorations,
                            Rand::PCG32 & randomGenerator )
     {
         if ( decorations.empty() ) {

--- a/src/fheroes2/maps/map_random_generator_helper.h
+++ b/src/fheroes2/maps/map_random_generator_helper.h
@@ -80,7 +80,7 @@ namespace Maps::Random_Generator
     bool canPlaceAllObjects( const MapStateManager & data, const std::vector<ObjectPlacement> & objects, const fheroes2::Point & position, const int32_t ground );
     bool canFitObjectSet( const MapStateManager & data, const ObjectSet & set, const fheroes2::Point & position, const int32_t ground );
     void markObjectPlacement( MapStateManager & data, const ObjectInfo & info, const fheroes2::Point & position );
-    void forceTempRoadOnTile( Map_Format::MapFormat & mapFormat, const int32_t tileIndex );
+    void forceTempRoadOnTile( Maps::Random_Generator::MapStateManager & data, Map_Format::MapFormat & mapFormat, const int32_t tileIndex );
 
     bool putObjectOnMap( Map_Format::MapFormat & mapFormat, Tile & tile, const ObjectGroup groupType, const int32_t objectIndex );
     bool placeActionObject( Map_Format::MapFormat & mapFormat, MapStateManager & data, Tile & tile, const ObjectGroup groupType, const int32_t type );
@@ -97,7 +97,7 @@ namespace Maps::Random_Generator
                                                                     std::vector<ObjectSet> objectSets, Rand::PCG32 & randomGenerator );
     void placeObjectSet( Map_Format::MapFormat & mapFormat, MapStateManager & data, Region & region, std::vector<ObjectSet> objectSets,
                          const MonsterStrength monsterStrength, const uint8_t expectedCount, Rand::PCG32 & randomGenerator );
-    void placeDecorations( Map_Format::MapFormat & mapFormat, MapStateManager & data, Region & region, const std::vector<DecorationSet> & decorations,
+    void placeDecorations( Map_Format::MapFormat & mapFormat, MapStateManager & data, const Region & region, const std::vector<DecorationSet> & decorations,
                            Rand::PCG32 & randomGenerator );
 
     // This function expects a valid tileIndex that will fit the set. Plan first before calling


### PR DESCRIPTION
Close #10769

The pick-up objects are placed on the roads and currently roads may go through ground objects ("obstacles").

This PR restricts planning paths and placing roads under the already placed objects. So the action objects now should not be placed over the unpassable parts of objects.
