### PR TITLE
Allow skipping hero recruitment animation on click (2nd version)

### DIFF
--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -508,8 +508,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         bool needRedraw = false;
         bool needFadeIn = false;
 
-        if ( alphaHero < 255 && fadeBuilding.isFadeDone()
-             && ( le.isMouseLeftButtonPressedInArea( dialogRoi ) || le.isMouseRightButtonPressedInArea( dialogRoi ) ) ) {
+        if ( alphaHero < 255 && fadeBuilding.isFadeDone() && ( le.isMouseLeftButtonPressedInArea( dialogRoi ) || le.isMouseRightButtonPressedInArea( dialogRoi ) ) ) {
             finishHeroRecruitAnimation();
         }
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -397,6 +397,20 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     buttonNextCastle.draw();
     buttonExit.draw();
 
+    auto finishHeroRecruitAnimation = [&]() {
+        if ( alphaHero >= 255 || hero == nullptr ) {
+            return;
+        }
+
+        alphaHero = 255;
+
+        // Hero fade-in animation is finished, we can set up his army bar.
+        bottomArmyBar.SetArmy( &hero->GetArmy() );
+
+        fheroes2::AlphaBlit( surfaceHero, display, dialogRoi.x, dialogRoi.y + 356, static_cast<uint8_t>( alphaHero ) );
+        display.render( dialogRoi );
+    };
+
     std::string statusMessage;
     LocalEvent & le = LocalEvent::Get();
     auto updateStatusBar = [&]() {
@@ -493,6 +507,11 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     while ( le.HandleEvents() && result == CastleDialogReturnValue::DoNothing ) {
         bool needRedraw = false;
         bool needFadeIn = false;
+
+        if ( alphaHero < 255 && fadeBuilding.isFadeDone()
+             && ( le.isMouseLeftButtonPressedInArea( dialogRoi ) || le.isMouseRightButtonPressedInArea( dialogRoi ) ) ) {
+            finishHeroRecruitAnimation();
+        }
 
         // During hero purchase or building construction skip any interaction with the dialog.
         if ( alphaHero >= 255 && fadeBuilding.isFadeDone() ) {


### PR DESCRIPTION
Same as 1st version of this PR- except that both left/right clicks not only stops the hero recruitment animation but also interacts with whatever you click on. 

As seen in this video:


https://github.com/user-attachments/assets/18bbc2e2-052c-4b09-9693-a2d1bef23991

