### PR TITLE
Allow interaction during hero recruitment and castle construction animations

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -508,12 +508,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         bool needRedraw = false;
         bool needFadeIn = false;
 
-        if ( alphaHero < 255 && fadeBuilding.isFadeDone() && ( le.MouseClickLeft( dialogRoi ) || le.MouseClickRight( dialogRoi ) ) ) {
-            finishHeroRecruitAnimation();
-
-            continue;
-        }
-
         // During hero purchase or building construction skip any interaction with the dialog.
         if ( alphaHero >= 255 && fadeBuilding.isFadeDone() ) {
             if ( buttonPrevCastle.isEnabled() ) {
@@ -800,19 +794,31 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             break;
         }
 
-        if ( alphaHero < 255 && Game::validateAnimationDelay( Game::DelayType::CASTLE_ITEM_UPDATE_DELAY ) ) {
-            alphaHero += 9;
-            if ( alphaHero >= 255 ) {
-                alphaHero = 255;
+        if ( alphaHero < 255 ) {
+            bool isHeroAnimationUpdated = false;
 
-                // Hero fade-in animation is finished, we can set up his army bar.
-                bottomArmyBar.SetArmy( &hero->GetArmy() );
+            if ( le.MouseClickLeft( dialogRoi ) || le.MouseClickRight( dialogRoi ) ) {
+                alphaHero = 255;
+                isHeroAnimationUpdated = true;
+            }
+            else if ( Game::validateAnimationDelay( Game::DelayType::CASTLE_ITEM_UPDATE_DELAY ) ) {
+                alphaHero += 9;
+                isHeroAnimationUpdated = true;
             }
 
-            fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
+            if ( isHeroAnimationUpdated ) {
+                if ( alphaHero >= 255 ) {
+                    alphaHero = 255;
 
-            if ( !needRedraw ) {
-                display.render( dialogRoi );
+                    // Hero fade-in animation is finished, we can set up his army bar.
+                    bottomArmyBar.SetArmy( &hero->GetArmy() );
+                }
+
+                fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
+
+                if ( !needRedraw ) {
+                    display.render( dialogRoi );
+                }
             }
         }
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -397,20 +397,6 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     buttonNextCastle.draw();
     buttonExit.draw();
 
-    auto finishHeroRecruitAnimation = [&]() {
-        if ( alphaHero >= 255 || hero == nullptr ) {
-            return;
-        }
-
-        alphaHero = 255;
-
-        // Hero fade-in animation is finished, we can set up his army bar.
-        bottomArmyBar.SetArmy( &hero->GetArmy() );
-
-        fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
-        display.render( dialogRoi );
-    };
-
     std::string statusMessage;
     LocalEvent & le = LocalEvent::Get();
     auto updateStatusBar = [&]() {

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -397,6 +397,20 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     buttonNextCastle.draw();
     buttonExit.draw();
 
+    auto finishHeroRecruitAnimation = [&]() {
+        if ( alphaHero >= 255 || hero == nullptr ) {
+            return;
+        }
+
+        alphaHero = 255;
+
+        // Hero fade-in animation is finished, we can set up his army bar.
+        bottomArmyBar.SetArmy( &hero->GetArmy() );
+
+        fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
+        display.render( dialogRoi );
+    };
+
     std::string statusMessage;
     LocalEvent & le = LocalEvent::Get();
     auto updateStatusBar = [&]() {
@@ -493,6 +507,13 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     while ( le.HandleEvents() && result == CastleDialogReturnValue::DoNothing ) {
         bool needRedraw = false;
         bool needFadeIn = false;
+
+        if ( alphaHero < 255 && fadeBuilding.isFadeDone()
+             && ( le.MouseClickLeft( dialogRoi ) || le.MouseClickRight( dialogRoi ) ) ) {
+            finishHeroRecruitAnimation();
+
+            continue;
+        }
 
         // During hero purchase or building construction skip any interaction with the dialog.
         if ( alphaHero >= 255 && fadeBuilding.isFadeDone() ) {

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -508,8 +508,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         bool needRedraw = false;
         bool needFadeIn = false;
 
-        if ( alphaHero < 255 && fadeBuilding.isFadeDone()
-             && ( le.MouseClickLeft( dialogRoi ) || le.MouseClickRight( dialogRoi ) ) ) {
+        if ( alphaHero < 255 && fadeBuilding.isFadeDone() && ( le.MouseClickLeft( dialogRoi ) || le.MouseClickRight( dialogRoi ) ) ) {
             finishHeroRecruitAnimation();
 
             continue;

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -783,7 +783,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         if ( alphaHero < 255 ) {
             bool isHeroAnimationUpdated = false;
 
-            if ( le.MouseClickLeft( dialogRoi ) || le.MouseClickRight( dialogRoi ) ) {
+            if ( le.MouseClickLeft( dialogRoi ) || le.MouseClickRight( dialogRoi ) || le.isAnyKeyPressed() ) {
                 alphaHero = 255;
                 isHeroAnimationUpdated = true;
             }

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -522,7 +522,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
                 display.render( dialogRoi );
             }
-}
+        }
 
         // During hero purchase or building construction skip any interaction with the dialog.
         if ( alphaHero >= 255 && fadeBuilding.isFadeDone() ) {

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -494,6 +494,36 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         bool needRedraw = false;
         bool needFadeIn = false;
 
+        const bool isMouseInteraction = le.isMouseLeftButtonPressedInArea( dialogRoi ) || le.isMouseRightButtonPressedInArea( dialogRoi );
+
+        if ( isMouseInteraction ) {
+            if ( alphaHero < 255 ) {
+                alphaHero = 255;
+
+                // Hero fade-in animation is finished, we can set up his army bar.
+                bottomArmyBar.SetArmy( &hero->GetArmy() );
+
+                fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
+            }
+
+            if ( !fadeBuilding.isFadeDone() ) {
+                const uint32_t build = fadeBuilding.getBuilding();
+
+                fadeBuilding.stopFade();
+
+                CastleDialog::redrawAllBuildings( *this, dialogRoi.getPosition(), cacheBuildings, fadeBuilding, castleAnimationIndex );
+
+                if ( BUILD_CAPTAIN == build ) {
+                    RedrawIcons( *this, hero, dialogRoi.getPosition() );
+                    fheroes2::drawCastleName( *this, display, dialogRoi.getPosition() );
+                }
+
+                fheroes2::drawResourcePanel( GetKingdom().GetFunds(), display, dialogRoi.getPosition() );
+
+                display.render( dialogRoi );
+            }
+}
+
         // During hero purchase or building construction skip any interaction with the dialog.
         if ( alphaHero >= 255 && fadeBuilding.isFadeDone() ) {
             if ( buttonPrevCastle.isEnabled() ) {
@@ -780,31 +810,20 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             break;
         }
 
-        if ( alphaHero < 255 ) {
-            bool isHeroAnimationUpdated = false;
+        if ( alphaHero < 255 && Game::validateAnimationDelay( Game::DelayType::CASTLE_ITEM_UPDATE_DELAY ) ) {
+            alphaHero += 9;
 
-            if ( le.MouseClickLeft( dialogRoi ) || le.MouseClickRight( dialogRoi ) || le.isAnyKeyPressed() ) {
+            if ( alphaHero >= 255 ) {
                 alphaHero = 255;
-                isHeroAnimationUpdated = true;
-            }
-            else if ( Game::validateAnimationDelay( Game::DelayType::CASTLE_ITEM_UPDATE_DELAY ) ) {
-                alphaHero += 9;
-                isHeroAnimationUpdated = true;
+
+                // Hero fade-in animation is finished, we can set up his army bar.
+                bottomArmyBar.SetArmy( &hero->GetArmy() );
             }
 
-            if ( isHeroAnimationUpdated ) {
-                if ( alphaHero >= 255 ) {
-                    alphaHero = 255;
+            fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
 
-                    // Hero fade-in animation is finished, we can set up his army bar.
-                    bottomArmyBar.SetArmy( &hero->GetArmy() );
-                }
-
-                fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
-
-                if ( !needRedraw ) {
-                    display.render( dialogRoi );
-                }
+            if ( !needRedraw ) {
+                display.render( dialogRoi );
             }
         }
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -399,17 +399,15 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
     std::string statusMessage;
     LocalEvent & le = LocalEvent::Get();
+
+    auto processArmyBarEvents = [&]() {
+        return ( bottomArmyBar.isValid()
+                 && ( ( le.isMouseCursorPosInArea( topArmyBar.GetArea() ) && topArmyBar.QueueEventProcessing( bottomArmyBar, &statusMessage ) )
+                      || ( le.isMouseCursorPosInArea( bottomArmyBar.GetArea() ) && bottomArmyBar.QueueEventProcessing( topArmyBar, &statusMessage ) ) ) )
+               || ( !bottomArmyBar.isValid() && le.isMouseCursorPosInArea( topArmyBar.GetArea() ) && topArmyBar.QueueEventProcessing( &statusMessage ) );
+    };
+
     auto updateStatusBar = [&]() {
-        bool isRedrawNeeded{ false };
-
-        // Army bar events processing.
-        if ( ( bottomArmyBar.isValid()
-               && ( ( le.isMouseCursorPosInArea( topArmyBar.GetArea() ) && topArmyBar.QueueEventProcessing( bottomArmyBar, &statusMessage ) )
-                    || ( le.isMouseCursorPosInArea( bottomArmyBar.GetArea() ) && bottomArmyBar.QueueEventProcessing( topArmyBar, &statusMessage ) ) ) )
-             || ( !bottomArmyBar.isValid() && le.isMouseCursorPosInArea( topArmyBar.GetArea() ) && topArmyBar.QueueEventProcessing( &statusMessage ) ) ) {
-            isRedrawNeeded = true;
-        }
-
         // Update status bar. It doesn't depend on animation status.
         // Animation queue starts from the lowest by Z-value buildings which means that they draw first and most likely overlap by the top buildings in the queue.
         // In this case we must revert the queue and finding the first suitable building.
@@ -464,7 +462,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
             display.updateNextRenderRoi( area );
         }
 
-        return isRedrawNeeded || area != fheroes2::Rect{};
+        return area != fheroes2::Rect{};
     };
 
     updateStatusBar();
@@ -496,6 +494,9 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
         const bool isMouseInteraction = le.isMouseLeftButtonPressedInArea( dialogRoi ) || le.isMouseRightButtonPressedInArea( dialogRoi );
 
+        const bool isArmyBarInteraction = isMouseInteraction && ( le.isMouseCursorPosInArea( topArmyBar.GetArea() ) || ( bottomArmyBar.isValid() 
+            && le.isMouseCursorPosInArea( bottomArmyBar.GetArea() ) ) );
+
         if ( isMouseInteraction ) {
             if ( alphaHero < 255 ) {
                 alphaHero = 255;
@@ -506,7 +507,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
                 fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
             }
 
-            if ( !fadeBuilding.isFadeDone() ) {
+            if ( !isArmyBarInteraction && !fadeBuilding.isFadeDone() ) {
                 const uint32_t build = fadeBuilding.getBuilding();
 
                 fadeBuilding.stopFade();
@@ -522,6 +523,10 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
                 display.render( dialogRoi );
             }
+        }
+
+        if ( alphaHero >= 255 ) {
+            needRedraw = needRedraw || processArmyBarEvents();
         }
 
         // During hero purchase or building construction skip any interaction with the dialog.

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -494,8 +494,9 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
 
         const bool isMouseInteraction = le.isMouseLeftButtonPressedInArea( dialogRoi ) || le.isMouseRightButtonPressedInArea( dialogRoi );
 
-        const bool isArmyBarInteraction = isMouseInteraction && ( le.isMouseCursorPosInArea( topArmyBar.GetArea() ) || ( bottomArmyBar.isValid() 
-            && le.isMouseCursorPosInArea( bottomArmyBar.GetArea() ) ) );
+        const bool isArmyBarInteraction
+            = isMouseInteraction
+              && ( le.isMouseCursorPosInArea( topArmyBar.GetArea() ) || ( bottomArmyBar.isValid() && le.isMouseCursorPosInArea( bottomArmyBar.GetArea() ) ) );
 
         if ( isMouseInteraction ) {
             if ( alphaHero < 255 ) {

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -219,7 +219,11 @@ namespace
             return str;
         }
 
-        return Army::TroopSizeString( troop );
+        std::string str = Army::TroopSizeString( troop );
+
+        str.append( "\n\nDiplomacy: Blocked\n(no room in army)" );
+
+        return str;
     }
 
     std::string showDwellingInfo( const Maps::Tile & tile, const bool isOwned )

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -213,7 +213,11 @@ namespace
             return str;
         }
 
-        return Army::TroopSizeString( troop );
+        std::string str = Army::TroopSizeString( troop );
+
+        str.append( "\n\nDiplomacy: Blocked\n(no room in army)" );
+
+        return str;
     }
 
     std::string showDwellingInfo( const Maps::Tile & tile, const bool isOwned )

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -219,11 +219,7 @@ namespace
             return str;
         }
 
-        std::string str = Army::TroopSizeString( troop );
-
-        str.append( "\n\nDiplomacy: Blocked\n(no room in army)" );
-
-        return str;
+        return Army::TroopSizeString( troop );
     }
 
     std::string showDwellingInfo( const Maps::Tile & tile, const bool isOwned )


### PR DESCRIPTION
This PR allows the player to skip the visual hero recruitment animation in the castle dialog by left-clicking or right-clicking while the animation is still playing.

The recruitment sound is not interrupted and continues playing until the end.

Currently- after recruiting a hero from a castle, the player has to wait until the full hero fade-in animation finishes before interacting with the castle dialog again.
This can feel unnecessarily interruptive, especially compared to other castle actions. 

Based on feedback from @zense, the intended behavior is that a click should finish the visual animation while the sound continues playing to the end.

Behavior after this change
If the player does nothing, the hero recruitment animation plays normally.
If the player left-clicks or right-clicks inside the castle dialog during the animation, the visual animation finishes immediately.
The first click only finishes the animation and does not trigger another castle action.
After that, the castle dialog becomes fully interactable again.
The recruitment sound continues playing normally.

- This change does not shorten the animation by default. It only allows the player to skip the visual waiting period through interaction.



https://github.com/user-attachments/assets/0649d012-1eea-4c95-8f78-e205c6fc558a

relates to #10834 