### PR TITLE
New Creature Week right-click delay fix

### DIFF
--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -576,7 +576,6 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
 
     if ( !( flags & BUTTONS ) ) {
         // This is when this dialog is called by a right mouse button press.
-
         display.render( restorer.rect() );
 
         while ( le.HandleEvents( true ) ) {
@@ -584,6 +583,9 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
                 break;
             }
         }
+
+        restorer.restore();
+        display.render( restorer.rect() );
 
         return Dialog::ZERO;
     }


### PR DESCRIPTION
Force the ArmyInfo right-click popup area to be restored and rendered immediately after the right mouse button is released.

Previously the temporary popup relied on ImageRestorer cleanup when returning, but the restored area was not rendered immediately. This could leave the popup visible for a brief moment, especially on slower systems or debug builds.

### FIX:
https://github.com/user-attachments/assets/e516eadd-0421-4b99-817a-737378bd3fa3

### CURRENT:


https://github.com/user-attachments/assets/de94d557-f751-4ab2-a07b-a6cf25638d35

Closes #10850
