### PR TITLE
Add Traditional Chinese (zh_TW) translation source

### DIFF
--- a/files/lang/zh_TW.po
+++ b/files/lang/zh_TW.po
@@ -1,0 +1,12103 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: fheroes2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-31 03:40+0800\n"
+"PO-Revision-Date: 2026-05-31 03:39+0800\n"
+"Last-Translator: Peter Dave Hello <hsu@peterdavehello.org>\n"
+"Language-Team: \n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "SELECT"
+msgstr "選擇"
+
+msgid "ABOUT"
+msgstr "關於"
+
+msgid "S"
+msgstr "S"
+
+msgid "M"
+msgstr "M"
+
+msgid "L"
+msgstr "L"
+
+msgid "X-L"
+msgstr "X-L"
+
+msgid "ALL"
+msgstr "全部"
+
+msgid "EXIT"
+msgstr "離開"
+
+msgid "smallerButton|EXIT"
+msgstr "離開"
+
+msgid "OKAY"
+msgstr "確定"
+
+msgid "HEROES"
+msgstr "英雄"
+
+msgid ""
+"TOWNS/\n"
+"CASTLES"
+msgstr ""
+"城鎮/\n"
+"城堡"
+
+msgid "CANCEL"
+msgstr "取消"
+
+msgid "ACCEPT"
+msgstr "接受"
+
+msgid "DECLINE"
+msgstr "拒絕"
+
+msgid "LEARN"
+msgstr "學習"
+
+msgid "TRADE"
+msgstr "交易"
+
+msgid "YES"
+msgstr "是"
+
+msgid "NO"
+msgstr "否"
+
+msgid "DISMISS"
+msgstr "解散"
+
+msgid "UPGRADE"
+msgstr "升級"
+
+msgid "GIFT"
+msgstr "贈禮"
+
+msgid "RESTART"
+msgstr "重新開始"
+
+msgid "MAX"
+msgstr "最大"
+
+msgid "MIN"
+msgstr "最小"
+
+msgid ""
+"D\n"
+"I\n"
+"S\n"
+"M\n"
+"I\n"
+"S\n"
+"S"
+msgstr ""
+"解\n"
+"散"
+
+msgid ""
+"E\n"
+"X\n"
+"I\n"
+"T"
+msgstr ""
+"離\n"
+"開"
+
+msgid ""
+"C\n"
+"A\n"
+"M\n"
+"P\n"
+"A\n"
+"I\n"
+"G\n"
+"N"
+msgstr ""
+"戰\n"
+"役"
+
+msgid ""
+"S\n"
+"T\n"
+"A\n"
+"N\n"
+"D\n"
+"A\n"
+"R\n"
+"D"
+msgstr ""
+"標\n"
+"準"
+
+msgid ""
+"NEW\n"
+"GAME"
+msgstr ""
+"新\n"
+"遊戲"
+
+msgid ""
+"LOAD\n"
+"GAME"
+msgstr ""
+"載入\n"
+"遊戲"
+
+msgid ""
+"RESTART\n"
+"GAME"
+msgstr ""
+"重新\n"
+"開始"
+
+msgid ""
+"SAVE\n"
+"GAME"
+msgstr ""
+"儲存\n"
+"遊戲"
+
+msgid ""
+"QUICK\n"
+"SAVE"
+msgstr ""
+"快速\n"
+"存檔"
+
+msgid "QUIT"
+msgstr "結束"
+
+msgid ""
+"START\n"
+"MAP"
+msgstr ""
+"開始\n"
+"地圖"
+
+msgid ""
+"MAIN\n"
+"MENU"
+msgstr ""
+"主\n"
+"選單"
+
+msgid ""
+"NEW\n"
+"MAP"
+msgstr ""
+"新\n"
+"地圖"
+
+msgid ""
+"LOAD\n"
+"MAP"
+msgstr ""
+"載入\n"
+"地圖"
+
+msgid ""
+"SAVE\n"
+"MAP"
+msgstr ""
+"儲存\n"
+"地圖"
+
+msgid "INFO"
+msgstr "資訊"
+
+msgid ""
+"BATTLE\n"
+"ONLY"
+msgstr ""
+"僅限\n"
+"戰鬥"
+
+msgid "SETTINGS"
+msgstr "設定"
+
+msgid ""
+"STANDARD\n"
+"GAME"
+msgstr ""
+"標準\n"
+"遊戲"
+
+msgid ""
+"CAMPAIGN\n"
+"GAME"
+msgstr ""
+"戰役\n"
+"遊戲"
+
+msgid ""
+"MULTI-\n"
+"PLAYER\n"
+"GAME"
+msgstr ""
+"多人\n"
+"遊戲"
+
+msgid "HOT SEAT"
+msgstr "熱座模式"
+
+msgid "2 PLAYERS"
+msgstr "2 位玩家"
+
+msgid "3 PLAYERS"
+msgstr "3 位玩家"
+
+msgid "4 PLAYERS"
+msgstr "4 位玩家"
+
+msgid "5 PLAYERS"
+msgstr "5 位玩家"
+
+msgid "6 PLAYERS"
+msgstr "6 位玩家"
+
+msgid ""
+"ORIGINAL\n"
+"CAMPAIGN"
+msgstr ""
+"原版\n"
+"戰役"
+
+msgid ""
+"EXPANSION\n"
+"CAMPAIGN"
+msgstr ""
+"資料片\n"
+"戰役"
+
+msgid "editorMainMenu|BACK"
+msgstr "返回"
+
+msgid ""
+"newMap|FROM\n"
+"SCRATCH"
+msgstr ""
+"從頭\n"
+"開始"
+
+msgid "newMap|RANDOM"
+msgstr "隨機"
+
+msgid "DIFFICULTY"
+msgstr "難度"
+
+msgid "VIEW INTRO"
+msgstr "觀看序幕"
+
+msgid "RESET"
+msgstr "重置"
+
+msgid "START"
+msgstr "開始"
+
+msgid ""
+"P\n"
+"A\n"
+"T\n"
+"R\n"
+"O\n"
+"L"
+msgstr ""
+"巡\n"
+"邏"
+
+msgid "army|Few"
+msgstr "少量"
+
+msgid "Warrior"
+msgstr "戰士"
+
+msgid "Builder"
+msgstr "建設者"
+
+msgid "Explorer"
+msgstr "探索者"
+
+msgid "None"
+msgstr "無"
+
+msgid ""
+"%{monster}\n"
+"%{range}"
+msgstr ""
+"%{monster}\n"
+"%{range}"
+
+msgid ""
+"A few\n"
+"%{monster}"
+msgstr ""
+"少量\n"
+"%{monster}"
+
+msgid ""
+"Several\n"
+"%{monster}"
+msgstr ""
+"數個\n"
+"%{monster}"
+
+msgid ""
+"A pack of\n"
+"%{monster}"
+msgstr ""
+"一群\n"
+"%{monster}"
+
+msgid ""
+"Lots of\n"
+"%{monster}"
+msgstr ""
+"大量\n"
+"%{monster}"
+
+msgid ""
+"A horde of\n"
+"%{monster}"
+msgstr ""
+"一大群\n"
+"%{monster}"
+
+msgid ""
+"A throng of\n"
+"%{monster}"
+msgstr ""
+"一大批\n"
+"%{monster}"
+
+msgid ""
+"A swarm of\n"
+"%{monster}"
+msgstr ""
+"蜂擁的\n"
+"%{monster}"
+
+msgid ""
+"Zounds...\n"
+"%{monster}"
+msgstr ""
+"數不清的\n"
+"%{monster}"
+
+msgid ""
+"A legion of\n"
+"%{monster}"
+msgstr ""
+"軍團規模的\n"
+"%{monster}"
+
+msgid "army|Several"
+msgstr "數個"
+
+msgid "army|Pack"
+msgstr "一群"
+
+msgid "army|Lots"
+msgstr "大量"
+
+msgid "army|Horde"
+msgstr "一大群"
+
+msgid "army|Throng"
+msgstr "一大批"
+
+msgid "army|Swarm"
+msgstr "蜂擁"
+
+msgid "army|Zounds"
+msgstr "數不清"
+
+msgid "army|Legion"
+msgstr "軍團"
+
+msgid "All %{race} troops +1"
+msgstr "所有 %{race} 部隊 +1"
+
+msgid "NeutralRaceTroops|Neutral"
+msgstr "中立"
+
+msgid "Troops of %{count} alignments -%{penalty}"
+msgstr "%{count} 種陣營的部隊 -%{penalty}"
+
+msgid "Some undead in army -1"
+msgstr "軍隊中有部分亡靈 -1"
+
+msgid ""
+"Default\n"
+"troop"
+msgstr ""
+"預設\n"
+"部隊"
+
+msgid "View %{name}"
+msgstr "檢視 %{name}"
+
+msgid "Move the %{name} "
+msgstr "移動 %{name} "
+
+msgid "Move or right click to redistribute %{name}"
+msgstr "移動或按右鍵重新分配 %{name}"
+
+msgid "Combine %{name} armies"
+msgstr "合併 %{name} 軍隊"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "交換 %{name2} 與 %{name}"
+
+msgid "Select %{name}"
+msgstr "選擇 %{name}"
+
+msgid "Cannot move last troop"
+msgstr "無法移動最後一支部隊"
+
+msgid "Move the %{name}"
+msgstr "移動 %{name}"
+
+msgid "Set %{monster} Count:"
+msgstr "設定 %{monster} 數量："
+
+msgid "%{name} destroys half the enemy troops!"
+msgid_plural "%{name} destroy half the enemy troops!"
+msgstr[0] "%{name} 摧毀了一半的敵方部隊！"
+
+msgid "%{name} has turned off the auto combat"
+msgstr "%{name} 已關閉自動戰鬥"
+
+msgid "%{name} has turned on the auto combat"
+msgstr "%{name} 已開啟自動戰鬥"
+
+msgid "Spell failed!"
+msgstr "法術失敗！"
+
+msgid ""
+"The Sphere of Negation artifact is in effect for this battle, disabling all "
+"combat spells."
+msgstr ""
+"否定之球神器在此戰鬥中生效，所有戰鬥法術均被封鎖。"
+
+msgid "You cannot cast spells without a commanding hero."
+msgstr "沒有指揮英雄就無法施放法術。"
+
+msgid "You have already cast a spell this round."
+msgstr "本回合已經施放過法術了。"
+
+msgid "That spell will have no effect!"
+msgstr "該法術不會有任何效果！"
+
+msgid "You may only summon one type of elemental per combat."
+msgstr "每場戰鬥只能召喚一種元素生物。"
+
+msgid ""
+"There is no open space adjacent to your hero where you can summon an "
+"Elemental to."
+msgstr ""
+"英雄旁邊沒有空位可以召喚元素生物。"
+
+msgid ""
+"The Moat interrupts any movement through it and reduces the defense skill of "
+"troops present in it by %{count}."
+msgstr ""
+"護城河會中斷經過的一切移動，並將停留其中部隊的防禦技能降低 %{count}。"
+
+msgid "battleAnimation|Speed: %{speed}"
+msgstr "速度：%{speed}"
+
+msgid "battleAnimation|Speed"
+msgstr "速度"
+
+msgid "Interface"
+msgstr "介面"
+
+msgid "Settings"
+msgstr "設定"
+
+msgid "Auto Spell Casting"
+msgstr "自動施法"
+
+msgid "Off"
+msgstr "關閉"
+
+msgid "On"
+msgstr "開啟"
+
+msgid "Set the speed of combat actions and animations."
+msgstr "調整戰鬥動作與動畫的速度。"
+
+msgid "Change the interface settings of the game."
+msgstr "變更遊戲的介面設定。"
+
+msgid "Interface Settings"
+msgstr "介面設定"
+
+msgid ""
+"Toggle whether or not the computer will cast spells for you when auto combat "
+"is on. (Note: This does not affect spell casting for computer players in any "
+"way, nor does it affect quick combat.)"
+msgstr ""
+"切換自動戰鬥時是否由電腦代為施法。（注意：此選項不會影響電腦玩家的施法方式，"
+"也不會影響快速戰鬥。）"
+
+msgid "Audio"
+msgstr "音效"
+
+msgid "Change the audio settings of the game."
+msgstr "變更遊戲的音效設定。"
+
+msgid "Check and configure all the hot keys present in the game."
+msgstr "檢查並調整遊戲中所有的快速鍵。"
+
+msgid "Hot Keys"
+msgstr "快速鍵"
+
+msgid "Exit this menu."
+msgstr "離開此選單。"
+
+msgid "Okay"
+msgstr "確定"
+
+msgid "The enemy has surrendered!"
+msgstr "敵人已投降！"
+
+msgid "Their cowardice costs them %{gold} gold."
+msgstr "怯懦使他們損失了 %{gold} 金幣。"
+
+msgid "The enemy has fled!"
+msgstr "敵人逃跑了！"
+
+msgid "A glorious victory!"
+msgstr "光榮的勝利！"
+
+msgid "For valor in combat, %{name} receives %{exp} experience."
+msgstr "因在戰鬥中英勇表現，%{name} 獲得了 %{exp} 點經驗值。"
+
+msgid "The cowardly %{name} flees from battle."
+msgstr "懦弱的 %{name} 從戰場上逃走了。"
+
+msgid "%{name} surrenders to the enemy, and departs in shame."
+msgstr "%{name} 向敵人投降，羞愧地離去。"
+
+msgid "Your forces suffer a bitter defeat, and %{name} abandons your cause."
+msgstr "軍隊遭受慘敗，%{name} 拋棄了你的陣營。"
+
+msgid "Your forces suffer a bitter defeat."
+msgstr "軍隊遭受了慘敗。"
+
+msgid "Battlefield Casualties"
+msgstr "戰場傷亡"
+
+msgid "Attacker"
+msgstr "進攻方"
+
+msgid "Defender"
+msgstr "防守方"
+
+msgid "Click to leave the battle results."
+msgstr "按一下離開戰鬥結果。"
+
+msgid "Click to restart the battle in manual mode."
+msgstr "按一下以手動模式重新開始戰鬥。"
+
+msgid "Restart"
+msgstr "重新開始"
+
+msgid "You have captured an enemy artifact!"
+msgstr "繳獲了一件敵方神器！"
+
+msgid "As you reach for the %{name}, it mysteriously disappears."
+msgstr "當你伸手去拿 %{name} 時，它神祕地消失了。"
+
+msgid "As your enemy reaches for the %{name}, it mysteriously disappears."
+msgstr "當敵人伸手去拿 %{name} 時，它神祕地消失了。"
+
+msgid "Necromancy!"
+msgstr "亡靈巫術！"
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+"藉由施展亡靈巫術的黑暗力量，你復活了 %{count} 具敵方屍體，化為 %{monster} 為"
+"你效力。"
+
+msgid "%{name} the %{race}"
+msgstr "%{name}，%{race}"
+
+msgid "Captain of %{name}"
+msgstr "%{name} 的隊長"
+
+msgid "Attack"
+msgstr "攻擊"
+
+msgid "Defense"
+msgstr "防禦"
+
+msgid "Spell Power"
+msgstr "魔法力量"
+
+msgid "Knowledge"
+msgstr "知識"
+
+msgid "Morale"
+msgstr "士氣"
+
+msgid "Luck"
+msgstr "運氣"
+
+msgid "Spell Points"
+msgstr "魔法值"
+
+msgid "Cast Spell"
+msgstr "施放法術"
+
+msgid "Retreat"
+msgstr "撤退"
+
+msgid "Surrender"
+msgstr "投降"
+
+msgid "Cancel"
+msgstr "取消"
+
+msgid "Hero Screen"
+msgstr "英雄畫面"
+
+msgid "Captain's Options"
+msgstr "隊長選項"
+
+msgid "Hero's Options"
+msgstr "英雄選項"
+
+msgid ""
+"Cast a magical spell. You may only cast one spell per combat round. The "
+"round is reset when every creature has had a turn."
+msgstr ""
+"施放法術。每回合只能施放一個法術，當所有生物都行動過後回合即重置。"
+
+msgid ""
+"Retreat your hero, abandoning your creatures. Your hero will be available "
+"for you to recruit again, however, the hero will have only a novice hero's "
+"forces."
+msgstr ""
+"撤退英雄並拋棄部隊。英雄可重新招募，但只會擁有新手英雄的起始兵力。"
+
+msgid ""
+"Surrendering costs gold. However if you pay the ransom, the hero and all of "
+"his or her surviving creatures will be available to recruit again. The cost "
+"of surrender is half of the total cost of the non-temporary troops remaining "
+"in the army."
+msgstr ""
+"投降需要支付黃金。不過若支付贖金，英雄及其所有倖存部隊均可重新招募。投降費用"
+"為軍隊中所有非臨時部隊總成本的一半。"
+
+msgid "Open Hero Screen to view full information about the hero."
+msgstr "開啟英雄畫面以檢視英雄的完整資訊。"
+
+msgid "Return to the battle."
+msgstr "返回戰鬥。"
+
+msgid "Not enough gold (%{gold})"
+msgstr "黃金不足 (%{gold})"
+
+msgid "%{name} states:"
+msgstr "%{name} 表示："
+
+msgid "Captain of %{name} states:"
+msgstr "%{name} 的隊長表示："
+
+msgid ""
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
+msgstr ""
+"「我接受你的投降。支付 %{price} 金幣後，你和部隊就能安全離開。」"
+
+msgid "View %{monster} info"
+msgstr "檢視 %{monster} 資訊"
+
+msgid "Fly %{monster} here"
+msgstr "令 %{monster} 飛到此處"
+
+msgid "Move %{monster} here"
+msgstr "移動 %{monster} 到此處"
+
+msgid "Shoot %{monster}"
+msgstr "射擊 %{monster}"
+
+msgid "(1 shot left)"
+msgid_plural "(%{count} shots left)"
+msgstr[0] "(剩餘 1 次射擊)"
+
+msgid "Attack %{monster}"
+msgstr "攻擊 %{monster}"
+
+msgid "Turn %{turn}"
+msgstr "回合 %{turn}"
+
+msgid "Teleport here"
+msgstr "傳送至此"
+
+msgid "Invalid teleport destination"
+msgstr "無效的傳送目的地"
+
+msgid "Cast %{spell} on %{monster}"
+msgstr "對 %{monster} 施放 %{spell}"
+
+msgid "Cast %{spell}"
+msgstr "施放 %{spell}"
+
+msgid "Select spell target"
+msgstr "選擇法術目標"
+
+msgid "Are you sure you want to enable the auto combat mode?"
+msgstr "確定要啟用自動戰鬥模式嗎？"
+
+msgid "Are you sure you want to resolve the battle in the quick combat mode?"
+msgstr "確定要以快速戰鬥模式結算這場戰鬥嗎？"
+
+msgid "View Ballista info"
+msgstr "檢視弩砲資訊"
+
+msgid "Ballista"
+msgstr "弩砲"
+
+msgid "Automatic combat modes"
+msgstr "自動戰鬥模式"
+
+msgid "Automatic Combat Modes"
+msgstr "自動戰鬥模式"
+
+msgid ""
+"Choose between proceeding the combat in auto combat mode or in quick combat "
+"mode."
+msgstr ""
+"請選擇以自動戰鬥模式或快速戰鬥模式繼續戰鬥。"
+
+msgid "Customize system options"
+msgstr "自訂系統選項"
+
+msgid "Allows you to customize the combat screen."
+msgstr "可自訂戰鬥畫面。"
+
+msgid "System Options"
+msgstr "系統選項"
+
+msgid "Skip this unit"
+msgstr "略過此單位"
+
+msgid "Skip"
+msgstr "略過"
+
+msgid ""
+"Skips the current creature. The current creature ends its turn and does not "
+"get to go again until the next round."
+msgstr ""
+"略過目前的生物。該生物結束其回合，直到下一回合才能再次行動。"
+
+msgid "View Captain's options"
+msgstr "檢視隊長選項"
+
+msgid "View Hero's options"
+msgstr "檢視英雄選項"
+
+msgid "View opposing Captain"
+msgstr "檢視對方隊長"
+
+msgid "View opposing Hero"
+msgstr "檢視對方英雄"
+
+msgid "Hide logs"
+msgstr "隱藏記錄"
+
+msgid "Show logs"
+msgstr "顯示記錄"
+
+msgid "Message Bar"
+msgstr "訊息列"
+
+msgid "Shows the results of individual monster's actions."
+msgstr "顯示各怪物的行動結果。"
+
+msgid ""
+"AUTO\n"
+"COMBAT"
+msgstr ""
+"自動\n"
+"戰鬥"
+
+msgid ""
+"QUICK\n"
+"COMBAT"
+msgstr ""
+"快速\n"
+"戰鬥"
+
+msgid "The computer continues the combat for you."
+msgstr "由電腦繼續為你戰鬥。"
+
+msgid ""
+"autoCombat|This can be interrupted at any moment by pressing the Auto Combat "
+"hotkey or the default Cancel key, or by performing a left or right click "
+"anywhere on the game screen."
+msgstr ""
+"可隨時按下自動戰鬥快速鍵、預設取消鍵，或在遊戲畫面任意處左鍵或右鍵按一下來中"
+"斷。"
+
+msgid "Auto Combat"
+msgstr "自動戰鬥"
+
+msgid "The combat is resolved from the current state."
+msgstr "從目前狀態結算戰鬥結果。"
+
+msgid "quickCombat|This cannot be undone."
+msgstr "此操作無法復原。"
+
+msgid "Quick Combat"
+msgstr "快速戰鬥"
+
+msgid "The %{name} skips their turn."
+msgid_plural "The %{name} skip their turn."
+msgstr[0] "%{name} 略過了回合。"
+
+msgid "%{attacker} does %{damage} damage."
+msgid_plural "%{attacker} do %{damage} damage."
+msgstr[0] "%{attacker} 造成了 %{damage} 點傷害。"
+
+msgid "1 creature perishes."
+msgid_plural "%{count} creatures perish."
+msgstr[0] "1 個生物陣亡。"
+
+msgid "1 %{defender} perishes."
+msgid_plural "%{count} %{defender} perish."
+msgstr[0] "1 個 %{defender} 陣亡。"
+
+msgid "1 soul is incorporated."
+msgid_plural "%{count} souls are incorporated."
+msgstr[0] "1 個靈魂被吸收。"
+
+msgid "1 %{unit} is revived."
+msgid_plural "%{count} %{unit} are revived."
+msgstr[0] "1 個 %{unit} 被復活。"
+
+msgid "Moved %{monster}: from [%{src}] to [%{dst}]."
+msgstr "已移動 %{monster}: 從 [%{src}] 到 [%{dst}]。"
+
+msgid "The %{name} resists the spell!"
+msgid_plural "The %{name} resist the spell!"
+msgstr[0] "%{name} 抵抗了法術！"
+
+msgid "%{name} casts %{spell} on the %{troop}."
+msgstr "%{name} 對 %{troop} 施放了 %{spell}。"
+
+msgid "%{name} casts %{spell}."
+msgstr "%{name} 施放了 %{spell}。"
+
+msgid "The %{spell} does %{damage} damage to one undead creature."
+msgstr "%{spell} 對一個亡靈生物造成了 %{damage} 點傷害。"
+
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr "%{spell} 對所有亡靈生物造成了 %{damage} 點傷害。"
+
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr "%{spell} 造成了 %{damage} 點傷害，%{count} 個生物陣亡。"
+
+msgid "The %{spell} does %{damage} damage."
+msgstr "%{spell} 造成了 %{damage} 點傷害。"
+
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "%{spell} 對一個活體生物造成了 %{damage} 點傷害。"
+
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "%{spell} 對所有活體生物造成了 %{damage} 點傷害。"
+
+msgid "The %{attacker}'s attack blinds the %{target}!"
+msgid_plural "The %{attacker}' attack blinds the %{target}!"
+msgstr[0] "%{attacker} 的攻擊使 %{target} 目盲了！"
+
+msgid "The %{attacker}'s gaze turns the %{target} to stone!"
+msgid_plural "The %{attacker}' gaze turns the %{target} to stone!"
+msgstr[0] "%{attacker} 的凝視使 %{target} 石化了！"
+
+msgid "The %{attacker}'s curse falls upon the %{target}!"
+msgid_plural "The %{attacker}' curse falls upon the %{target}!"
+msgstr[0] "%{attacker} 的詛咒降臨在 %{target} 身上！"
+
+msgid "The %{target} is paralyzed by the %{attacker}!"
+msgid_plural "The %{target} are paralyzed by the %{attacker}!"
+msgstr[0] "%{target} 被 %{attacker} 麻痺了！"
+
+msgid "The %{attacker} dispels all good spells on your %{target}!"
+msgid_plural "The %{attacker} dispel all good spells on your %{target}!"
+msgstr[0] "%{attacker} 解除了 %{target} 身上所有的增益法術！"
+
+msgid "The %{attacker} casts %{spell} on the %{target}!"
+msgid_plural "The %{attacker} cast %{spell} on the %{target}!"
+msgstr[0] "%{attacker} 對 %{target} 施放了 %{spell}！"
+
+msgid "Bad luck descends on the %{attacker}."
+msgstr "厄運降臨在 %{attacker} 身上。"
+
+msgid "Good luck shines on the %{attacker}."
+msgstr "好運眷顧了 %{attacker}。"
+
+msgid "High morale enables the %{monster} to attack again."
+msgstr "高昂士氣使 %{monster} 得以再次攻擊。"
+
+msgid "Low morale causes the %{monster} to freeze in panic."
+msgstr "低落士氣使 %{monster} 因恐慌而僵住。"
+
+msgid "%{tower} does %{damage} damage."
+msgstr "%{tower} 造成了 %{damage} 點傷害。"
+
+msgid "The mirror image is created."
+msgstr "鏡像已建立。"
+
+msgid "The mirror image is destroyed!"
+msgstr "鏡像被摧毀了！"
+
+msgid "Are you sure you want to interrupt the auto combat mode?"
+msgstr "確定要中斷自動戰鬥模式嗎？"
+
+msgid "Error"
+msgstr "錯誤"
+
+msgid "No spells to cast."
+msgstr "沒有可施放的法術。"
+
+msgid "Are you sure you want to retreat?"
+msgstr "確定要撤退嗎？"
+
+msgid "Retreat disabled"
+msgstr "撤退已停用"
+
+msgid "Surrender disabled"
+msgstr "投降已停用"
+
+msgid "Damage: %{max}"
+msgstr "傷害：%{max}"
+
+msgid "Damage: %{min} - %{max}"
+msgstr "傷害：%{min} - %{max}"
+
+msgid "Perish: %{max}"
+msgstr "陣亡：%{max}"
+
+msgid "Perish: %{min} - %{max}"
+msgstr "陣亡：%{min} - %{max}"
+
+msgid "battle_turn_order|Top"
+msgstr "頂部"
+
+msgid "battle_turn_order|Bottom"
+msgstr "底部"
+
+msgid "Turn Order"
+msgstr "行動順序"
+
+msgid "Grid"
+msgstr "格線"
+
+msgid "Damage Info"
+msgstr "傷害資訊"
+
+msgid "Shadow Movement"
+msgstr "移動陰影"
+
+msgid "Shadow Cursor"
+msgstr "游標陰影"
+
+msgid "Movement Area"
+msgstr "移動範圍"
+
+msgid "Toggle to display the turn order during the battle."
+msgstr "切換是否在戰鬥中顯示行動順序。"
+
+msgid ""
+"Toggle the hex grid on or off. The hex grid always underlies movement, even "
+"if turned off. This switch only determines if the grid is visible."
+msgstr ""
+"切換六角格線的顯示。格線始終作為移動的基礎存在，此開關僅決定是否顯示格線。"
+
+msgid "Toggle to display damage information during the battle."
+msgstr "切換是否在戰鬥中顯示傷害資訊。"
+
+msgid ""
+"Toggle on or off shadows showing where your creatures can move and attack."
+msgstr ""
+"切換是否顯示生物可移動和攻擊範圍的陰影。"
+
+msgid ""
+"Toggle on or off a shadow showing the current hex location of the mouse "
+"cursor."
+msgstr ""
+"切換是否顯示滑鼠游標目前所在六角格的陰影。"
+
+msgid "Toggle showing the movement area of a highlighted creature on or off."
+msgstr "切換是否顯示選取生物的移動範圍。"
+
+msgid ""
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
+msgstr ""
+"憑藉敏銳的觀察力，%{name} 學會了魔法 %{spell}。"
+
+msgid "Human"
+msgstr "人類"
+
+msgid "Terrain"
+msgstr "地形"
+
+msgid "Battle Only"
+msgstr "僅限戰鬥"
+
+msgid "Start"
+msgstr "開始"
+
+msgid "Start the battle."
+msgstr "開始戰鬥。"
+
+msgid "Exit"
+msgstr "離開"
+
+msgid "Reset"
+msgstr "重置"
+
+msgid "Reset to default settings."
+msgstr "重置為預設設定。"
+
+msgid ""
+"The battle will take place on a randomly selected terrain. Click to change "
+"the terrain type."
+msgstr ""
+"戰鬥將在隨機選取的地形上進行。按一下可變更地形類型。"
+
+msgid ""
+"The battle will take place on %{terrain-type} terrain. Click to change the "
+"terrain type."
+msgstr ""
+"戰鬥將在 %{terrain-type} 地形上進行。按一下可變更地形類型。"
+
+msgid "Please select another hero."
+msgstr "請選擇另一位英雄。"
+
+msgid "Click to select a hero."
+msgstr "按一下選擇一位英雄。"
+
+msgid "Hero"
+msgstr "英雄"
+
+msgid ""
+"If this checkbox is checked, the defending hero is going be human-controlled."
+msgstr ""
+"勾選此選項後，防守方英雄將由人類玩家控制。"
+
+msgid "%{race1} %{name1} vs %{race2} %{name2}"
+msgstr "%{race1} %{name1} 對 %{race2} %{name2}"
+
+msgid "Monsters"
+msgstr "怪物"
+
+msgid "N/A"
+msgstr "不適用"
+
+msgid "Left Turret"
+msgstr "左箭塔"
+
+msgid "Right Turret"
+msgstr "右箭塔"
+
+msgid "The %{name} fires with the strength of %{count} Archers"
+msgstr "%{name} 以 %{count} 名弓箭手的力量進行射擊"
+
+msgid "each with a +%{attack} bonus to their attack skill."
+msgstr "每位均有 +%{attack} 的攻擊技能加成。"
+
+msgid "The %{name} is destroyed."
+msgstr "%{name} 被摧毀了。"
+
+msgid "%{count} %{name} rises from the dead!"
+msgid_plural "%{count} %{name} rise from the dead!"
+msgstr[0] "%{count} 個 %{name} 從死亡中復活了！"
+
+msgid "Dwarven Alliance"
+msgstr "矮人聯盟"
+
+msgid "Sorceress Guild"
+msgstr "女巫公會"
+
+msgid "Necromancer Guild"
+msgstr "亡靈法師公會"
+
+msgid "Ogre Alliance"
+msgstr "食人魔聯盟"
+
+msgid "Dwarfbane"
+msgstr "矮人剋星"
+
+msgid "Dragon Alliance"
+msgstr "巨龍聯盟"
+
+msgid "Elven Alliance"
+msgstr "精靈聯盟"
+
+msgid "Kraeger defeated"
+msgstr "Kraeger 被擊敗"
+
+msgid "Wayward Son"
+msgstr "離家之子"
+
+msgid "Uncle Ivan"
+msgstr "Ivan 叔叔"
+
+msgid "Annexation"
+msgstr "併吞"
+
+msgid "Force of Arms"
+msgstr "武力征服"
+
+msgid "Save the Dwarves"
+msgstr "拯救矮人"
+
+msgid "Carator Mines"
+msgstr "Carator 礦場"
+
+msgid "Turning Point"
+msgstr "轉捩點"
+
+msgid "scenarioName|Defender"
+msgstr "守衛者"
+
+msgid "Corlagon's Defense"
+msgstr "Corlagon 的防線"
+
+msgid "The Crown"
+msgstr "王冠"
+
+msgid "The Gauntlet"
+msgstr "護手"
+
+msgid "Betrayal"
+msgstr "背叛"
+
+msgid "Final Justice"
+msgstr "最終審判"
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother. They are not allied with each other, so they "
+"will spend most of their time fighting with one another. Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+"Roland 需要你擊敗城堡附近的領主，以展開他對抗其兄弟的叛亂戰爭。他們彼此並未結"
+"盟，所以大部分時間會自相殘殺。擊敗所有敵方城堡和英雄即可獲勝。"
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+"當地領主拒絕向 Roland 效忠，必須加以鎮壓。他們富有且強大，請做好艱苦戰鬥的準"
+"備。佔領所有敵方城堡即可獲勝。"
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+"你的任務是保護矮人免受 Archibald 軍隊的侵害。佔領所有敵方城鎮和城堡即可獲勝，"
+"但不可同時失去所有矮人城鎮，否則敵人就贏了。"
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resources "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+"你將面對四個結盟的敵人，在一場直截了當的資源與寶藏爭奪中作戰。佔領所有敵方城"
+"堡即可獲勝。"
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+"敵人結盟對抗你且起始位置很近，請做好戰鬥準備。必須佔領這個小山谷中的所有四座"
+"城堡才能獲勝。"
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+"Noraston 的女巫公會請求 Roland 援助，對抗 Archibald 盟友的進攻。佔領所有敵方"
+"城堡即可獲勝，不可失去 Noraston，否則場景失敗。（提示：海洋中的島嶼上有一座敵"
+"方城堡。）"
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+"盡可能集結大軍，在 8 週內佔領敵方城堡。你只面對一個敵人，但必須長途跋涉才能到"
+"達敵方城堡。此場景結束時軍隊中的所有部隊將伴隨你進入最終決戰。"
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+"在 Archibald 的英雄之前找到王冠。Roland 需要王冠來進行對 Archibald 的最終決"
+"戰。"
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+"三個結盟的敵人擋在你與勝利之間，其中包括 Lord Corlagon。Roland 位於西北方的城"
+"堡；如果他落入敵手，你就輸了。記住，俘獲 Lord Corlagon 可確保他不會在最終場景"
+"中與你為敵。"
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+"這是最終決戰。你和敵人都武裝到牙齒，所有人都結盟對抗你。俘獲 Archibald 即可結"
+"束戰爭！"
+
+msgid ""
+"Switching sides leaves you with three castles against the enemy's one. This "
+"battle will be the easiest one you will face for the rest of the war..."
+"traitor."
+msgstr ""
+"叛變後你擁有三座城堡對抗敵方的一座。這將是這場戰爭中你面對最簡單的戰鬥……叛"
+"徒。"
+
+msgid "Barbarian Wars"
+msgstr "野蠻人之戰"
+
+msgid "First Blood"
+msgstr "初戰"
+
+msgid "Necromancers"
+msgstr "亡靈法師們"
+
+msgid "Slay the Dwarves"
+msgstr "屠殺矮人"
+
+msgid "Country Lords"
+msgstr "鄉間領主"
+
+msgid "Dragon Master"
+msgstr "龍族大師"
+
+msgid "Rebellion"
+msgstr "叛亂"
+
+msgid "Apocalypse"
+msgstr "天啟"
+
+msgid "Greater Glory"
+msgstr "更大的榮耀"
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region. They "
+"are not allied with one another, so they will spend most of their energy "
+"fighting amongst themselves. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+"Archibald 國王要求你擊敗此地區的三個敵人。他們彼此並未結盟，所以大部分精力會"
+"花在自相殘殺上。當你佔領所有敵方城堡且不再有敵方英雄時即獲勝。"
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+"你必須征服並統一北方的野蠻人部族。如同前一個任務，敵人並未結盟對抗你，但他們"
+"擁有更多資源。當你佔領所有敵方城堡且不再有敵方英雄時即獲勝。"
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+"自以為正義的巫師奪取了亡靈法師的城堡。你必須奪回它才能獲勝。記住，雖然你開局"
+"擁有強大的軍隊，但沒有城堡，必須在 7 天內攻佔一座，否則戰敗。（提示：最近的城"
+"堡在東南方。）"
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+"在矮人干涉 Archibald 國王的計畫之前必須先征服他們。Roland 的軍隊有多位英雄和"
+"許多城鎮，請做好多方向進攻的準備。必須佔領所有敵方城鎮和城堡才能獲勝。"
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+"你必須鎮壓由 Roland 軍隊領導的農民起義。所有人都結盟對抗你，但你有經驗豐富的"
+"英雄 Lord Corlagon 助陣。佔領所有敵方城堡即可獲勝。"
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win."
+msgstr ""
+"此任務中有兩個結盟的敵人對抗你。他們都裝備精良，想將你逐出島嶼。避開他們並佔"
+"領龍族之城即可獲勝。"
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+"你的命令是征服宣誓效忠 Roland 的鄉間領主。所有敵方城堡都團結對抗你。由於你開"
+"局沒有城堡，必須趕在本週結束前攻佔一座。佔領所有敵方城堡即可獲勝。"
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+"在 Roland 的英雄之前找到王冠。Archibald 需要王冠來進行對 Roland 的最終決戰。"
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+"這是最終決戰。你和敵人都武裝到牙齒，所有人都結盟對抗你。俘獲 Roland 即可贏得"
+"戰爭，但不可在戰鬥中失去 Archibald！"
+
+msgid "Arrow's Flight"
+msgstr "箭矢之途"
+
+msgid "Island of Chaos"
+msgstr "混沌之島"
+
+msgid "The Abyss"
+msgstr "深淵"
+
+msgid "Uprising"
+msgstr "起義"
+
+msgid "Aurora Borealis"
+msgstr "極光"
+
+msgid "Betrayal's End"
+msgstr "背叛的終結"
+
+msgid "Corruption's Heart"
+msgstr "腐敗之心"
+
+msgid "The Giant's Pass"
+msgstr "巨人之關"
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+"鎮壓不服從的當地領主，為帝國在此地區的運作提供設施。"
+
+msgid ""
+"Eliminate all opposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+"消滅此區域的所有反對勢力，接著你就能取得神器的第一塊碎片。"
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+"東北方的女巫們正在叛亂！為了帝國的利益，你必須在前往山區的途中鎮壓她們微弱的"
+"起義。"
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+"Kraeger 已為你的到來做好準備，安排了一支亡靈法師部隊阻撓你的任務。你必須在第"
+"三週的第一天之前攻佔 Scabsdale 城堡，否則亡靈法師將強大到無法對抗。"
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+"此地區的野蠻人暴君尚未察覺你的存在。趕緊在被發現和遭受攻擊之前增強實力！鎮壓"
+"所有敵方勢力以確保此地區的安全。"
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+"帝國在此地區很薄弱。你無法完全鎮壓此地所有勢力，所以在報復來臨之前盡可能掠"
+"奪。記住，你的真正目標是奪取 Anduran 頭盔。"
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr "為了帝國的利益，消滅 Kraeger。"
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+"終於，你有了機會和設施來為帝國剷除亡靈法師的邪惡。徹底消滅他們，你將被世代傳"
+"頌為英雄。"
+
+msgid "Border Towns"
+msgstr "邊境城鎮"
+
+msgid "Conquer and Unify"
+msgstr "征服與統一"
+
+msgid "Crazy Uncle Ivan"
+msgstr "瘋狂的 Ivan 叔叔"
+
+msgid "The Wayward Son"
+msgstr "離家之子"
+
+msgid "Ivory Gates"
+msgstr "象牙之門"
+
+msgid "The Elven Lands"
+msgstr "精靈之地"
+
+msgid "The Epic Battle"
+msgstr "史詩之戰"
+
+msgid "The Southern War"
+msgstr "南方戰爭"
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+"征服並統一所有敵對部族。不可失去英雄 Jarkonas，他是所有後裔的始祖。"
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+"你的宿敵 Harondale 王國正在進攻邊境上的薄弱城鎮！從他們的首波攻擊中恢復，並徹"
+"底擊潰他們！"
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+"找到你離家出走的兒子 Joseph，傳聞他住在荒涼之地。在第三個月的第一天之前完成此"
+"事，否則對你的家族毫無幫助。"
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be of no help to your kingdom."
+msgstr ""
+"拯救你瘋狂的 Ivan 叔叔。在第四個月的第一天之前找到他，否則對王國毫無幫助。"
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+"摧毀正在進攻王國南部邊境的野蠻人！收復失去的城鎮，然後入侵叢林王國。不留任何"
+"敵人。"
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr "奪回因叛變而淪陷的象牙之門城堡。"
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so we will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+"贏得精靈的好感。他們不允許砍伐樹木，所以我們每兩週會送你木材。你必須在第七個"
+"月的第一天之前完成任務，否則王國必將淪陷。"
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+"這是對宿敵 Harondale 王國的最終決戰。消滅所有敵人，不可失去英雄 Jarkonas VI。"
+
+msgid "Fount of Wizardry"
+msgstr "巫術之泉"
+
+msgid "Power's End"
+msgstr "力量的終結"
+
+msgid "The Eternal Scrolls"
+msgstr "永恆卷軸"
+
+msgid "The Shrouded Isles"
+msgstr "迷霧群島"
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+"你的任務是消滅迷霧群島上交戰中的法師。完成此任務將使你有機會對抗勁敵。"
+
+msgid ""
+"The location of the great library has been discovered! You must make your "
+"way to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+"大圖書館的位置已被發現！你必須前往該處，奪回它所在的 Chronos 城。"
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your prize. "
+"Find the Orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+"找到傳說中埋藏在此地的否定之球。石碑上刻有線索，能引導你找到寶物。在第六個月"
+"的第一天之前找到它，否則你的對手肯定會搶先到達泉源。"
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+"你必須奪取魔法城堡——巫術之泉所在之地。完成此任務，你的勝利將是至高無上的。"
+
+msgid "Blood is Thicker"
+msgstr "血濃於水"
+
+msgid "King and Country"
+msgstr "國王與國家"
+
+msgid "Pirate Isles"
+msgstr "海盜群島"
+
+msgid "Stranded"
+msgstr "擱淺"
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+"佔領東南海岸外島嶼上的城鎮，以建造船隻返回大陸。不可失去英雄 Gallavant。"
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+"找到並擊敗海盜首領 Martine，他藏身在海盜灣。不可失去 Gallavant，否則任務就結"
+"束了。"
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+"消滅所有反對 Alberon 領主統治的勢力。Gallavant 不可戰死。"
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+"推翻 Alberon 領主根深柢固的統治，以你的名義佔領所有土地。Gallavant 不可戰死。"
+
+msgid " bane"
+msgstr "剋星"
+
+msgid " alliance"
+msgstr "聯盟"
+
+msgid "Carry-over forces"
+msgstr "延續兵力"
+
+msgid " bonus"
+msgstr "加成"
+
+msgid " defeated"
+msgstr "被擊敗"
+
+msgid " will always run away from your army."
+msgstr "會永遠逃離你的軍隊。"
+
+msgid " will be willing to join your army."
+msgstr "會願意加入你的軍隊。"
+
+msgid "\"%{artifact}\" artifact will be carried over in the campaign."
+msgstr "神器「%{artifact}」將延續至戰役中。"
+
+msgid "The army will be carried over in the campaign."
+msgstr "軍隊將延續至戰役中。"
+
+msgid "The kingdom will have +%{count} %{resource} each day."
+msgstr "王國每日將額外獲得 +%{count} %{resource}。"
+
+msgid "The \"%{spell}\" spell will be carried over in the campaign."
+msgstr "「%{spell}」法術將延續至戰役中。"
+
+msgid "%{hero} can be hired during scenarios."
+msgstr "%{hero} 可在場景中招募。"
+
+msgid "%{hero} has been defeated and will not appear in subsequent scenarios."
+msgstr "%{hero} 已被擊敗，不會出現在後續場景中。"
+
+msgid "The dwarves recognize their allies and gladly join your forces."
+msgstr "矮人認出了盟友，欣然加入你的隊伍。"
+
+msgid "The ogres recognize you as the Dwarfbane and lumber over to join you."
+msgstr "食人魔認出你是矮人剋星，笨重地走來加入你。"
+
+msgid ""
+"The dragons, snarling and growling, agree to join forces with you, their "
+"'Ally'."
+msgstr ""
+"巨龍們咆哮嘶吼著，同意與牠們的「盟友」你併肩作戰。"
+
+msgid ""
+"As you approach the group of elves, their leader calls them all to "
+"attention. He shouts to them, \"Who of you is brave enough to join this "
+"fearless ally of ours?\" The group explodes with cheers as they run to join "
+"your ranks."
+msgstr ""
+"當你接近精靈群時，他們的首領召集所有人注意。他對他們喊道：「你們誰夠勇敢，願"
+"意加入我們這位無畏的盟友？」人群爆發出歡呼聲，紛紛跑來加入你的隊伍。"
+
+msgid ""
+"The dwarves hail you, \"Any friend of Roland is a friend of ours. You may "
+"pass.\""
+msgstr ""
+"矮人向你致意：「凡是 Roland 的朋友，都是我們的朋友。請通行吧。」"
+
+msgid ""
+"The ogres give you a grunt of recognition, \"Archibald's allies may pass.\""
+msgstr ""
+"食人魔發出認可的咕噥聲：「Archibald 的盟友可以通行。」"
+
+msgid ""
+"The dragons see you and call out. \"Our alliance with Archibald compels us "
+"to join you. Unfortunately you have no room. A pity!\" They quickly scatter."
+msgstr ""
+"巨龍們看到你並呼喊：「我們與 Archibald 的聯盟迫使我們加入你，但很遺憾你沒有空"
+"位，太可惜了！」牠們很快四散離去。"
+
+msgid ""
+"The elves stand at attention as you approach. Their leader calls to you and "
+"says, \"Let us not impede your progress, ally! Move on, and may victory be "
+"yours.\""
+msgstr ""
+"精靈們在你接近時立正站好。他們的首領對你喊道：「讓我們不要阻礙盟友的進展！請"
+"繼續前進，願勝利屬於你。」"
+
+msgid "\"The Dwarfbane!!!!, run for your lives.\""
+msgstr "「矮人剋星！！！！快逃命吧。」"
+
+msgid "campaignBonus|Animate Dead"
+msgstr "操控亡靈"
+
+msgid "campaignBonus|Chain Lightning"
+msgstr "連鎖閃電"
+
+msgid "campaignBonus|Fireblast"
+msgstr "烈焰爆裂"
+
+msgid "campaignBonus|Mass Curse"
+msgstr "群體詛咒"
+
+msgid "campaignBonus|Mass Haste"
+msgstr "群體加速"
+
+msgid "campaignBonus|Mirror Image"
+msgstr "鏡像術"
+
+msgid "campaignBonus|Resurrect"
+msgstr "復活術"
+
+msgid "campaignBonus|Steelskin"
+msgstr "鋼膚術"
+
+msgid "campaignBonus|Summon Earth"
+msgstr "召喚土元素"
+
+msgid "campaignBonus|View Heroes"
+msgstr "探查英雄"
+
+msgid "campaignBonus|Ballista"
+msgstr "弩砲"
+
+msgid "campaignBonus|Black Pearl"
+msgstr "Black Pearl"
+
+msgid "campaignBonus|Caster's Bracelet"
+msgstr "Caster's Bracelet of Magic"
+
+msgid "campaignBonus|Defender Helm"
+msgstr "Defender Helm of Protection"
+
+msgid "campaignBonus|Breastplate"
+msgstr "Breastplate of Anduran"
+
+msgid "campaignBonus|Dragon Sword"
+msgstr "Dragon Sword of Dominion"
+
+msgid "campaignBonus|Fizbin Medal"
+msgstr "Fizbin of Misfortune"
+
+msgid "campaignBonus|Foremost Scroll"
+msgstr "Foremost Scroll of Knowledge"
+
+msgid "campaignBonus|Gauntlets"
+msgstr "Armored Gauntlets of Protection"
+
+msgid "campaignBonus|Hideous Mask"
+msgstr "Hideous Mask"
+
+msgid "campaignBonus|Mage's Ring"
+msgstr "Mage's Ring of Power"
+
+msgid "campaignBonus|Major Scroll"
+msgstr "Major Scroll of Knowledge"
+
+msgid "campaignBonus|Medal of Honor"
+msgstr "Medal of Honor"
+
+msgid "campaignBonus|Medal of Valor"
+msgstr "Medal of Valor"
+
+msgid "campaignBonus|Minor Scroll"
+msgstr "Minor Scroll of Knowledge"
+
+msgid "campaignBonus|Nomad Boots"
+msgstr "Nomad Boots of Mobility"
+
+msgid "campaignBonus|Power Axe"
+msgstr "Power Axe of Dominion"
+
+msgid "campaignBonus|Spiked Shield"
+msgstr "Spiked Shield"
+
+msgid "campaignBonus|Stealth Shield"
+msgstr "Stealth Shield of Protection"
+
+msgid "campaignBonus|Tax Lien"
+msgstr "Tax Lien"
+
+msgid "campaignBonus|Thunder Mace"
+msgstr "Thunder Mace of Dominion"
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr "Traveler's Boots of Mobility"
+
+msgid "campaignBonus|White Pearl"
+msgstr "White Pearl"
+
+msgid "campaignBonus|Basic Archery"
+msgstr "基礎箭術"
+
+msgid "campaignBonus|Advanced Archery"
+msgstr "進階箭術"
+
+msgid "campaignBonus|Expert Archery"
+msgstr "專家箭術"
+
+msgid "campaignBonus|Basic Ballistics"
+msgstr "基礎彈道術"
+
+msgid "campaignBonus|Advanced Ballistics"
+msgstr "進階彈道術"
+
+msgid "campaignBonus|Expert Ballistics"
+msgstr "專家彈道術"
+
+msgid "campaignBonus|Basic Diplomacy"
+msgstr "基礎外交術"
+
+msgid "campaignBonus|Advanced Diplomacy"
+msgstr "進階外交術"
+
+msgid "campaignBonus|Expert Diplomacy"
+msgstr "專家外交術"
+
+msgid "campaignBonus|Basic Eagle Eye"
+msgstr "基礎鷹眼術"
+
+msgid "campaignBonus|Advanced Eagle Eye"
+msgstr "進階鷹眼術"
+
+msgid "campaignBonus|Expert Eagle Eye"
+msgstr "專家鷹眼術"
+
+msgid "campaignBonus|Basic Estates"
+msgstr "基礎產業術"
+
+msgid "campaignBonus|Advanced Estates"
+msgstr "進階產業術"
+
+msgid "campaignBonus|Expert Estates"
+msgstr "專家產業術"
+
+msgid "campaignBonus|Basic Leadership"
+msgstr "基礎領導術"
+
+msgid "campaignBonus|Advanced Leadership"
+msgstr "進階領導術"
+
+msgid "campaignBonus|Expert Leadership"
+msgstr "專家領導術"
+
+msgid "campaignBonus|Basic Logistics"
+msgstr "基礎後勤術"
+
+msgid "campaignBonus|Advanced Logistics"
+msgstr "進階後勤術"
+
+msgid "campaignBonus|Expert Logistics"
+msgstr "專家後勤術"
+
+msgid "campaignBonus|Basic Luck"
+msgstr "基礎運氣"
+
+msgid "campaignBonus|Advanced Luck"
+msgstr "進階運氣"
+
+msgid "campaignBonus|Expert Luck"
+msgstr "專家運氣"
+
+msgid "campaignBonus|Basic Mysticism"
+msgstr "基礎神祕術"
+
+msgid "campaignBonus|Advanced Mysticism"
+msgstr "進階神祕術"
+
+msgid "campaignBonus|Expert Mysticism"
+msgstr "專家神祕術"
+
+msgid "campaignBonus|Basic Navigation"
+msgstr "基礎航海術"
+
+msgid "campaignBonus|Advanced Navigation"
+msgstr "進階航海術"
+
+msgid "campaignBonus|Expert Navigation"
+msgstr "專家航海術"
+
+msgid "campaignBonus|Basic Necromancy"
+msgstr "基礎亡靈巫術"
+
+msgid "campaignBonus|Advanced Necromancy"
+msgstr "進階亡靈巫術"
+
+msgid "campaignBonus|Expert Necromancy"
+msgstr "專家亡靈巫術"
+
+msgid "campaignBonus|Basic Pathfinding"
+msgstr "基礎尋路術"
+
+msgid "campaignBonus|Advanced Pathfinding"
+msgstr "進階尋路術"
+
+msgid "campaignBonus|Expert Pathfinding"
+msgstr "專家尋路術"
+
+msgid "campaignBonus|Basic Scouting"
+msgstr "基礎偵察術"
+
+msgid "campaignBonus|Advanced Scouting"
+msgstr "進階偵察術"
+
+msgid "campaignBonus|Expert Scouting"
+msgstr "專家偵察術"
+
+msgid "campaignBonus|Basic Wisdom"
+msgstr "基礎智慧"
+
+msgid "campaignBonus|Advanced Wisdom"
+msgstr "進階智慧"
+
+msgid "campaignBonus|Expert Wisdom"
+msgstr "專家智慧"
+
+msgid ""
+"The main hero will have the \"%{artifact}\" artifact at the start of the "
+"scenario."
+msgstr ""
+"主英雄在場景開始時將擁有「%{artifact}」神器。"
+
+msgid ""
+"The kingdom will receive %{amount} additional %{resource} at the start of "
+"the scenario."
+msgstr ""
+"王國在場景開始時將額外獲得 %{amount} %{resource}。"
+
+msgid ""
+"The kingdom will have %{amount} less %{resource} at the start of the "
+"scenario."
+msgstr ""
+"王國在場景開始時將減少 %{amount} %{resource}。"
+
+msgid ""
+"The main hero will have %{count} %{monster} at the start of the scenario."
+msgstr ""
+"主英雄在場景開始時將擁有 %{count} 個 %{monster}。"
+
+msgid ""
+"The main hero will have the \"%{spell}\" spell at the start of the scenario."
+msgstr ""
+"主英雄在場景開始時將擁有「%{spell}」法術。"
+
+msgid "The starting alignment of the scenario will be %{race}."
+msgstr "此場景的起始陣營將是 %{race}。"
+
+msgid ""
+"The main hero will receive a +%{count} to their %{skill} at the start of the "
+"scenario."
+msgstr ""
+"主英雄在場景開始時其 %{skill} 將獲得 +%{count} 加成。"
+
+msgid "The main hero will have %{skill} at the start of the scenario."
+msgstr "主英雄在場景開始時將擁有 %{skill}。"
+
+msgid "Roland"
+msgstr "Roland"
+
+msgid "Archibald"
+msgstr "Archibald"
+
+msgid "Price of Loyalty"
+msgstr "忠誠的代價"
+
+msgid "Voyage Home"
+msgstr "歸鄉之旅"
+
+msgid "Wizard's Isle"
+msgstr "巫師之島"
+
+msgid "Descendants"
+msgstr "後裔"
+
+msgid "Cannot build. You have already built here today."
+msgstr "無法建造，今日已經建造過了。"
+
+msgid "For this action it is necessary to build a castle first."
+msgstr "此操作需要先建造城堡。"
+
+msgid "The %{building} produces %{monster}."
+msgstr "%{building} 生產 %{monster}。"
+
+msgid "Requires:"
+msgstr "需求："
+
+msgid "Exit this menu without doing anything."
+msgstr "離開此選單，不進行任何操作。"
+
+msgid "Cannot build %{name}. The castle is too far away from an ocean."
+msgstr "無法建造 %{name}，城堡離海洋太遠。"
+
+msgid "This building has been disabled."
+msgstr "此建築已被停用。"
+
+msgid "Cannot afford the %{name}."
+msgstr "無法負擔 %{name} 的費用。"
+
+msgid "The %{name} is already built."
+msgstr "%{name} 已經建造完成。"
+
+msgid "Cannot build the %{name}."
+msgstr "無法建造 %{name}。"
+
+msgid "Build %{name}."
+msgstr "建造 %{name}。"
+
+msgid "Blackridge"
+msgstr "Blackridge"
+
+msgid "Hillstone"
+msgstr "Hillstone"
+
+msgid "Pinehurst"
+msgstr "Pinehurst"
+
+msgid "Whiteshield"
+msgstr "Whiteshield"
+
+msgid "Woodhaven"
+msgstr "Woodhaven"
+
+msgid "Blackwind"
+msgstr "Blackwind"
+
+msgid "Bloodreign"
+msgstr "Bloodreign"
+
+msgid "Dragontooth"
+msgstr "Dragontooth"
+
+msgid "Greywind"
+msgstr "Greywind"
+
+msgid "Portsmith"
+msgstr "Portsmith"
+
+msgid "Atlantium"
+msgstr "Atlantium"
+
+msgid "Middle Gate"
+msgstr "Middle Gate"
+
+msgid "Sansobar"
+msgstr "Sansobar"
+
+msgid "Tundara"
+msgstr "Tundara"
+
+msgid "Vulcania"
+msgstr "Vulcania"
+
+msgid "Baywatch"
+msgstr "Baywatch"
+
+msgid "Fountainhead"
+msgstr "Fountainhead"
+
+msgid "Vertigo"
+msgstr "Vertigo"
+
+msgid "Wildabar"
+msgstr "Wildabar"
+
+msgid "Winterkill"
+msgstr "Winterkill"
+
+msgid "Brindamoor"
+msgstr "Brindamoor"
+
+msgid "Lakeside"
+msgstr "Lakeside"
+
+msgid "Nightshadow"
+msgstr "Nightshadow"
+
+msgid "Olympus"
+msgstr "Olympus"
+
+msgid "Sandcaster"
+msgstr "Sandcaster"
+
+msgid "Alamar"
+msgstr "Alamar"
+
+msgid "Burlock"
+msgstr "Burlock"
+
+msgid "Dragadune"
+msgstr "Dragadune"
+
+msgid "Kalindra"
+msgstr "Kalindra"
+
+msgid "Xabran"
+msgstr "Xabran"
+
+msgid "Algary"
+msgstr "Algary"
+
+msgid "Basenji"
+msgstr "Basenji"
+
+msgid "Blackfang"
+msgstr "Blackfang"
+
+msgid "New Dawn"
+msgstr "New Dawn"
+
+msgid "Sorpigal"
+msgstr "Sorpigal"
+
+msgid "Avone"
+msgstr "Avone"
+
+msgid "Big Oak"
+msgstr "Big Oak"
+
+msgid "Chandler"
+msgstr "Chandler"
+
+msgid "Erliquin"
+msgstr "Erliquin"
+
+msgid "Hampshire"
+msgstr "Hampshire"
+
+msgid "Antioch"
+msgstr "Antioch"
+
+msgid "Avalon"
+msgstr "Avalon"
+
+msgid "Roc Haven"
+msgstr "Roc Haven"
+
+msgid "South Mill"
+msgstr "South Mill"
+
+msgid "Weed Patch"
+msgstr "Weed Patch"
+
+msgid "Brownston"
+msgstr "Brownston"
+
+msgid "Hilltop"
+msgstr "Hilltop"
+
+msgid "Weddington"
+msgstr "Weddington"
+
+msgid "Westfork"
+msgstr "Westfork"
+
+msgid "Whittingham"
+msgstr "Whittingham"
+
+msgid "Cathcart"
+msgstr "Cathcart"
+
+msgid "Elk's Head"
+msgstr "Elk's Head"
+
+msgid "Roscomon"
+msgstr "Roscomon"
+
+msgid "Sherman"
+msgstr "Sherman"
+
+msgid "Yorksford"
+msgstr "Yorksford"
+
+msgid "Blackburn"
+msgstr "Blackburn"
+
+msgid "Blacksford"
+msgstr "Blacksford"
+
+msgid "Burton"
+msgstr "Burton"
+
+msgid "Pig's Eye"
+msgstr "Pig's Eye"
+
+msgid "Viper's Nest"
+msgstr "Viper's Nest"
+
+msgid "Fenton"
+msgstr "Fenton"
+
+msgid "Lankershire"
+msgstr "Lankershire"
+
+msgid "Lombard"
+msgstr "Lombard"
+
+msgid "Timberhill"
+msgstr "Timberhill"
+
+msgid "Troy"
+msgstr "Troy"
+
+msgid "Forder Oaks"
+msgstr "Forder Oaks"
+
+msgid "Meramec"
+msgstr "Meramec"
+
+msgid "Quick Silver"
+msgstr "Quick Silver"
+
+msgid "Westmoor"
+msgstr "Westmoor"
+
+msgid "Willow"
+msgstr "Willow"
+
+msgid "Corackston"
+msgstr "Corackston"
+
+msgid "Sheltemburg"
+msgstr "Sheltemburg"
+
+msgid "Cannot recruit - you already have a Hero in this town."
+msgstr "無法招募——此城鎮中已有英雄。"
+
+msgid "Cannot recruit - you have too many Heroes."
+msgstr "無法招募——英雄數量已達上限。"
+
+msgid "Cannot afford a Hero."
+msgstr "無法負擔英雄的招募費用。"
+
+msgid "There is no room in the garrison for this army."
+msgstr "城防部隊中沒有空間容納此軍隊。"
+
+msgid "Fortifications"
+msgstr "防禦工事"
+
+msgid "Farm"
+msgstr "農場"
+
+msgid "Thatched Hut"
+msgstr "茅草屋"
+
+msgid "Archery Range"
+msgstr "射箭場"
+
+msgid "Upg. Archery Range"
+msgstr "進階射箭場"
+
+msgid "Blacksmith"
+msgstr "鐵匠鋪"
+
+msgid "Upg. Blacksmith"
+msgstr "進階鐵匠鋪"
+
+msgid "Armory"
+msgstr "兵器庫"
+
+msgid "Upg. Armory"
+msgstr "進階兵器庫"
+
+msgid "Jousting Arena"
+msgstr "馬上比武場"
+
+msgid "Upg. Jousting Arena"
+msgstr "進階馬上比武場"
+
+msgid "Cathedral"
+msgstr "大教堂"
+
+msgid "Upg. Cathedral"
+msgstr "進階大教堂"
+
+msgid "Coliseum"
+msgstr "競技場"
+
+msgid "Garbage Heap"
+msgstr "垃圾堆"
+
+msgid "Hut"
+msgstr "小屋"
+
+msgid "Stick Hut"
+msgstr "木棍屋"
+
+msgid "Upg. Stick Hut"
+msgstr "進階木棍屋"
+
+msgid "Den"
+msgstr "獸穴"
+
+msgid "Adobe"
+msgstr "土坯屋"
+
+msgid "Upg. Adobe"
+msgstr "進階土坯屋"
+
+msgid "Bridge"
+msgstr "橋樑"
+
+msgid "Upg. Bridge"
+msgstr "進階橋樑"
+
+msgid "Pyramid"
+msgstr "金字塔"
+
+msgid "Rainbow"
+msgstr "彩虹"
+
+msgid "Crystal Garden"
+msgstr "水晶花園"
+
+msgid "Treehouse"
+msgstr "樹屋"
+
+msgid "Cottage"
+msgstr "小木屋"
+
+msgid "Upg. Cottage"
+msgstr "進階小木屋"
+
+msgid "Stonehenge"
+msgstr "巨石陣"
+
+msgid "Upg. Stonehenge"
+msgstr "進階巨石陣"
+
+msgid "Fenced Meadow"
+msgstr "圍籬草地"
+
+msgid "sorceress|Red Tower"
+msgstr "紅塔"
+
+msgid "Dungeon"
+msgstr "地牢"
+
+msgid "Waterfall"
+msgstr "瀑布"
+
+msgid "Cave"
+msgstr "洞穴"
+
+msgid "Crypt"
+msgstr "墓穴"
+
+msgid "Nest"
+msgstr "巢穴"
+
+msgid "Maze"
+msgstr "迷宮"
+
+msgid "Upg. Maze"
+msgstr "進階迷宮"
+
+msgid "Swamp"
+msgstr "沼澤"
+
+msgid "Green Tower"
+msgstr "綠塔"
+
+msgid "warlock|Red Tower"
+msgstr "紅塔"
+
+msgid "Black Tower"
+msgstr "黑塔"
+
+msgid "Library"
+msgstr "圖書館"
+
+msgid "Orchard"
+msgstr "果園"
+
+msgid "Habitat"
+msgstr "棲息地"
+
+msgid "Pen"
+msgstr "圍欄"
+
+msgid "Foundry"
+msgstr "鑄造廠"
+
+msgid "Upg. Foundry"
+msgstr "進階鑄造廠"
+
+msgid "Cliff Nest"
+msgstr "懸崖巢穴"
+
+msgid "Ivory Tower"
+msgstr "象牙塔"
+
+msgid "Upg. Ivory Tower"
+msgstr "進階象牙塔"
+
+msgid "Cloud Castle"
+msgstr "雲端城堡"
+
+msgid "Upg. Cloud Castle"
+msgstr "進階雲端城堡"
+
+msgid "Storm"
+msgstr "風暴"
+
+msgid "Skull Pile"
+msgstr "骷髏堆"
+
+msgid "Excavation"
+msgstr "發掘地"
+
+msgid "Graveyard"
+msgstr "墓地"
+
+msgid "Upg. Graveyard"
+msgstr "進階墓地"
+
+msgid "Upg. Pyramid"
+msgstr "進階金字塔"
+
+msgid "Mansion"
+msgstr "宅邸"
+
+msgid "Upg. Mansion"
+msgstr "進階宅邸"
+
+msgid "Mausoleum"
+msgstr "陵寢"
+
+msgid "Upg. Mausoleum"
+msgstr "進階陵寢"
+
+msgid "Laboratory"
+msgstr "實驗室"
+
+msgid "Shrine"
+msgstr "神殿"
+
+msgid "Special"
+msgstr "特殊"
+
+msgid "Horde Building"
+msgstr "增產建築"
+
+msgid "Dwelling 1"
+msgstr "住所 1"
+
+msgid "Dwelling 2"
+msgstr "住所 2"
+
+msgid "Upg. Dwelling 2"
+msgstr "進階住所 2"
+
+msgid "Dwelling 3"
+msgstr "住所 3"
+
+msgid "Upg. Dwelling 3"
+msgstr "進階住所 3"
+
+msgid "Dwelling 4"
+msgstr "住所 4"
+
+msgid "Upg. Dwelling 4"
+msgstr "進階住所 4"
+
+msgid "Dwelling 5"
+msgstr "住所 5"
+
+msgid "Upg. Dwelling 5"
+msgstr "進階住所 5"
+
+msgid "Dwelling 6"
+msgstr "住所 6"
+
+msgid "Upg. Dwelling 6"
+msgstr "進階住所 6"
+
+msgid "2x Upg. Dwelling 6"
+msgstr "二階住所 6"
+
+msgid ""
+"The Fortifications increase the toughness of the walls, increasing the "
+"number of turns it takes to knock them down."
+msgstr ""
+"防禦工事增強城牆的堅固程度，增加擊倒城牆所需的回合數。"
+
+msgid "The Farm increases production of Peasants by %{count} per week."
+msgstr "農場每週增加 %{count} 個農民的產量。"
+
+msgid ""
+"The Coliseum provides inspiring spectacles to defending troops, raising "
+"their morale by two during combat."
+msgstr ""
+"競技場為守軍提供鼓舞人心的表演，在戰鬥中將士氣提升 2 點。"
+
+msgid "The Garbage Heap increases production of Goblins by %{count} per week."
+msgstr "垃圾堆每週增加 %{count} 個哥布林的產量。"
+
+msgid "The Rainbow increases the luck of the defending units by two."
+msgstr "彩虹將守軍的運氣提升 2 點。"
+
+msgid ""
+"The Crystal Garden increases production of Sprites by %{count} per week."
+msgstr ""
+"水晶花園每週增加 %{count} 個精靈的產量。"
+
+msgid "The Dungeon increases the income of the town by %{count} gold per day."
+msgstr "地牢每日增加城鎮 %{count} 金幣的收入。"
+
+msgid "The Waterfall increases production of Centaurs by %{count} per week."
+msgstr "瀑布每週增加 %{count} 個半人馬的產量。"
+
+msgid ""
+"The Library increases the number of spells in the Guild by one for each "
+"level of the guild."
+msgstr ""
+"圖書館讓公會每個等級多增加一個法術。"
+
+msgid "The Orchard increases production of Halflings by %{count} per week."
+msgstr "果園每週增加 %{count} 個半身人的產量。"
+
+msgid "The Storm adds +2 to the power of spells of a defending spell caster."
+msgstr "風暴為防守方施法者的法術力量增加 +2。"
+
+msgid "The Skull Pile increases production of Skeletons by %{count} per week."
+msgstr "骷髏堆每週增加 %{count} 個骷髏兵的產量。"
+
+msgid "The Special building gives a specific bonus to the chosen castle type."
+msgstr "特殊建築為所選城堡類型提供特定加成。"
+
+msgid ""
+"The Horde Building increases the growth rate of the level 1 creatures by 8 "
+"per week."
+msgstr ""
+"增產建築每週增加 8 個一階生物的產量。"
+
+msgid "Thieves' Guild"
+msgstr "盜賊公會"
+
+msgid "Tavern"
+msgstr "酒館"
+
+msgid "Shipyard"
+msgstr "造船廠"
+
+msgid "Well"
+msgstr "水井"
+
+msgid "Statue"
+msgstr "雕像"
+
+msgid "Marketplace"
+msgstr "市場"
+
+msgid "Moat"
+msgstr "護城河"
+
+msgid "Castle"
+msgstr "城堡"
+
+msgid "Tent"
+msgstr "帳篷"
+
+msgid "Captain's Quarters"
+msgstr "隊長營房"
+
+msgid "Mage Guild, Level 1"
+msgstr "法師公會，等級 1"
+
+msgid "Mage Guild, Level 2"
+msgstr "法師公會，等級 2"
+
+msgid "Mage Guild, Level 3"
+msgstr "法師公會，等級 3"
+
+msgid "Mage Guild, Level 4"
+msgstr "法師公會，等級 4"
+
+msgid "Mage Guild, Level 5"
+msgstr "法師公會，等級 5"
+
+msgid ""
+"The Shrine increases the necromancy skill of all your necromancers by 10 "
+"percent."
+msgstr ""
+"神殿使所有亡靈法師的亡靈巫術技能提升 10%。"
+
+msgid ""
+"The Thieves' Guild provides information on enemy players. Thieves' Guilds "
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
+msgstr ""
+"盜賊公會提供敵方玩家的情報。盜賊公會也能提供敵方城鎮的偵察資訊。擁有越多公會"
+"可獲得越多情報。"
+
+msgid "The Tavern increases morale for troops defending the castle."
+msgstr "酒館提升防守城堡部隊的士氣。"
+
+msgid "The Shipyard allows ships to be built."
+msgstr "造船廠可建造船隻。"
+
+msgid ""
+"The Well increases the growth rate of all dwellings by %{count} creatures "
+"per week."
+msgstr ""
+"水井每週增加所有住所 %{count} 個生物的產量。"
+
+msgid "The Statue increases the town's income by %{count} gold per day."
+msgstr "雕像每日增加城鎮 %{count} 金幣的收入。"
+
+msgid "The Left Turret provides extra firepower during castle combat."
+msgstr "左箭塔在城堡戰鬥中提供額外火力。"
+
+msgid "The Right Turret provides extra firepower during castle combat."
+msgstr "右箭塔在城堡戰鬥中提供額外火力。"
+
+msgid ""
+"The Marketplace can be used to convert one type of resource into another. "
+"The more marketplaces you control, the better the exchange rate."
+msgstr ""
+"市場可用來轉換資源類型。控制的市場越多，兌換比率越好。"
+
+msgid ""
+"The Moat slows and weakens attacking units. Any walking unit entering the "
+"moat must end its turn there and can only move within the moat one hex at a "
+"time. Any creature present in the moat will have its defense skill reduced "
+"by %{count}."
+msgstr ""
+"護城河會減緩和削弱進攻的部隊。任何步行單位進入護城河後必須在該處結束回合，且"
+"每次只能在河中移動一格。停留在護城河中的所有生物防禦技能將降低 %{count}。"
+
+msgid ""
+"The Castle improves the town's defense and increases its income to %{count} "
+"gold per day."
+msgstr ""
+"城堡改善城鎮的防禦，並將收入增加至每日 %{count} 金幣。"
+
+msgid ""
+"The Tent provides workers to build a castle, provided the materials and the "
+"gold are available."
+msgstr ""
+"帳篷提供工人來建造城堡，前提是有足夠的材料和黃金。"
+
+msgid ""
+"The Captain's Quarters provides a captain to assist in the castle's defense "
+"when no hero is present."
+msgstr ""
+"隊長營房在沒有英雄駐守時提供一名隊長協助城堡防禦。"
+
+msgid ""
+"The Mage Guild allows heroes to learn spells and replenish their spell "
+"points."
+msgstr ""
+"法師公會讓英雄學習法術並補充魔法值。"
+
+msgid "Recruit %{name}"
+msgstr "招募 %{name}"
+
+msgid "Month: %{month}, Week: %{week}, Day: %{day}"
+msgstr "月：%{month}，週：%{week}，日：%{day}"
+
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+"必須購買法術書才能使用法師公會，但目前沒有空間放置法術書。嘗試將一件神器轉交"
+"給其他英雄。"
+
+msgid "Exit Castle"
+msgstr "離開城堡"
+
+msgid "Exit Town"
+msgstr "離開城鎮"
+
+msgid "Show Income"
+msgstr "顯示收入"
+
+msgid "Show previous town"
+msgstr "顯示上一個城鎮"
+
+msgid "Show next town"
+msgstr "顯示下一個城鎮"
+
+msgid "View Hero"
+msgstr "檢視英雄"
+
+msgid "Click to show the next town."
+msgstr "按一下顯示下一個城鎮。"
+
+msgid "Click to show the previous town."
+msgstr "按一下顯示上一個城鎮。"
+
+msgid "This town may not be upgraded to a castle."
+msgstr "此城鎮無法升級為城堡。"
+
+msgid "Town"
+msgstr "城鎮"
+
+msgid "The above spells are available here."
+msgstr "以上法術在此處可用。"
+
+msgid "The spells the hero can learn have been added to their book."
+msgstr "英雄可學習的法術已加入其法術書。"
+
+msgid "Exit Mage Guild"
+msgstr "離開法師公會"
+
+msgid "A generous tip for the barkeep yields the following rumor:"
+msgstr "給酒保一筆大方的小費後得到了以下傳言："
+
+msgid "Recruit Hero"
+msgstr "招募英雄"
+
+msgid "%{name} is a level %{value} %{race} "
+msgstr "%{name} 是等級 %{value} 的 %{race} "
+
+msgid "with %{count} artifacts."
+msgstr "擁有 %{count} 件神器。"
+
+msgid "with 1 artifact."
+msgstr "擁有 1 件神器。"
+
+msgid "without artifacts."
+msgstr "沒有神器。"
+
+msgid "Recruit %{name} the %{race}"
+msgstr "招募 %{race} %{name}"
+
+msgid ""
+"'Spread' combat formation spreads the castle's units from the top to the "
+"bottom of the battlefield, with at least one empty space between each unit."
+msgstr ""
+"「分散」陣型將城堡的部隊從戰場頂部到底部展開，每支部隊之間至少保留一格空間。"
+
+msgid ""
+"'Grouped' combat formation bunches the castle's units together in the center "
+"of the castle's side of the battlefield."
+msgstr ""
+"「集中」陣型將城堡的部隊集中在戰場己方一側的中央。"
+
+msgid "Castle Options. Month: %{month}, Week: %{week}, Day: %{day}"
+msgstr "城堡選項。月：%{month}，週：%{week}，日：%{day}"
+
+msgid "Set garrison combat formation to 'Spread'"
+msgstr "將城防戰鬥陣型設為「分散」"
+
+msgid "Set garrison combat formation to 'Grouped'"
+msgstr "將城防戰鬥陣型設為「集中」"
+
+msgid "Exit Castle Options"
+msgstr "離開城堡選項"
+
+msgid "Spread Formation"
+msgstr "分散陣型"
+
+msgid "Grouped Formation"
+msgstr "集中陣型"
+
+msgid "Not enough resources to recruit creatures."
+msgstr "資源不足，無法招募生物。"
+
+msgid "You are unable to recruit at this time, your ranks are full."
+msgstr "目前無法招募，部隊已滿編。"
+
+msgid "No creatures available for purchase."
+msgstr "沒有可招募的生物。"
+
+msgid "Recruit Creatures"
+msgstr "招募生物"
+
+msgid "Hire all creatures in the town."
+msgstr "招募城鎮中的所有生物。"
+
+msgid "Max"
+msgstr "最大"
+
+msgid "Available"
+msgstr "可用"
+
+msgid "Town Population Information and Statistics"
+msgstr "城鎮人口資訊與統計"
+
+msgid "Damage"
+msgstr "傷害"
+
+msgid "HP"
+msgstr "生命值"
+
+msgid "Speed"
+msgstr "速度"
+
+msgid "Growth"
+msgstr "成長"
+
+msgid "week"
+msgstr "週"
+
+msgid "View World"
+msgstr "檢視世界"
+
+msgid "View the entire world."
+msgstr "檢視整個世界。"
+
+msgid "Puzzle"
+msgstr "拼圖"
+
+msgid "View the obelisk puzzle."
+msgstr "檢視方尖碑拼圖。"
+
+msgid "Scenario Information"
+msgstr "場景資訊"
+
+msgid "View information on the scenario you are currently playing."
+msgstr "檢視目前正在進行的場景資訊。"
+
+msgid "Dig for the Ultimate Artifact."
+msgstr "挖掘終極神器。"
+
+msgid "Digging"
+msgstr "挖掘"
+
+msgid "Arena"
+msgstr "競技場"
+
+msgid ""
+"You enter the arena and face a pack of vicious lions. You handily defeat "
+"them, to the wild cheers of the crowd. Impressed by your skill, the aged "
+"trainer of gladiators agrees to train you in a skill of your choice."
+msgstr ""
+"你進入競技場面對一群兇猛的獅子。你輕鬆擊敗了牠們，觀眾瘋狂歡呼。角鬥士訓練師"
+"年事已高，十分欣賞你的技術，同意讓你選擇一項技能接受訓練。"
+
+msgid "Attack Skill"
+msgstr "攻擊技能"
+
+msgid "Defense Skill"
+msgstr "防禦技能"
+
+msgid "Shots"
+msgstr "射擊次數"
+
+msgid "Shots Left"
+msgstr "剩餘射擊次數"
+
+msgid "Hit Points"
+msgstr "生命值"
+
+msgid "Hit Points Left"
+msgstr "剩餘生命值"
+
+msgid "You can't afford to upgrade your troops!"
+msgstr "無法負擔部隊的升級費用！"
+
+msgid ""
+"Your troops can be upgraded, but it will cost you dearly. Do you wish to "
+"upgrade them?"
+msgstr ""
+"部隊可以升級，但費用不菲。確定要升級嗎？"
+
+msgid "Are you sure you want to dismiss this army?"
+msgstr "確定要解散此軍隊嗎？"
+
+msgid "Upgrade"
+msgstr "升級"
+
+msgid "Upgrade your troops."
+msgstr "升級部隊。"
+
+msgid "Dismiss"
+msgstr "解散"
+
+msgid "Dismiss this army."
+msgstr "解散此軍隊。"
+
+msgid ""
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+"一群 %{monster} 渴望更偉大的榮耀，希望加入你的隊伍。\n"
+"是否接受？"
+
+msgid "Followers"
+msgstr "追隨者"
+
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
+"army for the sum of %{gold} gold.\n"
+"Do you accept?"
+msgstr ""
+"%{monster} 被你的外交辭令打動，願意以 %{gold} 金幣加入你的軍隊。\n"
+"是否接受？"
+
+msgid ""
+"The creatures are swayed by your diplomatic\n"
+"tongue, and make you an offer:\n"
+"\n"
+msgstr ""
+"這些生物被你的外交辭令打動，\n"
+"向你提出了一個條件:\n"
+"\n"
+
+msgid ""
+"%{offer} of the %{total} %{monster} will join your army, and the rest will "
+"leave you alone, for the sum of %{gold} gold.\n"
+"Do you accept?"
+msgstr ""
+"%{total} 個 %{monster} 中有 %{offer} 個願意加入你的軍隊，其餘的則會離開，費用"
+"為 %{gold} 金幣。\n"
+"是否接受？"
+
+msgid ""
+"All %{offer} of the %{monster} will join your army for the sum of %{gold} "
+"gold.\n"
+"Do you accept?"
+msgstr ""
+"全部 %{offer} 個 %{monster} 願意以 %{gold} 金幣加入你的軍隊。\n"
+"是否接受？"
+
+msgid "(Rate: %{percent})"
+msgstr "(比率：%{percent})"
+
+msgid "off"
+msgstr "關閉"
+
+msgid "Music"
+msgstr "音樂"
+
+msgid "Effects"
+msgstr "音效"
+
+msgid "MIDI"
+msgstr "MIDI"
+
+msgid "MIDI Expansion"
+msgstr "MIDI 擴充"
+
+msgid "External"
+msgstr "外部"
+
+msgid "Music Type"
+msgstr "音樂類型"
+
+msgid "3D Audio"
+msgstr "3D 音效"
+
+msgid "Toggle ambient music level."
+msgstr "調整環境音樂音量。"
+
+msgid "Toggle foreground sounds level."
+msgstr "調整前景音效音量。"
+
+msgid "Change the type of music."
+msgstr "變更音樂類型。"
+
+msgid "Toggle the 3D effect of foreground sounds."
+msgstr "切換前景音效的 3D 效果。"
+
+msgid "Build a new ship:"
+msgstr "建造新船："
+
+msgid "Resource cost:"
+msgstr "資源花費："
+
+msgid "Total: "
+msgstr "總計："
+
+msgid "Need: "
+msgstr "需要："
+
+msgid "Restart Game"
+msgstr "重新開始遊戲"
+
+msgid "There was an issue during saving."
+msgstr "儲存時發生問題。"
+
+msgid "New Game"
+msgstr "新遊戲"
+
+msgid "Start a single or multi-player game."
+msgstr "開始單人或多人遊戲。"
+
+msgid "Load Game"
+msgstr "載入遊戲"
+
+msgid "Load a previously saved game."
+msgstr "載入先前儲存的遊戲。"
+
+msgid "Restart the scenario."
+msgstr "重新開始此場景。"
+
+msgid "Save Game"
+msgstr "儲存遊戲"
+
+msgid "Save the current game."
+msgstr "儲存目前的遊戲。"
+
+msgid "Quick Save"
+msgstr "快速存檔"
+
+msgid "Save the current game without name selection."
+msgstr "不選擇名稱直接儲存目前的遊戲。"
+
+msgid "Quit"
+msgstr "結束"
+
+msgid "Quit out of Heroes of Might and Magic II."
+msgstr "結束 Heroes of Might and Magic II。"
+
+msgid "Change the language of the game."
+msgstr "變更遊戲的語言。"
+
+msgid "Select Game Language"
+msgstr "選擇遊戲語言"
+
+msgid "Change the graphics settings of the game."
+msgstr "變更遊戲的圖形設定。"
+
+msgid "Graphics"
+msgstr "圖形"
+
+msgid "Mouse Cursor"
+msgstr "滑鼠游標"
+
+msgid "Toggle colored cursor on or off. This is only an aesthetic choice."
+msgstr "切換彩色游標的開關。這僅為視覺偏好設定。"
+
+msgid "Interface Type"
+msgstr "介面類型"
+
+msgid "Toggle the type of interface you want to use."
+msgstr "切換要使用的介面類型。"
+
+msgid "Text Support"
+msgstr "文字輔助"
+
+msgid ""
+"Toggle text support mode to output extra information about windows and "
+"events in the game."
+msgstr ""
+"切換文字輔助模式，以輸出關於遊戲視窗和事件的額外資訊。"
+
+msgid ""
+"Map\n"
+"Difficulty"
+msgstr ""
+"地圖\n"
+"難度"
+
+msgid ""
+"Game\n"
+"Difficulty"
+msgstr ""
+"遊戲\n"
+"難度"
+
+msgid "Rating"
+msgstr "評分"
+
+msgid "Map Size"
+msgstr "地圖大小"
+
+msgid "Opponents"
+msgstr "對手"
+
+msgid "Class"
+msgstr "職業"
+
+msgid ""
+"Victory\n"
+"Conditions"
+msgstr ""
+"勝利\n"
+"條件"
+
+msgid ""
+"Loss\n"
+"Conditions"
+msgstr ""
+"失敗\n"
+"條件"
+
+msgid "About"
+msgstr "關於"
+
+msgid "Click to read notes from the map creator."
+msgstr "按一下閱讀地圖製作者的備註。"
+
+msgid "Map Description"
+msgstr "地圖描述"
+
+msgid "First select recipients!"
+msgstr "請先選擇收禮對象！"
+
+msgid "You cannot select %{resource}!"
+msgstr "無法選擇 %{resource}！"
+
+msgid "Set %{resource-type} Count"
+msgstr "設定 %{resource-type} 數量"
+
+msgid "Select Recipients"
+msgstr "選擇收禮對象"
+
+msgid "Your Funds"
+msgstr "你的資金"
+
+msgid "Planned Gift"
+msgstr "計畫贈禮"
+
+msgid "Gift from %{name}"
+msgstr "來自 %{name} 的贈禮"
+
+msgid "Resolution"
+msgstr "解析度"
+
+msgid "Fullscreen"
+msgstr "全螢幕"
+
+msgid "window|Mode"
+msgstr "視窗模式"
+
+msgid "Windowed"
+msgstr "視窗化"
+
+msgid "V-Sync"
+msgstr "垂直同步"
+
+msgid "FPS"
+msgstr "FPS"
+
+msgid "System Info"
+msgstr "系統資訊"
+
+msgid "Nearest"
+msgstr "鄰近取樣"
+
+msgid "Screen Scaling Type"
+msgstr "螢幕縮放類型"
+
+msgid "Linear"
+msgstr "線性"
+
+msgid "Change the resolution of the game."
+msgstr "變更遊戲的解析度。"
+
+msgid "Select Game Resolution"
+msgstr "選擇遊戲解析度"
+
+msgid "Toggle between fullscreen and windowed modes."
+msgstr "切換全螢幕與視窗模式。"
+
+msgid ""
+"Toggle the type of screen scaling you want to use. Linear scaling makes the "
+"resized screen image blurry while nearest scaling preserves the sharpness of "
+"the original game. The nearest scaling looks best on integer scales, for "
+"example 2.0x or 3.0x."
+msgstr ""
+"切換要使用的螢幕縮放類型。線性縮放會使畫面模糊，而鄰近取樣則保留原始遊戲的清"
+"晰度。鄰近取樣在整數倍率 (如 2.0x 或 3.0x) 下效果最佳。"
+
+msgid ""
+"The V-Sync option can be enabled to resolve flickering issues on some "
+"monitors."
+msgstr ""
+"可啟用垂直同步選項來解決某些螢幕上的閃爍問題。"
+
+msgid "Show extra information such as FPS and current time."
+msgstr "顯示額外資訊，例如 FPS 和目前時間。"
+
+msgid "Hotkey: "
+msgstr "快速鍵： "
+
+msgid "Category: "
+msgstr "分類："
+
+msgid "Event: "
+msgstr "事件："
+
+msgid "Hot Keys:"
+msgstr "快速鍵："
+
+msgid "Hide"
+msgstr "隱藏"
+
+msgid "Show"
+msgstr "顯示"
+
+msgid "Army Estimation"
+msgstr "軍隊估算"
+
+msgid "Canonical"
+msgstr "正規"
+
+msgid "Numeric"
+msgstr "數值"
+
+msgid "Toggle interface visibility."
+msgstr "切換介面可見度。"
+
+msgid "Scroll Speed"
+msgstr "捲動速度"
+
+msgid "Sets the speed at which you scroll the window."
+msgstr "調整視窗捲動的速度。"
+
+msgid ""
+"Toggle how army sizes are displayed when right-clicking armies on the "
+"adventure map. \n"
+"\n"
+"Canonical: Army sizes are shown as descriptive text (e.g. \"Few\").\n"
+"\n"
+"Numeric: Army sizes are shown as numeric ranges (e.g. \"1-4\")."
+msgstr ""
+"切換在冒險地圖上右鍵按一下軍隊時的顯示方式。\n"
+"\n"
+"正規：軍隊數量以描述性文字顯示 (例如「少量」)。\n"
+"\n"
+"數值：軍隊數量以數字範圍顯示 (例如「1-4」)。"
+
+msgid "Select Game Language:"
+msgstr "選擇遊戲語言："
+
+msgid "Select Language:"
+msgstr "選擇語言："
+
+msgid "Click to choose the selected language."
+msgstr "按一下選擇所選的語言。"
+
+msgid "%{name} has gained a level."
+msgstr "%{name} 升級了。"
+
+msgid "%{skill} +1"
+msgstr "%{skill} +1"
+
+msgid "You have learned %{skill}."
+msgstr "學會了 %{skill}。"
+
+msgid ""
+"%{name} has gained a level.\n"
+"\n"
+"%{skill} +1"
+msgstr ""
+"%{name} 升級了。\n"
+"\n"
+"%{skill} +1"
+
+msgid ""
+"You may learn either:\n"
+"%{skill1}\n"
+"or\n"
+"%{skill2}"
+msgstr ""
+"可以學習以下其一:\n"
+"%{skill1}\n"
+"或\n"
+"%{skill2}"
+
+msgid "Learn %{secondary-skill}"
+msgstr "學習 %{secondary-skill}"
+
+msgid "n/a"
+msgstr "不適用"
+
+msgid ""
+"Please inspect our fine wares. If you feel like offering a trade, click on "
+"the items you wish to trade with and for."
+msgstr ""
+"請瀏覽我們的精美商品。若有意交易，請按一下要交易的物品。"
+
+msgid ""
+"You have received quite a bargain. I expect to make no profit on the deal. "
+"Can I interest you in any of my other wares?"
+msgstr ""
+"你得到了相當划算的交易，我預計不會有任何利潤。還對我的其他商品感興趣嗎？"
+
+msgid "I can offer you %{count} for 1 unit of %{resfrom}."
+msgstr "可以提供 %{count} 換取 1 單位的 %{resfrom}。"
+
+msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
+msgstr "可以提供 1 單位的 %{resto} 換取 %{count} 單位的 %{resfrom}。"
+
+msgid "Min"
+msgstr "最小"
+
+msgid "Qty to trade"
+msgstr "交易數量"
+
+msgid "Trading Post"
+msgstr "交易站"
+
+msgid "Your Resources"
+msgstr "你的資源"
+
+msgid "Available Trades"
+msgstr "可用交易"
+
+msgid "guarded by %{count} %{monster}"
+msgstr "由 %{count} 個 %{monster} 守衛"
+
+msgid "guarded by "
+msgstr "守衛者："
+
+msgid "(available: %{count})"
+msgstr "(可用：%{count})"
+
+msgid "(empty)"
+msgstr "(空)"
+
+msgid "already learned"
+msgstr "已學會"
+
+msgid "treeOfKnowledge|free"
+msgstr "免費"
+
+msgid "already claimed"
+msgstr "已領取"
+
+msgid "not claimed"
+msgstr "未領取"
+
+msgid "already knows this skill"
+msgstr "已知曉此技能"
+
+msgid "already has max skills"
+msgstr "技能數已滿"
+
+msgid "(already visited)"
+msgstr "(已造訪)"
+
+msgid "(not visited)"
+msgstr "(未造訪)"
+
+msgid "%{color} Barrier"
+msgstr "%{color}屏障"
+
+msgid "(tent visited)"
+msgstr "(帳篷已造訪)"
+
+msgid "%{color} Tent"
+msgstr "%{color}帳篷"
+
+msgid "Road"
+msgstr "道路"
+
+msgid "(digging ok)"
+msgstr "(可挖掘)"
+
+msgid "(no digging)"
+msgstr "(無法挖掘)"
+
+msgid "penalty: %{cost}"
+msgstr "懲罰：%{cost}"
+
+msgid "Defenders:"
+msgstr "守衛者："
+
+msgid "Unknown"
+msgstr "未知"
+
+msgid "heroQuickInfo|(Level %{level})"
+msgstr "(等級 %{level})"
+
+msgid "Attack:"
+msgstr "攻擊："
+
+msgid "Defense:"
+msgstr "防禦："
+
+msgid "Spell Power:"
+msgstr "魔法力量："
+
+msgid "Knowledge:"
+msgstr "知識："
+
+msgid "Spell Points:"
+msgstr "魔法值："
+
+msgid "Move Points:"
+msgstr "移動力："
+
+msgid "Uncharted Territory"
+msgstr "未探索區域"
+
+msgid "Random Map Generator"
+msgstr "隨機地圖產生器"
+
+msgid "rmg|Player count:"
+msgstr "玩家數量："
+
+msgid "rmg|Map layout:"
+msgstr "地圖佈局："
+
+msgid "rmg|Water percentage:"
+msgstr "水域百分比："
+
+msgid "rmg|Monster strength:"
+msgstr "怪物強度："
+
+msgid "rmg|Resource availability:"
+msgstr "資源可用性："
+
+msgid "rmg|Map seed:"
+msgstr "地圖種子碼："
+
+msgid "Click to generate a new map."
+msgstr "按一下產生新地圖。"
+
+msgid "Return to the previous menu."
+msgstr "返回上一個選單。"
+
+msgid "Cost per troop:"
+msgstr "每支部隊花費："
+
+msgid "Available: %{count}"
+msgstr "可用：%{count}"
+
+msgid "Number to buy:"
+msgstr "購買數量："
+
+msgid "Recruit selected monsters."
+msgstr "招募選取的怪物。"
+
+msgid "Select maximum monsters to be recruited."
+msgstr "選擇最大招募數量。"
+
+msgid "Select only 1 monster to be recruited."
+msgstr "選擇僅招募 1 個怪物。"
+
+msgid "Select this game resolution."
+msgstr "選擇此遊戲解析度。"
+
+msgid ""
+"Selecting this resolution will set a resolution that is scaled from the "
+"original resolution (%{resolution}) by multiplying it with the number in the "
+"brackets (%{scale}).\n"
+"\n"
+"A resolution with a clean integer number (2.0x, 3.0x etc.) will usually look "
+"better because the pixels are upscaled evenly in both horizontal and "
+"vertical directions."
+msgstr ""
+"選擇此解析度將以原始解析度 (%{resolution}) 乘以括號中的數字 (%{scale}) 來設"
+"定。\n"
+"\n"
+"使用整數倍率 (2.0x、3.0x 等) 的解析度通常看起來更好，因為畫素在水平和垂直方向"
+"上均勻放大。"
+
+msgid "Select Game Resolution:"
+msgstr "選擇遊戲解析度："
+
+msgid "Click to apply the selected resolution."
+msgstr "按一下套用選取的解析度。"
+
+msgid "Click to select the maximum amount."
+msgstr "按一下選擇最大數量。"
+
+msgid "Click to select the minimum amount."
+msgstr "按一下選擇最小數量。"
+
+msgid "Click to apply the entered number."
+msgstr "按一下套用輸入的數字。"
+
+msgid "Click to apply the entered text."
+msgstr "按一下套用輸入的文字。"
+
+msgid "Click to open the Virtual Keyboard dialog."
+msgstr "按一下開啟虛擬鍵盤對話方塊。"
+
+msgid "Open Virtual Keyboard"
+msgstr "開啟虛擬鍵盤"
+
+msgid "How many creatures do you wish to move?"
+msgstr "要移動多少生物？"
+
+msgid "Select how many units to separate into:"
+msgstr "選擇要分出多少單位："
+
+msgid "Map: "
+msgstr "地圖："
+
+msgid ""
+"\n"
+"\n"
+"Month: "
+msgstr ""
+"\n"
+"\n"
+"月："
+
+msgid ", Week: "
+msgstr "，週："
+
+msgid ", Day: "
+msgstr "，日："
+
+msgid ""
+"\n"
+"\n"
+"Location: "
+msgstr ""
+"\n"
+"\n"
+"位置："
+
+msgid "saveLoadDialog|Name"
+msgstr "名稱"
+
+msgid "saveLoadDialog|Date"
+msgstr "日期"
+
+msgid "Are you sure you want to delete file:"
+msgstr "確定要刪除此檔案嗎："
+
+msgid "Warning"
+msgstr "警告"
+
+msgid "Click to save the current game."
+msgstr "按一下儲存目前的遊戲。"
+
+msgid "Click to load a previously saved game."
+msgstr "按一下載入先前儲存的遊戲。"
+
+msgid "Click here if you wish to sort save files by their name."
+msgstr "按此處以依名稱排序存檔。"
+
+msgid "Sort by Name"
+msgstr "依名稱排序"
+
+msgid ""
+"Click here if you you wish to sort save files by their last modified date."
+msgstr ""
+"按此處以依修改日期排序存檔。"
+
+msgid "Sort by Date"
+msgstr "依日期排序"
+
+msgid "File to Save:"
+msgstr "儲存檔案："
+
+msgid "File to Load:"
+msgstr "載入檔案："
+
+msgid "Terrain object"
+msgstr "地形物件"
+
+msgid "There is nothing to select from."
+msgstr "沒有可選擇的選項。"
+
+msgid "There are no castles to select from."
+msgstr "沒有可選擇的城堡。"
+
+msgid "Accept the choice made."
+msgstr "確認所做的選擇。"
+
+msgid "Click to enable all items."
+msgstr "按一下啟用所有選項。"
+
+msgid "Enable All Items"
+msgstr "啟用所有選項"
+
+msgid "Click to disable all items."
+msgstr "按一下停用所有選項。"
+
+msgid "Disable All Items"
+msgstr "停用所有選項"
+
+msgid "There are no secondary skills to select from."
+msgstr "沒有可選擇的次要技能。"
+
+msgid "Select Skill:"
+msgstr "選擇技能："
+
+msgid "There are no spells to select."
+msgstr "沒有可選擇的法術。"
+
+msgid "Select Spell:"
+msgstr "選擇法術："
+
+msgid "There are no artifacts to select from."
+msgstr "沒有可選擇的神器。"
+
+msgid "Select Artifact:"
+msgstr "選擇神器："
+
+msgid "There are no monsters to select from."
+msgstr "沒有可選擇的怪物。"
+
+msgid "Select Monster:"
+msgstr "選擇怪物："
+
+msgid "There are no heroes to select from."
+msgstr "沒有可選擇的英雄。"
+
+msgid "Select Hero:"
+msgstr "選擇英雄："
+
+msgid "Select Monsters:"
+msgstr "選擇怪物："
+
+msgid "Select Artifacts:"
+msgstr "選擇神器："
+
+msgid "race|Random"
+msgstr "隨機"
+
+msgid "Click to start placing the selected hero."
+msgstr "按一下開始放置選取的英雄。"
+
+msgid "%{color} %{race}"
+msgstr "%{color} %{race}"
+
+msgid "You will place"
+msgstr "你將放置"
+
+msgid "Click to select this class."
+msgstr "按一下選擇此職業。"
+
+msgid "Click to select this color."
+msgstr "按一下選擇此顏色。"
+
+msgid "Select Treasure:"
+msgstr "選擇寶藏："
+
+msgid "Select Ocean Object:"
+msgstr "選擇海洋物件："
+
+msgid "Castle/town placing:"
+msgstr "城堡/城鎮放置："
+
+msgid "doubleLinedRace|Neutral"
+msgstr "中立"
+
+msgid "TOWN"
+msgstr "城鎮"
+
+msgid "CASTLE"
+msgstr "城堡"
+
+msgid "Click to start placing the selected castle/town."
+msgstr "按一下開始放置選取的城堡/城鎮。"
+
+msgid "Click to select town placing."
+msgstr "按一下選擇城鎮放置。"
+
+msgid "Click to select castle placing."
+msgstr "按一下選擇城堡放置。"
+
+msgid "%{color} %{race} %{townOrCastle}"
+msgstr "%{color} %{race} %{townOrCastle}"
+
+msgid "race|Neutral"
+msgstr "中立"
+
+msgid "Select Dwelling:"
+msgstr "選擇住所："
+
+msgid "Select Landscape Object:"
+msgstr "選擇地景物件："
+
+msgid "Mine placing:"
+msgstr "礦場放置："
+
+msgid ""
+"Resource\n"
+"type:"
+msgstr ""
+"資源\n"
+"類型："
+
+msgid "%{mineName} appearance:"
+msgstr "%{mineName} 外觀："
+
+msgid "Click to select the color."
+msgstr "按一下選擇顏色。"
+
+msgid "Click to select %{object} as the resource generator to be placed."
+msgstr "按一下選擇 %{object} 作為要放置的資源產生器。"
+
+msgid "Select Mountain Object:"
+msgstr "選擇山脈物件："
+
+msgid "Select Rock Object:"
+msgstr "選擇岩石物件："
+
+msgid "Select Tree Object:"
+msgstr "選擇樹木物件："
+
+msgid "Select Power Up Object:"
+msgstr "選擇增強物件："
+
+msgid "Select Adventure Object:"
+msgstr "選擇冒險物件："
+
+msgid "Select color:"
+msgstr "選擇顏色："
+
+msgid "Players Icon"
+msgstr "玩家圖示"
+
+msgid ""
+"Indicates how many players total are in the scenario. Any positions not "
+"occupied by human players will be occupied by computer players."
+msgstr ""
+"顯示場景中的總玩家數。未被人類玩家佔據的位置將由電腦玩家佔據。"
+
+msgid ""
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
+msgstr ""
+"顯示地圖大小是\n"
+"小型 (36 x 36)、中型\n"
+"(72 x 72)、大型 (108 x 108)\n"
+"或超大型 (144 x 144)。"
+
+msgid "Size Icon"
+msgstr "大小圖示"
+
+msgid "The Succession Wars"
+msgstr "繼位戰爭"
+
+msgid "The Price of Loyalty"
+msgstr "忠誠的代價"
+
+msgid "Resurrection"
+msgstr "復甦"
+
+msgid "This map is made for \"%{game-version}\" version of the game."
+msgstr "此地圖是為遊戲的「%{game-version}」版本製作的。"
+
+msgid "Map Type"
+msgstr "地圖類型"
+
+msgid "Map Type:\n"
+msgstr "地圖類型:\n"
+
+msgid ""
+"\n"
+"\n"
+"Supported languages:\n"
+msgstr ""
+"\n"
+"\n"
+"支援的語言:\n"
+
+msgid "Lose all your heroes and towns."
+msgstr "失去所有英雄和城鎮。"
+
+msgid "Lose a specific town."
+msgstr "失去特定城鎮。"
+
+msgid "Lose a specific hero."
+msgstr "失去特定英雄。"
+
+msgid "Run out of time. Fail to win by a certain point."
+msgstr "時間耗盡，未能在期限前獲勝。"
+
+msgid "Loss Condition"
+msgstr "失敗條件"
+
+msgid "Defeat all enemy heroes and towns."
+msgstr "擊敗所有敵方英雄和城鎮。"
+
+msgid "Capture a specific town."
+msgstr "佔領特定城鎮。"
+
+msgid "Defeat a specific hero."
+msgstr "擊敗特定英雄。"
+
+msgid "Find a specific artifact."
+msgstr "找到特定神器。"
+
+msgid "Your side must defeat the opposing side."
+msgstr "必須擊敗對方。"
+
+msgid "Accumulate a large amount of gold."
+msgstr "累積大量黃金。"
+
+msgid "Victory Condition"
+msgstr "勝利條件"
+
+msgid "Map difficulty:"
+msgstr "地圖難度："
+
+msgid "N"
+msgstr "N"
+
+msgid "Are you sure you want to delete the map:"
+msgstr "確定要刪除此地圖嗎："
+
+msgid "No maps exist at that size."
+msgstr "沒有該大小的地圖。"
+
+msgid "Small Maps"
+msgstr "小型地圖"
+
+msgid "View only maps of size small (36 x 36)."
+msgstr "僅顯示小型 (36 x 36) 地圖。"
+
+msgid "Medium Maps"
+msgstr "中型地圖"
+
+msgid "View only maps of size medium (72 x 72)."
+msgstr "僅顯示中型 (72 x 72) 地圖。"
+
+msgid "Large Maps"
+msgstr "大型地圖"
+
+msgid "View only maps of size large (108 x 108)."
+msgstr "僅顯示大型 (108 x 108) 地圖。"
+
+msgid "Extra Large Maps"
+msgstr "超大地圖"
+
+msgid "View only maps of size extra large (144 x 144)."
+msgstr "僅顯示超大型 (144 x 144) 地圖。"
+
+msgid "All Maps"
+msgstr "所有地圖"
+
+msgid "View all maps, regardless of size."
+msgstr "顯示所有地圖，不限大小。"
+
+msgid "Selected Name"
+msgstr "選取的名稱"
+
+msgid "The name of the currently selected map."
+msgstr "目前選取地圖的名稱。"
+
+msgid "Selected Map Difficulty"
+msgstr "選取地圖的難度"
+
+msgid ""
+"The map difficulty of the currently selected map. The map difficulty is "
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
+msgstr ""
+"目前選取地圖的難度。地圖難度由場景設計者決定。地圖難度越高，敵人可能越多或越"
+"強、資源越少，或出現其他對人類玩家不利的特殊條件。"
+
+msgid "Selected Map Description"
+msgstr "選取地圖的描述"
+
+msgid "Jump"
+msgstr "跳躍"
+
+msgid "Hero Speed"
+msgstr "英雄速度"
+
+msgid "Don't Show"
+msgstr "不顯示"
+
+msgid "Enemy Speed"
+msgstr "敵方速度"
+
+msgid "Auto Resolve"
+msgstr "自動結算"
+
+msgid "Auto, No Spells"
+msgstr "自動，無法術"
+
+msgid "Battles"
+msgstr "戰鬥"
+
+msgid "combatMode|Manual"
+msgstr "手動"
+
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr "變更英雄在主畫面上的移動速度。"
+
+msgid ""
+"Sets the speed that computer heroes move at. You can also elect not to view "
+"computer movement at all."
+msgstr ""
+"設定電腦英雄的移動速度。也可以選擇完全不顯示電腦的移動。"
+
+msgid "Toggle instant battle mode."
+msgstr "切換即時戰鬥模式。"
+
+msgid "Att."
+msgstr "攻"
+
+msgid "Def."
+msgstr "防"
+
+msgid "Power"
+msgstr "力量"
+
+msgid "Knowl"
+msgstr "知識"
+
+msgid "1st"
+msgstr "第一"
+
+msgid "2nd"
+msgstr "第二"
+
+msgid "3rd"
+msgstr "第三"
+
+msgid "4th"
+msgstr "第四"
+
+msgid "5th"
+msgstr "第五"
+
+msgid "6th"
+msgstr "第六"
+
+msgid "Oracle: Player Rankings"
+msgstr "神諭：玩家排名"
+
+msgid "Thieves' Guild: Player Rankings"
+msgstr "盜賊公會：玩家排名"
+
+msgid "Number of Towns:"
+msgstr "城鎮數："
+
+msgid "Number of Castles:"
+msgstr "城堡數："
+
+msgid "Number of Heroes:"
+msgstr "英雄數："
+
+msgid "Gold in Treasury:"
+msgstr "國庫黃金："
+
+msgid "Wood & Ore:"
+msgstr "木材與礦石："
+
+msgid "Gems, Cr, Slf & Mer:"
+msgstr "寶石、水晶、硫磺與水銀："
+
+msgid "Obelisks Found:"
+msgstr "已發現方尖碑："
+
+msgid "Artifacts:"
+msgstr "神器："
+
+msgid "Total Army Strength:"
+msgstr "軍隊總戰力："
+
+msgid "Income:"
+msgstr "收入："
+
+msgid "Best Hero:"
+msgstr "最佳英雄："
+
+msgid "Best Hero Stats:"
+msgstr "最佳英雄屬性："
+
+msgid "Personality:"
+msgstr "性格："
+
+msgid "Best Monster:"
+msgstr "最強怪物："
+
+msgid "Random Castle Name"
+msgstr "隨機城堡名稱"
+
+msgid "Random Town Name"
+msgstr "隨機城鎮名稱"
+
+msgid "BANNED SPELLS"
+msgstr "停用法術"
+
+msgid "Click to accept the changes made."
+msgstr "按一下接受所做的變更。"
+
+msgid "Exit this dialog, discarding the changes made."
+msgstr "離開此對話方塊，放棄所做的變更。"
+
+msgid "Click to ban spells from appearing in the Mage Guild."
+msgstr "按一下禁止法術出現在法師公會中。"
+
+msgid "Banned Spells"
+msgstr "停用法術"
+
+msgid "Select spells that will appear in the Mage Guild."
+msgstr "選擇將出現在法師公會中的法術。"
+
+msgid "SET SPELLS"
+msgstr "設定法術"
+
+msgid "Allow Castle build"
+msgstr "允許建造城堡"
+
+msgid "Default Buildings"
+msgstr "預設建築"
+
+msgid "RESTRICT"
+msgstr "限制"
+
+msgid "Default Army"
+msgstr "預設軍隊"
+
+msgid "Castle Army"
+msgstr "城堡軍隊"
+
+msgid "Town Army"
+msgstr "城鎮軍隊"
+
+msgid "You have unsaved changes. Do you wish to proceed?"
+msgstr "有未儲存的變更。確定要繼續嗎？"
+
+msgid "Click to change the Castle name."
+msgstr "按一下變更城堡名稱。"
+
+msgid "Enter Castle name:"
+msgstr "輸入城堡名稱："
+
+msgid "Reset the Castle name."
+msgstr "重置城堡名稱。"
+
+msgid "Allow to build a castle in this town."
+msgstr "允許在此城鎮建造城堡。"
+
+msgid "Toggle the use of default buildings. Custom buildings will be reset!"
+msgstr "切換使用預設建築。自訂建築將被重置！"
+
+msgid "Toggle building construction restriction mode."
+msgstr "切換建築建造限制模式。"
+
+msgid "Restrict Building Construction"
+msgstr "限制建築建造"
+
+msgid "Use default defenders army."
+msgstr "使用預設守軍。"
+
+msgid "Reset the army."
+msgstr "重置軍隊。"
+
+msgid "Set custom Castle Army."
+msgstr "設定自訂城堡軍隊。"
+
+msgid "Set spells to appear in the Mage Guild."
+msgstr "設定出現在法師公會中的法術。"
+
+msgid "Set Spells"
+msgstr "設定法術"
+
+msgid "Castle Settings"
+msgstr "城堡設定"
+
+msgid "Message Text:"
+msgstr "訊息文字："
+
+msgid "Reward:"
+msgstr "獎勵："
+
+msgid "Player colors allowed to get event:"
+msgstr "允許取得事件的玩家顏色："
+
+msgid "Computer colors allowed to get event:"
+msgstr "允許取得事件的電腦顏色："
+
+msgid "First day of occurrence:"
+msgstr "首次發生日："
+
+msgid "Repeat period (days):"
+msgstr "重複週期 (天):"
+
+msgid "Allow %{color} human player to get event"
+msgstr "允許 %{color} 人類玩家取得事件"
+
+msgid ""
+"If this checkbox is checked, this event will trigger for the %{color} player "
+"if they are controlled by a human."
+msgstr ""
+"勾選此選項且 %{color} 玩家由人類控制時，此事件就會觸發。"
+
+msgid "Allow %{color} computer player to get event"
+msgstr "允許 %{color} 電腦玩家取得事件"
+
+msgid ""
+"If this checkbox is checked, this event will trigger for the %{color} player "
+"if they are controlled by a computer."
+msgstr ""
+"勾選此選項且 %{color} 玩家由電腦控制時，此事件就會觸發。"
+
+msgid "Set %{resource-type} Count:"
+msgstr "設定 %{resource-type} 數量："
+
+msgid "Message:"
+msgstr "訊息："
+
+msgid "Click to save the Event properties."
+msgstr "按一下儲存事件屬性。"
+
+msgid "No resources will be given as a reward."
+msgstr "不會給予任何資源作為獎勵。"
+
+msgid "Resources"
+msgstr "資源"
+
+msgid "Resources will be given as a reward."
+msgstr "將給予資源作為獎勵。"
+
+msgid "Click here to change the event message."
+msgstr "按此處變更事件訊息。"
+
+msgid "Event Message Text"
+msgstr "事件訊息文字"
+
+msgid "Day: %{day}"
+msgstr "日：%{day}"
+
+msgid "Daily events:"
+msgstr "每日事件："
+
+msgid "Click to save the events."
+msgstr "按一下儲存事件。"
+
+msgid "Add Event"
+msgstr "新增事件"
+
+msgid "Add an additional event."
+msgstr "新增額外的事件。"
+
+msgid "Edit Event"
+msgstr "編輯事件"
+
+msgid "Edit an existing event."
+msgstr "編輯既有的事件。"
+
+msgid "Delete Event"
+msgstr "刪除事件"
+
+msgid "Delete an existing event."
+msgstr "刪除既有的事件。"
+
+msgid "Effects:"
+msgstr "效果："
+
+msgid "Conditions:"
+msgstr "條件："
+
+msgid "Cancel event after first visit"
+msgstr "首次造訪後取消事件"
+
+msgid "Computer colors allowed to get the event:"
+msgstr "允許取得事件的電腦顏色："
+
+msgid "Set Experience value:"
+msgstr "設定經驗值："
+
+msgid "Artifact"
+msgstr "神器"
+
+msgid "No artifact will be given by the event."
+msgstr "此事件不會給予任何神器。"
+
+msgid "Delete Artifact"
+msgstr "刪除神器"
+
+msgid "Delete an artifact from the event."
+msgstr "從事件中刪除神器。"
+
+msgid "No Secondary Skill will be given by the event."
+msgstr "此事件不會給予任何次要技能。"
+
+msgid "Secondary Skill"
+msgstr "次要技能"
+
+msgid "Delete Secondary Skill"
+msgstr "刪除次要技能"
+
+msgid "Delete the Secondary Skill from the event."
+msgstr "從事件中刪除次要技能。"
+
+msgid "No resources will be part of this event."
+msgstr "此事件不包含任何資源。"
+
+msgid "These resources will be a part of the event."
+msgstr "這些資源將成為事件的一部分。"
+
+msgid ""
+"If this checkbox is checked, the event will trigger only once. If not "
+"checked, the event will trigger every time one of the specified players "
+"crosses the event tile."
+msgstr ""
+"勾選此選項後，事件只會觸發一次。若未勾選，每次指定的玩家經過事件格時都會觸"
+"發。"
+
+msgid "Click to make selection."
+msgstr "按一下進行選擇。"
+
+msgid "%{objects} cannot be placed on water."
+msgstr "%{objects} 無法放置在水上。"
+
+msgid ""
+"The Ultimate Artifact can only be placed on terrain where digging is "
+"possible."
+msgstr ""
+"終極神器只能放置在可挖掘的地形上。"
+
+msgid "%{objects} must be placed on water."
+msgstr "%{objects} 必須放置在水上。"
+
+msgid "Action objects cannot be placed outside the map."
+msgstr "動作物件無法放置在地圖外。"
+
+msgid "Action objects must be placed on clear tiles."
+msgstr "動作物件必須放置在空白格上。"
+
+msgid "A maximum of %{count} %{objects} can be placed on the map."
+msgstr "地圖上最多可放置 %{count} 個 %{objects}。"
+
+msgid "Not able to generate a map with given parameters."
+msgstr "無法以指定參數產生地圖。"
+
+msgid ""
+"Do you wish to return to the game's Main Menu? All unsaved changes will be "
+"lost."
+msgstr ""
+"確定要返回遊戲主選單嗎？所有未儲存的變更將會遺失。"
+
+msgid "Editor"
+msgstr "編輯器"
+
+msgid ""
+"Are you sure you want to load a new map? (Any unsaved changes to the current "
+"map will be lost.)"
+msgstr ""
+"確定要載入新地圖嗎？（目前地圖所有未儲存的變更將會遺失。）"
+
+msgid ""
+"Are you sure you want to create a new map? (Any unsaved changes to the "
+"current map will be lost.)"
+msgstr ""
+"確定要建立新地圖嗎？（目前地圖所有未儲存的變更將會遺失。）"
+
+msgid "Main Menu"
+msgstr "主選單"
+
+msgid ""
+"Do you wish to return to the game's Main Menu? (Any unsaved changes to the "
+"current map will be lost.)"
+msgstr ""
+"確定要返回遊戲主選單嗎？（目前地圖所有未儲存的變更將會遺失。）"
+
+msgid "Unsaved Changes"
+msgstr "未儲存的變更"
+
+msgid ""
+"This map has either terrain changes, undo history or has not yet been saved "
+"to a file.\n"
+"\n"
+"Do you wish to save the current map?"
+msgstr ""
+"此地圖有地形變更、復原歷史紀錄或尚未儲存至檔案。\n"
+"\n"
+"是否要儲存目前的地圖？"
+
+msgid "Unplayable Map"
+msgstr "無法遊玩的地圖"
+
+msgid ""
+"This map is not playable. You need at least one human player for the map to "
+"be playable."
+msgstr ""
+"此地圖無法遊玩。至少需要一位人類玩家才能遊玩。"
+
+msgid "Start Map"
+msgstr "開始地圖"
+
+msgid ""
+"Do you wish to leave the Editor and start the map? (Any unsaved changes to "
+"the current map will be lost.)"
+msgstr ""
+"確定要離開編輯器並開始地圖嗎？（目前地圖所有未儲存的變更將會遺失。）"
+
+msgid "Create a new map from scratch."
+msgstr "從頭建立新地圖。"
+
+msgid "New Map"
+msgstr "新地圖"
+
+msgid "Load Map"
+msgstr "載入地圖"
+
+msgid "Load an existing map."
+msgstr "載入既有的地圖。"
+
+msgid "Save Map"
+msgstr "儲存地圖"
+
+msgid "Save the current map."
+msgstr "儲存目前的地圖。"
+
+msgid "Quit out of the map editor."
+msgstr "離開地圖編輯器。"
+
+msgid "Return to the game's Main Menu."
+msgstr "返回遊戲主選單。"
+
+msgid "Leave the Editor and play the map in the Standard Game mode."
+msgstr "離開編輯器，以標準遊戲模式遊玩此地圖。"
+
+msgid "Input %{object} text:"
+msgstr "輸入 %{object} 文字："
+
+msgid "Set Random Ultimate Artifact Radius:"
+msgstr "設定隨機終極神器半徑："
+
+msgid "%{object} has no properties to change."
+msgstr "%{object} 沒有可變更的屬性。"
+
+msgid "This artifact"
+msgstr "此神器"
+
+msgid "The total number of obelisks is %{count}."
+msgstr "方尖碑總數為 %{count}。"
+
+msgid "There are no players on the map, so no one can own this object."
+msgstr "地圖上沒有玩家，因此無人可擁有此物件。"
+
+msgid "Roads"
+msgstr "道路"
+
+msgid "Streams"
+msgstr "溪流"
+
+msgid ""
+"A maximum of %{count} heroes including jailed heroes can be placed on the "
+"map."
+msgstr ""
+"地圖上最多可放置 %{count} 位英雄（含被囚禁的英雄）。"
+
+msgid ""
+"A maximum of %{count} heroes of the same color can be placed on the map."
+msgstr ""
+"地圖上最多可放置 %{count} 位相同顏色的英雄。"
+
+msgid "Failed to update player information."
+msgstr "更新玩家資訊失敗。"
+
+msgid "Only one Random Ultimate Artifact can be placed on the map."
+msgstr "地圖上只能放置一個隨機終極神器。"
+
+msgid "A maximum of %{count} obelisks can be placed on the map."
+msgstr "地圖上最多可放置 %{count} 座方尖碑。"
+
+msgid "The same object exists on the tile."
+msgstr "此格上已存在相同的物件。"
+
+msgid "The map is corrupted."
+msgstr "地圖已損壞。"
+
+msgid "Unable to locate data directory to save the map."
+msgstr "無法找到儲存地圖的資料目錄。"
+
+msgid "Unable to create a directory to save the map."
+msgstr "無法建立儲存地圖的目錄。"
+
+msgid "Unable to locate a directory to save the map."
+msgstr "無法找到儲存地圖的目錄。"
+
+msgid "Are you sure you want to overwrite the existing map?"
+msgstr "確定要覆寫既有的地圖嗎？"
+
+msgid "Map saved to: "
+msgstr "地圖已儲存至："
+
+msgid "Failed to save the map."
+msgstr "地圖儲存失敗。"
+
+msgid "Used to place %{object}."
+msgstr "用於放置 %{object}。"
+
+msgid "Select object type"
+msgstr "選擇物件類型"
+
+msgid ""
+"Click here to\n"
+"select a monster."
+msgstr ""
+"按此處\n"
+"選擇怪物。"
+
+msgid ""
+"Click here to\n"
+"select another monster."
+msgstr ""
+"按此處\n"
+"選擇另一個怪物。"
+
+msgid "Erase"
+msgstr "清除"
+
+msgid "Mountains"
+msgstr "山脈"
+
+msgid "Rocks"
+msgstr "岩石"
+
+msgid "Trees"
+msgstr "樹木"
+
+msgid "Water Objects"
+msgstr "水域物件"
+
+msgid "Miscellaneous"
+msgstr "雜項"
+
+msgid "Artifacts"
+msgstr "神器"
+
+msgid "Dwellings"
+msgstr "住所"
+
+msgid "Mines"
+msgstr "礦場"
+
+msgid "Power-ups"
+msgstr "增強物件"
+
+msgid "Treasures"
+msgstr "寶藏"
+
+msgid "Heroes"
+msgstr "英雄"
+
+msgid "Towns"
+msgstr "城鎮"
+
+msgid "editorDetailMode|Edit"
+msgstr "編輯"
+
+msgid "editorDetailMode|Move"
+msgstr "移動"
+
+msgid "editorDetailMode|Copy"
+msgstr "複製"
+
+msgid "editorErasure|Mountains"
+msgstr "山脈"
+
+msgid "editorErasure|Rocks"
+msgstr "岩石"
+
+msgid "editorErasure|Trees"
+msgstr "樹木"
+
+msgid "editorErasure|Miscellaneous and Water landscape objects"
+msgstr "雜項與水域地景物件"
+
+msgid "editorErasure|Adventure non pickable objects"
+msgstr "不可拾取的冒險物件"
+
+msgid "editorErasure|Castles"
+msgstr "城堡"
+
+msgid "editorErasure|Adventure pickable objects"
+msgstr "可拾取的冒險物件"
+
+msgid "editorErasure|Monsters"
+msgstr "怪物"
+
+msgid "editorErasure|Heroes"
+msgstr "英雄"
+
+msgid "editorErasure|Roads"
+msgstr "道路"
+
+msgid "editorErasure|Streams"
+msgstr "溪流"
+
+msgid ""
+"Draws terrain in\n"
+"%{size} by %{size} square increments."
+msgstr ""
+"以 %{size} x %{size} 格為單位\n"
+"繪製地形。"
+
+msgid ""
+"Erases objects in\n"
+"%{size} by %{size} square increments."
+msgstr ""
+"以 %{size} x %{size} 格為單位\n"
+"清除物件。"
+
+msgid "Small Brush"
+msgstr "小筆刷"
+
+msgid "Medium Brush"
+msgstr "中筆刷"
+
+msgid "Large Brush"
+msgstr "大筆刷"
+
+msgid "Area Fill"
+msgstr "區域填充"
+
+msgid "Used to click and drag for filling in large areas."
+msgstr "按住並拖曳以填充大範圍區域。"
+
+msgid "Clear Area"
+msgstr "清除區域"
+
+msgid "Used to click and drag for clearing large areas."
+msgstr "按住並拖曳以清除大範圍區域。"
+
+msgid ""
+"Costs %{rate} times normal movement for all heroes. (Pathfinding reduces or "
+"eliminates the penalty.)"
+msgstr ""
+"所有英雄經過時需消耗正常移動力的 %{rate} 倍。（尋路技能可降低或消除此懲罰。）"
+
+msgid "Traversable only by boat."
+msgstr "只能以船隻通行。"
+
+msgid "No special modifiers."
+msgstr "無特殊修飾。"
+
+msgid "Edit objects on the Adventure Map."
+msgstr "編輯冒險地圖上的物件。"
+
+msgid "Move objects on the Adventure Map."
+msgstr "移動冒險地圖上的物件。"
+
+msgid "Copy objects on the Adventure Map."
+msgstr "複製冒險地圖上的物件。"
+
+msgid "Toggle the erasure of %{type} objects."
+msgstr "切換 %{type} 物件的清除。"
+
+msgid ""
+"Objects of this type will be deleted with the Erase tool. Left-click here to "
+"deselect this type. Press and hold this button to deselect all other object "
+"types."
+msgstr ""
+"此類型的物件將被清除工具刪除。左鍵按一下此處取消選取此類型。長按此按鈕取消選"
+"取所有其他物件類型。"
+
+msgid ""
+"Objects of this type will NOT be deleted with the Erase tool. Left-click "
+"here to select this type. Press and hold this button to select all other "
+"object types."
+msgstr ""
+"此類型的物件不會被清除工具刪除。左鍵按一下此處選取此類型。長按此按鈕選取所有"
+"其他物件類型。"
+
+msgid "Terrain Mode"
+msgstr "地形模式"
+
+msgid "Used to draw the underlying grass, dirt, water, etc. on the map."
+msgstr "用於在地圖上繪製草地、泥土、水域等基礎地形。"
+
+msgid "Landscape Objects Mode"
+msgstr "地景物件模式"
+
+msgid ""
+"Used to place landscape objects (mountains, rocks, trees, etc.) on the map."
+msgstr ""
+"用於在地圖上放置地景物件（山脈、岩石、樹木等）。"
+
+msgid "Detail Mode"
+msgstr "細節模式"
+
+msgid "Used for moving or customizing objects."
+msgstr "用於移動或自訂物件。"
+
+msgid "Adventure Objects Mode"
+msgstr "冒險物件模式"
+
+msgid ""
+"Used to place adventure objects (artifacts, dwellings, mines, treasures, "
+"etc.) on the map."
+msgstr ""
+"用於在地圖上放置冒險物件（神器、住所、礦場、寶藏等）。"
+
+msgid "Kingdom Objects Mode"
+msgstr "王國物件模式"
+
+msgid "Used to place kingdom objects (towns, castles and heroes) on the map."
+msgstr "用於在地圖上放置王國物件 (城鎮、城堡和英雄)。"
+
+msgid "Monsters Mode"
+msgstr "怪物模式"
+
+msgid "Used to place monsters on the map."
+msgstr "用於在地圖上放置怪物。"
+
+msgid "Allows you to draw streams by clicking and dragging."
+msgstr "按住並拖曳以繪製溪流。"
+
+msgid "Stream Mode"
+msgstr "溪流模式"
+
+msgid "Allows you to draw roads by clicking and dragging."
+msgstr "按住並拖曳以繪製道路。"
+
+msgid "Road Mode"
+msgstr "道路模式"
+
+msgid "Erase Mode"
+msgstr "清除模式"
+
+msgid "Used to erase objects from the map."
+msgstr "用於清除地圖上的物件。"
+
+msgid "Change between zoom and normal view."
+msgstr "切換縮放與正常檢視。"
+
+msgid "Magnify"
+msgstr "放大"
+
+msgid "Undo"
+msgstr "復原"
+
+msgid "Undo your last action."
+msgstr "復原上一個動作。"
+
+msgid "Redo"
+msgstr "重做"
+
+msgid "Redo the last undone action."
+msgstr "重做上一個復原的動作。"
+
+msgid "Edit map title, description, and other general information."
+msgstr "編輯地圖示題、描述和其他一般資訊。"
+
+msgid "Specifications"
+msgstr "規格"
+
+msgid "File Options"
+msgstr "檔案選項"
+
+msgid ""
+"Open the file options menu, where you can save or load maps, or quit out of "
+"the editor."
+msgstr ""
+"開啟檔案選項選單，可儲存或載入地圖，或離開編輯器。"
+
+msgid "View the editor system options, which let you customize the editor."
+msgstr "檢視編輯器系統選項，可自訂編輯器。"
+
+msgid "Supported languages:"
+msgstr "支援的語言："
+
+msgid "Language"
+msgstr "語言"
+
+msgid "This language already exists in the list."
+msgstr "此語言已存在於列表中。"
+
+msgid "A map should have at least one language."
+msgstr "地圖至少應有一種語言。"
+
+msgid "Click to apply changes."
+msgstr "按一下套用變更。"
+
+msgid "Add Language"
+msgstr "新增語言"
+
+msgid "Add an additional language."
+msgstr "新增額外的語言。"
+
+msgid "Delete Language"
+msgstr "刪除語言"
+
+msgid "Delete an existing language."
+msgstr "刪除既有的語言。"
+
+msgid "Failed to generate a random map with given parameters."
+msgstr "無法以指定參數產生隨機地圖。"
+
+msgid ""
+"Create a new map, either from scratch or using the random map generator."
+msgstr ""
+"建立新地圖，可從頭開始或使用隨機地圖產生器。"
+
+msgid "Exit the Editor and return to the game's Main Menu."
+msgstr "離開編輯器並返回遊戲主選單。"
+
+msgid "From Scratch"
+msgstr "從頭開始"
+
+msgid "Start from scratch with a blank map."
+msgstr "從空白地圖開始。"
+
+msgid "Create a randomly generated map."
+msgstr "建立隨機產生的地圖。"
+
+msgid "Random"
+msgstr "隨機"
+
+msgid "Back"
+msgstr "返回"
+
+msgid "Return to the Editor's main menu options."
+msgstr "返回編輯器主選單。"
+
+msgid ""
+"Generate a random map that is %{size} squares wide and %{size} squares high."
+msgstr ""
+"產生一張 %{size} x %{size} 格的隨機地圖。"
+
+msgid "Create a map that is %{size} squares wide and %{size} squares high."
+msgstr "建立一張 %{size} x %{size} 格的地圖。"
+
+msgid "Return to the previous menu options."
+msgstr "返回上一個選單。"
+
+msgid "No maps available!"
+msgstr "沒有可用的地圖！"
+
+msgid "[%{pos}]: %{race} hero"
+msgstr "[%{pos}]: %{race} 英雄"
+
+msgid "[%{pos}]: %{name}, %{race} hero"
+msgstr "[%{pos}]: %{name}，%{race} 英雄"
+
+msgid "[%{pos}]: %{race} castle"
+msgstr "[%{pos}]: %{race} 城堡"
+
+msgid "[%{pos}]: %{race} town"
+msgstr "[%{pos}]: %{race} 城鎮"
+
+msgid "[%{pos}]: %{name}, %{race} castle"
+msgstr "[%{pos}]: %{name}，%{race} 城堡"
+
+msgid "[%{pos}]: %{name}, %{race} town"
+msgstr "[%{pos}]: %{name}，%{race} 城鎮"
+
+msgid "None."
+msgstr "無。"
+
+msgid "One side defeats the other."
+msgstr "一方擊敗另一方。"
+
+msgid "Accumulate gold."
+msgstr "累積黃金。"
+
+msgid "Run out of time."
+msgstr "時間耗盡。"
+
+msgid "alliance|1st"
+msgstr "第一"
+
+msgid "alliance|2nd"
+msgstr "第二"
+
+msgid "alliance|3rd"
+msgstr "第三"
+
+msgid "alliance|4th"
+msgstr "第四"
+
+msgid "alliance|5th"
+msgstr "第五"
+
+msgid "Special Loss Condition"
+msgstr "特殊失敗條件"
+
+msgid "Special Victory Condition"
+msgstr "特殊勝利條件"
+
+msgid "Allow standard victory conditions"
+msgstr "允許標準勝利條件"
+
+msgid "Allow this condition also for AI"
+msgstr "同時允許 AI 使用此條件"
+
+msgid "Set alliances:"
+msgstr "設定聯盟："
+
+msgid "{%number} alliance: "
+msgstr "第 {%number} 聯盟："
+
+msgid "Gold:"
+msgstr "黃金："
+
+msgid "Select a Town to capture to achieve victory"
+msgstr "選擇要佔領以獲勝的城鎮"
+
+msgid "Click here to change the town needed to capture to achieve victory."
+msgstr "按此處變更需要佔領以獲勝的城鎮。"
+
+msgid "Select a Hero to defeat to achieve victory"
+msgstr "選擇要擊敗以獲勝的英雄"
+
+msgid "Click here to change the hero needed to defeat to achieve victory."
+msgstr "按此處變更需要擊敗以獲勝的英雄。"
+
+msgid "Put %{color} player in the %{alliance} alliance"
+msgstr "將 %{color} 玩家加入第 %{alliance} 聯盟"
+
+msgid ""
+"If this checkbox is checked, the %{color} player will be in the %{alliance} "
+"alliance."
+msgstr ""
+"勾選此選項後，%{color} 玩家將加入第 %{alliance} 聯盟。"
+
+msgid "Days:"
+msgstr "天數："
+
+msgid "Select a Town to lose to suffer defeat"
+msgstr "選擇失去即落敗的城鎮"
+
+msgid "Click here to change the town whose loss would mean defeat."
+msgstr "按此處變更失去即落敗的城鎮。"
+
+msgid "Select a Hero to lose to suffer defeat"
+msgstr "選擇失去即落敗的英雄"
+
+msgid "Click here to change the hero whose loss would mean defeat."
+msgstr "按此處變更失去即落敗的英雄。"
+
+msgid "Map Difficulty"
+msgstr "地圖難度"
+
+msgid "RUMORS"
+msgstr "謠言"
+
+msgid "EVENTS"
+msgstr "事件"
+
+msgid "LANGUAGE"
+msgstr "語言"
+
+msgid "map|ABOUT"
+msgstr "關於"
+
+msgid "Change Map Name:"
+msgstr "變更地圖名稱："
+
+msgid "Change Map Description:"
+msgstr "變更地圖描述："
+
+msgid "map|About"
+msgstr "關於"
+
+msgid "Click to edit custom rumors."
+msgstr "按一下編輯自訂謠言。"
+
+msgid "Rumors"
+msgstr "謠言"
+
+msgid "Click to edit daily events."
+msgstr "按一下編輯每日事件。"
+
+msgid "Events"
+msgstr "事件"
+
+msgid "Click to change the language of the map."
+msgstr "按一下變更地圖語言。"
+
+msgid ""
+"Click to edit notes from the map creator. These notes are optional and do "
+"not appear during gameplay."
+msgstr ""
+"按一下編輯地圖製作者備註。此備註為選填，不會在遊玩時顯示。"
+
+msgid "Click to change your map name."
+msgstr "按一下變更地圖名稱。"
+
+msgid "Map Name"
+msgstr "地圖名稱"
+
+msgid "Click to change the description of the current map."
+msgstr "按一下變更目前地圖的描述。"
+
+msgid "Click to change the victory condition of the current map."
+msgstr "按一下變更目前地圖的勝利條件。"
+
+msgid "Click to change the loss condition of the current map."
+msgstr "按一下變更目前地圖的失敗條件。"
+
+msgid "Indicates the player types in the scenario. Click to change."
+msgstr "顯示場景中的玩家類型。按一下可變更。"
+
+msgid "Player Type"
+msgstr "玩家類型"
+
+msgid ""
+"Click to set map difficulty. More difficult maps might include more or "
+"stronger enemies, fewer resources, or other special conditions making things "
+"tougher for the human player."
+msgstr ""
+"按一下設定地圖難度。地圖難度越高，敵人可能越多或越強、資源越少，或出現其他對"
+"人類玩家不利的特殊條件。"
+
+msgid ""
+"editor|%{object}\n"
+"(%{color} player)"
+msgstr ""
+"%{object}\n"
+"(%{color}玩家)"
+
+msgid "editor|%{count} %{resource}"
+msgstr "%{count} %{resource}"
+
+msgid "Animation"
+msgstr "動畫"
+
+msgid "Passability"
+msgstr "通行性"
+
+msgid "Toggle animation of the objects."
+msgstr "切換物件的動畫。"
+
+msgid "Toggle display of objects' passability."
+msgstr "切換物件通行性的顯示。"
+
+msgid "Rumors:"
+msgstr "謠言："
+
+msgid "Rumor:"
+msgstr "謠言："
+
+msgid "Rumor"
+msgstr "謠言"
+
+msgid "This rumor already exists in the list."
+msgstr "此謠言已存在於列表中。"
+
+msgid "Click to save the rumors."
+msgstr "按一下儲存謠言。"
+
+msgid "Add Rumor"
+msgstr "新增謠言"
+
+msgid "Add an additional rumor."
+msgstr "新增額外的謠言。"
+
+msgid "Edit Rumor"
+msgstr "編輯謠言"
+
+msgid "Edit an existing rumor."
+msgstr "編輯既有的謠言。"
+
+msgid "Delete Rumor"
+msgstr "刪除謠言"
+
+msgid "Delete an existing rumor."
+msgstr "刪除既有的謠言。"
+
+msgid ""
+"\n"
+"\n"
+"Language:\n"
+msgstr ""
+"\n"
+"\n"
+"語言:\n"
+
+msgid ""
+"\n"
+"\n"
+"Size: "
+msgstr ""
+"\n"
+"\n"
+"大小："
+
+msgid ""
+"\n"
+"\n"
+"Description: "
+msgstr ""
+"\n"
+"\n"
+"描述："
+
+msgid "Save Map:"
+msgstr "儲存地圖："
+
+msgid "Click to save the current map."
+msgstr "按一下儲存目前的地圖。"
+
+msgid "Click to enable all secondary skills."
+msgstr "按一下啟用所有次要技能。"
+
+msgid "Enable All Secondary Skills"
+msgstr "啟用所有次要技能"
+
+msgid "Click to disable all secondary skills."
+msgstr "按一下停用所有次要技能。"
+
+msgid "Disable All Secondary Skills"
+msgstr "停用所有次要技能"
+
+msgid "Click to show only level %{level} spells."
+msgstr "按一下僅顯示等級 %{level} 法術。"
+
+msgid "Spells level"
+msgstr "法術等級"
+
+msgid "Click to enable all spells."
+msgstr "按一下啟用所有法術。"
+
+msgid "Enable All Spells"
+msgstr "啟用所有法術"
+
+msgid "Click to disable all spells."
+msgstr "按一下停用所有法術。"
+
+msgid "Disable All Spells"
+msgstr "停用所有法術"
+
+msgid "Riddle:"
+msgstr "謎語："
+
+msgid "Answers:"
+msgstr "答案："
+
+msgid "Answer:"
+msgstr "答案："
+
+msgid "Answer"
+msgstr "答案"
+
+msgid "This answer exists in the list."
+msgstr "此答案已存在於列表中。"
+
+msgid "Click to save the Sphinx properties."
+msgstr "按一下儲存人面獅身像屬性。"
+
+msgid "Add Answer"
+msgstr "新增答案"
+
+msgid "Add an additional answer for the question."
+msgstr "為問題新增額外的答案。"
+
+msgid "Edit Answer"
+msgstr "編輯答案"
+
+msgid "Edit an existing answer for the question."
+msgstr "編輯既有的答案。"
+
+msgid "Delete Answer"
+msgstr "刪除答案"
+
+msgid "Delete an existing answer for the question."
+msgstr "刪除既有的答案。"
+
+msgid "Riddle"
+msgstr "謎語"
+
+msgid "No artifact will be given as a reward."
+msgstr "不會給予任何神器作為獎勵。"
+
+msgid "Delete an artifact from the reward."
+msgstr "從獎勵中刪除神器。"
+
+msgid "Day: %{day} Week: %{week} Month: %{month}"
+msgstr "日：%{day} 週：%{week} 月：%{month}"
+
+msgid "difficulty|Easy"
+msgstr "簡單"
+
+msgid "difficulty|Normal"
+msgstr "普通"
+
+msgid "difficulty|Hard"
+msgstr "困難"
+
+msgid "difficulty|Expert"
+msgstr "專家"
+
+msgid "difficulty|Impossible"
+msgstr "不可能"
+
+msgid "and more..."
+msgstr "以及更多……"
+
+msgid "Easy"
+msgstr "簡單"
+
+msgid "Normal"
+msgstr "普通"
+
+msgid "Hard"
+msgstr "困難"
+
+msgid "Campaign Difficulty"
+msgstr "戰役難度"
+
+msgid ""
+"Choose this difficulty to experience the game's story with less challenge. "
+"The AI will be weaker than at Normal difficulty."
+msgstr ""
+"選擇此難度以較輕鬆的方式體驗遊戲劇情。AI 將比普通難度更弱。"
+
+msgid ""
+"Choose this difficulty to experience the campaign as per the original design."
+msgstr ""
+"選擇此難度以原始設計體驗戰役。"
+
+msgid ""
+"Choose this difficulty if you want more challenge. The AI will be stronger "
+"than at Normal difficulty."
+msgstr ""
+"想要更多挑戰時，請選擇此難度。AI 會比普通難度更強。"
+
+msgid ""
+"Congratulations!\n"
+"\n"
+"Days: %{days}\n"
+msgstr ""
+"恭喜！\n"
+"\n"
+"天數：%{days}\n"
+
+msgid ""
+"\n"
+"Difficulty: %{difficulty}\n"
+"\n"
+msgstr ""
+"\n"
+"難度：%{difficulty}\n"
+"\n"
+
+msgid ""
+"Score: %{score}\n"
+"\n"
+"Rating:\n"
+"%{rating}"
+msgstr ""
+"分數：%{score}\n"
+"\n"
+"評價:\n"
+"%{rating}"
+
+msgid "Start the selected scenario."
+msgstr "開始選取的場景。"
+
+msgid "View Intro"
+msgstr "觀看序幕"
+
+msgid "View the intro video for the current state of the campaign."
+msgstr "觀看目前戰役狀態的序幕影片。"
+
+msgid ""
+"Select the campaign difficulty. This can be changed at any point during the "
+"campaign. However, the final score will be calculated based solely on the "
+"lowest difficulty of a completed scenario during the campaign."
+msgstr ""
+"選擇戰役難度。可在戰役中隨時變更。但最終分數將僅依據戰役中已完成場景的最低難"
+"度計算。"
+
+msgid "Restart the current scenario."
+msgstr "重新開始目前的場景。"
+
+msgid "Difficulty"
+msgstr "難度"
+
+msgid ""
+"You have changed the campaign difficulty. The final high score will be "
+"calculated based solely on the lowest difficulty level for a completed "
+"scenario during the campaign. Do you want to proceed?"
+msgstr ""
+"你已變更了戰役難度。最終最高分將僅依據戰役中已完成場景的最低難度等級計算。確"
+"定要繼續嗎？"
+
+msgid "Are you sure you want to restart this scenario?"
+msgstr "確定要重新開始此場景嗎？"
+
+msgid "Campaign Scenario loading failure"
+msgstr "戰役場景載入失敗"
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr "請確認戰役檔案正確且存在。"
+
+msgid "Days spent"
+msgstr "所花天數"
+
+msgid "The number of days spent on this campaign."
+msgstr "在此戰役所花費的天數。"
+
+msgid "Scenario Title"
+msgstr "場景標題"
+
+msgid "Project Coordination and Core Development"
+msgstr "專案統籌與核心開發"
+
+msgid "Development"
+msgstr "開發"
+
+msgid "Visit us at"
+msgstr "造訪我們"
+
+msgid "QA and Support"
+msgstr "品質保證與技術支援"
+
+msgid "Dev and Support"
+msgstr "開發與技術支援"
+
+msgid "Special Thanks to"
+msgstr "特別感謝"
+
+msgid "and all the people who have helped make the project possible!"
+msgstr "以及所有協助讓這個專案成真的人們！"
+
+msgid "Support us at"
+msgstr "贊助我們"
+
+msgid "local-donation-platform|https://www.patreon.com/fheroes2"
+msgstr "https://www.patreon.com/fheroes2"
+
+msgid "Connect with us at"
+msgstr "聯絡我們"
+
+msgid "local-social-network|https://www.facebook.com/groups/fheroes2"
+msgstr "https://www.facebook.com/groups/fheroes2"
+
+msgid "Need help with the game?"
+msgstr "需要遊戲協助嗎？"
+
+msgid "Original project before 0.7"
+msgstr "0.7 版之前的原始專案"
+
+msgid "Heroes of Might and Magic II: The Succession Wars team"
+msgstr "Heroes of Might and Magic II: The Succession Wars 團隊"
+
+msgid "Designed and Directed"
+msgstr "設計與監製"
+
+msgid "Programming and Design"
+msgstr "程式設計與設計"
+
+msgid "Executive Producer"
+msgstr "執行製作人"
+
+msgid "Producer"
+msgstr "製作人"
+
+msgid "Additional Design"
+msgstr "額周邊裝置計"
+
+msgid "Additional Programming"
+msgstr "額外程式設計"
+
+msgid "Musical Production"
+msgstr "音樂製作"
+
+msgid "Music and Sound Design"
+msgstr "音樂與聲音設計"
+
+msgid "Vocalists"
+msgstr "歌手"
+
+msgid "Art Director"
+msgstr "藝術總監"
+
+msgid "Assistant Art Director"
+msgstr "助理藝術總監"
+
+msgid "Artists"
+msgstr "美術設計師"
+
+msgid "QA Manager"
+msgstr "品質保證經理"
+
+msgid "QA"
+msgstr "品質保證"
+
+msgid "Writing"
+msgstr "文案撰寫"
+
+msgid "Manual and Helpfile"
+msgstr "手冊與說明檔"
+
+msgid "Scenarios"
+msgstr "場景設計"
+
+msgid "Heroes of Might and Magic II: The Price of Loyalty team"
+msgstr "Heroes of Might and Magic II: The Price of Loyalty 團隊"
+
+msgid "Design Lead"
+msgstr "首席設計師"
+
+msgid "Designers"
+msgstr "設計師"
+
+msgid "Programming Lead"
+msgstr "首席程式設計師"
+
+msgid "Art Lead"
+msgstr "首席美術設計師"
+
+msgid "Playtesters"
+msgstr "遊戲測試員"
+
+msgid "Designer"
+msgstr "設計師"
+
+msgid "Producers"
+msgstr "製作人"
+
+msgid "QA Managers"
+msgstr "品質保證經理"
+
+msgid "Sound Design"
+msgstr "聲音設計"
+
+msgid "Town Themes"
+msgstr "城鎮主題音樂"
+
+msgid "Alto Sax"
+msgstr "中音薩克斯風"
+
+msgid "Harpsichord and Piano"
+msgstr "大鍵琴與鋼琴"
+
+msgid "Basso Vocal"
+msgstr "低音聲樂"
+
+msgid "Soprano Vocal"
+msgstr "女高音聲樂"
+
+msgid "Recorded at %{recordingStudio}"
+msgstr "錄製於 %{recordingStudio}"
+
+msgid "credits|Manual"
+msgstr "手冊"
+
+msgid "German Consultant"
+msgstr "德文顧問"
+
+msgid "Map Designers"
+msgstr "地圖設計師"
+
+msgid "Package Design"
+msgstr "包裝設計"
+
+msgid "To exit fheroes2, press the Home button or swipe up."
+msgstr "若要離開 fheroes2，請按主畫面按鈕或向上滑動。"
+
+msgid "Are you sure you want to quit?"
+msgstr "確定要結束嗎？"
+
+msgid "High Scores"
+msgstr "最高分"
+
+msgid "Your Name"
+msgstr "你的名稱"
+
+msgid "Unknown Hero"
+msgstr "無名英雄"
+
+msgid "Standard"
+msgstr "標準"
+
+msgid "View High Scores for Standard Maps."
+msgstr "檢視標準地圖的最高分排行榜。"
+
+msgid "Campaign"
+msgstr "戰役"
+
+msgid "View High Scores for Campaigns."
+msgstr "檢視戰役的最高分排行榜。"
+
+msgid "hotkey|default okay event"
+msgstr "預設確認事件"
+
+msgid "hotkey|default cancel event"
+msgstr "預設取消事件"
+
+msgid "hotkey|default left"
+msgstr "預設向左"
+
+msgid "hotkey|default right"
+msgstr "預設向右"
+
+msgid "hotkey|default up"
+msgstr "預設向上"
+
+msgid "hotkey|default down"
+msgstr "預設向下"
+
+msgid "hotkey|toggle fullscreen"
+msgstr "切換全螢幕"
+
+msgid "hotkey|toggle text support mode"
+msgstr "切換文字輔助模式"
+
+msgid "hotkey|toggle developer mode"
+msgstr "切換開發者模式"
+
+msgid "hotkey|quit"
+msgstr "結束"
+
+msgid "hotkey|new game"
+msgstr "新遊戲"
+
+msgid "hotkey|load game"
+msgstr "載入遊戲"
+
+msgid "hotkey|high scores"
+msgstr "最高分"
+
+msgid "hotkey|credits"
+msgstr "製作名單"
+
+msgid "hotkey|standard game"
+msgstr "標準遊戲"
+
+msgid "hotkey|campaign game"
+msgstr "戰役遊戲"
+
+msgid "hotkey|multi-player game"
+msgstr "多人遊戲"
+
+msgid "hotkey|settings"
+msgstr "設定"
+
+msgid "hotkey|select map"
+msgstr "選擇地圖"
+
+msgid "hotkey|select small map size"
+msgstr "選擇小型地圖"
+
+msgid "hotkey|select medium map size"
+msgstr "選擇中型地圖"
+
+msgid "hotkey|select large map size"
+msgstr "選擇大型地圖"
+
+msgid "hotkey|select extra large map size"
+msgstr "選擇超大型地圖"
+
+msgid "hotkey|select all map sizes"
+msgstr "選擇所有地圖大小"
+
+msgid "hotkey|hot seat game"
+msgstr "熱座遊戲"
+
+msgid "hotkey|battle only game"
+msgstr "僅限戰鬥遊戲"
+
+msgid "hotkey|choose the original campaign"
+msgstr "選擇原版戰役"
+
+msgid "hotkey|choose the expansion campaign"
+msgstr "選擇資料片戰役"
+
+msgid "hotkey|map editor main menu"
+msgstr "地圖編輯器主選單"
+
+msgid "hotkey|new map menu"
+msgstr "新地圖選單"
+
+msgid "hotkey|load map menu"
+msgstr "載入地圖選單"
+
+msgid "hotkey|new map from scratch"
+msgstr "從頭建立新地圖"
+
+msgid "hotkey|new random map"
+msgstr "新隨機地圖"
+
+msgid "hotkey|undo last action"
+msgstr "復原上一個動作"
+
+msgid "hotkey|redo last action"
+msgstr "重做上一個動作"
+
+msgid "hotkey|open game main menu"
+msgstr "開啟遊戲主選單"
+
+msgid "hotkey|toggle passability"
+msgstr "切換通行性"
+
+msgid "hotkey|re-generate random map"
+msgstr "重新產生隨機地圖"
+
+msgid "hotkey|re-configure random map"
+msgstr "重新設定隨機地圖"
+
+msgid "hotkey|output all text"
+msgstr "輸出所有文字"
+
+msgid "hotkey|roland campaign"
+msgstr "Roland 戰役"
+
+msgid "hotkey|archibald campaign"
+msgstr "Archibald 戰役"
+
+msgid "hotkey|price of loyalty campaign"
+msgstr "忠誠的代價戰役"
+
+msgid "hotkey|voyage home campaign"
+msgstr "歸鄉之旅戰役"
+
+msgid "hotkey|wizard's isle campaign"
+msgstr "巫師之島戰役"
+
+msgid "hotkey|descendants campaign"
+msgstr "後裔戰役"
+
+msgid "hotkey|select first campaign bonus"
+msgstr "選擇第一項戰役獎勵"
+
+msgid "hotkey|select second campaign bonus"
+msgstr "選擇第二項戰役獎勵"
+
+msgid "hotkey|select third campaign bonus"
+msgstr "選擇第三項戰役獎勵"
+
+msgid "hotkey|view campaign intro"
+msgstr "觀看戰役序幕"
+
+msgid "hotkey|select campaign difficulty"
+msgstr "選擇戰役難度"
+
+msgid "hotkey|restart campaign scenario"
+msgstr "重新開始戰役場景"
+
+msgid "hotkey|world map left"
+msgstr "世界地圖向左"
+
+msgid "hotkey|world map right"
+msgstr "世界地圖向右"
+
+msgid "hotkey|world map up"
+msgstr "世界地圖向上"
+
+msgid "hotkey|world map down"
+msgstr "世界地圖向下"
+
+msgid "hotkey|world map up left"
+msgstr "世界地圖左上"
+
+msgid "hotkey|world map up right"
+msgstr "世界地圖右上"
+
+msgid "hotkey|world map down left"
+msgstr "世界地圖左下"
+
+msgid "hotkey|world map down right"
+msgstr "世界地圖右下"
+
+msgid "hotkey|save game"
+msgstr "儲存遊戲"
+
+msgid "hotkey|quick save"
+msgstr "快速存檔"
+
+msgid "hotkey|next hero"
+msgstr "下一位英雄"
+
+msgid "hotkey|change to hero under cursor"
+msgstr "切換至游標下的英雄"
+
+msgid "hotkey|hold and left click to move hero portrait to top of list"
+msgstr "按住並左鍵按一下以將英雄肖像移至列表頂端"
+
+msgid "hotkey|start hero movement"
+msgstr "開始英雄移動"
+
+msgid "hotkey|cast adventure spell"
+msgstr "施放冒險法術"
+
+msgid "hotkey|put hero to sleep"
+msgstr "讓英雄休息"
+
+msgid "hotkey|next town"
+msgstr "下一座城鎮"
+
+msgid "hotkey|end turn"
+msgstr "結束回合"
+
+msgid "hotkey|file options"
+msgstr "檔案選項"
+
+msgid "hotkey|adventure options"
+msgstr "冒險選項"
+
+msgid "hotkey|puzzle map"
+msgstr "拼圖地圖"
+
+msgid "hotkey|scenario information"
+msgstr "場景資訊"
+
+msgid "hotkey|dig for artifact"
+msgstr "挖掘神器"
+
+msgid "hotkey|view world"
+msgstr "檢視世界"
+
+msgid "hotkey|kingdom summary"
+msgstr "王國摘要"
+
+msgid "hotkey|default action"
+msgstr "預設動作"
+
+msgid "hotkey|open focus"
+msgstr "開啟焦點"
+
+msgid "hotkey|system options"
+msgstr "系統選項"
+
+msgid "hotkey|scroll left"
+msgstr "向左捲動"
+
+msgid "hotkey|scroll right"
+msgstr "向右捲動"
+
+msgid "hotkey|scroll up"
+msgstr "向上捲動"
+
+msgid "hotkey|scroll down"
+msgstr "向下捲動"
+
+msgid "hotkey|toggle control panel"
+msgstr "切換控制台"
+
+msgid "hotkey|toggle radar"
+msgstr "切換雷達"
+
+msgid "hotkey|toggle buttons"
+msgstr "切換按鈕"
+
+msgid "hotkey|toggle status"
+msgstr "切換狀態"
+
+msgid "hotkey|toggle icons"
+msgstr "切換圖示"
+
+msgid "hotkey|transfer control to ai"
+msgstr "將控制權移轉給 AI"
+
+msgid "hotkey|retreat from battle"
+msgstr "從戰鬥中撤退"
+
+msgid "hotkey|surrender during battle"
+msgstr "在戰鬥中投降"
+
+msgid "hotkey|toggle auto combat mode"
+msgstr "切換自動戰鬥模式"
+
+msgid "hotkey|quick combat"
+msgstr "快速戰鬥"
+
+msgid "hotkey|battle options"
+msgstr "戰鬥選項"
+
+msgid "hotkey|skip turn in battle"
+msgstr "在戰鬥中略過回合"
+
+msgid "hotkey|cast battle spell"
+msgstr "施放戰鬥法術"
+
+msgid "hotkey|toggle display of battle turn order"
+msgstr "切換戰鬥行動順序顯示"
+
+msgid "hotkey|dwelling level 1"
+msgstr "住所等級 1"
+
+msgid "hotkey|dwelling level 2"
+msgstr "住所等級 2"
+
+msgid "hotkey|dwelling level 3"
+msgstr "住所等級 3"
+
+msgid "hotkey|dwelling level 4"
+msgstr "住所等級 4"
+
+msgid "hotkey|dwelling level 5"
+msgstr "住所等級 5"
+
+msgid "hotkey|dwelling level 6"
+msgstr "住所等級 6"
+
+msgid "hotkey|well"
+msgstr "水井"
+
+msgid "hotkey|marketplace"
+msgstr "市場"
+
+msgid "hotkey|mage guild"
+msgstr "法師公會"
+
+msgid "hotkey|shipyard"
+msgstr "造船廠"
+
+msgid "hotkey|thieves guild"
+msgstr "盜賊公會"
+
+msgid "hotkey|tavern"
+msgstr "酒館"
+
+msgid "hotkey|construction screen"
+msgstr "建造畫面"
+
+msgid "hotkey|buy all monsters in well"
+msgstr "從水井購買所有怪物"
+
+msgid "hotkey|merge troops with hero"
+msgstr "合併部隊至英雄"
+
+msgid "hotkey|merge troops with garrison"
+msgstr "合併部隊至城防"
+
+msgid "hotkey|split stack by half"
+msgstr "將部隊分為一半"
+
+msgid "hotkey|split stack by one"
+msgstr "將部隊分出一個"
+
+msgid "hotkey|join stacks"
+msgstr "合併部隊"
+
+msgid "hotkey|upgrade troop"
+msgstr "升級部隊"
+
+msgid "hotkey|dismiss hero or troop"
+msgstr "解散英雄或部隊"
+
+msgid "hotkey|exchange all troops"
+msgstr "交換所有部隊"
+
+msgid ""
+"Do you want to regain control from AI? The effect will take place only on "
+"the next turn."
+msgstr ""
+"確定要從 AI 奪回控制權嗎？效果將在下一回合生效。"
+
+msgid ""
+"Do you want to transfer control from you to the AI? The effect will take "
+"place only on the next turn."
+msgstr ""
+"確定要將控制權移轉給 AI 嗎？效果將在下一回合生效。"
+
+msgid "Default Actions"
+msgstr "預設操作"
+
+msgid "Global Actions"
+msgstr "全域操作"
+
+msgid "World Map"
+msgstr "世界地圖"
+
+msgid "Battle Screen"
+msgstr "戰鬥畫面"
+
+msgid "Town Screen"
+msgstr "城鎮畫面"
+
+msgid "Army Actions"
+msgstr "軍隊操作"
+
+msgid "The save file is corrupted."
+msgstr "存檔已損壞。"
+
+msgid "Unsupported save format: "
+msgstr "不支援的存檔格式："
+
+msgid "Current game version: "
+msgstr "目前遊戲版本："
+
+msgid "Last supported version: "
+msgstr "最後支援的版本："
+
+msgid "This file contains a save with an invalid game type."
+msgstr "此檔案包含無效遊戲類型的存檔。"
+
+msgid ""
+"This save file requires \"The Price of Loyalty\" game assets, but they have "
+"not been provided to the engine."
+msgstr ""
+"此存檔需要「The Price of Loyalty」遊戲資源，但尚未提供給引擎。"
+
+msgid "This saved game is localized to '"
+msgstr "此存檔的語系為「"
+
+msgid "' language, but the current language of the game is '"
+msgstr "」，但目前遊戲的語言為「"
+
+msgid "No save files to load."
+msgstr "沒有可載入的存檔。"
+
+msgid "A single player game playing out a single map."
+msgstr "在單一地圖上進行的單人遊戲。"
+
+msgid "Standard Game"
+msgstr "標準遊戲"
+
+msgid "A single player game playing through a series of maps."
+msgstr "依序遊玩一系列地圖的單人遊戲。"
+
+msgid "Campaign Game"
+msgstr "戰役遊戲"
+
+msgid "Multi-Player Game"
+msgstr "多人遊戲"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+"多人遊戲，多位人類玩家在同一張地圖上彼此競爭。"
+
+msgid "Hot Seat"
+msgstr "熱座模式"
+
+msgid ""
+"Play a Hot Seat game, where 2 to 6 players play around the same computer, "
+"switching into the 'Hot Seat' when it is their turn."
+msgstr ""
+"進行熱座遊戲，2 至 6 位玩家在同一台電腦上輪流遊玩。"
+
+msgid "Cancel back to the main menu."
+msgstr "取消並返回主選單。"
+
+msgid "fheroes2 Resurrection Team presents"
+msgstr "fheroes2 Resurrection Team 獻上"
+
+msgid "Welcome to Heroes of Might and Magic II powered by fheroes2 engine!"
+msgstr "歡迎遊玩由 fheroes2 引擎驅動的 Heroes of Might and Magic II！"
+
+msgid ""
+"\n"
+"\n"
+"To simulate a right-click with a touch to get info on various items, you "
+"need to first touch and keep touching on the item of interest and then touch "
+"anywhere else on the screen. While holding the second finger, you can remove "
+"the first one from the screen and keep viewing the information on the item."
+msgstr ""
+"\n"
+"\n"
+"想以觸控方式模擬右鍵取得各種物件的資訊，請先觸碰並按住想檢視的物件，然後再觸"
+"碰螢幕上的其他位置。按住第二根手指的同時，可以移開第一根手指並繼續檢視該物件"
+"的資訊。"
+
+msgid ""
+"\n"
+"\n"
+"Before starting the game, please select a game resolution."
+msgstr ""
+"\n"
+"\n"
+"開始遊戲前，請先選擇遊戲解析度。"
+
+msgid "Greetings!"
+msgstr "歡迎！"
+
+msgid "Quit Heroes of Might and Magic II and return to the operating system."
+msgstr "結束 Heroes of Might and Magic II 並返回作業系統。"
+
+msgid "Credits"
+msgstr "製作名單"
+
+msgid "View the credits screen."
+msgstr "檢視製作名單。"
+
+msgid "View the high scores screen."
+msgstr "檢視最高分排行榜。"
+
+msgid "Create new or modify existing maps."
+msgstr "建立新地圖或修改既有地圖。"
+
+msgid "Change language, resolution and settings of the game."
+msgstr "變更遊戲的語言、解析度和設定。"
+
+msgid "Game Settings"
+msgstr "遊戲設定"
+
+msgid ""
+"The required video files for the campaign selection window are missing. "
+"Please make sure that all necessary files are present in the system."
+msgstr ""
+"戰役選擇視窗所需的影片檔案遺失，請確認所有必要檔案已存在於系統中。"
+
+msgid "Loading video. Please wait..."
+msgstr "正在載入影片，請稍候……"
+
+msgid ""
+"fheroes2 needs data files from the original Heroes of Might and Magic II to "
+"operate. You appear to be using the demo version of Heroes of Might and "
+"Magic II for this purpose. Please note that only one scenario will be "
+"available in this setup."
+msgstr ""
+"fheroes2 需要原版 Heroes of Might and Magic II 的資料檔案才能執行。你似乎正在"
+"使用 Heroes of Might and Magic II 的試玩版。請注意在此設定下只有一個場景可"
+"用。"
+
+msgid ""
+"A multi-player game, with several human players competing against each other "
+"on a single map."
+msgstr ""
+"多人遊戲，多位人類玩家在同一張地圖上彼此競爭。"
+
+msgid "Setup and play a battle without loading any map."
+msgstr "直接開始一場戰鬥，無須載入地圖。"
+
+msgid "2 Players"
+msgstr "2 位玩家"
+
+msgid ""
+"Play with 2 human players, and optionally, up to 4 additional computer "
+"players."
+msgstr ""
+"以 2 位人類玩家遊玩，可選擇加入最多 4 位電腦玩家。"
+
+msgid "3 Players"
+msgstr "3 位玩家"
+
+msgid ""
+"Play with 3 human players, and optionally, up to 3 additional computer "
+"players."
+msgstr ""
+"以 3 位人類玩家遊玩，可選擇加入最多 3 位電腦玩家。"
+
+msgid "4 Players"
+msgstr "4 位玩家"
+
+msgid ""
+"Play with 4 human players, and optionally, up to 2 additional computer "
+"players."
+msgstr ""
+"以 4 位人類玩家遊玩，可選擇加入最多 2 位電腦玩家。"
+
+msgid "5 Players"
+msgstr "5 位玩家"
+
+msgid ""
+"Play with 5 human players, and optionally, up to 1 additional computer "
+"player."
+msgstr ""
+"以 5 位人類玩家遊玩，可選擇加入最多 1 位電腦玩家。"
+
+msgid "6 Players"
+msgstr "6 位玩家"
+
+msgid "Play with 6 human players."
+msgstr "以 6 位人類玩家遊玩。"
+
+msgid "Original Campaign"
+msgstr "原版戰役"
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+"原版 Heroes of Might and Magic II 中 Roland 或 Archibald 的戰役。"
+
+msgid "Expansion Campaign"
+msgstr "資料片戰役"
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr "Price of Loyalty 資料片中四個新戰役之一。"
+
+msgid ""
+"Play a Hot Seat game, where 2 to 6 players play on the same device, "
+"switching into the 'Hot Seat' when it is their turn."
+msgstr ""
+"進行熱座遊戲，2 至 6 位玩家在同一台裝置上輪流遊玩。"
+
+msgid "Dragon city has fallen! You are now the Master of the Dragons."
+msgstr "龍族之城已經淪陷！你現在是龍族之主了。"
+
+msgid ""
+"You captured %{name}!\n"
+"You are victorious."
+msgstr ""
+"佔領了 %{name}！\n"
+"你獲得了勝利。"
+
+msgid ""
+"You have captured the enemy hero %{name}!\n"
+"Your quest is complete."
+msgstr ""
+"俘獲了敵方英雄 %{name}！\n"
+"任務完成。"
+
+msgid ""
+"You have found the %{name}.\n"
+"Your quest is complete."
+msgstr ""
+"找到了 %{name}。\n"
+"任務完成。"
+
+msgid "Ultimate Artifact"
+msgstr "終極神器"
+
+msgid ""
+"The enemy is beaten.\n"
+"Your side has triumphed!"
+msgstr ""
+"敵人被擊敗了。\n"
+"你方獲得了勝利！"
+
+msgid ""
+"You have built up over %{count} gold in your treasury.\n"
+"All enemies bow before your wealth and power."
+msgstr ""
+"國庫已累積超過 %{count} 金幣。\n"
+"所有敵人在你的財富與力量面前俯首稱臣。"
+
+msgid "Victory!"
+msgstr "勝利！"
+
+msgid ""
+"The enemy has captured %{name}!\n"
+"They are triumphant."
+msgstr ""
+"敵人佔領了 %{name}！\n"
+"他們獲得了勝利。"
+
+msgid ""
+"The enemy has found the %{name}.\n"
+"Your quest is a failure."
+msgstr ""
+"敵人找到了 %{name}。\n"
+"任務失敗。"
+
+msgid ""
+"The enemy has built up over %{count} gold in his treasury.\n"
+"You must bow done in defeat before his wealth and power."
+msgstr ""
+"敵人的國庫已累積超過 %{count} 金幣。\n"
+"你必須在其財富與力量面前認輸。"
+
+msgid "You have been eliminated from the game!!!"
+msgstr "你已被淘汰出局！！！"
+
+msgid ""
+"You have lost the hero %{name}.\n"
+"Your quest is over."
+msgstr ""
+"失去了英雄 %{name}。\n"
+"任務結束。"
+
+msgid ""
+"You have failed to complete your quest in time.\n"
+"All is lost."
+msgstr ""
+"未能在時限內完成任務。\n"
+"一切都完了。"
+
+msgid "Defeat!"
+msgstr "戰敗！"
+
+msgid ""
+"Base score: %{score}\n"
+"Difficulty: %{difficulty}\n"
+"\n"
+msgstr ""
+"基礎分數：%{score}\n"
+"難度：%{difficulty}\n"
+"\n"
+
+msgid "Defeat all enemy heroes and capture all enemy towns and castles."
+msgstr "擊敗所有敵方英雄，並佔領所有敵方城鎮和城堡。"
+
+msgid "Your side defeats the opposing side."
+msgstr "你方擊敗了對方。"
+
+msgid "Run out of time. (Fail to win by a certain point.)"
+msgstr "時間耗盡。(未能在期限前獲勝。)"
+
+msgid "You must defeat the enemy %{enemies}."
+msgid_plural "You must defeat the enemy alliance of %{enemies}."
+msgstr[0] "必須擊敗敵方 %{enemies}。"
+
+msgid ""
+"The alliance consisting of %{allies} and you must defeat the enemy "
+"%{enemies}."
+msgid_plural ""
+"The alliance consisting of %{allies} and you must defeat the enemy alliance "
+"of %{enemies}."
+msgstr[0] ""
+"由 %{allies} 和你組成的聯盟必須擊敗敵方 %{enemies}。"
+
+msgid "Capture the castle '%{name}'."
+msgstr "佔領城堡「%{name}」。"
+
+msgid "Capture the town '%{name}'."
+msgstr "佔領城鎮「%{name}」。"
+
+msgid "Defeat the hero '%{name}'."
+msgstr "擊敗英雄「%{name}」。"
+
+msgid "Find the ultimate artifact."
+msgstr "找到終極神器。"
+
+msgid "Find the '%{name}' artifact."
+msgstr "找到神器「%{name}」。"
+
+msgid "Accumulate %{count} gold."
+msgstr "累積 %{count} 金幣。"
+
+msgid ""
+", or you may win by defeating all enemy heroes and capturing all enemy towns "
+"and castles."
+msgstr ""
+"，或者也可以擊敗所有敵方英雄並佔領所有敵方城鎮和城堡來獲勝。"
+
+msgid "Lose the castle '%{name}'."
+msgstr "失去城堡「%{name}」。"
+
+msgid "Lose the town '%{name}'."
+msgstr "失去城鎮「%{name}」。"
+
+msgid "Lose the hero: %{name}."
+msgstr "失去英雄：%{name}。"
+
+msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
+msgstr "未能在第 %{month} 月第 %{week} 週第 %{day} 日結束前獲勝。"
+
+msgid "%{color} player has been vanquished!"
+msgstr "%{color}玩家已被消滅！"
+
+msgid "Major Event!"
+msgstr "重大事件！"
+
+msgid "Scenario:"
+msgstr "場景："
+
+msgid "Game Difficulty:"
+msgstr "遊戲難度："
+
+msgid "Opponents:"
+msgstr "對手："
+
+msgid "Class:"
+msgstr "職業："
+
+msgid "Rating %{rating}%"
+msgstr "評分 %{rating}%"
+
+msgid "Click here to select which scenario to play."
+msgstr "按此處選擇要遊玩的場景。"
+
+msgid "Scenario"
+msgstr "場景"
+
+msgid "Game Difficulty"
+msgstr "遊戲難度"
+
+msgid ""
+"This lets you change the starting difficulty at which you will play. Higher "
+"difficulty levels start you off with fewer resources, and at the higher "
+"settings, give extra resources to the computer."
+msgstr ""
+"可變更遊玩的起始難度。難度等級越高，開局資源就越少；在更高的設定下，電腦還會"
+"獲得額外資源。"
+
+msgid "Difficulty Rating"
+msgstr "難度評分"
+
+msgid ""
+"The difficulty rating reflects a combination of various settings for your "
+"game. This number will be applied to your final score."
+msgstr ""
+"難度評分反映了遊戲各項設定的綜合評估，此數值將計入最終分數。"
+
+msgid "Click to accept these settings and start a new game."
+msgstr "按一下接受這些設定並開始新遊戲。"
+
+msgid "Click to return to the main menu."
+msgstr "按一下返回主選單。"
+
+msgid "The map is corrupted or doesn't exist."
+msgstr "地圖已損壞或不存在。"
+
+msgid "Astrologers proclaim the Month of the %{name}."
+msgstr "占星師宣布這是 %{name} 之月。"
+
+msgid "New Month!"
+msgstr "新的月份！"
+
+msgid "Astrologers proclaim the Week of the %{name}."
+msgstr "占星師宣布這是 %{name} 之週。"
+
+msgid "New Week!"
+msgstr "新的一週！"
+
+msgid "After regular growth, the population of %{monster} is doubled!"
+msgstr "正常增長後，%{monster} 的族群數量翻倍！"
+
+msgid ""
+"After regular growth, the population of %{monster} increases by %{count} "
+"percent!"
+msgid_plural ""
+"After regular growth, the population of %{monster} increases by %{count} "
+"percent!"
+msgstr[0] ""
+"正常增長後，%{monster} 的族群數量增加 %{count}%！"
+
+msgid "%{monster} growth +%{count}."
+msgstr "%{monster} 增長 +%{count}。"
+
+msgid "All populations are halved."
+msgstr "所有生物族群減半。"
+
+msgid "All dwellings increase population."
+msgstr "所有住所增加族群數量。"
+
+msgid "Beware!"
+msgstr "小心！"
+
+msgid ""
+"%{color} player, this is your last day to capture a town, or you will be "
+"banished from this land."
+msgstr ""
+"%{color}玩家，這是佔領城鎮的最後一天，否則將被放逐。"
+
+msgid ""
+"%{color} player, you only have %{day} days left to capture a town, or you "
+"will be banished from this land."
+msgstr ""
+"%{color}玩家，僅剩 %{day} 天可以佔領城鎮，否則將被放逐。"
+
+msgid "%{color} player's turn."
+msgstr "%{color}玩家的回合。"
+
+msgid ""
+"%{color} player, you have lost your last town. If you do not conquer another "
+"town in the next week, you will be eliminated."
+msgstr ""
+"%{color}玩家，你失去了最後一座城鎮。若未能在下週內攻佔另一座城鎮，將被淘汰。"
+
+msgid ""
+"%{color} player, your heroes abandon you, and you are banished from this "
+"land."
+msgstr ""
+"%{color}玩家，英雄們拋棄了你，你被放逐出這片土地。"
+
+msgid "Lord Kilburn"
+msgstr "Lord Kilburn"
+
+msgid "Tsabu"
+msgstr "Tsabu"
+
+msgid "Sir Galant"
+msgstr "Sir Galant"
+
+msgid "Thundax"
+msgstr "Thundax"
+
+msgid "Lord Haart"
+msgstr "Lord Haart"
+
+msgid "Ariel"
+msgstr "Ariel"
+
+msgid "Rebecca"
+msgstr "Rebecca"
+
+msgid "Sandro"
+msgstr "Sandro"
+
+msgid "Crodo"
+msgstr "Crodo"
+
+msgid "Barock"
+msgstr "Barock"
+
+msgid "Antoine"
+msgstr "Antoine"
+
+msgid "Astra"
+msgstr "Astra"
+
+msgid "Agar"
+msgstr "Agar"
+
+msgid "Vatawna"
+msgstr "Vatawna"
+
+msgid "Vesper"
+msgstr "Vesper"
+
+msgid "Ambrose"
+msgstr "Ambrose"
+
+msgid "Troyan"
+msgstr "Troyan"
+
+msgid "Jojosh"
+msgstr "Jojosh"
+
+msgid "Wrathmont"
+msgstr "Wrathmont"
+
+msgid "Maximus"
+msgstr "Maximus"
+
+msgid "Next Hero"
+msgstr "下一位英雄"
+
+msgid "Select the next Hero."
+msgstr "選擇下一位英雄。"
+
+msgid "Hero Movement"
+msgstr "英雄移動"
+
+msgid ""
+"Start the Hero's movement along the current path or re-visit the object "
+"occupied by the Hero. Press and hold this button to reset the Hero's path."
+msgstr ""
+"沿目前路徑開始英雄的移動，或重新造訪英雄所在的物件。長按此按鈕可重置英雄的路"
+"徑。"
+
+msgid "Kingdom Summary"
+msgstr "王國摘要"
+
+msgid "View a summary of your Kingdom."
+msgstr "檢視王國摘要。"
+
+msgid "Cast an adventure spell."
+msgstr "施放冒險法術。"
+
+msgid "End Turn"
+msgstr "結束回合"
+
+msgid "End your turn and let the computer take its turn."
+msgstr "結束你的回合，讓電腦行動。"
+
+msgid "Adventure Options"
+msgstr "冒險選項"
+
+msgid "Bring up the adventure options menu."
+msgstr "開啟冒險選項選單。"
+
+msgid ""
+"Bring up the file options menu, allowing you to load, save, start a new game "
+"or quit."
+msgstr ""
+"開啟檔案選項選單，可載入、儲存、開始新遊戲或結束。"
+
+msgid "Bring up the system options menu, allowing you to customize your game."
+msgstr "開啟系統選項選單，以自訂遊戲。"
+
+msgid "Hero Movement Points"
+msgstr "英雄移動力"
+
+msgid ""
+"The hero's army cannot move anymore today. The movement points will be "
+"refilled tomorrow after you end your turn."
+msgstr ""
+"英雄的軍隊今日已無法繼續移動。結束回合後，明天移動力將會恢復。"
+
+msgid ""
+"One or more heroes may still move, are you sure you want to end your turn?"
+msgstr ""
+"仍有英雄可以移動，確定要結束回合嗎？"
+
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "確定要重新開始嗎？(目前的遊戲進度將會遺失。)"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr "確定要覆寫此名稱的存檔嗎？"
+
+msgid "Game saved successfully."
+msgstr "遊戲儲存成功。"
+
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr ""
+"確定要載入新遊戲嗎？（目前的遊戲進度將會遺失。）"
+
+msgid "Try looking on land!!!"
+msgstr "試試在陸地上尋找！！！"
+
+msgid ""
+"Searching for the Ultimate Artifact is fruitless. Your hero could not carry "
+"it even if he found it - all his artifact slots are full."
+msgstr ""
+"搜尋終極神器毫無結果。即使找到也無法攜帶——英雄的神器欄位已滿。"
+
+msgid "Digging for artifacts requires a whole day, try again tomorrow."
+msgstr "挖掘神器需要一整天的時間，請明天再試。"
+
+msgid ""
+"After spending many hours digging here, you have uncovered the %{artifact}."
+msgstr ""
+"經過數小時的挖掘，你發現了 %{artifact}。"
+
+msgid "Congratulations!"
+msgstr "恭喜！"
+
+msgid "Nothing here. Where could it be?"
+msgstr "這裡什麼都沒有。它會在哪裡呢？"
+
+msgid "Try searching on clear ground."
+msgstr "試試在空地上搜尋。"
+
+msgid "A miniature view of the known world. Left click to move viewing area."
+msgstr "已知世界的縮圖。左鍵按一下移動檢視區域。"
+
+msgid "Month: %{month} Week: %{week}"
+msgstr "月：%{month} 週：%{week}"
+
+msgid ""
+"You find a small\n"
+"quantity of %{resource}."
+msgstr ""
+"你發現了少量\n"
+"%{resource}。"
+
+msgid "Status Window"
+msgstr "狀態視窗"
+
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+"此視窗顯示英雄或王國的狀態資訊及日期。"
+
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date. Left click here to cycle through these windows."
+msgstr ""
+"此視窗顯示英雄或王國的狀態資訊及日期。左鍵按一下可切換不同視窗。"
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+"可變更玩家的起始位置和顏色。特定顏色將始終在特定位置開始。某些位置只能由電腦"
+"玩家或人類玩家使用。"
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+"可變更玩家的職業。職業並非總是可變更的。根據場景，玩家可能會獲得非其主要陣營"
+"的額外城鎮和/或英雄。"
+
+msgid "Handicap"
+msgstr "讓分"
+
+msgid ""
+"This lets you change the handicap of a particular player. Only human players "
+"may have a handicap. Handicapped players start with fewer resources and earn "
+"15 or 30% fewer resources per turn for mild and severe handicaps, "
+"respectively."
+msgstr ""
+"可變更特定玩家的讓分。只有人類玩家可設定讓分。有讓分的玩家以較少資源開局，輕"
+"度和重度讓分分別每回合減少 15% 或 30% 的資源收入。"
+
+msgid "%{color} player"
+msgstr "%{color}玩家"
+
+msgid "No Handicap"
+msgstr "無讓分"
+
+msgid ""
+"No special restrictions on starting resources and resource income per turn."
+msgstr ""
+"起始資源與每回合資源收入無特殊限制。"
+
+msgid "Mild Handicap"
+msgstr "輕度讓分"
+
+msgid ""
+"Players with mild handicap start with fewer resources and earn 15% fewer "
+"resources per turn."
+msgstr ""
+"輕度讓分的玩家以較少資源開局，且每回合收入減少 15%。"
+
+msgid "Severe Handicap"
+msgstr "重度讓分"
+
+msgid ""
+"Players with severe handicap start with fewer resources and earn 30% fewer "
+"resources per turn."
+msgstr ""
+"重度讓分的玩家以較少資源開局，且每回合收入減少 30%。"
+
+msgid ""
+"Default\n"
+"value"
+msgstr ""
+"預設\n"
+"數值"
+
+msgid "Set %{skill} Skill:"
+msgstr "設定 %{skill} 技能："
+
+msgid "Set %{skill} base value. Right-click to reset all skills to default."
+msgstr "設定 %{skill} 基礎值。右鍵按一下可將所有技能重置為預設。"
+
+msgid "View %{skill} Info"
+msgstr "檢視 %{skill} 資訊"
+
+msgid ""
+"Default\n"
+"skill"
+msgstr ""
+"預設\n"
+"技能"
+
+msgid "The available values range from %{min} to %{max}."
+msgstr "可用數值範圍為 %{min} 至 %{max}。"
+
+msgid "Uppercase"
+msgstr "大寫"
+
+msgid "Click to switch to uppercase letters."
+msgstr "按一下切換為大寫字母。"
+
+msgid "Keyboard|123"
+msgstr "123"
+
+msgid "Keyboard type"
+msgstr "鍵盤類型"
+
+msgid "Click to switch between keyboard types."
+msgstr "按一下切換鍵盤類型。"
+
+msgid "Keyboard|SPACE"
+msgstr "空格"
+
+msgid "Change language"
+msgstr "切換語言"
+
+msgid "Click to switch between languages."
+msgstr "按一下切換語言。"
+
+msgid "Backspace"
+msgstr "退格"
+
+msgid "Click to remove characters."
+msgstr "按一下刪除字元。"
+
+msgid "Lowercase"
+msgstr "小寫"
+
+msgid "Click to switch to lowercase letters."
+msgstr "按一下切換為小寫字母。"
+
+msgid "Keyboard|ABC"
+msgstr "ABC"
+
+msgid "Swap sign"
+msgstr "正負號切換"
+
+msgid "Click to switch between signed and unsigned numbers."
+msgstr "按一下切換正負數。"
+
+msgid "The entered value is invalid."
+msgstr "輸入的數值無效。"
+
+msgid ""
+"The entered value is out of range.\n"
+"It should be not less than %{minValue} and not more than %{maxValue}."
+msgstr ""
+"輸入的數值超出範圍。\n"
+"應不小於 %{minValue} 且不大於 %{maxValue}。"
+
+msgid "Kingdom Income"
+msgstr "王國收入"
+
+msgid "Kingdom Income per day."
+msgstr "王國每日收入。"
+
+msgid "For every lighthouse controlled, your ships will move further each day."
+msgstr "每控制一座燈塔，船隻每日可移動更遠。"
+
+msgid "English"
+msgstr "英文"
+
+msgid "French"
+msgstr "法文"
+
+msgid "Polish"
+msgstr "波蘭文"
+
+msgid "German"
+msgstr "德文"
+
+msgid "Russian"
+msgstr "俄文"
+
+msgid "Italian"
+msgstr "義大利文"
+
+msgid "Czech"
+msgstr "捷克文"
+
+msgid "Norwegian"
+msgstr "挪威文"
+
+msgid "Belarusian"
+msgstr "白俄羅斯文"
+
+msgid "Bulgarian"
+msgstr "保加利亞文"
+
+msgid "Ukrainian"
+msgstr "烏克蘭文"
+
+msgid "Romanian"
+msgstr "羅馬尼亞文"
+
+msgid "Spanish"
+msgstr "西班牙文"
+
+msgid "Swedish"
+msgstr "瑞典文"
+
+msgid "Portuguese"
+msgstr "葡萄牙文"
+
+msgid "Turkish"
+msgstr "土耳其文"
+
+msgid "Dutch"
+msgstr "荷蘭文"
+
+msgid "Hungarian"
+msgstr "匈牙利文"
+
+msgid "Danish"
+msgstr "丹麥文"
+
+msgid "Slovak"
+msgstr "斯洛伐克文"
+
+msgid "Vietnamese"
+msgstr "越南文"
+
+msgid "Greek"
+msgstr "希臘文"
+
+msgid "Esperanto"
+msgstr "世界語"
+
+msgid "Slow"
+msgstr "慢"
+
+msgid "Fast"
+msgstr "快"
+
+msgid "Very Fast"
+msgstr "非常快"
+
+msgid "Dynamic"
+msgstr "動態"
+
+msgid "Good"
+msgstr "善良"
+
+msgid "Evil"
+msgstr "邪惡"
+
+msgid "Black & White"
+msgstr "黑白"
+
+msgid "Color"
+msgstr "彩色"
+
+msgid "Configure"
+msgstr "設定"
+
+msgid ", FPS: "
+msgstr ", FPS: "
+
+msgid "Ector"
+msgstr "Ector"
+
+msgid "Gwenneth"
+msgstr "Gwenneth"
+
+msgid "Sir Gallant"
+msgstr "Sir Gallant"
+
+msgid "Tyro"
+msgstr "Tyro"
+
+msgid "Dimitry"
+msgstr "Dimitry"
+
+msgid "Ruby"
+msgstr "Ruby"
+
+msgid "Crag Hack"
+msgstr "Crag Hack"
+
+msgid "Fineous"
+msgstr "Fineous"
+
+msgid "Jaclyn"
+msgstr "Jaclyn"
+
+msgid "Jezebel"
+msgstr "Jezebel"
+
+msgid "Atlas"
+msgstr "Atlas"
+
+msgid "Ergon"
+msgstr "Ergon"
+
+msgid "Gem"
+msgstr "Gem"
+
+msgid "Natasha"
+msgstr "Natasha"
+
+msgid "Carlawn"
+msgstr "Carlawn"
+
+msgid "Luna"
+msgstr "Luna"
+
+msgid "Arie"
+msgstr "Arie"
+
+msgid "Barok"
+msgstr "Barok"
+
+msgid "Kastore"
+msgstr "Kastore"
+
+msgid "Falagar"
+msgstr "Falagar"
+
+msgid "Dawn"
+msgstr "Dawn"
+
+msgid "Flint"
+msgstr "Flint"
+
+msgid "Halon"
+msgstr "Halon"
+
+msgid "Myra"
+msgstr "Myra"
+
+msgid "Myrini"
+msgstr "Myrini"
+
+msgid "Wilfrey"
+msgstr "Wilfrey"
+
+msgid "Mandigal"
+msgstr "Mandigal"
+
+msgid "Sarakin"
+msgstr "Sarakin"
+
+msgid "Charity"
+msgstr "Charity"
+
+msgid "Darlana"
+msgstr "Darlana"
+
+msgid "Ranloo"
+msgstr "Ranloo"
+
+msgid "Rialdo"
+msgstr "Rialdo"
+
+msgid "Zam"
+msgstr "Zam"
+
+msgid "Zom"
+msgstr "Zom"
+
+msgid "Celia"
+msgstr "Celia"
+
+msgid "Roxana"
+msgstr "Roxana"
+
+msgid "Lord Corlagon"
+msgstr "Lord Corlagon"
+
+msgid "Lord Halton"
+msgstr "Lord Halton"
+
+msgid "Sister Eliza"
+msgstr "Sister Eliza"
+
+msgid "Brother Brax"
+msgstr "Brother Brax"
+
+msgid "Dainwin"
+msgstr "Dainwin"
+
+msgid "Gallavant"
+msgstr "Gallavant"
+
+msgid "Joseph"
+msgstr "Joseph"
+
+msgid "Mog"
+msgstr "Mog"
+
+msgid "Solmyr"
+msgstr "Solmyr"
+
+msgid "Ceallach"
+msgstr "Ceallach"
+
+msgid "Drakonia"
+msgstr "Drakonia"
+
+msgid "Elderian"
+msgstr "Elderian"
+
+msgid "Jarkonas"
+msgstr "Jarkonas"
+
+msgid "Martine"
+msgstr "Martine"
+
+msgid "shipAndGraveyard|%{object} robber"
+msgstr "%{object}強盜"
+
+msgid "pyramid|%{object} raided"
+msgstr "%{object}已被搜刮"
+
+msgid " gives you maximum morale"
+msgstr "給予你最高士氣"
+
+msgid " gives you maximum luck"
+msgstr "給予你最高運氣"
+
+msgid "You cannot have multiple spell books."
+msgstr "不能擁有多本法術書。"
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr "無法拾取此神器，神器欄位已滿！"
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr "要施放法術，必須先花 %{gold} 金幣購買法術書。"
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr "很遺憾，你目前似乎資金不足。"
+
+msgid "Do you wish to buy one?"
+msgstr "要購買一本嗎？"
+
+msgid "%{count} / day"
+msgstr "%{count} / 日"
+
+msgid "one"
+msgstr "一"
+
+msgid "two"
+msgstr "二"
+
+msgid "A whirlpool engulfs your ship. Some of your army has fallen overboard."
+msgstr "漩渦吞沒了你的船。部分軍隊落入水中。"
+
+msgid "Insulted by your refusal of their offer, the monsters attack!"
+msgstr "怪物因你拒絕牠們的提議而惱怒，發動了攻擊！"
+
+msgid ""
+"The %{monster}, awed by the power of your forces, begin to scatter.\n"
+"Do you wish to pursue and engage them?"
+msgstr ""
+"%{monster} 被你的軍隊力量震懾，開始四散逃離。\n"
+"是否要追擊？"
+
+msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
+msgstr "搜刮敵方營地時，你發現了一處隱藏的寶藏。"
+
+msgid ""
+"Your ship bumps into a barrel drifting at sea. Inside, you discover a stash "
+"of lost treasure."
+msgstr ""
+"你的船撞上了一個在海上漂流的木桶。裡面發現了一批遺落的寶藏。"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I have been working very hard to provide you with these resources, "
+"come back next week for more.\""
+msgstr ""
+"磨坊管理員宣布:\n"
+"「大人，我一直努力為您提供這些資源，請下週再來取用。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I am sorry, there are no resources currently available. Please try "
+"again next week.\""
+msgstr ""
+"磨坊管理員宣布:\n"
+"「大人，很抱歉，目前沒有可用的資源。請下週再來。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I have been working very hard to provide you with this gold, come "
+"back next week for more.\""
+msgstr ""
+"磨坊管理員宣布:\n"
+"「大人，我一直努力為您準備黃金，請下週再來取用。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I am sorry, there is no gold currently available. Please try again "
+"next week.\""
+msgstr ""
+"磨坊管理員宣布:\n"
+"「大人，很抱歉，目前沒有可用的黃金。請下週再來。」"
+
+msgid ""
+"You've found an abandoned lean-to.\n"
+"Poking about, you discover some resources hidden nearby."
+msgstr ""
+"你發現了一間廢棄的棚屋。\n"
+"四處翻找後，發現附近藏有一些資源。"
+
+msgid "The lean-to is long abandoned. There is nothing of value here."
+msgstr "棚屋早已荒廢，這裡沒有任何有價值的東西。"
+
+msgid ""
+"You catch a leprechaun foolishly sleeping amidst a cluster of magic "
+"mushrooms.\n"
+"In exchange for his freedom, he guides you to a small pot filled with "
+"precious things."
+msgstr ""
+"你發現一個妖精愚蠢地睡在一叢魔法蘑菇中間。\n"
+"為了換取自由，他帶你去了一個裝滿珍貴物品的小罐子。"
+
+msgid ""
+"You've found a magic garden, the kind of place that leprechauns and faeries "
+"like to cavort in, but there is no one here today.\n"
+"Perhaps you should try again next week."
+msgstr ""
+"你發現了一座魔法花園，是妖精和仙子喜歡嬉戲的地方，但今天這裡空無一人。\n"
+"或許下週再來試試。"
+
+msgid "You come upon the remains of an unfortunate adventurer."
+msgstr "你發現了一位不幸冒險者的遺骸。"
+
+msgid "Treasure"
+msgstr "寶藏"
+
+msgid "Searching through the tattered clothing, you find the %{artifact}."
+msgstr "翻找破舊的衣物時，你發現了 %{artifact}。"
+
+msgid "Searching through the tattered clothing, you find nothing."
+msgstr "翻找破舊的衣物，什麼都沒找到。"
+
+msgid ""
+"You come across an old wagon left by a trader who didn't quite make it to "
+"safe terrain."
+msgstr ""
+"你發現一輛舊馬車；留下它的商人沒能抵達安全地帶。"
+
+msgid "Unfortunately, others have found it first, and the wagon is empty."
+msgstr "很遺憾，其他人已捷足先登，馬車是空的。"
+
+msgid "Searching inside, you find the %{artifact}."
+msgstr "在裡面搜尋，你發現了 %{artifact}。"
+
+msgid "Inside, you find some of the wagon's cargo still intact."
+msgstr "在裡面，你發現了一些馬車貨物仍完好無損。"
+
+msgid "You search through the flotsam, and find some wood and some gold."
+msgstr "你翻找漂流物，發現了一些木材和黃金。"
+
+msgid "You search through the flotsam, and find some wood."
+msgstr "你翻找漂流物，發現了一些木材。"
+
+msgid "You search through the flotsam, but find nothing."
+msgstr "你翻找了漂流物，但什麼都沒找到。"
+
+msgid "Shrine of the 1st Circle"
+msgstr "第一環神殿"
+
+msgid ""
+"You come across a small shrine attended by a group of novice acolytes.\n"
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
+msgstr ""
+"你偶然發現一座由一群見習僧侶看管的小神殿。\n"
+"為了換取你的保護，他們同意教你一個簡單的法術——「%{spell}」。"
+
+msgid "Shrine of the 2nd Circle"
+msgstr "第二環神殿"
+
+msgid ""
+"You come across an ornate shrine attended by a group of rotund friars.\n"
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
+msgstr ""
+"你偶然發現一座由一群圓胖修士看管的華麗神殿。\n"
+"為了換取你的保護，他們同意教你一個法術——「%{spell}」。"
+
+msgid "Shrine of the 3rd Circle"
+msgstr "第三環神殿"
+
+msgid ""
+"You come across a lavish shrine attended by a group of high priests.\n"
+"In exchange for your protection, they agree to teach you a sophisticated "
+"spell - '%{spell}'."
+msgstr ""
+"你偶然發現一座由一群大祭司看管的奢華神殿。\n"
+"為了換取你的保護，他們同意教你一個高深法術——「%{spell}」。"
+
+msgid ""
+"\n"
+"Unfortunately, you do not have the wisdom to understand the spell, and you "
+"are unable to learn it."
+msgstr ""
+"\n"
+"很遺憾，你沒有足夠的智慧來理解此法術，無法學會它。"
+
+msgid ""
+"\n"
+"Unfortunately, you already have knowledge of this spell, so there is nothing "
+"more for them to teach you."
+msgstr ""
+"\n"
+"很遺憾，你已知曉此法術，他們無法再教你更多了。"
+
+msgid ""
+"\n"
+"Unfortunately, you have no Magic Book to record the spell with."
+msgstr ""
+"\n"
+"很遺憾，你沒有法術書來記錄此法術。"
+
+msgid ""
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
+"\n"
+msgstr ""
+"你走近小屋，看到裡面有一位女巫正在研讀一本關於 %{skill} 的古老典籍。\n"
+"\n"
+
+msgid ""
+"As you approach, she turns and focuses her one glass eye on you.\n"
+"\"You already know everything you deserve to learn!\" the witch screeches. "
+"\"NOW GET OUT OF MY HOUSE!\""
+msgstr ""
+"當你走近時，她轉過身用她的玻璃眼瞪著你。\n"
+"「你已經知道了所有你該學的東西！」女巫尖叫道。「立刻滾出我的房子！」"
+
+msgid ""
+"As you approach, she turns and speaks.\n"
+"\"You already know that which I would teach you. I can help you no further.\""
+msgstr ""
+"當你走近時，她轉過身說道。\n"
+"「你已經知道我要教的東西了。我無法再幫助你。」"
+
+msgid ""
+"An ancient and immortal witch living in a hut with bird's legs for stilts "
+"teaches you %{skill} for her own inscrutable purposes."
+msgstr ""
+"一位住在以鳥腿為支柱小屋中的古老不朽女巫，為了她不可測的目的教導了你 "
+"%{skill}。"
+
+msgid "As you drink the sweet water, you gain luck for your next battle."
+msgstr "喝下甘甜的泉水後，你的下一場戰鬥將獲得好運加成。"
+
+msgid "You drink from the enchanted fountain, but nothing happens."
+msgstr "你從施了魔法的噴泉中飲水，但什麼都沒發生。"
+
+msgid "You enter the faerie ring, but nothing happens."
+msgstr "你進入了妖精之環，但什麼都沒發生。"
+
+msgid ""
+"Upon entering the mystical faerie ring, your army gains luck for its next "
+"battle."
+msgstr ""
+"進入神祕的妖精之環後，軍隊在下一場戰鬥中將獲得好運加成。"
+
+msgid ""
+"You've found an ancient and weathered stone idol.\n"
+"It is supposed to grant luck to visitors, but since the stars are already "
+"smiling upon you, it does nothing."
+msgstr ""
+"你發現了一座古老且風化的石偶像。\n"
+"據說它能賜予造訪者好運，但由於幸運之星已經眷顧你了，所以毫無效果。"
+
+msgid ""
+"You've found an ancient and weathered stone idol.\n"
+"Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
+"touch."
+msgstr ""
+"你發現了一座古老且風化的石偶像。\n"
+"據說親吻它會帶來好運，於是你照做了。石頭觸感非常冰冷。"
+
+msgid "The mermaids silently entice you to return later and be blessed again."
+msgstr "美人魚靜靜地引誘你稍後再來接受祝福。"
+
+msgid ""
+"The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
+"Just for a moment, you forget your worries and bask in the beauty of the "
+"moment.\n"
+"The mermaids' charms bless you with increased luck for your next combat."
+msgstr ""
+"美人魚那神奇而撫慰人心的美麗觸及你和你的船員。\n"
+"短暫的一刻，你忘卻了煩憂，沉浸在美好之中。\n"
+"美人魚的魅力為你的下一場戰鬥賜予好運加成。"
+
+msgid ""
+"You come upon the pyramid of a great and ancient king.\n"
+"You are tempted to search it for treasure, but all the old stories warn of "
+"fearful curses and undead guardians.\n"
+"Will you search?"
+msgstr ""
+"你來到了一位偉大古代國王的金字塔前。\n"
+"你很想搜尋寶藏，但所有古老的故事都警告著可怕的詛咒和亡靈守衛。\n"
+"要搜尋嗎？"
+
+msgid ""
+"Upon defeating the monsters, you decipher an ancient glyph on the wall, "
+"telling the secret of the spell - '"
+msgstr ""
+"擊敗怪物後，你破譯了牆上的古老銘文，得知了法術的奧祕——「"
+
+msgid "Unfortunately, you have no Magic Book to record the spell with."
+msgstr "很遺憾，你沒有法術書來記錄此法術。"
+
+msgid ""
+"Unfortunately, you do not have the wisdom to understand the spell, and you "
+"are unable to learn it."
+msgstr ""
+"很遺憾，你沒有足夠的智慧來理解此法術，無法學會它。"
+
+msgid ""
+"You come upon the pyramid of a great and ancient king.\n"
+"Routine exploration reveals that the pyramid is completely empty."
+msgstr ""
+"你來到了一位偉大古代國王的金字塔前。\n"
+"例行探索後發現金字塔完全是空的。"
+
+msgid ""
+"A drink at the well is supposed to restore your spell points, but you are "
+"already at maximum."
+msgstr ""
+"在井中飲水據說能恢復魔法值，但你的魔法值已經是滿的了。"
+
+msgid "A second drink at the well in one day will not help you."
+msgstr "一天內在井中第二次飲水不會有幫助。"
+
+msgid "A drink from the well has restored your spell points to maximum."
+msgstr "井中的一口水已將你的魔法值恢復至最大值。"
+
+msgid ""
+"\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
+"everything we have to teach.\""
+msgstr ""
+"「抱歉，大人，」士兵的首領說道，「但你已經知道我們能教的一切了。」"
+
+msgid "The soldiers living in the fort teach you a few new defensive tricks."
+msgstr "駐守堡壘的士兵教了你一些新的防禦技巧。"
+
+msgid ""
+"You've come upon a mercenary camp practicing their tactics. \"You're too "
+"advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
+msgstr ""
+"你偶然來到一個正在練習戰術的傭兵營地。「你太強了，」傭兵隊長說道。「我們沒什"
+"麼能教你的了。」"
+
+msgid ""
+"You've come upon a mercenary camp practicing their tactics. The mercenaries "
+"welcome you and your troops and invite you to train with them."
+msgstr ""
+"你偶然來到一個正在練習戰術的傭兵營地。傭兵們歡迎你和你的部隊，邀請你們一起訓"
+"練。"
+
+msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
+msgstr "「走開！」巫醫吠道，「你已經知道我所知的一切了。」"
+
+msgid ""
+"An Orcish witch doctor living in the hut deepens your knowledge of magic by "
+"showing you how to cast stones, read portents, and decipher the intricacies "
+"of chicken entrails."
+msgstr ""
+"住在小屋裡的獸人巫醫向你展示如何投石占卜、解讀預兆和辨析雞內臟的複雜紋理，加"
+"深了你的魔法知識。"
+
+msgid ""
+"You've found a group of Druids worshipping at one of their strange stone "
+"edifices. Silently, the Druids turn you away, indicating they have nothing "
+"new to teach you."
+msgstr ""
+"你發現一群德魯伊正在其中一座奇異的石造建築前膜拜。德魯伊們默默將你拒之門外，"
+"示意他們沒有新東西可教你。"
+
+msgid ""
+"You've found a group of Druids worshipping at one of their strange stone "
+"edifices. Silently, they teach you new ways to cast spells."
+msgstr ""
+"你發現一群德魯伊正在其中一座奇異的石造建築前膜拜。他們默默教你施法的新方式。"
+
+msgid ""
+"You tentatively approach the burial ground of ancient warriors. Do you want "
+"to search the graves?"
+msgstr ""
+"你試探性地走向古代戰士的墓地。要搜尋墳墓嗎？"
+
+msgid ""
+"You spend several hours searching the graves and find nothing. Such a "
+"despicable act reduces your army's morale."
+msgstr ""
+"你花了數小時搜尋墳墓卻一無所獲。這種卑劣行為讓軍隊士氣下降。"
+
+msgid "Upon defeating the Zombies you search the graves and find something!"
+msgstr "擊敗殭屍後你搜尋了墳墓並找到了些東西！"
+
+msgid ""
+"The rotting hulk of a great pirate ship creaks eerily as it is pushed "
+"against the rocks. Do you wish to search the shipwreck?"
+msgstr ""
+"一艘巨大海盜船腐爛的殘骸被推靠在岩石上，發出詭異的嘎吱聲。要搜尋沉船嗎？"
+
+msgid ""
+"You spend several hours sifting through the debris and find nothing. Such a "
+"despicable act reduces your army's morale."
+msgstr ""
+"你花了數小時翻找殘骸卻一無所獲。這種卑劣行為讓軍隊士氣下降。"
+
+msgid ""
+"Upon defeating the Ghosts you sift through the debris and find something!"
+msgstr ""
+"擊敗幽靈後你篩查了殘骸並找到了些東西！"
+
+msgid ""
+"The rotting hulk of a great pirate ship creaks eerily as it is pushed "
+"against the rocks. Do you wish to search the ship?"
+msgstr ""
+"一艘巨大海盜船腐爛的殘骸被推靠在岩石上，發出詭異的嘎吱聲。要搜尋船隻嗎？"
+
+msgid ""
+"Upon defeating the Skeletons you sift through the debris and find something!"
+msgstr ""
+"擊敗骷髏兵後你篩查了殘骸並找到了些東西！"
+
+msgid "Your men spot a navigational buoy, confirming that you are on course."
+msgstr "你的船員發現了一個航標，確認航線正確。"
+
+msgid ""
+"Your men spot a navigational buoy, confirming that you are on course and "
+"increasing their morale."
+msgstr ""
+"你的船員發現了一個航標，確認航線正確，提振了士氣。"
+
+msgid ""
+"The drink at the oasis is refreshing, but offers no further benefit. The "
+"oasis might help again if you fought a battle first."
+msgstr ""
+"綠洲的水很清爽，但沒有額外效果。先打完一場仗後綠洲可能會再次生效。"
+
+msgid ""
+"A drink at the oasis fills your troops with strength and lifts their "
+"spirits. You can travel a bit further today."
+msgstr ""
+"在綠洲飲水使部隊充滿力量、精神振奮。今天可以多走一段路。"
+
+msgid ""
+"The drink at the watering hole is refreshing, but offers no further benefit. "
+"The watering hole might help again if you fought a battle first."
+msgstr ""
+"水源地的水很清爽，但沒有額外效果。先打完一場仗後水源地可能會再次生效。"
+
+msgid ""
+"A drink at the watering hole fills your troops with strength and lifts their "
+"spirits. You can travel a bit further today."
+msgstr ""
+"在水源地飲水使部隊充滿力量、精神振奮。今天可以多走一段路。"
+
+msgid ""
+"It doesn't help to pray twice before a battle. Come back after you've fought."
+msgstr ""
+"戰鬥前祈禱兩次沒有幫助。打完仗再回來吧。"
+
+msgid "A visit and a prayer at the temple raises the morale of your troops."
+msgstr "在神廟中造訪並祈禱提升了部隊的士氣。"
+
+msgid ""
+"An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
+"have taught you all I can.\""
+msgstr ""
+"一位年邁的騎士出現在涼亭的臺階上。「很抱歉，主公，我已經把能教的都教了。」"
+
+msgid ""
+"An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
+"you all that I know to aid you in your travels.\""
+msgstr ""
+"一位年邁的騎士出現在涼亭的臺階上。「主公，我將傾囊相授，助你旅途順利。」"
+
+msgid ""
+"You've pulled a shipwreck survivor from certain death in an unforgiving "
+"ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
+"you're all full.\""
+msgstr ""
+"你從無情的大海中救出了一位沉船倖存者。他感激地說：「我想給你一件神器作為回"
+"報，但你的神器欄位已滿了。」"
+
+msgid ""
+"You've pulled a shipwreck survivor from certain death in an unforgiving "
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
+msgstr ""
+"你從無情的大海中救出了一位沉船倖存者。他感激你的善舉，將 %{art} 送給你作為回"
+"報。"
+
+msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
+msgstr "一個妖精以 %{gold} 金幣的低價向你兜售 %{art}。"
+
+msgid ""
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
+msgstr ""
+"一個妖精以 %{gold} 金幣加 %{count} %{res} 的低價向你兜售 %{art}。"
+
+msgid "Do you wish to buy this artifact?"
+msgstr "要購買此神器嗎？"
+
+msgid ""
+"You try to pay the leprechaun, but realize that you can't afford it. The "
+"leprechaun stamps his foot and ignores you."
+msgstr ""
+"你想付錢給妖精，但發現負擔不起。妖精跺了跺腳，不理你了。"
+
+msgid ""
+"Insulted by your refusal of his generous offer, the leprechaun stamps his "
+"foot and ignores you."
+msgstr ""
+"妖精因你拒絕他慷慨的提議而受辱，跺了跺腳不理你了。"
+
+msgid "You've found the artifact: "
+msgstr "你找到了神器："
+
+msgid ""
+"You've found the humble dwelling of a withered hermit. The hermit tells you "
+"that he is willing to give the %{art} to the first wise person he meets."
+msgstr ""
+"你發現了一位枯槁隱士的簡陋居所。隱士告訴你，他願意將 %{art} 送給第一位遇到的"
+"有智慧者。"
+
+msgid ""
+"You've come across the spartan quarters of a retired soldier. The soldier "
+"tells you that he is willing to pass on the %{art} to the first true leader "
+"he meets."
+msgstr ""
+"你偶然發現一位退役士兵的簡樸住處。士兵告訴你，他願意將 %{art} 傳給第一位遇到"
+"的真正領袖。"
+
+msgid ""
+"You've encountered a strange person with a hat and an owl on it. He tells "
+"you that he is willing to give %{art} if you have %{skill}."
+msgstr ""
+"你遇到了一個戴著帽子、上面有隻貓頭鷹的奇人。他告訴你，若你擁有 %{skill}，他願"
+"意給你 %{art}。"
+
+msgid ""
+"You come upon an ancient artifact. As you reach for it, a pack of Rogues "
+"leap out of the brush to guard their stolen loot."
+msgstr ""
+"你發現了一件古老的神器。正當你伸手去拿時，一群盜賊從灌木叢中跳出，守衛他們偷"
+"來的贓物。"
+
+msgid ""
+"Through a clearing you observe an ancient artifact. Unfortunately, it's "
+"guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
+"artifact?"
+msgstr ""
+"隔著一片空地，你看到一件古老的神器。不幸的是，旁邊有 %{monster} 守衛。要為了"
+"神器與 %{monster} 戰鬥嗎？"
+
+msgid "Victorious, you take your prize, the %{art}."
+msgstr "你取得了勝利，拿走了獎品 %{art}。"
+
+msgid ""
+"Discretion is the better part of valor, and you decide to avoid this fight "
+"for today."
+msgstr ""
+"慎重是勇氣的一部分，你決定今天不打這場仗。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it, "
+"only to find it empty."
+msgstr ""
+"花了數小時從海中撈出寶箱後打開一看，裡面竟然是空的。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it "
+"and find %{gold} gold and the %{art}."
+msgstr ""
+"花了數小時從海中撈出寶箱後打開，發現了 %{gold} 金幣和 %{art}。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it "
+"and find %{gold} gold pieces."
+msgstr ""
+"花了數小時從海中撈出寶箱後打開，發現了 %{gold} 金幣。"
+
+msgid ""
+"After scouring the area, you fall upon a hidden treasure cache. You may take "
+"the gold or distribute the gold to the peasants for experience. Do you wish "
+"to keep the gold?"
+msgstr ""
+"搜尋此區域後，你發現了一處隱藏的寶藏。你可以拿走黃金，或將黃金分給農民以換取"
+"經驗值。要保留黃金嗎？"
+
+msgid ""
+"After scouring the area, you fall upon a hidden chest, containing the "
+"ancient artifact %{art}."
+msgstr ""
+"搜尋此區域後，你發現了一個隱藏的寶箱，裡面裝有古老的神器 %{art}。"
+
+msgid ""
+"You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
+"you wish to rub the lamp?"
+msgstr ""
+"你偶然發現一盞凹凸不平、鏽蝕的神燈深埋在地下。要擦拭神燈嗎？"
+
+msgid ""
+"You have taken control of the local Alchemist shop. It will provide you with "
+"%{count} unit of Mercury per day."
+msgstr ""
+"你取得了當地煉金術士商店的控制權。每日將提供 %{count} 單位的水銀。"
+
+msgid ""
+"You gain control of a sawmill. It will provide you with %{count} units of "
+"wood per day."
+msgstr ""
+"你取得了一座鋸木廠的控制權。每日將提供 %{count} 單位的木材。"
+
+msgid ""
+"You gain control of an ore mine. It will provide you with %{count} units of "
+"ore per day."
+msgstr ""
+"你取得了一座礦石礦場的控制權。每日將提供 %{count} 單位的礦石。"
+
+msgid ""
+"You gain control of a sulfur mine. It will provide you with %{count} unit of "
+"sulfur per day."
+msgstr ""
+"你取得了一座硫磺礦場的控制權。每日將提供 %{count} 單位的硫磺。"
+
+msgid ""
+"You gain control of a crystal mine. It will provide you with %{count} unit "
+"of crystal per day."
+msgstr ""
+"你取得了一座水晶礦場的控制權。每日將提供 %{count} 單位的水晶。"
+
+msgid ""
+"You gain control of a gem mine. It will provide you with %{count} unit of "
+"gems per day."
+msgstr ""
+"你取得了一座寶石礦場的控制權。每日將提供 %{count} 單位的寶石。"
+
+msgid ""
+"You gain control of a gold mine. It will provide you with %{count} gold per "
+"day."
+msgstr ""
+"你取得了一座金礦的控制權。每日將提供 %{count} 金幣。"
+
+msgid ""
+"The lighthouse is now under your control, and all of your ships will now "
+"move further each day."
+msgstr ""
+"燈塔現已在你的控制之下，所有船隻每日可移動更遠。"
+
+msgid "You gain control of a %{name}."
+msgstr "你取得了 %{name} 的控制權。"
+
+msgid ""
+"You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
+"wish to enter?"
+msgstr ""
+"你發現了一座廢棄金礦。礦場似乎鬧鬼。要進入嗎？"
+
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr "你擊敗了幽靈，得以恢復礦場的生產。"
+
+msgid ""
+"A group of %{monster} with a desire for greater glory wish to join you. Do "
+"you accept?"
+msgstr ""
+"一群渴望更偉大榮耀的 %{monster} 希望加入你。是否接受？"
+
+msgid "As you approach the dwelling, you notice that there is no one here."
+msgstr "當你接近住所時，發現這裡空無一人。"
+
+msgid ""
+"You search the ruins, but the Medusas that used to live here are gone. "
+"Perhaps there will be more next week."
+msgstr ""
+"你搜尋了遺跡，但曾住在這裡的美杜莎已經離開。或許下週會有更多。"
+
+msgid ""
+"You've found some Medusas living in the ruins. They are willing to join your "
+"army for a price. Do you want to recruit Medusas?"
+msgstr ""
+"你在遺跡中發現了一些美杜莎。她們願意以一定代價加入你的軍隊。要招募美杜莎嗎？"
+
+msgid ""
+"You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
+"there wish to join an army. Maybe next week."
+msgstr ""
+"你發現了一座精靈樹城。可惜，住在那裡的精靈都不想加入軍隊。也許下週吧。"
+
+msgid ""
+"Some of the Sprites living in the tree city are willing to join your army "
+"for a price. Do you want to recruit Sprites?"
+msgstr ""
+"住在樹城中的一些精靈願意以一定代價加入你的軍隊。要招募精靈嗎？"
+
+msgid ""
+"A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
+"later."
+msgstr ""
+"一輛色彩繽紛的盜賊馬車空置在此。也許稍後會有更多盜賊出現。"
+
+msgid ""
+"Distant sounds of music and laughter draw you to a colorful wagon housing "
+"Rogues. Do you wish to have any Rogues join your army?"
+msgstr ""
+"遠方傳來的音樂和笑聲將你引到一輛色彩繽紛的盜賊馬車旁。要讓盜賊加入你的軍隊"
+"嗎？"
+
+msgid ""
+"A group of tattered tents, billowing in the sandy wind, beckons you. The "
+"tents are unoccupied. Perhaps more Nomads will be here later."
+msgstr ""
+"一群在沙風中飄動的破舊帳篷向你招手。帳篷空無一人，也許稍後會有更多遊牧民出"
+"現。"
+
+msgid ""
+"A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
+"wish to have any Nomads join you during your travels?"
+msgstr ""
+"一群在沙風中飄動的破舊帳篷向你招手。要讓遊牧民在旅途中加入你嗎？"
+
+msgid "The pit of mud bubbles for a minute and then lies still."
+msgstr "泥坑冒了一分鐘的泡，然後歸於平靜。"
+
+msgid ""
+"As you approach the bubbling pit of mud, creatures begin to climb out and "
+"position themselves around it. In unison they say: \"Mother Earth would like "
+"to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
+msgstr ""
+"當你走近冒泡的泥坑時，生物開始從中爬出並圍繞著它。他們齊聲說道：「大地之母願"
+"意提供一些部隊給你。要招募土元素嗎？」"
+
+msgid "You enter the structure of white stone pillars, and find nothing."
+msgstr "你進入了白色石柱建築，什麼都沒找到。"
+
+msgid ""
+"White stone pillars support a roof that rises up to the sky. As you enter "
+"the structure, the dead air of the outside gives way to a whirling gust that "
+"almost pushes you back out. The air current materializes into a barely "
+"visible form. The creature asks, in what can only be described as a loud "
+"whisper: \"Why have you come? Are you here to call upon the forces of the "
+"air?\""
+msgstr ""
+"白色石柱撐起一座直入雲霄的屋頂。進入建築時，外面死寂的空氣消失了，一股旋風幾"
+"乎把你推回去。氣流凝聚成一個幾乎看不見的形體。那生物以只能形容為低沉耳語的聲"
+"音問道：「你為何而來？是要召喚空氣的力量嗎？」"
+
+msgid "No Fire Elementals approach you from the lava pool."
+msgstr "沒有火元素從岩漿池中靠近你。"
+
+msgid ""
+"Beneath a structure that serves to hold in heat, Fire Elementals move about "
+"in a fiery pool of molten lava. A group of them approach you and offer their "
+"services. Would you like to recruit Fire Elementals?"
+msgstr ""
+"在一座蓄熱建築下方，火元素在熾熱的岩漿池中活動。一群火元素走近你並提供服務。"
+"要招募火元素嗎？"
+
+msgid "A face forms in the water for a moment, and then is gone."
+msgstr "水面上短暫地浮現出一張臉，隨即消失。"
+
+msgid ""
+"Crystalline structures cast shadows over a small reflective pool of water. "
+"You peer into the pool, and a face that is not your own peers back. It asks: "
+"\"Would you like to call upon the powers of water?\""
+msgstr ""
+"水晶結構在一個小型反射水池上投下陰影。你凝視池中，一張不屬於你的面孔回望著"
+"你。它問道：「你想召喚水的力量嗎？」"
+
+msgid "This burial site is deathly still."
+msgstr "這片墓地死寂一片。"
+
+msgid ""
+"Restless spirits of long dead warriors seeking their final resting place "
+"offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
+msgstr ""
+"早已亡故的不安戰士靈魂尋找最終安息之地，願意加入你以期得到安寧。要招募幽靈"
+"嗎？"
+
+msgid ""
+"The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
+"some undead will move in next week."
+msgstr ""
+"亡者之城既無生者，也無亡靈。或許下週會有亡靈進駐。"
+
+msgid ""
+"Some Liches living here are willing to join your army for a price. Do you "
+"want to recruit Liches?"
+msgstr ""
+"住在此處的一些巫妖願意以一定代價加入你的軍隊。要招募巫妖嗎？"
+
+msgid ""
+"You've found the ruins of an ancient city, now inhabited solely by the "
+"undead. Will you search?"
+msgstr ""
+"你發現了一座古城遺跡，如今只有亡靈棲息。要搜尋嗎？"
+
+msgid ""
+"Some of the surviving Liches are impressed by your victory over their "
+"fellows, and offer to join you for a price. Do you want to recruit Liches?"
+msgstr ""
+"倖存的一些巫妖對你戰勝他們的同伴印象深刻，願意以一定代價加入你。要招募巫妖"
+"嗎？"
+
+msgid ""
+"You've found one of those bridges that Trolls are so fond of living under, "
+"but there are none here. Perhaps there will be some next week."
+msgstr ""
+"你找到了一座巨魔最愛棲息其下的橋，但這裡一個都沒有。也許下週會有。"
+
+msgid ""
+"Some Trolls living under a bridge are willing to join your army, but for a "
+"price. Do you want to recruit Trolls?"
+msgstr ""
+"住在橋下的一些巨魔願意以一定代價加入你的軍隊。要招募巨魔嗎？"
+
+msgid "Trolls living under the bridge challenge you. Will you fight them?"
+msgstr "住在橋下的巨魔向你挑戰。要戰鬥嗎？"
+
+msgid ""
+"A few Trolls remain, cowering under the bridge. They approach you and offer "
+"to join your forces as mercenaries. Do you want to buy any Trolls?"
+msgstr ""
+"幾個巨魔畏縮在橋下。他們走近你，提議以傭兵身分加入你的隊伍。要購買巨魔嗎？"
+
+msgid ""
+"The Dragon city has no Dragons willing to join you this week. Perhaps a "
+"Dragon will become available next week."
+msgstr ""
+"龍族之城本週沒有願意加入你的巨龍。也許下週會有。"
+
+msgid ""
+"The Dragon city is willing to offer some Dragons for your army for a price. "
+"Do you wish to recruit Dragons?"
+msgstr ""
+"龍族之城願意以一定代價為你的軍隊提供巨龍。要招募巨龍嗎？"
+
+msgid ""
+"You stand before the Dragon City, a place off-limits to mere humans. Do you "
+"wish to violate this rule and challenge the Dragons to a fight?"
+msgstr ""
+"你站在龍族之城前，這是凡人禁止踏入之地。要違反此規則向巨龍發起挑戰嗎？"
+
+msgid ""
+"Having defeated the Dragon champions, the city's leaders agree to supply "
+"some Dragons to your army for a price. Do you wish to recruit Dragons?"
+msgstr ""
+"擊敗龍族勇士後，城市首領同意讓你的軍隊付費招募巨龍。要招募巨龍嗎？"
+
+msgid "From the observation tower, you are able to see distant lands."
+msgstr "從觀測塔上，你可以看到遠方的土地。"
+
+msgid ""
+"The spring only refills once a week, and someone's already been here this "
+"week."
+msgstr ""
+"泉水每週只補充一次，本週已有人來過了。"
+
+msgid ""
+"A drink at the spring is supposed to give you twice your normal spell "
+"points, but you are already at that level."
+msgstr ""
+"泉水據說能給予你雙倍的正常魔法值，但你已經達到那個水平了。"
+
+msgid ""
+"A drink from the spring fills your blood with magic! You have twice your "
+"normal spell points in reserve."
+msgstr ""
+"泉水中的一口飲料讓你的血液充滿魔力！你的魔法值儲備達到正常值的兩倍。"
+
+msgid ""
+"Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
+"\"will not see the same student twice.\""
+msgstr ""
+"管家認出了你，拒絕讓你入內。「主人，」他說，「不會見同一個學生兩次。」"
+
+msgid ""
+"The butler admits you to see the master of the house. He trains you in the "
+"four skills a hero should know."
+msgstr ""
+"管家允許你謁見主人。他訓練你英雄應知的四項技能。"
+
+msgid ""
+"The butler opens the door and looks you up and down. \"You are neither "
+"famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
+"\"Come back when you think yourself worthy.\""
+msgstr ""
+"管家打開門，上下打量著你。「你既不夠出名也不夠圓滑，不配覲見我的主人，」他哼"
+"了一聲。「覺得自己配的時候再來吧。」"
+
+msgid " and "
+msgstr "和"
+
+msgid ""
+"All of the %{monsters} you have in your army have been trained by the battle "
+"masters of the fort. Your army now contains %{monsters2}."
+msgstr ""
+"你軍隊中所有的 %{monsters} 已經被堡壘的戰鬥大師訓練過了。軍隊現在包含 "
+"%{monsters2}。"
+
+msgid ""
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
+"such troops brought to them. Unfortunately, you have none with you."
+msgstr ""
+"食人魔、獸人和矮人的罕見聯盟願意訓練 (升級) 帶來的相關部隊。可惜，你沒有攜帶"
+"任何適用部隊。"
+
+msgid "All of your %{monsters} have been upgraded into %{monsters2}."
+msgstr "你所有的 %{monsters} 已升級為 %{monsters2}。"
+
+msgid ""
+"A blacksmith working at the foundry offers to convert all Pikemen and "
+"Swordsmen's weapons brought to him from iron to steel. He also says that he "
+"knows a process that will convert Iron Golems into Steel Golems. "
+"Unfortunately, you have none of these troops in your army, so he can't help "
+"you."
+msgstr ""
+"在鑄造廠工作的鐵匠願意將所有送來的槍兵和劍士的武器從鐵轉換為鋼。他還說他知道"
+"將鐵魔像轉換為鋼魔像的方法。可惜，你的軍隊中沒有這些部隊，他幫不了你。"
+
+msgid ""
+"The captain looks at you with surprise and says:\n"
+"\"You already have all the maps I know about. Let me fish in peace now.\""
+msgstr ""
+"船長驚訝地看著你說道:\n"
+"「你已經有了我知道的所有海圖。現在讓我安靜地釣魚吧。」"
+
+msgid ""
+"A retired captain living on this refurbished fishing platform offers to sell "
+"you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
+"to buy the maps?"
+msgstr ""
+"一位住在這個翻修過的釣魚平台上的退休船長，願意以 1,000 金幣賣給你他年輕時繪製"
+"的海圖。要購買嗎？"
+
+msgid ""
+"The captain sighs. \"You don't have enough money, eh? You can't expect me to "
+"give my maps away for free!\""
+msgstr ""
+"船長嘆了口氣。「你沒有足夠的錢嗎？總不能指望我免費送你海圖吧！」"
+
+msgid ""
+"You come upon an obelisk made from a type of stone you have never seen "
+"before. Staring at it intensely, the smooth surface suddenly changes to an "
+"inscription. The inscription is a piece of a lost ancient map. Quickly you "
+"copy down the piece and the inscription vanishes as abruptly as it appeared."
+msgstr ""
+"你發現了一座由前所未見的石材製成的方尖碑。你凝視著它，光滑的表面突然變成了銘"
+"文。銘文是一份失落古地圖的碎片。你迅速抄錄下來，銘文便如同出現時一樣突然消失"
+"了。"
+
+msgid "You have already been to this obelisk."
+msgstr "你已經來過這座方尖碑了。"
+
+msgid ""
+"Upon your approach, the tree opens its eyes in delight. \"It is good to see "
+"you, my student. I hope my teachings have helped you.\""
+msgstr ""
+"當你走近時，樹木高興地睜開了眼睛。「很高興見到你，我的學生。希望我的教導對你"
+"有所幫助。」"
+
+msgid ""
+"Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
+"adventurer! Allow me to teach you a little of what I have learned over the "
+"ages.\""
+msgstr ""
+"當你走近時，樹木高興地睜開了眼睛。「啊，一位冒險者！讓我教你一點我歷經數個世"
+"紀學到的知識。」"
+
+msgid "Upon your approach, the tree opens its eyes in delight."
+msgstr "當你走近時，樹木高興地睜開了眼睛。"
+
+msgid ""
+"\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
+"learned over the ages for a mere %{count} %{res}.\""
+msgstr ""
+"「啊，一位冒險者！我很樂意以僅僅 %{count} %{res} 教你一點我歷經數個世紀學到的"
+"知識。」"
+
+msgid "(Just bury it around my roots.)"
+msgstr "(只要埋在我的根部周圍就好。)"
+
+msgid "Tears brim in the eyes of the tree."
+msgstr "淚水湧上了樹木的眼眶。"
+
+msgid "\"I need %{count} %{res}.\""
+msgstr "「我需要 %{count} %{res}。」"
+
+msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
+msgstr "它低語道。(抽泣) 「好吧，付得起的時候再來吧。」"
+
+msgid ""
+"Nestled among the trees sits a blind seer. After you explain the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+"一位盲眼先知隱居在樹林間。在你說明旅程的目的後，先知啟動了水晶球，讓你看見對"
+"手的優勢和弱點。"
+
+msgid ""
+"The entrance to the cave is dark, and a foul, sulfurous smell issues from "
+"the cave mouth. Will you enter?"
+msgstr ""
+"洞穴入口一片漆黑，洞口散發著惡臭的硫磺味。要進入嗎？"
+
+msgid "Except for evidence of a terrible battle, the cave is empty."
+msgstr "除了一場慘烈戰鬥的痕跡外，洞穴是空的。"
+
+msgid ""
+"You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
+"\"you will fight and surely die. But I will give you a choice of deaths. You "
+"may fight me, or you may fight my servants. Do you prefer to fight my "
+"servants?\""
+msgstr ""
+"你在洞穴中發現了一個強大而猙獰的惡魔。「今天，」牠嘶啞地說，「你將戰鬥並必然"
+"死亡。但我給你選擇死法的機會。你可以和我打，或和我的僕從打。你想和我的僕從打"
+"嗎？」"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and receive %{exp} experience points."
+msgstr ""
+"惡魔發出挑戰的尖叫，並且發動攻擊！經過一場短暫而拚死的戰鬥，你殺死了怪物並獲"
+"得 %{exp} 點經驗值。"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
+msgstr ""
+"惡魔發出挑戰的尖叫，並且發動攻擊！經過一場短暫而拚死的戰鬥，你殺死了怪物並獲"
+"得 %{exp} 點經驗值和 %{count} 金幣。"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and find the %{art} in the back of the cave."
+msgstr ""
+"惡魔發出挑戰的尖叫，並且發動攻擊！經過一場短暫而拚死的戰鬥，你殺死了怪物並在"
+"洞穴深處找到了 %{art}。"
+
+msgid ""
+"Seeing that you do not have %{count} gold, the demon slashes you with its "
+"claws, and the last thing you see is a red haze."
+msgstr ""
+"看到你沒有 %{count} 金幣，惡魔用爪子劈向你，你最後看到的是一片紅色迷霧。"
+
+msgid ""
+"The Demon leaps upon you and has its claws at your throat before you can "
+"even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
+"to you for %{count} gold.\""
+msgstr ""
+"惡魔撲向你，在你拔劍之前就已把爪子抵在你的喉嚨上。「你的命是我的了，」牠說。"
+"「我願意以 %{count} 金幣把它賣還給你。」"
+
+msgid ""
+"Upon defeating the daemon's servants, you find a hidden cache with %{count} "
+"gold."
+msgstr ""
+"擊敗惡魔的僕從後，你找到了一處藏有 %{count} 金幣的隱密寶藏。"
+
+msgid ""
+"As you enter the Alchemist's Tower, a hobbled, graying man in a brown cloak "
+"makes his way towards you."
+msgstr ""
+"進入煉金術士之塔時，一位披著棕色斗篷、蹣跚而行的灰髮老人向你走來。"
+
+msgid "He checks your pack, and sees that you have 1 cursed item."
+msgid_plural ""
+"He checks your pack, and sees that you have %{count} cursed items."
+msgstr[0] "他檢查了你的背包，發現你有 1 件被詛咒的物品。"
+
+msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
+msgid_plural ""
+"For %{gold} gold, the alchemist will remove them for you. Do you pay?"
+msgstr[0] "煉金術士願意以 %{gold} 金幣為你移除它。要付費嗎？"
+
+msgid ""
+"After you consent to pay the requested amount of gold, the alchemist grabs "
+"the cursed artifact and throws it into his magical cauldron."
+msgid_plural ""
+"After you consent to pay the requested amount of gold, the alchemist grabs "
+"all cursed artifacts and throws them into his magical cauldron."
+msgstr[0] ""
+"你同意支付要求的金額後，煉金術士抓起受詛咒的神器，扔進他的魔法大鍋中。"
+
+msgid ""
+"You hear a voice from behind the locked door, \"You don't have enough gold "
+"to pay for my services.\""
+msgstr ""
+"你聽到鎖著的門後傳來聲音：「你的黃金不足，付不起我的服務費。」"
+
+msgid ""
+"You hear a voice from high above in the tower, \"Go away! I can't help you!\""
+msgstr ""
+"你聽到塔頂傳來聲音：「走開！我幫不了你！」"
+
+msgid ""
+"The head groom speaks to you, \"That is a fine looking horse you have. I am "
+"afraid we can give you no better, but the horses your cavalry are riding "
+"look to be of poor breeding stock. We have many trained war horses which "
+"would aid your riders greatly. I insist you take them.\""
+msgstr ""
+"馬夫長對你說：「你有一匹漂亮的好馬。恐怕我們無法給你更好的，但你騎兵的坐騎看"
+"起來血統不佳。我們有許多訓練有素的戰馬可以大大幫助你的騎手。我堅持讓你帶走牠"
+"們。」"
+
+msgid ""
+"As you approach the stables, the head groom appears, leading a fine looking "
+"war horse. \"This steed will help speed you in your travels. Alas, he will "
+"grow tired in a week. You must also let me give better horses to your "
+"mounted soldiers, their horses look shoddy and weak.\""
+msgstr ""
+"當你走近馬廄時，馬夫長出現了，牽著一匹漂亮的戰馬。「這匹駿馬將加速你的旅途。"
+"可惜牠一週後會疲勞。你也必須讓我給你的騎兵更好的坐騎，他們的馬看起來劣質又虛"
+"弱。」"
+
+msgid ""
+"The head groom approaches you and speaks, \"You already have a fine horse, "
+"and have no inexperienced cavalry which might make use of our trained war "
+"horses.\""
+msgstr ""
+"馬夫長走近你說道：「你已經有一匹好馬了，而且沒有需要我們訓練戰馬的新手騎"
+"兵。」"
+
+msgid ""
+"As you approach the stables, the head groom appears, leading a fine looking "
+"war horse. \"This steed will help speed you in your travels. Alas, his "
+"endurance will wane with a lot of heavy riding, and you must return for a "
+"fresh mount in a week. We also have many fine war horses which could benefit "
+"mounted soldiers, but you have none we can help.\""
+msgstr ""
+"當你走近馬廄時，馬夫長出現了，牽著一匹漂亮的戰馬。「這匹駿馬將加速你的旅途。"
+"可惜大量騎乘後牠的耐力會下降，你一週後必須回來換馬。我們還有許多好的戰馬可供"
+"騎兵使用，但你沒有我們能幫助的部隊。」"
+
+msgid "The Arena guards turn you away."
+msgstr "競技場的守衛將你拒之門外。"
+
+msgid ""
+"You have your crew stop up their ears with wax before the sirens' eerie song "
+"has any chance of luring them to a watery grave."
+msgstr ""
+"在海妖詭異的歌聲有機會將船員引入葬身之地前，你讓他們用蠟堵住耳朵。"
+
+msgid ""
+"As the sirens sing their eerie song, your small, determined army manages to "
+"overcome the urge to dive headlong into the sea."
+msgstr ""
+"海妖唱著詭異的歌聲時，你那小而堅決的軍隊成功克制了一頭栽入大海的衝動。"
+
+msgid ""
+"An eerie wailing song emanates from the sirens perched upon the rocks. Many "
+"of your crew fall under its spell, and dive into the water where they drown. "
+"You are now wiser for the visit, and gain %{exp} experience."
+msgstr ""
+"棲息在岩石上的海妖發出詭異的哀歌。許多船員中了咒語，跳入水中溺斃。經此一事你"
+"更加睿智，獲得 %{exp} 點經驗值。"
+
+msgid ""
+"In a dazzling display of daring, you break into the local jail and free the "
+"hero imprisoned there, who, in return, pledges loyalty to your cause."
+msgstr ""
+"憑藉驚人的膽識，你闖入了當地牢獄並釋放了被囚禁的英雄，作為回報，他向你效忠。"
+
+msgid ""
+"You already have %{count} heroes, and regretfully must leave the prisoner in "
+"this jail to languish in agony for untold days."
+msgstr ""
+"你已有 %{count} 位英雄，只能遺憾地將囚犯留在牢獄中繼續受苦。"
+
+msgid ""
+"You enter a rickety hut and talk to the magician who lives there. He tells "
+"you of places near and far which may aid you in your journeys."
+msgstr ""
+"你進入一間搖搖欲墜的小屋，與住在那裡的法師交談。他告訴你遠近各處可能對旅途有"
+"幫助的地點。"
+
+msgid "This eye seems to be intently studying its surroundings."
+msgstr "這隻眼睛似乎正專注地觀察著周圍環境。"
+
+msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
+msgstr "你遇到了一座巨大的人面獅身像。它異常沉默。"
+
+msgid ""
+"\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
+"shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
+"the challenge?\""
+msgstr ""
+"「我有一個謎語要考你，」人面獅身像說。「答對了就有獎賞。答錯了就會被吃掉。你"
+"接受挑戰嗎？」"
+
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+"\n"
+"'"
+msgstr ""
+"人面獅身像向你提出以下謎語:\n"
+"\n"
+"「"
+
+msgid ""
+"sphinx|'\n"
+"\n"
+"Your answer?"
+msgstr ""
+"」\n"
+"\n"
+"你的答案？"
+
+msgid ""
+"\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
+"you with a paw, knocking you to the ground. Another blow makes the world go "
+"black, and you know no more."
+msgstr ""
+"「你猜錯了，」人面獅身像微笑著說。牠一掌將你拍倒在地。又一擊讓世界陷入黑暗，"
+"你再也不知道了。"
+
+msgid ""
+"Looking somewhat disappointed, the Sphinx sighs. \"You've answered my riddle "
+"so here's your reward. Now begone.\""
+msgstr ""
+"人面獅身像看起來有些失望，嘆了口氣。「你回答了我的謎語，這是你的獎勵。現在離"
+"開吧。」"
+
+msgid ""
+"A magical barrier stands tall before you, blocking your way. Runes on the "
+"arch read,\n"
+"\"Speak the key and you may pass.\"\n"
+"As you speak the magic word, the glowing barrier dissolves into nothingness."
+msgstr ""
+"一道高大的魔法屏障擋住你的去路。拱門上的符文寫著:\n"
+"「說出通關密語即可通過。」\n"
+"當你說出魔法口令時，發光的屏障化為虛無消散了。"
+
+msgid ""
+"A magical barrier stands tall before you, blocking your way. Runes on the "
+"arch read,\n"
+"\"Speak the key and you may pass.\"\n"
+"You speak, and nothing happens."
+msgstr ""
+"一道高大的魔法屏障擋住你的去路。拱門上的符文寫著:\n"
+"「說出通關密語即可通過。」\n"
+"你開口了，但什麼都沒發生。"
+
+msgid ""
+"You enter the tent and see an old woman gazing into a magic gem. She looks "
+"up and says,\n"
+"\"In my travels, I have learned much in the way of arcane magic. A great "
+"oracle taught me his skill. I have the answer you seek.\""
+msgstr ""
+"你進入帳篷，看到一位老婦人正凝視著一顆魔法寶石。她抬頭說道:\n"
+"「在我的旅途中，我學到了許多奧術魔法。一位偉大先知將技藝傳授給我。我有你尋找"
+"的答案。」"
+
+msgid ""
+"The sting of your previous encounter still lingers, and you keep your "
+"distance from the intimidating cat until you have regained your courage in "
+"battle."
+msgstr ""
+"上次遭遇的刺痛仍在，你與那隻可怕的貓保持距離，直到在戰鬥中恢復勇氣。"
+
+msgid ""
+"You come upon a great cat, purring as it rubs against your leg. Charmed, you "
+"reach down, but it bites you and flees. At least the laughter at your "
+"misfortune lifts your troops' spirits."
+msgstr ""
+"你遇到一隻大貓，牠呼嚕著蹭你的腿。你著迷地伸手去摸，卻被咬了一口，貓隨即逃"
+"跑。至少部隊因你的糗事而歡笑，士氣有所提升。"
+
+msgid "No spell book is present."
+msgstr "目前沒有法術書。"
+
+msgid ""
+"This spell costs %{mana} spell points. You have no spell points, so you "
+"cannot cast it."
+msgstr ""
+"此法術需要 %{mana} 點魔法值。你沒有魔法值，因此無法施放。"
+
+msgid ""
+"This spell costs %{mana} spell points. You only have %{point} spell points, "
+"so you cannot cast it."
+msgstr ""
+"此法術需要 %{mana} 點魔法值。你只有 %{point} 點魔法值，因此無法施放。"
+
+msgid "The spell was not found."
+msgstr "未找到此法術。"
+
+msgid "Only heroes can cast this spell."
+msgstr "只有英雄能施放此法術。"
+
+msgid "This hero is not able to cast adventure spells."
+msgstr "此英雄無法施放冒險法術。"
+
+msgid "This spell cannot be cast on a boat."
+msgstr "此法術無法在船上施放。"
+
+msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
+msgstr "英雄今天太疲勞無法施放此法術。請明天再試。"
+
+msgid "This spell can only be cast near an ocean."
+msgstr "此法術只能在海洋附近施放。"
+
+msgid ""
+"There are no boats available and no ocean adjacent to the hero where this "
+"spell will work."
+msgstr ""
+"沒有可用的船隻，英雄附近也沒有可讓此法術生效的海洋。"
+
+msgid "There are no boats available for this spell."
+msgstr "沒有可供此法術使用的船隻。"
+
+msgid "There is no ocean adjacent to the hero where this spell will work."
+msgstr "英雄附近沒有可讓此法術生效的海洋。"
+
+msgid ""
+"You do not own any town or castle that is not currently occupied by a hero. "
+"This spell will have no effect."
+msgstr ""
+"你沒有任何未被英雄佔據的城鎮或城堡。此法術不會有效果。"
+
+msgid "This hero is already in a town, so this spell will have no effect."
+msgstr "此英雄已在城鎮中，法術不會有效果。"
+
+msgid ""
+"The nearest town is %{town}.\n"
+"\n"
+"This town is occupied by your hero %{hero}."
+msgstr ""
+"最近的城鎮是 %{town}。\n"
+"\n"
+"此城鎮被你的英雄 %{hero} 佔據。"
+
+msgid "This spell is already in effect."
+msgstr "此法術已在生效中。"
+
+msgid ""
+"No opponent neither has nor can have any hero under their command anymore. "
+"Casting this spell will have no effect."
+msgstr ""
+"沒有對手現在或未來會擁有英雄。施放此法術不會有效果。"
+
+msgid ""
+"No opponent has a hero under their command at this time. Casting this spell "
+"will have no effect."
+msgstr ""
+"目前沒有對手擁有英雄。施放此法術不會有效果。"
+
+msgid ""
+"You must be within %{count} spaces of a monster for the Visions spell to "
+"work."
+msgstr ""
+"必須在怪物 %{count} 格範圍內才能使幻視法術生效。"
+
+msgid ""
+"You must be standing on the entrance to a mine (sawmills and alchemist labs "
+"do not count) to cast this spell."
+msgstr ""
+"必須站在礦場入口 (鋸木廠和煉金術士實驗室不算) 才能施放此法術。"
+
+msgid "You must first defeat the ghosts guarding the mine to cast this spell."
+msgstr "必須先擊敗守衛礦場的幽靈才能施放此法術。"
+
+msgid ""
+"There are already at least as many elementals guarding the mine as this hero "
+"can generate. Casting this spell will have no effect."
+msgstr ""
+"守衛礦場的元素生物已達此英雄能產生的上限。施放此法術不會有效果。"
+
+msgid "%{name} the %{race} (Level %{level})"
+msgstr "%{name}，%{race} (等級 %{level})"
+
+msgid "Random hero (Level %{level})"
+msgstr "隨機英雄 (等級 %{level})"
+
+msgid "Random %{race} hero (Level %{level})"
+msgstr "隨機 %{race} 英雄 (等級 %{level})"
+
+msgid "Hero class:"
+msgstr "英雄職業："
+
+msgid "Are you sure you want to dismiss this Hero?"
+msgstr "確定要解散此英雄嗎？"
+
+msgid "Set custom Experience value. Current value is default."
+msgstr "設定自訂經驗值。目前為預設值。"
+
+msgid "Change Experience value. Right-click to reset to default value."
+msgstr "變更經驗值。右鍵按一下重置為預設值。"
+
+msgid "View Experience Info"
+msgstr "檢視經驗值資訊"
+
+msgid "Set custom Spell Points value. Current value is default."
+msgstr "設定自訂魔法值。目前為預設值。"
+
+msgid "Change Spell Points value. Right-click to reset to default value."
+msgstr "變更魔法值。右鍵按一下重置為預設值。"
+
+msgid "Set Spell Points value:"
+msgstr "設定魔法值："
+
+msgid "View Spell Points Info"
+msgstr "檢視魔法值資訊"
+
+msgid "Set patrol radius in tiles:"
+msgstr "設定巡邏半徑 (格數):"
+
+msgid "Enter hero's name:"
+msgstr "輸入英雄名稱："
+
+msgid "Click to change class."
+msgstr "按一下變更職業。"
+
+msgid ""
+"'Spread' combat formation spreads the hero's units from the top to the "
+"bottom of the battlefield, with at least one empty space between each unit."
+msgstr ""
+"「分散」陣型將英雄的部隊從戰場頂部到底部展開，每支部隊之間至少保留一格空間。"
+
+msgid ""
+"'Grouped' combat formation bunches the hero's army together in the center of "
+"their side of the battlefield."
+msgstr ""
+"「集中」陣型將英雄的軍隊集中在戰場己方一側的中央。"
+
+msgid "Exit Hero Screen"
+msgstr "離開英雄畫面"
+
+msgid "You cannot dismiss a hero in a castle"
+msgstr "無法在城堡中解散英雄"
+
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
+msgstr "場景禁止解散 %{race} %{name}"
+
+msgid "Dismiss %{name} the %{race}"
+msgstr "解散 %{race} %{name}"
+
+msgid "Show previous hero"
+msgstr "顯示上一位英雄"
+
+msgid "Show next hero"
+msgstr "顯示下一位英雄"
+
+msgid "Set army combat formation to 'Spread'"
+msgstr "將軍隊戰鬥陣型設為「分散」"
+
+msgid "Set army combat formation to 'Grouped'"
+msgstr "將軍隊戰鬥陣型設為「集中」"
+
+msgid "Set hero's Artifacts. Right-click to reset Artifact."
+msgstr "設定英雄的神器。右鍵按一下重置神器。"
+
+msgid "Set hero's Secondary Skills. Right-click to reset skill."
+msgstr "設定英雄的次要技能。右鍵按一下重置技能。"
+
+msgid "Set hero's Army. Right-click to reset unit."
+msgstr "設定英雄的軍隊。右鍵按一下重置單位。"
+
+msgid "Set hero's portrait. Right-click to reset to default."
+msgstr "設定英雄肖像。右鍵按一下重置為預設。"
+
+msgid "Click to change hero's name. Right-click to reset to default."
+msgstr "按一下變更英雄名稱。右鍵按一下重置為預設。"
+
+msgid "Hero is in patrol mode in %{tiles} tiles radius. Click to disable it."
+msgstr "英雄正在 %{tiles} 格半徑範圍內巡邏。按一下停用。"
+
+msgid "Click to enable hero's patrol mode."
+msgstr "按一下啟用英雄的巡邏模式。"
+
+msgid "Do you want to save the changes made?"
+msgstr "要儲存所做的變更嗎？"
+
+msgid "Blood Morale"
+msgstr "嗜血士氣"
+
+msgid "%{morale} Morale"
+msgstr "%{morale}士氣"
+
+msgid "%{luck} Luck"
+msgstr "%{luck}運氣"
+
+msgid "Current Luck Modifiers:"
+msgstr "目前運氣加成："
+
+msgid "Current Morale Modifiers:"
+msgstr "目前士氣加成："
+
+msgid "Entire army is undead, so morale does not apply."
+msgstr "全軍皆為亡靈，士氣不適用。"
+
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
+msgstr ""
+"目前經驗值 %{exp1}。\n"
+" 下一級 %{exp2}。"
+
+msgid "million|M"
+msgstr "M"
+
+msgid "Level %{level}"
+msgstr "等級 %{level}"
+
+msgid ""
+"%{name} currently has %{point} spell points out of a maximum of %{max}. The "
+"maximum number of spell points is 10 times the hero's knowledge. It is "
+"occasionally possible for the hero to have more than their maximum spell "
+"points via special events."
+msgstr ""
+"%{name} 目前有 %{point} 點魔法值，上限為 %{max}。魔法值上限為英雄知識值的 10 "
+"倍。透過特殊事件，英雄偶爾可以擁有超過上限的魔法值。"
+
+msgid "%{name1} meets %{name2}"
+msgstr "%{name1} 遇見 %{name2}"
+
+msgid "hero|Level %{level}"
+msgstr "等級 %{level}"
+
+msgid "Move all artifacts from %{from_hero_name} to %{to_hero_name}."
+msgstr "將所有神器從 %{from_hero_name} 移轉至 %{to_hero_name}。"
+
+msgid "Artifact Transfer"
+msgstr "神器移轉"
+
+msgid "Swap Artifacts"
+msgstr "交換神器"
+
+msgid "Swap all artifacts between heroes."
+msgstr "交換英雄之間的所有神器。"
+
+msgid "Move army from %{from_hero_name} to %{to_hero_name}."
+msgstr "將軍隊從 %{from_hero_name} 移動至 %{to_hero_name}。"
+
+msgid "Army Transfer"
+msgstr "軍隊移轉"
+
+msgid "Swap Armies"
+msgstr "交換軍隊"
+
+msgid "Swap armies between heroes."
+msgstr "交換英雄之間的軍隊。"
+
+msgid "Enemy heroes are now fully identifiable."
+msgstr "敵方英雄現已可完全辨識。"
+
+msgid "Identify Hero"
+msgstr "辨識英雄"
+
+msgid "Select town to port to."
+msgstr "選擇要傳送至的城鎮。"
+
+msgid "Town Portal"
+msgstr "城鎮傳送門"
+
+msgid "The creatures are willing to join us!"
+msgstr "這些生物願意加入我們！"
+
+msgid "All the creatures will join us..."
+msgstr "所有的生物都將加入我們……"
+
+msgid "The creature will join us..."
+msgid_plural "%{count} of the creatures will join us..."
+msgstr[0] "生物將加入我們……"
+
+msgid ""
+"\n"
+" for a fee of %{gold} gold."
+msgstr ""
+"\n"
+"費用為 %{gold} 金幣。"
+
+msgid "These weak creatures will surely flee before us."
+msgstr "這些弱小的生物肯定會在我們面前逃跑。"
+
+msgid "I fear these creatures are in the mood for a fight."
+msgstr "恐怕這些生物正準備要戰鬥。"
+
+msgid "The hero's attack skill is a bonus added to each unit's attack skill."
+msgstr "英雄的攻擊技能作為加成加到每支部隊的攻擊技能上。"
+
+msgid "The hero's defense skill is a bonus added to each unit's defense skill."
+msgstr "英雄的防禦技能作為加成加到每支部隊的防禦技能上。"
+
+msgid "The hero's spell power determines the duration or power of a spell."
+msgstr "英雄的魔法力量決定法術的持續時間或威力。"
+
+msgid ""
+"The hero's knowledge determines how many spell points the hero may have. "
+"Under normal circumstances, a hero is limited to 10 spell points per level "
+"of knowledge."
+msgstr ""
+"英雄的知識決定可擁有多少魔法值。正常情況下，英雄每點知識限制為 10 點魔法值。"
+
+msgid "Current Modifiers:"
+msgstr "目前加成："
+
+msgid "skill|Basic"
+msgstr "基礎"
+
+msgid "skill|Advanced"
+msgstr "進階"
+
+msgid "skill|Expert"
+msgstr "專家"
+
+msgid "Pathfinding"
+msgstr "尋路術"
+
+msgid "Archery"
+msgstr "箭術"
+
+msgid "Logistics"
+msgstr "後勤術"
+
+msgid "Scouting"
+msgstr "偵察術"
+
+msgid "Diplomacy"
+msgstr "外交術"
+
+msgid "Navigation"
+msgstr "航海術"
+
+msgid "Leadership"
+msgstr "領導術"
+
+msgid "Wisdom"
+msgstr "智慧"
+
+msgid "Mysticism"
+msgstr "神祕術"
+
+msgid "Ballistics"
+msgstr "彈道術"
+
+msgid "Eagle Eye"
+msgstr "鷹眼術"
+
+msgid "Necromancy"
+msgstr "亡靈巫術"
+
+msgid "Estates"
+msgstr "產業術"
+
+msgid "Advanced Archery"
+msgstr "進階箭術"
+
+msgid "Advanced Pathfinding"
+msgstr "進階尋路術"
+
+msgid "Basic Archery"
+msgstr "基礎箭術"
+
+msgid "Basic Pathfinding"
+msgstr "基礎尋路術"
+
+msgid "Expert Pathfinding"
+msgstr "專家尋路術"
+
+msgid "Advanced Logistics"
+msgstr "進階後勤術"
+
+msgid "Basic Logistics"
+msgstr "基礎後勤術"
+
+msgid "Basic Scouting"
+msgstr "基礎偵察術"
+
+msgid "Expert Archery"
+msgstr "專家箭術"
+
+msgid "Expert Logistics"
+msgstr "專家後勤術"
+
+msgid "Advanced Diplomacy"
+msgstr "進階外交術"
+
+msgid "Advanced Scouting"
+msgstr "進階偵察術"
+
+msgid "Basic Diplomacy"
+msgstr "基礎外交術"
+
+msgid "Expert Diplomacy"
+msgstr "專家外交術"
+
+msgid "Expert Scouting"
+msgstr "專家偵察術"
+
+msgid "Advanced Leadership"
+msgstr "進階領導術"
+
+msgid "Advanced Navigation"
+msgstr "進階航海術"
+
+msgid "Basic Leadership"
+msgstr "基礎領導術"
+
+msgid "Basic Navigation"
+msgstr "基礎航海術"
+
+msgid "Expert Navigation"
+msgstr "專家航海術"
+
+msgid "Advanced Wisdom"
+msgstr "進階智慧"
+
+msgid "Basic Mysticism"
+msgstr "基礎神祕術"
+
+msgid "Basic Wisdom"
+msgstr "基礎智慧"
+
+msgid "Expert Leadership"
+msgstr "專家領導術"
+
+msgid "Expert Wisdom"
+msgstr "專家智慧"
+
+msgid "Advanced Luck"
+msgstr "進階運氣"
+
+msgid "Advanced Mysticism"
+msgstr "進階神祕術"
+
+msgid "Basic Luck"
+msgstr "基礎運氣"
+
+msgid "Expert Luck"
+msgstr "專家運氣"
+
+msgid "Expert Mysticism"
+msgstr "專家神祕術"
+
+msgid "Advanced Ballistics"
+msgstr "進階彈道術"
+
+msgid "Advanced Eagle Eye"
+msgstr "進階鷹眼術"
+
+msgid "Basic Ballistics"
+msgstr "基礎彈道術"
+
+msgid "Basic Eagle Eye"
+msgstr "基礎鷹眼術"
+
+msgid "Expert Ballistics"
+msgstr "專家彈道術"
+
+msgid "Advanced Necromancy"
+msgstr "進階亡靈巫術"
+
+msgid "Basic Estates"
+msgstr "基礎產業術"
+
+msgid "Basic Necromancy"
+msgstr "基礎亡靈巫術"
+
+msgid "Expert Eagle Eye"
+msgstr "專家鷹眼術"
+
+msgid "Expert Necromancy"
+msgstr "專家亡靈巫術"
+
+msgid "Advanced Estates"
+msgstr "進階產業術"
+
+msgid "Expert Estates"
+msgstr "專家產業術"
+
+msgid ""
+"%{skill} reduces the movement penalty for rough terrain by %{count} percent."
+msgstr ""
+"%{skill} 將崎嶇地形的移動懲罰降低 %{count}%。"
+
+msgid "%{skill} eliminates the movement penalty for rough terrain."
+msgstr "%{skill} 消除崎嶇地形的移動懲罰。"
+
+msgid ""
+"%{skill} increases the damage done by the hero's range attacking creatures "
+"by %{count} percent, and eliminates the %{penalty} percent penalty when "
+"shooting past obstacles (e.g. castle walls)."
+msgstr ""
+"%{skill} 將英雄遠距攻擊生物的傷害提升 %{count}%，並消除穿過障礙物（例如城牆）"
+"射擊時 %{penalty}% 的懲罰。"
+
+msgid "%{skill} increases the hero's movement points by %{count} percent."
+msgstr "%{skill} 將英雄的移動力提升 %{count}%。"
+
+msgid "%{skill} increases the hero's viewable area by one square."
+msgid_plural "%{skill} increases the hero's viewable area by %{count} squares."
+msgstr[0] "%{skill} 將英雄的可視範圍增加一格。"
+
+msgid ""
+"%{skill} allows the hero to negotiate with monsters who are weaker than "
+"their army, and reduces the cost of surrender."
+msgstr ""
+"%{skill} 讓英雄能與比自身弱的怪物交涉，並降低投降的費用。"
+
+msgid ""
+"Approximately %{count} percent of the creatures may offer to join the hero."
+msgstr ""
+"約 %{count}% 的生物可能會主動加入英雄。"
+
+msgid "All of the creatures may offer to join the hero."
+msgstr "所有生物都可能主動加入英雄。"
+
+msgid ""
+"The cost of surrender is reduced to %{percent} percent of the total cost of "
+"troops in the army."
+msgstr ""
+"投降費用降為軍隊部隊總成本的 %{percent}%。"
+
+msgid ""
+"%{skill} increases the hero's movement points over water by %{count} percent."
+msgstr ""
+"%{skill} 將英雄的水上移動力提升 %{count}%。"
+
+msgid "%{skill} increases the hero's troops morale by %{count}."
+msgstr "%{skill} 將英雄部隊的士氣提升 %{count}。"
+
+msgid "%{skill} allows the hero to learn third level spells."
+msgstr "%{skill} 讓英雄能學習第三級法術。"
+
+msgid "%{skill} allows the hero to learn fourth level spells."
+msgstr "%{skill} 讓英雄能學習第四級法術。"
+
+msgid "%{skill} allows the hero to learn fifth level spells."
+msgstr "%{skill} 讓英雄能學習第五級法術。"
+
+msgid "%{skill} regenerates one additional spell point per day to the hero."
+msgid_plural ""
+"%{skill} regenerates %{count} additional spell points per day to the hero."
+msgstr[0] "%{skill} 每日為英雄額外恢復一點魔法值。"
+
+msgid "%{skill} increases the hero's luck by %{count}."
+msgstr "%{skill} 將英雄的運氣提升 %{count}。"
+
+msgid ""
+"%{skill} gives the hero's catapult shots a greater chance to hit and do "
+"damage to castle walls."
+msgstr ""
+"%{skill} 讓英雄的投石車射擊有更高機率命中並破壞城牆。"
+
+msgid ""
+"%{skill} gives the hero's catapult an extra shot, and each shot has a "
+"greater chance to hit and do damage to castle walls."
+msgstr ""
+"%{skill} 讓英雄的投石車多一次射擊機會，且每次射擊有更高機率命中並破壞城牆。"
+
+msgid ""
+"%{skill} gives the hero's catapult an extra shot, and each shot "
+"automatically destroys any wall, except a fortified wall in a Knight castle."
+msgstr ""
+"%{skill} 讓英雄的投石車多一次射擊機會，且每次射擊自動摧毀任何城牆，騎士城堡的"
+"強化城牆除外。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 1st or "
+"2nd level spell that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 讓英雄有 %{count}% 的機率學會敵人在戰鬥中施放的任何一、二級法術。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 3rd "
+"level spell (or below) that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 讓英雄有 %{count}% 的機率學會敵人在戰鬥中施放的任何三級 (含以下) 法"
+"術。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 4th "
+"level spell (or below) that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 讓英雄有 %{count}% 的機率學會敵人在戰鬥中施放的任何四級 (含以下) 法"
+"術。"
+
+msgid ""
+"%{skill} allows %{count} percent of the creatures killed in combat to be "
+"brought back from the dead as Skeletons."
+msgstr ""
+"%{skill} 讓戰鬥中被殺死的生物有 %{count}% 能以骷髏兵的形式復活。"
+
+msgid ""
+"The hero produces %{count} gold pieces per day as tax revenue from estates."
+msgstr ""
+"英雄每日從產業中獲得 %{count} 金幣的稅收。"
+
+msgid "Blue"
+msgstr "藍色"
+
+msgid "Green"
+msgstr "綠色"
+
+msgid "Red"
+msgstr "紅色"
+
+msgid "Yellow"
+msgstr "黃色"
+
+msgid "Orange"
+msgstr "橙色"
+
+msgid "Purple"
+msgstr "紫色"
+
+msgid "barrier|Aqua"
+msgstr "水藍"
+
+msgid "barrier|Blue"
+msgstr "藍色"
+
+msgid "barrier|Brown"
+msgstr "棕色"
+
+msgid "barrier|Gold"
+msgstr "金色"
+
+msgid "barrier|Green"
+msgstr "綠色"
+
+msgid "barrier|Orange"
+msgstr "橙色"
+
+msgid "barrier|Purple"
+msgstr "紫色"
+
+msgid "barrier|Red"
+msgstr "紅色"
+
+msgid "tent|Aqua"
+msgstr "水藍"
+
+msgid "tent|Blue"
+msgstr "藍色"
+
+msgid "tent|Brown"
+msgstr "棕色"
+
+msgid "tent|Gold"
+msgstr "金色"
+
+msgid "tent|Green"
+msgstr "綠色"
+
+msgid "tent|Orange"
+msgstr "橙色"
+
+msgid "tent|Purple"
+msgstr "紫色"
+
+msgid "tent|Red"
+msgstr "紅色"
+
+msgid "Experience"
+msgstr "經驗值"
+
+msgid ""
+"Experience allows your heroes to gain levels, increasing their primary and "
+"secondary skills."
+msgstr ""
+"經驗值讓英雄能升級，提升主要和次要技能。"
+
+msgid "Hero/Stats"
+msgstr "英雄/屬性"
+
+msgid "Skills"
+msgstr "技能"
+
+msgid "Town/Castle"
+msgstr "城鎮/城堡"
+
+msgid "Garrison"
+msgstr "城防部隊"
+
+msgid "Gold Per Day:"
+msgstr "每日黃金："
+
+msgid "View Heroes."
+msgstr "檢視英雄。"
+
+msgid "Towns/Castles"
+msgstr "城鎮/城堡"
+
+msgid "View Towns and Castles."
+msgstr "檢視城鎮和城堡。"
+
+msgid "luck|Cursed"
+msgstr "被詛咒"
+
+msgid "luck|Awful"
+msgstr "極差"
+
+msgid "luck|Bad"
+msgstr "差"
+
+msgid "luck|Normal"
+msgstr "普通"
+
+msgid "luck|Good"
+msgstr "好"
+
+msgid "luck|Great"
+msgstr "極好"
+
+msgid "luck|Irish"
+msgstr "幸運之極"
+
+msgid ""
+"%{luck-type} luck sometimes falls on the hero's units in combat, causing "
+"their attacks to only do half damage."
+msgstr ""
+"%{luck-type}運氣有時會降臨在英雄的部隊上，使其攻擊只造成一半的傷害。"
+
+msgid ""
+"%{luck-type} luck means the hero's units will never get lucky or unlucky "
+"attacks on the enemy."
+msgstr ""
+"%{luck-type} 運氣表示英雄的部隊在攻擊敵人時不會獲得好運或厄運效果。"
+
+msgid ""
+"%{luck-type} luck sometimes lets the hero's units get lucky attacks (double "
+"strength) in combat."
+msgstr ""
+"%{luck-type} 運氣有時會讓英雄的部隊在戰鬥中獲得幸運攻擊（雙倍傷害）。"
+
+msgid "morale|Treason"
+msgstr "叛變"
+
+msgid "morale|Awful"
+msgstr "極差"
+
+msgid "morale|Poor"
+msgstr "差"
+
+msgid "morale|Normal"
+msgstr "普通"
+
+msgid "morale|Good"
+msgstr "好"
+
+msgid "morale|Great"
+msgstr "極好"
+
+msgid "morale|Blood!"
+msgstr "嗜血！"
+
+msgid "%{morale-type} morale may cause the hero's units to freeze in combat."
+msgstr "%{morale-type}士氣可能導致英雄的部隊在戰鬥中僵住。"
+
+msgid ""
+"%{morale-type} morale means the hero's units will never be blessed with "
+"extra attacks or freeze in combat."
+msgstr ""
+"%{morale-type}士氣表示英雄的部隊不會獲得額外攻擊或在戰鬥中僵住。"
+
+msgid ""
+"%{morale-type} morale may give the hero's units extra attacks in combat."
+msgstr ""
+"%{morale-type}士氣可能讓英雄的部隊在戰鬥中獲得額外攻擊。"
+
+msgid "Blood"
+msgstr "嗜血"
+
+msgid "Knight"
+msgstr "騎士"
+
+msgid "Barbarian"
+msgstr "野蠻人"
+
+msgid "Sorceress"
+msgstr "女巫"
+
+msgid "Warlock"
+msgstr "術士"
+
+msgid "Wizard"
+msgstr "巫師"
+
+msgid "Necromancer"
+msgstr "亡靈法師"
+
+msgid "Multi"
+msgstr "混合"
+
+msgid "doubleLined|Knight"
+msgstr "騎士"
+
+msgid "doubleLined|Barbarian"
+msgstr "野蠻人"
+
+msgid "doubleLined|Sorceress"
+msgstr "女巫"
+
+msgid "doubleLined|Warlock"
+msgstr "術士"
+
+msgid "doubleLined|Wizard"
+msgstr "巫師"
+
+msgid ""
+"doubleLined|Necro-\n"
+"mancer"
+msgstr ""
+"亡靈\n"
+"法師"
+
+msgid "doubleLinedRace|Multi"
+msgstr "混合"
+
+msgid "doubleLinedRace|Random"
+msgstr "隨機"
+
+msgid "speed|Standing"
+msgstr "靜止"
+
+msgid "speed|Crawling"
+msgstr "極慢"
+
+msgid "speed|Very Slow"
+msgstr "非常慢"
+
+msgid "speed|Slow"
+msgstr "慢"
+
+msgid "speed|Average"
+msgstr "普通"
+
+msgid "speed|Fast"
+msgstr "快"
+
+msgid "speed|Very Fast"
+msgstr "非常快"
+
+msgid "speed|Ultra Fast"
+msgstr "極快"
+
+msgid "speed|Blazing"
+msgstr "疾速"
+
+msgid "speed|Instant"
+msgstr "瞬間"
+
+msgid "Click this button to adjust the level of zoom."
+msgstr "按此按鈕調整縮放等級。"
+
+msgid "Zoom"
+msgstr "縮放"
+
+msgid "week|Squirrel"
+msgstr "松鼠"
+
+msgid "week|Rabbit"
+msgstr "兔子"
+
+msgid "week|Gopher"
+msgstr "地鼠"
+
+msgid "week|Badger"
+msgstr "獾"
+
+msgid "week|Rat"
+msgstr "老鼠"
+
+msgid "week|Eagle"
+msgstr "老鷹"
+
+msgid "week|Weasel"
+msgstr "鼬鼠"
+
+msgid "week|Raven"
+msgstr "烏鴉"
+
+msgid "week|Mongoose"
+msgstr "貓鼬"
+
+msgid "week|Dog"
+msgstr "犬"
+
+msgid "week|Aardvark"
+msgstr "食蟻獸"
+
+msgid "week|Lizard"
+msgstr "蜥蜴"
+
+msgid "week|Tortoise"
+msgstr "陸龜"
+
+msgid "week|Hedgehog"
+msgstr "刺蝟"
+
+msgid "week|Condor"
+msgstr "禿鷲"
+
+msgid "week|Ant"
+msgstr "螞蟻"
+
+msgid "week|Grasshopper"
+msgstr "蚱蜢"
+
+msgid "week|Dragonfly"
+msgstr "蜻蜓"
+
+msgid "week|Spider"
+msgstr "蜘蛛"
+
+msgid "week|Butterfly"
+msgstr "蝴蝶"
+
+msgid "week|Bumblebee"
+msgstr "大黃蜂"
+
+msgid "week|Locust"
+msgstr "蝗蟲"
+
+msgid "week|Earthworm"
+msgstr "蚯蚓"
+
+msgid "week|Hornet"
+msgstr "胡蜂"
+
+msgid "week|Beetle"
+msgstr "甲蟲"
+
+msgid "week|PLAGUE"
+msgstr "瘟疫"
+
+msgid "week|Unnamed"
+msgstr "無名"
+
+msgid "Desert"
+msgstr "沙漠"
+
+msgid "Snow"
+msgstr "雪地"
+
+msgid "Wasteland"
+msgstr "荒地"
+
+msgid "Beach"
+msgstr "沙灘"
+
+msgid "Lava"
+msgstr "岩漿"
+
+msgid "Dirt"
+msgstr "泥土"
+
+msgid "Grass"
+msgstr "草地"
+
+msgid "Ocean"
+msgstr "海洋"
+
+msgid "map_layout|Mirrored"
+msgstr "鏡像"
+
+msgid "map_layout|Balanced"
+msgstr "平衡"
+
+msgid "map_layout|Islands"
+msgstr "群島"
+
+msgid "map_layout|Pyramid"
+msgstr "金字塔"
+
+msgid "map_layout|Quest"
+msgstr "任務"
+
+msgid "resource_density|Scarce"
+msgstr "稀少"
+
+msgid "resource_density|Normal"
+msgstr "正常"
+
+msgid "resource_density|Abundant"
+msgstr "豐富"
+
+msgid "monster_strength|Weak"
+msgstr "弱"
+
+msgid "monster_strength|Normal"
+msgstr "正常"
+
+msgid "monster_strength|Strong"
+msgstr "強"
+
+msgid "monster_strength|Deadly"
+msgstr "致命"
+
+msgid "maps|Small"
+msgstr "小型"
+
+msgid "maps|Medium"
+msgstr "中型"
+
+msgid "maps|Large"
+msgstr "大型"
+
+msgid "maps|Extra Large"
+msgstr "超大"
+
+msgid "maps|Custom Size"
+msgstr "自訂大小"
+
+msgid "Ore Mine"
+msgstr "礦石礦場"
+
+msgid "Sulfur Mine"
+msgstr "硫磺礦場"
+
+msgid "Crystal Mine"
+msgstr "水晶礦場"
+
+msgid "Gems Mine"
+msgstr "寶石礦場"
+
+msgid "Gold Mine"
+msgstr "金礦"
+
+msgid "Mine"
+msgstr "礦場"
+
+msgid "Burma shave."
+msgstr "Burma shave."
+
+msgid "Next sign 50 miles."
+msgstr "下個路標 50 英里。"
+
+msgid "See Rock City."
+msgstr "See Rock City."
+
+msgid "This space for rent."
+msgstr "此處招租。"
+
+msgid "No object"
+msgstr "無物件"
+
+msgid "Alchemist Lab"
+msgstr "煉金術士實驗室"
+
+msgid "Sign"
+msgstr "路標"
+
+msgid "Buoy"
+msgstr "浮標"
+
+msgid "Skeleton"
+msgstr "骷髏"
+
+msgid "Daemon Cave"
+msgstr "惡魔洞穴"
+
+msgid "Treasure Chest"
+msgstr "寶箱"
+
+msgid "Faerie Ring"
+msgstr "妖精之環"
+
+msgid "Campfire"
+msgstr "營火"
+
+msgid "Fountain"
+msgstr "噴泉"
+
+msgid "Gazebo"
+msgstr "涼亭"
+
+msgid "Genie Lamp"
+msgstr "精靈神燈"
+
+msgid "Archer's House"
+msgstr "弓箭手之屋"
+
+msgid "Goblin Hut"
+msgstr "哥布林小屋"
+
+msgid "Dwarf Cottage"
+msgstr "矮人小屋"
+
+msgid "Peasant Hut"
+msgstr "農民小屋"
+
+msgid "Stables"
+msgstr "馬廄"
+
+msgid "Alchemist's Tower"
+msgstr "煉金術士之塔"
+
+msgid "Event"
+msgstr "事件"
+
+msgid "Dragon City"
+msgstr "龍族之城"
+
+msgid "Lighthouse"
+msgid_plural "Lighthouses"
+msgstr[0] "燈塔"
+
+msgid "Water Wheel"
+msgid_plural "Water Wheels"
+msgstr[0] "水車"
+
+msgid "Monster"
+msgstr "怪物"
+
+msgid "Obelisk"
+msgstr "方尖碑"
+
+msgid "Oasis"
+msgstr "綠洲"
+
+msgid "Resource"
+msgstr "資源"
+
+msgid "Sawmill"
+msgstr "鋸木廠"
+
+msgid "Oracle"
+msgstr "神諭"
+
+msgid "Shrine of the First Circle"
+msgstr "第一環神殿"
+
+msgid "Shipwreck"
+msgstr "沉船"
+
+msgid "Sea Chest"
+msgstr "海中寶箱"
+
+msgid "Desert Tent"
+msgstr "沙漠帳篷"
+
+msgid "Stone Liths"
+msgstr "巨石陣"
+
+msgid "Wagon Camp"
+msgstr "馬車營地"
+
+msgid "Hut of the Magi"
+msgstr "法師小屋"
+
+msgid "Whirlpool"
+msgstr "漩渦"
+
+msgid "Windmill"
+msgid_plural "Windmills"
+msgstr[0] "風車"
+
+msgid "Mermaid"
+msgstr "美人魚"
+
+msgid "Boat"
+msgstr "船"
+
+msgid "Random Ultimate Artifact"
+msgstr "隨機終極神器"
+
+msgid "Random Artifact"
+msgstr "隨機神器"
+
+msgid "Random Resource"
+msgstr "隨機資源"
+
+msgid "Random Monster"
+msgstr "隨機怪物"
+
+msgid "Random Town"
+msgstr "隨機城鎮"
+
+msgid "Random Castle"
+msgstr "隨機城堡"
+
+msgid "Eye of the Magi"
+msgstr "法師之眼"
+
+msgid "Random Monster - weak"
+msgstr "隨機怪物 - 弱"
+
+msgid "Random Monster - medium"
+msgstr "隨機怪物 - 中"
+
+msgid "Random Monster - strong"
+msgstr "隨機怪物 - 強"
+
+msgid "Random Monster - very strong"
+msgstr "隨機怪物 - 極強"
+
+msgid "Nothing Special"
+msgstr "無特殊物件"
+
+msgid "Mossy Rock"
+msgstr "青苔岩石"
+
+msgid "Watch Tower"
+msgstr "瞭望塔"
+
+msgid "Tree House"
+msgstr "樹屋"
+
+msgid "Tree City"
+msgstr "樹城"
+
+msgid "Ruins"
+msgstr "遺跡"
+
+msgid "Fort"
+msgstr "堡壘"
+
+msgid "Abandoned Mine"
+msgstr "廢棄礦場"
+
+msgid "Sirens"
+msgstr "海妖"
+
+msgid "Standing Stones"
+msgstr "豎石"
+
+msgid "Idol"
+msgstr "偶像"
+
+msgid "Tree of Knowledge"
+msgstr "知識之樹"
+
+msgid "Witch Doctor's Hut"
+msgstr "巫醫小屋"
+
+msgid "Temple"
+msgstr "神廟"
+
+msgid "Hill Fort"
+msgstr "丘陵堡壘"
+
+msgid "Halfling Hole"
+msgstr "半身人洞穴"
+
+msgid "Mercenary Camp"
+msgstr "傭兵營地"
+
+msgid "Shrine of the Second Circle"
+msgstr "第二環神殿"
+
+msgid "Shrine of the Third Circle"
+msgstr "第三環神殿"
+
+msgid "City of the Dead"
+msgstr "亡者之城"
+
+msgid "Sphinx"
+msgstr "人面獅身像"
+
+msgid "Wagon"
+msgstr "馬車"
+
+msgid "Tar Pit"
+msgstr "焦油坑"
+
+msgid "Artesian Spring"
+msgstr "自流泉"
+
+msgid "Troll Bridge"
+msgstr "巨魔之橋"
+
+msgid "Watering Hole"
+msgstr "水源地"
+
+msgid "Witch's Hut"
+msgstr "女巫小屋"
+
+msgid "Xanadu"
+msgstr "世外桃源"
+
+msgid "Lean-To"
+msgstr "棚屋"
+
+msgid "Magellan's Maps"
+msgstr "麥哲倫的海圖"
+
+msgid "Flotsam"
+msgstr "漂流物"
+
+msgid "Derelict Ship"
+msgstr "廢棄船"
+
+msgid "Shipwreck Survivor"
+msgstr "沉船倖存者"
+
+msgid "Bottle"
+msgstr "瓶子"
+
+msgid "Magic Well"
+msgstr "魔法之井"
+
+msgid "Magic Garden"
+msgid_plural "Magic Gardens"
+msgstr[0] "魔法花園"
+
+msgid "Observation Tower"
+msgstr "觀測塔"
+
+msgid "Freeman's Foundry"
+msgstr "自由人鑄造廠"
+
+msgid "Reefs"
+msgstr "暗礁"
+
+msgid "Volcano"
+msgstr "火山"
+
+msgid "Flowers"
+msgstr "花叢"
+
+msgid "Rock"
+msgstr "岩石"
+
+msgid "Water Lake"
+msgstr "湖泊"
+
+msgid "Mandrake"
+msgstr "曼德拉草"
+
+msgid "Dead Tree"
+msgstr "枯樹"
+
+msgid "Stump"
+msgstr "樹樁"
+
+msgid "Crater"
+msgstr "火山口"
+
+msgid "Cactus"
+msgstr "仙人掌"
+
+msgid "Mound"
+msgstr "土丘"
+
+msgid "Dune"
+msgstr "沙丘"
+
+msgid "Lava Pool"
+msgstr "岩漿池"
+
+msgid "Shrub"
+msgstr "灌木"
+
+msgid "Barrow Mounds"
+msgstr "古墳"
+
+msgid "Random Artifact - Treasure"
+msgstr "隨機神器 - 寶藏"
+
+msgid "Random Artifact - Minor"
+msgstr "隨機神器 - 次要"
+
+msgid "Random Artifact - Major"
+msgstr "隨機神器 - 主要"
+
+msgid "Barrier"
+msgstr "屏障"
+
+msgid "Traveller's Tent"
+msgstr "旅人帳篷"
+
+msgid "Jail"
+msgstr "牢獄"
+
+msgid "Fire Summoning Altar"
+msgstr "火焰召喚祭壇"
+
+msgid "Air Summoning Altar"
+msgstr "空氣召喚祭壇"
+
+msgid "Earth Summoning Altar"
+msgstr "大地召喚祭壇"
+
+msgid "Water Summoning Altar"
+msgstr "水之召喚祭壇"
+
+msgid "Swampy Lake"
+msgstr "沼澤湖"
+
+msgid "Frozen Lake"
+msgstr "冰凍湖"
+
+msgid "Black Cat"
+msgstr "黑貓"
+
+msgid "Barrel"
+msgstr "木桶"
+
+msgid "randomRace|level 1 creatures"
+msgstr "1 階生物"
+
+msgid "randomRace|level 2 creatures"
+msgstr "2 階生物"
+
+msgid "randomRace|level 3 creatures"
+msgstr "3 階生物"
+
+msgid "randomRace|level 4 creatures"
+msgstr "4 階生物"
+
+msgid "randomRace|level 5 creatures"
+msgstr "5 階生物"
+
+msgid "randomRace|level 6 creatures"
+msgstr "6 階生物"
+
+msgid "Unknown Monsters"
+msgstr "未知怪物"
+
+msgid "Unknown Monster"
+msgstr "未知怪物"
+
+msgid "Peasant"
+msgstr "農民"
+
+msgid "Peasants"
+msgstr "農民"
+
+msgid "Archer"
+msgstr "弓箭手"
+
+msgid "Archers"
+msgstr "弓箭手"
+
+msgid "Ranger"
+msgstr "遊俠"
+
+msgid "Rangers"
+msgstr "遊俠"
+
+msgid "Pikeman"
+msgstr "槍兵"
+
+msgid "Pikemen"
+msgstr "槍兵"
+
+msgid "Veteran Pikeman"
+msgstr "老練槍兵"
+
+msgid "Veteran Pikemen"
+msgstr "老練槍兵"
+
+msgid "Swordsman"
+msgstr "劍士"
+
+msgid "Swordsmen"
+msgstr "劍士"
+
+msgid "Master Swordsman"
+msgstr "劍術大師"
+
+msgid "Master Swordsmen"
+msgstr "劍術大師"
+
+msgid "Cavalries"
+msgstr "騎兵"
+
+msgid "Cavalry"
+msgstr "騎兵"
+
+msgid "Champion"
+msgstr "勇士"
+
+msgid "Champions"
+msgstr "勇士"
+
+msgid "Paladin"
+msgstr "聖騎士"
+
+msgid "Paladins"
+msgstr "聖騎士"
+
+msgid "Crusader"
+msgstr "十字軍"
+
+msgid "Crusaders"
+msgstr "十字軍"
+
+msgid "Goblin"
+msgstr "哥布林"
+
+msgid "Goblins"
+msgstr "哥布林"
+
+msgid "Orc"
+msgstr "獸人"
+
+msgid "Orcs"
+msgstr "獸人"
+
+msgid "Orc Chief"
+msgstr "獸人首領"
+
+msgid "Orc Chiefs"
+msgstr "獸人首領"
+
+msgid "Wolf"
+msgstr "狼"
+
+msgid "Wolves"
+msgstr "狼"
+
+msgid "Ogre"
+msgstr "食人魔"
+
+msgid "Ogres"
+msgstr "食人魔"
+
+msgid "Ogre Lord"
+msgstr "食人魔領主"
+
+msgid "Ogre Lords"
+msgstr "食人魔領主"
+
+msgid "Troll"
+msgstr "巨魔"
+
+msgid "Trolls"
+msgstr "巨魔"
+
+msgid "War Troll"
+msgstr "戰爭巨魔"
+
+msgid "War Trolls"
+msgstr "戰爭巨魔"
+
+msgid "Cyclopes"
+msgstr "獨眼巨人"
+
+msgid "Cyclops"
+msgstr "獨眼巨人"
+
+msgid "Sprite"
+msgstr "精靈"
+
+msgid "Sprites"
+msgstr "精靈"
+
+msgid "Dwarf"
+msgstr "矮人"
+
+msgid "Dwarves"
+msgstr "矮人"
+
+msgid "Battle Dwarf"
+msgstr "戰鬥矮人"
+
+msgid "Battle Dwarves"
+msgstr "戰鬥矮人"
+
+msgid "Elf"
+msgstr "精靈弓手"
+
+msgid "Elves"
+msgstr "精靈弓手"
+
+msgid "Grand Elf"
+msgstr "大精靈弓手"
+
+msgid "Grand Elves"
+msgstr "大精靈弓手"
+
+msgid "Druid"
+msgstr "德魯伊"
+
+msgid "Druids"
+msgstr "德魯伊"
+
+msgid "Greater Druid"
+msgstr "高階德魯伊"
+
+msgid "Greater Druids"
+msgstr "高階德魯伊"
+
+msgid "Unicorn"
+msgstr "獨角獸"
+
+msgid "Unicorns"
+msgstr "獨角獸"
+
+msgid "Phoenix"
+msgstr "鳳凰"
+
+msgid "Phoenixes"
+msgstr "鳳凰"
+
+msgid "Centaur"
+msgstr "半人馬"
+
+msgid "Centaurs"
+msgstr "半人馬"
+
+msgid "Gargoyle"
+msgstr "石像鬼"
+
+msgid "Gargoyles"
+msgstr "石像鬼"
+
+msgid "Griffin"
+msgstr "獅鷲"
+
+msgid "Griffins"
+msgstr "獅鷲"
+
+msgid "Minotaur"
+msgstr "牛頭怪"
+
+msgid "Minotaurs"
+msgstr "牛頭怪"
+
+msgid "Minotaur King"
+msgstr "牛頭怪之王"
+
+msgid "Minotaur Kings"
+msgstr "牛頭怪之王"
+
+msgid "Hydra"
+msgstr "九頭蛇"
+
+msgid "Hydras"
+msgstr "九頭蛇"
+
+msgid "Green Dragon"
+msgstr "綠龍"
+
+msgid "Green Dragons"
+msgstr "綠龍"
+
+msgid "Red Dragon"
+msgstr "紅龍"
+
+msgid "Red Dragons"
+msgstr "紅龍"
+
+msgid "Black Dragon"
+msgstr "黑龍"
+
+msgid "Black Dragons"
+msgstr "黑龍"
+
+msgid "Halfling"
+msgstr "半身人"
+
+msgid "Halflings"
+msgstr "半身人"
+
+msgid "Boar"
+msgstr "野豬"
+
+msgid "Boars"
+msgstr "野豬"
+
+msgid "Iron Golem"
+msgstr "鐵魔像"
+
+msgid "Iron Golems"
+msgstr "鐵魔像"
+
+msgid "Steel Golem"
+msgstr "鋼魔像"
+
+msgid "Steel Golems"
+msgstr "鋼魔像"
+
+msgid "Roc"
+msgstr "大鵬"
+
+msgid "Rocs"
+msgstr "大鵬"
+
+msgid "Mage"
+msgstr "法師"
+
+msgid "Magi"
+msgstr "法師"
+
+msgid "Archmage"
+msgstr "大法師"
+
+msgid "Archmagi"
+msgstr "大法師"
+
+msgid "Giant"
+msgstr "巨人"
+
+msgid "Giants"
+msgstr "巨人"
+
+msgid "Titan"
+msgstr "泰坦"
+
+msgid "Titans"
+msgstr "泰坦"
+
+msgid "Skeletons"
+msgstr "骷髏兵"
+
+msgid "Zombie"
+msgstr "殭屍"
+
+msgid "Zombies"
+msgstr "殭屍"
+
+msgid "Mutant Zombie"
+msgstr "變異殭屍"
+
+msgid "Mutant Zombies"
+msgstr "變異殭屍"
+
+msgid "Mummies"
+msgstr "木乃伊"
+
+msgid "Mummy"
+msgstr "木乃伊"
+
+msgid "Royal Mummies"
+msgstr "皇家木乃伊"
+
+msgid "Royal Mummy"
+msgstr "皇家木乃伊"
+
+msgid "Vampire"
+msgstr "吸血鬼"
+
+msgid "Vampires"
+msgstr "吸血鬼"
+
+msgid "Vampire Lord"
+msgstr "吸血鬼領主"
+
+msgid "Vampire Lords"
+msgstr "吸血鬼領主"
+
+msgid "Lich"
+msgstr "巫妖"
+
+msgid "Liches"
+msgstr "巫妖"
+
+msgid "Power Lich"
+msgstr "強力巫妖"
+
+msgid "Power Liches"
+msgstr "強力巫妖"
+
+msgid "Bone Dragon"
+msgstr "骨龍"
+
+msgid "Bone Dragons"
+msgstr "骨龍"
+
+msgid "Rogue"
+msgstr "盜賊"
+
+msgid "Rogues"
+msgstr "盜賊"
+
+msgid "Nomad"
+msgstr "遊牧民"
+
+msgid "Nomads"
+msgstr "遊牧民"
+
+msgid "Ghost"
+msgstr "幽靈"
+
+msgid "Ghosts"
+msgstr "幽靈"
+
+msgid "Genie"
+msgstr "精怪"
+
+msgid "Genies"
+msgstr "精怪"
+
+msgid "Medusa"
+msgstr "美杜莎"
+
+msgid "Medusas"
+msgstr "美杜莎"
+
+msgid "Earth Elemental"
+msgstr "土元素"
+
+msgid "Earth Elementals"
+msgstr "土元素"
+
+msgid "Air Elemental"
+msgstr "風元素"
+
+msgid "Air Elementals"
+msgstr "風元素"
+
+msgid "Fire Elemental"
+msgstr "火元素"
+
+msgid "Fire Elementals"
+msgstr "火元素"
+
+msgid "Water Elemental"
+msgstr "水元素"
+
+msgid "Water Elementals"
+msgstr "水元素"
+
+msgid "Random Monsters"
+msgstr "隨機怪物"
+
+msgid "Random Monster 1"
+msgstr "隨機怪物 1"
+
+msgid "Random Monsters 1"
+msgstr "隨機怪物 1"
+
+msgid "Random Monster 2"
+msgstr "隨機怪物 2"
+
+msgid "Random Monsters 2"
+msgstr "隨機怪物 2"
+
+msgid "Random Monster 3"
+msgstr "隨機怪物 3"
+
+msgid "Random Monsters 3"
+msgstr "隨機怪物 3"
+
+msgid "Random Monster 4"
+msgstr "隨機怪物 4"
+
+msgid "Random Monsters 4"
+msgstr "隨機怪物 4"
+
+msgid "Double shot"
+msgstr "雙重射擊"
+
+msgid "2-hex monster"
+msgstr "佔兩格怪物"
+
+msgid "Double strike"
+msgstr "雙重打擊"
+
+msgid "Double damage to Undead"
+msgstr "對亡靈雙倍傷害"
+
+msgid "% magic resistance"
+msgstr "% 魔法抗性"
+
+msgid "Immune to Mind spells"
+msgstr "免疫心靈法術"
+
+msgid "Immune to Elemental spells"
+msgstr "免疫元素法術"
+
+msgid "Immune to Fire spells"
+msgstr "免疫火焰法術"
+
+msgid "Immune to Cold spells"
+msgstr "免疫冰霜法術"
+
+msgid "Immune to "
+msgstr "免疫 "
+
+msgid "% immunity to %{spell} spell"
+msgstr "% 免疫 %{spell} 法術"
+
+msgid "% damage from Elemental spells"
+msgstr "% 元素法術傷害"
+
+msgid "% damage from %{spell} spell"
+msgstr "% 來自 %{spell} 法術的傷害"
+
+msgid "% chance to Dispel beneficial spells"
+msgstr "% 機率驅散增益法術"
+
+msgid "% chance to Paralyze"
+msgstr "% 機率麻痺"
+
+msgid "% chance to Petrify"
+msgstr "% 機率石化"
+
+msgid "% chance to Blind"
+msgstr "% 機率目盲"
+
+msgid "% chance to Curse"
+msgstr "% 機率詛咒"
+
+msgid "% chance to cast %{spell} spell"
+msgstr "% 機率施放 %{spell} 法術"
+
+msgid "HP regeneration"
+msgstr "生命值再生"
+
+msgid "Two hexes attack"
+msgstr "兩格攻擊"
+
+msgid "Flyer"
+msgstr "飛行者"
+
+msgid "Unlimited retaliation"
+msgstr "無限反擊"
+
+msgid "Attacks all adjacent enemies"
+msgstr "攻擊所有相鄰敵人"
+
+msgid "No melee penalty"
+msgstr "無近戰懲罰"
+
+msgid "Dragon"
+msgstr "龍族"
+
+msgid "Undead"
+msgstr "亡靈"
+
+msgid "No enemy retaliation"
+msgstr "敵人無法反擊"
+
+msgid "HP drain"
+msgstr "生命值吸取"
+
+msgid "Cloud attack"
+msgstr "雲攻擊"
+
+msgid "Decreases enemy's morale by "
+msgstr "降低敵方士氣 "
+
+msgid "% chance to halve enemy"
+msgstr "% 機率使敵方減半"
+
+msgid "Soul Eater"
+msgstr "噬魂者"
+
+msgid "Elemental"
+msgstr "元素"
+
+msgid "No Morale"
+msgstr "無士氣"
+
+msgid "Earth creature"
+msgstr "土系生物"
+
+msgid "Air creature"
+msgstr "氣系生物"
+
+msgid "Fire creature"
+msgstr "火系生物"
+
+msgid "Water creature"
+msgstr "水系生物"
+
+msgid "Double damage from Fire spells"
+msgstr "受火焰法術雙倍傷害"
+
+msgid "Double damage from Cold spells"
+msgstr "受冰霜法術雙倍傷害"
+
+msgid "Double damage from Earth creatures"
+msgstr "受土系生物雙倍傷害"
+
+msgid "Double damage from Air creatures"
+msgstr "受氣系生物雙倍傷害"
+
+msgid "Double damage from Fire creatures"
+msgstr "受火系生物雙倍傷害"
+
+msgid "Double damage from Water creatures"
+msgstr "受水系生物雙倍傷害"
+
+msgid "Lightning"
+msgstr "閃電"
+
+msgid "% immunity to "
+msgstr "% 免疫 "
+
+msgid "% damage from "
+msgstr "% 傷害來自 "
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr "三件 Anduran 神器神奇地合而為一。"
+
+msgid "View Spells"
+msgstr "檢視法術"
+
+msgid "View %{name} Info"
+msgstr "檢視 %{name} 資訊"
+
+msgid "Move %{name}"
+msgstr "移動 %{name}"
+
+msgid "Cannot move the Spellbook"
+msgstr "無法移動法術書"
+
+msgid "This item can't be traded."
+msgstr "此物品無法交易。"
+
+msgid "Invalid Artifact"
+msgstr "無效的神器"
+
+msgid "The %{name} increases the hero's knowledge by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點知識。"
+
+msgid "Ultimate Book of Knowledge"
+msgstr "Ultimate Book of Knowledge"
+
+msgid "The %{name} increases the hero's attack skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點攻擊技能。"
+
+msgid "Ultimate Sword of Dominion"
+msgstr "Ultimate Sword of Dominion"
+
+msgid "The %{name} increases the hero's defense skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點防禦技能。"
+
+msgid "Ultimate Cloak of Protection"
+msgstr "Ultimate Cloak of Protection"
+
+msgid "The %{name} increases the hero's spell power by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點魔法力量。"
+
+msgid "Ultimate Wand of Magic"
+msgstr "Ultimate Wand of Magic"
+
+msgid ""
+"The %{name} increases the hero's attack and defense skills by %{count} each."
+msgstr ""
+"%{name} 各增加英雄 %{count} 點攻擊和防禦技能。"
+
+msgid "Ultimate Shield"
+msgstr "Ultimate Shield"
+
+msgid ""
+"The %{name} increases the hero's spell power and knowledge by %{count} each."
+msgstr ""
+"%{name} 各增加英雄 %{count} 點魔法力量和知識。"
+
+msgid "Ultimate Staff"
+msgstr "Ultimate Staff"
+
+msgid ""
+"The %{name} increases each of the hero's basic skills by %{count} points."
+msgstr ""
+"%{name} 增加英雄每項基礎技能 %{count} 點。"
+
+msgid "Ultimate Crown"
+msgstr "Ultimate Crown"
+
+msgid "Golden Goose"
+msgstr "Golden Goose"
+
+msgid "The %{name} brings in an income of %{count} gold per day."
+msgstr "%{name} 每日帶來 %{count} 金幣的收入。"
+
+msgid "Arcane Necklace of Magic"
+msgstr "Arcane Necklace of Magic"
+
+msgid ""
+"After rescuing a Sorceress from a cursed tomb, she rewards your heroism with "
+"an exquisite jeweled necklace."
+msgstr ""
+"從被詛咒的墳墓中救出一位女巫後，她以一條精美的珠寶項鍊酬謝你的英勇。"
+
+msgid "Caster's Bracelet of Magic"
+msgstr "Caster's Bracelet of Magic"
+
+msgid ""
+"While searching through the rubble of a caved-in mine, you free a group of "
+"trapped Dwarves. Grateful, the leader gives you a golden bracelet."
+msgstr ""
+"在搜尋塌陷礦坑的碎石時，你救出了一群被困的矮人。感激之餘，首領送給你一只金手"
+"鐲。"
+
+msgid "Mage's Ring of Power"
+msgstr "Mage's Ring of Power"
+
+msgid ""
+"A cry of pain leads you to a Centaur, caught in a trap. Upon setting the "
+"creature free, he hands you a small pouch. Emptying the contents, you find a "
+"dazzling jeweled ring."
+msgstr ""
+"一聲痛苦的呼喊引導你找到了一隻陷入陷阱的半人馬。將牠釋放後，牠遞給你一個小袋"
+"子。倒出內容物後，你發現了一枚耀眼的寶石戒指。"
+
+msgid "Witch's Broach of Magic"
+msgstr "Witch's Broach of Magic"
+
+msgid ""
+"Alongside the remains of a burnt witch lies a beautiful broach, intricately "
+"designed. Approaching the corpse with caution, you add the broach to your "
+"inventory."
+msgstr ""
+"在一具燒焦女巫的遺骸旁，放著一枚設計精美的胸針。你小心地靠近屍體，將胸針收入"
+"囊中。"
+
+msgid "Medal of Valor"
+msgstr "Medal of Valor"
+
+msgid "The %{name} increases the morale of the hero's army by %{count}."
+msgstr "%{name} 增加英雄軍隊 %{count} 點士氣。"
+
+msgid ""
+"Freeing a virtuous maiden from the clutches of an evil overlord, you are "
+"granted a Medal of Valor by the King's herald."
+msgstr ""
+"從邪惡領主的魔爪中救出了一位善良的少女，國王的傳令官授予你一枚英勇勳章。"
+
+msgid "Medal of Courage"
+msgstr "Medal of Courage"
+
+msgid ""
+"After saving a young boy from a vicious pack of Wolves, you return him to "
+"his father's manor. The grateful nobleman awards you with a Medal of Courage."
+msgstr ""
+"從兇猛的狼群中救出一個小男孩後，你將他送回父親的莊園。感激的貴族授予你一枚勇"
+"氣勳章。"
+
+msgid "Medal of Honor"
+msgstr "Medal of Honor"
+
+msgid ""
+"After freeing a princess of a neighboring kingdom from the evil clutches of "
+"despicable slavers, she awards you with a Medal of Honor."
+msgstr ""
+"從卑鄙奴隸販子的魔爪中解救了鄰國的公主後，她授予你一枚榮譽勳章。"
+
+msgid "Medal of Distinction"
+msgstr "Medal of Distinction"
+
+msgid ""
+"Ridding the countryside of the hideous Minotaur who made a sport of eating "
+"noblemen's Knights, you are honored with the Medal of Distinction."
+msgstr ""
+"剷除了以吞噬貴族騎士為樂的可怕牛頭怪後，你獲頒卓越勳章。"
+
+msgid "Fizbin of Misfortune"
+msgstr "Fizbin of Misfortune"
+
+msgid ""
+"The %{name} greatly decreases the morale of the hero's army by %{count}."
+msgstr ""
+"%{name} 大幅降低英雄軍隊 %{count} 點士氣。"
+
+msgid ""
+"You stumble upon a medal lying alongside the empty road. Adding the medal to "
+"your inventory, you become aware that you have acquired the undesirable "
+"Fizbin of Misfortune, greatly decreasing your army's morale."
+msgstr ""
+"你在空曠的路邊偶然發現了一枚勳章。將它收入囊中後，你意識到自己獲得了不祥的厄"
+"運徽記，大幅降低了軍隊的士氣。"
+
+msgid "Thunder Mace of Dominion"
+msgstr "Thunder Mace of Dominion"
+
+msgid ""
+"During a sudden storm, a bolt of lightning strikes a tree, splitting it. "
+"Inside the tree you find a mysterious mace."
+msgstr ""
+"突如其來的暴風雨中，一道閃電擊中了一棵樹，將其劈開。你在樹幹中找到了一把神秘"
+"的權杖。"
+
+msgid "Armored Gauntlets of Protection"
+msgstr "Armored Gauntlets of Protection"
+
+msgid "The %{name} increase the hero's defense skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點防禦技能。"
+
+msgid ""
+"You encounter the infamous Black Knight! After a grueling duel ending in a "
+"draw, the Knight, out of respect, offers you a pair of armored gauntlets."
+msgstr ""
+"你遇到了惡名昭彰的黑騎士！經過一場以平手收場的艱苦決鬥，騎士出於敬意送給你一"
+"副裝甲護手。"
+
+msgid "Defender Helm of Protection"
+msgstr "Defender Helm of Protection"
+
+msgid ""
+"A glint of golden light catches your eye. Upon further investigation, you "
+"find a golden helm hidden under a bush."
+msgstr ""
+"一道金色光芒吸引了你的注意。仔細調查後，你在灌木下發現了一頂金色頭盔。"
+
+msgid "Giant Flail of Dominion"
+msgstr "Giant Flail of Dominion"
+
+msgid ""
+"A clumsy Giant has killed himself with his own flail. Knowing your superior "
+"skill with this weapon, you confidently remove the spectacular flail from "
+"the fallen Giant."
+msgstr ""
+"一個笨拙的巨人被自己的連枷殺死了。深知自己對這種武器駕輕就熟，你自信地從倒下"
+"的巨人身上取下了壯觀的連枷。"
+
+msgid "Ballista of Quickness"
+msgstr "Ballista of Quickness"
+
+msgid "The %{name} gives the hero's catapult one extra shot per combat round."
+msgstr "%{name} 讓英雄的投石車每回合多一次射擊機會。"
+
+msgid ""
+"Walking through the ruins of an ancient walled city, you find the instrument "
+"of the city's destruction, an elaborately crafted ballista."
+msgstr ""
+"穿行於古代城牆城市的廢墟中，你找到了摧毀這座城市的工具——一架製作精良的弩砲。"
+
+msgid "Stealth Shield of Protection"
+msgstr "Stealth Shield of Protection"
+
+msgid ""
+"A stone statue of a warrior holds a silver shield. As you remove the shield, "
+"the statue crumbles into dust."
+msgstr ""
+"一尊戰士石像手持一面銀盾。當你取下盾牌時，石像碎成了塵土。"
+
+msgid "Dragon Sword of Dominion"
+msgstr "Dragon Sword of Dominion"
+
+msgid ""
+"As you are walking along a narrow path, a nearby bush suddenly bursts into "
+"flames. Before your eyes the flames become the image of a beautiful woman. "
+"She holds out a magnificent sword to you."
+msgstr ""
+"你沿著一條狹窄小徑行走時，附近的灌木突然燃燒起來。在你眼前，火焰化為一位美麗"
+"女性的形象。她向你遞出一把華麗的寶劍。"
+
+msgid "Power Axe of Dominion"
+msgstr "Power Axe of Dominion"
+
+msgid ""
+"You see a silver axe embedded deeply in the ground. After several "
+"unsuccessful attempts by your army to remove the axe, you tightly grip the "
+"handle of the axe and effortlessly pull it free."
+msgstr ""
+"你看到一把深深嵌入地面的銀斧。在軍隊數次嘗試拔出失敗後，你緊握斧柄，毫不費力"
+"地將其拔出。"
+
+msgid "Divine Breastplate of Protection"
+msgstr "Divine Breastplate of Protection"
+
+msgid ""
+"A gang of Rogues is sifting through the possessions of dead warriors. "
+"Scaring off the scavengers, you note the Rogues had overlooked a beautiful "
+"breastplate."
+msgstr ""
+"一群盜賊正在翻找死去戰士的遺物。你趕走了這些拾荒者，注意到盜賊們忽略了一件精"
+"美的胸甲。"
+
+msgid "Minor Scroll of Knowledge"
+msgstr "Minor Scroll of Knowledge"
+
+msgid ""
+"Before you appears a levitating glass case with a scroll, perched upon a bed "
+"of crimson velvet. At your touch, the lid opens and the scroll floats into "
+"your awaiting hands."
+msgstr ""
+"你面前出現了一個漂浮的玻璃箱，放置在深紅色天鵝絨上，內有一個捲軸。你一觸碰，"
+"蓋子便打開，捲軸飄入你等候的雙手中。"
+
+msgid "Major Scroll of Knowledge"
+msgstr "Major Scroll of Knowledge"
+
+msgid ""
+"Visiting a local wiseman, you explain the intent of your journey. He reaches "
+"into a sack and withdraws a yellowed scroll and hands it to you."
+msgstr ""
+"拜訪當地的智者時，你說明了旅程的目的。他從袋中取出一卷泛黃的捲軸遞給你。"
+
+msgid "Superior Scroll of Knowledge"
+msgstr "Superior Scroll of Knowledge"
+
+msgid ""
+"You come across the remains of an ancient Druid. Bones, yellowed with age, "
+"peer from the ragged folds of her robe. Searching the robe, you discover a "
+"scroll hidden in the folds."
+msgstr ""
+"你發現了一位古代德魯伊的遺骸。泛黃的白骨從破爛的袍褶中露出。搜尋袍子後，你在"
+"褶層中發現了一卷藏匿的捲軸。"
+
+msgid "Foremost Scroll of Knowledge"
+msgstr "Foremost Scroll of Knowledge"
+
+msgid ""
+"Mangled bones, yellowed with age, peer from the ragged folds of a dead "
+"Druid's robe. Searching the robe, you discover a scroll hidden within."
+msgstr ""
+"殘破泛黃的白骨從一位已故德魯伊破爛的袍子中露出。搜尋袍子後，你在其中發現了一"
+"卷藏匿的捲軸。"
+
+msgid "Endless Sack of Gold"
+msgstr "Endless Sack of Gold"
+
+msgid "The %{name} provides the hero with %{count} gold per day."
+msgstr "%{name} 每日為英雄提供 %{count} 金幣。"
+
+msgid ""
+"A little leprechaun dances gleefully around a magic sack. Seeing you "
+"approach, he stops in mid-stride. The little man screams and stamps his foot "
+"ferociously, vanishing into thin air. Remembering the old leprechaun saying "
+"'Finders Keepers', you grab the sack and leave."
+msgstr ""
+"一個小矮妖圍著一個魔法袋歡快地跳舞。看到你走近，他停下腳步，小矮人尖叫著猛跺"
+"腳，消失得無影無蹤。想起那句古老的矮妖格言「撿到就是你的」，你抓起袋子離開"
+"了。"
+
+msgid "Endless Bag of Gold"
+msgstr "Endless Bag of Gold"
+
+msgid ""
+"A noblewoman, separated from her traveling companions, asks for your help. "
+"After escorting her home, she rewards you with a bag filled with gold."
+msgstr ""
+"一位與旅伴走散的貴婦人請求你的幫助。護送她回家後，她以一袋金幣作為酬謝。"
+
+msgid "Endless Purse of Gold"
+msgstr "Endless Purse of Gold"
+
+msgid ""
+"In your travels, you find a leather purse filled with gold that once "
+"belonged to a great warrior king who had the ability to transform any "
+"inanimate object into gold."
+msgstr ""
+"旅途中，你找到了一個裝滿金幣的皮革錢包，它曾屬於一位擁有將任何無生命物體變成"
+"黃金能力的偉大戰士國王。"
+
+msgid "Nomad Boots of Mobility"
+msgstr "Nomad Boots of Mobility"
+
+msgid "The %{name} increase the hero's movement on land."
+msgstr "%{name} 增加英雄的陸上移動力。"
+
+msgid ""
+"A Nomad trader seeks protection from a tribe of Goblins. For your "
+"assistance, he gives you a finely crafted pair of boots made from the "
+"softest leather. Looking closely, you see fascinating ancient carvings "
+"engraved on the leather."
+msgstr ""
+"一位遊牧商人請求你保護他免受哥布林部落侵害。作為報答，他送給你一雙以最柔軟皮"
+"革精製的靴子。仔細觀察，你發現皮革上刻有迷人的古代雕紋。"
+
+msgid "Traveler's Boots of Mobility"
+msgstr "Traveler's Boots of Mobility"
+
+msgid ""
+"Discovering a pair of beautifully beaded boots made from the finest and "
+"softest leather, you thank the anonymous donor and add the boots to your "
+"inventory."
+msgstr ""
+"發現一雙以最精緻柔軟的皮革製成、綴滿珠飾的靴子，你感謝匿名贈予者並將靴子收入"
+"囊中。"
+
+msgid "Lucky Rabbit's Foot"
+msgstr "Lucky Rabbit's Foot"
+
+msgid "The %{name} increases the luck of the hero's army by %{count}."
+msgstr "%{name} 增加英雄軍隊 %{count} 點幸運。"
+
+msgid ""
+"A traveling merchant offers you a rabbit's foot, made of gleaming silver "
+"fur, for safe passage. The merchant explains the charm will increase your "
+"luck in combat."
+msgstr ""
+"一位旅行商人以一隻閃亮銀毛兔腳換取安全通行。商人解釋說這個護身符能增加你在戰"
+"鬥中的運氣。"
+
+msgid "Golden Horseshoe"
+msgstr "Golden Horseshoe"
+
+msgid ""
+"An ensnared Unicorn whinnies in fright. Murmuring soothing words, you set "
+"her free. Snorting and stamping her front hoof once, she gallops off. "
+"Looking down you see a golden horseshoe."
+msgstr ""
+"一隻被困住的獨角獸恐懼地嘶鳴。你輕聲安慰著將牠放走。牠噴了口氣、前蹄跺地一下"
+"便奔馳而去。你低頭發現了一隻金色馬蹄鐵。"
+
+msgid "Gambler's Lucky Coin"
+msgstr "Gambler's Lucky Coin"
+
+msgid ""
+"You have captured a mischievous imp who has been terrorizing the region. In "
+"exchange for his release, he rewards you with a magical coin."
+msgstr ""
+"你捕獲了一隻一直在恐嚇該地區的惡作劇小惡魔。為了換取自由，牠以一枚魔法硬幣作"
+"為報答。"
+
+msgid "Four-Leaf Clover"
+msgstr "Four-Leaf Clover"
+
+msgid ""
+"In the middle of a patch of dead and dry vegetation, to your surprise you "
+"find a healthy green four-leaf clover."
+msgstr ""
+"在一片枯死乾燥的植被中，你驚喜地發現了一株健康翠綠的四葉草。"
+
+msgid "True Compass of Mobility"
+msgstr "True Compass of Mobility"
+
+msgid "The %{name} increases the hero's movement on land and sea."
+msgstr "%{name} 增加英雄的陸上和海上移動力。"
+
+msgid ""
+"An old man claiming to be an inventor asks you to try his latest invention. "
+"He then hands you a compass."
+msgstr ""
+"一位自稱發明家的老人請你試試他的最新發明，然後遞給你一個指南針。"
+
+msgid "Sailor's Astrolabe of Mobility"
+msgstr "Sailor's Astrolabe of Mobility"
+
+msgid "The %{name} increases the hero's movement on sea."
+msgstr "%{name} 增加英雄的海上移動力。"
+
+msgid ""
+"An old sea captain is being tortured by Ogres. You save him, and in return "
+"he rewards you with a wondrous instrument to measure the distance of a star."
+msgstr ""
+"一位老海船長正被食人魔折磨。你救了他，作為回報，他送給你一件可以測量星辰距離"
+"的奇妙儀器。"
+
+msgid "Evil Eye"
+msgstr "Evil Eye"
+
+msgid "The %{name} reduces the casting cost of curse spells by half."
+msgstr "%{name} 將詛咒系法術的施放消耗減半。"
+
+msgid ""
+"While venturing into a decrepit hut you find the Skeleton of a long dead "
+"witch. Investigation of the remains reveals a glass eye rolling around "
+"inside an empty skull."
+msgstr ""
+"進入一間破敗的小屋時，你發現了一具早已死去的女巫骸骨。調查遺骸時，在空骷髏裡"
+"發現了一顆滾動的玻璃眼珠。"
+
+msgid "Enchanted Hourglass"
+msgstr "Enchanted Hourglass"
+
+msgid ""
+"The %{name} extends the duration of all the hero's spells by %{count} turns."
+msgstr ""
+"%{name} 延長英雄所有法術的持續時間 %{count} 回合。"
+
+msgid ""
+"A surprise turn in the landscape finds you in the midst of a grisly scene: "
+"Vultures picking at the aftermath of a terrible battle. Your cursory search "
+"of the remains turns up an enchanted hourglass."
+msgstr ""
+"地形的意外轉折使你置身於一幅恐怖的景象中：禿鷹在一場慘烈戰鬥的殘骸中啄食。你"
+"粗略搜尋遺骸，找到了一個魔法沙漏。"
+
+msgid "Gold Watch"
+msgstr "Gold Watch"
+
+msgid "The %{name} doubles the effectiveness of the hero's hypnotize spells."
+msgstr "%{name} 使英雄的催眠術效果加倍。"
+
+msgid ""
+"In reward for helping his cart out of a ditch, a traveling potion salesman "
+"gives you a \"magic\" gold watch. Unbeknownst to him, the watch really is "
+"magical."
+msgstr ""
+"為了答謝你幫他的貨車脫離溝渠，一位旅行藥劑商人送給你一隻「魔法」金錶。他自己"
+"都不知道，這隻錶真的是魔法物品。"
+
+msgid "Skullcap"
+msgstr "Skullcap"
+
+msgid "The %{name} halves the casting cost of all mind influencing spells."
+msgstr "%{name} 將所有精神系法術的施放消耗減半。"
+
+msgid ""
+"A brief stop at an improbable rural inn yields an exchange of money, tales, "
+"and accidentally, luggage. You find a magical skullcap in your new backpack."
+msgstr ""
+"在一間不起眼的鄉間旅店短暫停留，交換了金錢、故事，還不小心交換了行李。你在新"
+"背包中發現了一頂魔法骷髏帽。"
+
+msgid "Ice Cloak"
+msgstr "Ice Cloak"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from cold spells."
+msgstr ""
+"%{name} 將英雄部隊受到的冰系法術傷害減半。"
+
+msgid ""
+"Responding to the panicked cries of a damsel in distress, you discover a "
+"young woman fleeing from a hungry bear. You slay the beast in the nick of "
+"time, and the grateful Sorceress weaves a magic cloak from the bear's hide."
+msgstr ""
+"回應一位落難少女的驚恐求救，你發現一名年輕女子正在逃離一隻飢餓的熊。你及時殺"
+"死了野獸，感激的女巫用熊皮織成了一件魔法斗篷。"
+
+msgid "Fire Cloak"
+msgstr "Fire Cloak"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from fire spells."
+msgstr ""
+"%{name} 將英雄部隊受到的火系法術傷害減半。"
+
+msgid ""
+"You've come upon a fight between a Necromancer and a Paladin. The "
+"Necromancer blasts the Paladin with a fire bolt, bringing him to his knees. "
+"Acting quickly, you slay the evil one before the final blow. The grateful "
+"Paladin gives you the fire cloak that saved him."
+msgstr ""
+"你撞見了一場死靈法師與聖騎士的戰鬥。死靈法師以火焰箭擊中聖騎士，將他打跪在"
+"地。你迅速行動，在致命一擊前殺死了邪惡者。聖騎士滿懷感激，將救命的火焰斗篷送"
+"給你。"
+
+msgid "Lightning Helm"
+msgstr "Lightning Helm"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from lightning "
+"spells."
+msgstr ""
+"%{name} 將英雄部隊受到的雷電法術傷害減半。"
+
+msgid ""
+"A traveling tinker in need of supplies offers you a helm with a thunderbolt "
+"design on its top in exchange for food and water. Curious, you accept, and "
+"later find out that the helm is magical."
+msgstr ""
+"一位需要補給的旅行修補匠以頂部有雷電圖案的頭盔換取食物和水。出於好奇你接受"
+"了，後來發現這頂頭盔是魔法物品。"
+
+msgid "Evercold Icicle"
+msgstr "Evercold Icicle"
+
+msgid ""
+"The %{name} causes the hero's cold spells to do %{count} percent more damage "
+"to enemy troops."
+msgstr ""
+"%{name} 使英雄的冰系法術對敵軍造成額外 %{count}% 的傷害。"
+
+msgid ""
+"An icicle withstanding the full heat of the noonday sun attracts your "
+"attention. Intrigued, you break it off, and find that it does not melt in "
+"your hand."
+msgstr ""
+"一根在正午烈日下仍不融化的冰柱吸引了你的注意。你好奇地折斷它，發現它在手中不"
+"會融化。"
+
+msgid "Everhot Lava Rock"
+msgstr "Everhot Lava Rock"
+
+msgid ""
+"The %{name} causes the hero's fire spells to do %{count} percent more damage "
+"to enemy troops."
+msgstr ""
+"%{name} 使英雄的火系法術對敵軍造成額外 %{count}% 的傷害。"
+
+msgid ""
+"Your wanderings bring you into contact with a tribe of ape-like beings using "
+"a magical lava rock that never cools to light their fires. You take pity on "
+"them and teach them to make fire with sticks. Believing you to be a god, the "
+"apes give you their rock."
+msgstr ""
+"你在漫遊中遇到了一群類猿生物，牠們正使用一塊永不冷卻的魔法岩漿石生火。你同情"
+"牠們，教牠們用木棍生火。猿人們相信你是神明，將岩漿石送給了你。"
+
+msgid "Lightning Rod"
+msgstr "Lightning Rod"
+
+msgid ""
+"The %{name} causes the hero's lightning spells to do %{count} percent more "
+"damage to enemy troops."
+msgstr ""
+"%{name} 使英雄的雷電法術對敵軍造成額外 %{count}% 的傷害。"
+
+msgid ""
+"While waiting out a storm, a lighting bolt strikes a nearby cottage's "
+"lightning rod, which melts and falls to the ground. The tip of the rod, "
+"however, survives intact and makes your hair stand on end when you touch it. "
+"Hmm..."
+msgstr ""
+"等待暴風雨過去時，一道閃電擊中了附近小屋的避雷針，將其融化落地。然而針尖完好"
+"無損，觸碰它會讓你毛髮直豎。嗯……"
+
+msgid "Snake-Ring"
+msgstr "Snake-Ring"
+
+msgid "The %{name} halves the casting cost of all of the hero's bless spells."
+msgstr "%{name} 將英雄所有祝福法術的施放消耗減半。"
+
+msgid ""
+"You've found an oddly shaped ring on the finger of a long dead traveler. The "
+"ring looks like a snake biting its own tail."
+msgstr ""
+"你在一位早已死去的旅人手指上發現了一枚形狀奇特的戒指。戒指看起來像一條咬住自"
+"己尾巴的蛇。"
+
+msgid "Ankh"
+msgstr "Ankh"
+
+msgid ""
+"The %{name} doubles the effectiveness of all of the hero's resurrect and "
+"animate spells."
+msgstr ""
+"%{name} 使英雄所有復活和操控亡靈法術的效果加倍。"
+
+msgid ""
+"A fierce windstorm reveals the entrance to a buried tomb. Your investigation "
+"reveals that the tomb has already been looted, but the thieves overlooked an "
+"ankh on a silver chain in the dark."
+msgstr ""
+"一陣猛烈的風暴揭露了一座被埋葬墳墓的入口。你的調查發現墳墓已被洗劫一空，但盜"
+"賊在黑暗中忽略了一條銀鏈上的安卡十字架。"
+
+msgid "Book of Elements"
+msgstr "Book of Elements"
+
+msgid ""
+"The %{name} doubles the effectiveness of all of the hero's summoning spells."
+msgstr ""
+"%{name} 使英雄所有召喚法術的效果加倍。"
+
+msgid ""
+"You come across a conjurer who begs to accompany you and your army awhile "
+"for safety. You agree, and he offers as payment a copy of the book of the "
+"elements."
+msgstr ""
+"你遇到一位懇求隨你和你的軍隊同行以保安全的咒術師。你同意了，他以一本元素之書"
+"的抄本作為報酬。"
+
+msgid "Elemental Ring"
+msgstr "Elemental Ring"
+
+msgid "The %{name} halves the casting cost of all summoning spells."
+msgstr "%{name} 將所有召喚法術的施放消耗減半。"
+
+msgid ""
+"While pausing to rest, you notice a bobcat climbing a short tree to get at a "
+"crow's nest. On impulse, you climb the tree yourself and scare off the cat. "
+"When you look in the nest, you find a collection of shiny stones and a ring."
+msgstr ""
+"休息時，你注意到一隻山貓正爬上矮樹去抓烏鴉巢。你衝動地自己爬上樹趕走了貓。檢"
+"視巢穴時，你發現了一堆閃亮的石頭和一枚戒指。"
+
+msgid "Holy Pendant"
+msgstr "Holy Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to curse spells."
+msgstr "%{name} 使英雄所有部隊免疫詛咒法術。"
+
+msgid ""
+"In your wanderings you come across a hermit living in a small, tidy hut. "
+"Impressed with your mission, he takes time out from his meditations to bless "
+"and give you a charm against curses."
+msgstr ""
+"你在漫遊中遇到了一位住在整潔小屋中的隱士。對你的使命印象深刻，他從冥想中抽出"
+"時間為你祝福，並送你一個防禦詛咒的護身符。"
+
+msgid "Pendant of Free Will"
+msgstr "Pendant of Free Will"
+
+msgid "The %{name} makes all of the hero's troops immune to hypnotize spells."
+msgstr "%{name} 使英雄所有部隊免疫催眠術。"
+
+msgid ""
+"Responding to cries for help, you find river Sprites making a sport of "
+"dunking an old man. Feeling vengeful, you rescue the man and drag a Sprite "
+"onto dry land for awhile. The Sprite, uncomfortable in the air, gives you a "
+"magic pendant to let him go."
+msgstr ""
+"回應呼救聲，你發現河精靈正以把一位老人按入水中為樂。你氣憤地救了那人，並把一"
+"隻精靈拖到岸上。精靈在空氣中不舒服，送你一個魔法墜飾以求你放牠走。"
+
+msgid "Pendant of Life"
+msgstr "Pendant of Life"
+
+msgid "The %{name} makes all of the hero's troops immune to death spells."
+msgstr "%{name} 使英雄所有部隊免疫死亡法術。"
+
+msgid ""
+"A brief roadside encounter with a small caravan and a game of knucklebones "
+"wins a magic pendant. Its former owner says that it protects from "
+"Necromancers' death spells."
+msgstr ""
+"在路邊與一支小商隊偶遇，一場擲骨遊戲贏得了一個魔法墜飾。前任主人說它能抵禦死"
+"靈法師的死亡法術。"
+
+msgid "Serenity Pendant"
+msgstr "Serenity Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to berserk spells."
+msgstr "%{name} 使英雄所有部隊免疫狂暴法術。"
+
+msgid ""
+"The sounds of combat draw you to the scene of a fight between an old "
+"Barbarian and an eight-headed Hydra. Your timely intervention swings the "
+"battle in favor of the man, and he rewards you with a pendant he used to use "
+"to calm his mind for battle."
+msgstr ""
+"戰鬥的聲響將你引到一位老蠻族與一隻八頭九頭蛇的戰鬥現場。你的及時介入扭轉了戰"
+"局，他以一個曾用來讓自己冷靜作戰的墜飾作為報答。"
+
+msgid "Seeing-eye Pendant"
+msgstr "Seeing-eye Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to blindness spells."
+msgstr "%{name} 使英雄所有部隊免疫致盲法術。"
+
+msgid ""
+"You come upon a very old woman, long blind from cataracts and dying alone. "
+"You tend to her final needs and promise a proper burial. Grateful, she gives "
+"you a magic pendant emblazoned with a stylized eye. It lets you see with "
+"your eyes closed."
+msgstr ""
+"你遇到一位非常年邁的老婦人，她因白內障長期失明，獨自等死。你照料她最後的需求"
+"並承諾妥善安葬。感激之餘，她送你一個刻有風格化眼睛的魔法墜飾，讓你閉著眼也能"
+"看見。"
+
+msgid "Kinetic Pendant"
+msgstr "Kinetic Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to paralyze spells."
+msgstr "%{name} 使英雄所有部隊免疫麻痺法術。"
+
+msgid ""
+"You come across a golem wearing a glowing pendant and blocking your way. "
+"Acting on a hunch, you cut the pendant from its neck. Deprived of its power "
+"source, the golem breaks down, leaving you with the magical pendant."
+msgstr ""
+"你遇到一個戴著發光墜飾、擋住你去路的魔像。憑直覺行事，你切斷了牠脖子上的墜"
+"飾。失去能量來源的魔像隨即瓦解，留下魔法墜飾給你。"
+
+msgid "Pendant of Death"
+msgstr "Pendant of Death"
+
+msgid "The %{name} makes all of the hero's troops immune to holy spells."
+msgstr "%{name} 使英雄所有部隊免疫神聖法術。"
+
+msgid ""
+"A quick and deadly battle with a Necromancer wins you his magical pendant. "
+"Later, a Wizard tells you that the pendant protects undead under your "
+"control from holy word spells."
+msgstr ""
+"與一位死靈法師的快速致命戰鬥為你贏得了他的魔法墜飾。之後，一位巫師告訴你這個"
+"墜飾能保護你控制的亡靈免受神聖之語法術的影響。"
+
+msgid "Wand of Negation"
+msgstr "Wand of Negation"
+
+msgid ""
+"The %{name} makes all of the hero's troops immune to dispel magic spells."
+msgstr ""
+"%{name} 使英雄所有部隊免疫驅散魔法。"
+
+msgid ""
+"You meet an old Wizard friend of yours traveling in the opposite direction. "
+"He presents  you with a gift: A wand that prevents the use of the dispel "
+"magic spell on your allies."
+msgstr ""
+"你遇到了一位相識的老巫師朋友，他正往反方向旅行。他送給你一份禮物：一根能阻止"
+"敵人對你盟友使用驅散魔法的魔杖。"
+
+msgid "Golden Bow"
+msgstr "Golden Bow"
+
+msgid ""
+"The %{name} eliminates the %{count} percent penalty for the hero's troops "
+"shooting past obstacles (e.g. castle walls)."
+msgstr ""
+"%{name} 消除英雄部隊射擊穿越障礙物 (如城牆) 時的 %{count}% 懲罰。"
+
+msgid ""
+"A chance meeting with a famous Archer finds you in a game of knucklebones "
+"pitting his bow against your horse. You win."
+msgstr ""
+"偶遇一位著名弓箭手，你們以擲骰子比賽，以他的弓對你的馬作為賭注。你贏了。"
+
+msgid "Telescope"
+msgstr "Telescope"
+
+msgid ""
+"The %{name} increases the amount of terrain the hero reveals when "
+"adventuring by %{count} extra square."
+msgstr ""
+"%{name} 使英雄冒險時額外揭露 %{count} 格地形。"
+
+msgid ""
+"A merchant from far away lands trades you a new invention of his people for "
+"traveling supplies. It makes distant objects appear closer, and he calls "
+"it...\n"
+"\n"
+"a telescope."
+msgstr ""
+"一位來自遠方的商人以旅行補給換給你他的民族的新發明。它能讓遠處的物體看起來更"
+"近，他稱之為……\n"
+"\n"
+"望遠鏡。"
+
+msgid "Statesman's Quill"
+msgstr "Statesman's Quill"
+
+msgid ""
+"The %{name} reduces the cost of surrender to %{count} percent of the total "
+"cost of troops the hero has in their army."
+msgstr ""
+"%{name} 將投降費用降低至英雄軍隊總兵力價值的 %{count}%。"
+
+msgid ""
+"You pause to help a diplomat with a broken axle fix his problem. In "
+"gratitude, he gives you a writing quill with magical properties which he "
+"says will \"help people see things your way\"."
+msgstr ""
+"你停下來幫助一位車軸斷裂的外交官解決問題。出於感激，他送你一支具有魔法特性的"
+"鵝毛筆，說它能「幫助別人看到你的觀點」。"
+
+msgid "Wizard's Hat"
+msgstr "Wizard's Hat"
+
+msgid ""
+"The %{name} increases the duration of the hero's spells by %{count} turns."
+msgstr ""
+"%{name} 延長英雄法術的持續時間 %{count} 回合。"
+
+msgid ""
+"You see a Wizard fleeing from a Griffin and riding like the wind. The Wizard "
+"opens a portal and rides through, getting his hat knocked off by the edge of "
+"the gate. The Griffin follows; the gate closes. You pick the hat up, dust it "
+"off, and put it on."
+msgstr ""
+"你看到一位巫師騎馬疾風般地逃離一隻獅鷲。巫師打開一個傳送門衝了過去，帽子被門"
+"邊撞落。獅鷲跟著進去了，門隨即關閉。你撿起帽子，拍掉灰塵，戴在頭上。"
+
+msgid "Power Ring"
+msgstr "Power Ring"
+
+msgid "The %{name} returns %{count} extra spell points per day to the hero."
+msgstr "%{name} 每日額外恢復英雄 %{count} 點魔法值。"
+
+msgid ""
+"You find a small tree that closely resembles the great Warlock Carnauth with "
+"a ring around one of its twigs. Scraps of clothing and rotting leather lead "
+"you to suspect that it IS Carnauth, transformed. Since you can't help him, "
+"you take the magic ring."
+msgstr ""
+"你發現一棵小樹酷似偉大的術士 Carnauth，其中一根樹枝上套著一枚戒指。現場有碎布"
+"和腐爛的皮革，讓你懷疑這就是變形後的 Carnauth。既然幫不了他，你取走了魔法戒"
+"指。"
+
+msgid "Ammo Cart"
+msgstr "Ammo Cart"
+
+msgid ""
+"The %{name} provides endless ammunition for all of the hero's troops that "
+"shoot."
+msgstr ""
+"%{name} 為英雄所有遠距部隊提供無限彈藥。"
+
+msgid ""
+"An ammunition cart in the middle of an old battlefield catches your eye. "
+"Inspection shows it to be in good working order, so  you take it along."
+msgstr ""
+"一輛位於舊戰場中央的彈藥車吸引了你的目光。檢查後發現它仍能正常運作，於是你帶"
+"上了它。"
+
+msgid "Tax Lien"
+msgstr "Tax Lien"
+
+msgid "The %{name} costs the hero %{count} gold pieces per day."
+msgstr "%{name} 每日消耗英雄 %{count} 金幣。"
+
+msgid ""
+"Your big spending habits have earned you a massive tax bill that you can't "
+"hope to pay. The tax man takes pity and agrees to only take 250 gold a day "
+"from your account for life. Check here if you want one dollar to go to the "
+"presidential campaign election fund."
+msgstr ""
+"你揮金如土的習慣為你帶來了一張你無法支付的巨額稅單。稅務官大發慈悲，同意終身"
+"每日只從你的帳戶扣除 250 金幣。如果你想為總統競選基金捐一塊錢，請在此勾選。"
+
+msgid "Hideous Mask"
+msgstr "Hideous Mask"
+
+msgid "The %{name} prevents all 'wandering' armies from joining the hero."
+msgstr "%{name} 阻止所有流浪軍隊加入英雄。"
+
+msgid ""
+"Your looting of the grave of Sinfilas Gardolad, the famous shapeshifting "
+"Warlock, unearths his fabled mask. Trembling, you put it on and it twists "
+"your visage into an awful grimace! Oh no! It's actually the hideous mask of "
+"Gromluck Greene, and you are stuck with it."
+msgstr ""
+"你盜掘了著名變形術士 Sinfilas Gardolad 的墳墓，挖出了他傳說中的面具。你顫抖地"
+"戴上它，它將你的面容扭曲成可怕的鬼臉！糟糕！這其實是 Gromluck Greene 的醜陋面"
+"具，而且你摘不下來了。"
+
+msgid "Endless Pouch of Sulfur"
+msgstr "Endless Pouch of Sulfur"
+
+msgid "The %{name} provides %{count} unit of sulfur per day."
+msgstr "%{name} 每日提供 %{count} 單位硫磺。"
+
+msgid ""
+"You visit an alchemist who, upon seeing your army, is swayed by the "
+"righteousness of your cause. The newly loyal subject gives you his endless "
+"pouch of sulfur to help with the war effort."
+msgstr ""
+"你拜訪了一位煉金術士，他看到你的軍隊後被你的正義事業所感動。這位新近效忠的臣"
+"民送你無盡硫磺袋，協助你的戰事。"
+
+msgid "Endless Vial of Mercury"
+msgstr "Endless Vial of Mercury"
+
+msgid "The %{name} provides %{count} unit of mercury per day."
+msgstr "%{name} 每日提供 %{count} 單位水銀。"
+
+msgid ""
+"A brief stop at a hastily abandoned Wizard's tower turns up a magical vial "
+"of mercury that always has a little left on the bottom. Recognizing a "
+"treasure when you see one, you cap it and slip it in your pocket."
+msgstr ""
+"在一座匆忙廢棄的巫師塔短暫停留，你發現了一瓶底部永遠留有一些水銀的魔法瓶。識"
+"寶之人自然不會錯過，你蓋上瓶蓋塞進口袋。"
+
+msgid "Endless Pouch of Gems"
+msgstr "Endless Pouch of Gems"
+
+msgid "The %{name} provides %{count} unit of gems per day."
+msgstr "%{name} 每日提供 %{count} 單位寶石。"
+
+msgid ""
+"A short rainstorm brings forth a rainbow...and you can see the end of it. "
+"Riding quickly, you seize the pot of gold you find there. The leprechaun who "
+"owns it, unable to stop you from taking it, offers an endless pouch of gems "
+"for the return of his gold. You accept."
+msgstr ""
+"一陣短暫的雷陣雨帶來了彩虹……你看得到彩虹的盡頭。快馬加鞭，你奪取了那裡的金"
+"罐。擁有它的小矮妖無法阻止你，提議以一個無盡寶石袋換回他的金子。你接受了。"
+
+msgid "Endless Cord of Wood"
+msgstr "Endless Cord of Wood"
+
+msgid "The %{name} provides %{count} unit of wood per day."
+msgstr "%{name} 每日提供 %{count} 單位木材。"
+
+msgid ""
+"Pausing to rest and light a cook fire, you pull wood out of a nearby pile of "
+"dead wood. As you keep pulling wood from the pile, you notice that it "
+"doesn't shrink. You realize to your delight that the wood is enchanted, so "
+"you take it along."
+msgstr ""
+"休息生火時，你從附近的枯木堆中抽取木材。你不斷取出木材，卻注意到木堆沒有減"
+"少。你高興地意識到這些木材被施了魔法，於是將它帶走。"
+
+msgid "Endless Cart of Ore"
+msgstr "Endless Cart of Ore"
+
+msgid "The %{name} provides %{count} unit of ore per day."
+msgstr "%{name} 每日提供 %{count} 單位礦石。"
+
+msgid ""
+"You've found a Goblin weapon smithy making weapons for use against humans. "
+"With a tremendous yell you and your army descend upon their camp and drive "
+"them away. A search finds a magic ore cart that never runs out of iron."
+msgstr ""
+"你發現了一個哥布林武器鍛造所，正在製造對付人類的武器。你和軍隊大喊一聲衝進他"
+"們的營地，將他們趕跑。搜尋後發現了一輛永遠不會用完鐵礦的魔法礦車。"
+
+msgid "Endless Pouch of Crystal"
+msgstr "Endless Pouch of Crystal"
+
+msgid ""
+"Taking shelter from a storm in a small cave, you notice a small patch of "
+"crystal in one corner. Curious, you break a piece off and notice that the "
+"original crystal grows the lost piece back. You decide to stuff the entire "
+"patch into a pouch and take it with you."
+msgstr ""
+"在小洞穴中躲避暴風雨時，你注意到角落有一小片水晶。出於好奇，你折斷了一塊，發"
+"現原來的水晶長回了缺失的部分。你決定將整片水晶塞進袋子帶走。"
+
+msgid "The %{name} provides %{count} unit of crystal per day."
+msgstr "%{name} 每日提供 %{count} 單位水晶。"
+
+msgid "Spiked Helm"
+msgstr "Spiked Helm"
+
+msgid ""
+"Your army is ambushed by a small tribe of wild (and none too bright) Orcs. "
+"You fend them off easily and the survivors flee in all directions. One of "
+"the Orcs was wearing a polished spiked helm. Figuring it will make a good "
+"souvenir, you take it."
+msgstr ""
+"你的軍隊遭到一個野蠻 (而且不怎麼聰明) 的獸人小部落伏擊。你輕鬆擊退了他們，倖"
+"存者四散奔逃。其中一個獸人戴著一頂拋光的尖刺頭盔。想著它是個不錯的紀念品，你"
+"將它取走。"
+
+msgid "Spiked Shield"
+msgstr "Spiked Shield"
+
+msgid ""
+"You come upon a bridge spanning a dry gully. Before you can cross, a Troll "
+"steps out from under the bridge and demands payment before it will permit "
+"you to pass. You refuse, and the Troll charges, forcing you to slay it. You "
+"take its spiked shield as a trophy."
+msgstr ""
+"你來到一座橫跨乾涸溝壑的橋前。在你過橋之前，一隻巨魔從橋下走出，要求你付費才"
+"肯放行。你拒絕了，巨魔發起衝鋒，你被迫將牠斬殺。你取走了牠的尖刺盾牌作為戰利"
+"品。"
+
+msgid "White Pearl"
+msgstr "White Pearl"
+
+msgid ""
+"A walk across a dry saltwater lake bed yields an unlikely prize: A white "
+"pearl amidst shattered shells and debris."
+msgstr ""
+"穿越乾涸鹽湖湖床的途中，你獲得了意想不到的獎品：一顆藏在碎裂貝殼和殘骸中的白"
+"色珍珠。"
+
+msgid "Black Pearl"
+msgstr "Black Pearl"
+
+msgid ""
+"Rumors of a Griffin of unusual size preying upon the countryside lead you to "
+"its cave lair. A quick, brutal fight dispatches the beast, and a search of "
+"its foul nest turns up a huge black pearl."
+msgstr ""
+"關於一隻巨大獅鷲在鄉間捕食的傳言將你引到了牠的洞穴巢穴。一場快速而殘酷的戰鬥"
+"殺死了野獸。你搜尋牠骯髒的巢穴時，找到了一顆巨大的黑珍珠。"
+
+msgid "Magic Book"
+msgstr "Magic Book"
+
+msgid "The %{name} enables the hero to cast spells."
+msgstr "%{name} 使英雄能夠施放法術。"
+
+msgid ""
+"A young man approaches you: \"My Lord, allow me to show you my latest "
+"invention for spreading knowledge!\" You follow the man into his workshop "
+"and immediately observe a large apparatus with levers and cranks. \"This "
+"here is it!\" he says eagerly, \"The Printing Press.\" And before you get to "
+"say a word, he hands you a Magic Book."
+msgstr ""
+"一個年輕人走近你：「大人，讓我向您展示我傳播知識的最新發明！」你跟著他走進工"
+"坊，立刻看到一台帶有拉桿和曲柄的大型裝置。「這就是了！」他急切地說，「印刷"
+"機。」你還來不及說話，他就遞給你一本魔法書。"
+
+msgid "Victory can be achieved by finding any Ultimate Artifact."
+msgstr "找到任何終極神器即可獲勝。"
+
+msgid "Dummy 2"
+msgstr "Dummy 2"
+
+msgid "The reserved artifact."
+msgstr "保留的神器。"
+
+msgid "Dummy 3"
+msgstr "Dummy 3"
+
+msgid "Dummy 4"
+msgstr "Dummy 4"
+
+msgid "Spell Scroll"
+msgstr "Spell Scroll"
+
+msgid ""
+"This %{name} gives the hero the ability to cast the %{spell} spell if the "
+"hero has a Magic Book."
+msgstr ""
+"這個 %{name} 在英雄擁有魔法書的情況下賦予施放 %{spell} 法術的能力。"
+
+msgid ""
+"You find an elaborate container which houses an old vellum scroll. The runes "
+"on the container are very old, and the artistry with which it was put "
+"together is stunning. As you pull the scroll out, you feel imbued with "
+"magical power."
+msgstr ""
+"你找到了一個精緻的容器，裡面裝著一卷古老的羊皮紙捲軸。容器上的符文非常古老，"
+"其工藝令人驚嘆。當你抽出捲軸時，你感覺全身充滿了魔力。"
+
+msgid "Arm of the Martyr"
+msgstr "Arm of the Martyr"
+
+msgid ""
+"One of the less intelligent members of your party picks up an arm off of the "
+"ground. Despite its missing a body, it is still moving. Your troops find the "
+"dismembered arm repulsive, but you cannot bring yourself to drop it: it "
+"seems to hold some sort of magical power that influences your decision "
+"making."
+msgstr ""
+"你隊伍中一位不太聰明的成員從地上撿起了一隻手臂。儘管沒有身體，它仍在動。你的"
+"部隊對這隻斷臂感到噁心，但你就是放不下它：它似乎擁有某種影響你決策的魔力。"
+
+msgid ""
+"The %{name} increases the hero's spell power by %{count} but adds the undead "
+"morale penalty."
+msgstr ""
+"%{name} 增加英雄 %{count} 點魔法力量，但附加亡靈士氣懲罰。"
+
+msgid "Breastplate of Anduran"
+msgstr "Breastplate of Anduran"
+
+msgid "The %{name} increases the hero's defense by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點防禦。"
+
+msgid ""
+"You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
+"swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
+"you stand up, you feel a coldness against your skin. Looking down, you find "
+"that you are suddenly wearing a gleaming, ornate breastplate."
+msgstr ""
+"你來到一塊告示牌前。上面寫著：「此處安息著 Anduran 的遺體。鞠躬宣誓效忠，你將"
+"得到回報。」你照做了。站起身來時，你感覺一陣冰涼貼著皮膚。低頭一看，你發現自"
+"己突然穿上了一件閃亮華麗的胸甲。"
+
+msgid "Broach of Shielding"
+msgstr "Broach of Shielding"
+
+msgid ""
+"The %{name} provides %{count} percent protection from Armageddon and "
+"Elemental Storm, but decreases spell power by 2."
+msgstr ""
+"%{name} 提供 %{count}% 的末日審判和元素風暴防護，但降低 2 點魔法力量。"
+
+msgid ""
+"A kindly Sorceress thinks that your army's defenses could use a magical "
+"boost. She offers to enchant the Broach that you wear on your cloak, and you "
+"accept."
+msgstr ""
+"一位善良的女巫認為你軍隊的防禦可以用魔法強化。她提議為你斗篷上的胸針施加附"
+"魔，你接受了。"
+
+msgid "Battle Garb of Anduran"
+msgstr "Battle Garb of Anduran"
+
+msgid ""
+"The %{name} combines the powers of the three Anduran artifacts (+5 to "
+"attack, defense, and spell power). It also provides maximum luck and morale "
+"for the hero's troops and gives the hero the Town Portal spell."
+msgstr ""
+"%{name} 結合了三件 Anduran 神器的力量 (攻擊、防禦和魔法力量各 +5)。它還為英雄"
+"的部隊提供最大幸運和士氣，並賦予英雄城鎮傳送門法術。"
+
+msgid ""
+"Out of pity for a poor peasant, you purchase a chest of old junk they are "
+"hawking for too much gold. Later, as you search through it, you find it "
+"contains the 3 pieces of the legendary battle garb of Anduran!"
+msgstr ""
+"出於對一個貧窮農民的同情，你以過高的價格買下了他們叫賣的一箱舊破爛。後來翻找"
+"時，你發現裡面竟包含傳說中 Anduran 戰甲的 3 個部件！"
+
+msgid "Crystal Ball"
+msgstr "Crystal Ball"
+
+msgid ""
+"The %{name} lets the hero get more specific information about monsters, "
+"enemy heroes, and castles nearby the hero."
+msgstr ""
+"%{name} 讓英雄獲得附近怪物、敵方英雄和城堡的更詳細資訊。"
+
+msgid ""
+"You come upon a caravan of gypsies who are feasting and fortifying their "
+"bodies with mead. They call you forward and say \"If you prove that you can "
+"dance the Rama-Buta, we will reward you.\" You don't know it, but try "
+"anyway. They laugh hysterically, but admire your bravery, giving you a "
+"Crystal Ball."
+msgstr ""
+"你遇到了一支正在飲蜜酒歡宴的吉普賽商隊。他們叫你過去說：「如果你能跳 Rama-"
+"Buta 舞，我們就獎賞你。」你不會跳，但還是嘗試了。他們笑得前仰後合，但欽佩你的"
+"勇氣，送給你一顆水晶球。"
+
+msgid "Heart of Fire"
+msgstr "Heart of Fire"
+
+msgid ""
+"The %{name} provides %{count} percent protection from fire, but doubles the "
+"damage taken from cold."
+msgstr ""
+"%{name} 提供 %{count}% 的火焰防護，但受到的冰系傷害加倍。"
+
+msgid ""
+"You enter a recently burned glade and come upon a Fire Elemental sitting "
+"atop a rock. It looks up, its flaming face contorted in a look of severe "
+"pain. It then tosses a glowing object at you. You put up your hands to block "
+"it, but it passes right through them and sears itself into your chest."
+msgstr ""
+"你進入一片最近燒毀的林間空地，遇到一個坐在岩石上的火元素。牠抬頭看你，燃燒的"
+"臉龐扭曲著劇痛的表情。然後牠朝你拋出一個發光的物體。你舉起雙手阻擋，但它直接"
+"穿過，灼入你的胸膛。"
+
+msgid "Heart of Ice"
+msgstr "Heart of Ice"
+
+msgid ""
+"The %{name} provides %{count} percent protection from cold, but doubles the "
+"damage taken from fire."
+msgstr ""
+"%{name} 提供 %{count}% 的寒冰防護，但受到的火系傷害加倍。"
+
+msgid ""
+"Suddenly, a biting coldness engulfs your body. You seize up, falling from "
+"your horse. The pain subsides, but you still feel as if your chest is "
+"frozen. As you pick yourself up off of the ground, you hear hearty laughter. "
+"You turn around just in time to see a Frost Giant run off into the woods and "
+"disappear."
+msgstr ""
+"突然，刺骨的寒冷吞噬了你的身體。你全身僵硬，從馬上摔落。疼痛消退了，但你仍覺"
+"得胸口像是結了冰。當你從地上爬起時，聽到了爽朗的笑聲。你轉過身，恰好看見一個"
+"霜巨人跑入樹林中消失了。"
+
+msgid "Helmet of Anduran"
+msgstr "Helmet of Anduran"
+
+msgid ""
+"You spy a gleaming object poking up out of the ground. You send a member of "
+"your party over to investigate. He comes back with a golden helmet in his "
+"hands. You realize that it must be the helmet of the legendary Anduran, the "
+"only man who was known to wear solid gold armor."
+msgstr ""
+"你發現地面上露出一個閃光的物體。你派隊員去調查。他帶著一頂金色頭盔回來。你意"
+"識到這一定是傳說中 Anduran 的頭盔，他是唯一一位已知穿戴純金盔甲的人。"
+
+msgid "Holy Hammer"
+msgstr "Holy Hammer"
+
+msgid ""
+"You come upon a battle where a Paladin has been mortally wounded by a group "
+"of Zombies. He asks you to take his hammer and finish what he started. As "
+"you pick it up, it begins to hum, and then everything becomes a blur. The "
+"Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
+msgstr ""
+"你遇到一場戰鬥，一位聖騎士被一群殭屍重傷。他請你拿起他的錘子完成他的使命。當"
+"你撿起它時，錘子開始嗡鳴，然後一切變得模糊。殭屍們都倒下了，錘子滴著鮮血。你"
+"將它繫在腰帶上。"
+
+msgid "Legendary Scepter"
+msgstr "Legendary Scepter"
+
+msgid "The %{name} adds %{count} points to all attributes."
+msgstr "%{name} 增加所有屬性 %{count} 點。"
+
+msgid ""
+"Upon cresting a small hill, you come upon a ridiculous looking sight. A "
+"Sprite is attempting to carry a Scepter that is almost as big as it is. "
+"Trying not to laugh, you ask, \"Need help?\" The Sprite glares at you and "
+"answers: \"You think this is funny? Fine. You can carry it. I much prefer "
+"flying anyway.\""
+msgstr ""
+"翻過一座小丘，你看到了一幅滑稽的景象。一隻精靈正試圖搬運一根幾乎和牠一樣大的"
+"權杖。你忍住笑問道：「需要幫忙嗎？」精靈瞪著你回答：「你覺得這很好笑嗎？好"
+"吧，你來搬。反正我比較喜歡飛。」"
+
+msgid "Masthead"
+msgstr "Masthead"
+
+msgid ""
+"The %{name} boosts the hero's troops' luck and morale by %{count} each in "
+"sea combat."
+msgstr ""
+"%{name} 在海戰中各增加英雄部隊 %{count} 點幸運和士氣。"
+
+msgid ""
+"An old seaman tells you a tale of an enchanted masthead that he used in his "
+"youth to rally his crew during times of trouble. He then hands you a faded "
+"map that shows where he hid it. After much exploring, you find it stashed "
+"underneath a nearby dock."
+msgstr ""
+"一位老水手向你講述他年輕時用一個魔法船首像在危難時鼓舞船員的故事。然後他遞給"
+"你一張褪色的地圖，標示了他藏匿之處。經過一番探索，你在附近的碼頭下面找到了"
+"它。"
+
+msgid "Sphere of Negation"
+msgstr "Sphere of Negation"
+
+msgid "The %{name} disables all spell casting, for both sides, in combat."
+msgstr "%{name} 在戰鬥中禁止雙方施放任何法術。"
+
+msgid ""
+"You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
+"hands you a tiny sphere. As soon as you grasp it, you feel the magical "
+"energy drain from your limbs..."
+msgstr ""
+"你停下來幫助一個農民抓住逃跑的母馬。為表感謝，他遞給你一個小球體。你一握住"
+"它，就感覺魔力從四肢流失……"
+
+msgid "Staff of Wizardry"
+msgstr "Staff of Wizardry"
+
+msgid "The %{name} boosts the hero's spell power by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點魔法力量。"
+
+msgid ""
+"While out scaring up game, your troops find a mysterious staff levitating "
+"about three feet off of the ground. They hand it to you, and you notice an "
+"inscription. It reads: \"Brains best brawn and magic beats might. Heed my "
+"words, and you'll win every fight.\""
+msgstr ""
+"在外出驅趕獵物時，你的部隊發現了一根在離地三英尺處懸浮的神秘法杖。他們將它交"
+"給你，你注意到上面有銘文寫著：「智慧勝過蠻力，魔法克制武力。聽從我的話，你將"
+"贏得每場戰鬥。」"
+
+msgid "Sword Breaker"
+msgstr "Sword Breaker"
+
+msgid "The %{name} increases the hero's defense by %{count} and attack by 1."
+msgstr "%{name} 增加英雄 %{count} 點防禦和 1 點攻擊。"
+
+msgid ""
+"A former Captain of the Guard admires your quest and gives you the enchanted "
+"Sword Breaker that he relied on during his tour of duty."
+msgstr ""
+"一位前衛隊隊長欽佩你的壯舉，將他在任期間依賴的附魔碎劍器送給你。"
+
+msgid "Sword of Anduran"
+msgstr "Sword of Anduran"
+
+msgid ""
+"A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
+"will slay you where you stand.\" You refuse. The troll grabs the sword "
+"hanging from its belt, screams in pain, and runs away. Picking up the fabled "
+"sword, you give thanks that half-witted Trolls tend to grab the wrong end of "
+"sharp objects."
+msgstr ""
+"一隻巨魔攔住你說：「付我 5,000 金幣，否則 Anduran 之劍會就地斬殺你。」你拒絕"
+"了。巨魔抓住掛在腰帶上的劍，痛得尖叫著跑掉了。撿起這把傳說中的劍，你慶幸愚蠢"
+"的巨魔總是抓錯銳器的那一端。"
+
+msgid "Spade of Necromancy"
+msgstr "Spade of Necromancy"
+
+msgid "The %{name} gives the hero increased necromancy skill."
+msgstr "%{name} 增強英雄的死靈術技能。"
+
+msgid ""
+"A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
+"you discover it to be the enchanted shovel of the Gravediggers, long thought "
+"lost by mortals."
+msgstr ""
+"附近的土堆中插著一把骯髒的鏟子。經過調查，你發現它是掘墓人的魔法鏟，長久以來"
+"被凡人認為已失落。"
+
+msgid "spellBonus|selected by user"
+msgstr "使用者選擇"
+
+msgid "Wood"
+msgstr "木材"
+
+msgid "Mercury"
+msgstr "水銀"
+
+msgid "Ore"
+msgstr "礦石"
+
+msgid "Sulfur"
+msgstr "硫磺"
+
+msgid "Crystal"
+msgstr "水晶"
+
+msgid "Gems"
+msgstr "寶石"
+
+msgid "Gold"
+msgstr "黃金"
+
+msgid ""
+"There are seven resources in Heroes 2, used to build and improves castles, "
+"purchase troops and recruit heroes. Gold is the most common, required for "
+"virtually everything. Wood and ore are used for most buildings. Gems, "
+"Mercury, Sulfur and Crystal are rare magical resources used for the most "
+"powerful creatures and buildings."
+msgstr ""
+"Heroes 2 中有七種資源，用於建造和升級城堡、購買部隊和招募英雄。黃金是最常見"
+"的，幾乎所有事物都需要。木材和礦石用於大多數建築。寶石、水銀、硫磺和水晶是稀"
+"有的魔法資源，用於最強大的生物和建築。"
+
+msgid ""
+"Causes a giant fireball to strike the selected area, damaging all nearby "
+"creatures."
+msgstr ""
+"對選定區域發射巨大火球，傷害附近所有生物。"
+
+msgid "Fireball"
+msgstr "火球術"
+
+msgid "Fireblast"
+msgstr "烈焰爆裂"
+
+msgid ""
+"An improved version of fireball, fireblast affects two hexes around the "
+"center point of the spell, rather than one."
+msgstr ""
+"火球術的強化版，烈焰爆裂影響以施法中心為圓心兩格範圍內的區域，而非一格。"
+
+msgid "Causes a bolt of electrical energy to strike the selected creature."
+msgstr "對選定生物發射一道閃電。"
+
+msgid "Lightning Bolt"
+msgstr "閃電箭"
+
+msgid "Chain Lightning"
+msgstr "連鎖閃電"
+
+msgid ""
+"Causes a bolt of electrical energy to strike a selected creature, then "
+"strike the nearest creature with half damage, then strike the NEXT nearest "
+"creature with half again damage, and so on, until it becomes too weak to be "
+"harmful. Warning: This spell can hit your own creatures!"
+msgstr ""
+"對選定生物發射閃電，然後以一半傷害擊中最近的生物，再以一半傷害擊中下一個最近"
+"的生物，依此類推，直到威力不足以造成傷害。警告：此法術可能擊中己方生物！"
+
+msgid "Teleport"
+msgstr "Teleport"
+
+msgid ""
+"Teleports the creature you select to any open position on the battlefield."
+msgstr ""
+"將選定生物傳送到戰場上任意空位。"
+
+msgid "Cure"
+msgstr "治療"
+
+msgid ""
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
+msgstr ""
+"移除己方一個單位身上的所有負面法術，並依魔法力量等級每級恢復最多 %{count} 點"
+"生命值。"
+
+msgid "Mass Cure"
+msgstr "群體治療"
+
+msgid ""
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
+msgstr ""
+"移除己方部隊身上的所有負面法術，並依魔法力量等級，每級為每個生物恢復最多 "
+"%{count} 點生命值。"
+
+msgid "Resurrect"
+msgstr "復活術"
+
+msgid "Resurrects creatures from a damaged or dead unit until end of combat."
+msgstr "從受傷或死亡的單位中復活生物，效果持續至戰鬥結束。"
+
+msgid "Resurrect True"
+msgstr "完全復活"
+
+msgid "Resurrects creatures from a damaged or dead unit permanently."
+msgstr "永久復活受傷或死亡單位中的生物。"
+
+msgid "Haste"
+msgstr "加速術"
+
+msgid "Increases the speed of any creature by %{count}."
+msgstr "增加任意生物 %{count} 點速度。"
+
+msgid "Increases the speed of all of your creatures by %{count}."
+msgstr "增加己方所有生物 %{count} 點速度。"
+
+msgid "Mass Haste"
+msgstr "群體加速"
+
+msgid "Slows target to half movement rate."
+msgstr "將目標的移動速率減半。"
+
+msgid "spell|Slow"
+msgstr "緩速術"
+
+msgid "Mass Slow"
+msgstr "群體緩速"
+
+msgid "Slows all enemies to half movement rate."
+msgstr "將所有敵人的移動速率減半。"
+
+msgid "spell|Blind"
+msgstr "致盲術"
+
+msgid ""
+"Clouds the affected creatures' eyes, preventing them from moving and reduces "
+"the damage when retaliating by %{count} percent."
+msgstr ""
+"蒙蔽受影響生物的雙眼，使其無法移動，並降低 %{count}% 的反擊傷害。"
+
+msgid "Bless"
+msgstr "祝福"
+
+msgid "Causes the selected creatures to inflict maximum damage."
+msgstr "使選定生物造成最大傷害。"
+
+msgid "Causes all of your units to inflict maximum damage."
+msgstr "使己方所有單位造成最大傷害。"
+
+msgid "Mass Bless"
+msgstr "群體祝福"
+
+msgid "Magically increases the defense skill of the selected creatures."
+msgstr "以魔法增加選定生物的防禦技能。"
+
+msgid "Stoneskin"
+msgstr "石膚術"
+
+msgid "Steelskin"
+msgstr "鋼膚術"
+
+msgid ""
+"Increases the defense skill of the targeted creatures. This is an improved "
+"version of Stoneskin."
+msgstr ""
+"增加目標生物的防禦技能。此為石膚術的強化版。"
+
+msgid "Causes the selected creatures to inflict minimum damage."
+msgstr "使選定生物只能造成最低傷害。"
+
+msgid "Curse"
+msgstr "詛咒"
+
+msgid "Causes all enemy troops to inflict minimum damage."
+msgstr "使所有敵軍只能造成最低傷害。"
+
+msgid "Mass Curse"
+msgstr "群體詛咒"
+
+msgid "Damages all undead in the battle."
+msgstr "傷害戰鬥中所有亡靈。"
+
+msgid "Holy Word"
+msgstr "神聖之語"
+
+msgid ""
+"Damages all undead in the battle. This is an improved version of Holy Word."
+msgstr ""
+"傷害戰鬥中所有亡靈。此為神聖之語的強化版。"
+
+msgid "Holy Shout"
+msgstr "神聖吶喊"
+
+msgid "Anti-Magic"
+msgstr "反魔法結界"
+
+msgid "Prevents any magic against the selected creatures."
+msgstr "使選定生物免受任何魔法影響。"
+
+msgid "Dispel Magic"
+msgstr "驅散魔法"
+
+msgid "Removes all magic spells from a single target."
+msgstr "移除單一目標身上的所有魔法效果。"
+
+msgid "Mass Dispel"
+msgstr "群體驅散"
+
+msgid "Removes all magic spells from all creatures."
+msgstr "移除所有生物身上的所有魔法效果。"
+
+msgid "Causes a magic arrow to strike the selected target."
+msgstr "對選定目標射出一發魔法飛彈。"
+
+msgid "Magic Arrow"
+msgstr "魔法飛彈"
+
+msgid "Berserker"
+msgstr "Berserker"
+
+msgid "Causes a creature to attack its nearest neighbor."
+msgstr "使一個生物攻擊其最近的鄰居。"
+
+msgid "Armageddon"
+msgstr "Armageddon"
+
+msgid ""
+"Holy terror strikes the battlefield, causing severe damage to all creatures."
+msgstr ""
+"神聖恐懼降臨戰場，對所有生物造成嚴重傷害。"
+
+msgid "Elemental Storm"
+msgstr "元素風暴"
+
+msgid "Magical elements pour down on the battlefield, damaging all creatures."
+msgstr "魔法元素傾瀉至戰場，傷害所有生物。"
+
+msgid ""
+"A rain of rocks strikes an area of the battlefield, damaging all nearby "
+"creatures."
+msgstr ""
+"石雨襲擊戰場上的一個區域，傷害附近所有生物。"
+
+msgid "Meteor Shower"
+msgstr "隕石雨"
+
+msgid "Paralyze"
+msgstr "麻痺術"
+
+msgid "The targeted creatures are paralyzed, unable to move or retaliate."
+msgstr "目標生物陷入麻痺，無法移動或反擊。"
+
+msgid "Hypnotize"
+msgstr "催眠術"
+
+msgid ""
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
+msgstr ""
+"敵方單一單位生命值低於施法者魔法力量的 %{count} 倍時，即可將其控制。"
+
+msgid "Cold Ray"
+msgstr "寒冰射線"
+
+msgid "Drains body heat from a single enemy unit."
+msgstr "吸取單一敵方單位的體溫。"
+
+msgid "Cold Ring"
+msgstr "寒冰之環"
+
+msgid ""
+"Drains body heat from all units surrounding the center point, but not "
+"including the center point."
+msgstr ""
+"吸取中心點周圍所有單位的體溫，但不影響中心點。"
+
+msgid "Disrupting Ray"
+msgstr "瓦解射線"
+
+msgid "Reduces the defense rating of an enemy unit by three."
+msgstr "降低敵方單位 3 點防禦值。"
+
+msgid "Damages all living (non-undead) units in the battle."
+msgstr "傷害戰鬥中所有活體 (非亡靈) 單位。"
+
+msgid "Death Ripple"
+msgstr "死亡漣漪"
+
+msgid "Death Wave"
+msgstr "死亡波動"
+
+msgid ""
+"Damages all living (non-undead) units in the battle. This spell is an "
+"improved version of Death Ripple."
+msgstr ""
+"傷害戰鬥中所有活體 (非亡靈) 單位。此為死亡漣漪的強化版。"
+
+msgid "Dragon Slayer"
+msgstr "屠龍術"
+
+msgid "Greatly increases a unit's attack skill vs. Dragons."
+msgstr "大幅增加單位對龍族的攻擊技能。"
+
+msgid "Blood Lust"
+msgstr "嗜血術"
+
+msgid "Increases a unit's attack skill."
+msgstr "增加單位的攻擊技能。"
+
+msgid "Animate Dead"
+msgstr "操控亡靈"
+
+msgid "Resurrects creatures from a damaged or dead undead unit permanently."
+msgstr "永久復活受傷或死亡的亡靈單位中的生物。"
+
+msgid "Mirror Image"
+msgstr "鏡像術"
+
+msgid ""
+"Creates an illusionary unit that duplicates one of your existing units. This "
+"illusionary unit does the same damages as the original, but will vanish if "
+"it takes any damage."
+msgstr ""
+"建立一個複製己方現有單位的幻影。幻影單位造成與原單位相同的傷害，但受到任何傷"
+"害就會消失。"
+
+msgid "Shield"
+msgstr "護盾"
+
+msgid ""
+"Halves damage received from ranged attacks for a single unit. Does not "
+"affect damage received from Turrets or Ballistae."
+msgstr ""
+"將單一單位受到的遠距攻擊傷害減半。不影響箭塔或弩砲造成的傷害。"
+
+msgid "Mass Shield"
+msgstr "群體護盾"
+
+msgid ""
+"Halves damage received from ranged attacks for all of your units. Does not "
+"affect damage received from Turrets or Ballistae."
+msgstr ""
+"將己方所有單位受到的遠距攻擊傷害減半。不影響箭塔或弩砲造成的傷害。"
+
+msgid "Summon Earth Elemental"
+msgstr "召喚土元素"
+
+msgid "Summons Earth Elementals to fight for your army."
+msgstr "召喚土元素為你的軍隊作戰。"
+
+msgid "Summon Air Elemental"
+msgstr "召喚風元素"
+
+msgid "Summons Air Elementals to fight for your army."
+msgstr "召喚風元素為你的軍隊作戰。"
+
+msgid "Summon Fire Elemental"
+msgstr "召喚火元素"
+
+msgid "Summons Fire Elementals to fight for your army."
+msgstr "召喚火元素為你的軍隊作戰。"
+
+msgid "Summon Water Elemental"
+msgstr "召喚水元素"
+
+msgid "Summons Water Elementals to fight for your army."
+msgstr "召喚水元素為你的軍隊作戰。"
+
+msgid "Damages castle walls."
+msgstr "破壞城牆。"
+
+msgid "Earthquake"
+msgstr "地震"
+
+msgid "Causes all mines across the land to become visible."
+msgstr "顯示大地上所有礦場的位置。"
+
+msgid "View Mines"
+msgstr "探查礦場"
+
+msgid "Causes all resources across the land to become visible."
+msgstr "顯示大地上所有資源的位置。"
+
+msgid "View Resources"
+msgstr "探查資源"
+
+msgid "Causes all artifacts across the land to become visible."
+msgstr "顯示大地上所有神器的位置。"
+
+msgid "View Artifacts"
+msgstr "探查神器"
+
+msgid "Causes all towns and castles across the land to become visible."
+msgstr "顯示大地上所有城鎮和城堡的位置。"
+
+msgid "View Towns"
+msgstr "探查城鎮"
+
+msgid "Causes all Heroes across the land to become visible."
+msgstr "顯示大地上所有英雄的位置。"
+
+msgid "View Heroes"
+msgstr "探查英雄"
+
+msgid "Causes the entire land to become visible."
+msgstr "顯示整片大地的全貌。"
+
+msgid "View All"
+msgstr "全域探查"
+
+msgid "Allows the caster to view detailed information on enemy Heroes."
+msgstr "讓施法者檢視敵方英雄的詳細資訊。"
+
+msgid "Summon Boat"
+msgstr "召喚船隻"
+
+msgid ""
+"Summons the nearest unoccupied, friendly boat to an adjacent shore location. "
+"A friendly boat is one which you just built or were the most recent player "
+"to occupy."
+msgstr ""
+"召喚最近且無人佔用的友方船隻到相鄰海岸位置。友方船隻是你剛建造，或最近由你佔"
+"用過的船。"
+
+msgid "Allows the caster to magically transport to a nearby location."
+msgstr "讓施法者以魔法傳送到附近的位置。"
+
+msgid "Dimension Door"
+msgstr "次元之門"
+
+msgid "Town Gate"
+msgstr "城鎮傳送門"
+
+msgid ""
+"Returns the caster to the nearest town or castle currently owned. This spell "
+"cannot be cast if the hero is already in a town or a castle."
+msgstr ""
+"將施法者傳送至最近的己方城鎮或城堡。若英雄已在城鎮或城堡中，則無法施放此法"
+"術。"
+
+msgid ""
+"Returns the hero to the town or castle of choice, provided it is controlled "
+"by you."
+msgstr ""
+"將英雄傳送至你控制的指定城鎮或城堡。"
+
+msgid "Visions"
+msgstr "幻視"
+
+msgid ""
+"Visions predicts the likely outcome of an encounter with a neutral army camp."
+msgstr ""
+"幻視預測與中立軍隊營地遭遇的可能結果。"
+
+msgid "Haunt"
+msgstr "鬧鬼"
+
+msgid ""
+"Haunts a mine you control with Ghosts. This mine stops producing resources. "
+"(If I can't keep it, nobody will!)"
+msgstr ""
+"以幽靈纏繞你控制的礦場，使該礦場停止生產資源。（如果我留不住，誰也別想要！）"
+
+msgid "Set Earth Guardian"
+msgstr "設立土元素守衛"
+
+msgid "Sets Earth Elementals to guard a mine against enemy armies."
+msgstr "設立土元素守衛礦場以抵禦敵軍。"
+
+msgid "Set Air Guardian"
+msgstr "設立風元素守衛"
+
+msgid "Sets Air Elementals to guard a mine against enemy armies."
+msgstr "設立風元素守衛礦場以抵禦敵軍。"
+
+msgid "Set Fire Guardian"
+msgstr "設立火元素守衛"
+
+msgid "Sets Fire Elementals to guard a mine against enemy armies."
+msgstr "設立火元素守衛礦場以抵禦敵軍。"
+
+msgid "Set Water Guardian"
+msgstr "設立水元素守衛"
+
+msgid "Sets Water Elementals to guard a mine against enemy armies."
+msgstr "設立水元素守衛礦場以抵禦敵軍。"
+
+msgid "Random Spell"
+msgstr "隨機法術"
+
+msgid "Randomly selected spell of any level."
+msgstr "隨機選取任意等級的法術。"
+
+msgid "Random 1st Level Spell"
+msgstr "隨機 1 級法術"
+
+msgid "Randomly selected 1st level spell."
+msgstr "隨機選取 1 級法術。"
+
+msgid "Random 2nd Level Spell"
+msgstr "隨機 2 級法術"
+
+msgid "Randomly selected 2nd level spell."
+msgstr "隨機選取 2 級法術。"
+
+msgid "Random 3rd Level Spell"
+msgstr "隨機 3 級法術"
+
+msgid "Randomly selected 3rd level spell."
+msgstr "隨機選取 3 級法術。"
+
+msgid "Random 4th Level Spell"
+msgstr "隨機 4 級法術"
+
+msgid "Randomly selected 4th level spell."
+msgstr "隨機選取 4 級法術。"
+
+msgid "Random 5th Level Spell"
+msgstr "隨機 5 級法術"
+
+msgid "Randomly selected 5th level spell."
+msgstr "隨機選取 5 級法術。"
+
+msgid "Petrification"
+msgstr "石化術"
+
+msgid ""
+"Turns the affected creature into stone. A petrified creature receives half "
+"damage from a direct attack."
+msgstr ""
+"將受影響的生物變為石頭。石化生物遭受直接攻擊時，傷害減半。"
+
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr "你沒有魔法書，無法施放法術。"
+
+msgid "No spell to cast."
+msgstr "沒有可施放的法術。"
+
+msgid "Your hero has %{sp} spell points remaining out of %{max}."
+msgstr "英雄剩餘 %{sp}/%{max} 點魔法值。"
+
+msgid "View Adventure Spells"
+msgstr "檢視冒險法術"
+
+msgid "View Combat Spells"
+msgstr "檢視戰鬥法術"
+
+msgid "View previous page"
+msgstr "檢視上一頁"
+
+msgid "View next page"
+msgstr "檢視下一頁"
+
+msgid "Close Spellbook"
+msgstr "關閉法術書"
+
+msgid "View %{spell}"
+msgstr "檢視 %{spell}"
+
+msgid "This spell does %{damage} points of damage."
+msgstr "此法術造成 %{damage} 點傷害。"
+
+msgid ""
+"This spell summons\n"
+"%{count} %{monster}."
+msgstr ""
+"此法術召喚\n"
+"%{count} 個 %{monster}。"
+
+msgid "This spell restores %{hp} HP."
+msgstr "此法術恢復 %{hp} 點生命值。"
+
+msgid "This spell summons %{count} %{monster} to guard the mine."
+msgstr "此法術召喚 %{count} 個 %{monster} 守衛礦場。"
+
+msgid "The nearest town is %{town}."
+msgstr "最近的城鎮是 %{town}。"
+
+msgid "This town is occupied by your hero %{hero}."
+msgstr "此城鎮已由你的英雄 %{hero} 駐守。"
+
+msgid ""
+"This spell controls up to\n"
+"%{hp} HP."
+msgstr ""
+"此法術可控制\n"
+"最多 %{hp} 點生命值的單位。"
+
+msgid "The ultimate artifact is really the %{name}."
+msgstr "終極神器其實是 %{name}。"
+
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
+msgstr "終極神器可能在世界的 %{name} 區域找到。"
+
+msgid "north-west"
+msgstr "西北"
+
+msgid "north"
+msgstr "北方"
+
+msgid "north-east"
+msgstr "東北"
+
+msgid "west"
+msgstr "西方"
+
+msgid "center"
+msgstr "中央"
+
+msgid "east"
+msgstr "東方"
+
+msgid "south-west"
+msgstr "西南"
+
+msgid "south"
+msgstr "南方"
+
+msgid "south-east"
+msgstr "東南"
+
+msgid "The truth is out there."
+msgstr "真相就在那裡。"
+
+msgid "The dark side is stronger."
+msgstr "黑暗面更為強大。"
+
+msgid "The end of the world is near."
+msgstr "世界末日即將來臨。"
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr "殺手領主的骸骨埋藏在競技場的地基中。"
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr "黑龍隨時都能打敗泰坦。"
+
+msgid "He told her: Yada yada yada... and then she said: Blah, blah, blah..."
+msgstr "他跟她說：巴拉巴拉巴拉……然後她說：嘰哩呱啦……"
+
+msgid "An unknown force is being resurrected..."
+msgstr "一股未知的力量正在復甦……"


### PR DESCRIPTION
Add the zh_TW Traditional Chinese Gettext PO file as translation source
material without enabling it as a runtime language yet.

The engine currently lacks UTF-8/CJK font rendering support, so this
commit intentionally does not add a zh_TW MO build target or register
zh_TW in the language selector.

See upstream Chinese support discussion in #7933 and the UTF-8
refactoring note in #10218.