### PR TITLE
Add Diplomacy blocked-join messages

### DIFF
--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1719,8 +1719,8 @@ NeutralMonsterJoiningCondition Army::GetJoinSolution( const Heroes & hero, const
                         blockedJoiningReason = NeutralMonsterJoiningCondition::Reason::NoFreeSlot;
                     }
                 }
-                // The ability to immediately hire the entire stack of monsters is a mandatory condition for their joining due to hero's Diplomacy skill in accordance with
-                // the mechanics of the original game
+                // The ability to immediately hire the entire stack of monsters is a mandatory condition for their joining due to hero's Diplomacy skill in accordance
+                // with the mechanics of the original game
                 else if ( hero.GetKingdom().AllowPayment( Funds( Resource::GOLD, troop.GetTotalCost().gold ) ) ) {
                     return { NeutralMonsterJoiningCondition::Reason::ForMoney, amountToJoin, nullptr, nullptr };
                 }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1682,14 +1682,8 @@ NeutralMonsterJoiningCondition Army::GetJoinSolution( const Heroes & hero, const
     // Neutral monsters don't care about hero's stats. Ignoring hero's stats makes hero's army strength be smaller in eyes of neutrals and they won't join so often.
     const double armyStrengthRatio = Troops( hero.GetArmy().getTroops() ).GetStrength() / troop.GetStrength();
 
-    const bool canJoin = [&hero, &tile, &troop, armyStrengthRatio]() {
+    const bool canPotentiallyJoin = [&hero, &tile, armyStrengthRatio]() {
         if ( armyStrengthRatio <= 2 ) {
-            return false;
-        }
-
-        // The ability to accept monsters (a free slot or a stack of monsters of the same type) is a mandatory condition for their joining in accordance with the
-        // mechanics of the original game
-        if ( !hero.GetArmy().CanJoinTroop( troop ) ) {
             return false;
         }
 
@@ -1700,19 +1694,37 @@ NeutralMonsterJoiningCondition Army::GetJoinSolution( const Heroes & hero, const
         return !Maps::isMonsterOnTileJoinConditionSkip( tile );
     }();
 
-    if ( canJoin ) {
+    if ( canPotentiallyJoin ) {
+        const bool canJoinArmy = hero.GetArmy().CanJoinTroop( troop );
+
         if ( Maps::isMonsterOnTileJoinConditionFree( tile ) ) {
-            return { NeutralMonsterJoiningCondition::Reason::Free, troop.GetCount(), nullptr, nullptr };
+            if ( canJoinArmy ) {
+                return { NeutralMonsterJoiningCondition::Reason::Free, troop.GetCount(), nullptr, nullptr };
+            }
+
+            if ( hero.isControlHuman() ) {
+                return { NeutralMonsterJoiningCondition::Reason::NoFreeSlot, 0, nullptr, nullptr };
+            }
         }
 
         if ( hero.HasSecondarySkill( Skill::Secondary::DIPLOMACY ) ) {
             const uint32_t amountToJoin
                 = Monster::GetCountFromHitPoints( troop, troop.GetHitPoints() * hero.GetSecondarySkillValue( Skill::Secondary::DIPLOMACY ) / 100 );
 
-            // The ability to immediately hire the entire stack of monsters is a mandatory condition for their joining due to hero's Diplomacy skill in accordance with
-            // the mechanics of the original game
-            if ( amountToJoin > 0 && hero.GetKingdom().AllowPayment( Funds( Resource::GOLD, troop.GetTotalCost().gold ) ) ) {
-                return { NeutralMonsterJoiningCondition::Reason::ForMoney, amountToJoin, nullptr, nullptr };
+            if ( amountToJoin > 0 ) {
+                if ( !canJoinArmy ) {
+                    if ( hero.isControlHuman() ) {
+                        return { NeutralMonsterJoiningCondition::Reason::NoFreeSlot, 0, nullptr, nullptr };
+                    }
+                }
+                // The ability to immediately hire the entire stack of monsters is a mandatory condition for their joining due to hero's Diplomacy skill in accordance with
+                // the mechanics of the original game
+                else if ( hero.GetKingdom().AllowPayment( Funds( Resource::GOLD, troop.GetTotalCost().gold ) ) ) {
+                    return { NeutralMonsterJoiningCondition::Reason::ForMoney, amountToJoin, nullptr, nullptr };
+                }
+                else if ( hero.isControlHuman() ) {
+                    return { NeutralMonsterJoiningCondition::Reason::NotEnoughGold, 0, nullptr, nullptr };
+                }
             }
         }
     }

--- a/src/fheroes2/army/army.cpp
+++ b/src/fheroes2/army/army.cpp
@@ -1682,6 +1682,8 @@ NeutralMonsterJoiningCondition Army::GetJoinSolution( const Heroes & hero, const
     // Neutral monsters don't care about hero's stats. Ignoring hero's stats makes hero's army strength be smaller in eyes of neutrals and they won't join so often.
     const double armyStrengthRatio = Troops( hero.GetArmy().getTroops() ).GetStrength() / troop.GetStrength();
 
+    NeutralMonsterJoiningCondition::Reason blockedJoiningReason = NeutralMonsterJoiningCondition::Reason::None;
+
     const bool canPotentiallyJoin = [&hero, &tile, armyStrengthRatio]() {
         if ( armyStrengthRatio <= 2 ) {
             return false;
@@ -1703,7 +1705,7 @@ NeutralMonsterJoiningCondition Army::GetJoinSolution( const Heroes & hero, const
             }
 
             if ( hero.isControlHuman() ) {
-                return { NeutralMonsterJoiningCondition::Reason::NoFreeSlot, 0, nullptr, nullptr };
+                blockedJoiningReason = NeutralMonsterJoiningCondition::Reason::NoFreeSlot;
             }
         }
 
@@ -1714,7 +1716,7 @@ NeutralMonsterJoiningCondition Army::GetJoinSolution( const Heroes & hero, const
             if ( amountToJoin > 0 ) {
                 if ( !canJoinArmy ) {
                     if ( hero.isControlHuman() ) {
-                        return { NeutralMonsterJoiningCondition::Reason::NoFreeSlot, 0, nullptr, nullptr };
+                        blockedJoiningReason = NeutralMonsterJoiningCondition::Reason::NoFreeSlot;
                     }
                 }
                 // The ability to immediately hire the entire stack of monsters is a mandatory condition for their joining due to hero's Diplomacy skill in accordance with
@@ -1723,13 +1725,27 @@ NeutralMonsterJoiningCondition Army::GetJoinSolution( const Heroes & hero, const
                     return { NeutralMonsterJoiningCondition::Reason::ForMoney, amountToJoin, nullptr, nullptr };
                 }
                 else if ( hero.isControlHuman() ) {
-                    return { NeutralMonsterJoiningCondition::Reason::NotEnoughGold, 0, nullptr, nullptr };
+                    blockedJoiningReason = NeutralMonsterJoiningCondition::Reason::NotEnoughGold;
                 }
             }
         }
     }
 
-    if ( armyStrengthRatio > 5 && !hero.isControlAI() ) {
+    const bool willRunAway = armyStrengthRatio > 5 && !hero.isControlAI();
+
+    if ( blockedJoiningReason != NeutralMonsterJoiningCondition::Reason::None ) {
+        if ( willRunAway ) {
+            if ( blockedJoiningReason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot ) {
+                return { NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway, 0, nullptr, nullptr };
+            }
+
+            return { NeutralMonsterJoiningCondition::Reason::NotEnoughGoldAndRunAway, 0, nullptr, nullptr };
+        }
+
+        return { blockedJoiningReason, 0, nullptr, nullptr };
+    }
+
+    if ( willRunAway ) {
         // ... will surely flee before us
         return { NeutralMonsterJoiningCondition::Reason::RunAway, 0, nullptr, nullptr };
     }

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -146,7 +146,9 @@ struct NeutralMonsterJoiningCondition final
         ForMoney,
         RunAway,
         Alliance,
-        Bane
+        Bane,
+        NotEnoughGold,
+        NoFreeSlot
     };
 
     Reason reason{ Reason::None };

--- a/src/fheroes2/army/army.h
+++ b/src/fheroes2/army/army.h
@@ -148,7 +148,9 @@ struct NeutralMonsterJoiningCondition final
         Alliance,
         Bane,
         NotEnoughGold,
-        NoFreeSlot
+        NoFreeSlot,
+        NotEnoughGoldAndRunAway,
+        NoFreeSlotAndRunAway
     };
 
     Reason reason{ Reason::None };

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -436,8 +436,8 @@ namespace
         }
         else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot || join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway ) {
             fheroes2::showStandardTextMessage( "",
-                                               join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot 
-                                                   ? _( "The creatures would join your army, but your army has no room for them.\nThey prepare to fight." ) 
+                                               join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot
+                                                   ? _( "The creatures would join your army, but your army has no room for them.\nThey prepare to fight." )
                                                    : _( "The creatures would join your army, but your army has no room for them." ),
                                                Dialog::OK );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -416,6 +416,16 @@ namespace
             else {
                 fheroes2::showStandardTextMessage( "", _( "Insulted by your refusal of their offer, the monsters attack!" ), Dialog::OK );
             }
+        } else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGold ) {
+            fheroes2::showStandardTextMessage(
+                "",
+                _( "The creatures are willing to join your army, but you do not have enough gold." ),
+                Dialog::OK );
+        } else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot ) {
+            fheroes2::showStandardTextMessage(
+                "",
+                _( "The creatures are willing to join your army, but you have no free army slot available." ),
+                Dialog::OK );
         }
         else if ( join.reason == NeutralMonsterJoiningCondition::Reason::RunAway ) {
             DEBUG_LOG( DBG_GAME, DBG_INFO, troop.GetName() << " run away from " << hero.GetName() )

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -416,16 +416,42 @@ namespace
             else {
                 fheroes2::showStandardTextMessage( "", _( "Insulted by your refusal of their offer, the monsters attack!" ), Dialog::OK );
             }
-        } else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGold ) {
+        } 
+        else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGold
+                || join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGoldAndRunAway ) {
             fheroes2::showStandardTextMessage(
                 "",
-                _( "The creatures are willing to join your army, but you do not have enough gold." ),
+                join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGold
+                    ? _( "The creatures would join your army, but you do not have enough gold. \nThey prepare to fight." )
+                    : _( "The creatures would join your army, but you do not have enough gold." ),
                 Dialog::OK );
-        } else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot ) {
+
+            if ( join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGoldAndRunAway ) {
+                std::string message = _( "The %{monster}, awed by the power of your forces, begin to scatter.\nDo you wish to pursue and engage them?" );
+                StringReplaceWithLowercase( message, "%{monster}", troop.GetMultiName() );
+
+                if ( fheroes2::showStandardTextMessage( "", std::move( message ), Dialog::YES | Dialog::NO ) == Dialog::NO ) {
+                    destroy = true;
+                }
+            }
+        } 
+        else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot
+                    || join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway ) {
             fheroes2::showStandardTextMessage(
                 "",
-                _( "The creatures are willing to join your army, but you have no free army slot available." ),
+                join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot
+                    ? _( "The creatures would join your army, but your army has no room for them. \nThey prepare to fight." )
+                    : _( "The creatures would join your army, but your army has no room for them." ),
                 Dialog::OK );
+
+            if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway ) {
+                std::string message = _( "The %{monster}, awed by the power of your forces, begin to scatter.\nDo you wish to pursue and engage them?" );
+                StringReplaceWithLowercase( message, "%{monster}", troop.GetMultiName() );
+
+                if ( fheroes2::showStandardTextMessage( "", std::move( message ), Dialog::YES | Dialog::NO ) == Dialog::NO ) {
+                    destroy = true;
+                }
+            }
         }
         else if ( join.reason == NeutralMonsterJoiningCondition::Reason::RunAway ) {
             DEBUG_LOG( DBG_GAME, DBG_INFO, troop.GetName() << " run away from " << hero.GetName() )

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -835,7 +835,7 @@ namespace
         switch ( objectType ) {
         case MP2::OBJ_WINDMILL:
             msg = funds.GetValidItemsCount() > 0
-                      ? _( 
+                      ? _(
                           "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
                       : _( "The keeper of the mill announces:\n\"Milord, I am sorry, there are no resources currently available. Please try again next week.\"" );
             break;
@@ -853,9 +853,9 @@ namespace
 
         case MP2::OBJ_MAGIC_GARDEN:
             msg = funds.GetValidItemsCount() > 0
-                      ? _( 
+                      ? _(
                           "You catch a leprechaun foolishly sleeping amidst a cluster of magic mushrooms.\nIn exchange for his freedom, he guides you to a small pot filled with precious things." )
-                      : _( 
+                      : _(
                           "You've found a magic garden, the kind of place that leprechauns and faeries like to cavort in, but there is no one here today.\nPerhaps you should try again next week." );
             break;
 
@@ -1154,7 +1154,7 @@ namespace
             break;
 
         case MP2::OBJ_IDOL:
-            msg = visited ? _( 
+            msg = visited ? _(
                       "You've found an ancient and weathered stone idol.\nIt is supposed to grant luck to visitors, but since the stars are already smiling upon you, it does nothing." )
                           : _( "You've found an ancient and weathered stone idol.\nKissing it is supposed to be lucky, so you do. The stone is very cold to the touch." );
             break;
@@ -1162,7 +1162,7 @@ namespace
         case MP2::OBJ_MERMAID:
             msg = visited
                       ? _( "The mermaids silently entice you to return later and be blessed again." )
-                      : _( 
+                      : _(
                           "The magical, soothing beauty of the Mermaids reaches you and your crew.\nJust for a moment, you forget your worries and bask in the beauty of the moment.\nThe mermaids' charms bless you with increased luck for your next combat." );
             break;
 
@@ -1337,9 +1337,9 @@ namespace
 
         case MP2::OBJ_MERCENARY_CAMP:
             skill = Skill::Primary::ATTACK;
-            msg = visited ? _( 
+            msg = visited ? _(
                       "You've come upon a mercenary camp practicing their tactics. \"You're too advanced for us,\" the mercenary captain says. \"We can teach nothing more.\"" )
-                          : _( 
+                          : _(
                               "You've come upon a mercenary camp practicing their tactics. The mercenaries welcome you and your troops and invite you to train with them." );
             break;
 
@@ -1347,13 +1347,13 @@ namespace
             skill = Skill::Primary::KNOWLEDGE;
             msg = visited
                       ? _( "\"Go 'way!\", the witch doctor barks, \"you know all I know.\"" )
-                      : _( 
+                      : _(
                           "An Orcish witch doctor living in the hut deepens your knowledge of magic by showing you how to cast stones, read portents, and decipher the intricacies of chicken entrails." );
             break;
 
         case MP2::OBJ_STANDING_STONES:
             skill = Skill::Primary::POWER;
-            msg = visited ? _( 
+            msg = visited ? _(
                       "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, the Druids turn you away, indicating they have nothing new to teach you." )
                           : _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, they teach you new ways to cast spells." );
             break;
@@ -1511,7 +1511,7 @@ namespace
             break;
 
         case MP2::OBJ_WATERING_HOLE:
-            msg = visited ? _( 
+            msg = visited ? _(
                       "The drink at the watering hole is refreshing, but offers no further benefit. The watering hole might help again if you fought a battle first." )
                           : _( "A drink at the watering hole fills your troops with strength and lifts their spirits. You can travel a bit further today." );
             move = GameStatic::getMovementPointBonus( MP2::OBJ_WATERING_HOLE );
@@ -1522,7 +1522,7 @@ namespace
                           : _( "A visit and a prayer at the temple raises the morale of your troops." );
             break;
 
-        default:
+        default:    
             return;
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -830,7 +830,7 @@ namespace
         const Funds funds = getFundsFromTile( tile );
 
         std::string msg;
-        std::string caption = MP2::StringObject( objectType );  
+        std::string caption = MP2::StringObject( objectType );
 
         switch ( objectType ) {
         case MP2::OBJ_WINDMILL:
@@ -1522,7 +1522,7 @@ namespace
                           : _( "A visit and a prayer at the temple raises the morale of your troops." );
             break;
 
-        default:    
+        default:
             return;
         }
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -436,10 +436,10 @@ namespace
         }
         else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot || join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway ) {
             fheroes2::showStandardTextMessage( "",
-                                               +join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot +
-                                                   ? _( "The creatures would join your army, but your army has no room for them.\nThey prepare to fight." ) +
+                                               join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot 
+                                                   ? _( "The creatures would join your army, but your army has no room for them.\nThey prepare to fight." ) 
                                                    : _( "The creatures would join your army, but your army has no room for them." ),
-                                               +Dialog::OK );
+                                               Dialog::OK );
 
             if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway ) {
                 std::string message = _( "The %{monster}, awed by the power of your forces, begin to scatter.\nDo you wish to pursue and engage them?" );

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -830,12 +830,13 @@ namespace
         const Funds funds = getFundsFromTile( tile );
 
         std::string msg;
-        std::string caption = MP2::StringObject( objectType );
+        std::string caption = MP2::StringObject( objectType );  
 
         switch ( objectType ) {
         case MP2::OBJ_WINDMILL:
             msg = funds.GetValidItemsCount() > 0
-                      ? _( "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
+                      ? _( 
+                          "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
                       : _( "The keeper of the mill announces:\n\"Milord, I am sorry, there are no resources currently available. Please try again next week.\"" );
             break;
 
@@ -852,8 +853,10 @@ namespace
 
         case MP2::OBJ_MAGIC_GARDEN:
             msg = funds.GetValidItemsCount() > 0
-                      ? _( "You catch a leprechaun foolishly sleeping amidst a cluster of magic mushrooms.\nIn exchange for his freedom, he guides you to a small pot filled with precious things." )
-                      : _( "You've found a magic garden, the kind of place that leprechauns and faeries like to cavort in, but there is no one here today.\nPerhaps you should try again next week." );
+                      ? _( 
+                          "You catch a leprechaun foolishly sleeping amidst a cluster of magic mushrooms.\nIn exchange for his freedom, he guides you to a small pot filled with precious things." )
+                      : _( 
+                          "You've found a magic garden, the kind of place that leprechauns and faeries like to cavort in, but there is no one here today.\nPerhaps you should try again next week." );
             break;
 
         default:
@@ -1151,15 +1154,16 @@ namespace
             break;
 
         case MP2::OBJ_IDOL:
-            msg = visited
-                      ? _( "You've found an ancient and weathered stone idol.\nIt is supposed to grant luck to visitors, but since the stars are already smiling upon you, it does nothing." )
-                      : _( "You've found an ancient and weathered stone idol.\nKissing it is supposed to be lucky, so you do. The stone is very cold to the touch." );
+            msg = visited ? _( 
+                      "You've found an ancient and weathered stone idol.\nIt is supposed to grant luck to visitors, but since the stars are already smiling upon you, it does nothing." )
+                          : _( "You've found an ancient and weathered stone idol.\nKissing it is supposed to be lucky, so you do. The stone is very cold to the touch." );
             break;
 
         case MP2::OBJ_MERMAID:
             msg = visited
                       ? _( "The mermaids silently entice you to return later and be blessed again." )
-                      : _( "The magical, soothing beauty of the Mermaids reaches you and your crew.\nJust for a moment, you forget your worries and bask in the beauty of the moment.\nThe mermaids' charms bless you with increased luck for your next combat." );
+                      : _( 
+                          "The magical, soothing beauty of the Mermaids reaches you and your crew.\nJust for a moment, you forget your worries and bask in the beauty of the moment.\nThe mermaids' charms bless you with increased luck for your next combat." );
             break;
 
         default:
@@ -1333,23 +1337,25 @@ namespace
 
         case MP2::OBJ_MERCENARY_CAMP:
             skill = Skill::Primary::ATTACK;
-            msg = visited
-                      ? _( "You've come upon a mercenary camp practicing their tactics. \"You're too advanced for us,\" the mercenary captain says. \"We can teach nothing more.\"" )
-                      : _( "You've come upon a mercenary camp practicing their tactics. The mercenaries welcome you and your troops and invite you to train with them." );
+            msg = visited ? _( 
+                      "You've come upon a mercenary camp practicing their tactics. \"You're too advanced for us,\" the mercenary captain says. \"We can teach nothing more.\"" )
+                          : _( 
+                              "You've come upon a mercenary camp practicing their tactics. The mercenaries welcome you and your troops and invite you to train with them." );
             break;
 
         case MP2::OBJ_WITCH_DOCTORS_HUT:
             skill = Skill::Primary::KNOWLEDGE;
             msg = visited
                       ? _( "\"Go 'way!\", the witch doctor barks, \"you know all I know.\"" )
-                      : _( "An Orcish witch doctor living in the hut deepens your knowledge of magic by showing you how to cast stones, read portents, and decipher the intricacies of chicken entrails." );
+                      : _( 
+                          "An Orcish witch doctor living in the hut deepens your knowledge of magic by showing you how to cast stones, read portents, and decipher the intricacies of chicken entrails." );
             break;
 
         case MP2::OBJ_STANDING_STONES:
             skill = Skill::Primary::POWER;
-            msg = visited
-                      ? _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, the Druids turn you away, indicating they have nothing new to teach you." )
-                      : _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, they teach you new ways to cast spells." );
+            msg = visited ? _( 
+                      "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, the Druids turn you away, indicating they have nothing new to teach you." )
+                          : _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, they teach you new ways to cast spells." );
             break;
 
         default:
@@ -1505,9 +1511,9 @@ namespace
             break;
 
         case MP2::OBJ_WATERING_HOLE:
-            msg = visited
-                      ? _( "The drink at the watering hole is refreshing, but offers no further benefit. The watering hole might help again if you fought a battle first." )
-                      : _( "A drink at the watering hole fills your troops with strength and lifts their spirits. You can travel a bit further today." );
+            msg = visited ? _( 
+                      "The drink at the watering hole is refreshing, but offers no further benefit. The watering hole might help again if you fought a battle first." )
+                          : _( "A drink at the watering hole fills your troops with strength and lifts their spirits. You can travel a bit further today." );
             move = GameStatic::getMovementPointBonus( MP2::OBJ_WATERING_HOLE );
             break;
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -416,15 +416,14 @@ namespace
             else {
                 fheroes2::showStandardTextMessage( "", _( "Insulted by your refusal of their offer, the monsters attack!" ), Dialog::OK );
             }
-        } 
+        }
         else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGold
-                || join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGoldAndRunAway ) {
-            fheroes2::showStandardTextMessage(
-                "",
-                join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGold
-                    ? _( "The creatures would join your army, but you do not have enough gold.\nThey prepare to fight." )
-                    : _( "The creatures would join your army, but you do not have enough gold." ),
-                Dialog::OK );
+                  || join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGoldAndRunAway ) {
+            fheroes2::showStandardTextMessage( "",
+                                               join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot
+                                                   ? _( "The creatures would join your army, but your army has no room for them.\nThey prepare to fight." )
+                                                   : _( "The creatures would join your army, but your army has no room for them." ),
+                                               Dialog::OK );
 
             if ( join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGoldAndRunAway ) {
                 std::string message = _( "The %{monster}, awed by the power of your forces, begin to scatter.\nDo you wish to pursue and engage them?" );
@@ -434,15 +433,13 @@ namespace
                     destroy = true;
                 }
             }
-        } 
-        else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot
-                    || join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway ) {
-            fheroes2::showStandardTextMessage(
-                "",
-                join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot
-                    ? _( "The creatures would join your army, but your army has no room for them.\nThey prepare to fight." )
-                    : _( "The creatures would join your army, but your army has no room for them." ),
-                Dialog::OK );
+        }
+        else if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot || join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway ) {
+            fheroes2::showStandardTextMessage( "",
+                                               +join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot +
+                                                   ? _( "The creatures would join your army, but your army has no room for them.\nThey prepare to fight." ) +
+                                                   : _( "The creatures would join your army, but your army has no room for them." ),
+                                               +Dialog::OK );
 
             if ( join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlotAndRunAway ) {
                 std::string message = _( "The %{monster}, awed by the power of your forces, begin to scatter.\nDo you wish to pursue and engage them?" );
@@ -838,8 +835,7 @@ namespace
         switch ( objectType ) {
         case MP2::OBJ_WINDMILL:
             msg = funds.GetValidItemsCount() > 0
-                      ? _(
-                          "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
+                      ? _( "The keeper of the mill announces:\n\"Milord, I have been working very hard to provide you with these resources, come back next week for more.\"" )
                       : _( "The keeper of the mill announces:\n\"Milord, I am sorry, there are no resources currently available. Please try again next week.\"" );
             break;
 
@@ -856,10 +852,8 @@ namespace
 
         case MP2::OBJ_MAGIC_GARDEN:
             msg = funds.GetValidItemsCount() > 0
-                      ? _(
-                          "You catch a leprechaun foolishly sleeping amidst a cluster of magic mushrooms.\nIn exchange for his freedom, he guides you to a small pot filled with precious things." )
-                      : _(
-                          "You've found a magic garden, the kind of place that leprechauns and faeries like to cavort in, but there is no one here today.\nPerhaps you should try again next week." );
+                      ? _( "You catch a leprechaun foolishly sleeping amidst a cluster of magic mushrooms.\nIn exchange for his freedom, he guides you to a small pot filled with precious things." )
+                      : _( "You've found a magic garden, the kind of place that leprechauns and faeries like to cavort in, but there is no one here today.\nPerhaps you should try again next week." );
             break;
 
         default:
@@ -1157,16 +1151,15 @@ namespace
             break;
 
         case MP2::OBJ_IDOL:
-            msg = visited ? _(
-                      "You've found an ancient and weathered stone idol.\nIt is supposed to grant luck to visitors, but since the stars are already smiling upon you, it does nothing." )
-                          : _( "You've found an ancient and weathered stone idol.\nKissing it is supposed to be lucky, so you do. The stone is very cold to the touch." );
+            msg = visited
+                      ? _( "You've found an ancient and weathered stone idol.\nIt is supposed to grant luck to visitors, but since the stars are already smiling upon you, it does nothing." )
+                      : _( "You've found an ancient and weathered stone idol.\nKissing it is supposed to be lucky, so you do. The stone is very cold to the touch." );
             break;
 
         case MP2::OBJ_MERMAID:
             msg = visited
                       ? _( "The mermaids silently entice you to return later and be blessed again." )
-                      : _(
-                          "The magical, soothing beauty of the Mermaids reaches you and your crew.\nJust for a moment, you forget your worries and bask in the beauty of the moment.\nThe mermaids' charms bless you with increased luck for your next combat." );
+                      : _( "The magical, soothing beauty of the Mermaids reaches you and your crew.\nJust for a moment, you forget your worries and bask in the beauty of the moment.\nThe mermaids' charms bless you with increased luck for your next combat." );
             break;
 
         default:
@@ -1340,25 +1333,23 @@ namespace
 
         case MP2::OBJ_MERCENARY_CAMP:
             skill = Skill::Primary::ATTACK;
-            msg = visited ? _(
-                      "You've come upon a mercenary camp practicing their tactics. \"You're too advanced for us,\" the mercenary captain says. \"We can teach nothing more.\"" )
-                          : _(
-                              "You've come upon a mercenary camp practicing their tactics. The mercenaries welcome you and your troops and invite you to train with them." );
+            msg = visited
+                      ? _( "You've come upon a mercenary camp practicing their tactics. \"You're too advanced for us,\" the mercenary captain says. \"We can teach nothing more.\"" )
+                      : _( "You've come upon a mercenary camp practicing their tactics. The mercenaries welcome you and your troops and invite you to train with them." );
             break;
 
         case MP2::OBJ_WITCH_DOCTORS_HUT:
             skill = Skill::Primary::KNOWLEDGE;
             msg = visited
                       ? _( "\"Go 'way!\", the witch doctor barks, \"you know all I know.\"" )
-                      : _(
-                          "An Orcish witch doctor living in the hut deepens your knowledge of magic by showing you how to cast stones, read portents, and decipher the intricacies of chicken entrails." );
+                      : _( "An Orcish witch doctor living in the hut deepens your knowledge of magic by showing you how to cast stones, read portents, and decipher the intricacies of chicken entrails." );
             break;
 
         case MP2::OBJ_STANDING_STONES:
             skill = Skill::Primary::POWER;
-            msg = visited ? _(
-                      "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, the Druids turn you away, indicating they have nothing new to teach you." )
-                          : _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, they teach you new ways to cast spells." );
+            msg = visited
+                      ? _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, the Druids turn you away, indicating they have nothing new to teach you." )
+                      : _( "You've found a group of Druids worshipping at one of their strange stone edifices. Silently, they teach you new ways to cast spells." );
             break;
 
         default:
@@ -1514,9 +1505,9 @@ namespace
             break;
 
         case MP2::OBJ_WATERING_HOLE:
-            msg = visited ? _(
-                      "The drink at the watering hole is refreshing, but offers no further benefit. The watering hole might help again if you fought a battle first." )
-                          : _( "A drink at the watering hole fills your troops with strength and lifts their spirits. You can travel a bit further today." );
+            msg = visited
+                      ? _( "The drink at the watering hole is refreshing, but offers no further benefit. The watering hole might help again if you fought a battle first." )
+                      : _( "A drink at the watering hole fills your troops with strength and lifts their spirits. You can travel a bit further today." );
             move = GameStatic::getMovementPointBonus( MP2::OBJ_WATERING_HOLE );
             break;
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -422,7 +422,7 @@ namespace
             fheroes2::showStandardTextMessage(
                 "",
                 join.reason == NeutralMonsterJoiningCondition::Reason::NotEnoughGold
-                    ? _( "The creatures would join your army, but you do not have enough gold. \nThey prepare to fight." )
+                    ? _( "The creatures would join your army, but you do not have enough gold.\nThey prepare to fight." )
                     : _( "The creatures would join your army, but you do not have enough gold." ),
                 Dialog::OK );
 
@@ -440,7 +440,7 @@ namespace
             fheroes2::showStandardTextMessage(
                 "",
                 join.reason == NeutralMonsterJoiningCondition::Reason::NoFreeSlot
-                    ? _( "The creatures would join your army, but your army has no room for them. \nThey prepare to fight." )
+                    ? _( "The creatures would join your army, but your army has no room for them.\nThey prepare to fight." )
                     : _( "The creatures would join your army, but your army has no room for them." ),
                 Dialog::OK );
 


### PR DESCRIPTION
Added new Diplomacy-related messages for cases where neutral creatures would join the hero, but the offer cannot be completed because the hero has no room in the army or does not have enough gold.

Currently, there are 4 handled situations:

1. The hero has no room in the army:
"The creatures would join your army, but your army has no room for them.
They prepare to fight."

2. The hero does not have enough gold:
"The creatures would join your army, but you do not have enough gold.
They prepare to fight."

3. The hero has no room in the army, and the hero's army strength is also more than 5x stronger than the neutral army:
The blocked Diplomacy message is shown first, without the "They prepare to fight." part.
Then the regular run-away dialog is shown:
"The %{monster}, awed by the power of your forces, begin to scatter.
Do you wish to pursue and engage them?"

4. The hero does not have enough gold, and the hero's army strength is also more than 5x stronger than the neutral army:
Same behavior as case 3 — the blocked Diplomacy message is shown first, then the regular run-away dialog is shown.

Videos:

No room + 5x army strength:

https://github.com/user-attachments/assets/fbcd7f5c-9304-48f2-998d-329ce10f0155

Not enough gold + 5x army strength:

https://github.com/user-attachments/assets/4fb41c77-efca-4361-a6f3-44b8d49c215d

Not enough gold without run-away:

https://github.com/user-attachments/assets/8cfe0765-d704-44fe-80b2-699eae50ba5f

Closes #10825 