### PR TITLE
Editor: Quit confirmation dialog does not mention unsaved map changes

### DIFF
--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -50,7 +50,6 @@
 #include "editor_sphinx_window.h"
 #include "game.h"
 #include "game_delays.h"
-#include "game_exit.h"
 #include "game_hotkeys.h"
 #include "game_static.h"
 #include "ground.h"

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1551,7 +1551,7 @@ namespace Interface
 
         while ( res == fheroes2::GameMode::CANCEL ) {
             if ( !le.HandleEvents( Game::isDelayNeeded( delayTypes ), true ) ) {
-                if ( Game::processExitEvent(Game::ExitContext::EDITOR) == fheroes2::GameMode::QUIT_GAME ) {
+                if ( Game::processExitEvent( Game::ExitContext::EDITOR ) == fheroes2::GameMode::QUIT_GAME ) {
                     res = fheroes2::GameMode::QUIT_GAME;
 
                     break;
@@ -1565,7 +1565,7 @@ namespace Interface
             // Hotkeys' press event processing.
             if ( le.isAnyKeyPressed() ) {
                 if ( HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-                    res = Game::processExitEvent(Game::ExitContext::EDITOR);
+                    res = Game::processExitEvent( Game::ExitContext::EDITOR );
                 }
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::EDITOR_NEW_MAP_MENU ) ) {
                     res = eventNewMap();
@@ -2085,7 +2085,7 @@ namespace Interface
             }
 
             if ( le.MouseClickLeft( buttonQuit.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) ) {
-                if ( Game::processExitEvent(Game::ExitContext::EDITOR) == fheroes2::GameMode::QUIT_GAME ) {
+                if ( Game::processExitEvent( Game::ExitContext::EDITOR ) == fheroes2::GameMode::QUIT_GAME ) {
                     return fheroes2::GameMode::QUIT_GAME;
                 }
             }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1385,6 +1385,24 @@ namespace
         return os.str();
     }
 #endif
+
+    fheroes2::GameMode processEditorExitEvent()
+    {
+#if defined( __IPHONEOS__ )
+        // iOS discourages to exit a running application.
+        fheroes2::showStandardTextMessage( _( "Quit" ),
+                                           _( "To exit fheroes2, press the Home button or swipe up. (Any unsaved changes to the current map will be lost.)" ),
+                                           Dialog::OK );
+#else
+        if ( Dialog::YES
+             & fheroes2::showStandardTextMessage( _( "Quit" ), _( "Are you sure you want to quit? (Any unsaved changes to the current map will be lost.)" ),
+                                                  Dialog::YES | Dialog::NO ) ) {
+            return fheroes2::GameMode::QUIT_GAME;
+        }
+#endif
+
+        return fheroes2::GameMode::CANCEL;
+    }
 }
 
 namespace Interface
@@ -1551,7 +1569,7 @@ namespace Interface
 
         while ( res == fheroes2::GameMode::CANCEL ) {
             if ( !le.HandleEvents( Game::isDelayNeeded( delayTypes ), true ) ) {
-                if ( Game::processExitEvent( Game::ExitContext::EDITOR ) == fheroes2::GameMode::QUIT_GAME ) {
+                if ( processEditorExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                     res = fheroes2::GameMode::QUIT_GAME;
 
                     break;
@@ -1565,7 +1583,7 @@ namespace Interface
             // Hotkeys' press event processing.
             if ( le.isAnyKeyPressed() ) {
                 if ( HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-                    res = Game::processExitEvent( Game::ExitContext::EDITOR );
+                    res = processEditorExitEvent();
                 }
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::EDITOR_NEW_MAP_MENU ) ) {
                     res = eventNewMap();
@@ -2085,7 +2103,7 @@ namespace Interface
             }
 
             if ( le.MouseClickLeft( buttonQuit.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) ) {
-                if ( Game::processExitEvent( Game::ExitContext::EDITOR ) == fheroes2::GameMode::QUIT_GAME ) {
+                if ( processEditorExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
                     return fheroes2::GameMode::QUIT_GAME;
                 }
             }

--- a/src/fheroes2/editor/editor_interface.cpp
+++ b/src/fheroes2/editor/editor_interface.cpp
@@ -1551,7 +1551,7 @@ namespace Interface
 
         while ( res == fheroes2::GameMode::CANCEL ) {
             if ( !le.HandleEvents( Game::isDelayNeeded( delayTypes ), true ) ) {
-                if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
+                if ( Game::processExitEvent(Game::ExitContext::EDITOR) == fheroes2::GameMode::QUIT_GAME ) {
                     res = fheroes2::GameMode::QUIT_GAME;
 
                     break;
@@ -1565,7 +1565,7 @@ namespace Interface
             // Hotkeys' press event processing.
             if ( le.isAnyKeyPressed() ) {
                 if ( HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) || HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_CANCEL ) ) {
-                    res = Game::processExitEvent();
+                    res = Game::processExitEvent(Game::ExitContext::EDITOR);
                 }
                 else if ( HotKeyPressEvent( Game::HotKeyEvent::EDITOR_NEW_MAP_MENU ) ) {
                     res = eventNewMap();
@@ -2085,7 +2085,7 @@ namespace Interface
             }
 
             if ( le.MouseClickLeft( buttonQuit.area() ) || Game::HotKeyPressEvent( Game::HotKeyEvent::GLOBAL_APP_QUIT ) ) {
-                if ( Game::processExitEvent() == fheroes2::GameMode::QUIT_GAME ) {
+                if ( Game::processExitEvent(Game::ExitContext::EDITOR) == fheroes2::GameMode::QUIT_GAME ) {
                     return fheroes2::GameMode::QUIT_GAME;
                 }
             }

--- a/src/fheroes2/game/game_exit.cpp
+++ b/src/fheroes2/game/game_exit.cpp
@@ -30,30 +30,13 @@
 
 namespace Game
 {
-    fheroes2::GameMode processExitEvent( const ExitContext context /* = ExitContext::GAME */ )
+    fheroes2::GameMode processExitEvent()
     {
 #if defined( __IPHONEOS__ )
         // iOS discourages to exit a running application.
         fheroes2::showStandardTextMessage( _( "Quit" ), _( "To exit fheroes2, press the Home button or swipe up." ), Dialog::OK );
 #else
-        std::string message;
-
-        switch ( context ) {
-        case ExitContext::GAME:
-            message = _( "Are you sure you want to quit?" );
-            break;
-
-        case ExitContext::EDITOR:
-            message = _( "Are you sure you want to quit? (Any unsaved changes to the current map will be lost.)" );
-            break;
-
-        default:
-            // Have you added a new ExitContext enum? Update the logic above!
-            assert( 0 );
-            break;
-        }
-
-        if ( Dialog::YES & fheroes2::showStandardTextMessage( _( "Quit" ), message, Dialog::YES | Dialog::NO ) ) {
+        if ( Dialog::YES & fheroes2::showStandardTextMessage( _( "Quit" ), _( "Are you sure you want to quit?" ), Dialog::YES | Dialog::NO ) ) {
             return fheroes2::GameMode::QUIT_GAME;
         }
 #endif

--- a/src/fheroes2/game/game_exit.cpp
+++ b/src/fheroes2/game/game_exit.cpp
@@ -20,6 +20,9 @@
 
 #include "game_exit.h"
 
+#include <string>
+#include <cassert>
+
 #include "dialog.h"
 #include "game_mode.h"
 #include "translations.h"
@@ -27,13 +30,31 @@
 
 namespace Game
 {
-    fheroes2::GameMode processExitEvent()
+    fheroes2::GameMode processExitEvent(const ExitContext context /* = ExitContext::GAME */)
     {
 #if defined( __IPHONEOS__ )
         // iOS discourages to exit a running application.
         fheroes2::showStandardTextMessage( _( "Quit" ), _( "To exit fheroes2, press the Home button or swipe up." ), Dialog::OK );
 #else
-        if ( Dialog::YES & fheroes2::showStandardTextMessage( _( "Quit" ), _( "Are you sure you want to quit?" ), Dialog::YES | Dialog::NO ) ) {
+        std::string message;
+
+        switch (context)
+        {
+        case ExitContext::GAME:
+            message = _( "Are you sure you want to quit?" );
+            break;
+
+        case ExitContext::EDITOR:
+            message = _( "Are you sure you want to quit? (Any unsaved changes to the current map will be lost.)" );
+            break;
+        
+        default:
+            // Have you added a new ExitContext enum? Update the logic above!
+            assert( 0 );
+            break;
+        }
+
+        if ( Dialog::YES & fheroes2::showStandardTextMessage( _( "Quit" ), message, Dialog::YES | Dialog::NO ) ) {
             return fheroes2::GameMode::QUIT_GAME;
         }
 #endif

--- a/src/fheroes2/game/game_exit.cpp
+++ b/src/fheroes2/game/game_exit.cpp
@@ -30,7 +30,7 @@
 
 namespace Game
 {
-    fheroes2::GameMode processExitEvent(const ExitContext context /* = ExitContext::GAME */)
+    fheroes2::GameMode processExitEvent( const ExitContext context /* = ExitContext::GAME */ )
     {
 #if defined( __IPHONEOS__ )
         // iOS discourages to exit a running application.
@@ -38,8 +38,7 @@ namespace Game
 #else
         std::string message;
 
-        switch (context)
-        {
+        switch ( context ) {
         case ExitContext::GAME:
             message = _( "Are you sure you want to quit?" );
             break;
@@ -48,6 +47,7 @@ namespace Game
             message = _( "Are you sure you want to quit? (Any unsaved changes to the current map will be lost.)" );
             break;
         
+            
         default:
             // Have you added a new ExitContext enum? Update the logic above!
             assert( 0 );

--- a/src/fheroes2/game/game_exit.cpp
+++ b/src/fheroes2/game/game_exit.cpp
@@ -20,8 +20,8 @@
 
 #include "game_exit.h"
 
-#include <string>
 #include <cassert>
+#include <string>
 
 #include "dialog.h"
 #include "game_mode.h"
@@ -46,8 +46,7 @@ namespace Game
         case ExitContext::EDITOR:
             message = _( "Are you sure you want to quit? (Any unsaved changes to the current map will be lost.)" );
             break;
-        
-            
+
         default:
             // Have you added a new ExitContext enum? Update the logic above!
             assert( 0 );

--- a/src/fheroes2/game/game_exit.cpp
+++ b/src/fheroes2/game/game_exit.cpp
@@ -20,9 +20,6 @@
 
 #include "game_exit.h"
 
-#include <cassert>
-#include <string>
-
 #include "dialog.h"
 #include "game_mode.h"
 #include "translations.h"

--- a/src/fheroes2/game/game_exit.h
+++ b/src/fheroes2/game/game_exit.h
@@ -20,8 +20,6 @@
 
 #pragma once
 
-#include <cstdint>
-
 namespace fheroes2
 {
     enum class GameMode : int;

--- a/src/fheroes2/game/game_exit.h
+++ b/src/fheroes2/game/game_exit.h
@@ -37,5 +37,5 @@ namespace Game
         EDITOR,
     };
 
-    fheroes2::GameMode processExitEvent(const ExitContext context = ExitContext::GAME);
+    fheroes2::GameMode processExitEvent( const ExitContext context = ExitContext::GAME );
 }

--- a/src/fheroes2/game/game_exit.h
+++ b/src/fheroes2/game/game_exit.h
@@ -18,6 +18,10 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
+#pragma once
+
+#include <cstdint>
+
 namespace fheroes2
 {
     enum class GameMode : int;
@@ -25,5 +29,13 @@ namespace fheroes2
 
 namespace Game
 {
-    fheroes2::GameMode processExitEvent();
+    enum class ExitContext : uint8_t
+    {
+        GAME,
+
+        // Exiting from the map editor. Warn user about unsaved changes
+        EDITOR,
+    };
+
+    fheroes2::GameMode processExitEvent(const ExitContext context = ExitContext::GAME);
 }

--- a/src/fheroes2/game/game_exit.h
+++ b/src/fheroes2/game/game_exit.h
@@ -29,13 +29,5 @@ namespace fheroes2
 
 namespace Game
 {
-    enum class ExitContext : uint8_t
-    {
-        GAME,
-
-        // Exiting from the map editor. Warn user about unsaved changes
-        EDITOR,
-    };
-
-    fheroes2::GameMode processExitEvent( const ExitContext context = ExitContext::GAME );
+    fheroes2::GameMode processExitEvent();
 }


### PR DESCRIPTION
- Added ExitContext enum to `processExitEvent`. If the context is editor, then the exit prompt will warn user about unsaved changes.

Fixes #10763