### PR TITLE
Redraw adventure map icons and status panel on changing resources in castle view

### DIFF
--- a/src/fheroes2/castle/castle.h
+++ b/src/fheroes2/castle/castle.h
@@ -291,7 +291,7 @@ public:
     // Draw image castle to position.
     void DrawImageCastle( const fheroes2::Point & pt ) const;
 
-    CastleDialogReturnValue OpenDialog( const bool openConstructionWindow, const bool openMageGuildWindow, const bool fade, const bool renderBackgroundDialog );
+    CastleDialogReturnValue OpenDialog( const Castle::CastleDialogReturnValue openWindow, const bool fade, const bool renderBackgroundDialog );
 
     int GetAttackModificator( const std::string * /* unused */ ) const
     {

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -48,6 +48,7 @@
 #include "heroes_base.h"
 #include "icn.h"
 #include "image.h"
+#include "interface_base.h"
 #include "interface_gamearea.h"
 #include "kingdom.h"
 #include "localevent.h"
@@ -492,6 +493,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
     while ( le.HandleEvents() && result == CastleDialogReturnValue::DoNothing ) {
         bool needRedraw = false;
+        uint32_t needRedrawAdventureMap = 0;
         bool needFadeIn = false;
 
         // During hero purchase or building construction skip any interaction with the dialog.
@@ -597,6 +599,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                     }
 
                     needRedraw = true;
+                    needRedrawAdventureMap |= Interface::REDRAW_STATUS;
                 }
             }
 
@@ -669,6 +672,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                         if ( purchaseSpellBookIfNecessary( *this, hero ) ) {
                             // Guest hero purchased the spellbook, redraw the resource panel
                             needRedraw = true;
+                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
                         }
 
                         const auto mageGuildResult = mageGuildDialogHandler( hero );
@@ -684,6 +688,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                             = Dialog::RecruitMonster( Monster( _race, monsterDwelling ), getMonstersInDwelling( it->id ), true, recruitMonsterWindowOffsetY );
                         if ( Castle::RecruitMonster( monsterToRecruit ) ) {
                             needRedraw = true;
+                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
                         }
                     }
                     else {
@@ -722,6 +727,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
                             fadeBuilding.startFadeBoat();
                             needRedraw = true;
+                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
                             break;
                         }
 
@@ -729,12 +735,14 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                             const fheroes2::ButtonRestorer exitRestorer( buttonExit );
                             Dialog::Marketplace( GetKingdom(), false );
                             needRedraw = true;
+                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
                             break;
                         }
 
                         case BUILD_WELL:
                             _openWell();
                             needRedraw = true;
+                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
                             break;
 
                         case BUILD_TENT: {
@@ -755,12 +763,14 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                             AudioManager::PlaySound( M82::BUILDTWN );
                             fadeBuilding.startFadeBuilding( BUILD_CASTLE );
                             needRedraw = true;
+                            needRedrawAdventureMap |= Interface::REDRAW_CASTLES;
                             break;
                         }
 
                         case BUILD_CASTLE: {
                             result = constructionDialogHandler();
                             needRedraw = true;
+                            needRedrawAdventureMap |= Interface::REDRAW_CASTLES | Interface::REDRAW_HEROES | Interface::REDRAW_STATUS;
                             break;
                         }
 
@@ -850,6 +860,15 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             if ( !needRedraw ) {
                 ++castleAnimationIndex;
             }
+        }
+
+        // Redraw Adventure map status panel if needed and allowed
+        if ( needRedrawAdventureMap > 0 && !isDefaultScreenSize ) {
+            // Save current window before adventure map redraw
+            std::unique_ptr<fheroes2::ImageRestorer> const restorer_window
+                = std::make_unique<fheroes2::ImageRestorer>( display, dialogWithShadowRoi.x, dialogWithShadowRoi.y, dialogWithShadowRoi.width,
+                                                             dialogWithShadowRoi.height );
+            Interface::AdventureMap::Get().redraw( needRedrawAdventureMap );
         }
     }
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -218,8 +218,7 @@ namespace
     }
 }
 
-Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionWindow, const bool openMageGuildWindow, const bool fade,
-                                                    const bool renderBackgroundDialog )
+Castle::CastleDialogReturnValue Castle::OpenDialog( const Castle::CastleDialogReturnValue openWindow, const bool fade, const bool renderBackgroundDialog )
 {
     // Set the cursor image. This dialog does not require a cursor restorer. It is called from other dialogs that have the same cursor
     // or from the Game Area that will set the appropriate cursor after this dialog is closed.
@@ -310,17 +309,27 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         return CastleDialogReturnValue::DoNothing;
     };
 
-    if ( openConstructionWindow && isBuild( BUILD_CASTLE ) ) {
-        const CastleDialogReturnValue constructionResult = constructionDialogHandler();
-        if ( constructionResult != CastleDialogReturnValue::DoNothing ) {
-            return constructionResult;
+    switch ( openWindow ) {
+    case CastleDialogReturnValue::PreviousConstructionWindow:
+    case CastleDialogReturnValue::NextConstructionWindow:
+        if ( isBuild( BUILD_CASTLE ) ) {
+            const CastleDialogReturnValue constructionResult = constructionDialogHandler();
+            if ( constructionResult != CastleDialogReturnValue::DoNothing ) {
+                return constructionResult;
+            }
         }
-    }
-    else if ( openMageGuildWindow && isBuild( BUILD_MAGEGUILD ) ) {
-        const auto result = mageGuildDialogHandler( hero );
-        if ( result != CastleDialogReturnValue::DoNothing ) {
-            return result;
+        break;
+    case CastleDialogReturnValue::PreviousMageGuildWindow:
+    case CastleDialogReturnValue::NextMageGuildWindow:
+        if ( isBuild( BUILD_MAGEGUILD ) ) {
+            const auto result = mageGuildDialogHandler( hero );
+            if ( result != CastleDialogReturnValue::DoNothing ) {
+                return result;
+            }
         }
+        break;
+    default:
+        break;
     }
 
     const std::string currentDate = getDateString();

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -564,7 +564,10 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                 display.render( fheroes2::getBoundaryRect( topArmyBar.GetArea(), bottomArmyBar.GetArea() ) );
             }
 
-            needRedraw = needRedraw || updateStatusBar();
+            if ( updateStatusBar() ) {
+                needRedraw = true;
+                needRedrawAdventureMap |= Interface::REDRAW_STATUS;
+            }
 
             // Actions with hero army.
             if ( hero ) {
@@ -763,14 +766,14 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                             AudioManager::PlaySound( M82::BUILDTWN );
                             fadeBuilding.startFadeBuilding( BUILD_CASTLE );
                             needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_CASTLES;
+                            needRedrawAdventureMap |= Interface::REDRAW_CASTLES | Interface::REDRAW_STATUS;
                             break;
                         }
 
                         case BUILD_CASTLE: {
                             result = constructionDialogHandler();
                             needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_CASTLES | Interface::REDRAW_HEROES | Interface::REDRAW_STATUS;
+                            needRedrawAdventureMap |= Interface::REDRAW_HEROES | Interface::REDRAW_STATUS;
                             break;
                         }
 
@@ -824,6 +827,14 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             else {
                 display.render( dialogRoi );
             }
+            // Redraw Adventure map status panel if needed and allowed
+            if ( needRedrawAdventureMap > 0 && !isDefaultScreenSize ) {
+                // Save current window before adventure map redraw
+                const std::unique_ptr<fheroes2::ImageRestorer> windowRestorer
+                    = std::make_unique<fheroes2::ImageRestorer>( display, dialogWithShadowRoi.x, dialogWithShadowRoi.y, dialogWithShadowRoi.width,
+                                                                 dialogWithShadowRoi.height );
+                Interface::AdventureMap::Get().redraw( needRedrawAdventureMap );
+            }
         }
 
         needRedraw = fadeBuilding.updateFadeAlpha();
@@ -860,15 +871,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             if ( !needRedraw ) {
                 ++castleAnimationIndex;
             }
-        }
-
-        // Redraw Adventure map status panel if needed and allowed
-        if ( needRedrawAdventureMap > 0 && !isDefaultScreenSize ) {
-            // Save current window before adventure map redraw
-            std::unique_ptr<fheroes2::ImageRestorer> const restorer_window
-                = std::make_unique<fheroes2::ImageRestorer>( display, dialogWithShadowRoi.x, dialogWithShadowRoi.y, dialogWithShadowRoi.width,
-                                                             dialogWithShadowRoi.height );
-            Interface::AdventureMap::Get().redraw( needRedrawAdventureMap );
         }
     }
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -492,8 +492,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     Game::passAnimationDelay( Game::DelayType::CASTLE_AROUND_DELAY );
 
     while ( le.HandleEvents() && result == CastleDialogReturnValue::DoNothing ) {
-        bool needRedraw = false;
-        uint32_t needRedrawAdventureMap = 0;
+        uint32_t needRedraw = 0;
         bool needFadeIn = false;
 
         // During hero purchase or building construction skip any interaction with the dialog.
@@ -565,8 +564,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             }
 
             if ( updateStatusBar() ) {
-                needRedraw = true;
-                needRedrawAdventureMap |= Interface::REDRAW_STATUS;
+                needRedraw |= Interface::REDRAW_STATUS;
             }
 
             // Actions with hero army.
@@ -601,8 +599,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                         bottomArmyBar.ResetSelected();
                     }
 
-                    needRedraw = true;
-                    needRedrawAdventureMap |= Interface::REDRAW_STATUS;
+                    needRedraw |= Interface::REDRAW_STATUS;
                 }
             }
 
@@ -611,7 +608,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                 openHeroDialog( topArmyBar, bottomArmyBar, *hero );
 
                 needFadeIn = true;
-                needRedraw = true;
+                needRedraw |= Interface::REDRAW_STATUS;
             }
 
             // Get pressed hotkey.
@@ -674,8 +671,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
                         if ( purchaseSpellBookIfNecessary( *this, hero ) ) {
                             // Guest hero purchased the spellbook, redraw the resource panel
-                            needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
+                            needRedraw |= Interface::REDRAW_STATUS;
                         }
 
                         const auto mageGuildResult = mageGuildDialogHandler( hero );
@@ -690,8 +686,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                         const Troop monsterToRecruit
                             = Dialog::RecruitMonster( Monster( _race, monsterDwelling ), getMonstersInDwelling( it->id ), true, recruitMonsterWindowOffsetY );
                         if ( Castle::RecruitMonster( monsterToRecruit ) ) {
-                            needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
+                            needRedraw |= Interface::REDRAW_STATUS;
                         }
                     }
                     else {
@@ -729,23 +724,20 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                             }
 
                             fadeBuilding.startFadeBoat();
-                            needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
+                            needRedraw |= Interface::REDRAW_STATUS;
                             break;
                         }
 
                         case BUILD_MARKETPLACE: {
                             const fheroes2::ButtonRestorer exitRestorer( buttonExit );
                             Dialog::Marketplace( GetKingdom(), false );
-                            needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
+                            needRedraw |= Interface::REDRAW_STATUS;
                             break;
                         }
 
                         case BUILD_WELL:
                             _openWell();
-                            needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_STATUS;
+                            needRedraw |= Interface::REDRAW_STATUS;
                             break;
 
                         case BUILD_TENT: {
@@ -765,15 +757,13 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
                             AudioManager::PlaySound( M82::BUILDTWN );
                             fadeBuilding.startFadeBuilding( BUILD_CASTLE );
-                            needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_CASTLES | Interface::REDRAW_STATUS;
+                            needRedraw |= Interface::REDRAW_CASTLES | Interface::REDRAW_STATUS;
                             break;
                         }
 
                         case BUILD_CASTLE: {
                             result = constructionDialogHandler();
-                            needRedraw = true;
-                            needRedrawAdventureMap |= Interface::REDRAW_HEROES | Interface::REDRAW_STATUS;
+                            needRedraw |= Interface::REDRAW_HEROES | Interface::REDRAW_STATUS;
                             break;
                         }
 
@@ -804,12 +794,12 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
             fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
 
-            if ( !needRedraw ) {
+            if ( needRedraw == 0 ) {
                 display.render( dialogRoi );
             }
         }
 
-        if ( needRedraw ) {
+        if ( needRedraw > 0 ) {
             // Redraw the bottom part of the castle dialog (army bars, resources, exit button).
             topArmyBar.Redraw( display );
             if ( bottomArmyBar.isValid() && alphaHero >= 255 ) {
@@ -827,17 +817,18 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             else {
                 display.render( dialogRoi );
             }
-            // Redraw Adventure map status panel if needed and allowed
-            if ( needRedrawAdventureMap > 0 && !isDefaultScreenSize ) {
+            // Redraw Adventure map elements if needed and allowed
+            if ( !isDefaultScreenSize ) {
                 // Save current window before adventure map redraw
                 const std::unique_ptr<fheroes2::ImageRestorer> windowRestorer
                     = std::make_unique<fheroes2::ImageRestorer>( display, dialogWithShadowRoi.x, dialogWithShadowRoi.y, dialogWithShadowRoi.width,
                                                                  dialogWithShadowRoi.height );
-                Interface::AdventureMap::Get().redraw( needRedrawAdventureMap );
+                Interface::AdventureMap::Get().redraw( needRedraw );
             }
         }
 
-        needRedraw = fadeBuilding.updateFadeAlpha();
+        // We don't need to redraw adventure map, use variable as we want
+        needRedraw = fadeBuilding.updateFadeAlpha() ? 1 : 0;
         if ( fadeBuilding.isFadeDone() ) {
             const uint32_t build = fadeBuilding.getBuilding();
 
@@ -863,12 +854,12 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         }
 
         // Castle dialog animation.
-        if ( Game::validateAnimationDelay( Game::DelayType::CASTLE_AROUND_DELAY ) || needRedraw ) {
+        if ( Game::validateAnimationDelay( Game::DelayType::CASTLE_AROUND_DELAY ) || needRedraw > 0 ) {
             CastleDialog::redrawAllBuildings( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
 
             display.render( dialogRoi );
 
-            if ( !needRedraw ) {
+            if ( needRedraw == 0 ) {
                 ++castleAnimationIndex;
             }
         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -308,6 +308,7 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */, con
     bool openConstructionWindow{ false };
     bool openMageGuildWindow{ false };
     Castle::CastleDialogReturnValue result = ( *it )->OpenDialog( openConstructionWindow, openMageGuildWindow, true, renderBackgroundDialog );
+    Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();
 
     while ( result != Castle::CastleDialogReturnValue::Close ) {
         switch ( result ) {
@@ -332,6 +333,12 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */, con
         }
 
         assert( it != myCastles.end() );
+        // Set selected castle and redraw adventure map only in high resolution
+        if ( !fheroes2::Display::instance().isDefaultSize() ) {
+            SetUpdateSoundsOnFocusUpdate( false );
+            adventureMapInterface.SetFocus( *it );
+            adventureMapInterface.redraw( Interface::REDRAW_CASTLES | Interface::REDRAW_RADAR | Interface::REDRAW_STATUS );
+        }
 
         openConstructionWindow
             = ( result == Castle::CastleDialogReturnValue::PreviousConstructionWindow ) || ( result == Castle::CastleDialogReturnValue::NextConstructionWindow );
@@ -345,8 +352,6 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */, con
     // If Castle dialog background was not rendered than we have opened it from other dialog (Kingdom Overview)
     // and there is no need update Adventure map interface at this time.
     if ( renderBackgroundDialog ) {
-        Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();
-
         if ( heroCountBefore != myKingdom.GetHeroes().size() ) {
             // A hero could be recruited in the castle or a hero could be dismissed by opening hero's dialog
             // and switching to the other hero and dismissing this hero. We need to update the hero list scrollbar.

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -25,7 +25,6 @@
 
 #include <algorithm>
 #include <cassert>
-#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -298,19 +297,17 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */, con
 
     const Settings & conf = Settings::Get();
     Kingdom & myKingdom = world.GetKingdom( conf.CurrentColor() );
+    const bool isDefaultScreenSize = fheroes2::Display::instance().isDefaultSize();
     const VecCastles & myCastles = myKingdom.GetCastles();
     VecCastles::const_iterator it = std::find( myCastles.begin(), myCastles.end(), &castle );
 
-    const size_t heroCountBefore = myKingdom.GetHeroes().size();
-
     assert( it != myCastles.end() );
 
-    bool openConstructionWindow{ false };
-    bool openMageGuildWindow{ false };
-    Castle::CastleDialogReturnValue result = ( *it )->OpenDialog( openConstructionWindow, openMageGuildWindow, true, renderBackgroundDialog );
+    Castle::CastleDialogReturnValue result = Castle::CastleDialogReturnValue::DoNothing;
     Interface::AdventureMap & adventureMapInterface = Interface::AdventureMap::Get();
 
     while ( result != Castle::CastleDialogReturnValue::Close ) {
+        result = ( *it )->OpenDialog( result, false, renderBackgroundDialog );
         switch ( result ) {
         case Castle::CastleDialogReturnValue::PreviousCastle:
         case Castle::CastleDialogReturnValue::PreviousConstructionWindow:
@@ -334,59 +331,31 @@ void Game::OpenCastleDialog( Castle & castle, bool updateFocus /* = true */, con
 
         assert( it != myCastles.end() );
         // Set selected castle and redraw adventure map only in high resolution
-        if ( !fheroes2::Display::instance().isDefaultSize() ) {
+        if ( updateFocus && result != Castle::CastleDialogReturnValue::DoNothing && !isDefaultScreenSize ) {
             SetUpdateSoundsOnFocusUpdate( false );
             adventureMapInterface.SetFocus( *it );
             adventureMapInterface.redraw( Interface::REDRAW_CASTLES | Interface::REDRAW_RADAR | Interface::REDRAW_STATUS );
         }
-
-        openConstructionWindow
-            = ( result == Castle::CastleDialogReturnValue::PreviousConstructionWindow ) || ( result == Castle::CastleDialogReturnValue::NextConstructionWindow );
-
-        openMageGuildWindow
-            = ( result == Castle::CastleDialogReturnValue::PreviousMageGuildWindow ) || ( result == Castle::CastleDialogReturnValue::NextMageGuildWindow );
-
-        result = ( *it )->OpenDialog( openConstructionWindow, openMageGuildWindow, false, renderBackgroundDialog );
     }
+    restoreSoundsForCurrentFocus();
 
     // If Castle dialog background was not rendered than we have opened it from other dialog (Kingdom Overview)
     // and there is no need update Adventure map interface at this time.
     if ( renderBackgroundDialog ) {
-        if ( heroCountBefore != myKingdom.GetHeroes().size() ) {
-            // A hero could be recruited in the castle or a hero could be dismissed by opening hero's dialog
-            // and switching to the other hero and dismissing this hero. We need to update the hero list scrollbar.
-            // NOTICE: we can update the scrollbar only here - after exiting the castle screen not to interfere with castle screen image.
-            adventureMapInterface.GetIconsPanel().resetIcons( ICON_HEROES );
-        }
-
         if ( updateFocus ) {
             assert( it != myCastles.end() );
 
-            // When exiting the castle, we must focus on it or on the hero visiting this castle.
+            // When exiting the castle, we must focus on the hero visiting this castle.
             Heroes * heroInCastle = world.getTile( ( *it )->GetIndex() ).getHero();
-            if ( heroInCastle == nullptr ) {
-                adventureMapInterface.SetFocus( *it );
-            }
-            else {
+            if ( heroInCastle != nullptr ) {
                 adventureMapInterface.SetFocus( heroInCastle, false );
             }
         }
-        else {
-            // If we don't update focus, we still have to restore environment sounds and terrain music theme
-            restoreSoundsForCurrentFocus();
-        }
-
-        // The castle garrison can change
-        adventureMapInterface.RedrawFocus();
 
         // Fade-in game screen only for 640x480 resolution.
-        if ( fheroes2::Display::instance().isDefaultSize() ) {
+        if ( isDefaultScreenSize ) {
             setDisplayFadeIn();
         }
-    }
-    else {
-        // If we opened the castle dialog from other dialog, we have to restore environment sounds and terrain music theme instead of the castle's music theme
-        restoreSoundsForCurrentFocus();
     }
 }
 

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -924,6 +924,13 @@ void Kingdom::openOverviewDialog()
         if ( Modes( KINGDOM_OVERVIEW_CASTLE_SELECTION ) ) {
             // Funds could be changed only after an action in the castle.
             RedrawFundsInfo( cur_pt, *this );
+            // Update adventure map status too.
+            if ( !isDefaultScreenSize ) {
+                const std::unique_ptr<fheroes2::ImageRestorer> windowsRestorer
+                    = std::make_unique<fheroes2::ImageRestorer>( display, background.windowArea().x, background.windowArea().y, background.windowArea().width,
+                                                                 background.windowArea().height );
+                Interface::AdventureMap::Get().redraw( Interface::REDRAW_STATUS );
+            }
         }
 
         if ( needFadeIn ) {


### PR DESCRIPTION
This change allows to redraw some interface elements in adventure map in higher resolutions, allowing keep state of resources and heroes/castles in sync.

Fixes #2598.
Fixes #5976.