### PR TITLE
Speed up object evaluation for AI on the Adventure Map

### DIFF
--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -438,9 +438,8 @@ bool AI::isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const 
 bool AI::isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex )
 {
     switch ( objectType ) {
-    // These objects can be visited only once.
+    // Magellan's Maps object should be visited only once.
     case MP2::OBJ_MAGELLANS_MAPS:
-    case MP2::OBJ_OBELISK:
         return kingdom.isVisited( objectType );
     // Heroes cannot re-capture their own or ally's objects.
     case MP2::OBJ_ALCHEMIST_LAB:
@@ -461,6 +460,9 @@ bool AI::isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectTyp
 
         return fogCountToUncoverByTower < 0;
     }
+    // An obelisk should be visited only once.
+    case MP2::OBJ_OBELISK:
+        return kingdom.isVisited( tileIndex, objectType );
     // Traveller's Tent should be visited only once.
     case MP2::OBJ_TRAVELLER_TENT:
         return kingdom.isTravellerTentVisited( Maps::getBarrierColorFromTile( world.getTile( tileIndex ) ) );

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -472,6 +472,9 @@ bool AI::isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectTyp
     case MP2::OBJ_PYRAMID:
     case MP2::OBJ_SHIPWRECK:
         return kingdom.isVisited( tileIndex, objectType ) || !Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
+    // A Hut of Magi should uncover all areas at once so visiting any other similar object makes no sense.
+    case MP2::OBJ_HUT_OF_MAGI:
+        return kingdom.isVisited( objectType ) || !Maps::doesObjectExistOnMap( MP2::OBJ_EYE_OF_MAGI );
     // No value objects.
     case MP2::OBJ_BOAT:
     case MP2::OBJ_EYE_OF_MAGI:

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -435,57 +435,93 @@ bool AI::isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const 
     return Maps::isValidAbsIndex( idx ) && world.getTile( idx ).isSuitableForUltimateArtifact();
 }
 
-bool AI::isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex )
+bool AI::isValuableAdventureMapObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex )
 {
+    if ( !MP2::isInGameActionObject( objectType ) ) {
+        // Only action objects has any value.
+        return false;
+    }
+
     switch ( objectType ) {
-    // Magellan's Maps object should be visited only once.
+    case MP2::OBJ_CASTLE: {
+        const Castle * castle = world.getCastleEntrance( Maps::GetPoint( tileIndex ) );
+        if ( castle == nullptr ) {
+            // How is it possible that a castle does not exist?
+            assert( 0 );
+            return false;
+        }
+
+        if ( kingdom.GetColor() == castle->GetColor() ) {
+            return true;
+        }
+
+        // We can interact only with enemy castles.
+        return !Players::isFriends( kingdom.GetColor(), static_cast<PlayerColorsSet>( castle->GetColor() ) );
+    }
+    case MP2::OBJ_HERO: {
+        const Heroes * otherHero = world.getTile( tileIndex ).getHero();
+        if ( otherHero == nullptr ) {
+            // How is it possible that a hero does not exist?
+            assert( 0 );
+            return false;
+        }
+
+        if ( kingdom.GetColor() == otherHero->GetColor() ) {
+            return true;
+        }
+
+        // We can interact only with enemy heroes.
+        return !Players::isFriends( kingdom.GetColor(), static_cast<PlayerColorsSet>( otherHero->GetColor() ) );
+    }
     case MP2::OBJ_MAGELLANS_MAPS:
-        return kingdom.isVisited( objectType );
-    // Heroes cannot re-capture their own or ally's objects.
+        // Magellan's Maps object should be visited only once.
+        return !kingdom.isVisited( objectType );
+    
     case MP2::OBJ_ALCHEMIST_LAB:
     case MP2::OBJ_LIGHTHOUSE:
     case MP2::OBJ_MINE:
     case MP2::OBJ_SAWMILL:
-        return kingdom.isFriends( Maps::getColorFromTile( world.getTile( tileIndex ) ) );
-    // Single visit objects with no resources have no value.
+        // Heroes cannot re-capture their own or ally's objects.
+        return !Players::isFriends( kingdom.GetColor(), static_cast<PlayerColorsSet>( Maps::getColorFromTile( world.getTile( tileIndex ) ) ) );
     case MP2::OBJ_DAEMON_CAVE:
     case MP2::OBJ_LEAN_TO:
     case MP2::OBJ_SKELETON:
     case MP2::OBJ_WAGON:
-        return !Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
-    // If Observation Tower uncovers nothing, then we skip it.
+        // Single visit objects with no resources have no value.
+        return Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
     case MP2::OBJ_OBSERVATION_TOWER: {
+        // If Observation Tower uncovers nothing, then we skip it.
         const int32_t fogCountToUncoverByTower
             = Maps::getFogTileCountToBeRevealed( tileIndex, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), kingdom.GetColor() );
 
-        return fogCountToUncoverByTower <= 0;
+        return fogCountToUncoverByTower > 0;
     }
-    // An obelisk should be visited only once.
     case MP2::OBJ_OBELISK:
-        return kingdom.isVisited( tileIndex, objectType );
-    // Traveller's Tent should be visited only once.
+        // An obelisk should be visited only once.
+        return !kingdom.isVisited( tileIndex, objectType );
     case MP2::OBJ_TRAVELLER_TENT:
-        return kingdom.isTravellerTentVisited( Maps::getBarrierColorFromTile( world.getTile( tileIndex ) ) );
-    // Single visit objects with no resources have no value.
+        // Traveller's Tent should be visited only once.
+        return !kingdom.isTravellerTentVisited( Maps::getBarrierColorFromTile( world.getTile( tileIndex ) ) );
     case MP2::OBJ_DERELICT_SHIP:
     case MP2::OBJ_GRAVEYARD:
     case MP2::OBJ_PYRAMID:
     case MP2::OBJ_SHIPWRECK:
-        return kingdom.isVisited( tileIndex, objectType ) || !Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
-    // A Hut of Magi should uncover all areas at once so visiting any other similar object makes no sense.
+        // Single visit objects with no resources have no value.
+        return !kingdom.isVisited( tileIndex, objectType ) && Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
     case MP2::OBJ_HUT_OF_MAGI:
-        return kingdom.isVisited( objectType ) || !Maps::doesObjectExistOnMap( MP2::OBJ_EYE_OF_MAGI );
-    // No value objects.
+        // A Hut of Magi should uncover all areas at once so visiting any other similar object makes no sense.
+        return !kingdom.isVisited( objectType ) && Maps::doesObjectExistOnMap( MP2::OBJ_EYE_OF_MAGI );
     case MP2::OBJ_BOAT:
     case MP2::OBJ_EYE_OF_MAGI:
     case MP2::OBJ_ORACLE:
     case MP2::OBJ_SIGN:
     case MP2::OBJ_STONE_LITHS:
     case MP2::OBJ_WHIRLPOOL:
-        return true;
+        // These objects aren't considered valuable.
+        return false;
     default:
         break;
     }
 
-    return false;
+    return true;
 }

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -438,33 +438,39 @@ bool AI::isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const 
 bool AI::isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex )
 {
     switch ( objectType ) {
+    // These objects can be visited only once.
     case MP2::OBJ_MAGELLANS_MAPS:
+    case MP2::OBJ_OBELISK:
         return kingdom.isVisited( objectType );
+    // Heroes cannot re-capture their own or ally's objects.
     case MP2::OBJ_ALCHEMIST_LAB:
     case MP2::OBJ_LIGHTHOUSE:
     case MP2::OBJ_MINE:
     case MP2::OBJ_SAWMILL:
         return kingdom.isFriends( Maps::getColorFromTile( world.getTile( tileIndex ) ) );
+    // Single visit objects with no resources have no value.
     case MP2::OBJ_DAEMON_CAVE:
     case MP2::OBJ_LEAN_TO:
     case MP2::OBJ_SKELETON:
     case MP2::OBJ_WAGON:
         return !Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
+    // If Observation Tower uncovers nothing, then we skip it.
     case MP2::OBJ_OBSERVATION_TOWER: {
         const int32_t fogCountToUncoverByTower
             = Maps::getFogTileCountToBeRevealed( tileIndex, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), kingdom.GetColor() );
 
         return fogCountToUncoverByTower < 0;
     }
-    case MP2::OBJ_OBELISK:
-        return kingdom.isVisited( tileIndex, objectType );
+    // Traveller's Tent should be visited only once.
     case MP2::OBJ_TRAVELLER_TENT:
         return kingdom.isTravellerTentVisited( Maps::getBarrierColorFromTile( world.getTile( tileIndex ) ) );
+    // Single visit objects with no resources have no value.
     case MP2::OBJ_DERELICT_SHIP:
     case MP2::OBJ_GRAVEYARD:
     case MP2::OBJ_PYRAMID:
     case MP2::OBJ_SHIPWRECK:
         return kingdom.isVisited( tileIndex, objectType ) || !Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
+    // No value objects.
     case MP2::OBJ_BOAT:
     case MP2::OBJ_EYE_OF_MAGI:
     case MP2::OBJ_ORACLE:

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -39,11 +39,13 @@
 #include "color.h"
 #include "difficulty.h"
 #include "game.h"
+#include "game_static.h"
 #include "heroes.h"
 #include "kingdom.h"
 #include "logging.h"
 #include "maps.h"
 #include "maps_tiles.h"
+#include "maps_tiles_helper.h"
 #include "mp2.h"
 #include "payment.h"
 #include "players.h"
@@ -433,9 +435,36 @@ bool AI::isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const 
     return Maps::isValidAbsIndex( idx ) && world.getTile( idx ).isSuitableForUltimateArtifact();
 }
 
-bool AI::isUselessActionObject( const MP2::MapObjectType objectType )
+bool AI::isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex )
 {
     switch ( objectType ) {
+    case MP2::OBJ_MAGELLANS_MAPS:
+        return kingdom.isVisited( objectType );
+    case MP2::OBJ_ALCHEMIST_LAB:
+    case MP2::OBJ_LIGHTHOUSE:
+    case MP2::OBJ_MINE:
+    case MP2::OBJ_SAWMILL:
+        return kingdom.isFriends( Maps::getColorFromTile( world.getTile( tileIndex ) ) );
+    case MP2::OBJ_DAEMON_CAVE:
+    case MP2::OBJ_LEAN_TO:
+    case MP2::OBJ_SKELETON:
+    case MP2::OBJ_WAGON:
+        return !Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
+    case MP2::OBJ_OBSERVATION_TOWER: {
+        const int32_t fogCountToUncoverByTower
+            = Maps::getFogTileCountToBeRevealed( tileIndex, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), kingdom.GetColor() );
+
+        return fogCountToUncoverByTower < 0;
+    }
+    case MP2::OBJ_OBELISK:
+        return kingdom.isVisited( tileIndex, objectType );
+    case MP2::OBJ_TRAVELLER_TENT:
+        return kingdom.isTravellerTentVisited( Maps::getBarrierColorFromTile( world.getTile( tileIndex ) ) );
+    case MP2::OBJ_DERELICT_SHIP:
+    case MP2::OBJ_GRAVEYARD:
+    case MP2::OBJ_PYRAMID:
+    case MP2::OBJ_SHIPWRECK:
+        return kingdom.isVisited( tileIndex, objectType ) || !Maps::doesTileContainValuableItems( world.getTile( tileIndex ) );
     case MP2::OBJ_BOAT:
     case MP2::OBJ_EYE_OF_MAGI:
     case MP2::OBJ_ORACLE:

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -458,7 +458,7 @@ bool AI::isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectTyp
         const int32_t fogCountToUncoverByTower
             = Maps::getFogTileCountToBeRevealed( tileIndex, GameStatic::getFogDiscoveryDistance( GameStatic::FogDiscoveryType::OBSERVATION_TOWER ), kingdom.GetColor() );
 
-        return fogCountToUncoverByTower < 0;
+        return fogCountToUncoverByTower <= 0;
     }
     // An obelisk should be visited only once.
     case MP2::OBJ_OBELISK:

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -438,7 +438,7 @@ bool AI::isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const 
 bool AI::isValuableAdventureMapObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex )
 {
     if ( !MP2::isInGameActionObject( objectType ) ) {
-        // Only action objects has any value.
+        // Only action objects have any value.
         return false;
     }
 
@@ -476,7 +476,6 @@ bool AI::isValuableAdventureMapObject( const Kingdom & kingdom, const MP2::MapOb
     case MP2::OBJ_MAGELLANS_MAPS:
         // Magellan's Maps object should be visited only once.
         return !kingdom.isVisited( objectType );
-    
     case MP2::OBJ_ALCHEMIST_LAB:
     case MP2::OBJ_LIGHTHOUSE:
     case MP2::OBJ_MINE:

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -52,11 +52,6 @@
 #include "resource_trading.h"
 #include "world.h"
 
-namespace MP2
-{
-    enum MapObjectType : uint16_t;
-}
-
 bool AI::BuildIfPossible( Castle & castle, const BuildingType building )
 {
     switch ( castle.CheckBuyBuilding( building ) ) {

--- a/src/fheroes2/ai/ai_common.cpp
+++ b/src/fheroes2/ai/ai_common.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2025                                             *
+ *   Copyright (C) 2020 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -44,6 +44,7 @@
 #include "logging.h"
 #include "maps.h"
 #include "maps_tiles.h"
+#include "mp2.h"
 #include "payment.h"
 #include "players.h"
 #include "puzzle.h"
@@ -435,4 +436,21 @@ bool AI::isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const 
     const int32_t idx = art.getPosition();
 
     return Maps::isValidAbsIndex( idx ) && world.getTile( idx ).isSuitableForUltimateArtifact();
+}
+
+bool AI::isUselessActionObject( const MP2::MapObjectType objectType )
+{
+    switch ( objectType ) {
+    case MP2::OBJ_BOAT:
+    case MP2::OBJ_EYE_OF_MAGI:
+    case MP2::OBJ_ORACLE:
+    case MP2::OBJ_SIGN:
+    case MP2::OBJ_STONE_LITHS:
+    case MP2::OBJ_WHIRLPOOL:
+        return true;
+    default:
+        break;
+    }
+
+    return false;
 }

--- a/src/fheroes2/ai/ai_common.h
+++ b/src/fheroes2/ai/ai_common.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -32,6 +32,11 @@ class UltimateArtifact;
 struct Funds;
 
 enum BuildingType : uint32_t;
+
+namespace MP2
+{
+    enum MapObjectType : uint16_t;
+}
 
 namespace AI
 {
@@ -72,4 +77,7 @@ namespace AI
     // the Ultimate Artifact is considered available to the given hero if this hero knows its exact location and there
     // is a free slot in the hero's artifact bag. See the implementation for details.
     bool isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const Heroes & hero );
+
+    // Returns true if the AI has no benefit of visiting this object under any circumstances.
+    bool isUselessActionObject( const MP2::MapObjectType objectType );
 }

--- a/src/fheroes2/ai/ai_common.h
+++ b/src/fheroes2/ai/ai_common.h
@@ -79,5 +79,5 @@ namespace AI
     bool isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const Heroes & hero );
 
     // Returns true if the AI has no benefit of visiting this object under any circumstances.
-    bool isUselessActionObject( const MP2::MapObjectType objectType );
+    bool isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex );
 }

--- a/src/fheroes2/ai/ai_common.h
+++ b/src/fheroes2/ai/ai_common.h
@@ -78,6 +78,6 @@ namespace AI
     // is a free slot in the hero's artifact bag. See the implementation for details.
     bool isUltimateArtifactAvailableToHero( const UltimateArtifact & art, const Heroes & hero );
 
-    // Returns true if the AI has no benefit of visiting this object under any circumstances.
-    bool isUselessActionObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex );
+    // Returns true if the AI has some benefit of visiting this object under any circumstances.
+    bool isValuableAdventureMapObject( const Kingdom & kingdom, const MP2::MapObjectType objectType, const int32_t tileIndex );
 }

--- a/src/fheroes2/ai/ai_hero_action.cpp
+++ b/src/fheroes2/ai/ai_hero_action.cpp
@@ -1715,7 +1715,7 @@ namespace
         Maps::Tile & tile = world.getTile( dst_index );
         const Kingdom & kingdom = hero.GetKingdom();
 
-        if ( kingdom.IsVisitTravelersTent( getBarrierColorFromTile( tile ) ) ) {
+        if ( kingdom.isTravellerTentVisited( getBarrierColorFromTile( tile ) ) ) {
             removeMainObjectFromTile( tile );
             resetObjectMetadata( tile );
         }
@@ -1728,7 +1728,7 @@ namespace
         const Maps::Tile & tile = world.getTile( dst_index );
         Kingdom & kingdom = hero.GetKingdom();
 
-        kingdom.SetVisitTravelersTent( getBarrierColorFromTile( tile ) );
+        kingdom.markTravellerTentVisited( getBarrierColorFromTile( tile ) );
     }
 
     void AIToShipwreckSurvivor( Heroes & hero, const MP2::MapObjectType objectType, int32_t dst_index )

--- a/src/fheroes2/ai/ai_planner.cpp
+++ b/src/fheroes2/ai/ai_planner.cpp
@@ -177,7 +177,7 @@ void AI::Planner::updateMapActionObjectCache( const Kingdom & kingdom, const int
     const MP2::MapObjectType objectType = world.getTile( mapIndex ).getMainObjectType();
 
     if ( !isValuableAdventureMapObject( kingdom, objectType, mapIndex ) ) {
-         _mapActionObjects.erase( mapIndex );
+        _mapActionObjects.erase( mapIndex );
 
         return;
     }

--- a/src/fheroes2/ai/ai_planner.cpp
+++ b/src/fheroes2/ai/ai_planner.cpp
@@ -27,6 +27,7 @@
 #include <utility>
 #include <vector>
 
+#include "ai_common.h"
 #include "army.h"
 #include "heroes.h"
 #include "kingdom.h"
@@ -50,7 +51,7 @@ void AI::Planner::revealFog( const Maps::Tile & tile, const Kingdom & kingdom )
         return;
     }
 
-    updateMapActionObjectCache( tile.GetIndex() );
+    updateMapActionObjectCache( kingdom, tile.GetIndex() );
     updatePriorityAttackTarget( kingdom, tile );
 
     // If this is an action object and one of AI heroes is moving,
@@ -171,12 +172,12 @@ double AI::Planner::getFundsValueBasedOnPriority( const Funds & funds ) const
     return value;
 }
 
-void AI::Planner::updateMapActionObjectCache( const int mapIndex )
+void AI::Planner::updateMapActionObjectCache( const Kingdom & kingdom, const int mapIndex )
 {
     const MP2::MapObjectType objectType = world.getTile( mapIndex ).getMainObjectType();
 
-    if ( !MP2::isInGameActionObject( objectType ) ) {
-        _mapActionObjects.erase( mapIndex );
+    if ( !isValuableAdventureMapObject( kingdom, objectType, mapIndex ) ) {
+         _mapActionObjects.erase( mapIndex );
 
         return;
     }

--- a/src/fheroes2/ai/ai_planner.h
+++ b/src/fheroes2/ai/ai_planner.h
@@ -233,7 +233,7 @@ namespace AI
         bool purchaseNewHeroes( const std::vector<AICastle> & sortedCastleList, const std::set<int> & castlesInDanger, const int32_t availableHeroCount,
                                 const bool moreTasksForHeroes );
 
-        void updateMapActionObjectCache( const int mapIndex );
+        void updateMapActionObjectCache( const Kingdom & kingdom, const int mapIndex );
 
         std::set<int> findCastlesInDanger( const Kingdom & kingdom );
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -350,7 +350,7 @@ namespace
             return !hero.isObjectTypeVisited( objectType ) && hero.GetMorale() < Morale::BLOOD && !army.AllTroopsAreUndead();
 
         case MP2::OBJ_MAGELLANS_MAPS:
-            return !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) && kingdom.AllowPayment( PaymentConditions::getMagellansMapsPurchasePrice() );
+            return !kingdom.isVisited( objectType ) && kingdom.AllowPayment( PaymentConditions::getMagellansMapsPurchasePrice() );
 
         case MP2::OBJ_ALCHEMIST_LAB:
         case MP2::OBJ_LIGHTHOUSE:
@@ -415,7 +415,7 @@ namespace
         }
 
         case MP2::OBJ_OBELISK:
-            return !kingdom.isVisited( tile );
+            return !kingdom.isVisited( index, objectType );
 
         case MP2::OBJ_BARRIER:
             return kingdom.isTravellerTentVisited( getBarrierColorFromTile( tile ) );
@@ -442,7 +442,7 @@ namespace
                 return false;
             }
 
-            if ( !hero.isVisited( tile, Visit::GLOBAL ) ) {
+            if ( !kingdom.isVisited( index, objectType ) ) {
                 // This shrine has not been visited by any hero. It's worth to do it.
                 return true;
             }
@@ -480,7 +480,7 @@ namespace
                 return false;
             }
 
-            if ( !hero.isVisited( tile, Visit::GLOBAL ) ) {
+            if ( !kingdom.isVisited( index, objectType ) ) {
                 // The AI heroes should not have prior knowledge what skill this object has.
                 return true;
             }
@@ -668,14 +668,14 @@ namespace
         case MP2::OBJ_DERELICT_SHIP:
         case MP2::OBJ_GRAVEYARD:
         case MP2::OBJ_SHIPWRECK:
-            if ( !hero.isVisited( tile, Visit::GLOBAL ) && doesTileContainValuableItems( tile ) ) {
+            if ( !kingdom.isVisited( index, objectType ) && doesTileContainValuableItems( tile ) ) {
                 Army enemy( tile );
                 return enemy.isValid() && isHeroStrongerThan( tile, ai, heroArmyStrength, 2 );
             }
             break;
 
         case MP2::OBJ_PYRAMID:
-            if ( !hero.isVisited( tile, Visit::GLOBAL ) && doesTileContainValuableItems( tile ) ) {
+            if ( !kingdom.isVisited( index, objectType ) && doesTileContainValuableItems( tile ) ) {
                 Army enemy( tile );
                 return enemy.isValid() && Skill::Level::EXPERT == hero.GetLevelSkill( Skill::Secondary::WISDOM )
                        && isHeroStrongerThan( tile, ai, heroArmyStrength, AI::ARMY_ADVANTAGE_LARGE );
@@ -728,7 +728,7 @@ namespace
         case MP2::OBJ_JAIL:
             return kingdom.GetHeroes().size() < Kingdom::GetMaxHeroes();
         case MP2::OBJ_HUT_OF_MAGI:
-            return !hero.isObjectTypeVisited( objectType, Visit::GLOBAL ) && Maps::doesObjectExistOnMap( MP2::OBJ_EYE_OF_MAGI );
+            return !kingdom.isVisited( objectType ) && Maps::doesObjectExistOnMap( MP2::OBJ_EYE_OF_MAGI );
 
         case MP2::OBJ_ALCHEMIST_TOWER: {
             const BagArtifacts & bag = hero.GetBagArtifacts();

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2905,8 +2905,8 @@ void AI::Planner::HeroesBeginMovement( Heroes & hero )
 
     const int32_t formerBoatIdx = HeroesCastSummonBoat( hero, nextTileIdx );
 
-    updateMapActionObjectCache( formerBoatIdx );
-    updateMapActionObjectCache( nextTileIdx );
+    updateMapActionObjectCache( hero.GetKingdom(), formerBoatIdx );
+    updateMapActionObjectCache( hero.GetKingdom(), nextTileIdx );
 }
 
 void AI::Planner::HeroesActionComplete( Heroes & hero, const int32_t tileIndex, const MP2::MapObjectType objectType )
@@ -2932,7 +2932,7 @@ void AI::Planner::HeroesActionComplete( Heroes & hero, const int32_t tileIndex, 
 
     updatePriorityTargets( hero, tileIndex, objectType );
 
-    updateMapActionObjectCache( tileIndex );
+    updateMapActionObjectCache( hero.GetKingdom(), tileIndex );
 }
 
 void AI::Planner::HeroesActionNewPosition( Heroes & hero )
@@ -3007,8 +3007,8 @@ void AI::Planner::HeroesActionNewPosition( Heroes & hero )
 
     const int32_t formerBoatIdx = HeroesCastSummonBoat( hero, nextTileIdx );
 
-    updateMapActionObjectCache( formerBoatIdx );
-    updateMapActionObjectCache( nextTileIdx );
+    updateMapActionObjectCache( hero.GetKingdom(), formerBoatIdx );
+    updateMapActionObjectCache( hero.GetKingdom(), nextTileIdx );
 }
 
 bool AI::Planner::isValidHeroObject( const Heroes & hero, const int32_t index, const bool underHero )
@@ -3167,8 +3167,8 @@ fheroes2::GameMode AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & curre
                     // and this results in inserting a new hero position into the action object cache. Perform the necessary updates.
                     assert( bestHero->isActive() && bestHero->GetIndex() != prevHeroPosition );
 
-                    updateMapActionObjectCache( prevHeroPosition );
-                    updateMapActionObjectCache( bestHero->GetIndex() );
+                    updateMapActionObjectCache( bestHero->GetKingdom(), prevHeroPosition );
+                    updateMapActionObjectCache( bestHero->GetKingdom(), bestHero->GetIndex() );
 
                     prevHeroPosition = bestHero->GetIndex();
                 }
@@ -3197,11 +3197,11 @@ fheroes2::GameMode AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & curre
 
         if ( !bestHero->isActive() || bestHero->GetIndex() != prevHeroPosition ) {
             // The hero died or moved to another position. We have to update the action object cache.
-            updateMapActionObjectCache( prevHeroPosition );
+            updateMapActionObjectCache( bestHero->GetKingdom(), prevHeroPosition );
 
             if ( bestHero->isActive() ) {
                 // Hero moved to another position and is still alive.
-                updateMapActionObjectCache( bestHero->GetIndex() );
+                updateMapActionObjectCache( bestHero->GetKingdom(), bestHero->GetIndex() );
             }
         }
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2905,8 +2905,9 @@ void AI::Planner::HeroesBeginMovement( Heroes & hero )
 
     const int32_t formerBoatIdx = HeroesCastSummonBoat( hero, nextTileIdx );
 
-    updateMapActionObjectCache( hero.GetKingdom(), formerBoatIdx );
-    updateMapActionObjectCache( hero.GetKingdom(), nextTileIdx );
+    const auto & kingdom = hero.GetKingdom();
+    updateMapActionObjectCache( kingdom, formerBoatIdx );
+    updateMapActionObjectCache( kingdom, nextTileIdx );
 }
 
 void AI::Planner::HeroesActionComplete( Heroes & hero, const int32_t tileIndex, const MP2::MapObjectType objectType )
@@ -3007,8 +3008,9 @@ void AI::Planner::HeroesActionNewPosition( Heroes & hero )
 
     const int32_t formerBoatIdx = HeroesCastSummonBoat( hero, nextTileIdx );
 
-    updateMapActionObjectCache( hero.GetKingdom(), formerBoatIdx );
-    updateMapActionObjectCache( hero.GetKingdom(), nextTileIdx );
+    const auto & kingdom = hero.GetKingdom();
+    updateMapActionObjectCache( kingdom, formerBoatIdx );
+    updateMapActionObjectCache( kingdom, nextTileIdx );
 }
 
 bool AI::Planner::isValidHeroObject( const Heroes & hero, const int32_t index, const bool underHero )
@@ -3167,8 +3169,9 @@ fheroes2::GameMode AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & curre
                     // and this results in inserting a new hero position into the action object cache. Perform the necessary updates.
                     assert( bestHero->isActive() && bestHero->GetIndex() != prevHeroPosition );
 
-                    updateMapActionObjectCache( bestHero->GetKingdom(), prevHeroPosition );
-                    updateMapActionObjectCache( bestHero->GetKingdom(), bestHero->GetIndex() );
+                    const auto & kingdom = bestHero->GetKingdom();
+                    updateMapActionObjectCache( kingdom, prevHeroPosition );
+                    updateMapActionObjectCache( kingdom, bestHero->GetIndex() );
 
                     prevHeroPosition = bestHero->GetIndex();
                 }
@@ -3196,12 +3199,13 @@ fheroes2::GameMode AI::Planner::HeroesTurn( VecHeroes & heroes, uint32_t & curre
         }
 
         if ( !bestHero->isActive() || bestHero->GetIndex() != prevHeroPosition ) {
+            const auto & kingdom = bestHero->GetKingdom();
             // The hero died or moved to another position. We have to update the action object cache.
-            updateMapActionObjectCache( bestHero->GetKingdom(), prevHeroPosition );
+            updateMapActionObjectCache( kingdom, prevHeroPosition );
 
             if ( bestHero->isActive() ) {
                 // Hero moved to another position and is still alive.
-                updateMapActionObjectCache( bestHero->GetKingdom(), bestHero->GetIndex() );
+                updateMapActionObjectCache( kingdom, bestHero->GetIndex() );
             }
         }
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -749,7 +749,7 @@ namespace
         case MP2::OBJ_TRADING_POST:
             return false;
 
-        // The below objects must never being analyzed.
+        // The following objects must never be analyzed.
         // AI should never consider a boat as a destination point. It uses them only to make a path.
         case MP2::OBJ_BOAT:
         // Eye of Magi is not an action object at all.

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -741,6 +741,15 @@ namespace
             return kingdom.AllowPayment( payment );
         }
 
+        // TODO: AI has no brains to handle Sirens object.
+        case MP2::OBJ_SIRENS:
+        // TODO: AI doesn't know how it use Sphinx object properly.
+        case MP2::OBJ_SPHINX:
+        // TODO: AI doesn't know how it use Trading Post object properly.
+        case MP2::OBJ_TRADING_POST:
+            return false;
+
+        // The below objects must never being analyzed.
         // AI should never consider a boat as a destination point. It uses them only to make a path.
         case MP2::OBJ_BOAT:
         // Eye of Magi is not an action object at all.
@@ -749,16 +758,11 @@ namespace
         case MP2::OBJ_ORACLE:
         // AI doesn't read messages.
         case MP2::OBJ_SIGN:
-        // TODO: AI has no brains to handle Sirens object.
-        case MP2::OBJ_SIRENS:
-        // TODO: AI doesn't know how it use Sphinx object properly.
-        case MP2::OBJ_SPHINX:
         // AI should never consider a stone lith as a destination point. It uses them only to make a path.
         case MP2::OBJ_STONE_LITHS:
-        // TODO: AI doesn't know how it use Trading Post object properly.
-        case MP2::OBJ_TRADING_POST:
         // AI should never consider a whirlpool as a destination point. It uses them only to make a path.
         case MP2::OBJ_WHIRLPOOL:
+            assert( 0 );
             return false;
 
         default:

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -747,9 +747,9 @@ namespace
         case MP2::OBJ_EYE_OF_MAGI:
         // No use of these object for AI.
         case MP2::OBJ_ORACLE:
-        // AI has no brains to do anything from sign messages.
+        // AI doesn't read messages.
         case MP2::OBJ_SIGN:
-        // AI has no brains to handle Sirens object.
+        // TODO: AI has no brains to handle Sirens object.
         case MP2::OBJ_SIRENS:
         // TODO: AI doesn't know how it use Sphinx object properly.
         case MP2::OBJ_SPHINX:

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -418,10 +418,10 @@ namespace
             return !kingdom.isVisited( tile );
 
         case MP2::OBJ_BARRIER:
-            return kingdom.IsVisitTravelersTent( getBarrierColorFromTile( tile ) );
+            return kingdom.isTravellerTentVisited( getBarrierColorFromTile( tile ) );
 
         case MP2::OBJ_TRAVELLER_TENT:
-            return !kingdom.IsVisitTravelersTent( getBarrierColorFromTile( tile ) );
+            return !kingdom.isTravellerTentVisited( getBarrierColorFromTile( tile ) );
 
         case MP2::OBJ_SHRINE_FIRST_CIRCLE:
         case MP2::OBJ_SHRINE_SECOND_CIRCLE:

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -717,7 +717,6 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
 
     for ( int idx = 0; idx < mapSize; ++idx ) {
         const Maps::Tile & tile = world.getTile( idx );
-        MP2::MapObjectType objectType = tile.getMainObjectType();
 
         const uint32_t regionID = tile.GetRegion();
         if ( regionID >= _regions.size() ) {
@@ -729,6 +728,7 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
             continue;
         }
 
+        MP2::MapObjectType objectType = tile.getMainObjectType();
         if ( !MP2::isInGameActionObject( objectType ) ) {
             continue;
         }

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -725,7 +725,6 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
             continue;
         }
 
-        RegionStats & stats = _regions[regionID];
         if ( !isUnderViewSpell && tile.isFog( myColor ) ) {
             continue;
         }
@@ -753,6 +752,7 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
             assert( 0 );
         }
 
+        RegionStats & stats = _regions[regionID];
         if ( objectType == MP2::OBJ_HERO ) {
             const Heroes * hero = tile.getHero();
             assert( hero != nullptr );

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -729,13 +729,9 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
         }
 
         MP2::MapObjectType objectType = tile.getMainObjectType();
-        if ( !MP2::isInGameActionObject( objectType ) ) {
-            continue;
-        }
-
         // Remove useless objects for AI heroes as they bring no value.
         // It is good to exclude them here to avoid unnecessary calculations.
-        if ( isUselessActionObject( kingdom, objectType, idx ) ) {
+        if ( !isValuableAdventureMapObject( kingdom, objectType, idx ) ) {
             continue;
         }
 

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -734,6 +734,21 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
             continue;
         }
 
+        // Remove useless objects for AI heroes as they bring no value.
+        // It is good to exclude them here to avoid unnecessary calculations.
+        // Refer to isValidObjectForHero() function in ai_planner_hero.cpp file.
+        switch ( objectType ) {
+        case MP2::OBJ_BOAT:
+        case MP2::OBJ_EYE_OF_MAGI:
+        case MP2::OBJ_ORACLE:
+        case MP2::OBJ_SIGN:
+        case MP2::OBJ_STONE_LITHS:
+        case MP2::OBJ_WHIRLPOOL:
+            continue;
+        default:
+            break;
+        }
+
         if ( const auto [dummy, inserted] = _mapActionObjects.try_emplace( idx, objectType ); !inserted ) {
             assert( 0 );
         }

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -735,7 +735,7 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
 
         // Remove useless objects for AI heroes as they bring no value.
         // It is good to exclude them here to avoid unnecessary calculations.
-        if ( isUselessActionObject( objectType ) ) {
+        if ( isUselessActionObject( kingdom, objectType, idx ) ) {
             continue;
         }
 

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -735,17 +735,8 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
 
         // Remove useless objects for AI heroes as they bring no value.
         // It is good to exclude them here to avoid unnecessary calculations.
-        // Refer to isValidObjectForHero() function in ai_planner_hero.cpp file.
-        switch ( objectType ) {
-        case MP2::OBJ_BOAT:
-        case MP2::OBJ_EYE_OF_MAGI:
-        case MP2::OBJ_ORACLE:
-        case MP2::OBJ_SIGN:
-        case MP2::OBJ_STONE_LITHS:
-        case MP2::OBJ_WHIRLPOOL:
+        if ( isUselessActionObject( objectType ) ) {
             continue;
-        default:
-            break;
         }
 
         if ( const auto [dummy, inserted] = _mapActionObjects.try_emplace( idx, objectType ); !inserted ) {

--- a/src/fheroes2/ai/ai_planner_kingdom.cpp
+++ b/src/fheroes2/ai/ai_planner_kingdom.cpp
@@ -862,7 +862,7 @@ fheroes2::GameMode AI::Planner::KingdomTurn( Kingdom & kingdom )
         if ( purchaseNewHeroes( sortedCastleList, castlesInDanger, availableHeroCount, moreTaskForHeroes ) ) {
             assert( !heroes.empty() && heroes.back() != nullptr );
 
-            updateMapActionObjectCache( heroes.back()->GetIndex() );
+            updateMapActionObjectCache( heroes.back()->GetKingdom(), heroes.back()->GetIndex() );
 
             ++availableHeroCount;
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -374,7 +374,7 @@ namespace
         const int32_t barrierColor = getBarrierColorFromTile( tile );
         StringReplace( str, "%{color}", fheroes2::getBarrierColorName( barrierColor ) );
 
-        if ( kingdom.IsVisitTravelersTent( barrierColor ) ) {
+        if ( kingdom.isTravellerTentVisited( barrierColor ) ) {
             str.append( "\n\n" );
             str.append( _( "(tent visited)" ) );
         }
@@ -388,7 +388,7 @@ namespace
         const int32_t tentColor = getBarrierColorFromTile( tile );
         StringReplace( str, "%{color}", fheroes2::getTentColorName( tentColor ) );
 
-        if ( kingdom.IsVisitTravelersTent( tentColor ) ) {
+        if ( kingdom.isTravellerTentVisited( tentColor ) ) {
             str.append( "\n\n" );
             str.append( _( "(already visited)" ) );
         }

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -3656,7 +3656,7 @@ namespace
 
         std::string title = MP2::StringObject( objectType );
 
-        if ( kingdom.IsVisitTravelersTent( getBarrierColorFromTile( tile ) ) ) {
+        if ( kingdom.isTravellerTentVisited( getBarrierColorFromTile( tile ) ) ) {
             AudioManager::PlaySound( M82::EXPERNCE );
 
             fheroes2::showStandardTextMessage(
@@ -3692,7 +3692,7 @@ namespace
             _( "You enter the tent and see an old woman gazing into a magic gem. She looks up and says,\n\"In my travels, I have learned much in the way of arcane magic. A great oracle taught me his skill. I have the answer you seek.\"" ),
             Dialog::OK );
 
-        kingdom.SetVisitTravelersTent( tentColor );
+        kingdom.markTravellerTentVisited( tentColor );
     }
 
     // Black Cat gives +3 morale and -2 luck.

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -537,18 +537,6 @@ const Recruits & Kingdom::GetRecruits()
     return recruits;
 }
 
-void Kingdom::SetVisitTravelersTent( const int barrierColor )
-{
-    // visited_tents_color is a bitfield
-    _visitedTentsColors |= ( 1 << barrierColor );
-}
-
-bool Kingdom::IsVisitTravelersTent( const int barrierColor ) const
-{
-    // visited_tents_color is a bitfield
-    return ( _visitedTentsColors & ( 1 << barrierColor ) ) != 0;
-}
-
 bool Kingdom::AllowRecruitHero( bool check_payment ) const
 {
     return ( heroes.size() < GetMaxHeroes() ) && ( !check_payment || AllowPayment( PaymentConditions::RecruitHero() ) );
@@ -913,6 +901,11 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
     }
 
     return false;
+}
+
+bool Kingdom::isFriends( const PlayerColor color ) const
+{
+    return ( Color::allPlayerColors() & color ) && ( _color == color || Players::isFriends( _color, static_cast<PlayerColorsSet>( color ) ) );
 }
 
 Cost Kingdom::_getKingdomStartingResources( const int difficulty ) const

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -421,39 +421,6 @@ void Kingdom::SetVisited( int32_t index, const MP2::MapObjectType objectType )
         visit_object.emplace_front( index, objectType );
 }
 
-bool Kingdom::isValidKingdomObjectForAI( const Maps::Tile & tile, const MP2::MapObjectType objectType ) const
-{
-    if ( !MP2::isInGameActionObject( objectType ) ) {
-        return false;
-    }
-
-    if ( isVisited( tile.GetIndex(), objectType ) ) {
-        return false;
-    }
-
-    // Check castle first to ignore guest hero (tile with both Castle and Hero)
-    if ( tile.getMainObjectType( false ) == MP2::OBJ_CASTLE ) {
-        const PlayerColor tileColor = getColorFromTile( tile );
-
-        // Castle can only be visited if it either belongs to this kingdom or is an enemy castle (in the latter case, an attack may occur)
-        return _color == tileColor || !Players::isFriends( _color, static_cast<PlayerColorsSet>( tileColor ) );
-    }
-
-    // Hero object can overlay other objects when standing on top of it: force check with getMainObjectType( true )
-    if ( objectType == MP2::OBJ_HERO ) {
-        const Heroes * hero = tile.getHero();
-
-        // Hero can only be met if he either belongs to this kingdom or is an enemy hero (in the latter case, an attack will occur)
-        return hero && ( _color == hero->GetColor() || !Players::isFriends( _color, static_cast<PlayerColorsSet>( hero->GetColor() ) ) );
-    }
-
-    if ( MP2::isCaptureObject( objectType ) ) {
-        return !Players::isFriends( _color, static_cast<PlayerColorsSet>( getColorFromTile( tile ) ) );
-    }
-
-    return true;
-}
-
 bool Kingdom::opponentsCanRecruitMoreHeroes() const
 {
     for ( const PlayerColor opponentColor : Players::getInPlayOpponents( GetColor() ) ) {
@@ -897,11 +864,6 @@ bool Kingdom::IsTileVisibleFromCrystalBall( const int32_t dest ) const
     }
 
     return false;
-}
-
-bool Kingdom::isFriends( const PlayerColor color ) const
-{
-    return ( Color::allPlayerColors() & color ) && ( _color == color || Players::isFriends( _color, static_cast<PlayerColorsSet>( color ) ) );
 }
 
 Cost Kingdom::_getKingdomStartingResources( const int difficulty ) const

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -427,21 +427,6 @@ bool Kingdom::isValidKingdomObjectForAI( const Maps::Tile & tile, const MP2::Map
         return false;
     }
 
-    // Remove useless objects for AI heroes as they bring no value.
-    // It is good to exclude them here to avoid unnecessary calculations.
-    // Refer to isValidObjectForHero() function in ai_planner_hero.cpp file.
-    switch ( objectType ) {
-    case MP2::OBJ_BOAT:
-    case MP2::OBJ_EYE_OF_MAGI:
-    case MP2::OBJ_ORACLE:
-    case MP2::OBJ_SIGN:
-    case MP2::OBJ_STONE_LITHS:
-    case MP2::OBJ_WHIRLPOOL:
-        return false;
-    default:
-        break;
-    }
-
     if ( isVisited( tile.GetIndex(), objectType ) ) {
         return false;
     }

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -421,10 +421,25 @@ void Kingdom::SetVisited( int32_t index, const MP2::MapObjectType objectType )
         visit_object.emplace_front( index, objectType );
 }
 
-bool Kingdom::isValidKingdomObject( const Maps::Tile & tile, const MP2::MapObjectType objectType ) const
+bool Kingdom::isValidKingdomObjectForAI( const Maps::Tile & tile, const MP2::MapObjectType objectType ) const
 {
     if ( !MP2::isInGameActionObject( objectType ) ) {
         return false;
+    }
+
+    // Remove useless objects for AI heroes as they bring no value.
+    // It is good to exclude them here to avoid unnecessary calculations.
+    // Refer to isValidObjectForHero() function in ai_planner_hero.cpp file.
+    switch ( objectType ) {
+    case MP2::OBJ_BOAT:
+    case MP2::OBJ_EYE_OF_MAGI:
+    case MP2::OBJ_ORACLE:
+    case MP2::OBJ_SIGN:
+    case MP2::OBJ_STONE_LITHS:
+    case MP2::OBJ_WHIRLPOOL:
+        return false;
+    default:
+        break;
     }
 
     if ( isVisited( tile.GetIndex(), objectType ) ) {

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -45,7 +45,6 @@
 #include "maps.h"
 #include "maps_fileinfo.h"
 #include "maps_tiles.h"
-#include "maps_tiles_helper.h"
 #include "math_base.h"
 #include "mp2.h"
 #include "payment.h"

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -451,10 +451,6 @@ bool Kingdom::isValidKingdomObjectForAI( const Maps::Tile & tile, const MP2::Map
         return !Players::isFriends( _color, static_cast<PlayerColorsSet>( getColorFromTile( tile ) ) );
     }
 
-    if ( MP2::isValuableResourceObject( objectType ) ) {
-        return doesTileContainValuableItems( tile );
-    }
-
     return true;
 }
 

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -210,8 +210,6 @@ public:
     bool isVisited( const Maps::Tile & ) const;
     bool isVisited( int32_t, const MP2::MapObjectType objectType ) const;
 
-    bool isValidKingdomObjectForAI( const Maps::Tile & tile, const MP2::MapObjectType objectType ) const;
-
     bool opponentsCanRecruitMoreHeroes() const;
     bool opponentsHaveHeroes() const;
 
@@ -237,8 +235,6 @@ public:
     // Checks whether this tile is visible to any hero who has an artifact with the VIEW_MONSTER_INFORMATION
     // bonus (for example, a Crystal Ball)
     bool IsTileVisibleFromCrystalBall( const int32_t dest ) const;
-
-    bool isFriends( const PlayerColor color ) const;
 
     static uint32_t GetMaxHeroes();
 

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -210,7 +210,7 @@ public:
     bool isVisited( const Maps::Tile & ) const;
     bool isVisited( int32_t, const MP2::MapObjectType objectType ) const;
 
-    bool isValidKingdomObject( const Maps::Tile & tile, const MP2::MapObjectType objectType ) const;
+    bool isValidKingdomObjectForAI( const Maps::Tile & tile, const MP2::MapObjectType objectType ) const;
 
     bool opponentsCanRecruitMoreHeroes() const;
     bool opponentsHaveHeroes() const;

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -222,14 +222,23 @@ public:
         return puzzle_maps;
     }
 
-    void SetVisitTravelersTent( const int barrierColor );
-    bool IsVisitTravelersTent( const int barrierColor ) const;
+    void markTravellerTentVisited( const int barrierColor )
+    {
+        _visitedTentsColors |= ( 1 << barrierColor );
+    }
+
+    bool isTravellerTentVisited( const int barrierColor ) const
+    {
+        return ( _visitedTentsColors & ( 1 << barrierColor ) ) != 0;
+    }
 
     void LossPostActions();
 
     // Checks whether this tile is visible to any hero who has an artifact with the VIEW_MONSTER_INFORMATION
     // bonus (for example, a Crystal Ball)
     bool IsTileVisibleFromCrystalBall( const int32_t dest ) const;
+
+    bool isFriends( const PlayerColor color ) const;
 
     static uint32_t GetMaxHeroes();
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -1172,11 +1172,12 @@ std::vector<IndexObject> AIWorldPathfinder::getObjectsOnTheWay( const int target
     const Kingdom & kingdom = world.GetKingdom( _color );
     std::set<int> uniqueIndices;
 
-    const auto validateAndAdd = [&kingdom, &result, &uniqueIndices]( int index ) {
-        const MP2::MapObjectType objectType = world.getTile( index ).getMainObjectType();
+    const auto validateAndAdd = [&kingdom, &result, &uniqueIndices]( const int index ) {
+        const auto & tile = world.getTile( index );
+        const MP2::MapObjectType objectType = tile.getMainObjectType();
 
         // std::set insert returns a pair, second value is true if it was unique
-        if ( uniqueIndices.insert( index ).second && kingdom.isValidKingdomObject( world.getTile( index ), objectType ) ) {
+        if ( uniqueIndices.insert( index ).second && kingdom.isValidKingdomObjectForAI( tile, objectType ) ) {
             result.emplace_back( index, objectType );
         }
     };

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -186,7 +186,7 @@ namespace
 
         // AI may have the key for the barrier
         if ( objectType == MP2::OBJ_BARRIER ) {
-            return world.GetKingdom( color ).IsVisitTravelersTent( getBarrierColorFromTile( tile ) );
+            return world.GetKingdom( color ).isTravellerTentVisited( getBarrierColorFromTile( tile ) );
         }
 
         // AI can use boats to overcome water obstacles
@@ -1174,15 +1174,14 @@ std::vector<IndexObject> AIWorldPathfinder::getObjectsOnTheWay( const int target
     std::set<int> uniqueIndices;
 
     const auto validateAndAdd = [&kingdom, &result, &uniqueIndices]( const int index ) {
-        const auto & tile = world.getTile( index );
-
         // std::set insert returns a pair, second value is true if it was unique.
         if ( !uniqueIndices.insert( index ).second ) {
             return;
         }
 
+        const auto & tile = world.getTile( index );
         const MP2::MapObjectType objectType = tile.getMainObjectType();
-        if ( AI::isUselessActionObject( objectType ) ) {
+        if ( AI::isUselessActionObject( kingdom, objectType, index ) ) {
             return;
         }
 

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -1181,11 +1181,7 @@ std::vector<IndexObject> AIWorldPathfinder::getObjectsOnTheWay( const int target
 
         const auto & tile = world.getTile( index );
         const MP2::MapObjectType objectType = tile.getMainObjectType();
-        if ( AI::isUselessActionObject( kingdom, objectType, index ) ) {
-            return;
-        }
-
-        if ( kingdom.isValidKingdomObjectForAI( tile, objectType ) ) {
+        if ( AI::isValuableAdventureMapObject( kingdom, objectType, index ) ) {
             result.emplace_back( index, objectType );
         }
     };

--- a/src/fheroes2/world/world_pathfinding.cpp
+++ b/src/fheroes2/world/world_pathfinding.cpp
@@ -29,6 +29,7 @@
 #include <tuple>
 #include <utility>
 
+#include "ai_common.h"
 #include "army.h"
 #include "artifact.h"
 #include "castle.h"
@@ -1174,10 +1175,18 @@ std::vector<IndexObject> AIWorldPathfinder::getObjectsOnTheWay( const int target
 
     const auto validateAndAdd = [&kingdom, &result, &uniqueIndices]( const int index ) {
         const auto & tile = world.getTile( index );
-        const MP2::MapObjectType objectType = tile.getMainObjectType();
 
-        // std::set insert returns a pair, second value is true if it was unique
-        if ( uniqueIndices.insert( index ).second && kingdom.isValidKingdomObjectForAI( tile, objectType ) ) {
+        // std::set insert returns a pair, second value is true if it was unique.
+        if ( !uniqueIndices.insert( index ).second ) {
+            return;
+        }
+
+        const MP2::MapObjectType objectType = tile.getMainObjectType();
+        if ( AI::isUselessActionObject( objectType ) ) {
+            return;
+        }
+
+        if ( kingdom.isValidKingdomObjectForAI( tile, objectType ) ) {
             result.emplace_back( index, objectType );
         }
     };


### PR DESCRIPTION
- replace `Kingdom::isValidKingdomObject()` by `AI::isValuableAdventureMapObject()` as the later function contains much more accurate checks
- call `AI::isValuableAdventureMapObject()` within AI kingdom evaluation stage to avoid adding objects into the list of potential places to visit for heroes. We shouldn't waste computational resources for what we know brings no value for AI
- replace some `hero.isVisited(.., Visit::GLOBAL)` by `kingdom.isVisited()` as the former function function calls the later one internally. Also, replaced `isVisited( tile )` by `isVisited( index, object)` as the first function does exactly the same. So, we won't waste CPU cycles for the same thing

relates to #10508

