### PR TITLE
added counter for thieves guild dialog

### DIFF
--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -288,6 +288,14 @@ void Dialog::ThievesGuild( const bool oracle )
     fheroes2::Text text;
     fheroes2::Point offset( startOffsetX, dialogRoi.y + 3 );
 
+    if ( !oracle ) {
+        std::string thievesGuildCountText = _( "Owned Thieves' Guilds: %{count}" );
+        StringReplace( thievesGuildCountText, "%{count}", thievesGuildCount );
+
+        text.set( thievesGuildCountText, fheroes2::FontType::smallWhite() );
+        text.draw( textOffsetX - text.width(), dialogRoi.y + 16, display );
+    }
+
     for ( size_t player = 0; player < playersCount; ++player ) {
         text.set( getPlayerOrderString( player ), fheroes2::FontType::normalWhite() );
         text.draw( offset.x - text.width() / 2, offset.y, display );


### PR DESCRIPTION
Adds a small “Owned Thieves’ Guilds: X” counter to the regular Thieves’ Guild dialog.

The counter is displayed in the empty space above “Number of Towns:”, aligned with the existing left-side category labels. It is not displayed in the Oracle dialog, since Oracle rankings are not based on the number of Thieves’ Guilds owned by the player.

<img width="1325" height="1038" alt="Screenshot 2026-06-14 033142" src="https://github.com/user-attachments/assets/686a9dbe-35a2-4a90-9a5c-1809e922bb56" />

related discussion: #10831 