### PR TITLE
Swapping Archery Range Sprites

### DIFF
--- a/src/fheroes2/agg/agg_image.cpp
+++ b/src/fheroes2/agg/agg_image.cpp
@@ -5645,6 +5645,13 @@ namespace
             }
             break;
         }
+        case ICN::CSTLKNGT:
+            if ( _icnVsSprite[id].size() > 30 ) {
+                // Knight castle construction images for Archery are swapped.
+                // We have to fix it in the resources.
+                std::swap( _icnVsSprite[id][20], _icnVsSprite[id][25] );
+            }
+            break;
         default:
             break;
         }

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -96,25 +96,6 @@ namespace
         return nullptr;
     }
 
-    // swap archery range sprite with upg. archery range
-    int getBuildingSpriteIndex( const int race, const BuildingType buildingType )
-    {
-        if ( race == Race::KNGT ) {
-            switch ( buildingType ) {
-            case DWELLING_MONSTER2:
-                return fheroes2::getIndexBuildingSprite( DWELLING_UPGRADE2 );
-
-            case DWELLING_UPGRADE2:
-                return fheroes2::getIndexBuildingSprite( DWELLING_MONSTER2 );
-
-            default:
-                break;
-            }
-        }
-
-        return fheroes2::getIndexBuildingSprite( buildingType );
-    }
-
     struct BuildingStats final
     {
         uint32_t type{ BUILD_NOTHING };
@@ -373,7 +354,7 @@ void BuildingInfo::Redraw() const
     }
 
     fheroes2::Display & display = fheroes2::Display::instance();
-    const int index = getBuildingSpriteIndex( castle.GetRace(), static_cast<BuildingType>( _buildingType ) );
+    const int index = fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) );
 
     const fheroes2::Sprite & buildingFrame = fheroes2::AGG::GetICN( ICN::BLDGXTRA, 0 );
     fheroes2::Blit( buildingFrame, display, area.x, area.y );
@@ -506,7 +487,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
     fheroes2::Blit( buildingFrame, display, pos.x, pos.y );
 
     const fheroes2::Sprite & buildingImage
-        = fheroes2::AGG::GetICN( ICN::getBuildingIcnId( castle.GetRace() ), getBuildingSpriteIndex( castle.GetRace(), static_cast<BuildingType>( _buildingType ) ) );
+        = fheroes2::AGG::GetICN( ICN::getBuildingIcnId( castle.GetRace() ), fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) ) );
     pos.x = dialogRoi.x + ( dialogRoi.width - buildingImage.width() ) / 2;
     pos.y += 1;
     fheroes2::Blit( buildingImage, display, pos.x, pos.y );

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -96,6 +96,25 @@ namespace
         return nullptr;
     }
 
+    // swap archery range sprite with upg. archery range
+    int getBuildingSpriteIndex( const int race, const BuildingType buildingType )
+    {
+        if ( race == Race::KNGT ) {
+            switch ( buildingType ) {
+            case DWELLING_MONSTER2:
+                return fheroes2::getIndexBuildingSprite( DWELLING_UPGRADE2 );
+
+            case DWELLING_UPGRADE2:
+                return fheroes2::getIndexBuildingSprite( DWELLING_MONSTER2 );
+
+            default:
+                break;
+            }
+        }
+
+        return fheroes2::getIndexBuildingSprite( buildingType );
+    }
+
     struct BuildingStats final
     {
         uint32_t type{ BUILD_NOTHING };
@@ -354,7 +373,7 @@ void BuildingInfo::Redraw() const
     }
 
     fheroes2::Display & display = fheroes2::Display::instance();
-    const int index = fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) );
+    const int index = getBuildingSpriteIndex( castle.GetRace(), static_cast<BuildingType>( _buildingType ) );
 
     const fheroes2::Sprite & buildingFrame = fheroes2::AGG::GetICN( ICN::BLDGXTRA, 0 );
     fheroes2::Blit( buildingFrame, display, area.x, area.y );
@@ -487,7 +506,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
     fheroes2::Blit( buildingFrame, display, pos.x, pos.y );
 
     const fheroes2::Sprite & buildingImage
-        = fheroes2::AGG::GetICN( ICN::getBuildingIcnId( castle.GetRace() ), fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) ) );
+        = fheroes2::AGG::GetICN( ICN::getBuildingIcnId( castle.GetRace() ), getBuildingSpriteIndex( castle.GetRace(), static_cast<BuildingType>( _buildingType ) ) );
     pos.x = dialogRoi.x + ( dialogRoi.width - buildingImage.width() ) / 2;
     pos.y += 1;
     fheroes2::Blit( buildingImage, display, pos.x, pos.y );

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -1547,9 +1547,9 @@ int Castle::GetICNBuilding( const uint32_t buildingType, const int race )
         case DWELLING_MONSTER1:
             return ICN::TWNKDW_0;
         case DWELLING_MONSTER2:
-            return ICN::TWNKDW_1;
-        case DWELLING_UPGRADE2:
             return ICN::TWNKUP_1;
+        case DWELLING_UPGRADE2:
+            return ICN::TWNKDW_1;
         case DWELLING_MONSTER3:
             return ICN::TWNKDW_2;
         case DWELLING_UPGRADE3:


### PR DESCRIPTION
Currently the RED archers come from a BLUE archery range,
while the BLUE rangers come from RED upgraded archery range.

This was mentioned in #2059: "To comply with the creature buildings color code, red for unimproved buildings and blue for upgraded buildings.
Knight castle, inverted the sprites for the Archery Range and the Upg. Archery Range (red and blue)."

So I swapped the sprites- both in the castle dialog, and in the construction dialog.


https://github.com/user-attachments/assets/aebd2927-9cb5-4ce5-8788-27c664ec9c38



<img width="600" alt="Screenshot 2026-06-17 083220" src="https://github.com/user-attachments/assets/532fa8cb-21d2-4689-ba94-b8dafc58b10e" />

<img width="600" alt="Screenshot 2026-06-17 083152" src="https://github.com/user-attachments/assets/4edeec91-dbe9-4666-b687-ee0aae40dbce" />

<img width="600" alt="Screenshot 2026-06-17 083302" src="https://github.com/user-attachments/assets/db85e0d6-fe79-4f68-bdbe-dca969aaaa9c" />

<img width="600" alt="Screenshot 2026-06-17 083311" src="https://github.com/user-attachments/assets/8dc586bb-d58c-435a-a94a-84eb70067515" />

<img width="600" alt="Screenshot 2026-06-17 083338" src="https://github.com/user-attachments/assets/786a1015-bfbc-40d8-9788-ca7a8c5a9995" />


mentioned in #10839 