### PR TITLE
Fixed validation issue when updating enemy army

### DIFF
--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -450,6 +450,12 @@ bool Battle::Only::setup( const bool allowBackup, bool & resetBattleSetup )
                     }
 
                     updateHero( first, windowOffset );
+
+                    if ( first.controlType == CONTROL_AI ) {
+                        buttonStart.enable();
+                        buttonStart.draw();
+                        needRender = true;
+                    }
                 }
 
                 titleRoiRestorer.restore();
@@ -608,6 +614,9 @@ void Battle::Only::updateHero( ArmyInfo & info, const fheroes2::Point & offset )
     if ( info.hero == nullptr ) {
         return;
     }
+
+    info.monster.Reset();
+    info.monster.GetTroop( 0 )->Set( defaultMonster );
 
     updateArmyUI( info.ui, info.hero, offset, info.armyId );
 }

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -355,6 +355,23 @@ bool Battle::Only::setup( const bool allowBackup, bool & resetBattleSetup )
     fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonStartIcn, 0 ), display, buttonStart.area().getPosition(), shadowOffset );
     fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonExitIcn, 0 ), display, buttonExit.area().getPosition(), shadowOffset );
 
+    auto updateStartButton = [&buttonStart]( const Army & first, const Army & second ) {
+        const bool isArmyValid = ( first.isValid() && second.isValid() );
+        if ( isArmyValid && !buttonStart.isEnabled() ) {
+            buttonStart.enable();
+            buttonStart.draw();
+            return true;
+        }
+
+        if ( !isArmyValid && buttonStart.isEnabled() ) {
+            buttonStart.disable();
+            buttonStart.draw();
+            return true;
+        }
+
+        return false;
+    };
+
     buttonStart.draw();
     buttonExit.draw();
     buttonReset.draw();
@@ -451,11 +468,7 @@ bool Battle::Only::setup( const bool allowBackup, bool & resetBattleSetup )
 
                     updateHero( first, windowOffset );
 
-                    if ( first.controlType == CONTROL_AI ) {
-                        buttonStart.enable();
-                        buttonStart.draw();
-                        needRender = true;
-                    }
+                    needRender = needRender || updateStartButton( first.monster, second.monster );
                 }
 
                 titleRoiRestorer.restore();
@@ -500,17 +513,7 @@ bool Battle::Only::setup( const bool allowBackup, bool & resetBattleSetup )
 
                 armyInfo[firstId].needRedraw = true;
 
-                const bool isArmyValid = ( armyInfo[firstId].monster.isValid() && armyInfo[secondId].monster.isValid() );
-                if ( isArmyValid && !buttonStart.isEnabled() ) {
-                    buttonStart.enable();
-                    buttonStart.draw();
-                    needRender = true;
-                }
-                else if ( !isArmyValid && buttonStart.isEnabled() ) {
-                    buttonStart.disable();
-                    buttonStart.draw();
-                    needRender = true;
-                }
+                needRender = needRender || updateStartButton( armyInfo[firstId].monster, armyInfo[secondId].monster );
             }
             else if ( firstUI.artifact != nullptr && le.isMouseCursorPosInArea( firstUI.artifact->GetArea() ) && firstUI.artifact->QueueEventProcessing() ) {
                 if ( firstUI.army != nullptr && firstUI.army->isSelected() ) {


### PR DESCRIPTION
Fixed issue where if the enemy army had no units and then we would add an enemy hero, we were only update the UI and not the ArmyInfo field, causing the validation check to always give us false and thus having the start button disabled.

More over, this fixes 

##
Test cases

Before doing the below test cases, reset UI.

Test 1:
- Remove enemy army
- Start button is disabled / Cant enter game with enter keyboard
- Add enemy army
- Start button is enabled.


Test 2:
- Add enemy hero
- Remove a unit
- Enemy hero has atleast 1 army and the start button is active

Test 3:
- Remove enemy army
- Add enemy hero
- Start button become active
- Remove enemy unity
- Start button is still active

##

Related Issue #10811 