### PR TITLE
Do not allow to place Adventure Map Events on other objects

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -370,6 +370,7 @@ namespace
                 case MP2::OBJ_BARRIER:
                 case MP2::OBJ_BOTTLE:
                 case MP2::OBJ_CAMPFIRE:
+                case MP2::OBJ_EVENT:
                 case MP2::OBJ_FLOTSAM:
                 case MP2::OBJ_HERO:
                 case MP2::OBJ_GENIE_LAMP:


### PR DESCRIPTION
relates to #10784

This is because events are removable objects.