### PR TITLE
Adventure map, status window layout alignment fix

### DIFF
--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -154,18 +154,20 @@ void Interface::StatusPanel::_redraw() const
         }
     }
     else {
+        const int32_t offsetY = pos.height > stonHeight ? ( pos.height - stonHeight ) / 2 : 0;
+
         switch ( _state ) {
         case StatusType::STATUS_DAY:
             _drawDayInfo();
             break;
         case StatusType::STATUS_FUNDS:
-            _drawKingdomInfo();
+            _drawKingdomInfo( offsetY );
             break;
         case StatusType::STATUS_ARMY:
-            _drawArmyInfo();
+            _drawArmyInfo( offsetY );
             break;
         case StatusType::STATUS_RESOURCE:
-            _drawResourceInfo();
+            _drawResourceInfo( offsetY );
             break;
         case StatusType::STATUS_UNKNOWN:
         case StatusType::STATUS_AITURN:

--- a/src/fheroes2/gui/interface_status.h
+++ b/src/fheroes2/gui/interface_status.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -90,10 +90,10 @@ namespace Interface
         void _redraw() const;
 
     private:
-        void _drawKingdomInfo( const int32_t offsetY = 0 ) const;
+        void _drawKingdomInfo( const int32_t offsetY ) const;
         void _drawDayInfo( const int32_t offsetY = 0 ) const;
-        void _drawArmyInfo( const int32_t offsetY = 0 ) const;
-        void _drawResourceInfo( const int32_t offsetY = 0 ) const;
+        void _drawArmyInfo( const int32_t offsetY ) const;
+        void _drawResourceInfo( const int32_t offsetY ) const;
         void _drawBackground() const;
         void _drawAITurns() const;
 


### PR DESCRIPTION
This fixes the graphical issue that in higher resolutions- the bottom right status window which shows army/resources/day info  (left-clicks cycles them) - is always to the top of that box.

They are now aligned in the middle of the box. 
This is only relevant to the army info & resources info cycles. NOT the day info, as the visual is meant there to be to the top of the box and aligning it to the middle looks wrong.

### current:
<img width="402" height="326" alt="589976055-6c5302d1-b185-4739-8237-8366253fd1a9" src="https://github.com/user-attachments/assets/dff8dd56-d16d-4d09-ac2e-11b4f8c78ec3" />

### fix:
<img width="300"  alt="Screenshot 2026-06-16 122012" src="https://github.com/user-attachments/assets/53ec4980-4a68-4f89-8891-e5e617aee766" />
<br>
<br>
<img width="300" alt="Screenshot 2026-06-16 122001" src="https://github.com/user-attachments/assets/b17229c8-db33-4811-a473-3507eac3180b" />


### unchanged day info:
<img width="300" alt="Screenshot 2026-06-16 122025" src="https://github.com/user-attachments/assets/cf750513-e3ec-40b1-90f9-a04a58111a73" />


fixes #10751 