### PR TITLE
Fix assertion hit for AI battle during Teleport spell evaluation

### DIFF
--- a/src/fheroes2/ai/ai_battle_spell.cpp
+++ b/src/fheroes2/ai/ai_battle_spell.cpp
@@ -134,7 +134,7 @@ AI::SpellSelection AI::BattlePlanner::selectBestSpell( Battle::Arena & arena, co
             checkSelectBestSpell( spell, spellDragonSlayerValue( spell, friendly, enemies ) );
         }
         else if ( spell == Spell::TELEPORT ) {
-            checkSelectBestSpell( spell, spellTeleportValue( arena, spell, currentUnit, enemies ) );
+            checkSelectBestSpell( spell, spellTeleportValue( arena, spell, currentUnit, trueEnemies ) );
         }
         else if ( spell == Spell::EARTHQUAKE ) {
             checkSelectBestSpell( spell, spellEarthquakeValue( arena, spell, friendly ) );
@@ -851,6 +851,11 @@ AI::SpellcastOutcome AI::BattlePlanner::spellTeleportValue( Battle::Arena & aren
                                                             const Battle::Units & enemies ) const
 {
     assert( spell == Spell::TELEPORT );
+
+    if ( currentUnit.Modes( Battle::SP_HYPNOTIZE ) ) {
+        // TODO: implement Teleport for Hypnotized units.
+        return {};
+    }
 
     // Teleport spell is useful in many cases. The current implementation focuses only on offensive movements for melee units.
 


### PR DESCRIPTION
This happens when the same unit is under Hypnotize spell and was considered as one of the enemies.

Moreover, it is useless to use this spell on Hypnotized units till we implement logic to purposely move them far away.

These changes also fix one of the assertions related to this condition during battles.