### PR TITLE
Added morale/luck proc chances to their descriptions

### DIFF
--- a/src/fheroes2/kingdom/luck.cpp
+++ b/src/fheroes2/kingdom/luck.cpp
@@ -52,6 +52,30 @@ std::string Luck::String( int luck )
     return "Unknown";
 }
 
+std::string Luck::Percent( int luck )
+{
+    switch ( luck ) {
+    case Luck::CURSED:
+        return _( "luck|25%" );
+    case Luck::AWFUL:
+        return _( "luck|16.7%" );
+    case Luck::BAD:
+        return _( "luck|8.3%" );
+    case Luck::NORMAL:
+        return _( "luck|0%" );
+    case Luck::GOOD:
+        return _( "luck|4.2%" );
+    case Luck::GREAT:
+        return _( "luck|8.3%" );
+    case Luck::IRISH:
+        return _( "luck|12.5%" );
+    default:
+        break;
+    }
+
+    return "Unknown";
+}
+
 std::string Luck::Description( int luck )
 {
     std::string msg;
@@ -60,7 +84,7 @@ std::string Luck::Description( int luck )
     case Luck::CURSED:
     case Luck::AWFUL:
     case Luck::BAD:
-        msg = _( "%{luck-type} luck sometimes falls on the hero's units in combat, causing their attacks to only do half damage." );
+        msg = _( "%{luck-type} luck sometimes falls on the hero's units in combat, causing their attacks to only do half damage. \nChance: %{luck-percent}" );
         break;
     case Luck::NORMAL:
         msg = _( "%{luck-type} luck means the hero's units will never get lucky or unlucky attacks on the enemy." );
@@ -68,13 +92,14 @@ std::string Luck::Description( int luck )
     case Luck::GOOD:
     case Luck::GREAT:
     case Luck::IRISH:
-        msg = _( "%{luck-type} luck sometimes lets the hero's units get lucky attacks (double strength) in combat." );
+        msg = _( "%{luck-type} luck sometimes lets the hero's units get lucky attacks (double strength) in combat. \nChance: %{luck-percent}" );
         break;
     default:
         return "Unknown";
     }
 
     StringReplace( msg, "%{luck-type}", Luck::String( luck ) );
+    StringReplace( msg, "%{luck-percent}", Luck::Percent( luck ) );
     return msg;
 }
 

--- a/src/fheroes2/kingdom/luck.h
+++ b/src/fheroes2/kingdom/luck.h
@@ -40,6 +40,7 @@ namespace Luck
     };
 
     std::string String( int );
+    std::string Percent( int );
     std::string Description( int );
     int Normalize( const int luck );
 }

--- a/src/fheroes2/kingdom/morale.cpp
+++ b/src/fheroes2/kingdom/morale.cpp
@@ -52,6 +52,30 @@ std::string Morale::String( int morale )
     return "Unknown";
 }
 
+std::string Morale::Percent( int morale )
+{
+    switch ( morale ) {
+    case Morale::TREASON:
+        return _( "morale|25%" );
+    case Morale::AWFUL:
+        return _( "morale|16.7%" );
+    case Morale::POOR:
+        return _( "morale|8.3%" );
+    case Morale::NORMAL:
+        return _( "morale|0%" );
+    case Morale::GOOD:
+        return _( "morale|4.2%" );
+    case Morale::GREAT:
+        return _( "morale|8.3%" );
+    case Morale::BLOOD:
+        return _( "morale|12.5%" );
+    default:
+        break;
+    }
+
+    return "Unknown";
+}
+
 std::string Morale::Description( int morale )
 {
     std::string msg;
@@ -60,7 +84,7 @@ std::string Morale::Description( int morale )
     case Morale::TREASON:
     case Morale::AWFUL:
     case Morale::POOR:
-        msg = _( "%{morale-type} morale may cause the hero's units to freeze in combat." );
+        msg = _( "%{morale-type} morale may cause the hero's units to freeze in combat.\nChance: %{morale-percent}" );
         break;
     case Morale::NORMAL:
         msg = _( "%{morale-type} morale means the hero's units will never be blessed with extra attacks or freeze in combat." );
@@ -68,7 +92,7 @@ std::string Morale::Description( int morale )
     case Morale::GOOD:
     case Morale::GREAT:
     case Morale::BLOOD:
-        msg = _( "%{morale-type} morale may give the hero's units extra attacks in combat." );
+        msg = _( "%{morale-type} morale may give the hero's units extra attacks in combat.\nChance: %{morale-percent}" );
         break;
     default:
         return "Unknown";
@@ -80,6 +104,8 @@ std::string Morale::Description( int morale )
     else {
         StringReplace( msg, "%{morale-type}", Morale::String( morale ) );
     }
+
+    StringReplace( msg, "%{morale-percent}", Morale::Percent( morale ) );
 
     return msg;
 }

--- a/src/fheroes2/kingdom/morale.h
+++ b/src/fheroes2/kingdom/morale.h
@@ -40,6 +40,7 @@ namespace Morale
     };
 
     std::string String( int );
+    std::string Percent( int );
     std::string Description( int );
     int Normalize( const int morale );
 }


### PR DESCRIPTION
This is a very simple QoL addition- add a string that will help people know the meaning of the -3 to +3 luck\morale.
<img width="689" height="586" alt="Screenshot 2026-06-01 203800" src="https://github.com/user-attachments/assets/f7aff721-0be4-4f2d-b7d4-bdafe3495e8a" />
<img width="684" height="536" alt="Screenshot 2026-06-01 203836" src="https://github.com/user-attachments/assets/7932c0eb-be5f-474f-8645-4970039fcbd0" />

This change would make morale/luck mechanics more transparent and help new players understand how significant these stats are.

Related to #10805 