### PR TITLE
Make AI heroes stay in castles if they get movement bonus next day

### DIFF
--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2940,8 +2940,8 @@ void AI::Planner::HeroesActionComplete( Heroes & hero, const int32_t tileIndex, 
             uint32_t speedDifference{ fastestTroop->GetSpeed() - slowestSpeed };
             if ( speedDifference * 100U >= hero.GetMovePoints() ) {
                 // Seems like leaving all slow units in the castle might give a movement boost next day.
-                const Troops castleBackup{ castle->GetArmy() };
-                const Troops heroBackup{ heroArmy };
+                const Troops castleBackup{ castle->GetArmy().getTroops() };
+                const Troops heroBackup{ heroArmy.getTroops() };
 
                 transferSlowestTroopsToGarrison( &hero, castle );
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2947,6 +2947,8 @@ void AI::Planner::HeroesActionComplete( Heroes & hero, const int32_t tileIndex, 
 
                 // Verify that the movement bonus is still applicable.
                 slowestTroop = heroArmy.GetSlowestTroop();
+                assert( slowestTroop != nullptr );
+
                 speedDifference = slowestTroop->GetSpeed() - slowestSpeed;
                 if ( speedDifference * 100U >= hero.GetMovePoints() ) {
                     hero.SetModes( Heroes::SLEEPER );

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2940,8 +2940,8 @@ void AI::Planner::HeroesActionComplete( Heroes & hero, const int32_t tileIndex, 
             uint32_t speedDifference{ fastestTroop->GetSpeed() - slowestSpeed };
             if ( speedDifference * 100U >= hero.GetMovePoints() ) {
                 // Seems like leaving all slow units in the castle might give a movement boost next day.
-                Troops castleBackup{ castle->GetArmy() };
-                Troops heroBackup{ heroArmy };
+                const Troops castleBackup{ castle->GetArmy() };
+                const Troops heroBackup{ heroArmy };
 
                 transferSlowestTroopsToGarrison( &hero, castle );
 

--- a/src/fheroes2/ai/ai_planner_hero.cpp
+++ b/src/fheroes2/ai/ai_planner_hero.cpp
@@ -2923,6 +2923,41 @@ void AI::Planner::HeroesActionComplete( Heroes & hero, const int32_t tileIndex, 
             }
 
             reinforceCastle( *castle );
+
+            // If the hero has very little movement points, we can check whether it is worth keeping him in the castle for the next turn.
+            //
+            // Each step in monster speed gives 100 movement points (see Heroes::GetMaxMovePoints() method).
+            // So, we need to get the difference in speed between slowest and fastest units, and compare it with movement points left for this turn.
+            Army & heroArmy = hero.GetArmy();
+            const Troop * slowestTroop = heroArmy.GetSlowestTroop();
+            const Troop * fastestTroop = heroArmy.GetFastestTroop();
+
+            assert( slowestTroop != nullptr );
+            assert( fastestTroop != nullptr );
+
+            const uint32_t slowestSpeed{ slowestTroop->GetSpeed() };
+
+            uint32_t speedDifference{ fastestTroop->GetSpeed() - slowestSpeed };
+            if ( speedDifference * 100U >= hero.GetMovePoints() ) {
+                // Seems like leaving all slow units in the castle might give a movement boost next day.
+                Troops castleBackup{ castle->GetArmy() };
+                Troops heroBackup{ heroArmy };
+
+                transferSlowestTroopsToGarrison( &hero, castle );
+
+                // Verify that the movement bonus is still applicable.
+                slowestTroop = heroArmy.GetSlowestTroop();
+                speedDifference = slowestTroop->GetSpeed() - slowestSpeed;
+                if ( speedDifference * 100U >= hero.GetMovePoints() ) {
+                    hero.SetModes( Heroes::SLEEPER );
+                    DEBUG_LOG( DBG_AI, DBG_TRACE, hero.GetName() << " stays in " << castle->GetName() << " castle till the next turn to get movement boost." )
+                }
+                else {
+                    // Nope. We can't get the movement bonus.
+                    castle->GetArmy().Assign( castleBackup );
+                    heroArmy.Assign( heroBackup );
+                }
+            }
         }
         else {
             OptimizeTroopsOrder( hero.GetArmy() );

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -605,6 +605,11 @@ Troop * Troops::GetSlowestTroop() const
     return getBestMatchToCondition( Army::SlowestTroop );
 }
 
+Troop * Troops::GetFastestTroop() const
+{
+    return getBestMatchToCondition( Army::FastestTroop );
+}
+
 void Troops::MergeSameMonsterTroops()
 {
     for ( size_t slot = 0; slot < size(); ++slot ) {

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -101,6 +101,7 @@ public:
     Troop * GetFirstValid() const;
     Troop * GetWeakestTroop() const;
     Troop * GetSlowestTroop() const;
+    Troop * GetFastestTroop() const;
 
     void SortStrongest();
 

--- a/src/fheroes2/heroes/heroes.h
+++ b/src/fheroes2/heroes/heroes.h
@@ -438,6 +438,7 @@ public:
     // Returns the maximum number of hero movement points, depending on the specified surface type (water or land)
     uint32_t GetMaxMovePoints( const bool onWater ) const;
 
+    // Returns the movement points for the current turn.
     uint32_t GetMovePoints() const
     {
         return _movePoints;


### PR DESCRIPTION
The same tactic is widely used by human players. It not only gives movement points but also restores spell points for the hero.