### PR TITLE
Fix missing fog unveiling in auto-playtest mode

### DIFF
--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -472,7 +472,7 @@ void Maps::ClearFog( const int32_t tileIndex, const int32_t scoutingDistance, co
 
     const bool isAIPlayer = kingdom.isControlAI();
     const bool isHumanOrHumanFriend = !isAIPlayer || Players::isFriends( playerColor, Players::HumanColors() ) ||
-                                      ( !Settings::Get().IsGameType( Game::TYPE_AUTO_PLAYTEST ) || fheroes2::AutoPlaytest::instance().isAnimationEnabled() );
+                                      ( Settings::Get().IsGameType( Game::TYPE_AUTO_PLAYTEST ) && fheroes2::AutoPlaytest::instance().isAnimationEnabled() );
 
     const fheroes2::Point center = Maps::GetPoint( tileIndex );
     const int32_t squaredScoutingRadiusLimit = getSquaredScoutingRadiusLimit( scoutingDistance );

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -34,6 +34,8 @@
 #include "army.h"
 #include "color.h"
 #include "direction.h"
+#include "game.h"
+#include "game_auto_playtest.h"
 #include "heroes.h"
 #include "kingdom.h"
 #include "logging.h"
@@ -43,6 +45,7 @@
 #include "players.h"
 #include "race.h"
 #include "resource.h"
+#include "settings.h"
 #include "translations.h"
 #include "world.h"
 
@@ -468,7 +471,8 @@ void Maps::ClearFog( const int32_t tileIndex, const int32_t scoutingDistance, co
     const Kingdom & kingdom = world.GetKingdom( playerColor );
 
     const bool isAIPlayer = kingdom.isControlAI();
-    const bool isHumanOrHumanFriend = !isAIPlayer || Players::isFriends( playerColor, Players::HumanColors() );
+    const bool isHumanOrHumanFriend = !isAIPlayer || Players::isFriends( playerColor, Players::HumanColors() ) ||
+                                      ( !Settings::Get().IsGameType( Game::TYPE_AUTO_PLAYTEST ) || fheroes2::AutoPlaytest::instance().isAnimationEnabled() );
 
     const fheroes2::Point center = Maps::GetPoint( tileIndex );
     const int32_t squaredScoutingRadiusLimit = getSquaredScoutingRadiusLimit( scoutingDistance );

--- a/src/fheroes2/maps/maps.cpp
+++ b/src/fheroes2/maps/maps.cpp
@@ -471,8 +471,8 @@ void Maps::ClearFog( const int32_t tileIndex, const int32_t scoutingDistance, co
     const Kingdom & kingdom = world.GetKingdom( playerColor );
 
     const bool isAIPlayer = kingdom.isControlAI();
-    const bool isHumanOrHumanFriend = !isAIPlayer || Players::isFriends( playerColor, Players::HumanColors() ) ||
-                                      ( Settings::Get().IsGameType( Game::TYPE_AUTO_PLAYTEST ) && fheroes2::AutoPlaytest::instance().isAnimationEnabled() );
+    const bool isHumanOrHumanFriend = !isAIPlayer || Players::isFriends( playerColor, Players::HumanColors() )
+                                      || ( Settings::Get().IsGameType( Game::TYPE_AUTO_PLAYTEST ) && fheroes2::AutoPlaytest::instance().isAnimationEnabled() );
 
     const fheroes2::Point center = Maps::GetPoint( tileIndex );
     const int32_t squaredScoutingRadiusLimit = getSquaredScoutingRadiusLimit( scoutingDistance );


### PR DESCRIPTION
regression from #10807

Before the fix:

https://github.com/user-attachments/assets/06f35d19-39aa-4b1c-8166-17f86f142500

After the fix:

https://github.com/user-attachments/assets/0540bdd7-d40f-482d-a8f9-ba997e9bb72d

close #10853