### PR TITLE
Add Chinese translations and legacy map text decoding with cjk and sdl2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,6 +38,7 @@ list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 #
 option(ENABLE_IMAGE "Enable the use of SDL_image (requires libpng)" OFF)
 option(ENABLE_TOOLS "Enable the build of additional tools" OFF)
+option(ENABLE_CJK_TEXT "Enable UTF-8 CJK text rendering through SDL_ttf when SDL_ttf is available" ON)
 
 # Available only on macOS
 cmake_dependent_option(MACOS_APP_BUNDLE "Create a Mac app bundle" OFF "APPLE" OFF)
@@ -58,11 +59,25 @@ find_package(${USE_SDL_VERSION} REQUIRED)
 find_package(${USE_SDL_VERSION}_mixer REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Threads)
+if(NOT WIN32)
+	find_package(Iconv QUIET)
+	if(NOT Iconv_FOUND)
+		message(WARNING "Iconv was not found. Legacy GBK/Big5 map text decoding will be disabled, but the game will still build.")
+	endif()
+endif(NOT WIN32)
 
 if(ENABLE_IMAGE)
 	find_package(${USE_SDL_VERSION}_image REQUIRED)
 	find_package(PNG REQUIRED)
 endif(ENABLE_IMAGE)
+if(ENABLE_CJK_TEXT)
+	find_package(${USE_SDL_VERSION}_ttf QUIET)
+	if(TARGET ${USE_SDL_VERSION}_ttf::${USE_SDL_VERSION}_ttf)
+		set(FHEROES2_CJK_TEXT_AVAILABLE ON)
+	else()
+		message(WARNING "SDL_ttf was not found. UTF-8 CJK text rendering will be disabled, but the game will still build.")
+	endif()
+endif(ENABLE_CJK_TEXT)
 
 #
 # Source files
@@ -70,6 +85,17 @@ endif(ENABLE_IMAGE)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 add_subdirectory(src)
+
+set(FHEROES2_FONT_FILES)
+if(EXISTS "${CMAKE_SOURCE_DIR}/files/fonts")
+	file(
+		GLOB FHEROES2_FONT_FILES
+		CONFIGURE_DEPENDS
+		"${CMAKE_SOURCE_DIR}/files/fonts/*.ttf"
+		"${CMAKE_SOURCE_DIR}/files/fonts/*.ttc"
+		"${CMAKE_SOURCE_DIR}/files/fonts/*.otf"
+		)
+endif()
 
 #
 # Translation files
@@ -113,11 +139,26 @@ if(MACOS_APP_BUNDLE)
 		DEPENDS translations
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/files/lang
 		)
+	if(FHEROES2_FONT_FILES)
+		add_custom_target(
+			app_bundle_fonts
+			ALL
+			COMMAND ${CMAKE_COMMAND} -E make_directory "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.app/Contents/Resources/files/fonts"
+			COMMAND ${CMAKE_COMMAND} -E copy ${FHEROES2_FONT_FILES} "${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.app/Contents/Resources/files/fonts"
+			DEPENDS fheroes2
+			)
+	else()
+		add_custom_target(
+			app_bundle_fonts
+			ALL
+			DEPENDS fheroes2
+			)
+	endif()
 	add_custom_target(
 		run_dylibbundler
 		ALL
 		COMMAND dylibbundler -od -b -x ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.app/Contents/MacOS/${PROJECT_NAME} -d ${CMAKE_RUNTIME_OUTPUT_DIRECTORY}/${PROJECT_NAME}.app/Contents/libs
-		DEPENDS fheroes2 app_bundle_fh2m_maps app_bundle_h2d_files app_bundle_translations
+		DEPENDS fheroes2 app_bundle_fh2m_maps app_bundle_h2d_files app_bundle_translations app_bundle_fonts
 		WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
 		)
 endif(MACOS_APP_BUNDLE)
@@ -132,6 +173,16 @@ if(NOT MACOS_APP_BUNDLE)
 		FILES_MATCHING
 		PATTERN *.h2d
 		)
+	if(FHEROES2_FONT_FILES)
+		install(
+			DIRECTORY files/fonts/
+			DESTINATION ${FHEROES2_DATA}/files/fonts
+			FILES_MATCHING
+			PATTERN *.ttf
+			PATTERN *.ttc
+			PATTERN *.otf
+			)
+	endif()
 	install(
 		DIRECTORY maps/
 		DESTINATION ${FHEROES2_DATA}/maps

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,8 @@
 # FHEROES2_WITH_ASAN: build with UB Sanitizer and Address Sanitizer (small runtime overhead, incompatible with FHEROES2_WITH_TSAN)
 # FHEROES2_WITH_TSAN: build with UB Sanitizer and Thread Sanitizer (large runtime overhead, incompatible with FHEROES2_WITH_ASAN)
 # FHEROES2_WITH_IMAGE: build with SDL_image (requires libpng)
+# FHEROES2_WITH_CJK_TEXT: build with SDL_ttf-based UTF-8 CJK text rendering (auto-detected by default, set to 0 to disable)
+# FHEROES2_WITH_ICONV: build with iconv-based legacy GBK/Big5 map text decoding
 # FHEROES2_WITH_SYSTEM_SMACKER: build with an external libsmacker instead of the bundled one
 # FHEROES2_WITH_TOOLS: build additional tools
 # FHEROES2_MACOS_APP_BUNDLE: create a Mac app bundle (only valid when building on macOS)
@@ -46,6 +48,7 @@ ifdef FHEROES2_MACOS_APP_BUNDLE
 	cp files/data/*.h2d fheroes2.app/Contents/Resources/h2d
 	cp files/lang/*.mo fheroes2.app/Contents/Resources/translations
 	cp maps/*.fh2m fheroes2.app/Contents/Resources/maps
+	if [ -d files/fonts ]; then mkdir -p fheroes2.app/Contents/Resources/files/fonts; find files/fonts -type f \( -name '*.ttf' -o -name '*.ttc' -o -name '*.otf' \) -exec cp {} fheroes2.app/Contents/Resources/files/fonts \; ; fi
 	cp src/dist/fheroes2/fheroes2 fheroes2.app/Contents/MacOS
 	cp src/resources/fheroes2.icns fheroes2.app/Contents/Resources
 	sed -e "s/\$${MACOSX_BUNDLE_BUNDLE_NAME}/$(PROJECT_NAME)/" \

--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ To assist with the graphical asset efforts of the project, please look at our [*
 
 If you would like to help translating the project, please read the [**translation guide**](docs/TRANSLATION.md).
 
+For Simplified/Traditional Chinese rendering and legacy map text decoding, see the [**Chinese support guide**](docs/CHINESE_SUPPORT.md).
+
 ### Developing fheroes2 documentation site
 
 To build the [website](https://ihhub.github.io/fheroes2/) from source, please follow

--- a/docs/CHINESE_SUPPORT.md
+++ b/docs/CHINESE_SUPPORT.md
@@ -1,0 +1,49 @@
+# [fheroes2](../README.md) Chinese (CJK) Support
+
+This document describes how Simplified and Traditional Chinese rendering works in fheroes2 and what the
+user has to provide to use it. Unlike the other localizations, Chinese is not rendered through an 8-bit
+code page baked into the bitmap font. Instead it is kept as UTF-8 and drawn at runtime through SDL_ttf
+using a separate CJK font.
+
+## Build requirements
+
+CJK rendering depends on **SDL_ttf**:
+
+- CMake: the `ENABLE_CJK_TEXT` option is `ON` by default. SDL_ttf is detected automatically; if it is not
+  found, the game still builds and simply runs without CJK rendering.
+- Makefile: pass `FHEROES2_WITH_CJK_TEXT=1` (auto-detected through `pkg-config` when available).
+
+Decoding of legacy map text (see below) additionally depends on **iconv** on non-Windows platforms
+(`FHEROES2_WITH_ICONV=1` / detected automatically by CMake). On Windows the system code page conversion
+API is used instead, so iconv is not required there.
+
+If the game is built without SDL_ttf, Simplified/Traditional Chinese are hidden from the language
+selection dialog and the game falls back to English.
+
+## Providing a CJK font
+
+**No CJK font is bundled with the project.** Fonts are large and have their own licensing terms, so each
+user supplies one. The font is located in this order:
+
+1. The `cjk_font_path` value in `fheroes2.cfg`, pointing to a `.ttf`, `.ttc`, or `.otf` file. This may be
+   a redistributable font shipped alongside the game or a font already installed on the system.
+2. Any `.ttf` / `.ttc` / `.otf` file placed under `files/fonts/` next to the game data.
+
+When packaging a build that bundles a font, make sure the font's license permits redistribution
+(for example the SIL Open Font License). Do **not** commit font files into the repository.
+
+## Legacy map text decoding (GBK / Big5)
+
+Classic Heroes of Might and Magic II maps (`.mp2`) store text in legacy Chinese encodings (GBK for
+Simplified Chinese, Big5 for Traditional Chinese), not UTF-8. fheroes2 decodes such text to UTF-8 on the
+fly so it can be displayed with the CJK font.
+
+This decoding is **only attempted when the active text language is Simplified or Traditional Chinese**:
+
+- For original `.mp2` maps there is no reliable per-map language marker, so the **current UI language** is
+  used. If the UI is set to English while loading a Chinese `.mp2` map, the legacy text is left untouched
+  and will appear as raw bytes. Switch the UI to the matching Chinese variant to see it decoded.
+- For fheroes2 (`.fh2m`) maps the language selected for the map guides the decoding.
+
+This is an intentional trade-off: blindly reinterpreting every high-bit byte sequence as GBK/Big5 would
+corrupt text in other languages. Text that already is valid UTF-8 is never re-decoded.

--- a/files/lang/Makefile
+++ b/files/lang/Makefile
@@ -21,6 +21,7 @@
 ICONV  = iconv
 # TODO: consider converting game fonts and texts to UTF-8 in the engine instead
 MSGFMT = sed -e '1,20 s/UTF-8/$(1)/' $< | $(ICONV) -f utf-8 -t $(1) | if msgfmt --help | grep -q no-convert >/dev/null 2>/dev/null; then msgfmt - -o $@ --no-convert; else msgfmt - -o $@; fi
+UTF8_MSGFMT = if msgfmt --help | grep -q no-convert >/dev/null 2>/dev/null; then msgfmt $< -o $@ --no-convert; else msgfmt $< -o $@; fi
 
 .PHONY: all clean merge
 
@@ -58,6 +59,13 @@ lt.mo: lt.po
 # Vietnamese uses CP1258
 vi.mo: vi.po
 	$(call MSGFMT,CP1258)
+
+# Simplified and Traditional Chinese stay UTF-8 and are rendered through the runtime CJK fallback font path.
+zh_CN.mo: zh_CN.po
+	$(UTF8_MSGFMT)
+
+zh_TW.mo: zh_TW.po
+	$(UTF8_MSGFMT)
 
 # Romanian uses ISO-8859-16
 ro.mo: ro.po

--- a/files/lang/zh_CN.po
+++ b/files/lang/zh_CN.po
@@ -1,0 +1,12093 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: fheroes2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-31 03:40+0800\n"
+"PO-Revision-Date: 2026-06-22 00:00+0800\n"
+"Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
+"Language-Team: Chinese\n"
+"Language: zh_CN\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "SELECT"
+msgstr "选择"
+
+msgid "ABOUT"
+msgstr "关于"
+
+msgid "S"
+msgstr "S"
+
+msgid "M"
+msgstr "M"
+
+msgid "L"
+msgstr "L"
+
+msgid "X-L"
+msgstr "X-L"
+
+msgid "ALL"
+msgstr "全部"
+
+msgid "EXIT"
+msgstr "离开"
+
+msgid "smallerButton|EXIT"
+msgstr "离开"
+
+msgid "OKAY"
+msgstr "确定"
+
+msgid "HEROES"
+msgstr "英雄"
+
+msgid ""
+"TOWNS/\n"
+"CASTLES"
+msgstr ""
+"城镇/\n"
+"城堡"
+
+msgid "CANCEL"
+msgstr "取消"
+
+msgid "ACCEPT"
+msgstr "接受"
+
+msgid "DECLINE"
+msgstr "拒绝"
+
+msgid "LEARN"
+msgstr "学习"
+
+msgid "TRADE"
+msgstr "交易"
+
+msgid "YES"
+msgstr "是"
+
+msgid "NO"
+msgstr "否"
+
+msgid "DISMISS"
+msgstr "解散"
+
+msgid "UPGRADE"
+msgstr "升级"
+
+msgid "GIFT"
+msgstr "赠礼"
+
+msgid "RESTART"
+msgstr "重新开始"
+
+msgid "MAX"
+msgstr "最大"
+
+msgid "MIN"
+msgstr "最小"
+
+msgid ""
+"D\n"
+"I\n"
+"S\n"
+"M\n"
+"I\n"
+"S\n"
+"S"
+msgstr ""
+"解\n"
+"散"
+
+msgid ""
+"E\n"
+"X\n"
+"I\n"
+"T"
+msgstr ""
+"离\n"
+"开"
+
+msgid ""
+"C\n"
+"A\n"
+"M\n"
+"P\n"
+"A\n"
+"I\n"
+"G\n"
+"N"
+msgstr ""
+"战\n"
+"役"
+
+msgid ""
+"S\n"
+"T\n"
+"A\n"
+"N\n"
+"D\n"
+"A\n"
+"R\n"
+"D"
+msgstr ""
+"标\n"
+"准"
+
+msgid ""
+"NEW\n"
+"GAME"
+msgstr ""
+"新\n"
+"游戏"
+
+msgid ""
+"LOAD\n"
+"GAME"
+msgstr ""
+"载入\n"
+"游戏"
+
+msgid ""
+"RESTART\n"
+"GAME"
+msgstr ""
+"重新\n"
+"开始"
+
+msgid ""
+"SAVE\n"
+"GAME"
+msgstr ""
+"储存\n"
+"游戏"
+
+msgid ""
+"QUICK\n"
+"SAVE"
+msgstr ""
+"快速\n"
+"存档"
+
+msgid "QUIT"
+msgstr "结束"
+
+msgid ""
+"START\n"
+"MAP"
+msgstr ""
+"开始\n"
+"地图"
+
+msgid ""
+"MAIN\n"
+"MENU"
+msgstr ""
+"主\n"
+"选单"
+
+msgid ""
+"NEW\n"
+"MAP"
+msgstr ""
+"新\n"
+"地图"
+
+msgid ""
+"LOAD\n"
+"MAP"
+msgstr "载入地图"
+
+msgid ""
+"SAVE\n"
+"MAP"
+msgstr "储存地图"
+
+msgid "INFO"
+msgstr "资讯"
+
+msgid ""
+"BATTLE\n"
+"ONLY"
+msgstr "仅限战斗"
+
+msgid "SETTINGS"
+msgstr "设定"
+
+msgid ""
+"STANDARD\n"
+"GAME"
+msgstr "标准游戏"
+
+msgid ""
+"CAMPAIGN\n"
+"GAME"
+msgstr "战役游戏"
+
+msgid ""
+"MULTI-\n"
+"PLAYER\n"
+"GAME"
+msgstr "多人游戏"
+
+msgid "HOT SEAT"
+msgstr "热座模式"
+
+msgid "2 PLAYERS"
+msgstr "2 位玩家"
+
+msgid "3 PLAYERS"
+msgstr "3 位玩家"
+
+msgid "4 PLAYERS"
+msgstr "4 位玩家"
+
+msgid "5 PLAYERS"
+msgstr "5 位玩家"
+
+msgid "6 PLAYERS"
+msgstr "6 位玩家"
+
+msgid ""
+"ORIGINAL\n"
+"CAMPAIGN"
+msgstr "原版战役"
+
+msgid ""
+"EXPANSION\n"
+"CAMPAIGN"
+msgstr "资料片战役"
+
+msgid "editorMainMenu|BACK"
+msgstr "返回"
+
+msgid ""
+"newMap|FROM\n"
+"SCRATCH"
+msgstr ""
+"从头\n"
+"开始"
+
+msgid "newMap|RANDOM"
+msgstr "随机"
+
+msgid "DIFFICULTY"
+msgstr "难度"
+
+msgid "VIEW INTRO"
+msgstr "观看序幕"
+
+msgid "RESET"
+msgstr "重置"
+
+msgid "START"
+msgstr "开始"
+
+msgid ""
+"P\n"
+"A\n"
+"T\n"
+"R\n"
+"O\n"
+"L"
+msgstr ""
+"巡\n"
+"逻"
+
+msgid "army|Few"
+msgstr "班"
+
+msgid "Warrior"
+msgstr "战士"
+
+msgid "Builder"
+msgstr "建设者"
+
+msgid "Explorer"
+msgstr "探索者"
+
+msgid "None"
+msgstr "无"
+
+msgid ""
+"%{monster}\n"
+"%{range}"
+msgstr ""
+"%{monster}\n"
+"%{range}"
+
+msgid ""
+"A few\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"班"
+
+msgid ""
+"Several\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"排"
+
+msgid ""
+"A pack of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"连"
+
+msgid ""
+"Lots of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"营"
+
+msgid ""
+"A horde of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"团"
+
+msgid ""
+"A throng of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"旅"
+
+msgid ""
+"A swarm of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"师"
+
+msgid ""
+"Zounds...\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"军"
+
+msgid ""
+"A legion of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"集团军"
+
+msgid "army|Several"
+msgstr "排"
+
+msgid "army|Pack"
+msgstr "连"
+
+msgid "army|Lots"
+msgstr "营"
+
+msgid "army|Horde"
+msgstr "团"
+
+msgid "army|Throng"
+msgstr "旅"
+
+msgid "army|Swarm"
+msgstr "师"
+
+msgid "army|Zounds"
+msgstr "军"
+
+msgid "army|Legion"
+msgstr "集团军"
+
+msgid "All %{race} troops +1"
+msgstr "所有 %{race} 部队 +1"
+
+msgid "NeutralRaceTroops|Neutral"
+msgstr "中立"
+
+msgid "Troops of %{count} alignments -%{penalty}"
+msgstr "%{count} 种阵营的部队 -%{penalty}"
+
+msgid "Some undead in army -1"
+msgstr "军队中有部分亡灵 -1"
+
+msgid ""
+"Default\n"
+"troop"
+msgstr ""
+"预设\n"
+"部队"
+
+msgid "View %{name}"
+msgstr "检视 %{name}"
+
+msgid "Move the %{name} "
+msgstr "移动 %{name} "
+
+msgid "Move or right click to redistribute %{name}"
+msgstr "移动或按右键重新分配 %{name}"
+
+msgid "Combine %{name} armies"
+msgstr "合并 %{name} 军队"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "交换 %{name2} 与 %{name}"
+
+msgid "Select %{name}"
+msgstr "选择 %{name}"
+
+msgid "Cannot move last troop"
+msgstr "无法移动最后一支部队"
+
+msgid "Move the %{name}"
+msgstr "移动 %{name}"
+
+msgid "Set %{monster} Count:"
+msgstr "设定 %{monster} 数量："
+
+msgid "%{name} destroys half the enemy troops!"
+msgid_plural "%{name} destroy half the enemy troops!"
+msgstr[0] "%{name} 摧毁了一半的敌方部队！"
+
+msgid "%{name} has turned off the auto combat"
+msgstr "%{name} 已关闭自动战斗"
+
+msgid "%{name} has turned on the auto combat"
+msgstr "%{name} 已开启自动战斗"
+
+msgid "Spell failed!"
+msgstr "法术失败！"
+
+msgid ""
+"The Sphere of Negation artifact is in effect for this battle, disabling all "
+"combat spells."
+msgstr ""
+"否定之球神器在此战斗中生效，所有战斗法术均被封锁。"
+
+msgid "You cannot cast spells without a commanding hero."
+msgstr "没有指挥英雄就无法施放法术。"
+
+msgid "You have already cast a spell this round."
+msgstr "本回合已经施放过法术了。"
+
+msgid "That spell will have no effect!"
+msgstr "该法术不会有任何效果！"
+
+msgid "You may only summon one type of elemental per combat."
+msgstr "每场战斗只能召唤一种元素生物。"
+
+msgid ""
+"There is no open space adjacent to your hero where you can summon an "
+"Elemental to."
+msgstr ""
+"英雄旁边没有空位可以召唤元素生物。"
+
+msgid ""
+"The Moat interrupts any movement through it and reduces the defense skill of "
+"troops present in it by %{count}."
+msgstr ""
+"护城河会中断经过的一切移动，并将停留其中部队的防御技能降低 %{count}。"
+
+msgid "battleAnimation|Speed: %{speed}"
+msgstr "速度：%{speed}"
+
+msgid "battleAnimation|Speed"
+msgstr "速度"
+
+msgid "Interface"
+msgstr "介面"
+
+msgid "Settings"
+msgstr "设定"
+
+msgid "Auto Spell Casting"
+msgstr "自动施法"
+
+msgid "Off"
+msgstr "关闭"
+
+msgid "On"
+msgstr "开启"
+
+msgid "Set the speed of combat actions and animations."
+msgstr "调整战斗动作与动画的速度。"
+
+msgid "Change the interface settings of the game."
+msgstr "变更游戏的介面设定。"
+
+msgid "Interface Settings"
+msgstr "介面设定"
+
+msgid ""
+"Toggle whether or not the computer will cast spells for you when auto combat "
+"is on. (Note: This does not affect spell casting for computer players in any "
+"way, nor does it affect quick combat.)"
+msgstr ""
+"切换自动战斗时是否由电脑代为施法。（注意：此选项不会影响电脑玩家的施法方式，"
+"也不会影响快速战斗。）"
+
+msgid "Audio"
+msgstr "音效"
+
+msgid "Change the audio settings of the game."
+msgstr "变更游戏的音效设定。"
+
+msgid "Check and configure all the hot keys present in the game."
+msgstr "检查并调整游戏中所有的快速键。"
+
+msgid "Hot Keys"
+msgstr "快速键"
+
+msgid "Exit this menu."
+msgstr "离开此选单。"
+
+msgid "Okay"
+msgstr "确定"
+
+msgid "The enemy has surrendered!"
+msgstr "敌人已投降！"
+
+msgid "Their cowardice costs them %{gold} gold."
+msgstr "怯懦使他们损失了 %{gold} 金币。"
+
+msgid "The enemy has fled!"
+msgstr "敌人逃跑了！"
+
+msgid "A glorious victory!"
+msgstr "光荣的胜利！"
+
+msgid "For valor in combat, %{name} receives %{exp} experience."
+msgstr "因在战斗中英勇表现，%{name} 获得了 %{exp} 点经验值。"
+
+msgid "The cowardly %{name} flees from battle."
+msgstr "懦弱的 %{name} 从战场上逃走了。"
+
+msgid "%{name} surrenders to the enemy, and departs in shame."
+msgstr "%{name} 向敌人投降，羞愧地离去。"
+
+msgid "Your forces suffer a bitter defeat, and %{name} abandons your cause."
+msgstr "军队遭受惨败，%{name} 抛弃了你的阵营。"
+
+msgid "Your forces suffer a bitter defeat."
+msgstr "军队遭受了惨败。"
+
+msgid "Battlefield Casualties"
+msgstr "战场伤亡"
+
+msgid "Attacker"
+msgstr "进攻方"
+
+msgid "Defender"
+msgstr "防守方"
+
+msgid "Click to leave the battle results."
+msgstr "按一下离开战斗结果。"
+
+msgid "Click to restart the battle in manual mode."
+msgstr "按一下以手动模式重新开始战斗。"
+
+msgid "Restart"
+msgstr "重新开始"
+
+msgid "You have captured an enemy artifact!"
+msgstr "缴获了一件敌方神器！"
+
+msgid "As you reach for the %{name}, it mysteriously disappears."
+msgstr "当你伸手去拿 %{name} 时，它神秘地消失了。"
+
+msgid "As your enemy reaches for the %{name}, it mysteriously disappears."
+msgstr "当敌人伸手去拿 %{name} 时，它神秘地消失了。"
+
+msgid "Necromancy!"
+msgstr "亡灵巫术！"
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+"借由施展亡灵巫术的黑暗力量，你复活了 %{count} 具敌方尸体，化为 %{monster} 为"
+"你效力。"
+
+msgid "%{name} the %{race}"
+msgstr "%{name}，%{race}"
+
+msgid "Captain of %{name}"
+msgstr "%{name} 的队长"
+
+msgid "Attack"
+msgstr "攻击"
+
+msgid "Defense"
+msgstr "防御"
+
+msgid "Spell Power"
+msgstr "魔法力量"
+
+msgid "Knowledge"
+msgstr "知识"
+
+msgid "Morale"
+msgstr "士气"
+
+msgid "Luck"
+msgstr "运气"
+
+msgid "Spell Points"
+msgstr "魔法值"
+
+msgid "Cast Spell"
+msgstr "施放法术"
+
+msgid "Retreat"
+msgstr "撤退"
+
+msgid "Surrender"
+msgstr "投降"
+
+msgid "Cancel"
+msgstr "取消"
+
+msgid "Hero Screen"
+msgstr "英雄画面"
+
+msgid "Captain's Options"
+msgstr "队长选项"
+
+msgid "Hero's Options"
+msgstr "英雄选项"
+
+msgid ""
+"Cast a magical spell. You may only cast one spell per combat round. The "
+"round is reset when every creature has had a turn."
+msgstr ""
+"施放法术。每回合只能施放一个法术，当所有生物都行动过后回合即重置。"
+
+msgid ""
+"Retreat your hero, abandoning your creatures. Your hero will be available "
+"for you to recruit again, however, the hero will have only a novice hero's "
+"forces."
+msgstr ""
+"撤退英雄并抛弃部队。英雄可重新招募，但只会拥有新手英雄的起始兵力。"
+
+msgid ""
+"Surrendering costs gold. However if you pay the ransom, the hero and all of "
+"his or her surviving creatures will be available to recruit again. The cost "
+"of surrender is half of the total cost of the non-temporary troops remaining "
+"in the army."
+msgstr ""
+"投降需要支付黄金。不过若支付赎金，英雄及其所有幸存部队均可重新招募。投降费用"
+"为军队中所有非临时部队总成本的一半。"
+
+msgid "Open Hero Screen to view full information about the hero."
+msgstr "开启英雄画面以检视英雄的完整资讯。"
+
+msgid "Return to the battle."
+msgstr "返回战斗。"
+
+msgid "Not enough gold (%{gold})"
+msgstr "黄金不足 (%{gold})"
+
+msgid "%{name} states:"
+msgstr "%{name} 表示："
+
+msgid "Captain of %{name} states:"
+msgstr "%{name} 的队长表示："
+
+msgid ""
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
+msgstr ""
+"「我接受你的投降。支付 %{price} 金币后，你和部队就能安全离开。」"
+
+msgid "View %{monster} info"
+msgstr "检视 %{monster} 资讯"
+
+msgid "Fly %{monster} here"
+msgstr "令 %{monster} 飞到此处"
+
+msgid "Move %{monster} here"
+msgstr "移动 %{monster} 到此处"
+
+msgid "Shoot %{monster}"
+msgstr "射击 %{monster}"
+
+msgid "(1 shot left)"
+msgid_plural "(%{count} shots left)"
+msgstr[0] "(剩余 1 次射击)"
+
+msgid "Attack %{monster}"
+msgstr "攻击 %{monster}"
+
+msgid "Turn %{turn}"
+msgstr "回合 %{turn}"
+
+msgid "Teleport here"
+msgstr "传送至此"
+
+msgid "Invalid teleport destination"
+msgstr "无效的传送目的地"
+
+msgid "Cast %{spell} on %{monster}"
+msgstr "对 %{monster} 施放 %{spell}"
+
+msgid "Cast %{spell}"
+msgstr "施放 %{spell}"
+
+msgid "Select spell target"
+msgstr "选择法术目标"
+
+msgid "Are you sure you want to enable the auto combat mode?"
+msgstr "确定要启用自动战斗模式吗？"
+
+msgid "Are you sure you want to resolve the battle in the quick combat mode?"
+msgstr "确定要以快速战斗模式结算这场战斗吗？"
+
+msgid "View Ballista info"
+msgstr "检视弩砲资讯"
+
+msgid "Ballista"
+msgstr "弩砲"
+
+msgid "Automatic combat modes"
+msgstr "自动战斗模式"
+
+msgid "Automatic Combat Modes"
+msgstr "自动战斗模式"
+
+msgid ""
+"Choose between proceeding the combat in auto combat mode or in quick combat "
+"mode."
+msgstr ""
+"请选择以自动战斗模式或快速战斗模式继续战斗。"
+
+msgid "Customize system options"
+msgstr "自订系统选项"
+
+msgid "Allows you to customize the combat screen."
+msgstr "可自订战斗画面。"
+
+msgid "System Options"
+msgstr "系统选项"
+
+msgid "Skip this unit"
+msgstr "略过此单位"
+
+msgid "Skip"
+msgstr "略过"
+
+msgid ""
+"Skips the current creature. The current creature ends its turn and does not "
+"get to go again until the next round."
+msgstr ""
+"略过目前的生物。该生物结束其回合，直到下一回合才能再次行动。"
+
+msgid "View Captain's options"
+msgstr "检视队长选项"
+
+msgid "View Hero's options"
+msgstr "检视英雄选项"
+
+msgid "View opposing Captain"
+msgstr "检视对方队长"
+
+msgid "View opposing Hero"
+msgstr "检视对方英雄"
+
+msgid "Hide logs"
+msgstr "隐藏记录"
+
+msgid "Show logs"
+msgstr "显示记录"
+
+msgid "Message Bar"
+msgstr "讯息列"
+
+msgid "Shows the results of individual monster's actions."
+msgstr "显示各怪物的行动结果。"
+
+msgid ""
+"AUTO\n"
+"COMBAT"
+msgstr ""
+"自动\n"
+"战斗"
+
+msgid ""
+"QUICK\n"
+"COMBAT"
+msgstr ""
+"快速\n"
+"战斗"
+
+msgid "The computer continues the combat for you."
+msgstr "由电脑继续为你战斗。"
+
+msgid ""
+"autoCombat|This can be interrupted at any moment by pressing the Auto Combat "
+"hotkey or the default Cancel key, or by performing a left or right click "
+"anywhere on the game screen."
+msgstr ""
+"可随时按下自动战斗快速键、预设取消键，或在游戏画面任意处左键或右键按一下来中"
+"断。"
+
+msgid "Auto Combat"
+msgstr "自动战斗"
+
+msgid "The combat is resolved from the current state."
+msgstr "从目前状态结算战斗结果。"
+
+msgid "quickCombat|This cannot be undone."
+msgstr "此操作无法复原。"
+
+msgid "Quick Combat"
+msgstr "快速战斗"
+
+msgid "The %{name} skips their turn."
+msgid_plural "The %{name} skip their turn."
+msgstr[0] "%{name} 略过了回合。"
+
+msgid "%{attacker} does %{damage} damage."
+msgid_plural "%{attacker} do %{damage} damage."
+msgstr[0] "%{attacker} 造成了 %{damage} 点伤害。"
+
+msgid "1 creature perishes."
+msgid_plural "%{count} creatures perish."
+msgstr[0] "1 个生物阵亡。"
+
+msgid "1 %{defender} perishes."
+msgid_plural "%{count} %{defender} perish."
+msgstr[0] "1 个 %{defender} 阵亡。"
+
+msgid "1 soul is incorporated."
+msgid_plural "%{count} souls are incorporated."
+msgstr[0] "1 个灵魂被吸收。"
+
+msgid "1 %{unit} is revived."
+msgid_plural "%{count} %{unit} are revived."
+msgstr[0] "1 个 %{unit} 被复活。"
+
+msgid "Moved %{monster}: from [%{src}] to [%{dst}]."
+msgstr "已移动 %{monster}: 从 [%{src}] 到 [%{dst}]。"
+
+msgid "The %{name} resists the spell!"
+msgid_plural "The %{name} resist the spell!"
+msgstr[0] "%{name} 抵抗了法术！"
+
+msgid "%{name} casts %{spell} on the %{troop}."
+msgstr "%{name} 对 %{troop} 施放了 %{spell}。"
+
+msgid "%{name} casts %{spell}."
+msgstr "%{name} 施放了 %{spell}。"
+
+msgid "The %{spell} does %{damage} damage to one undead creature."
+msgstr "%{spell} 对一个亡灵生物造成了 %{damage} 点伤害。"
+
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr "%{spell} 对所有亡灵生物造成了 %{damage} 点伤害。"
+
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr "%{spell} 造成了 %{damage} 点伤害，%{count} 个生物阵亡。"
+
+msgid "The %{spell} does %{damage} damage."
+msgstr "%{spell} 造成了 %{damage} 点伤害。"
+
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "%{spell} 对一个活体生物造成了 %{damage} 点伤害。"
+
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "%{spell} 对所有活体生物造成了 %{damage} 点伤害。"
+
+msgid "The %{attacker}'s attack blinds the %{target}!"
+msgid_plural "The %{attacker}' attack blinds the %{target}!"
+msgstr[0] "%{attacker} 的攻击使 %{target} 目盲了！"
+
+msgid "The %{attacker}'s gaze turns the %{target} to stone!"
+msgid_plural "The %{attacker}' gaze turns the %{target} to stone!"
+msgstr[0] "%{attacker} 的凝视使 %{target} 石化了！"
+
+msgid "The %{attacker}'s curse falls upon the %{target}!"
+msgid_plural "The %{attacker}' curse falls upon the %{target}!"
+msgstr[0] "%{attacker} 的诅咒降临在 %{target} 身上！"
+
+msgid "The %{target} is paralyzed by the %{attacker}!"
+msgid_plural "The %{target} are paralyzed by the %{attacker}!"
+msgstr[0] "%{target} 被 %{attacker} 麻痹了！"
+
+msgid "The %{attacker} dispels all good spells on your %{target}!"
+msgid_plural "The %{attacker} dispel all good spells on your %{target}!"
+msgstr[0] "%{attacker} 解除了 %{target} 身上所有的增益法术！"
+
+msgid "The %{attacker} casts %{spell} on the %{target}!"
+msgid_plural "The %{attacker} cast %{spell} on the %{target}!"
+msgstr[0] "%{attacker} 对 %{target} 施放了 %{spell}！"
+
+msgid "Bad luck descends on the %{attacker}."
+msgstr "厄运降临在 %{attacker} 身上。"
+
+msgid "Good luck shines on the %{attacker}."
+msgstr "好运眷顾了 %{attacker}。"
+
+msgid "High morale enables the %{monster} to attack again."
+msgstr "高昂士气使 %{monster} 得以再次攻击。"
+
+msgid "Low morale causes the %{monster} to freeze in panic."
+msgstr "低落士气使 %{monster} 因恐慌而僵住。"
+
+msgid "%{tower} does %{damage} damage."
+msgstr "%{tower} 造成了 %{damage} 点伤害。"
+
+msgid "The mirror image is created."
+msgstr "镜像已建立。"
+
+msgid "The mirror image is destroyed!"
+msgstr "镜像被摧毁了！"
+
+msgid "Are you sure you want to interrupt the auto combat mode?"
+msgstr "确定要中断自动战斗模式吗？"
+
+msgid "Error"
+msgstr "错误"
+
+msgid "No spells to cast."
+msgstr "没有可施放的法术。"
+
+msgid "Are you sure you want to retreat?"
+msgstr "确定要撤退吗？"
+
+msgid "Retreat disabled"
+msgstr "撤退已停用"
+
+msgid "Surrender disabled"
+msgstr "投降已停用"
+
+msgid "Damage: %{max}"
+msgstr "伤害：%{max}"
+
+msgid "Damage: %{min} - %{max}"
+msgstr "伤害：%{min} - %{max}"
+
+msgid "Perish: %{max}"
+msgstr "阵亡：%{max}"
+
+msgid "Perish: %{min} - %{max}"
+msgstr "阵亡：%{min} - %{max}"
+
+msgid "battle_turn_order|Top"
+msgstr "顶部"
+
+msgid "battle_turn_order|Bottom"
+msgstr "底部"
+
+msgid "Turn Order"
+msgstr "行动顺序"
+
+msgid "Grid"
+msgstr "格线"
+
+msgid "Damage Info"
+msgstr "伤害资讯"
+
+msgid "Shadow Movement"
+msgstr "移动阴影"
+
+msgid "Shadow Cursor"
+msgstr "游标阴影"
+
+msgid "Movement Area"
+msgstr "移动范围"
+
+msgid "Toggle to display the turn order during the battle."
+msgstr "切换是否在战斗中显示行动顺序。"
+
+msgid ""
+"Toggle the hex grid on or off. The hex grid always underlies movement, even "
+"if turned off. This switch only determines if the grid is visible."
+msgstr ""
+"切换六角格线的显示。格线始终作为移动的基础存在，此开关仅决定是否显示格线。"
+
+msgid "Toggle to display damage information during the battle."
+msgstr "切换是否在战斗中显示伤害资讯。"
+
+msgid ""
+"Toggle on or off shadows showing where your creatures can move and attack."
+msgstr ""
+"切换是否显示生物可移动和攻击范围的阴影。"
+
+msgid ""
+"Toggle on or off a shadow showing the current hex location of the mouse "
+"cursor."
+msgstr ""
+"切换是否显示滑鼠游标目前所在六角格的阴影。"
+
+msgid "Toggle showing the movement area of a highlighted creature on or off."
+msgstr "切换是否显示选取生物的移动范围。"
+
+msgid ""
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
+msgstr ""
+"凭借敏锐的观察力，%{name} 学会了魔法 %{spell}。"
+
+msgid "Human"
+msgstr "人类"
+
+msgid "Terrain"
+msgstr "地形"
+
+msgid "Battle Only"
+msgstr "仅限战斗"
+
+msgid "Start"
+msgstr "开始"
+
+msgid "Start the battle."
+msgstr "开始战斗。"
+
+msgid "Exit"
+msgstr "离开"
+
+msgid "Reset"
+msgstr "重置"
+
+msgid "Reset to default settings."
+msgstr "重置为预设设定。"
+
+msgid ""
+"The battle will take place on a randomly selected terrain. Click to change "
+"the terrain type."
+msgstr ""
+"战斗将在随机选取的地形上进行。按一下可变更地形类型。"
+
+msgid ""
+"The battle will take place on %{terrain-type} terrain. Click to change the "
+"terrain type."
+msgstr ""
+"战斗将在 %{terrain-type} 地形上进行。按一下可变更地形类型。"
+
+msgid "Please select another hero."
+msgstr "请选择另一位英雄。"
+
+msgid "Click to select a hero."
+msgstr "按一下选择一位英雄。"
+
+msgid "Hero"
+msgstr "英雄"
+
+msgid ""
+"If this checkbox is checked, the defending hero is going be human-controlled."
+msgstr ""
+"勾选此选项后，防守方英雄将由人类玩家控制。"
+
+msgid "%{race1} %{name1} vs %{race2} %{name2}"
+msgstr "%{race1} %{name1} 对 %{race2} %{name2}"
+
+msgid "Monsters"
+msgstr "怪物"
+
+msgid "N/A"
+msgstr "不适用"
+
+msgid "Left Turret"
+msgstr "左箭塔"
+
+msgid "Right Turret"
+msgstr "右箭塔"
+
+msgid "The %{name} fires with the strength of %{count} Archers"
+msgstr "%{name} 以 %{count} 名弓箭手的力量进行射击"
+
+msgid "each with a +%{attack} bonus to their attack skill."
+msgstr "每位均有 +%{attack} 的攻击技能加成。"
+
+msgid "The %{name} is destroyed."
+msgstr "%{name} 被摧毁了。"
+
+msgid "%{count} %{name} rises from the dead!"
+msgid_plural "%{count} %{name} rise from the dead!"
+msgstr[0] "%{count} 个 %{name} 从死亡中复活了！"
+
+msgid "Dwarven Alliance"
+msgstr "矮人联盟"
+
+msgid "Sorceress Guild"
+msgstr "女巫公会"
+
+msgid "Necromancer Guild"
+msgstr "亡灵法师公会"
+
+msgid "Ogre Alliance"
+msgstr "食人魔联盟"
+
+msgid "Dwarfbane"
+msgstr "矮人克星"
+
+msgid "Dragon Alliance"
+msgstr "巨龙联盟"
+
+msgid "Elven Alliance"
+msgstr "精灵联盟"
+
+msgid "Kraeger defeated"
+msgstr "Kraeger 被击败"
+
+msgid "Wayward Son"
+msgstr "离家之子"
+
+msgid "Uncle Ivan"
+msgstr "Ivan 叔叔"
+
+msgid "Annexation"
+msgstr "并吞"
+
+msgid "Force of Arms"
+msgstr "武力征服"
+
+msgid "Save the Dwarves"
+msgstr "拯救矮人"
+
+msgid "Carator Mines"
+msgstr "Carator 矿场"
+
+msgid "Turning Point"
+msgstr "转捩点"
+
+msgid "scenarioName|Defender"
+msgstr "守卫者"
+
+msgid "Corlagon's Defense"
+msgstr "Corlagon 的防线"
+
+msgid "The Crown"
+msgstr "王冠"
+
+msgid "The Gauntlet"
+msgstr "护手"
+
+msgid "Betrayal"
+msgstr "背叛"
+
+msgid "Final Justice"
+msgstr "最终审判"
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother. They are not allied with each other, so they "
+"will spend most of their time fighting with one another. Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+"Roland 需要你击败城堡附近的领主，以展开他对抗其兄弟的叛乱战争。他们彼此并未结"
+"盟，所以大部分时间会自相残杀。击败所有敌方城堡和英雄即可获胜。"
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+"当地领主拒绝向 Roland 效忠，必须加以镇压。他们富有且强大，请做好艰苦战斗的准"
+"备。占领所有敌方城堡即可获胜。"
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+"你的任务是保护矮人免受 Archibald 军队的侵害。占领所有敌方城镇和城堡即可获胜，"
+"但不可同时失去所有矮人城镇，否则敌人就赢了。"
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resources "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+"你将面对四个结盟的敌人，在一场直截了当的资源与宝藏争夺中作战。占领所有敌方城"
+"堡即可获胜。"
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+"敌人结盟对抗你且起始位置很近，请做好战斗准备。必须占领这个小山谷中的所有四座"
+"城堡才能获胜。"
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+"Noraston 的女巫公会请求 Roland 援助，对抗 Archibald 盟友的进攻。占领所有敌方"
+"城堡即可获胜，不可失去 Noraston，否则场景失败。（提示：海洋中的岛屿上有一座敌"
+"方城堡。）"
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+"尽可能集结大军，在 8 周内占领敌方城堡。你只面对一个敌人，但必须长途跋涉才能到"
+"达敌方城堡。此场景结束时军队中的所有部队将伴随你进入最终决战。"
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+"在 Archibald 的英雄之前找到王冠。Roland 需要王冠来进行对 Archibald 的最终决"
+"战。"
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+"三个结盟的敌人挡在你与胜利之间，其中包括 Lord Corlagon。Roland 位于西北方的城"
+"堡；如果他落入敌手，你就输了。记住，俘获 Lord Corlagon 可确保他不会在最终场景"
+"中与你为敌。"
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+"这是最终决战。你和敌人都武装到牙齿，所有人都结盟对抗你。俘获 Archibald 即可结"
+"束战争！"
+
+msgid ""
+"Switching sides leaves you with three castles against the enemy's one. This "
+"battle will be the easiest one you will face for the rest of the war..."
+"traitor."
+msgstr ""
+"叛变后你拥有三座城堡对抗敌方的一座。这将是这场战争中你面对最简单的战斗……叛"
+"徒。"
+
+msgid "Barbarian Wars"
+msgstr "野蛮人之战"
+
+msgid "First Blood"
+msgstr "初战"
+
+msgid "Necromancers"
+msgstr "亡灵法师们"
+
+msgid "Slay the Dwarves"
+msgstr "屠杀矮人"
+
+msgid "Country Lords"
+msgstr "乡间领主"
+
+msgid "Dragon Master"
+msgstr "龙族大师"
+
+msgid "Rebellion"
+msgstr "叛乱"
+
+msgid "Apocalypse"
+msgstr "天启"
+
+msgid "Greater Glory"
+msgstr "更大的荣耀"
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region. They "
+"are not allied with one another, so they will spend most of their energy "
+"fighting amongst themselves. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+"Archibald 国王要求你击败此地区的三个敌人。他们彼此并未结盟，所以大部分精力会"
+"花在自相残杀上。当你占领所有敌方城堡且不再有敌方英雄时即获胜。"
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+"你必须征服并统一北方的野蛮人部族。如同前一个任务，敌人并未结盟对抗你，但他们"
+"拥有更多资源。当你占领所有敌方城堡且不再有敌方英雄时即获胜。"
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+"自以为正义的巫师夺取了亡灵法师的城堡。你必须夺回它才能获胜。记住，虽然你开局"
+"拥有强大的军队，但没有城堡，必须在 7 天内攻占一座，否则战败。（提示：最近的城"
+"堡在东南方。）"
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+"在矮人干涉 Archibald 国王的计划之前必须先征服他们。Roland 的军队有多位英雄和"
+"许多城镇，请做好多方向进攻的准备。必须占领所有敌方城镇和城堡才能获胜。"
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+"你必须镇压由 Roland 军队领导的农民起义。所有人都结盟对抗你，但你有经验丰富的"
+"英雄 Lord Corlagon 助阵。占领所有敌方城堡即可获胜。"
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win."
+msgstr ""
+"此任务中有两个结盟的敌人对抗你。他们都装备精良，想将你逐出岛屿。避开他们并占"
+"领龙族之城即可获胜。"
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+"你的命令是征服宣誓效忠 Roland 的乡间领主。所有敌方城堡都团结对抗你。由于你开"
+"局没有城堡，必须赶在本周结束前攻占一座。占领所有敌方城堡即可获胜。"
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+"在 Roland 的英雄之前找到王冠。Archibald 需要王冠来进行对 Roland 的最终决战。"
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+"这是最终决战。你和敌人都武装到牙齿，所有人都结盟对抗你。俘获 Roland 即可赢得"
+"战争，但不可在战斗中失去 Archibald！"
+
+msgid "Arrow's Flight"
+msgstr "箭矢之途"
+
+msgid "Island of Chaos"
+msgstr "混沌之岛"
+
+msgid "The Abyss"
+msgstr "深渊"
+
+msgid "Uprising"
+msgstr "起义"
+
+msgid "Aurora Borealis"
+msgstr "极光"
+
+msgid "Betrayal's End"
+msgstr "背叛的终结"
+
+msgid "Corruption's Heart"
+msgstr "腐败之心"
+
+msgid "The Giant's Pass"
+msgstr "巨人之关"
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+"镇压不服从的当地领主，为帝国在此地区的运作提供设施。"
+
+msgid ""
+"Eliminate all opposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+"消灭此区域的所有反对势力，接着你就能取得神器的第一块碎片。"
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+"东北方的女巫们正在叛乱！为了帝国的利益，你必须在前往山区的途中镇压她们微弱的"
+"起义。"
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+"Kraeger 已为你的到来做好准备，安排了一支亡灵法师部队阻挠你的任务。你必须在第"
+"三周的第一天之前攻占 Scabsdale 城堡，否则亡灵法师将强大到无法对抗。"
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+"此地区的野蛮人暴君尚未察觉你的存在。赶紧在被发现和遭受攻击之前增强实力！镇压"
+"所有敌方势力以确保此地区的安全。"
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+"帝国在此地区很薄弱。你无法完全镇压此地所有势力，所以在报复来临之前尽可能掠"
+"夺。记住，你的真正目标是夺取 Anduran 头盔。"
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr "为了帝国的利益，消灭 Kraeger。"
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+"终于，你有了机会和设施来为帝国铲除亡灵法师的邪恶。彻底消灭他们，你将被世代传"
+"颂为英雄。"
+
+msgid "Border Towns"
+msgstr "边境城镇"
+
+msgid "Conquer and Unify"
+msgstr "征服与统一"
+
+msgid "Crazy Uncle Ivan"
+msgstr "疯狂的 Ivan 叔叔"
+
+msgid "The Wayward Son"
+msgstr "离家之子"
+
+msgid "Ivory Gates"
+msgstr "象牙之门"
+
+msgid "The Elven Lands"
+msgstr "精灵之地"
+
+msgid "The Epic Battle"
+msgstr "史诗之战"
+
+msgid "The Southern War"
+msgstr "南方战争"
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+"征服并统一所有敌对部族。不可失去英雄 Jarkonas，他是所有后裔的始祖。"
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+"你的宿敌 Harondale 王国正在进攻边境上的薄弱城镇！从他们的首波攻击中恢复，并彻"
+"底击溃他们！"
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+"找到你离家出走的儿子 Joseph，传闻他住在荒凉之地。在第三个月的第一天之前完成此"
+"事，否则对你的家族毫无帮助。"
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be of no help to your kingdom."
+msgstr ""
+"拯救你疯狂的 Ivan 叔叔。在第四个月的第一天之前找到他，否则对王国毫无帮助。"
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+"摧毁正在进攻王国南部边境的野蛮人！收复失去的城镇，然后入侵丛林王国。不留任何"
+"敌人。"
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr "夺回因叛变而沦陷的象牙之门城堡。"
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so we will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+"赢得精灵的好感。他们不允许砍伐树木，所以我们每两周会送你木材。你必须在第七个"
+"月的第一天之前完成任务，否则王国必将沦陷。"
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+"这是对宿敌 Harondale 王国的最终决战。消灭所有敌人，不可失去英雄 Jarkonas VI。"
+
+msgid "Fount of Wizardry"
+msgstr "巫术之泉"
+
+msgid "Power's End"
+msgstr "力量的终结"
+
+msgid "The Eternal Scrolls"
+msgstr "永恒卷轴"
+
+msgid "The Shrouded Isles"
+msgstr "迷雾群岛"
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+"你的任务是消灭迷雾群岛上交战中的法师。完成此任务将使你有机会对抗劲敌。"
+
+msgid ""
+"The location of the great library has been discovered! You must make your "
+"way to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+"大图书馆的位置已被发现！你必须前往该处，夺回它所在的 Chronos 城。"
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your prize. "
+"Find the Orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+"找到传说中埋藏在此地的否定之球。石碑上刻有线索，能引导你找到宝物。在第六个月"
+"的第一天之前找到它，否则你的对手肯定会抢先到达泉源。"
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+"你必须夺取魔法城堡——巫术之泉所在之地。完成此任务，你的胜利将是至高无上的。"
+
+msgid "Blood is Thicker"
+msgstr "血浓于水"
+
+msgid "King and Country"
+msgstr "国王与国家"
+
+msgid "Pirate Isles"
+msgstr "海盗群岛"
+
+msgid "Stranded"
+msgstr "搁浅"
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+"占领东南海岸外岛屿上的城镇，以建造船只返回大陆。不可失去英雄 Gallavant。"
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+"找到并击败海盗首领 Martine，他藏身在海盗湾。不可失去 Gallavant，否则任务就结"
+"束了。"
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+"消灭所有反对 Alberon 领主统治的势力。Gallavant 不可战死。"
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+"推翻 Alberon 领主根深柢固的统治，以你的名义占领所有土地。Gallavant 不可战死。"
+
+msgid " bane"
+msgstr "克星"
+
+msgid " alliance"
+msgstr "联盟"
+
+msgid "Carry-over forces"
+msgstr "延续兵力"
+
+msgid " bonus"
+msgstr "加成"
+
+msgid " defeated"
+msgstr "被击败"
+
+msgid " will always run away from your army."
+msgstr "会永远逃离你的军队。"
+
+msgid " will be willing to join your army."
+msgstr "会愿意加入你的军队。"
+
+msgid "\"%{artifact}\" artifact will be carried over in the campaign."
+msgstr "神器「%{artifact}」将延续至战役中。"
+
+msgid "The army will be carried over in the campaign."
+msgstr "军队将延续至战役中。"
+
+msgid "The kingdom will have +%{count} %{resource} each day."
+msgstr "王国每日将额外获得 +%{count} %{resource}。"
+
+msgid "The \"%{spell}\" spell will be carried over in the campaign."
+msgstr "「%{spell}」法术将延续至战役中。"
+
+msgid "%{hero} can be hired during scenarios."
+msgstr "%{hero} 可在场景中招募。"
+
+msgid "%{hero} has been defeated and will not appear in subsequent scenarios."
+msgstr "%{hero} 已被击败，不会出现在后续场景中。"
+
+msgid "The dwarves recognize their allies and gladly join your forces."
+msgstr "矮人认出了盟友，欣然加入你的队伍。"
+
+msgid "The ogres recognize you as the Dwarfbane and lumber over to join you."
+msgstr "食人魔认出你是矮人克星，笨重地走来加入你。"
+
+msgid ""
+"The dragons, snarling and growling, agree to join forces with you, their "
+"'Ally'."
+msgstr ""
+"巨龙们咆哮嘶吼着，同意与牠们的「盟友」你并肩作战。"
+
+msgid ""
+"As you approach the group of elves, their leader calls them all to "
+"attention. He shouts to them, \"Who of you is brave enough to join this "
+"fearless ally of ours?\" The group explodes with cheers as they run to join "
+"your ranks."
+msgstr ""
+"当你接近精灵群时，他们的首领召集所有人注意。他对他们喊道：「你们谁够勇敢，愿"
+"意加入我们这位无畏的盟友？」人群爆发出欢呼声，纷纷跑来加入你的队伍。"
+
+msgid ""
+"The dwarves hail you, \"Any friend of Roland is a friend of ours. You may "
+"pass.\""
+msgstr ""
+"矮人向你致意：「凡是 Roland 的朋友，都是我们的朋友。请通行吧。」"
+
+msgid ""
+"The ogres give you a grunt of recognition, \"Archibald's allies may pass.\""
+msgstr ""
+"食人魔发出认可的咕哝声：「Archibald 的盟友可以通行。」"
+
+msgid ""
+"The dragons see you and call out. \"Our alliance with Archibald compels us "
+"to join you. Unfortunately you have no room. A pity!\" They quickly scatter."
+msgstr ""
+"巨龙们看到你并呼喊：「我们与 Archibald 的联盟迫使我们加入你，但很遗憾你没有空"
+"位，太可惜了！」牠们很快四散离去。"
+
+msgid ""
+"The elves stand at attention as you approach. Their leader calls to you and "
+"says, \"Let us not impede your progress, ally! Move on, and may victory be "
+"yours.\""
+msgstr ""
+"精灵们在你接近时立正站好。他们的首领对你喊道：「让我们不要阻碍盟友的进展！请"
+"继续前进，愿胜利属于你。」"
+
+msgid "\"The Dwarfbane!!!!, run for your lives.\""
+msgstr "「矮人克星！！！！快逃命吧。」"
+
+msgid "campaignBonus|Animate Dead"
+msgstr "操控亡灵"
+
+msgid "campaignBonus|Chain Lightning"
+msgstr "连锁闪电"
+
+msgid "campaignBonus|Fireblast"
+msgstr "烈焰爆裂"
+
+msgid "campaignBonus|Mass Curse"
+msgstr "群体诅咒"
+
+msgid "campaignBonus|Mass Haste"
+msgstr "群体加速"
+
+msgid "campaignBonus|Mirror Image"
+msgstr "镜像术"
+
+msgid "campaignBonus|Resurrect"
+msgstr "复活术"
+
+msgid "campaignBonus|Steelskin"
+msgstr "钢肤术"
+
+msgid "campaignBonus|Summon Earth"
+msgstr "召唤土元素"
+
+msgid "campaignBonus|View Heroes"
+msgstr "探查英雄"
+
+msgid "campaignBonus|Ballista"
+msgstr "弩砲"
+
+msgid "campaignBonus|Black Pearl"
+msgstr "Black Pearl"
+
+msgid "campaignBonus|Caster's Bracelet"
+msgstr "Caster's Bracelet of Magic"
+
+msgid "campaignBonus|Defender Helm"
+msgstr "Defender Helm of Protection"
+
+msgid "campaignBonus|Breastplate"
+msgstr "Breastplate of Anduran"
+
+msgid "campaignBonus|Dragon Sword"
+msgstr "Dragon Sword of Dominion"
+
+msgid "campaignBonus|Fizbin Medal"
+msgstr "Fizbin of Misfortune"
+
+msgid "campaignBonus|Foremost Scroll"
+msgstr "Foremost Scroll of Knowledge"
+
+msgid "campaignBonus|Gauntlets"
+msgstr "Armored Gauntlets of Protection"
+
+msgid "campaignBonus|Hideous Mask"
+msgstr "Hideous Mask"
+
+msgid "campaignBonus|Mage's Ring"
+msgstr "Mage's Ring of Power"
+
+msgid "campaignBonus|Major Scroll"
+msgstr "Major Scroll of Knowledge"
+
+msgid "campaignBonus|Medal of Honor"
+msgstr "Medal of Honor"
+
+msgid "campaignBonus|Medal of Valor"
+msgstr "Medal of Valor"
+
+msgid "campaignBonus|Minor Scroll"
+msgstr "Minor Scroll of Knowledge"
+
+msgid "campaignBonus|Nomad Boots"
+msgstr "Nomad Boots of Mobility"
+
+msgid "campaignBonus|Power Axe"
+msgstr "Power Axe of Dominion"
+
+msgid "campaignBonus|Spiked Shield"
+msgstr "Spiked Shield"
+
+msgid "campaignBonus|Stealth Shield"
+msgstr "Stealth Shield of Protection"
+
+msgid "campaignBonus|Tax Lien"
+msgstr "Tax Lien"
+
+msgid "campaignBonus|Thunder Mace"
+msgstr "Thunder Mace of Dominion"
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr "Traveler's Boots of Mobility"
+
+msgid "campaignBonus|White Pearl"
+msgstr "White Pearl"
+
+msgid "campaignBonus|Basic Archery"
+msgstr "基础箭术"
+
+msgid "campaignBonus|Advanced Archery"
+msgstr "进阶箭术"
+
+msgid "campaignBonus|Expert Archery"
+msgstr "专家箭术"
+
+msgid "campaignBonus|Basic Ballistics"
+msgstr "基础弹道术"
+
+msgid "campaignBonus|Advanced Ballistics"
+msgstr "进阶弹道术"
+
+msgid "campaignBonus|Expert Ballistics"
+msgstr "专家弹道术"
+
+msgid "campaignBonus|Basic Diplomacy"
+msgstr "基础外交术"
+
+msgid "campaignBonus|Advanced Diplomacy"
+msgstr "进阶外交术"
+
+msgid "campaignBonus|Expert Diplomacy"
+msgstr "专家外交术"
+
+msgid "campaignBonus|Basic Eagle Eye"
+msgstr "基础鹰眼术"
+
+msgid "campaignBonus|Advanced Eagle Eye"
+msgstr "进阶鹰眼术"
+
+msgid "campaignBonus|Expert Eagle Eye"
+msgstr "专家鹰眼术"
+
+msgid "campaignBonus|Basic Estates"
+msgstr "基础产业术"
+
+msgid "campaignBonus|Advanced Estates"
+msgstr "进阶产业术"
+
+msgid "campaignBonus|Expert Estates"
+msgstr "专家产业术"
+
+msgid "campaignBonus|Basic Leadership"
+msgstr "基础领导术"
+
+msgid "campaignBonus|Advanced Leadership"
+msgstr "进阶领导术"
+
+msgid "campaignBonus|Expert Leadership"
+msgstr "专家领导术"
+
+msgid "campaignBonus|Basic Logistics"
+msgstr "基础后勤术"
+
+msgid "campaignBonus|Advanced Logistics"
+msgstr "进阶后勤术"
+
+msgid "campaignBonus|Expert Logistics"
+msgstr "专家后勤术"
+
+msgid "campaignBonus|Basic Luck"
+msgstr "基础运气"
+
+msgid "campaignBonus|Advanced Luck"
+msgstr "进阶运气"
+
+msgid "campaignBonus|Expert Luck"
+msgstr "专家运气"
+
+msgid "campaignBonus|Basic Mysticism"
+msgstr "基础神秘术"
+
+msgid "campaignBonus|Advanced Mysticism"
+msgstr "进阶神秘术"
+
+msgid "campaignBonus|Expert Mysticism"
+msgstr "专家神秘术"
+
+msgid "campaignBonus|Basic Navigation"
+msgstr "基础航海术"
+
+msgid "campaignBonus|Advanced Navigation"
+msgstr "进阶航海术"
+
+msgid "campaignBonus|Expert Navigation"
+msgstr "专家航海术"
+
+msgid "campaignBonus|Basic Necromancy"
+msgstr "基础亡灵巫术"
+
+msgid "campaignBonus|Advanced Necromancy"
+msgstr "进阶亡灵巫术"
+
+msgid "campaignBonus|Expert Necromancy"
+msgstr "专家亡灵巫术"
+
+msgid "campaignBonus|Basic Pathfinding"
+msgstr "基础寻路术"
+
+msgid "campaignBonus|Advanced Pathfinding"
+msgstr "进阶寻路术"
+
+msgid "campaignBonus|Expert Pathfinding"
+msgstr "专家寻路术"
+
+msgid "campaignBonus|Basic Scouting"
+msgstr "基础侦察术"
+
+msgid "campaignBonus|Advanced Scouting"
+msgstr "进阶侦察术"
+
+msgid "campaignBonus|Expert Scouting"
+msgstr "专家侦察术"
+
+msgid "campaignBonus|Basic Wisdom"
+msgstr "基础智慧"
+
+msgid "campaignBonus|Advanced Wisdom"
+msgstr "进阶智慧"
+
+msgid "campaignBonus|Expert Wisdom"
+msgstr "专家智慧"
+
+msgid ""
+"The main hero will have the \"%{artifact}\" artifact at the start of the "
+"scenario."
+msgstr ""
+"主英雄在场景开始时将拥有「%{artifact}」神器。"
+
+msgid ""
+"The kingdom will receive %{amount} additional %{resource} at the start of "
+"the scenario."
+msgstr ""
+"王国在场景开始时将额外获得 %{amount} %{resource}。"
+
+msgid ""
+"The kingdom will have %{amount} less %{resource} at the start of the "
+"scenario."
+msgstr ""
+"王国在场景开始时将减少 %{amount} %{resource}。"
+
+msgid ""
+"The main hero will have %{count} %{monster} at the start of the scenario."
+msgstr ""
+"主英雄在场景开始时将拥有 %{count} 个 %{monster}。"
+
+msgid ""
+"The main hero will have the \"%{spell}\" spell at the start of the scenario."
+msgstr ""
+"主英雄在场景开始时将拥有「%{spell}」法术。"
+
+msgid "The starting alignment of the scenario will be %{race}."
+msgstr "此场景的起始阵营将是 %{race}。"
+
+msgid ""
+"The main hero will receive a +%{count} to their %{skill} at the start of the "
+"scenario."
+msgstr ""
+"主英雄在场景开始时其 %{skill} 将获得 +%{count} 加成。"
+
+msgid "The main hero will have %{skill} at the start of the scenario."
+msgstr "主英雄在场景开始时将拥有 %{skill}。"
+
+msgid "Roland"
+msgstr "Roland"
+
+msgid "Archibald"
+msgstr "Archibald"
+
+msgid "Price of Loyalty"
+msgstr "忠诚的代价"
+
+msgid "Voyage Home"
+msgstr "归乡之旅"
+
+msgid "Wizard's Isle"
+msgstr "巫师之岛"
+
+msgid "Descendants"
+msgstr "后裔"
+
+msgid "Cannot build. You have already built here today."
+msgstr "无法建造，今日已经建造过了。"
+
+msgid "For this action it is necessary to build a castle first."
+msgstr "此操作需要先建造城堡。"
+
+msgid "The %{building} produces %{monster}."
+msgstr "%{building} 生产 %{monster}。"
+
+msgid "Requires:"
+msgstr "需求："
+
+msgid "Exit this menu without doing anything."
+msgstr "离开此选单，不进行任何操作。"
+
+msgid "Cannot build %{name}. The castle is too far away from an ocean."
+msgstr "无法建造 %{name}，城堡离海洋太远。"
+
+msgid "This building has been disabled."
+msgstr "此建筑已被停用。"
+
+msgid "Cannot afford the %{name}."
+msgstr "无法负担 %{name} 的费用。"
+
+msgid "The %{name} is already built."
+msgstr "%{name} 已经建造完成。"
+
+msgid "Cannot build the %{name}."
+msgstr "无法建造 %{name}。"
+
+msgid "Build %{name}."
+msgstr "建造 %{name}。"
+
+msgid "Blackridge"
+msgstr "Blackridge"
+
+msgid "Hillstone"
+msgstr "Hillstone"
+
+msgid "Pinehurst"
+msgstr "Pinehurst"
+
+msgid "Whiteshield"
+msgstr "Whiteshield"
+
+msgid "Woodhaven"
+msgstr "Woodhaven"
+
+msgid "Blackwind"
+msgstr "Blackwind"
+
+msgid "Bloodreign"
+msgstr "Bloodreign"
+
+msgid "Dragontooth"
+msgstr "Dragontooth"
+
+msgid "Greywind"
+msgstr "Greywind"
+
+msgid "Portsmith"
+msgstr "Portsmith"
+
+msgid "Atlantium"
+msgstr "Atlantium"
+
+msgid "Middle Gate"
+msgstr "Middle Gate"
+
+msgid "Sansobar"
+msgstr "Sansobar"
+
+msgid "Tundara"
+msgstr "Tundara"
+
+msgid "Vulcania"
+msgstr "Vulcania"
+
+msgid "Baywatch"
+msgstr "Baywatch"
+
+msgid "Fountainhead"
+msgstr "Fountainhead"
+
+msgid "Vertigo"
+msgstr "Vertigo"
+
+msgid "Wildabar"
+msgstr "Wildabar"
+
+msgid "Winterkill"
+msgstr "Winterkill"
+
+msgid "Brindamoor"
+msgstr "Brindamoor"
+
+msgid "Lakeside"
+msgstr "Lakeside"
+
+msgid "Nightshadow"
+msgstr "Nightshadow"
+
+msgid "Olympus"
+msgstr "Olympus"
+
+msgid "Sandcaster"
+msgstr "Sandcaster"
+
+msgid "Alamar"
+msgstr "Alamar"
+
+msgid "Burlock"
+msgstr "Burlock"
+
+msgid "Dragadune"
+msgstr "Dragadune"
+
+msgid "Kalindra"
+msgstr "Kalindra"
+
+msgid "Xabran"
+msgstr "Xabran"
+
+msgid "Algary"
+msgstr "Algary"
+
+msgid "Basenji"
+msgstr "Basenji"
+
+msgid "Blackfang"
+msgstr "Blackfang"
+
+msgid "New Dawn"
+msgstr "New Dawn"
+
+msgid "Sorpigal"
+msgstr "Sorpigal"
+
+msgid "Avone"
+msgstr "Avone"
+
+msgid "Big Oak"
+msgstr "Big Oak"
+
+msgid "Chandler"
+msgstr "Chandler"
+
+msgid "Erliquin"
+msgstr "Erliquin"
+
+msgid "Hampshire"
+msgstr "Hampshire"
+
+msgid "Antioch"
+msgstr "Antioch"
+
+msgid "Avalon"
+msgstr "Avalon"
+
+msgid "Roc Haven"
+msgstr "Roc Haven"
+
+msgid "South Mill"
+msgstr "South Mill"
+
+msgid "Weed Patch"
+msgstr "Weed Patch"
+
+msgid "Brownston"
+msgstr "Brownston"
+
+msgid "Hilltop"
+msgstr "Hilltop"
+
+msgid "Weddington"
+msgstr "Weddington"
+
+msgid "Westfork"
+msgstr "Westfork"
+
+msgid "Whittingham"
+msgstr "Whittingham"
+
+msgid "Cathcart"
+msgstr "Cathcart"
+
+msgid "Elk's Head"
+msgstr "Elk's Head"
+
+msgid "Roscomon"
+msgstr "Roscomon"
+
+msgid "Sherman"
+msgstr "Sherman"
+
+msgid "Yorksford"
+msgstr "Yorksford"
+
+msgid "Blackburn"
+msgstr "Blackburn"
+
+msgid "Blacksford"
+msgstr "Blacksford"
+
+msgid "Burton"
+msgstr "Burton"
+
+msgid "Pig's Eye"
+msgstr "Pig's Eye"
+
+msgid "Viper's Nest"
+msgstr "Viper's Nest"
+
+msgid "Fenton"
+msgstr "Fenton"
+
+msgid "Lankershire"
+msgstr "Lankershire"
+
+msgid "Lombard"
+msgstr "Lombard"
+
+msgid "Timberhill"
+msgstr "Timberhill"
+
+msgid "Troy"
+msgstr "Troy"
+
+msgid "Forder Oaks"
+msgstr "Forder Oaks"
+
+msgid "Meramec"
+msgstr "Meramec"
+
+msgid "Quick Silver"
+msgstr "Quick Silver"
+
+msgid "Westmoor"
+msgstr "Westmoor"
+
+msgid "Willow"
+msgstr "Willow"
+
+msgid "Corackston"
+msgstr "Corackston"
+
+msgid "Sheltemburg"
+msgstr "Sheltemburg"
+
+msgid "Cannot recruit - you already have a Hero in this town."
+msgstr "无法招募——此城镇中已有英雄。"
+
+msgid "Cannot recruit - you have too many Heroes."
+msgstr "无法招募——英雄数量已达上限。"
+
+msgid "Cannot afford a Hero."
+msgstr "无法负担英雄的招募费用。"
+
+msgid "There is no room in the garrison for this army."
+msgstr "城防部队中没有空间容纳此军队。"
+
+msgid "Fortifications"
+msgstr "防御工事"
+
+msgid "Farm"
+msgstr "农场"
+
+msgid "Thatched Hut"
+msgstr "茅草屋"
+
+msgid "Archery Range"
+msgstr "射箭场"
+
+msgid "Upg. Archery Range"
+msgstr "进阶射箭场"
+
+msgid "Blacksmith"
+msgstr "铁匠铺"
+
+msgid "Upg. Blacksmith"
+msgstr "进阶铁匠铺"
+
+msgid "Armory"
+msgstr "兵器库"
+
+msgid "Upg. Armory"
+msgstr "进阶兵器库"
+
+msgid "Jousting Arena"
+msgstr "马上比武场"
+
+msgid "Upg. Jousting Arena"
+msgstr "进阶马上比武场"
+
+msgid "Cathedral"
+msgstr "大教堂"
+
+msgid "Upg. Cathedral"
+msgstr "进阶大教堂"
+
+msgid "Coliseum"
+msgstr "竞技场"
+
+msgid "Garbage Heap"
+msgstr "垃圾堆"
+
+msgid "Hut"
+msgstr "小屋"
+
+msgid "Stick Hut"
+msgstr "木棍屋"
+
+msgid "Upg. Stick Hut"
+msgstr "进阶木棍屋"
+
+msgid "Den"
+msgstr "兽穴"
+
+msgid "Adobe"
+msgstr "土坯屋"
+
+msgid "Upg. Adobe"
+msgstr "进阶土坯屋"
+
+msgid "Bridge"
+msgstr "桥梁"
+
+msgid "Upg. Bridge"
+msgstr "进阶桥梁"
+
+msgid "Pyramid"
+msgstr "金字塔"
+
+msgid "Rainbow"
+msgstr "彩虹"
+
+msgid "Crystal Garden"
+msgstr "水晶花园"
+
+msgid "Treehouse"
+msgstr "树屋"
+
+msgid "Cottage"
+msgstr "小木屋"
+
+msgid "Upg. Cottage"
+msgstr "进阶小木屋"
+
+msgid "Stonehenge"
+msgstr "巨石阵"
+
+msgid "Upg. Stonehenge"
+msgstr "进阶巨石阵"
+
+msgid "Fenced Meadow"
+msgstr "围篱草地"
+
+msgid "sorceress|Red Tower"
+msgstr "红塔"
+
+msgid "Dungeon"
+msgstr "地牢"
+
+msgid "Waterfall"
+msgstr "瀑布"
+
+msgid "Cave"
+msgstr "洞穴"
+
+msgid "Crypt"
+msgstr "墓穴"
+
+msgid "Nest"
+msgstr "巢穴"
+
+msgid "Maze"
+msgstr "迷宫"
+
+msgid "Upg. Maze"
+msgstr "进阶迷宫"
+
+msgid "Swamp"
+msgstr "沼泽"
+
+msgid "Green Tower"
+msgstr "绿塔"
+
+msgid "warlock|Red Tower"
+msgstr "红塔"
+
+msgid "Black Tower"
+msgstr "黑塔"
+
+msgid "Library"
+msgstr "图书馆"
+
+msgid "Orchard"
+msgstr "果园"
+
+msgid "Habitat"
+msgstr "栖息地"
+
+msgid "Pen"
+msgstr "围栏"
+
+msgid "Foundry"
+msgstr "铸造厂"
+
+msgid "Upg. Foundry"
+msgstr "进阶铸造厂"
+
+msgid "Cliff Nest"
+msgstr "悬崖巢穴"
+
+msgid "Ivory Tower"
+msgstr "象牙塔"
+
+msgid "Upg. Ivory Tower"
+msgstr "进阶象牙塔"
+
+msgid "Cloud Castle"
+msgstr "云端城堡"
+
+msgid "Upg. Cloud Castle"
+msgstr "进阶云端城堡"
+
+msgid "Storm"
+msgstr "风暴"
+
+msgid "Skull Pile"
+msgstr "骷髅堆"
+
+msgid "Excavation"
+msgstr "发掘地"
+
+msgid "Graveyard"
+msgstr "墓地"
+
+msgid "Upg. Graveyard"
+msgstr "进阶墓地"
+
+msgid "Upg. Pyramid"
+msgstr "进阶金字塔"
+
+msgid "Mansion"
+msgstr "宅邸"
+
+msgid "Upg. Mansion"
+msgstr "进阶宅邸"
+
+msgid "Mausoleum"
+msgstr "陵寝"
+
+msgid "Upg. Mausoleum"
+msgstr "进阶陵寝"
+
+msgid "Laboratory"
+msgstr "实验室"
+
+msgid "Shrine"
+msgstr "神殿"
+
+msgid "Special"
+msgstr "特殊"
+
+msgid "Horde Building"
+msgstr "增产建筑"
+
+msgid "Dwelling 1"
+msgstr "住所 1"
+
+msgid "Dwelling 2"
+msgstr "住所 2"
+
+msgid "Upg. Dwelling 2"
+msgstr "进阶住所 2"
+
+msgid "Dwelling 3"
+msgstr "住所 3"
+
+msgid "Upg. Dwelling 3"
+msgstr "进阶住所 3"
+
+msgid "Dwelling 4"
+msgstr "住所 4"
+
+msgid "Upg. Dwelling 4"
+msgstr "进阶住所 4"
+
+msgid "Dwelling 5"
+msgstr "住所 5"
+
+msgid "Upg. Dwelling 5"
+msgstr "进阶住所 5"
+
+msgid "Dwelling 6"
+msgstr "住所 6"
+
+msgid "Upg. Dwelling 6"
+msgstr "进阶住所 6"
+
+msgid "2x Upg. Dwelling 6"
+msgstr "二阶住所 6"
+
+msgid ""
+"The Fortifications increase the toughness of the walls, increasing the "
+"number of turns it takes to knock them down."
+msgstr ""
+"防御工事增强城墙的坚固程度，增加击倒城墙所需的回合数。"
+
+msgid "The Farm increases production of Peasants by %{count} per week."
+msgstr "农场每周增加 %{count} 个农民的产量。"
+
+msgid ""
+"The Coliseum provides inspiring spectacles to defending troops, raising "
+"their morale by two during combat."
+msgstr ""
+"竞技场为守军提供鼓舞人心的表演，在战斗中将士气提升 2 点。"
+
+msgid "The Garbage Heap increases production of Goblins by %{count} per week."
+msgstr "垃圾堆每周增加 %{count} 个妖怪的产量。"
+
+msgid "The Rainbow increases the luck of the defending units by two."
+msgstr "彩虹将守军的运气提升 2 点。"
+
+msgid ""
+"The Crystal Garden increases production of Sprites by %{count} per week."
+msgstr ""
+"水晶花园每周增加 %{count} 个精灵的产量。"
+
+msgid "The Dungeon increases the income of the town by %{count} gold per day."
+msgstr "地牢每日增加城镇 %{count} 金币的收入。"
+
+msgid "The Waterfall increases production of Centaurs by %{count} per week."
+msgstr "瀑布每周增加 %{count} 个半人马的产量。"
+
+msgid ""
+"The Library increases the number of spells in the Guild by one for each "
+"level of the guild."
+msgstr ""
+"图书馆让公会每个等级多增加一个法术。"
+
+msgid "The Orchard increases production of Halflings by %{count} per week."
+msgstr "果园每周增加 %{count} 个侏儒的产量。"
+
+msgid "The Storm adds +2 to the power of spells of a defending spell caster."
+msgstr "风暴为防守方施法者的法术力量增加 +2。"
+
+msgid "The Skull Pile increases production of Skeletons by %{count} per week."
+msgstr "骷髅堆每周增加 %{count} 个骷髅兵的产量。"
+
+msgid "The Special building gives a specific bonus to the chosen castle type."
+msgstr "特殊建筑为所选城堡类型提供特定加成。"
+
+msgid ""
+"The Horde Building increases the growth rate of the level 1 creatures by 8 "
+"per week."
+msgstr ""
+"增产建筑每周增加 8 个一阶生物的产量。"
+
+msgid "Thieves' Guild"
+msgstr "盗贼公会"
+
+msgid "Tavern"
+msgstr "酒馆"
+
+msgid "Shipyard"
+msgstr "造船厂"
+
+msgid "Well"
+msgstr "水井"
+
+msgid "Statue"
+msgstr "雕像"
+
+msgid "Marketplace"
+msgstr "市场"
+
+msgid "Moat"
+msgstr "护城河"
+
+msgid "Castle"
+msgstr "城堡"
+
+msgid "Tent"
+msgstr "帐篷"
+
+msgid "Captain's Quarters"
+msgstr "队长营房"
+
+msgid "Mage Guild, Level 1"
+msgstr "法师公会，等级 1"
+
+msgid "Mage Guild, Level 2"
+msgstr "法师公会，等级 2"
+
+msgid "Mage Guild, Level 3"
+msgstr "法师公会，等级 3"
+
+msgid "Mage Guild, Level 4"
+msgstr "法师公会，等级 4"
+
+msgid "Mage Guild, Level 5"
+msgstr "法师公会，等级 5"
+
+msgid ""
+"The Shrine increases the necromancy skill of all your necromancers by 10 "
+"percent."
+msgstr ""
+"神殿使所有亡灵法师的亡灵巫术技能提升 10%。"
+
+msgid ""
+"The Thieves' Guild provides information on enemy players. Thieves' Guilds "
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
+msgstr ""
+"盗贼公会提供敌方玩家的情报。盗贼公会也能提供敌方城镇的侦察资讯。拥有越多公会"
+"可获得越多情报。"
+
+msgid "The Tavern increases morale for troops defending the castle."
+msgstr "酒馆提升防守城堡部队的士气。"
+
+msgid "The Shipyard allows ships to be built."
+msgstr "造船厂可建造船只。"
+
+msgid ""
+"The Well increases the growth rate of all dwellings by %{count} creatures "
+"per week."
+msgstr ""
+"水井每周增加所有住所 %{count} 个生物的产量。"
+
+msgid "The Statue increases the town's income by %{count} gold per day."
+msgstr "雕像每日增加城镇 %{count} 金币的收入。"
+
+msgid "The Left Turret provides extra firepower during castle combat."
+msgstr "左箭塔在城堡战斗中提供额外火力。"
+
+msgid "The Right Turret provides extra firepower during castle combat."
+msgstr "右箭塔在城堡战斗中提供额外火力。"
+
+msgid ""
+"The Marketplace can be used to convert one type of resource into another. "
+"The more marketplaces you control, the better the exchange rate."
+msgstr ""
+"市场可用来转换资源类型。控制的市场越多，兑换比率越好。"
+
+msgid ""
+"The Moat slows and weakens attacking units. Any walking unit entering the "
+"moat must end its turn there and can only move within the moat one hex at a "
+"time. Any creature present in the moat will have its defense skill reduced "
+"by %{count}."
+msgstr ""
+"护城河会减缓和削弱进攻的部队。任何步行单位进入护城河后必须在该处结束回合，且"
+"每次只能在河中移动一格。停留在护城河中的所有生物防御技能将降低 %{count}。"
+
+msgid ""
+"The Castle improves the town's defense and increases its income to %{count} "
+"gold per day."
+msgstr ""
+"城堡改善城镇的防御，并将收入增加至每日 %{count} 金币。"
+
+msgid ""
+"The Tent provides workers to build a castle, provided the materials and the "
+"gold are available."
+msgstr ""
+"帐篷提供工人来建造城堡，前提是有足够的材料和黄金。"
+
+msgid ""
+"The Captain's Quarters provides a captain to assist in the castle's defense "
+"when no hero is present."
+msgstr ""
+"队长营房在没有英雄驻守时提供一名队长协助城堡防御。"
+
+msgid ""
+"The Mage Guild allows heroes to learn spells and replenish their spell "
+"points."
+msgstr ""
+"法师公会让英雄学习法术并补充魔法值。"
+
+msgid "Recruit %{name}"
+msgstr "招募 %{name}"
+
+msgid "Month: %{month}, Week: %{week}, Day: %{day}"
+msgstr "月：%{month}，周：%{week}，日：%{day}"
+
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+"必须购买法术书才能使用法师公会，但目前没有空间放置法术书。尝试将一件神器转交"
+"给其他英雄。"
+
+msgid "Exit Castle"
+msgstr "离开城堡"
+
+msgid "Exit Town"
+msgstr "离开城镇"
+
+msgid "Show Income"
+msgstr "显示收入"
+
+msgid "Show previous town"
+msgstr "显示上一个城镇"
+
+msgid "Show next town"
+msgstr "显示下一个城镇"
+
+msgid "View Hero"
+msgstr "检视英雄"
+
+msgid "Click to show the next town."
+msgstr "按一下显示下一个城镇。"
+
+msgid "Click to show the previous town."
+msgstr "按一下显示上一个城镇。"
+
+msgid "This town may not be upgraded to a castle."
+msgstr "此城镇无法升级为城堡。"
+
+msgid "Town"
+msgstr "城镇"
+
+msgid "The above spells are available here."
+msgstr "以上法术在此处可用。"
+
+msgid "The spells the hero can learn have been added to their book."
+msgstr "英雄可学习的法术已加入其法术书。"
+
+msgid "Exit Mage Guild"
+msgstr "离开法师公会"
+
+msgid "A generous tip for the barkeep yields the following rumor:"
+msgstr "给酒保一笔大方的小费后得到了以下传言："
+
+msgid "Recruit Hero"
+msgstr "招募英雄"
+
+msgid "%{name} is a level %{value} %{race} "
+msgstr "%{name} 是等级 %{value} 的 %{race} "
+
+msgid "with %{count} artifacts."
+msgstr "拥有 %{count} 件神器。"
+
+msgid "with 1 artifact."
+msgstr "拥有 1 件神器。"
+
+msgid "without artifacts."
+msgstr "没有神器。"
+
+msgid "Recruit %{name} the %{race}"
+msgstr "招募 %{race} %{name}"
+
+msgid ""
+"'Spread' combat formation spreads the castle's units from the top to the "
+"bottom of the battlefield, with at least one empty space between each unit."
+msgstr ""
+"「分散」阵型将城堡的部队从战场顶部到底部展开，每支部队之间至少保留一格空间。"
+
+msgid ""
+"'Grouped' combat formation bunches the castle's units together in the center "
+"of the castle's side of the battlefield."
+msgstr ""
+"「集中」阵型将城堡的部队集中在战场己方一侧的中央。"
+
+msgid "Castle Options. Month: %{month}, Week: %{week}, Day: %{day}"
+msgstr "城堡选项。月：%{month}，周：%{week}，日：%{day}"
+
+msgid "Set garrison combat formation to 'Spread'"
+msgstr "将城防战斗阵型设为「分散」"
+
+msgid "Set garrison combat formation to 'Grouped'"
+msgstr "将城防战斗阵型设为「集中」"
+
+msgid "Exit Castle Options"
+msgstr "离开城堡选项"
+
+msgid "Spread Formation"
+msgstr "分散阵型"
+
+msgid "Grouped Formation"
+msgstr "集中阵型"
+
+msgid "Not enough resources to recruit creatures."
+msgstr "资源不足，无法招募生物。"
+
+msgid "You are unable to recruit at this time, your ranks are full."
+msgstr "目前无法招募，部队已满编。"
+
+msgid "No creatures available for purchase."
+msgstr "没有可招募的生物。"
+
+msgid "Recruit Creatures"
+msgstr "招募生物"
+
+msgid "Hire all creatures in the town."
+msgstr "招募城镇中的所有生物。"
+
+msgid "Max"
+msgstr "最大"
+
+msgid "Available"
+msgstr "可用"
+
+msgid "Town Population Information and Statistics"
+msgstr "城镇人口资讯与统计"
+
+msgid "Damage"
+msgstr "伤害"
+
+msgid "HP"
+msgstr "生命值"
+
+msgid "Speed"
+msgstr "速度"
+
+msgid "Growth"
+msgstr "成长"
+
+msgid "week"
+msgstr "周"
+
+msgid "View World"
+msgstr "检视世界"
+
+msgid "View the entire world."
+msgstr "检视整个世界。"
+
+msgid "Puzzle"
+msgstr "拼图"
+
+msgid "View the obelisk puzzle."
+msgstr "检视方尖碑拼图。"
+
+msgid "Scenario Information"
+msgstr "场景资讯"
+
+msgid "View information on the scenario you are currently playing."
+msgstr "检视目前正在进行的场景资讯。"
+
+msgid "Dig for the Ultimate Artifact."
+msgstr "挖掘终极神器。"
+
+msgid "Digging"
+msgstr "挖掘"
+
+msgid "Arena"
+msgstr "竞技场"
+
+msgid ""
+"You enter the arena and face a pack of vicious lions. You handily defeat "
+"them, to the wild cheers of the crowd. Impressed by your skill, the aged "
+"trainer of gladiators agrees to train you in a skill of your choice."
+msgstr ""
+"你进入竞技场面对一群凶猛的狮子。你轻松击败了牠们，观众疯狂欢呼。角斗士训练师"
+"年事已高，十分欣赏你的技术，同意让你选择一项技能接受训练。"
+
+msgid "Attack Skill"
+msgstr "攻击技能"
+
+msgid "Defense Skill"
+msgstr "防御技能"
+
+msgid "Shots"
+msgstr "射击次数"
+
+msgid "Shots Left"
+msgstr "剩余射击次数"
+
+msgid "Hit Points"
+msgstr "生命值"
+
+msgid "Hit Points Left"
+msgstr "剩余生命值"
+
+msgid "You can't afford to upgrade your troops!"
+msgstr "无法负担部队的升级费用！"
+
+msgid ""
+"Your troops can be upgraded, but it will cost you dearly. Do you wish to "
+"upgrade them?"
+msgstr ""
+"部队可以升级，但费用不菲。确定要升级吗？"
+
+msgid "Are you sure you want to dismiss this army?"
+msgstr "确定要解散此军队吗？"
+
+msgid "Upgrade"
+msgstr "升级"
+
+msgid "Upgrade your troops."
+msgstr "升级部队。"
+
+msgid "Dismiss"
+msgstr "解散"
+
+msgid "Dismiss this army."
+msgstr "解散此军队。"
+
+msgid ""
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+"一群 %{monster} 渴望更伟大的荣耀，希望加入你的队伍。\n"
+"是否接受？"
+
+msgid "Followers"
+msgstr "追随者"
+
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
+"army for the sum of %{gold} gold.\n"
+"Do you accept?"
+msgstr ""
+"%{monster} 被你的外交辞令打动，愿意以 %{gold} 金币加入你的军队。\n"
+"是否接受？"
+
+msgid ""
+"The creatures are swayed by your diplomatic\n"
+"tongue, and make you an offer:\n"
+"\n"
+msgstr ""
+"这些生物被你的外交辞令打动，\n"
+"向你提出了一个条件:\n"
+"\n"
+
+msgid ""
+"%{offer} of the %{total} %{monster} will join your army, and the rest will "
+"leave you alone, for the sum of %{gold} gold.\n"
+"Do you accept?"
+msgstr ""
+"%{total} 个 %{monster} 中有 %{offer} 个愿意加入你的军队，其余的则会离开，费用"
+"为 %{gold} 金币。\n"
+"是否接受？"
+
+msgid ""
+"All %{offer} of the %{monster} will join your army for the sum of %{gold} "
+"gold.\n"
+"Do you accept?"
+msgstr ""
+"全部 %{offer} 个 %{monster} 愿意以 %{gold} 金币加入你的军队。\n"
+"是否接受？"
+
+msgid "(Rate: %{percent})"
+msgstr "(比率：%{percent})"
+
+msgid "off"
+msgstr "关闭"
+
+msgid "Music"
+msgstr "音乐"
+
+msgid "Effects"
+msgstr "音效"
+
+msgid "MIDI"
+msgstr "MIDI"
+
+msgid "MIDI Expansion"
+msgstr "MIDI 扩充"
+
+msgid "External"
+msgstr "外部"
+
+msgid "Music Type"
+msgstr "音乐类型"
+
+msgid "3D Audio"
+msgstr "3D 音效"
+
+msgid "Toggle ambient music level."
+msgstr "调整环境音乐音量。"
+
+msgid "Toggle foreground sounds level."
+msgstr "调整前景音效音量。"
+
+msgid "Change the type of music."
+msgstr "变更音乐类型。"
+
+msgid "Toggle the 3D effect of foreground sounds."
+msgstr "切换前景音效的 3D 效果。"
+
+msgid "Build a new ship:"
+msgstr "建造新船："
+
+msgid "Resource cost:"
+msgstr "资源花费："
+
+msgid "Total: "
+msgstr "总计："
+
+msgid "Need: "
+msgstr "需要："
+
+msgid "Restart Game"
+msgstr "重新开始游戏"
+
+msgid "There was an issue during saving."
+msgstr "储存时发生问题。"
+
+msgid "New Game"
+msgstr "新游戏"
+
+msgid "Start a single or multi-player game."
+msgstr "开始单人或多人游戏。"
+
+msgid "Load Game"
+msgstr "载入游戏"
+
+msgid "Load a previously saved game."
+msgstr "载入先前储存的游戏。"
+
+msgid "Restart the scenario."
+msgstr "重新开始此场景。"
+
+msgid "Save Game"
+msgstr "储存游戏"
+
+msgid "Save the current game."
+msgstr "储存目前的游戏。"
+
+msgid "Quick Save"
+msgstr "快速存档"
+
+msgid "Save the current game without name selection."
+msgstr "不选择名称直接储存目前的游戏。"
+
+msgid "Quit"
+msgstr "结束"
+
+msgid "Quit out of Heroes of Might and Magic II."
+msgstr "结束 Heroes of Might and Magic II。"
+
+msgid "Change the language of the game."
+msgstr "变更游戏的语言。"
+
+msgid "Select Game Language"
+msgstr "选择游戏语言"
+
+msgid "Change the graphics settings of the game."
+msgstr "变更游戏的图形设定。"
+
+msgid "Graphics"
+msgstr "图形"
+
+msgid "Mouse Cursor"
+msgstr "滑鼠游标"
+
+msgid "Toggle colored cursor on or off. This is only an aesthetic choice."
+msgstr "切换彩色游标的开关。这仅为视觉偏好设定。"
+
+msgid "Interface Type"
+msgstr "介面类型"
+
+msgid "Toggle the type of interface you want to use."
+msgstr "切换要使用的介面类型。"
+
+msgid "Text Support"
+msgstr "文字辅助"
+
+msgid ""
+"Toggle text support mode to output extra information about windows and "
+"events in the game."
+msgstr ""
+"切换文字辅助模式，以输出关于游戏视窗和事件的额外资讯。"
+
+msgid ""
+"Map\n"
+"Difficulty"
+msgstr ""
+"地图\n"
+"难度"
+
+msgid ""
+"Game\n"
+"Difficulty"
+msgstr ""
+"游戏\n"
+"难度"
+
+msgid "Rating"
+msgstr "评分"
+
+msgid "Map Size"
+msgstr "地图大小"
+
+msgid "Opponents"
+msgstr "对手"
+
+msgid "Class"
+msgstr "职业"
+
+msgid ""
+"Victory\n"
+"Conditions"
+msgstr ""
+"胜利\n"
+"条件"
+
+msgid ""
+"Loss\n"
+"Conditions"
+msgstr ""
+"失败\n"
+"条件"
+
+msgid "About"
+msgstr "关于"
+
+msgid "Click to read notes from the map creator."
+msgstr "按一下阅读地图制作者的备注。"
+
+msgid "Map Description"
+msgstr "地图描述"
+
+msgid "First select recipients!"
+msgstr "请先选择收礼对象！"
+
+msgid "You cannot select %{resource}!"
+msgstr "无法选择 %{resource}！"
+
+msgid "Set %{resource-type} Count"
+msgstr "设定 %{resource-type} 数量"
+
+msgid "Select Recipients"
+msgstr "选择收礼对象"
+
+msgid "Your Funds"
+msgstr "你的资金"
+
+msgid "Planned Gift"
+msgstr "计划赠礼"
+
+msgid "Gift from %{name}"
+msgstr "来自 %{name} 的赠礼"
+
+msgid "Resolution"
+msgstr "解析度"
+
+msgid "Fullscreen"
+msgstr "全萤幕"
+
+msgid "window|Mode"
+msgstr "视窗模式"
+
+msgid "Windowed"
+msgstr "视窗化"
+
+msgid "V-Sync"
+msgstr "垂直同步"
+
+msgid "FPS"
+msgstr "FPS"
+
+msgid "System Info"
+msgstr "系统资讯"
+
+msgid "Nearest"
+msgstr "邻近取样"
+
+msgid "Screen Scaling Type"
+msgstr "萤幕缩放类型"
+
+msgid "Linear"
+msgstr "线性"
+
+msgid "Change the resolution of the game."
+msgstr "变更游戏的解析度。"
+
+msgid "Select Game Resolution"
+msgstr "选择游戏解析度"
+
+msgid "Toggle between fullscreen and windowed modes."
+msgstr "切换全萤幕与视窗模式。"
+
+msgid ""
+"Toggle the type of screen scaling you want to use. Linear scaling makes the "
+"resized screen image blurry while nearest scaling preserves the sharpness of "
+"the original game. The nearest scaling looks best on integer scales, for "
+"example 2.0x or 3.0x."
+msgstr ""
+"切换要使用的萤幕缩放类型。线性缩放会使画面模糊，而邻近取样则保留原始游戏的清"
+"晰度。邻近取样在整数倍率 (如 2.0x 或 3.0x) 下效果最佳。"
+
+msgid ""
+"The V-Sync option can be enabled to resolve flickering issues on some "
+"monitors."
+msgstr ""
+"可启用垂直同步选项来解决某些萤幕上的闪烁问题。"
+
+msgid "Show extra information such as FPS and current time."
+msgstr "显示额外资讯，例如 FPS 和目前时间。"
+
+msgid "Hotkey: "
+msgstr "快速键： "
+
+msgid "Category: "
+msgstr "分类："
+
+msgid "Event: "
+msgstr "事件："
+
+msgid "Hot Keys:"
+msgstr "快速键："
+
+msgid "Hide"
+msgstr "隐藏"
+
+msgid "Show"
+msgstr "显示"
+
+msgid "Army Estimation"
+msgstr "军队估算"
+
+msgid "Canonical"
+msgstr "正规"
+
+msgid "Numeric"
+msgstr "数值"
+
+msgid "Toggle interface visibility."
+msgstr "切换介面可见度。"
+
+msgid "Scroll Speed"
+msgstr "卷动速度"
+
+msgid "Sets the speed at which you scroll the window."
+msgstr "调整视窗卷动的速度。"
+
+msgid ""
+"Toggle how army sizes are displayed when right-clicking armies on the "
+"adventure map. \n"
+"\n"
+"Canonical: Army sizes are shown as descriptive text (e.g. \"Few\").\n"
+"\n"
+"Numeric: Army sizes are shown as numeric ranges (e.g. \"1-4\")."
+msgstr ""
+"切换在冒险地图上右键按一下军队时的显示方式。\n"
+"\n"
+"正规：军队数量以描述性文字显示 (例如「少量」)。\n"
+"\n"
+"数值：军队数量以数字范围显示 (例如「1-4」)。"
+
+msgid "Select Game Language:"
+msgstr "选择游戏语言："
+
+msgid "Select Language:"
+msgstr "选择语言："
+
+msgid "Click to choose the selected language."
+msgstr "按一下选择所选的语言。"
+
+msgid "%{name} has gained a level."
+msgstr "%{name} 升级了。"
+
+msgid "%{skill} +1"
+msgstr "%{skill} +1"
+
+msgid "You have learned %{skill}."
+msgstr "学会了 %{skill}。"
+
+msgid ""
+"%{name} has gained a level.\n"
+"\n"
+"%{skill} +1"
+msgstr ""
+"%{name} 升级了。\n"
+"\n"
+"%{skill} +1"
+
+msgid ""
+"You may learn either:\n"
+"%{skill1}\n"
+"or\n"
+"%{skill2}"
+msgstr ""
+"可以学习以下其一:\n"
+"%{skill1}\n"
+"或\n"
+"%{skill2}"
+
+msgid "Learn %{secondary-skill}"
+msgstr "学习 %{secondary-skill}"
+
+msgid "n/a"
+msgstr "不适用"
+
+msgid ""
+"Please inspect our fine wares. If you feel like offering a trade, click on "
+"the items you wish to trade with and for."
+msgstr ""
+"请浏览我们的精美商品。若有意交易，请按一下要交易的物品。"
+
+msgid ""
+"You have received quite a bargain. I expect to make no profit on the deal. "
+"Can I interest you in any of my other wares?"
+msgstr ""
+"你得到了相当划算的交易，我预计不会有任何利润。还对我的其他商品感兴趣吗？"
+
+msgid "I can offer you %{count} for 1 unit of %{resfrom}."
+msgstr "可以提供 %{count} 换取 1 单位的 %{resfrom}。"
+
+msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
+msgstr "可以提供 1 单位的 %{resto} 换取 %{count} 单位的 %{resfrom}。"
+
+msgid "Min"
+msgstr "最小"
+
+msgid "Qty to trade"
+msgstr "交易数量"
+
+msgid "Trading Post"
+msgstr "交易站"
+
+msgid "Your Resources"
+msgstr "你的资源"
+
+msgid "Available Trades"
+msgstr "可用交易"
+
+msgid "guarded by %{count} %{monster}"
+msgstr "由 %{count} 个 %{monster} 守卫"
+
+msgid "guarded by "
+msgstr "守卫者："
+
+msgid "(available: %{count})"
+msgstr "(可用：%{count})"
+
+msgid "(empty)"
+msgstr "(空)"
+
+msgid "already learned"
+msgstr "已学会"
+
+msgid "treeOfKnowledge|free"
+msgstr "免费"
+
+msgid "already claimed"
+msgstr "已领取"
+
+msgid "not claimed"
+msgstr "未领取"
+
+msgid "already knows this skill"
+msgstr "已知晓此技能"
+
+msgid "already has max skills"
+msgstr "技能数已满"
+
+msgid "(already visited)"
+msgstr "(已造访)"
+
+msgid "(not visited)"
+msgstr "(未造访)"
+
+msgid "%{color} Barrier"
+msgstr "%{color}屏障"
+
+msgid "(tent visited)"
+msgstr "(帐篷已造访)"
+
+msgid "%{color} Tent"
+msgstr "%{color}帐篷"
+
+msgid "Road"
+msgstr "道路"
+
+msgid "(digging ok)"
+msgstr "(可挖掘)"
+
+msgid "(no digging)"
+msgstr "(无法挖掘)"
+
+msgid "penalty: %{cost}"
+msgstr "惩罚：%{cost}"
+
+msgid "Defenders:"
+msgstr "守卫者："
+
+msgid "Unknown"
+msgstr "未知"
+
+msgid "heroQuickInfo|(Level %{level})"
+msgstr "(等级 %{level})"
+
+msgid "Attack:"
+msgstr "攻击："
+
+msgid "Defense:"
+msgstr "防御："
+
+msgid "Spell Power:"
+msgstr "魔法力量："
+
+msgid "Knowledge:"
+msgstr "知识："
+
+msgid "Spell Points:"
+msgstr "魔法值："
+
+msgid "Move Points:"
+msgstr "移动力："
+
+msgid "Uncharted Territory"
+msgstr "未探索区域"
+
+msgid "Random Map Generator"
+msgstr "随机地图产生器"
+
+msgid "rmg|Player count:"
+msgstr "玩家数量："
+
+msgid "rmg|Map layout:"
+msgstr "地图布局："
+
+msgid "rmg|Water percentage:"
+msgstr "水域百分比："
+
+msgid "rmg|Monster strength:"
+msgstr "怪物强度："
+
+msgid "rmg|Resource availability:"
+msgstr "资源可用性："
+
+msgid "rmg|Map seed:"
+msgstr "地图种子码："
+
+msgid "Click to generate a new map."
+msgstr "按一下产生新地图。"
+
+msgid "Return to the previous menu."
+msgstr "返回上一个选单。"
+
+msgid "Cost per troop:"
+msgstr "每支部队花费："
+
+msgid "Available: %{count}"
+msgstr "可用：%{count}"
+
+msgid "Number to buy:"
+msgstr "购买数量："
+
+msgid "Recruit selected monsters."
+msgstr "招募选取的怪物。"
+
+msgid "Select maximum monsters to be recruited."
+msgstr "选择最大招募数量。"
+
+msgid "Select only 1 monster to be recruited."
+msgstr "选择仅招募 1 个怪物。"
+
+msgid "Select this game resolution."
+msgstr "选择此游戏解析度。"
+
+msgid ""
+"Selecting this resolution will set a resolution that is scaled from the "
+"original resolution (%{resolution}) by multiplying it with the number in the "
+"brackets (%{scale}).\n"
+"\n"
+"A resolution with a clean integer number (2.0x, 3.0x etc.) will usually look "
+"better because the pixels are upscaled evenly in both horizontal and "
+"vertical directions."
+msgstr ""
+"选择此解析度将以原始解析度 (%{resolution}) 乘以括号中的数字 (%{scale}) 来设"
+"定。\n"
+"\n"
+"使用整数倍率 (2.0x、3.0x 等) 的解析度通常看起来更好，因为画素在水平和垂直方向"
+"上均匀放大。"
+
+msgid "Select Game Resolution:"
+msgstr "选择游戏解析度："
+
+msgid "Click to apply the selected resolution."
+msgstr "按一下套用选取的解析度。"
+
+msgid "Click to select the maximum amount."
+msgstr "按一下选择最大数量。"
+
+msgid "Click to select the minimum amount."
+msgstr "按一下选择最小数量。"
+
+msgid "Click to apply the entered number."
+msgstr "按一下套用输入的数字。"
+
+msgid "Click to apply the entered text."
+msgstr "按一下套用输入的文字。"
+
+msgid "Click to open the Virtual Keyboard dialog."
+msgstr "按一下开启虚拟键盘对话方块。"
+
+msgid "Open Virtual Keyboard"
+msgstr "开启虚拟键盘"
+
+msgid "How many creatures do you wish to move?"
+msgstr "要移动多少生物？"
+
+msgid "Select how many units to separate into:"
+msgstr "选择要分出多少单位："
+
+msgid "Map: "
+msgstr "地图："
+
+msgid ""
+"\n"
+"\n"
+"Month: "
+msgstr ""
+"\n"
+"\n"
+"月："
+
+msgid ", Week: "
+msgstr "，周："
+
+msgid ", Day: "
+msgstr "，日："
+
+msgid ""
+"\n"
+"\n"
+"Location: "
+msgstr ""
+"\n"
+"\n"
+"位置："
+
+msgid "saveLoadDialog|Name"
+msgstr "名称"
+
+msgid "saveLoadDialog|Date"
+msgstr "日期"
+
+msgid "Are you sure you want to delete file:"
+msgstr "确定要删除此档案吗："
+
+msgid "Warning"
+msgstr "警告"
+
+msgid "Click to save the current game."
+msgstr "按一下储存目前的游戏。"
+
+msgid "Click to load a previously saved game."
+msgstr "按一下载入先前储存的游戏。"
+
+msgid "Click here if you wish to sort save files by their name."
+msgstr "按此处以依名称排序存档。"
+
+msgid "Sort by Name"
+msgstr "依名称排序"
+
+msgid ""
+"Click here if you you wish to sort save files by their last modified date."
+msgstr ""
+"按此处以依修改日期排序存档。"
+
+msgid "Sort by Date"
+msgstr "依日期排序"
+
+msgid "File to Save:"
+msgstr "储存档案："
+
+msgid "File to Load:"
+msgstr "载入档案："
+
+msgid "Terrain object"
+msgstr "地形物件"
+
+msgid "There is nothing to select from."
+msgstr "没有可选择的选项。"
+
+msgid "There are no castles to select from."
+msgstr "没有可选择的城堡。"
+
+msgid "Accept the choice made."
+msgstr "确认所做的选择。"
+
+msgid "Click to enable all items."
+msgstr "按一下启用所有选项。"
+
+msgid "Enable All Items"
+msgstr "启用所有选项"
+
+msgid "Click to disable all items."
+msgstr "按一下停用所有选项。"
+
+msgid "Disable All Items"
+msgstr "停用所有选项"
+
+msgid "There are no secondary skills to select from."
+msgstr "没有可选择的次要技能。"
+
+msgid "Select Skill:"
+msgstr "选择技能："
+
+msgid "There are no spells to select."
+msgstr "没有可选择的法术。"
+
+msgid "Select Spell:"
+msgstr "选择法术："
+
+msgid "There are no artifacts to select from."
+msgstr "没有可选择的神器。"
+
+msgid "Select Artifact:"
+msgstr "选择神器："
+
+msgid "There are no monsters to select from."
+msgstr "没有可选择的怪物。"
+
+msgid "Select Monster:"
+msgstr "选择怪物："
+
+msgid "There are no heroes to select from."
+msgstr "没有可选择的英雄。"
+
+msgid "Select Hero:"
+msgstr "选择英雄："
+
+msgid "Select Monsters:"
+msgstr "选择怪物："
+
+msgid "Select Artifacts:"
+msgstr "选择神器："
+
+msgid "race|Random"
+msgstr "随机"
+
+msgid "Click to start placing the selected hero."
+msgstr "按一下开始放置选取的英雄。"
+
+msgid "%{color} %{race}"
+msgstr "%{color} %{race}"
+
+msgid "You will place"
+msgstr "你将放置"
+
+msgid "Click to select this class."
+msgstr "按一下选择此职业。"
+
+msgid "Click to select this color."
+msgstr "按一下选择此颜色。"
+
+msgid "Select Treasure:"
+msgstr "选择宝藏："
+
+msgid "Select Ocean Object:"
+msgstr "选择海洋物件："
+
+msgid "Castle/town placing:"
+msgstr "城堡/城镇放置："
+
+msgid "doubleLinedRace|Neutral"
+msgstr "中立"
+
+msgid "TOWN"
+msgstr "城镇"
+
+msgid "CASTLE"
+msgstr "城堡"
+
+msgid "Click to start placing the selected castle/town."
+msgstr "按一下开始放置选取的城堡/城镇。"
+
+msgid "Click to select town placing."
+msgstr "按一下选择城镇放置。"
+
+msgid "Click to select castle placing."
+msgstr "按一下选择城堡放置。"
+
+msgid "%{color} %{race} %{townOrCastle}"
+msgstr "%{color} %{race} %{townOrCastle}"
+
+msgid "race|Neutral"
+msgstr "中立"
+
+msgid "Select Dwelling:"
+msgstr "选择住所："
+
+msgid "Select Landscape Object:"
+msgstr "选择地景物件："
+
+msgid "Mine placing:"
+msgstr "矿场放置："
+
+msgid ""
+"Resource\n"
+"type:"
+msgstr ""
+"资源\n"
+"类型："
+
+msgid "%{mineName} appearance:"
+msgstr "%{mineName} 外观："
+
+msgid "Click to select the color."
+msgstr "按一下选择颜色。"
+
+msgid "Click to select %{object} as the resource generator to be placed."
+msgstr "按一下选择 %{object} 作为要放置的资源产生器。"
+
+msgid "Select Mountain Object:"
+msgstr "选择山脉物件："
+
+msgid "Select Rock Object:"
+msgstr "选择岩石物件："
+
+msgid "Select Tree Object:"
+msgstr "选择树木物件："
+
+msgid "Select Power Up Object:"
+msgstr "选择增强物件："
+
+msgid "Select Adventure Object:"
+msgstr "选择冒险物件："
+
+msgid "Select color:"
+msgstr "选择颜色："
+
+msgid "Players Icon"
+msgstr "玩家图示"
+
+msgid ""
+"Indicates how many players total are in the scenario. Any positions not "
+"occupied by human players will be occupied by computer players."
+msgstr ""
+"显示场景中的总玩家数。未被人类玩家占据的位置将由电脑玩家占据。"
+
+msgid ""
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
+msgstr ""
+"显示地图大小是\n"
+"小型 (36 x 36)、中型\n"
+"(72 x 72)、大型 (108 x 108)\n"
+"或超大型 (144 x 144)。"
+
+msgid "Size Icon"
+msgstr "大小图示"
+
+msgid "The Succession Wars"
+msgstr "继位战争"
+
+msgid "The Price of Loyalty"
+msgstr "忠诚的代价"
+
+msgid "Resurrection"
+msgstr "复苏"
+
+msgid "This map is made for \"%{game-version}\" version of the game."
+msgstr "此地图是为游戏的「%{game-version}」版本制作的。"
+
+msgid "Map Type"
+msgstr "地图类型"
+
+msgid "Map Type:\n"
+msgstr "地图类型:\n"
+
+msgid ""
+"\n"
+"\n"
+"Supported languages:\n"
+msgstr ""
+"\n"
+"\n"
+"支援的语言:\n"
+
+msgid "Lose all your heroes and towns."
+msgstr "失去所有英雄和城镇。"
+
+msgid "Lose a specific town."
+msgstr "失去特定城镇。"
+
+msgid "Lose a specific hero."
+msgstr "失去特定英雄。"
+
+msgid "Run out of time. Fail to win by a certain point."
+msgstr "时间耗尽，未能在期限前获胜。"
+
+msgid "Loss Condition"
+msgstr "失败条件"
+
+msgid "Defeat all enemy heroes and towns."
+msgstr "击败所有敌方英雄和城镇。"
+
+msgid "Capture a specific town."
+msgstr "占领特定城镇。"
+
+msgid "Defeat a specific hero."
+msgstr "击败特定英雄。"
+
+msgid "Find a specific artifact."
+msgstr "找到特定神器。"
+
+msgid "Your side must defeat the opposing side."
+msgstr "必须击败对方。"
+
+msgid "Accumulate a large amount of gold."
+msgstr "累积大量黄金。"
+
+msgid "Victory Condition"
+msgstr "胜利条件"
+
+msgid "Map difficulty:"
+msgstr "地图难度："
+
+msgid "N"
+msgstr "N"
+
+msgid "Are you sure you want to delete the map:"
+msgstr "确定要删除此地图吗："
+
+msgid "No maps exist at that size."
+msgstr "没有该大小的地图。"
+
+msgid "Small Maps"
+msgstr "小型地图"
+
+msgid "View only maps of size small (36 x 36)."
+msgstr "仅显示小型 (36 x 36) 地图。"
+
+msgid "Medium Maps"
+msgstr "中型地图"
+
+msgid "View only maps of size medium (72 x 72)."
+msgstr "仅显示中型 (72 x 72) 地图。"
+
+msgid "Large Maps"
+msgstr "大型地图"
+
+msgid "View only maps of size large (108 x 108)."
+msgstr "仅显示大型 (108 x 108) 地图。"
+
+msgid "Extra Large Maps"
+msgstr "超大地图"
+
+msgid "View only maps of size extra large (144 x 144)."
+msgstr "仅显示超大型 (144 x 144) 地图。"
+
+msgid "All Maps"
+msgstr "所有地图"
+
+msgid "View all maps, regardless of size."
+msgstr "显示所有地图，不限大小。"
+
+msgid "Selected Name"
+msgstr "选取的名称"
+
+msgid "The name of the currently selected map."
+msgstr "目前选取地图的名称。"
+
+msgid "Selected Map Difficulty"
+msgstr "选取地图的难度"
+
+msgid ""
+"The map difficulty of the currently selected map. The map difficulty is "
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
+msgstr ""
+"目前选取地图的难度。地图难度由场景设计者决定。地图难度越高，敌人可能越多或越"
+"强、资源越少，或出现其他对人类玩家不利的特殊条件。"
+
+msgid "Selected Map Description"
+msgstr "选取地图的描述"
+
+msgid "Jump"
+msgstr "跳跃"
+
+msgid "Hero Speed"
+msgstr "英雄速度"
+
+msgid "Don't Show"
+msgstr "不显示"
+
+msgid "Enemy Speed"
+msgstr "敌方速度"
+
+msgid "Auto Resolve"
+msgstr "自动结算"
+
+msgid "Auto, No Spells"
+msgstr "自动，无法术"
+
+msgid "Battles"
+msgstr "战斗"
+
+msgid "combatMode|Manual"
+msgstr "手动"
+
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr "变更英雄在主画面上的移动速度。"
+
+msgid ""
+"Sets the speed that computer heroes move at. You can also elect not to view "
+"computer movement at all."
+msgstr ""
+"设定电脑英雄的移动速度。也可以选择完全不显示电脑的移动。"
+
+msgid "Toggle instant battle mode."
+msgstr "切换即时战斗模式。"
+
+msgid "Att."
+msgstr "攻"
+
+msgid "Def."
+msgstr "防"
+
+msgid "Power"
+msgstr "力量"
+
+msgid "Knowl"
+msgstr "知识"
+
+msgid "1st"
+msgstr "第一"
+
+msgid "2nd"
+msgstr "第二"
+
+msgid "3rd"
+msgstr "第三"
+
+msgid "4th"
+msgstr "第四"
+
+msgid "5th"
+msgstr "第五"
+
+msgid "6th"
+msgstr "第六"
+
+msgid "Oracle: Player Rankings"
+msgstr "神谕：玩家排名"
+
+msgid "Thieves' Guild: Player Rankings"
+msgstr "盗贼公会：玩家排名"
+
+msgid "Number of Towns:"
+msgstr "城镇数："
+
+msgid "Number of Castles:"
+msgstr "城堡数："
+
+msgid "Number of Heroes:"
+msgstr "英雄数："
+
+msgid "Gold in Treasury:"
+msgstr "国库黄金："
+
+msgid "Wood & Ore:"
+msgstr "木材与矿石："
+
+msgid "Gems, Cr, Slf & Mer:"
+msgstr "宝石、水晶、硫磺与水银："
+
+msgid "Obelisks Found:"
+msgstr "已发现方尖碑："
+
+msgid "Artifacts:"
+msgstr "神器："
+
+msgid "Total Army Strength:"
+msgstr "军队总战力："
+
+msgid "Income:"
+msgstr "收入："
+
+msgid "Best Hero:"
+msgstr "最佳英雄："
+
+msgid "Best Hero Stats:"
+msgstr "最佳英雄属性："
+
+msgid "Personality:"
+msgstr "性格："
+
+msgid "Best Monster:"
+msgstr "最强怪物："
+
+msgid "Random Castle Name"
+msgstr "随机城堡名称"
+
+msgid "Random Town Name"
+msgstr "随机城镇名称"
+
+msgid "BANNED SPELLS"
+msgstr "停用法术"
+
+msgid "Click to accept the changes made."
+msgstr "按一下接受所做的变更。"
+
+msgid "Exit this dialog, discarding the changes made."
+msgstr "离开此对话方块，放弃所做的变更。"
+
+msgid "Click to ban spells from appearing in the Mage Guild."
+msgstr "按一下禁止法术出现在法师公会中。"
+
+msgid "Banned Spells"
+msgstr "停用法术"
+
+msgid "Select spells that will appear in the Mage Guild."
+msgstr "选择将出现在法师公会中的法术。"
+
+msgid "SET SPELLS"
+msgstr "设定法术"
+
+msgid "Allow Castle build"
+msgstr "允许建造城堡"
+
+msgid "Default Buildings"
+msgstr "预设建筑"
+
+msgid "RESTRICT"
+msgstr "限制"
+
+msgid "Default Army"
+msgstr "预设军队"
+
+msgid "Castle Army"
+msgstr "城堡军队"
+
+msgid "Town Army"
+msgstr "城镇军队"
+
+msgid "You have unsaved changes. Do you wish to proceed?"
+msgstr "有未储存的变更。确定要继续吗？"
+
+msgid "Click to change the Castle name."
+msgstr "按一下变更城堡名称。"
+
+msgid "Enter Castle name:"
+msgstr "输入城堡名称："
+
+msgid "Reset the Castle name."
+msgstr "重置城堡名称。"
+
+msgid "Allow to build a castle in this town."
+msgstr "允许在此城镇建造城堡。"
+
+msgid "Toggle the use of default buildings. Custom buildings will be reset!"
+msgstr "切换使用预设建筑。自订建筑将被重置！"
+
+msgid "Toggle building construction restriction mode."
+msgstr "切换建筑建造限制模式。"
+
+msgid "Restrict Building Construction"
+msgstr "限制建筑建造"
+
+msgid "Use default defenders army."
+msgstr "使用预设守军。"
+
+msgid "Reset the army."
+msgstr "重置军队。"
+
+msgid "Set custom Castle Army."
+msgstr "设定自订城堡军队。"
+
+msgid "Set spells to appear in the Mage Guild."
+msgstr "设定出现在法师公会中的法术。"
+
+msgid "Set Spells"
+msgstr "设定法术"
+
+msgid "Castle Settings"
+msgstr "城堡设定"
+
+msgid "Message Text:"
+msgstr "讯息文字："
+
+msgid "Reward:"
+msgstr "奖励："
+
+msgid "Player colors allowed to get event:"
+msgstr "允许取得事件的玩家颜色："
+
+msgid "Computer colors allowed to get event:"
+msgstr "允许取得事件的电脑颜色："
+
+msgid "First day of occurrence:"
+msgstr "首次发生日："
+
+msgid "Repeat period (days):"
+msgstr "重复周期 (天):"
+
+msgid "Allow %{color} human player to get event"
+msgstr "允许 %{color} 人类玩家取得事件"
+
+msgid ""
+"If this checkbox is checked, this event will trigger for the %{color} player "
+"if they are controlled by a human."
+msgstr ""
+"勾选此选项且 %{color} 玩家由人类控制时，此事件就会触发。"
+
+msgid "Allow %{color} computer player to get event"
+msgstr "允许 %{color} 电脑玩家取得事件"
+
+msgid ""
+"If this checkbox is checked, this event will trigger for the %{color} player "
+"if they are controlled by a computer."
+msgstr ""
+"勾选此选项且 %{color} 玩家由电脑控制时，此事件就会触发。"
+
+msgid "Set %{resource-type} Count:"
+msgstr "设定 %{resource-type} 数量："
+
+msgid "Message:"
+msgstr "讯息："
+
+msgid "Click to save the Event properties."
+msgstr "按一下储存事件属性。"
+
+msgid "No resources will be given as a reward."
+msgstr "不会给予任何资源作为奖励。"
+
+msgid "Resources"
+msgstr "资源"
+
+msgid "Resources will be given as a reward."
+msgstr "将给予资源作为奖励。"
+
+msgid "Click here to change the event message."
+msgstr "按此处变更事件讯息。"
+
+msgid "Event Message Text"
+msgstr "事件讯息文字"
+
+msgid "Day: %{day}"
+msgstr "日：%{day}"
+
+msgid "Daily events:"
+msgstr "每日事件："
+
+msgid "Click to save the events."
+msgstr "按一下储存事件。"
+
+msgid "Add Event"
+msgstr "新增事件"
+
+msgid "Add an additional event."
+msgstr "新增额外的事件。"
+
+msgid "Edit Event"
+msgstr "编辑事件"
+
+msgid "Edit an existing event."
+msgstr "编辑既有的事件。"
+
+msgid "Delete Event"
+msgstr "删除事件"
+
+msgid "Delete an existing event."
+msgstr "删除既有的事件。"
+
+msgid "Effects:"
+msgstr "效果："
+
+msgid "Conditions:"
+msgstr "条件："
+
+msgid "Cancel event after first visit"
+msgstr "首次造访后取消事件"
+
+msgid "Computer colors allowed to get the event:"
+msgstr "允许取得事件的电脑颜色："
+
+msgid "Set Experience value:"
+msgstr "设定经验值："
+
+msgid "Artifact"
+msgstr "神器"
+
+msgid "No artifact will be given by the event."
+msgstr "此事件不会给予任何神器。"
+
+msgid "Delete Artifact"
+msgstr "删除神器"
+
+msgid "Delete an artifact from the event."
+msgstr "从事件中删除神器。"
+
+msgid "No Secondary Skill will be given by the event."
+msgstr "此事件不会给予任何次要技能。"
+
+msgid "Secondary Skill"
+msgstr "次要技能"
+
+msgid "Delete Secondary Skill"
+msgstr "删除次要技能"
+
+msgid "Delete the Secondary Skill from the event."
+msgstr "从事件中删除次要技能。"
+
+msgid "No resources will be part of this event."
+msgstr "此事件不包含任何资源。"
+
+msgid "These resources will be a part of the event."
+msgstr "这些资源将成为事件的一部分。"
+
+msgid ""
+"If this checkbox is checked, the event will trigger only once. If not "
+"checked, the event will trigger every time one of the specified players "
+"crosses the event tile."
+msgstr ""
+"勾选此选项后，事件只会触发一次。若未勾选，每次指定的玩家经过事件格时都会触"
+"发。"
+
+msgid "Click to make selection."
+msgstr "按一下进行选择。"
+
+msgid "%{objects} cannot be placed on water."
+msgstr "%{objects} 无法放置在水上。"
+
+msgid ""
+"The Ultimate Artifact can only be placed on terrain where digging is "
+"possible."
+msgstr ""
+"终极神器只能放置在可挖掘的地形上。"
+
+msgid "%{objects} must be placed on water."
+msgstr "%{objects} 必须放置在水上。"
+
+msgid "Action objects cannot be placed outside the map."
+msgstr "动作物件无法放置在地图外。"
+
+msgid "Action objects must be placed on clear tiles."
+msgstr "动作物件必须放置在空白格上。"
+
+msgid "A maximum of %{count} %{objects} can be placed on the map."
+msgstr "地图上最多可放置 %{count} 个 %{objects}。"
+
+msgid "Not able to generate a map with given parameters."
+msgstr "无法以指定参数产生地图。"
+
+msgid ""
+"Do you wish to return to the game's Main Menu? All unsaved changes will be "
+"lost."
+msgstr ""
+"确定要返回游戏主选单吗？所有未储存的变更将会遗失。"
+
+msgid "Editor"
+msgstr "编辑器"
+
+msgid ""
+"Are you sure you want to load a new map? (Any unsaved changes to the current "
+"map will be lost.)"
+msgstr ""
+"确定要载入新地图吗？（目前地图所有未储存的变更将会遗失。）"
+
+msgid ""
+"Are you sure you want to create a new map? (Any unsaved changes to the "
+"current map will be lost.)"
+msgstr ""
+"确定要建立新地图吗？（目前地图所有未储存的变更将会遗失。）"
+
+msgid "Main Menu"
+msgstr "主选单"
+
+msgid ""
+"Do you wish to return to the game's Main Menu? (Any unsaved changes to the "
+"current map will be lost.)"
+msgstr ""
+"确定要返回游戏主选单吗？（目前地图所有未储存的变更将会遗失。）"
+
+msgid "Unsaved Changes"
+msgstr "未储存的变更"
+
+msgid ""
+"This map has either terrain changes, undo history or has not yet been saved "
+"to a file.\n"
+"\n"
+"Do you wish to save the current map?"
+msgstr ""
+"此地图有地形变更、复原历史纪录或尚未储存至档案。\n"
+"\n"
+"是否要储存目前的地图？"
+
+msgid "Unplayable Map"
+msgstr "无法游玩的地图"
+
+msgid ""
+"This map is not playable. You need at least one human player for the map to "
+"be playable."
+msgstr ""
+"此地图无法游玩。至少需要一位人类玩家才能游玩。"
+
+msgid "Start Map"
+msgstr "开始地图"
+
+msgid ""
+"Do you wish to leave the Editor and start the map? (Any unsaved changes to "
+"the current map will be lost.)"
+msgstr ""
+"确定要离开编辑器并开始地图吗？（目前地图所有未储存的变更将会遗失。）"
+
+msgid "Create a new map from scratch."
+msgstr "从头建立新地图。"
+
+msgid "New Map"
+msgstr "新地图"
+
+msgid "Load Map"
+msgstr "载入地图"
+
+msgid "Load an existing map."
+msgstr "载入既有的地图。"
+
+msgid "Save Map"
+msgstr "储存地图"
+
+msgid "Save the current map."
+msgstr "储存目前的地图。"
+
+msgid "Quit out of the map editor."
+msgstr "离开地图编辑器。"
+
+msgid "Return to the game's Main Menu."
+msgstr "返回游戏主选单。"
+
+msgid "Leave the Editor and play the map in the Standard Game mode."
+msgstr "离开编辑器，以标准游戏模式游玩此地图。"
+
+msgid "Input %{object} text:"
+msgstr "输入 %{object} 文字："
+
+msgid "Set Random Ultimate Artifact Radius:"
+msgstr "设定随机终极神器半径："
+
+msgid "%{object} has no properties to change."
+msgstr "%{object} 没有可变更的属性。"
+
+msgid "This artifact"
+msgstr "此神器"
+
+msgid "The total number of obelisks is %{count}."
+msgstr "方尖碑总数为 %{count}。"
+
+msgid "There are no players on the map, so no one can own this object."
+msgstr "地图上没有玩家，因此无人可拥有此物件。"
+
+msgid "Roads"
+msgstr "道路"
+
+msgid "Streams"
+msgstr "溪流"
+
+msgid ""
+"A maximum of %{count} heroes including jailed heroes can be placed on the "
+"map."
+msgstr ""
+"地图上最多可放置 %{count} 位英雄（含被囚禁的英雄）。"
+
+msgid ""
+"A maximum of %{count} heroes of the same color can be placed on the map."
+msgstr ""
+"地图上最多可放置 %{count} 位相同颜色的英雄。"
+
+msgid "Failed to update player information."
+msgstr "更新玩家资讯失败。"
+
+msgid "Only one Random Ultimate Artifact can be placed on the map."
+msgstr "地图上只能放置一个随机终极神器。"
+
+msgid "A maximum of %{count} obelisks can be placed on the map."
+msgstr "地图上最多可放置 %{count} 座方尖碑。"
+
+msgid "The same object exists on the tile."
+msgstr "此格上已存在相同的物件。"
+
+msgid "The map is corrupted."
+msgstr "地图已损坏。"
+
+msgid "Unable to locate data directory to save the map."
+msgstr "无法找到储存地图的资料目录。"
+
+msgid "Unable to create a directory to save the map."
+msgstr "无法建立储存地图的目录。"
+
+msgid "Unable to locate a directory to save the map."
+msgstr "无法找到储存地图的目录。"
+
+msgid "Are you sure you want to overwrite the existing map?"
+msgstr "确定要覆写既有的地图吗？"
+
+msgid "Map saved to: "
+msgstr "地图已储存至："
+
+msgid "Failed to save the map."
+msgstr "地图储存失败。"
+
+msgid "Used to place %{object}."
+msgstr "用于放置 %{object}。"
+
+msgid "Select object type"
+msgstr "选择物件类型"
+
+msgid ""
+"Click here to\n"
+"select a monster."
+msgstr ""
+"按此处\n"
+"选择怪物。"
+
+msgid ""
+"Click here to\n"
+"select another monster."
+msgstr ""
+"按此处\n"
+"选择另一个怪物。"
+
+msgid "Erase"
+msgstr "清除"
+
+msgid "Mountains"
+msgstr "山脉"
+
+msgid "Rocks"
+msgstr "岩石"
+
+msgid "Trees"
+msgstr "树木"
+
+msgid "Water Objects"
+msgstr "水域物件"
+
+msgid "Miscellaneous"
+msgstr "杂项"
+
+msgid "Artifacts"
+msgstr "神器"
+
+msgid "Dwellings"
+msgstr "住所"
+
+msgid "Mines"
+msgstr "矿场"
+
+msgid "Power-ups"
+msgstr "增强物件"
+
+msgid "Treasures"
+msgstr "宝藏"
+
+msgid "Heroes"
+msgstr "英雄"
+
+msgid "Towns"
+msgstr "城镇"
+
+msgid "editorDetailMode|Edit"
+msgstr "编辑"
+
+msgid "editorDetailMode|Move"
+msgstr "移动"
+
+msgid "editorDetailMode|Copy"
+msgstr "复制"
+
+msgid "editorErasure|Mountains"
+msgstr "山脉"
+
+msgid "editorErasure|Rocks"
+msgstr "岩石"
+
+msgid "editorErasure|Trees"
+msgstr "树木"
+
+msgid "editorErasure|Miscellaneous and Water landscape objects"
+msgstr "杂项与水域地景物件"
+
+msgid "editorErasure|Adventure non pickable objects"
+msgstr "不可拾取的冒险物件"
+
+msgid "editorErasure|Castles"
+msgstr "城堡"
+
+msgid "editorErasure|Adventure pickable objects"
+msgstr "可拾取的冒险物件"
+
+msgid "editorErasure|Monsters"
+msgstr "怪物"
+
+msgid "editorErasure|Heroes"
+msgstr "英雄"
+
+msgid "editorErasure|Roads"
+msgstr "道路"
+
+msgid "editorErasure|Streams"
+msgstr "溪流"
+
+msgid ""
+"Draws terrain in\n"
+"%{size} by %{size} square increments."
+msgstr ""
+"以 %{size} x %{size} 格为单位\n"
+"绘制地形。"
+
+msgid ""
+"Erases objects in\n"
+"%{size} by %{size} square increments."
+msgstr ""
+"以 %{size} x %{size} 格为单位\n"
+"清除物件。"
+
+msgid "Small Brush"
+msgstr "小笔刷"
+
+msgid "Medium Brush"
+msgstr "中笔刷"
+
+msgid "Large Brush"
+msgstr "大笔刷"
+
+msgid "Area Fill"
+msgstr "区域填充"
+
+msgid "Used to click and drag for filling in large areas."
+msgstr "按住并拖曳以填充大范围区域。"
+
+msgid "Clear Area"
+msgstr "清除区域"
+
+msgid "Used to click and drag for clearing large areas."
+msgstr "按住并拖曳以清除大范围区域。"
+
+msgid ""
+"Costs %{rate} times normal movement for all heroes. (Pathfinding reduces or "
+"eliminates the penalty.)"
+msgstr ""
+"所有英雄经过时需消耗正常移动力的 %{rate} 倍。（寻路技能可降低或消除此惩罚。）"
+
+msgid "Traversable only by boat."
+msgstr "只能以船只通行。"
+
+msgid "No special modifiers."
+msgstr "无特殊修饰。"
+
+msgid "Edit objects on the Adventure Map."
+msgstr "编辑冒险地图上的物件。"
+
+msgid "Move objects on the Adventure Map."
+msgstr "移动冒险地图上的物件。"
+
+msgid "Copy objects on the Adventure Map."
+msgstr "复制冒险地图上的物件。"
+
+msgid "Toggle the erasure of %{type} objects."
+msgstr "切换 %{type} 物件的清除。"
+
+msgid ""
+"Objects of this type will be deleted with the Erase tool. Left-click here to "
+"deselect this type. Press and hold this button to deselect all other object "
+"types."
+msgstr ""
+"此类型的物件将被清除工具删除。左键按一下此处取消选取此类型。长按此按钮取消选"
+"取所有其他物件类型。"
+
+msgid ""
+"Objects of this type will NOT be deleted with the Erase tool. Left-click "
+"here to select this type. Press and hold this button to select all other "
+"object types."
+msgstr ""
+"此类型的物件不会被清除工具删除。左键按一下此处选取此类型。长按此按钮选取所有"
+"其他物件类型。"
+
+msgid "Terrain Mode"
+msgstr "地形模式"
+
+msgid "Used to draw the underlying grass, dirt, water, etc. on the map."
+msgstr "用于在地图上绘制草地、泥土、水域等基础地形。"
+
+msgid "Landscape Objects Mode"
+msgstr "地景物件模式"
+
+msgid ""
+"Used to place landscape objects (mountains, rocks, trees, etc.) on the map."
+msgstr ""
+"用于在地图上放置地景物件（山脉、岩石、树木等）。"
+
+msgid "Detail Mode"
+msgstr "细节模式"
+
+msgid "Used for moving or customizing objects."
+msgstr "用于移动或自订物件。"
+
+msgid "Adventure Objects Mode"
+msgstr "冒险物件模式"
+
+msgid ""
+"Used to place adventure objects (artifacts, dwellings, mines, treasures, "
+"etc.) on the map."
+msgstr ""
+"用于在地图上放置冒险物件（神器、住所、矿场、宝藏等）。"
+
+msgid "Kingdom Objects Mode"
+msgstr "王国物件模式"
+
+msgid "Used to place kingdom objects (towns, castles and heroes) on the map."
+msgstr "用于在地图上放置王国物件 (城镇、城堡和英雄)。"
+
+msgid "Monsters Mode"
+msgstr "怪物模式"
+
+msgid "Used to place monsters on the map."
+msgstr "用于在地图上放置怪物。"
+
+msgid "Allows you to draw streams by clicking and dragging."
+msgstr "按住并拖曳以绘制溪流。"
+
+msgid "Stream Mode"
+msgstr "溪流模式"
+
+msgid "Allows you to draw roads by clicking and dragging."
+msgstr "按住并拖曳以绘制道路。"
+
+msgid "Road Mode"
+msgstr "道路模式"
+
+msgid "Erase Mode"
+msgstr "清除模式"
+
+msgid "Used to erase objects from the map."
+msgstr "用于清除地图上的物件。"
+
+msgid "Change between zoom and normal view."
+msgstr "切换缩放与正常检视。"
+
+msgid "Magnify"
+msgstr "放大"
+
+msgid "Undo"
+msgstr "复原"
+
+msgid "Undo your last action."
+msgstr "复原上一个动作。"
+
+msgid "Redo"
+msgstr "重做"
+
+msgid "Redo the last undone action."
+msgstr "重做上一个复原的动作。"
+
+msgid "Edit map title, description, and other general information."
+msgstr "编辑地图示题、描述和其他一般资讯。"
+
+msgid "Specifications"
+msgstr "规格"
+
+msgid "File Options"
+msgstr "档案选项"
+
+msgid ""
+"Open the file options menu, where you can save or load maps, or quit out of "
+"the editor."
+msgstr ""
+"开启档案选项选单，可储存或载入地图，或离开编辑器。"
+
+msgid "View the editor system options, which let you customize the editor."
+msgstr "检视编辑器系统选项，可自订编辑器。"
+
+msgid "Supported languages:"
+msgstr "支援的语言："
+
+msgid "Language"
+msgstr "语言"
+
+msgid "This language already exists in the list."
+msgstr "此语言已存在于列表中。"
+
+msgid "A map should have at least one language."
+msgstr "地图至少应有一种语言。"
+
+msgid "Click to apply changes."
+msgstr "按一下套用变更。"
+
+msgid "Add Language"
+msgstr "新增语言"
+
+msgid "Add an additional language."
+msgstr "新增额外的语言。"
+
+msgid "Delete Language"
+msgstr "删除语言"
+
+msgid "Delete an existing language."
+msgstr "删除既有的语言。"
+
+msgid "Failed to generate a random map with given parameters."
+msgstr "无法以指定参数产生随机地图。"
+
+msgid ""
+"Create a new map, either from scratch or using the random map generator."
+msgstr ""
+"建立新地图，可从头开始或使用随机地图产生器。"
+
+msgid "Exit the Editor and return to the game's Main Menu."
+msgstr "离开编辑器并返回游戏主选单。"
+
+msgid "From Scratch"
+msgstr "从头开始"
+
+msgid "Start from scratch with a blank map."
+msgstr "从空白地图开始。"
+
+msgid "Create a randomly generated map."
+msgstr "建立随机产生的地图。"
+
+msgid "Random"
+msgstr "随机"
+
+msgid "Back"
+msgstr "返回"
+
+msgid "Return to the Editor's main menu options."
+msgstr "返回编辑器主选单。"
+
+msgid ""
+"Generate a random map that is %{size} squares wide and %{size} squares high."
+msgstr ""
+"产生一张 %{size} x %{size} 格的随机地图。"
+
+msgid "Create a map that is %{size} squares wide and %{size} squares high."
+msgstr "建立一张 %{size} x %{size} 格的地图。"
+
+msgid "Return to the previous menu options."
+msgstr "返回上一个选单。"
+
+msgid "No maps available!"
+msgstr "没有可用的地图！"
+
+msgid "[%{pos}]: %{race} hero"
+msgstr "[%{pos}]: %{race} 英雄"
+
+msgid "[%{pos}]: %{name}, %{race} hero"
+msgstr "[%{pos}]: %{name}，%{race} 英雄"
+
+msgid "[%{pos}]: %{race} castle"
+msgstr "[%{pos}]: %{race} 城堡"
+
+msgid "[%{pos}]: %{race} town"
+msgstr "[%{pos}]: %{race} 城镇"
+
+msgid "[%{pos}]: %{name}, %{race} castle"
+msgstr "[%{pos}]: %{name}，%{race} 城堡"
+
+msgid "[%{pos}]: %{name}, %{race} town"
+msgstr "[%{pos}]: %{name}，%{race} 城镇"
+
+msgid "None."
+msgstr "无。"
+
+msgid "One side defeats the other."
+msgstr "一方击败另一方。"
+
+msgid "Accumulate gold."
+msgstr "累积黄金。"
+
+msgid "Run out of time."
+msgstr "时间耗尽。"
+
+msgid "alliance|1st"
+msgstr "第一"
+
+msgid "alliance|2nd"
+msgstr "第二"
+
+msgid "alliance|3rd"
+msgstr "第三"
+
+msgid "alliance|4th"
+msgstr "第四"
+
+msgid "alliance|5th"
+msgstr "第五"
+
+msgid "Special Loss Condition"
+msgstr "特殊失败条件"
+
+msgid "Special Victory Condition"
+msgstr "特殊胜利条件"
+
+msgid "Allow standard victory conditions"
+msgstr "允许标准胜利条件"
+
+msgid "Allow this condition also for AI"
+msgstr "同时允许 AI 使用此条件"
+
+msgid "Set alliances:"
+msgstr "设定联盟："
+
+msgid "{%number} alliance: "
+msgstr "第 {%number} 联盟："
+
+msgid "Gold:"
+msgstr "黄金："
+
+msgid "Select a Town to capture to achieve victory"
+msgstr "选择要占领以获胜的城镇"
+
+msgid "Click here to change the town needed to capture to achieve victory."
+msgstr "按此处变更需要占领以获胜的城镇。"
+
+msgid "Select a Hero to defeat to achieve victory"
+msgstr "选择要击败以获胜的英雄"
+
+msgid "Click here to change the hero needed to defeat to achieve victory."
+msgstr "按此处变更需要击败以获胜的英雄。"
+
+msgid "Put %{color} player in the %{alliance} alliance"
+msgstr "将 %{color} 玩家加入第 %{alliance} 联盟"
+
+msgid ""
+"If this checkbox is checked, the %{color} player will be in the %{alliance} "
+"alliance."
+msgstr ""
+"勾选此选项后，%{color} 玩家将加入第 %{alliance} 联盟。"
+
+msgid "Days:"
+msgstr "天数："
+
+msgid "Select a Town to lose to suffer defeat"
+msgstr "选择失去即落败的城镇"
+
+msgid "Click here to change the town whose loss would mean defeat."
+msgstr "按此处变更失去即落败的城镇。"
+
+msgid "Select a Hero to lose to suffer defeat"
+msgstr "选择失去即落败的英雄"
+
+msgid "Click here to change the hero whose loss would mean defeat."
+msgstr "按此处变更失去即落败的英雄。"
+
+msgid "Map Difficulty"
+msgstr "地图难度"
+
+msgid "RUMORS"
+msgstr "谣言"
+
+msgid "EVENTS"
+msgstr "事件"
+
+msgid "LANGUAGE"
+msgstr "语言"
+
+msgid "map|ABOUT"
+msgstr "关于"
+
+msgid "Change Map Name:"
+msgstr "变更地图名称："
+
+msgid "Change Map Description:"
+msgstr "变更地图描述："
+
+msgid "map|About"
+msgstr "关于"
+
+msgid "Click to edit custom rumors."
+msgstr "按一下编辑自订谣言。"
+
+msgid "Rumors"
+msgstr "谣言"
+
+msgid "Click to edit daily events."
+msgstr "按一下编辑每日事件。"
+
+msgid "Events"
+msgstr "事件"
+
+msgid "Click to change the language of the map."
+msgstr "按一下变更地图语言。"
+
+msgid ""
+"Click to edit notes from the map creator. These notes are optional and do "
+"not appear during gameplay."
+msgstr ""
+"按一下编辑地图制作者备注。此备注为选填，不会在游玩时显示。"
+
+msgid "Click to change your map name."
+msgstr "按一下变更地图名称。"
+
+msgid "Map Name"
+msgstr "地图名称"
+
+msgid "Click to change the description of the current map."
+msgstr "按一下变更目前地图的描述。"
+
+msgid "Click to change the victory condition of the current map."
+msgstr "按一下变更目前地图的胜利条件。"
+
+msgid "Click to change the loss condition of the current map."
+msgstr "按一下变更目前地图的失败条件。"
+
+msgid "Indicates the player types in the scenario. Click to change."
+msgstr "显示场景中的玩家类型。按一下可变更。"
+
+msgid "Player Type"
+msgstr "玩家类型"
+
+msgid ""
+"Click to set map difficulty. More difficult maps might include more or "
+"stronger enemies, fewer resources, or other special conditions making things "
+"tougher for the human player."
+msgstr ""
+"按一下设定地图难度。地图难度越高，敌人可能越多或越强、资源越少，或出现其他对"
+"人类玩家不利的特殊条件。"
+
+msgid ""
+"editor|%{object}\n"
+"(%{color} player)"
+msgstr ""
+"%{object}\n"
+"(%{color}玩家)"
+
+msgid "editor|%{count} %{resource}"
+msgstr "%{count} %{resource}"
+
+msgid "Animation"
+msgstr "动画"
+
+msgid "Passability"
+msgstr "通行性"
+
+msgid "Toggle animation of the objects."
+msgstr "切换物件的动画。"
+
+msgid "Toggle display of objects' passability."
+msgstr "切换物件通行性的显示。"
+
+msgid "Rumors:"
+msgstr "谣言："
+
+msgid "Rumor:"
+msgstr "谣言："
+
+msgid "Rumor"
+msgstr "谣言"
+
+msgid "This rumor already exists in the list."
+msgstr "此谣言已存在于列表中。"
+
+msgid "Click to save the rumors."
+msgstr "按一下储存谣言。"
+
+msgid "Add Rumor"
+msgstr "新增谣言"
+
+msgid "Add an additional rumor."
+msgstr "新增额外的谣言。"
+
+msgid "Edit Rumor"
+msgstr "编辑谣言"
+
+msgid "Edit an existing rumor."
+msgstr "编辑既有的谣言。"
+
+msgid "Delete Rumor"
+msgstr "删除谣言"
+
+msgid "Delete an existing rumor."
+msgstr "删除既有的谣言。"
+
+msgid ""
+"\n"
+"\n"
+"Language:\n"
+msgstr ""
+"\n"
+"\n"
+"语言:\n"
+
+msgid ""
+"\n"
+"\n"
+"Size: "
+msgstr ""
+"\n"
+"\n"
+"大小："
+
+msgid ""
+"\n"
+"\n"
+"Description: "
+msgstr ""
+"\n"
+"\n"
+"描述："
+
+msgid "Save Map:"
+msgstr "储存地图："
+
+msgid "Click to save the current map."
+msgstr "按一下储存目前的地图。"
+
+msgid "Click to enable all secondary skills."
+msgstr "按一下启用所有次要技能。"
+
+msgid "Enable All Secondary Skills"
+msgstr "启用所有次要技能"
+
+msgid "Click to disable all secondary skills."
+msgstr "按一下停用所有次要技能。"
+
+msgid "Disable All Secondary Skills"
+msgstr "停用所有次要技能"
+
+msgid "Click to show only level %{level} spells."
+msgstr "按一下仅显示等级 %{level} 法术。"
+
+msgid "Spells level"
+msgstr "法术等级"
+
+msgid "Click to enable all spells."
+msgstr "按一下启用所有法术。"
+
+msgid "Enable All Spells"
+msgstr "启用所有法术"
+
+msgid "Click to disable all spells."
+msgstr "按一下停用所有法术。"
+
+msgid "Disable All Spells"
+msgstr "停用所有法术"
+
+msgid "Riddle:"
+msgstr "谜语："
+
+msgid "Answers:"
+msgstr "答案："
+
+msgid "Answer:"
+msgstr "答案："
+
+msgid "Answer"
+msgstr "答案"
+
+msgid "This answer exists in the list."
+msgstr "此答案已存在于列表中。"
+
+msgid "Click to save the Sphinx properties."
+msgstr "按一下储存人面狮身像属性。"
+
+msgid "Add Answer"
+msgstr "新增答案"
+
+msgid "Add an additional answer for the question."
+msgstr "为问题新增额外的答案。"
+
+msgid "Edit Answer"
+msgstr "编辑答案"
+
+msgid "Edit an existing answer for the question."
+msgstr "编辑既有的答案。"
+
+msgid "Delete Answer"
+msgstr "删除答案"
+
+msgid "Delete an existing answer for the question."
+msgstr "删除既有的答案。"
+
+msgid "Riddle"
+msgstr "谜语"
+
+msgid "No artifact will be given as a reward."
+msgstr "不会给予任何神器作为奖励。"
+
+msgid "Delete an artifact from the reward."
+msgstr "从奖励中删除神器。"
+
+msgid "Day: %{day} Week: %{week} Month: %{month}"
+msgstr "日：%{day} 周：%{week} 月：%{month}"
+
+msgid "difficulty|Easy"
+msgstr "简单"
+
+msgid "difficulty|Normal"
+msgstr "普通"
+
+msgid "difficulty|Hard"
+msgstr "困难"
+
+msgid "difficulty|Expert"
+msgstr "专家"
+
+msgid "difficulty|Impossible"
+msgstr "不可能"
+
+msgid "and more..."
+msgstr "以及更多……"
+
+msgid "Easy"
+msgstr "简单"
+
+msgid "Normal"
+msgstr "普通"
+
+msgid "Hard"
+msgstr "困难"
+
+msgid "Campaign Difficulty"
+msgstr "战役难度"
+
+msgid ""
+"Choose this difficulty to experience the game's story with less challenge. "
+"The AI will be weaker than at Normal difficulty."
+msgstr ""
+"选择此难度以较轻松的方式体验游戏剧情。AI 将比普通难度更弱。"
+
+msgid ""
+"Choose this difficulty to experience the campaign as per the original design."
+msgstr ""
+"选择此难度以原始设计体验战役。"
+
+msgid ""
+"Choose this difficulty if you want more challenge. The AI will be stronger "
+"than at Normal difficulty."
+msgstr ""
+"想要更多挑战时，请选择此难度。AI 会比普通难度更强。"
+
+msgid ""
+"Congratulations!\n"
+"\n"
+"Days: %{days}\n"
+msgstr ""
+"恭喜！\n"
+"\n"
+"天数：%{days}\n"
+
+msgid ""
+"\n"
+"Difficulty: %{difficulty}\n"
+"\n"
+msgstr ""
+"\n"
+"难度：%{difficulty}\n"
+"\n"
+
+msgid ""
+"Score: %{score}\n"
+"\n"
+"Rating:\n"
+"%{rating}"
+msgstr ""
+"分数：%{score}\n"
+"\n"
+"评价:\n"
+"%{rating}"
+
+msgid "Start the selected scenario."
+msgstr "开始选取的场景。"
+
+msgid "View Intro"
+msgstr "观看序幕"
+
+msgid "View the intro video for the current state of the campaign."
+msgstr "观看目前战役状态的序幕影片。"
+
+msgid ""
+"Select the campaign difficulty. This can be changed at any point during the "
+"campaign. However, the final score will be calculated based solely on the "
+"lowest difficulty of a completed scenario during the campaign."
+msgstr ""
+"选择战役难度。可在战役中随时变更。但最终分数将仅依据战役中已完成场景的最低难"
+"度计算。"
+
+msgid "Restart the current scenario."
+msgstr "重新开始目前的场景。"
+
+msgid "Difficulty"
+msgstr "难度"
+
+msgid ""
+"You have changed the campaign difficulty. The final high score will be "
+"calculated based solely on the lowest difficulty level for a completed "
+"scenario during the campaign. Do you want to proceed?"
+msgstr ""
+"你已变更了战役难度。最终最高分将仅依据战役中已完成场景的最低难度等级计算。确"
+"定要继续吗？"
+
+msgid "Are you sure you want to restart this scenario?"
+msgstr "确定要重新开始此场景吗？"
+
+msgid "Campaign Scenario loading failure"
+msgstr "战役场景载入失败"
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr "请确认战役档案正确且存在。"
+
+msgid "Days spent"
+msgstr "所花天数"
+
+msgid "The number of days spent on this campaign."
+msgstr "在此战役所花费的天数。"
+
+msgid "Scenario Title"
+msgstr "场景标题"
+
+msgid "Project Coordination and Core Development"
+msgstr "专案统筹与核心开发"
+
+msgid "Development"
+msgstr "开发"
+
+msgid "Visit us at"
+msgstr "造访我们"
+
+msgid "QA and Support"
+msgstr "品质保证与技术支援"
+
+msgid "Dev and Support"
+msgstr "开发与技术支援"
+
+msgid "Special Thanks to"
+msgstr "特别感谢"
+
+msgid "and all the people who have helped make the project possible!"
+msgstr "以及所有协助让这个专案成真的人们！"
+
+msgid "Support us at"
+msgstr "赞助我们"
+
+msgid "local-donation-platform|https://www.patreon.com/fheroes2"
+msgstr "https://www.patreon.com/fheroes2"
+
+msgid "Connect with us at"
+msgstr "联络我们"
+
+msgid "local-social-network|https://www.facebook.com/groups/fheroes2"
+msgstr "https://www.facebook.com/groups/fheroes2"
+
+msgid "Need help with the game?"
+msgstr "需要游戏协助吗？"
+
+msgid "Original project before 0.7"
+msgstr "0.7 版之前的原始专案"
+
+msgid "Heroes of Might and Magic II: The Succession Wars team"
+msgstr "Heroes of Might and Magic II: The Succession Wars 团队"
+
+msgid "Designed and Directed"
+msgstr "设计与监制"
+
+msgid "Programming and Design"
+msgstr "程式设计与设计"
+
+msgid "Executive Producer"
+msgstr "执行制作人"
+
+msgid "Producer"
+msgstr "制作人"
+
+msgid "Additional Design"
+msgstr "额周边装置计"
+
+msgid "Additional Programming"
+msgstr "额外程式设计"
+
+msgid "Musical Production"
+msgstr "音乐制作"
+
+msgid "Music and Sound Design"
+msgstr "音乐与声音设计"
+
+msgid "Vocalists"
+msgstr "歌手"
+
+msgid "Art Director"
+msgstr "艺术总监"
+
+msgid "Assistant Art Director"
+msgstr "助理艺术总监"
+
+msgid "Artists"
+msgstr "美术设计师"
+
+msgid "QA Manager"
+msgstr "品质保证经理"
+
+msgid "QA"
+msgstr "品质保证"
+
+msgid "Writing"
+msgstr "文案撰写"
+
+msgid "Manual and Helpfile"
+msgstr "手册与说明档"
+
+msgid "Scenarios"
+msgstr "场景设计"
+
+msgid "Heroes of Might and Magic II: The Price of Loyalty team"
+msgstr "Heroes of Might and Magic II: The Price of Loyalty 团队"
+
+msgid "Design Lead"
+msgstr "首席设计师"
+
+msgid "Designers"
+msgstr "设计师"
+
+msgid "Programming Lead"
+msgstr "首席程式设计师"
+
+msgid "Art Lead"
+msgstr "首席美术设计师"
+
+msgid "Playtesters"
+msgstr "游戏测试员"
+
+msgid "Designer"
+msgstr "设计师"
+
+msgid "Producers"
+msgstr "制作人"
+
+msgid "QA Managers"
+msgstr "品质保证经理"
+
+msgid "Sound Design"
+msgstr "声音设计"
+
+msgid "Town Themes"
+msgstr "城镇主题音乐"
+
+msgid "Alto Sax"
+msgstr "中音萨克斯风"
+
+msgid "Harpsichord and Piano"
+msgstr "大键琴与钢琴"
+
+msgid "Basso Vocal"
+msgstr "低音声乐"
+
+msgid "Soprano Vocal"
+msgstr "女高音声乐"
+
+msgid "Recorded at %{recordingStudio}"
+msgstr "录制于 %{recordingStudio}"
+
+msgid "credits|Manual"
+msgstr "手册"
+
+msgid "German Consultant"
+msgstr "德文顾问"
+
+msgid "Map Designers"
+msgstr "地图设计师"
+
+msgid "Package Design"
+msgstr "包装设计"
+
+msgid "To exit fheroes2, press the Home button or swipe up."
+msgstr "若要离开 fheroes2，请按主画面按钮或向上滑动。"
+
+msgid "Are you sure you want to quit?"
+msgstr "确定要结束吗？"
+
+msgid "High Scores"
+msgstr "最高分"
+
+msgid "Your Name"
+msgstr "你的名称"
+
+msgid "Unknown Hero"
+msgstr "无名英雄"
+
+msgid "Standard"
+msgstr "标准"
+
+msgid "View High Scores for Standard Maps."
+msgstr "检视标准地图的最高分排行榜。"
+
+msgid "Campaign"
+msgstr "战役"
+
+msgid "View High Scores for Campaigns."
+msgstr "检视战役的最高分排行榜。"
+
+msgid "hotkey|default okay event"
+msgstr "预设确认事件"
+
+msgid "hotkey|default cancel event"
+msgstr "预设取消事件"
+
+msgid "hotkey|default left"
+msgstr "预设向左"
+
+msgid "hotkey|default right"
+msgstr "预设向右"
+
+msgid "hotkey|default up"
+msgstr "预设向上"
+
+msgid "hotkey|default down"
+msgstr "预设向下"
+
+msgid "hotkey|toggle fullscreen"
+msgstr "切换全萤幕"
+
+msgid "hotkey|toggle text support mode"
+msgstr "切换文字辅助模式"
+
+msgid "hotkey|toggle developer mode"
+msgstr "切换开发者模式"
+
+msgid "hotkey|quit"
+msgstr "结束"
+
+msgid "hotkey|new game"
+msgstr "新游戏"
+
+msgid "hotkey|load game"
+msgstr "载入游戏"
+
+msgid "hotkey|high scores"
+msgstr "最高分"
+
+msgid "hotkey|credits"
+msgstr "制作名单"
+
+msgid "hotkey|standard game"
+msgstr "标准游戏"
+
+msgid "hotkey|campaign game"
+msgstr "战役游戏"
+
+msgid "hotkey|multi-player game"
+msgstr "多人游戏"
+
+msgid "hotkey|settings"
+msgstr "设定"
+
+msgid "hotkey|select map"
+msgstr "选择地图"
+
+msgid "hotkey|select small map size"
+msgstr "选择小型地图"
+
+msgid "hotkey|select medium map size"
+msgstr "选择中型地图"
+
+msgid "hotkey|select large map size"
+msgstr "选择大型地图"
+
+msgid "hotkey|select extra large map size"
+msgstr "选择超大型地图"
+
+msgid "hotkey|select all map sizes"
+msgstr "选择所有地图大小"
+
+msgid "hotkey|hot seat game"
+msgstr "热座游戏"
+
+msgid "hotkey|battle only game"
+msgstr "仅限战斗游戏"
+
+msgid "hotkey|choose the original campaign"
+msgstr "选择原版战役"
+
+msgid "hotkey|choose the expansion campaign"
+msgstr "选择资料片战役"
+
+msgid "hotkey|map editor main menu"
+msgstr "地图编辑器主选单"
+
+msgid "hotkey|new map menu"
+msgstr "新地图选单"
+
+msgid "hotkey|load map menu"
+msgstr "载入地图选单"
+
+msgid "hotkey|new map from scratch"
+msgstr "从头建立新地图"
+
+msgid "hotkey|new random map"
+msgstr "新随机地图"
+
+msgid "hotkey|undo last action"
+msgstr "复原上一个动作"
+
+msgid "hotkey|redo last action"
+msgstr "重做上一个动作"
+
+msgid "hotkey|open game main menu"
+msgstr "开启游戏主选单"
+
+msgid "hotkey|toggle passability"
+msgstr "切换通行性"
+
+msgid "hotkey|re-generate random map"
+msgstr "重新产生随机地图"
+
+msgid "hotkey|re-configure random map"
+msgstr "重新设定随机地图"
+
+msgid "hotkey|output all text"
+msgstr "输出所有文字"
+
+msgid "hotkey|roland campaign"
+msgstr "Roland 战役"
+
+msgid "hotkey|archibald campaign"
+msgstr "Archibald 战役"
+
+msgid "hotkey|price of loyalty campaign"
+msgstr "忠诚的代价战役"
+
+msgid "hotkey|voyage home campaign"
+msgstr "归乡之旅战役"
+
+msgid "hotkey|wizard's isle campaign"
+msgstr "巫师之岛战役"
+
+msgid "hotkey|descendants campaign"
+msgstr "后裔战役"
+
+msgid "hotkey|select first campaign bonus"
+msgstr "选择第一项战役奖励"
+
+msgid "hotkey|select second campaign bonus"
+msgstr "选择第二项战役奖励"
+
+msgid "hotkey|select third campaign bonus"
+msgstr "选择第三项战役奖励"
+
+msgid "hotkey|view campaign intro"
+msgstr "观看战役序幕"
+
+msgid "hotkey|select campaign difficulty"
+msgstr "选择战役难度"
+
+msgid "hotkey|restart campaign scenario"
+msgstr "重新开始战役场景"
+
+msgid "hotkey|world map left"
+msgstr "世界地图向左"
+
+msgid "hotkey|world map right"
+msgstr "世界地图向右"
+
+msgid "hotkey|world map up"
+msgstr "世界地图向上"
+
+msgid "hotkey|world map down"
+msgstr "世界地图向下"
+
+msgid "hotkey|world map up left"
+msgstr "世界地图左上"
+
+msgid "hotkey|world map up right"
+msgstr "世界地图右上"
+
+msgid "hotkey|world map down left"
+msgstr "世界地图左下"
+
+msgid "hotkey|world map down right"
+msgstr "世界地图右下"
+
+msgid "hotkey|save game"
+msgstr "储存游戏"
+
+msgid "hotkey|quick save"
+msgstr "快速存档"
+
+msgid "hotkey|next hero"
+msgstr "下一位英雄"
+
+msgid "hotkey|change to hero under cursor"
+msgstr "切换至游标下的英雄"
+
+msgid "hotkey|hold and left click to move hero portrait to top of list"
+msgstr "按住并左键按一下以将英雄肖像移至列表顶端"
+
+msgid "hotkey|start hero movement"
+msgstr "开始英雄移动"
+
+msgid "hotkey|cast adventure spell"
+msgstr "施放冒险法术"
+
+msgid "hotkey|put hero to sleep"
+msgstr "让英雄休息"
+
+msgid "hotkey|next town"
+msgstr "下一座城镇"
+
+msgid "hotkey|end turn"
+msgstr "结束回合"
+
+msgid "hotkey|file options"
+msgstr "档案选项"
+
+msgid "hotkey|adventure options"
+msgstr "冒险选项"
+
+msgid "hotkey|puzzle map"
+msgstr "拼图地图"
+
+msgid "hotkey|scenario information"
+msgstr "场景资讯"
+
+msgid "hotkey|dig for artifact"
+msgstr "挖掘神器"
+
+msgid "hotkey|view world"
+msgstr "检视世界"
+
+msgid "hotkey|kingdom summary"
+msgstr "王国摘要"
+
+msgid "hotkey|default action"
+msgstr "预设动作"
+
+msgid "hotkey|open focus"
+msgstr "开启焦点"
+
+msgid "hotkey|system options"
+msgstr "系统选项"
+
+msgid "hotkey|scroll left"
+msgstr "向左卷动"
+
+msgid "hotkey|scroll right"
+msgstr "向右卷动"
+
+msgid "hotkey|scroll up"
+msgstr "向上卷动"
+
+msgid "hotkey|scroll down"
+msgstr "向下卷动"
+
+msgid "hotkey|toggle control panel"
+msgstr "切换控制台"
+
+msgid "hotkey|toggle radar"
+msgstr "切换雷达"
+
+msgid "hotkey|toggle buttons"
+msgstr "切换按钮"
+
+msgid "hotkey|toggle status"
+msgstr "切换状态"
+
+msgid "hotkey|toggle icons"
+msgstr "切换图示"
+
+msgid "hotkey|transfer control to ai"
+msgstr "将控制权移转给 AI"
+
+msgid "hotkey|retreat from battle"
+msgstr "从战斗中撤退"
+
+msgid "hotkey|surrender during battle"
+msgstr "在战斗中投降"
+
+msgid "hotkey|toggle auto combat mode"
+msgstr "切换自动战斗模式"
+
+msgid "hotkey|quick combat"
+msgstr "快速战斗"
+
+msgid "hotkey|battle options"
+msgstr "战斗选项"
+
+msgid "hotkey|skip turn in battle"
+msgstr "在战斗中略过回合"
+
+msgid "hotkey|cast battle spell"
+msgstr "施放战斗法术"
+
+msgid "hotkey|toggle display of battle turn order"
+msgstr "切换战斗行动顺序显示"
+
+msgid "hotkey|dwelling level 1"
+msgstr "住所等级 1"
+
+msgid "hotkey|dwelling level 2"
+msgstr "住所等级 2"
+
+msgid "hotkey|dwelling level 3"
+msgstr "住所等级 3"
+
+msgid "hotkey|dwelling level 4"
+msgstr "住所等级 4"
+
+msgid "hotkey|dwelling level 5"
+msgstr "住所等级 5"
+
+msgid "hotkey|dwelling level 6"
+msgstr "住所等级 6"
+
+msgid "hotkey|well"
+msgstr "水井"
+
+msgid "hotkey|marketplace"
+msgstr "市场"
+
+msgid "hotkey|mage guild"
+msgstr "法师公会"
+
+msgid "hotkey|shipyard"
+msgstr "造船厂"
+
+msgid "hotkey|thieves guild"
+msgstr "盗贼公会"
+
+msgid "hotkey|tavern"
+msgstr "酒馆"
+
+msgid "hotkey|construction screen"
+msgstr "建造画面"
+
+msgid "hotkey|buy all monsters in well"
+msgstr "从水井购买所有怪物"
+
+msgid "hotkey|merge troops with hero"
+msgstr "合并部队至英雄"
+
+msgid "hotkey|merge troops with garrison"
+msgstr "合并部队至城防"
+
+msgid "hotkey|split stack by half"
+msgstr "将部队分为一半"
+
+msgid "hotkey|split stack by one"
+msgstr "将部队分出一个"
+
+msgid "hotkey|join stacks"
+msgstr "合并部队"
+
+msgid "hotkey|upgrade troop"
+msgstr "升级部队"
+
+msgid "hotkey|dismiss hero or troop"
+msgstr "解散英雄或部队"
+
+msgid "hotkey|exchange all troops"
+msgstr "交换所有部队"
+
+msgid ""
+"Do you want to regain control from AI? The effect will take place only on "
+"the next turn."
+msgstr ""
+"确定要从 AI 夺回控制权吗？效果将在下一回合生效。"
+
+msgid ""
+"Do you want to transfer control from you to the AI? The effect will take "
+"place only on the next turn."
+msgstr ""
+"确定要将控制权移转给 AI 吗？效果将在下一回合生效。"
+
+msgid "Default Actions"
+msgstr "预设操作"
+
+msgid "Global Actions"
+msgstr "全域操作"
+
+msgid "World Map"
+msgstr "世界地图"
+
+msgid "Battle Screen"
+msgstr "战斗画面"
+
+msgid "Town Screen"
+msgstr "城镇画面"
+
+msgid "Army Actions"
+msgstr "军队操作"
+
+msgid "The save file is corrupted."
+msgstr "存档已损坏。"
+
+msgid "Unsupported save format: "
+msgstr "不支援的存档格式："
+
+msgid "Current game version: "
+msgstr "目前游戏版本："
+
+msgid "Last supported version: "
+msgstr "最后支援的版本："
+
+msgid "This file contains a save with an invalid game type."
+msgstr "此档案包含无效游戏类型的存档。"
+
+msgid ""
+"This save file requires \"The Price of Loyalty\" game assets, but they have "
+"not been provided to the engine."
+msgstr ""
+"此存档需要「The Price of Loyalty」游戏资源，但尚未提供给引擎。"
+
+msgid "This saved game is localized to '"
+msgstr "此存档的语系为「"
+
+msgid "' language, but the current language of the game is '"
+msgstr "」，但目前游戏的语言为「"
+
+msgid "No save files to load."
+msgstr "没有可载入的存档。"
+
+msgid "A single player game playing out a single map."
+msgstr "在单一地图上进行的单人游戏。"
+
+msgid "Standard Game"
+msgstr "标准游戏"
+
+msgid "A single player game playing through a series of maps."
+msgstr "依序游玩一系列地图的单人游戏。"
+
+msgid "Campaign Game"
+msgstr "战役游戏"
+
+msgid "Multi-Player Game"
+msgstr "多人游戏"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+"多人游戏，多位人类玩家在同一张地图上彼此竞争。"
+
+msgid "Hot Seat"
+msgstr "热座模式"
+
+msgid ""
+"Play a Hot Seat game, where 2 to 6 players play around the same computer, "
+"switching into the 'Hot Seat' when it is their turn."
+msgstr ""
+"进行热座游戏，2 至 6 位玩家在同一台电脑上轮流游玩。"
+
+msgid "Cancel back to the main menu."
+msgstr "取消并返回主选单。"
+
+msgid "fheroes2 Resurrection Team presents"
+msgstr "fheroes2 Resurrection Team 献上"
+
+msgid "Welcome to Heroes of Might and Magic II powered by fheroes2 engine!"
+msgstr "欢迎游玩由 fheroes2 引擎驱动的 Heroes of Might and Magic II！"
+
+msgid ""
+"\n"
+"\n"
+"To simulate a right-click with a touch to get info on various items, you "
+"need to first touch and keep touching on the item of interest and then touch "
+"anywhere else on the screen. While holding the second finger, you can remove "
+"the first one from the screen and keep viewing the information on the item."
+msgstr ""
+"\n"
+"\n"
+"想以触控方式模拟右键取得各种物件的资讯，请先触碰并按住想检视的物件，然后再触"
+"碰萤幕上的其他位置。按住第二根手指的同时，可以移开第一根手指并继续检视该物件"
+"的资讯。"
+
+msgid ""
+"\n"
+"\n"
+"Before starting the game, please select a game resolution."
+msgstr ""
+"\n"
+"\n"
+"开始游戏前，请先选择游戏解析度。"
+
+msgid "Greetings!"
+msgstr "欢迎！"
+
+msgid "Quit Heroes of Might and Magic II and return to the operating system."
+msgstr "结束 Heroes of Might and Magic II 并返回作业系统。"
+
+msgid "Credits"
+msgstr "制作名单"
+
+msgid "View the credits screen."
+msgstr "检视制作名单。"
+
+msgid "View the high scores screen."
+msgstr "检视最高分排行榜。"
+
+msgid "Create new or modify existing maps."
+msgstr "建立新地图或修改既有地图。"
+
+msgid "Change language, resolution and settings of the game."
+msgstr "变更游戏的语言、解析度和设定。"
+
+msgid "Game Settings"
+msgstr "游戏设定"
+
+msgid ""
+"The required video files for the campaign selection window are missing. "
+"Please make sure that all necessary files are present in the system."
+msgstr ""
+"战役选择视窗所需的影片档案遗失，请确认所有必要档案已存在于系统中。"
+
+msgid "Loading video. Please wait..."
+msgstr "正在载入影片，请稍候……"
+
+msgid ""
+"fheroes2 needs data files from the original Heroes of Might and Magic II to "
+"operate. You appear to be using the demo version of Heroes of Might and "
+"Magic II for this purpose. Please note that only one scenario will be "
+"available in this setup."
+msgstr ""
+"fheroes2 需要原版 Heroes of Might and Magic II 的资料档案才能执行。你似乎正在"
+"使用 Heroes of Might and Magic II 的试玩版。请注意在此设定下只有一个场景可"
+"用。"
+
+msgid ""
+"A multi-player game, with several human players competing against each other "
+"on a single map."
+msgstr ""
+"多人游戏，多位人类玩家在同一张地图上彼此竞争。"
+
+msgid "Setup and play a battle without loading any map."
+msgstr "直接开始一场战斗，无须载入地图。"
+
+msgid "2 Players"
+msgstr "2 位玩家"
+
+msgid ""
+"Play with 2 human players, and optionally, up to 4 additional computer "
+"players."
+msgstr ""
+"以 2 位人类玩家游玩，可选择加入最多 4 位电脑玩家。"
+
+msgid "3 Players"
+msgstr "3 位玩家"
+
+msgid ""
+"Play with 3 human players, and optionally, up to 3 additional computer "
+"players."
+msgstr ""
+"以 3 位人类玩家游玩，可选择加入最多 3 位电脑玩家。"
+
+msgid "4 Players"
+msgstr "4 位玩家"
+
+msgid ""
+"Play with 4 human players, and optionally, up to 2 additional computer "
+"players."
+msgstr ""
+"以 4 位人类玩家游玩，可选择加入最多 2 位电脑玩家。"
+
+msgid "5 Players"
+msgstr "5 位玩家"
+
+msgid ""
+"Play with 5 human players, and optionally, up to 1 additional computer "
+"player."
+msgstr ""
+"以 5 位人类玩家游玩，可选择加入最多 1 位电脑玩家。"
+
+msgid "6 Players"
+msgstr "6 位玩家"
+
+msgid "Play with 6 human players."
+msgstr "以 6 位人类玩家游玩。"
+
+msgid "Original Campaign"
+msgstr "原版战役"
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+"原版 Heroes of Might and Magic II 中 Roland 或 Archibald 的战役。"
+
+msgid "Expansion Campaign"
+msgstr "资料片战役"
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr "Price of Loyalty 资料片中四个新战役之一。"
+
+msgid ""
+"Play a Hot Seat game, where 2 to 6 players play on the same device, "
+"switching into the 'Hot Seat' when it is their turn."
+msgstr ""
+"进行热座游戏，2 至 6 位玩家在同一台装置上轮流游玩。"
+
+msgid "Dragon city has fallen! You are now the Master of the Dragons."
+msgstr "龙族之城已经沦陷！你现在是龙族之主了。"
+
+msgid ""
+"You captured %{name}!\n"
+"You are victorious."
+msgstr ""
+"占领了 %{name}！\n"
+"你获得了胜利。"
+
+msgid ""
+"You have captured the enemy hero %{name}!\n"
+"Your quest is complete."
+msgstr ""
+"俘获了敌方英雄 %{name}！\n"
+"任务完成。"
+
+msgid ""
+"You have found the %{name}.\n"
+"Your quest is complete."
+msgstr ""
+"找到了 %{name}。\n"
+"任务完成。"
+
+msgid "Ultimate Artifact"
+msgstr "终极神器"
+
+msgid ""
+"The enemy is beaten.\n"
+"Your side has triumphed!"
+msgstr ""
+"敌人被击败了。\n"
+"你方获得了胜利！"
+
+msgid ""
+"You have built up over %{count} gold in your treasury.\n"
+"All enemies bow before your wealth and power."
+msgstr ""
+"国库已累积超过 %{count} 金币。\n"
+"所有敌人在你的财富与力量面前俯首称臣。"
+
+msgid "Victory!"
+msgstr "胜利！"
+
+msgid ""
+"The enemy has captured %{name}!\n"
+"They are triumphant."
+msgstr ""
+"敌人占领了 %{name}！\n"
+"他们获得了胜利。"
+
+msgid ""
+"The enemy has found the %{name}.\n"
+"Your quest is a failure."
+msgstr ""
+"敌人找到了 %{name}。\n"
+"任务失败。"
+
+msgid ""
+"The enemy has built up over %{count} gold in his treasury.\n"
+"You must bow done in defeat before his wealth and power."
+msgstr ""
+"敌人的国库已累积超过 %{count} 金币。\n"
+"你必须在其财富与力量面前认输。"
+
+msgid "You have been eliminated from the game!!!"
+msgstr "你已被淘汰出局！！！"
+
+msgid ""
+"You have lost the hero %{name}.\n"
+"Your quest is over."
+msgstr ""
+"失去了英雄 %{name}。\n"
+"任务结束。"
+
+msgid ""
+"You have failed to complete your quest in time.\n"
+"All is lost."
+msgstr ""
+"未能在时限内完成任务。\n"
+"一切都完了。"
+
+msgid "Defeat!"
+msgstr "战败！"
+
+msgid ""
+"Base score: %{score}\n"
+"Difficulty: %{difficulty}\n"
+"\n"
+msgstr ""
+"基础分数：%{score}\n"
+"难度：%{difficulty}\n"
+"\n"
+
+msgid "Defeat all enemy heroes and capture all enemy towns and castles."
+msgstr "击败所有敌方英雄，并占领所有敌方城镇和城堡。"
+
+msgid "Your side defeats the opposing side."
+msgstr "你方击败了对方。"
+
+msgid "Run out of time. (Fail to win by a certain point.)"
+msgstr "时间耗尽。(未能在期限前获胜。)"
+
+msgid "You must defeat the enemy %{enemies}."
+msgid_plural "You must defeat the enemy alliance of %{enemies}."
+msgstr[0] "必须击败敌方 %{enemies}。"
+
+msgid ""
+"The alliance consisting of %{allies} and you must defeat the enemy "
+"%{enemies}."
+msgid_plural ""
+"The alliance consisting of %{allies} and you must defeat the enemy alliance "
+"of %{enemies}."
+msgstr[0] ""
+"由 %{allies} 和你组成的联盟必须击败敌方 %{enemies}。"
+
+msgid "Capture the castle '%{name}'."
+msgstr "占领城堡「%{name}」。"
+
+msgid "Capture the town '%{name}'."
+msgstr "占领城镇「%{name}」。"
+
+msgid "Defeat the hero '%{name}'."
+msgstr "击败英雄「%{name}」。"
+
+msgid "Find the ultimate artifact."
+msgstr "找到终极神器。"
+
+msgid "Find the '%{name}' artifact."
+msgstr "找到神器「%{name}」。"
+
+msgid "Accumulate %{count} gold."
+msgstr "累积 %{count} 金币。"
+
+msgid ""
+", or you may win by defeating all enemy heroes and capturing all enemy towns "
+"and castles."
+msgstr ""
+"，或者也可以击败所有敌方英雄并占领所有敌方城镇和城堡来获胜。"
+
+msgid "Lose the castle '%{name}'."
+msgstr "失去城堡「%{name}」。"
+
+msgid "Lose the town '%{name}'."
+msgstr "失去城镇「%{name}」。"
+
+msgid "Lose the hero: %{name}."
+msgstr "失去英雄：%{name}。"
+
+msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
+msgstr "未能在第 %{month} 月第 %{week} 周第 %{day} 日结束前获胜。"
+
+msgid "%{color} player has been vanquished!"
+msgstr "%{color}玩家已被消灭！"
+
+msgid "Major Event!"
+msgstr "重大事件！"
+
+msgid "Scenario:"
+msgstr "场景："
+
+msgid "Game Difficulty:"
+msgstr "游戏难度："
+
+msgid "Opponents:"
+msgstr "对手："
+
+msgid "Class:"
+msgstr "职业："
+
+msgid "Rating %{rating}%"
+msgstr "评分 %{rating}%"
+
+msgid "Click here to select which scenario to play."
+msgstr "按此处选择要游玩的场景。"
+
+msgid "Scenario"
+msgstr "场景"
+
+msgid "Game Difficulty"
+msgstr "游戏难度"
+
+msgid ""
+"This lets you change the starting difficulty at which you will play. Higher "
+"difficulty levels start you off with fewer resources, and at the higher "
+"settings, give extra resources to the computer."
+msgstr ""
+"可变更游玩的起始难度。难度等级越高，开局资源就越少；在更高的设定下，电脑还会"
+"获得额外资源。"
+
+msgid "Difficulty Rating"
+msgstr "难度评分"
+
+msgid ""
+"The difficulty rating reflects a combination of various settings for your "
+"game. This number will be applied to your final score."
+msgstr ""
+"难度评分反映了游戏各项设定的综合评估，此数值将计入最终分数。"
+
+msgid "Click to accept these settings and start a new game."
+msgstr "按一下接受这些设定并开始新游戏。"
+
+msgid "Click to return to the main menu."
+msgstr "按一下返回主选单。"
+
+msgid "The map is corrupted or doesn't exist."
+msgstr "地图已损坏或不存在。"
+
+msgid "Astrologers proclaim the Month of the %{name}."
+msgstr "占星师宣布这是 %{name} 之月。"
+
+msgid "New Month!"
+msgstr "新的月份！"
+
+msgid "Astrologers proclaim the Week of the %{name}."
+msgstr "占星师宣布这是 %{name} 之周。"
+
+msgid "New Week!"
+msgstr "新的一周！"
+
+msgid "After regular growth, the population of %{monster} is doubled!"
+msgstr "正常增长后，%{monster} 的族群数量翻倍！"
+
+msgid ""
+"After regular growth, the population of %{monster} increases by %{count} "
+"percent!"
+msgid_plural ""
+"After regular growth, the population of %{monster} increases by %{count} "
+"percent!"
+msgstr[0] ""
+"正常增长后，%{monster} 的族群数量增加 %{count}%！"
+
+msgid "%{monster} growth +%{count}."
+msgstr "%{monster} 增长 +%{count}。"
+
+msgid "All populations are halved."
+msgstr "所有生物族群减半。"
+
+msgid "All dwellings increase population."
+msgstr "所有住所增加族群数量。"
+
+msgid "Beware!"
+msgstr "小心！"
+
+msgid ""
+"%{color} player, this is your last day to capture a town, or you will be "
+"banished from this land."
+msgstr ""
+"%{color}玩家，这是占领城镇的最后一天，否则将被放逐。"
+
+msgid ""
+"%{color} player, you only have %{day} days left to capture a town, or you "
+"will be banished from this land."
+msgstr ""
+"%{color}玩家，仅剩 %{day} 天可以占领城镇，否则将被放逐。"
+
+msgid "%{color} player's turn."
+msgstr "%{color}玩家的回合。"
+
+msgid ""
+"%{color} player, you have lost your last town. If you do not conquer another "
+"town in the next week, you will be eliminated."
+msgstr ""
+"%{color}玩家，你失去了最后一座城镇。若未能在下周内攻占另一座城镇，将被淘汰。"
+
+msgid ""
+"%{color} player, your heroes abandon you, and you are banished from this "
+"land."
+msgstr ""
+"%{color}玩家，英雄们抛弃了你，你被放逐出这片土地。"
+
+msgid "Lord Kilburn"
+msgstr "Lord Kilburn"
+
+msgid "Tsabu"
+msgstr "Tsabu"
+
+msgid "Sir Galant"
+msgstr "Sir Galant"
+
+msgid "Thundax"
+msgstr "Thundax"
+
+msgid "Lord Haart"
+msgstr "Lord Haart"
+
+msgid "Ariel"
+msgstr "Ariel"
+
+msgid "Rebecca"
+msgstr "Rebecca"
+
+msgid "Sandro"
+msgstr "Sandro"
+
+msgid "Crodo"
+msgstr "Crodo"
+
+msgid "Barock"
+msgstr "Barock"
+
+msgid "Antoine"
+msgstr "Antoine"
+
+msgid "Astra"
+msgstr "Astra"
+
+msgid "Agar"
+msgstr "Agar"
+
+msgid "Vatawna"
+msgstr "Vatawna"
+
+msgid "Vesper"
+msgstr "Vesper"
+
+msgid "Ambrose"
+msgstr "Ambrose"
+
+msgid "Troyan"
+msgstr "Troyan"
+
+msgid "Jojosh"
+msgstr "Jojosh"
+
+msgid "Wrathmont"
+msgstr "Wrathmont"
+
+msgid "Maximus"
+msgstr "Maximus"
+
+msgid "Next Hero"
+msgstr "下一位英雄"
+
+msgid "Select the next Hero."
+msgstr "选择下一位英雄。"
+
+msgid "Hero Movement"
+msgstr "英雄移动"
+
+msgid ""
+"Start the Hero's movement along the current path or re-visit the object "
+"occupied by the Hero. Press and hold this button to reset the Hero's path."
+msgstr ""
+"沿目前路径开始英雄的移动，或重新造访英雄所在的物件。长按此按钮可重置英雄的路"
+"径。"
+
+msgid "Kingdom Summary"
+msgstr "王国摘要"
+
+msgid "View a summary of your Kingdom."
+msgstr "检视王国摘要。"
+
+msgid "Cast an adventure spell."
+msgstr "施放冒险法术。"
+
+msgid "End Turn"
+msgstr "结束回合"
+
+msgid "End your turn and let the computer take its turn."
+msgstr "结束你的回合，让电脑行动。"
+
+msgid "Adventure Options"
+msgstr "冒险选项"
+
+msgid "Bring up the adventure options menu."
+msgstr "开启冒险选项选单。"
+
+msgid ""
+"Bring up the file options menu, allowing you to load, save, start a new game "
+"or quit."
+msgstr ""
+"开启档案选项选单，可载入、储存、开始新游戏或结束。"
+
+msgid "Bring up the system options menu, allowing you to customize your game."
+msgstr "开启系统选项选单，以自订游戏。"
+
+msgid "Hero Movement Points"
+msgstr "英雄移动力"
+
+msgid ""
+"The hero's army cannot move anymore today. The movement points will be "
+"refilled tomorrow after you end your turn."
+msgstr ""
+"英雄的军队今日已无法继续移动。结束回合后，明天移动力将会恢复。"
+
+msgid ""
+"One or more heroes may still move, are you sure you want to end your turn?"
+msgstr ""
+"仍有英雄可以移动，确定要结束回合吗？"
+
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "确定要重新开始吗？(目前的游戏进度将会遗失。)"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr "确定要覆写此名称的存档吗？"
+
+msgid "Game saved successfully."
+msgstr "游戏储存成功。"
+
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr ""
+"确定要载入新游戏吗？（目前的游戏进度将会遗失。）"
+
+msgid "Try looking on land!!!"
+msgstr "试试在陆地上寻找！！！"
+
+msgid ""
+"Searching for the Ultimate Artifact is fruitless. Your hero could not carry "
+"it even if he found it - all his artifact slots are full."
+msgstr ""
+"搜寻终极神器毫无结果。即使找到也无法携带——英雄的神器栏位已满。"
+
+msgid "Digging for artifacts requires a whole day, try again tomorrow."
+msgstr "挖掘神器需要一整天的时间，请明天再试。"
+
+msgid ""
+"After spending many hours digging here, you have uncovered the %{artifact}."
+msgstr ""
+"经过数小时的挖掘，你发现了 %{artifact}。"
+
+msgid "Congratulations!"
+msgstr "恭喜！"
+
+msgid "Nothing here. Where could it be?"
+msgstr "这里什么都没有。它会在哪里呢？"
+
+msgid "Try searching on clear ground."
+msgstr "试试在空地上搜寻。"
+
+msgid "A miniature view of the known world. Left click to move viewing area."
+msgstr "已知世界的缩图。左键按一下移动检视区域。"
+
+msgid "Month: %{month} Week: %{week}"
+msgstr "月：%{month} 周：%{week}"
+
+msgid ""
+"You find a small\n"
+"quantity of %{resource}."
+msgstr ""
+"你发现了少量\n"
+"%{resource}。"
+
+msgid "Status Window"
+msgstr "状态视窗"
+
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+"此视窗显示英雄或王国的状态资讯及日期。"
+
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date. Left click here to cycle through these windows."
+msgstr ""
+"此视窗显示英雄或王国的状态资讯及日期。左键按一下可切换不同视窗。"
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+"可变更玩家的起始位置和颜色。特定颜色将始终在特定位置开始。某些位置只能由电脑"
+"玩家或人类玩家使用。"
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+"可变更玩家的职业。职业并非总是可变更的。根据场景，玩家可能会获得非其主要阵营"
+"的额外城镇和/或英雄。"
+
+msgid "Handicap"
+msgstr "让分"
+
+msgid ""
+"This lets you change the handicap of a particular player. Only human players "
+"may have a handicap. Handicapped players start with fewer resources and earn "
+"15 or 30% fewer resources per turn for mild and severe handicaps, "
+"respectively."
+msgstr ""
+"可变更特定玩家的让分。只有人类玩家可设定让分。有让分的玩家以较少资源开局，轻"
+"度和重度让分分别每回合减少 15% 或 30% 的资源收入。"
+
+msgid "%{color} player"
+msgstr "%{color}玩家"
+
+msgid "No Handicap"
+msgstr "无让分"
+
+msgid ""
+"No special restrictions on starting resources and resource income per turn."
+msgstr ""
+"起始资源与每回合资源收入无特殊限制。"
+
+msgid "Mild Handicap"
+msgstr "轻度让分"
+
+msgid ""
+"Players with mild handicap start with fewer resources and earn 15% fewer "
+"resources per turn."
+msgstr ""
+"轻度让分的玩家以较少资源开局，且每回合收入减少 15%。"
+
+msgid "Severe Handicap"
+msgstr "重度让分"
+
+msgid ""
+"Players with severe handicap start with fewer resources and earn 30% fewer "
+"resources per turn."
+msgstr ""
+"重度让分的玩家以较少资源开局，且每回合收入减少 30%。"
+
+msgid ""
+"Default\n"
+"value"
+msgstr ""
+"预设\n"
+"数值"
+
+msgid "Set %{skill} Skill:"
+msgstr "设定 %{skill} 技能："
+
+msgid "Set %{skill} base value. Right-click to reset all skills to default."
+msgstr "设定 %{skill} 基础值。右键按一下可将所有技能重置为预设。"
+
+msgid "View %{skill} Info"
+msgstr "检视 %{skill} 资讯"
+
+msgid ""
+"Default\n"
+"skill"
+msgstr ""
+"预设\n"
+"技能"
+
+msgid "The available values range from %{min} to %{max}."
+msgstr "可用数值范围为 %{min} 至 %{max}。"
+
+msgid "Uppercase"
+msgstr "大写"
+
+msgid "Click to switch to uppercase letters."
+msgstr "按一下切换为大写字母。"
+
+msgid "Keyboard|123"
+msgstr "123"
+
+msgid "Keyboard type"
+msgstr "键盘类型"
+
+msgid "Click to switch between keyboard types."
+msgstr "按一下切换键盘类型。"
+
+msgid "Keyboard|SPACE"
+msgstr "空格"
+
+msgid "Change language"
+msgstr "切换语言"
+
+msgid "Click to switch between languages."
+msgstr "按一下切换语言。"
+
+msgid "Backspace"
+msgstr "退格"
+
+msgid "Click to remove characters."
+msgstr "按一下删除字元。"
+
+msgid "Lowercase"
+msgstr "小写"
+
+msgid "Click to switch to lowercase letters."
+msgstr "按一下切换为小写字母。"
+
+msgid "Keyboard|ABC"
+msgstr "ABC"
+
+msgid "Swap sign"
+msgstr "正负号切换"
+
+msgid "Click to switch between signed and unsigned numbers."
+msgstr "按一下切换正负数。"
+
+msgid "The entered value is invalid."
+msgstr "输入的数值无效。"
+
+msgid ""
+"The entered value is out of range.\n"
+"It should be not less than %{minValue} and not more than %{maxValue}."
+msgstr ""
+"输入的数值超出范围。\n"
+"应不小于 %{minValue} 且不大于 %{maxValue}。"
+
+msgid "Kingdom Income"
+msgstr "王国收入"
+
+msgid "Kingdom Income per day."
+msgstr "王国每日收入。"
+
+msgid "For every lighthouse controlled, your ships will move further each day."
+msgstr "每控制一座灯塔，船只每日可移动更远。"
+
+msgid "English"
+msgstr "英文"
+
+msgid "French"
+msgstr "法文"
+
+msgid "Polish"
+msgstr "波兰文"
+
+msgid "German"
+msgstr "德文"
+
+msgid "Russian"
+msgstr "俄文"
+
+msgid "Italian"
+msgstr "义大利文"
+
+msgid "Czech"
+msgstr "捷克文"
+
+msgid "Norwegian"
+msgstr "挪威文"
+
+msgid "Belarusian"
+msgstr "白俄罗斯文"
+
+msgid "Bulgarian"
+msgstr "保加利亚文"
+
+msgid "Ukrainian"
+msgstr "乌克兰文"
+
+msgid "Romanian"
+msgstr "罗马尼亚文"
+
+msgid "Spanish"
+msgstr "西班牙文"
+
+msgid "Swedish"
+msgstr "瑞典文"
+
+msgid "Portuguese"
+msgstr "葡萄牙文"
+
+msgid "Turkish"
+msgstr "土耳其文"
+
+msgid "Dutch"
+msgstr "荷兰文"
+
+msgid "Hungarian"
+msgstr "匈牙利文"
+
+msgid "Danish"
+msgstr "丹麦文"
+
+msgid "Slovak"
+msgstr "斯洛伐克文"
+
+msgid "Vietnamese"
+msgstr "越南文"
+
+msgid "Greek"
+msgstr "希腊文"
+
+msgid "Esperanto"
+msgstr "世界语"
+
+msgid "Simplified Chinese"
+msgstr "简体中文"
+
+msgid "Traditional Chinese"
+msgstr "繁体中文"
+
+msgid "Slow"
+msgstr "慢"
+
+msgid "Fast"
+msgstr "快"
+
+msgid "Very Fast"
+msgstr "非常快"
+
+msgid "Dynamic"
+msgstr "动态"
+
+msgid "Good"
+msgstr "善良"
+
+msgid "Evil"
+msgstr "邪恶"
+
+msgid "Black & White"
+msgstr "黑白"
+
+msgid "Color"
+msgstr "彩色"
+
+msgid "Configure"
+msgstr "设定"
+
+msgid ", FPS: "
+msgstr ", FPS: "
+
+msgid "Ector"
+msgstr "Ector"
+
+msgid "Gwenneth"
+msgstr "Gwenneth"
+
+msgid "Sir Gallant"
+msgstr "Sir Gallant"
+
+msgid "Tyro"
+msgstr "Tyro"
+
+msgid "Dimitry"
+msgstr "Dimitry"
+
+msgid "Ruby"
+msgstr "Ruby"
+
+msgid "Crag Hack"
+msgstr "Crag Hack"
+
+msgid "Fineous"
+msgstr "Fineous"
+
+msgid "Jaclyn"
+msgstr "Jaclyn"
+
+msgid "Jezebel"
+msgstr "Jezebel"
+
+msgid "Atlas"
+msgstr "Atlas"
+
+msgid "Ergon"
+msgstr "Ergon"
+
+msgid "Gem"
+msgstr "Gem"
+
+msgid "Natasha"
+msgstr "Natasha"
+
+msgid "Carlawn"
+msgstr "Carlawn"
+
+msgid "Luna"
+msgstr "Luna"
+
+msgid "Arie"
+msgstr "Arie"
+
+msgid "Barok"
+msgstr "Barok"
+
+msgid "Kastore"
+msgstr "Kastore"
+
+msgid "Falagar"
+msgstr "Falagar"
+
+msgid "Dawn"
+msgstr "Dawn"
+
+msgid "Flint"
+msgstr "Flint"
+
+msgid "Halon"
+msgstr "Halon"
+
+msgid "Myra"
+msgstr "Myra"
+
+msgid "Myrini"
+msgstr "Myrini"
+
+msgid "Wilfrey"
+msgstr "Wilfrey"
+
+msgid "Mandigal"
+msgstr "Mandigal"
+
+msgid "Sarakin"
+msgstr "Sarakin"
+
+msgid "Charity"
+msgstr "Charity"
+
+msgid "Darlana"
+msgstr "Darlana"
+
+msgid "Ranloo"
+msgstr "Ranloo"
+
+msgid "Rialdo"
+msgstr "Rialdo"
+
+msgid "Zam"
+msgstr "Zam"
+
+msgid "Zom"
+msgstr "Zom"
+
+msgid "Celia"
+msgstr "Celia"
+
+msgid "Roxana"
+msgstr "Roxana"
+
+msgid "Lord Corlagon"
+msgstr "Lord Corlagon"
+
+msgid "Lord Halton"
+msgstr "Lord Halton"
+
+msgid "Sister Eliza"
+msgstr "Sister Eliza"
+
+msgid "Brother Brax"
+msgstr "Brother Brax"
+
+msgid "Dainwin"
+msgstr "Dainwin"
+
+msgid "Gallavant"
+msgstr "Gallavant"
+
+msgid "Joseph"
+msgstr "Joseph"
+
+msgid "Mog"
+msgstr "Mog"
+
+msgid "Solmyr"
+msgstr "Solmyr"
+
+msgid "Ceallach"
+msgstr "Ceallach"
+
+msgid "Drakonia"
+msgstr "Drakonia"
+
+msgid "Elderian"
+msgstr "Elderian"
+
+msgid "Jarkonas"
+msgstr "Jarkonas"
+
+msgid "Martine"
+msgstr "Martine"
+
+msgid "shipAndGraveyard|%{object} robber"
+msgstr "%{object}强盗"
+
+msgid "pyramid|%{object} raided"
+msgstr "%{object}已被搜刮"
+
+msgid " gives you maximum morale"
+msgstr "给予你最高士气"
+
+msgid " gives you maximum luck"
+msgstr "给予你最高运气"
+
+msgid "You cannot have multiple spell books."
+msgstr "不能拥有多本法术书。"
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr "无法拾取此神器，神器栏位已满！"
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr "要施放法术，必须先花 %{gold} 金币购买法术书。"
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr "很遗憾，你目前似乎资金不足。"
+
+msgid "Do you wish to buy one?"
+msgstr "要购买一本吗？"
+
+msgid "%{count} / day"
+msgstr "%{count} / 日"
+
+msgid "one"
+msgstr "一"
+
+msgid "two"
+msgstr "二"
+
+msgid "A whirlpool engulfs your ship. Some of your army has fallen overboard."
+msgstr "漩涡吞没了你的船。部分军队落入水中。"
+
+msgid "Insulted by your refusal of their offer, the monsters attack!"
+msgstr "怪物因你拒绝牠们的提议而恼怒，发动了攻击！"
+
+msgid ""
+"The %{monster}, awed by the power of your forces, begin to scatter.\n"
+"Do you wish to pursue and engage them?"
+msgstr ""
+"%{monster} 被你的军队力量震慑，开始四散逃离。\n"
+"是否要追击？"
+
+msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
+msgstr "搜刮敌方营地时，你发现了一处隐藏的宝藏。"
+
+msgid ""
+"Your ship bumps into a barrel drifting at sea. Inside, you discover a stash "
+"of lost treasure."
+msgstr ""
+"你的船撞上了一个在海上漂流的木桶。里面发现了一批遗落的宝藏。"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I have been working very hard to provide you with these resources, "
+"come back next week for more.\""
+msgstr ""
+"磨坊管理员宣布:\n"
+"「大人，我一直努力为您提供这些资源，请下周再来取用。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I am sorry, there are no resources currently available. Please try "
+"again next week.\""
+msgstr ""
+"磨坊管理员宣布:\n"
+"「大人，很抱歉，目前没有可用的资源。请下周再来。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I have been working very hard to provide you with this gold, come "
+"back next week for more.\""
+msgstr ""
+"磨坊管理员宣布:\n"
+"「大人，我一直努力为您准备黄金，请下周再来取用。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I am sorry, there is no gold currently available. Please try again "
+"next week.\""
+msgstr ""
+"磨坊管理员宣布:\n"
+"「大人，很抱歉，目前没有可用的黄金。请下周再来。」"
+
+msgid ""
+"You've found an abandoned lean-to.\n"
+"Poking about, you discover some resources hidden nearby."
+msgstr ""
+"你发现了一间废弃的棚屋。\n"
+"四处翻找后，发现附近藏有一些资源。"
+
+msgid "The lean-to is long abandoned. There is nothing of value here."
+msgstr "棚屋早已荒废，这里没有任何有价值的东西。"
+
+msgid ""
+"You catch a leprechaun foolishly sleeping amidst a cluster of magic "
+"mushrooms.\n"
+"In exchange for his freedom, he guides you to a small pot filled with "
+"precious things."
+msgstr ""
+"你发现一个妖精愚蠢地睡在一丛魔法蘑菇中间。\n"
+"为了换取自由，他带你去了一个装满珍贵物品的小罐子。"
+
+msgid ""
+"You've found a magic garden, the kind of place that leprechauns and faeries "
+"like to cavort in, but there is no one here today.\n"
+"Perhaps you should try again next week."
+msgstr ""
+"你发现了一座魔法花园，是妖精和仙子喜欢嬉戏的地方，但今天这里空无一人。\n"
+"或许下周再来试试。"
+
+msgid "You come upon the remains of an unfortunate adventurer."
+msgstr "你发现了一位不幸冒险者的遗骸。"
+
+msgid "Treasure"
+msgstr "宝藏"
+
+msgid "Searching through the tattered clothing, you find the %{artifact}."
+msgstr "翻找破旧的衣物时，你发现了 %{artifact}。"
+
+msgid "Searching through the tattered clothing, you find nothing."
+msgstr "翻找破旧的衣物，什么都没找到。"
+
+msgid ""
+"You come across an old wagon left by a trader who didn't quite make it to "
+"safe terrain."
+msgstr ""
+"你发现一辆旧马车；留下它的商人没能抵达安全地带。"
+
+msgid "Unfortunately, others have found it first, and the wagon is empty."
+msgstr "很遗憾，其他人已捷足先登，马车是空的。"
+
+msgid "Searching inside, you find the %{artifact}."
+msgstr "在里面搜寻，你发现了 %{artifact}。"
+
+msgid "Inside, you find some of the wagon's cargo still intact."
+msgstr "在里面，你发现了一些马车货物仍完好无损。"
+
+msgid "You search through the flotsam, and find some wood and some gold."
+msgstr "你翻找漂流物，发现了一些木材和黄金。"
+
+msgid "You search through the flotsam, and find some wood."
+msgstr "你翻找漂流物，发现了一些木材。"
+
+msgid "You search through the flotsam, but find nothing."
+msgstr "你翻找了漂流物，但什么都没找到。"
+
+msgid "Shrine of the 1st Circle"
+msgstr "第一环神殿"
+
+msgid ""
+"You come across a small shrine attended by a group of novice acolytes.\n"
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
+msgstr ""
+"你偶然发现一座由一群见习僧侣看管的小神殿。\n"
+"为了换取你的保护，他们同意教你一个简单的法术——「%{spell}」。"
+
+msgid "Shrine of the 2nd Circle"
+msgstr "第二环神殿"
+
+msgid ""
+"You come across an ornate shrine attended by a group of rotund friars.\n"
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
+msgstr ""
+"你偶然发现一座由一群圆胖修士看管的华丽神殿。\n"
+"为了换取你的保护，他们同意教你一个法术——「%{spell}」。"
+
+msgid "Shrine of the 3rd Circle"
+msgstr "第三环神殿"
+
+msgid ""
+"You come across a lavish shrine attended by a group of high priests.\n"
+"In exchange for your protection, they agree to teach you a sophisticated "
+"spell - '%{spell}'."
+msgstr ""
+"你偶然发现一座由一群大祭司看管的奢华神殿。\n"
+"为了换取你的保护，他们同意教你一个高深法术——「%{spell}」。"
+
+msgid ""
+"\n"
+"Unfortunately, you do not have the wisdom to understand the spell, and you "
+"are unable to learn it."
+msgstr ""
+"\n"
+"很遗憾，你没有足够的智慧来理解此法术，无法学会它。"
+
+msgid ""
+"\n"
+"Unfortunately, you already have knowledge of this spell, so there is nothing "
+"more for them to teach you."
+msgstr ""
+"\n"
+"很遗憾，你已知晓此法术，他们无法再教你更多了。"
+
+msgid ""
+"\n"
+"Unfortunately, you have no Magic Book to record the spell with."
+msgstr ""
+"\n"
+"很遗憾，你没有法术书来记录此法术。"
+
+msgid ""
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
+"\n"
+msgstr ""
+"你走近小屋，看到里面有一位女巫正在研读一本关于 %{skill} 的古老典籍。\n"
+"\n"
+
+msgid ""
+"As you approach, she turns and focuses her one glass eye on you.\n"
+"\"You already know everything you deserve to learn!\" the witch screeches. "
+"\"NOW GET OUT OF MY HOUSE!\""
+msgstr ""
+"当你走近时，她转过身用她的玻璃眼瞪着你。\n"
+"「你已经知道了所有你该学的东西！」女巫尖叫道。「立刻滚出我的房子！」"
+
+msgid ""
+"As you approach, she turns and speaks.\n"
+"\"You already know that which I would teach you. I can help you no further.\""
+msgstr ""
+"当你走近时，她转过身说道。\n"
+"「你已经知道我要教的东西了。我无法再帮助你。」"
+
+msgid ""
+"An ancient and immortal witch living in a hut with bird's legs for stilts "
+"teaches you %{skill} for her own inscrutable purposes."
+msgstr ""
+"一位住在以鸟腿为支柱小屋中的古老不朽女巫，为了她不可测的目的教导了你 "
+"%{skill}。"
+
+msgid "As you drink the sweet water, you gain luck for your next battle."
+msgstr "喝下甘甜的泉水后，你的下一场战斗将获得好运加成。"
+
+msgid "You drink from the enchanted fountain, but nothing happens."
+msgstr "你从施了魔法的喷泉中饮水，但什么都没发生。"
+
+msgid "You enter the faerie ring, but nothing happens."
+msgstr "你进入了妖精之环，但什么都没发生。"
+
+msgid ""
+"Upon entering the mystical faerie ring, your army gains luck for its next "
+"battle."
+msgstr ""
+"进入神秘的妖精之环后，军队在下一场战斗中将获得好运加成。"
+
+msgid ""
+"You've found an ancient and weathered stone idol.\n"
+"It is supposed to grant luck to visitors, but since the stars are already "
+"smiling upon you, it does nothing."
+msgstr ""
+"你发现了一座古老且风化的石偶像。\n"
+"据说它能赐予造访者好运，但由于幸运之星已经眷顾你了，所以毫无效果。"
+
+msgid ""
+"You've found an ancient and weathered stone idol.\n"
+"Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
+"touch."
+msgstr ""
+"你发现了一座古老且风化的石偶像。\n"
+"据说亲吻它会带来好运，于是你照做了。石头触感非常冰冷。"
+
+msgid "The mermaids silently entice you to return later and be blessed again."
+msgstr "美人鱼静静地引诱你稍后再来接受祝福。"
+
+msgid ""
+"The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
+"Just for a moment, you forget your worries and bask in the beauty of the "
+"moment.\n"
+"The mermaids' charms bless you with increased luck for your next combat."
+msgstr ""
+"美人鱼那神奇而抚慰人心的美丽触及你和你的船员。\n"
+"短暂的一刻，你忘却了烦忧，沉浸在美好之中。\n"
+"美人鱼的魅力为你的下一场战斗赐予好运加成。"
+
+msgid ""
+"You come upon the pyramid of a great and ancient king.\n"
+"You are tempted to search it for treasure, but all the old stories warn of "
+"fearful curses and undead guardians.\n"
+"Will you search?"
+msgstr ""
+"你来到了一位伟大古代国王的金字塔前。\n"
+"你很想搜寻宝藏，但所有古老的故事都警告着可怕的诅咒和亡灵守卫。\n"
+"要搜寻吗？"
+
+msgid ""
+"Upon defeating the monsters, you decipher an ancient glyph on the wall, "
+"telling the secret of the spell - '"
+msgstr ""
+"击败怪物后，你破译了墙上的古老铭文，得知了法术的奥秘——「"
+
+msgid "Unfortunately, you have no Magic Book to record the spell with."
+msgstr "很遗憾，你没有法术书来记录此法术。"
+
+msgid ""
+"Unfortunately, you do not have the wisdom to understand the spell, and you "
+"are unable to learn it."
+msgstr ""
+"很遗憾，你没有足够的智慧来理解此法术，无法学会它。"
+
+msgid ""
+"You come upon the pyramid of a great and ancient king.\n"
+"Routine exploration reveals that the pyramid is completely empty."
+msgstr ""
+"你来到了一位伟大古代国王的金字塔前。\n"
+"例行探索后发现金字塔完全是空的。"
+
+msgid ""
+"A drink at the well is supposed to restore your spell points, but you are "
+"already at maximum."
+msgstr ""
+"在井中饮水据说能恢复魔法值，但你的魔法值已经是满的了。"
+
+msgid "A second drink at the well in one day will not help you."
+msgstr "一天内在井中第二次饮水不会有帮助。"
+
+msgid "A drink from the well has restored your spell points to maximum."
+msgstr "井中的一口水已将你的魔法值恢复至最大值。"
+
+msgid ""
+"\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
+"everything we have to teach.\""
+msgstr ""
+"「抱歉，大人，」士兵的首领说道，「但你已经知道我们能教的一切了。」"
+
+msgid "The soldiers living in the fort teach you a few new defensive tricks."
+msgstr "驻守堡垒的士兵教了你一些新的防御技巧。"
+
+msgid ""
+"You've come upon a mercenary camp practicing their tactics. \"You're too "
+"advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
+msgstr ""
+"你偶然来到一个正在练习战术的佣兵营地。「你太强了，」佣兵队长说道。「我们没什"
+"么能教你的了。」"
+
+msgid ""
+"You've come upon a mercenary camp practicing their tactics. The mercenaries "
+"welcome you and your troops and invite you to train with them."
+msgstr ""
+"你偶然来到一个正在练习战术的佣兵营地。佣兵们欢迎你和你的部队，邀请你们一起训"
+"练。"
+
+msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
+msgstr "「走开！」巫医吠道，「你已经知道我所知的一切了。」"
+
+msgid ""
+"An Orcish witch doctor living in the hut deepens your knowledge of magic by "
+"showing you how to cast stones, read portents, and decipher the intricacies "
+"of chicken entrails."
+msgstr ""
+"住在小屋里的海怪巫医向你展示如何投石占卜、解读预兆和辨析鸡内脏的复杂纹理，加"
+"深了你的魔法知识。"
+
+msgid ""
+"You've found a group of Druids worshipping at one of their strange stone "
+"edifices. Silently, the Druids turn you away, indicating they have nothing "
+"new to teach you."
+msgstr ""
+"你发现一群德鲁伊正在其中一座奇异的石造建筑前膜拜。德鲁伊们默默将你拒之门外，"
+"示意他们没有新东西可教你。"
+
+msgid ""
+"You've found a group of Druids worshipping at one of their strange stone "
+"edifices. Silently, they teach you new ways to cast spells."
+msgstr ""
+"你发现一群德鲁伊正在其中一座奇异的石造建筑前膜拜。他们默默教你施法的新方式。"
+
+msgid ""
+"You tentatively approach the burial ground of ancient warriors. Do you want "
+"to search the graves?"
+msgstr ""
+"你试探性地走向古代战士的墓地。要搜寻坟墓吗？"
+
+msgid ""
+"You spend several hours searching the graves and find nothing. Such a "
+"despicable act reduces your army's morale."
+msgstr ""
+"你花了数小时搜寻坟墓却一无所获。这种卑劣行为让军队士气下降。"
+
+msgid "Upon defeating the Zombies you search the graves and find something!"
+msgstr "击败僵尸后你搜寻了坟墓并找到了些东西！"
+
+msgid ""
+"The rotting hulk of a great pirate ship creaks eerily as it is pushed "
+"against the rocks. Do you wish to search the shipwreck?"
+msgstr ""
+"一艘巨大海盗船腐烂的残骸被推靠在岩石上，发出诡异的嘎吱声。要搜寻沉船吗？"
+
+msgid ""
+"You spend several hours sifting through the debris and find nothing. Such a "
+"despicable act reduces your army's morale."
+msgstr ""
+"你花了数小时翻找残骸却一无所获。这种卑劣行为让军队士气下降。"
+
+msgid ""
+"Upon defeating the Ghosts you sift through the debris and find something!"
+msgstr ""
+"击败鬼怪后你筛查了残骸并找到了些东西！"
+
+msgid ""
+"The rotting hulk of a great pirate ship creaks eerily as it is pushed "
+"against the rocks. Do you wish to search the ship?"
+msgstr ""
+"一艘巨大海盗船腐烂的残骸被推靠在岩石上，发出诡异的嘎吱声。要搜寻船只吗？"
+
+msgid ""
+"Upon defeating the Skeletons you sift through the debris and find something!"
+msgstr ""
+"击败骷髅兵后你筛查了残骸并找到了些东西！"
+
+msgid "Your men spot a navigational buoy, confirming that you are on course."
+msgstr "你的船员发现了一个航标，确认航线正确。"
+
+msgid ""
+"Your men spot a navigational buoy, confirming that you are on course and "
+"increasing their morale."
+msgstr ""
+"你的船员发现了一个航标，确认航线正确，提振了士气。"
+
+msgid ""
+"The drink at the oasis is refreshing, but offers no further benefit. The "
+"oasis might help again if you fought a battle first."
+msgstr ""
+"绿洲的水很清爽，但没有额外效果。先打完一场仗后绿洲可能会再次生效。"
+
+msgid ""
+"A drink at the oasis fills your troops with strength and lifts their "
+"spirits. You can travel a bit further today."
+msgstr ""
+"在绿洲饮水使部队充满力量、精神振奋。今天可以多走一段路。"
+
+msgid ""
+"The drink at the watering hole is refreshing, but offers no further benefit. "
+"The watering hole might help again if you fought a battle first."
+msgstr ""
+"水源地的水很清爽，但没有额外效果。先打完一场仗后水源地可能会再次生效。"
+
+msgid ""
+"A drink at the watering hole fills your troops with strength and lifts their "
+"spirits. You can travel a bit further today."
+msgstr ""
+"在水源地饮水使部队充满力量、精神振奋。今天可以多走一段路。"
+
+msgid ""
+"It doesn't help to pray twice before a battle. Come back after you've fought."
+msgstr ""
+"战斗前祈祷两次没有帮助。打完仗再回来吧。"
+
+msgid "A visit and a prayer at the temple raises the morale of your troops."
+msgstr "在神庙中造访并祈祷提升了部队的士气。"
+
+msgid ""
+"An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
+"have taught you all I can.\""
+msgstr ""
+"一位年迈的骑士出现在凉亭的台阶上。「很抱歉，主公，我已经把能教的都教了。」"
+
+msgid ""
+"An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
+"you all that I know to aid you in your travels.\""
+msgstr ""
+"一位年迈的骑士出现在凉亭的台阶上。「主公，我将倾囊相授，助你旅途顺利。」"
+
+msgid ""
+"You've pulled a shipwreck survivor from certain death in an unforgiving "
+"ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
+"you're all full.\""
+msgstr ""
+"你从无情的大海中救出了一位沉船幸存者。他感激地说：「我想给你一件神器作为回"
+"报，但你的神器栏位已满了。」"
+
+msgid ""
+"You've pulled a shipwreck survivor from certain death in an unforgiving "
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
+msgstr ""
+"你从无情的大海中救出了一位沉船幸存者。他感激你的善举，将 %{art} 送给你作为回"
+"报。"
+
+msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
+msgstr "一个妖精以 %{gold} 金币的低价向你兜售 %{art}。"
+
+msgid ""
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
+msgstr ""
+"一个妖精以 %{gold} 金币加 %{count} %{res} 的低价向你兜售 %{art}。"
+
+msgid "Do you wish to buy this artifact?"
+msgstr "要购买此神器吗？"
+
+msgid ""
+"You try to pay the leprechaun, but realize that you can't afford it. The "
+"leprechaun stamps his foot and ignores you."
+msgstr ""
+"你想付钱给妖精，但发现负担不起。妖精跺了跺脚，不理你了。"
+
+msgid ""
+"Insulted by your refusal of his generous offer, the leprechaun stamps his "
+"foot and ignores you."
+msgstr ""
+"妖精因你拒绝他慷慨的提议而受辱，跺了跺脚不理你了。"
+
+msgid "You've found the artifact: "
+msgstr "你找到了神器："
+
+msgid ""
+"You've found the humble dwelling of a withered hermit. The hermit tells you "
+"that he is willing to give the %{art} to the first wise person he meets."
+msgstr ""
+"你发现了一位枯槁隐士的简陋居所。隐士告诉你，他愿意将 %{art} 送给第一位遇到的"
+"有智慧者。"
+
+msgid ""
+"You've come across the spartan quarters of a retired soldier. The soldier "
+"tells you that he is willing to pass on the %{art} to the first true leader "
+"he meets."
+msgstr ""
+"你偶然发现一位退役士兵的简朴住处。士兵告诉你，他愿意将 %{art} 传给第一位遇到"
+"的真正领袖。"
+
+msgid ""
+"You've encountered a strange person with a hat and an owl on it. He tells "
+"you that he is willing to give %{art} if you have %{skill}."
+msgstr ""
+"你遇到了一个戴着帽子、上面有只猫头鹰的奇人。他告诉你，若你拥有 %{skill}，他愿"
+"意给你 %{art}。"
+
+msgid ""
+"You come upon an ancient artifact. As you reach for it, a pack of Rogues "
+"leap out of the brush to guard their stolen loot."
+msgstr ""
+"你发现了一件古老的神器。正当你伸手去拿时，一群盗贼从灌木丛中跳出，守卫他们偷"
+"来的赃物。"
+
+msgid ""
+"Through a clearing you observe an ancient artifact. Unfortunately, it's "
+"guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
+"artifact?"
+msgstr ""
+"隔着一片空地，你看到一件古老的神器。不幸的是，旁边有 %{monster} 守卫。要为了"
+"神器与 %{monster} 战斗吗？"
+
+msgid "Victorious, you take your prize, the %{art}."
+msgstr "你取得了胜利，拿走了奖品 %{art}。"
+
+msgid ""
+"Discretion is the better part of valor, and you decide to avoid this fight "
+"for today."
+msgstr ""
+"慎重是勇气的一部分，你决定今天不打这场仗。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it, "
+"only to find it empty."
+msgstr ""
+"花了数小时从海中捞出宝箱后打开一看，里面竟然是空的。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it "
+"and find %{gold} gold and the %{art}."
+msgstr ""
+"花了数小时从海中捞出宝箱后打开，发现了 %{gold} 金币和 %{art}。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it "
+"and find %{gold} gold pieces."
+msgstr ""
+"花了数小时从海中捞出宝箱后打开，发现了 %{gold} 金币。"
+
+msgid ""
+"After scouring the area, you fall upon a hidden treasure cache. You may take "
+"the gold or distribute the gold to the peasants for experience. Do you wish "
+"to keep the gold?"
+msgstr ""
+"搜寻此区域后，你发现了一处隐藏的宝藏。你可以拿走黄金，或将黄金分给农民以换取"
+"经验值。要保留黄金吗？"
+
+msgid ""
+"After scouring the area, you fall upon a hidden chest, containing the "
+"ancient artifact %{art}."
+msgstr ""
+"搜寻此区域后，你发现了一个隐藏的宝箱，里面装有古老的神器 %{art}。"
+
+msgid ""
+"You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
+"you wish to rub the lamp?"
+msgstr ""
+"你偶然发现一盏凹凸不平、锈蚀的神灯深埋在地下。要擦拭神灯吗？"
+
+msgid ""
+"You have taken control of the local Alchemist shop. It will provide you with "
+"%{count} unit of Mercury per day."
+msgstr ""
+"你取得了当地炼金术士商店的控制权。每日将提供 %{count} 单位的水银。"
+
+msgid ""
+"You gain control of a sawmill. It will provide you with %{count} units of "
+"wood per day."
+msgstr ""
+"你取得了一座锯木厂的控制权。每日将提供 %{count} 单位的木材。"
+
+msgid ""
+"You gain control of an ore mine. It will provide you with %{count} units of "
+"ore per day."
+msgstr ""
+"你取得了一座矿石矿场的控制权。每日将提供 %{count} 单位的矿石。"
+
+msgid ""
+"You gain control of a sulfur mine. It will provide you with %{count} unit of "
+"sulfur per day."
+msgstr ""
+"你取得了一座硫磺矿场的控制权。每日将提供 %{count} 单位的硫磺。"
+
+msgid ""
+"You gain control of a crystal mine. It will provide you with %{count} unit "
+"of crystal per day."
+msgstr ""
+"你取得了一座水晶矿场的控制权。每日将提供 %{count} 单位的水晶。"
+
+msgid ""
+"You gain control of a gem mine. It will provide you with %{count} unit of "
+"gems per day."
+msgstr ""
+"你取得了一座宝石矿场的控制权。每日将提供 %{count} 单位的宝石。"
+
+msgid ""
+"You gain control of a gold mine. It will provide you with %{count} gold per "
+"day."
+msgstr ""
+"你取得了一座金矿的控制权。每日将提供 %{count} 金币。"
+
+msgid ""
+"The lighthouse is now under your control, and all of your ships will now "
+"move further each day."
+msgstr ""
+"灯塔现已在你的控制之下，所有船只每日可移动更远。"
+
+msgid "You gain control of a %{name}."
+msgstr "你取得了 %{name} 的控制权。"
+
+msgid ""
+"You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
+"wish to enter?"
+msgstr ""
+"你发现了一座废弃金矿。矿场似乎闹鬼。要进入吗？"
+
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr "你击败了鬼怪，得以恢复矿场的生产。"
+
+msgid ""
+"A group of %{monster} with a desire for greater glory wish to join you. Do "
+"you accept?"
+msgstr ""
+"一群渴望更伟大荣耀的 %{monster} 希望加入你。是否接受？"
+
+msgid "As you approach the dwelling, you notice that there is no one here."
+msgstr "当你接近住所时，发现这里空无一人。"
+
+msgid ""
+"You search the ruins, but the Medusas that used to live here are gone. "
+"Perhaps there will be more next week."
+msgstr ""
+"你搜寻了遗迹，但曾住在这里的美杜莎已经离开。或许下周会有更多。"
+
+msgid ""
+"You've found some Medusas living in the ruins. They are willing to join your "
+"army for a price. Do you want to recruit Medusas?"
+msgstr ""
+"你在遗迹中发现了一些美杜莎。她们愿意以一定代价加入你的军队。要招募美杜莎吗？"
+
+msgid ""
+"You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
+"there wish to join an army. Maybe next week."
+msgstr ""
+"你发现了一座精灵树城。可惜，住在那里的精灵都不想加入军队。也许下周吧。"
+
+msgid ""
+"Some of the Sprites living in the tree city are willing to join your army "
+"for a price. Do you want to recruit Sprites?"
+msgstr ""
+"住在树城中的一些精灵愿意以一定代价加入你的军队。要招募精灵吗？"
+
+msgid ""
+"A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
+"later."
+msgstr ""
+"一辆色彩缤纷的盗贼马车空置在此。也许稍后会有更多盗贼出现。"
+
+msgid ""
+"Distant sounds of music and laughter draw you to a colorful wagon housing "
+"Rogues. Do you wish to have any Rogues join your army?"
+msgstr ""
+"远方传来的音乐和笑声将你引到一辆色彩缤纷的盗贼马车旁。要让盗贼加入你的军队"
+"吗？"
+
+msgid ""
+"A group of tattered tents, billowing in the sandy wind, beckons you. The "
+"tents are unoccupied. Perhaps more Nomads will be here later."
+msgstr ""
+"一群在沙风中飘动的破旧帐篷向你招手。帐篷空无一人，也许稍后会有更多游牧民出"
+"现。"
+
+msgid ""
+"A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
+"wish to have any Nomads join you during your travels?"
+msgstr ""
+"一群在沙风中飘动的破旧帐篷向你招手。要让游牧民在旅途中加入你吗？"
+
+msgid "The pit of mud bubbles for a minute and then lies still."
+msgstr "泥坑冒了一分钟的泡，然后归于平静。"
+
+msgid ""
+"As you approach the bubbling pit of mud, creatures begin to climb out and "
+"position themselves around it. In unison they say: \"Mother Earth would like "
+"to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
+msgstr ""
+"当你走近冒泡的泥坑时，生物开始从中爬出并围绕着它。他们齐声说道：「大地之母愿"
+"意提供一些部队给你。要招募土元素吗？」"
+
+msgid "You enter the structure of white stone pillars, and find nothing."
+msgstr "你进入了白色石柱建筑，什么都没找到。"
+
+msgid ""
+"White stone pillars support a roof that rises up to the sky. As you enter "
+"the structure, the dead air of the outside gives way to a whirling gust that "
+"almost pushes you back out. The air current materializes into a barely "
+"visible form. The creature asks, in what can only be described as a loud "
+"whisper: \"Why have you come? Are you here to call upon the forces of the "
+"air?\""
+msgstr ""
+"白色石柱撑起一座直入云霄的屋顶。进入建筑时，外面死寂的空气消失了，一股旋风几"
+"乎把你推回去。气流凝聚成一个几乎看不见的形体。那生物以只能形容为低沉耳语的声"
+"音问道：「你为何而来？是要召唤空气的力量吗？」"
+
+msgid "No Fire Elementals approach you from the lava pool."
+msgstr "没有火元素从岩浆池中靠近你。"
+
+msgid ""
+"Beneath a structure that serves to hold in heat, Fire Elementals move about "
+"in a fiery pool of molten lava. A group of them approach you and offer their "
+"services. Would you like to recruit Fire Elementals?"
+msgstr ""
+"在一座蓄热建筑下方，火元素在炽热的岩浆池中活动。一群火元素走近你并提供服务。"
+"要招募火元素吗？"
+
+msgid "A face forms in the water for a moment, and then is gone."
+msgstr "水面上短暂地浮现出一张脸，随即消失。"
+
+msgid ""
+"Crystalline structures cast shadows over a small reflective pool of water. "
+"You peer into the pool, and a face that is not your own peers back. It asks: "
+"\"Would you like to call upon the powers of water?\""
+msgstr ""
+"水晶结构在一个小型反射水池上投下阴影。你凝视池中，一张不属于你的面孔回望着"
+"你。它问道：「你想召唤水的力量吗？」"
+
+msgid "This burial site is deathly still."
+msgstr "这片墓地死寂一片。"
+
+msgid ""
+"Restless spirits of long dead warriors seeking their final resting place "
+"offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
+msgstr ""
+"早已亡故的不安战士灵魂寻找最终安息之地，愿意加入你以期得到安宁。要招募鬼怪"
+"吗？"
+
+msgid ""
+"The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
+"some undead will move in next week."
+msgstr ""
+"亡者之城既无生者，也无亡灵。或许下周会有亡灵进驻。"
+
+msgid ""
+"Some Liches living here are willing to join your army for a price. Do you "
+"want to recruit Liches?"
+msgstr ""
+"住在此处的一些地鬼愿意以一定代价加入你的军队。要招募地鬼吗？"
+
+msgid ""
+"You've found the ruins of an ancient city, now inhabited solely by the "
+"undead. Will you search?"
+msgstr ""
+"你发现了一座古城遗迹，如今只有亡灵栖息。要搜寻吗？"
+
+msgid ""
+"Some of the surviving Liches are impressed by your victory over their "
+"fellows, and offer to join you for a price. Do you want to recruit Liches?"
+msgstr ""
+"幸存的一些地鬼对你战胜他们的同伴印象深刻，愿意以一定代价加入你。要招募地鬼"
+"吗？"
+
+msgid ""
+"You've found one of those bridges that Trolls are so fond of living under, "
+"but there are none here. Perhaps there will be some next week."
+msgstr ""
+"你找到了一座索尔最爱栖息其下的桥，但这里一个都没有。也许下周会有。"
+
+msgid ""
+"Some Trolls living under a bridge are willing to join your army, but for a "
+"price. Do you want to recruit Trolls?"
+msgstr ""
+"住在桥下的一些索尔愿意以一定代价加入你的军队。要招募索尔吗？"
+
+msgid "Trolls living under the bridge challenge you. Will you fight them?"
+msgstr "住在桥下的索尔向你挑战。要战斗吗？"
+
+msgid ""
+"A few Trolls remain, cowering under the bridge. They approach you and offer "
+"to join your forces as mercenaries. Do you want to buy any Trolls?"
+msgstr ""
+"几个索尔畏缩在桥下。他们走近你，提议以佣兵身分加入你的队伍。要购买索尔吗？"
+
+msgid ""
+"The Dragon city has no Dragons willing to join you this week. Perhaps a "
+"Dragon will become available next week."
+msgstr ""
+"龙族之城本周没有愿意加入你的巨龙。也许下周会有。"
+
+msgid ""
+"The Dragon city is willing to offer some Dragons for your army for a price. "
+"Do you wish to recruit Dragons?"
+msgstr ""
+"龙族之城愿意以一定代价为你的军队提供巨龙。要招募巨龙吗？"
+
+msgid ""
+"You stand before the Dragon City, a place off-limits to mere humans. Do you "
+"wish to violate this rule and challenge the Dragons to a fight?"
+msgstr ""
+"你站在龙族之城前，这是凡人禁止踏入之地。要违反此规则向巨龙发起挑战吗？"
+
+msgid ""
+"Having defeated the Dragon champions, the city's leaders agree to supply "
+"some Dragons to your army for a price. Do you wish to recruit Dragons?"
+msgstr ""
+"击败龙族勇士后，城市首领同意让你的军队付费招募巨龙。要招募巨龙吗？"
+
+msgid "From the observation tower, you are able to see distant lands."
+msgstr "从观测塔上，你可以看到远方的土地。"
+
+msgid ""
+"The spring only refills once a week, and someone's already been here this "
+"week."
+msgstr ""
+"泉水每周只补充一次，本周已有人来过了。"
+
+msgid ""
+"A drink at the spring is supposed to give you twice your normal spell "
+"points, but you are already at that level."
+msgstr ""
+"泉水据说能给予你双倍的正常魔法值，但你已经达到那个水平了。"
+
+msgid ""
+"A drink from the spring fills your blood with magic! You have twice your "
+"normal spell points in reserve."
+msgstr ""
+"泉水中的一口饮料让你的血液充满魔力！你的魔法值储备达到正常值的两倍。"
+
+msgid ""
+"Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
+"\"will not see the same student twice.\""
+msgstr ""
+"管家认出了你，拒绝让你入内。「主人，」他说，「不会见同一个学生两次。」"
+
+msgid ""
+"The butler admits you to see the master of the house. He trains you in the "
+"four skills a hero should know."
+msgstr ""
+"管家允许你谒见主人。他训练你英雄应知的四项技能。"
+
+msgid ""
+"The butler opens the door and looks you up and down. \"You are neither "
+"famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
+"\"Come back when you think yourself worthy.\""
+msgstr ""
+"管家打开门，上下打量着你。「你既不够出名也不够圆滑，不配觐见我的主人，」他哼"
+"了一声。「觉得自己配的时候再来吧。」"
+
+msgid " and "
+msgstr "和"
+
+msgid ""
+"All of the %{monsters} you have in your army have been trained by the battle "
+"masters of the fort. Your army now contains %{monsters2}."
+msgstr ""
+"你军队中所有的 %{monsters} 已经被堡垒的战斗大师训练过了。军队现在包含 "
+"%{monsters2}。"
+
+msgid ""
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
+"such troops brought to them. Unfortunately, you have none with you."
+msgstr ""
+"食人魔、海怪和矮人的罕见联盟愿意训练 (升级) 带来的相关部队。可惜，你没有携带"
+"任何适用部队。"
+
+msgid "All of your %{monsters} have been upgraded into %{monsters2}."
+msgstr "你所有的 %{monsters} 已升级为 %{monsters2}。"
+
+msgid ""
+"A blacksmith working at the foundry offers to convert all Pikemen and "
+"Swordsmen's weapons brought to him from iron to steel. He also says that he "
+"knows a process that will convert Iron Golems into Steel Golems. "
+"Unfortunately, you have none of these troops in your army, so he can't help "
+"you."
+msgstr ""
+"在铸造厂工作的铁匠愿意将所有送来的枪兵和剑客的武器从铁转换为钢。他还说他知道"
+"将机器人转换为钢铁机器人的方法。可惜，你的军队中没有这些部队，他帮不了你。"
+
+msgid ""
+"The captain looks at you with surprise and says:\n"
+"\"You already have all the maps I know about. Let me fish in peace now.\""
+msgstr ""
+"船长惊讶地看着你说道:\n"
+"「你已经有了我知道的所有海图。现在让我安静地钓鱼吧。」"
+
+msgid ""
+"A retired captain living on this refurbished fishing platform offers to sell "
+"you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
+"to buy the maps?"
+msgstr ""
+"一位住在这个翻修过的钓鱼平台上的退休船长，愿意以 1,000 金币卖给你他年轻时绘制"
+"的海图。要购买吗？"
+
+msgid ""
+"The captain sighs. \"You don't have enough money, eh? You can't expect me to "
+"give my maps away for free!\""
+msgstr ""
+"船长叹了口气。「你没有足够的钱吗？总不能指望我免费送你海图吧！」"
+
+msgid ""
+"You come upon an obelisk made from a type of stone you have never seen "
+"before. Staring at it intensely, the smooth surface suddenly changes to an "
+"inscription. The inscription is a piece of a lost ancient map. Quickly you "
+"copy down the piece and the inscription vanishes as abruptly as it appeared."
+msgstr ""
+"你发现了一座由前所未见的石材制成的方尖碑。你凝视着它，光滑的表面突然变成了铭"
+"文。铭文是一份失落古地图的碎片。你迅速抄录下来，铭文便如同出现时一样突然消失"
+"了。"
+
+msgid "You have already been to this obelisk."
+msgstr "你已经来过这座方尖碑了。"
+
+msgid ""
+"Upon your approach, the tree opens its eyes in delight. \"It is good to see "
+"you, my student. I hope my teachings have helped you.\""
+msgstr ""
+"当你走近时，树木高兴地睁开了眼睛。「很高兴见到你，我的学生。希望我的教导对你"
+"有所帮助。」"
+
+msgid ""
+"Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
+"adventurer! Allow me to teach you a little of what I have learned over the "
+"ages.\""
+msgstr ""
+"当你走近时，树木高兴地睁开了眼睛。「啊，一位冒险者！让我教你一点我历经数个世"
+"纪学到的知识。」"
+
+msgid "Upon your approach, the tree opens its eyes in delight."
+msgstr "当你走近时，树木高兴地睁开了眼睛。"
+
+msgid ""
+"\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
+"learned over the ages for a mere %{count} %{res}.\""
+msgstr ""
+"「啊，一位冒险者！我很乐意以仅仅 %{count} %{res} 教你一点我历经数个世纪学到的"
+"知识。」"
+
+msgid "(Just bury it around my roots.)"
+msgstr "(只要埋在我的根部周围就好。)"
+
+msgid "Tears brim in the eyes of the tree."
+msgstr "泪水涌上了树木的眼眶。"
+
+msgid "\"I need %{count} %{res}.\""
+msgstr "「我需要 %{count} %{res}。」"
+
+msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
+msgstr "它低语道。(抽泣) 「好吧，付得起的时候再来吧。」"
+
+msgid ""
+"Nestled among the trees sits a blind seer. After you explain the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+"一位盲眼先知隐居在树林间。在你说明旅程的目的后，先知启动了水晶球，让你看见对"
+"手的优势和弱点。"
+
+msgid ""
+"The entrance to the cave is dark, and a foul, sulfurous smell issues from "
+"the cave mouth. Will you enter?"
+msgstr ""
+"洞穴入口一片漆黑，洞口散发着恶臭的硫磺味。要进入吗？"
+
+msgid "Except for evidence of a terrible battle, the cave is empty."
+msgstr "除了一场惨烈战斗的痕迹外，洞穴是空的。"
+
+msgid ""
+"You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
+"\"you will fight and surely die. But I will give you a choice of deaths. You "
+"may fight me, or you may fight my servants. Do you prefer to fight my "
+"servants?\""
+msgstr ""
+"你在洞穴中发现了一个强大而狰狞的恶魔。「今天，」牠嘶哑地说，「你将战斗并必然"
+"死亡。但我给你选择死法的机会。你可以和我打，或和我的仆从打。你想和我的仆从打"
+"吗？」"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and receive %{exp} experience points."
+msgstr ""
+"恶魔发出挑战的尖叫，并且发动攻击！经过一场短暂而拚死的战斗，你杀死了怪物并获"
+"得 %{exp} 点经验值。"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
+msgstr ""
+"恶魔发出挑战的尖叫，并且发动攻击！经过一场短暂而拚死的战斗，你杀死了怪物并获"
+"得 %{exp} 点经验值和 %{count} 金币。"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and find the %{art} in the back of the cave."
+msgstr ""
+"恶魔发出挑战的尖叫，并且发动攻击！经过一场短暂而拚死的战斗，你杀死了怪物并在"
+"洞穴深处找到了 %{art}。"
+
+msgid ""
+"Seeing that you do not have %{count} gold, the demon slashes you with its "
+"claws, and the last thing you see is a red haze."
+msgstr ""
+"看到你没有 %{count} 金币，恶魔用爪子劈向你，你最后看到的是一片红色迷雾。"
+
+msgid ""
+"The Demon leaps upon you and has its claws at your throat before you can "
+"even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
+"to you for %{count} gold.\""
+msgstr ""
+"恶魔扑向你，在你拔剑之前就已把爪子抵在你的喉咙上。「你的命是我的了，」牠说。"
+"「我愿意以 %{count} 金币把它卖还给你。」"
+
+msgid ""
+"Upon defeating the daemon's servants, you find a hidden cache with %{count} "
+"gold."
+msgstr ""
+"击败恶魔的仆从后，你找到了一处藏有 %{count} 金币的隐密宝藏。"
+
+msgid ""
+"As you enter the Alchemist's Tower, a hobbled, graying man in a brown cloak "
+"makes his way towards you."
+msgstr ""
+"进入炼金术士之塔时，一位披着棕色斗篷、蹒跚而行的灰发老人向你走来。"
+
+msgid "He checks your pack, and sees that you have 1 cursed item."
+msgid_plural ""
+"He checks your pack, and sees that you have %{count} cursed items."
+msgstr[0] "他检查了你的背包，发现你有 1 件被诅咒的物品。"
+
+msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
+msgid_plural ""
+"For %{gold} gold, the alchemist will remove them for you. Do you pay?"
+msgstr[0] "炼金术士愿意以 %{gold} 金币为你移除它。要付费吗？"
+
+msgid ""
+"After you consent to pay the requested amount of gold, the alchemist grabs "
+"the cursed artifact and throws it into his magical cauldron."
+msgid_plural ""
+"After you consent to pay the requested amount of gold, the alchemist grabs "
+"all cursed artifacts and throws them into his magical cauldron."
+msgstr[0] ""
+"你同意支付要求的金额后，炼金术士抓起受诅咒的神器，扔进他的魔法大锅中。"
+
+msgid ""
+"You hear a voice from behind the locked door, \"You don't have enough gold "
+"to pay for my services.\""
+msgstr ""
+"你听到锁着的门后传来声音：「你的黄金不足，付不起我的服务费。」"
+
+msgid ""
+"You hear a voice from high above in the tower, \"Go away! I can't help you!\""
+msgstr ""
+"你听到塔顶传来声音：「走开！我帮不了你！」"
+
+msgid ""
+"The head groom speaks to you, \"That is a fine looking horse you have. I am "
+"afraid we can give you no better, but the horses your cavalry are riding "
+"look to be of poor breeding stock. We have many trained war horses which "
+"would aid your riders greatly. I insist you take them.\""
+msgstr ""
+"马夫长对你说：「你有一匹漂亮的好马。恐怕我们无法给你更好的，但你骑士的坐骑看"
+"起来血统不佳。我们有许多训练有素的战马可以大大帮助你的骑手。我坚持让你带走牠"
+"们。」"
+
+msgid ""
+"As you approach the stables, the head groom appears, leading a fine looking "
+"war horse. \"This steed will help speed you in your travels. Alas, he will "
+"grow tired in a week. You must also let me give better horses to your "
+"mounted soldiers, their horses look shoddy and weak.\""
+msgstr ""
+"当你走近马厩时，马夫长出现了，牵着一匹漂亮的战马。「这匹骏马将加速你的旅途。"
+"可惜牠一周后会疲劳。你也必须让我给你的骑士更好的坐骑，他们的马看起来劣质又虚"
+"弱。」"
+
+msgid ""
+"The head groom approaches you and speaks, \"You already have a fine horse, "
+"and have no inexperienced cavalry which might make use of our trained war "
+"horses.\""
+msgstr ""
+"马夫长走近你说道：「你已经有一匹好马了，而且没有需要我们训练战马的新手骑"
+"兵。」"
+
+msgid ""
+"As you approach the stables, the head groom appears, leading a fine looking "
+"war horse. \"This steed will help speed you in your travels. Alas, his "
+"endurance will wane with a lot of heavy riding, and you must return for a "
+"fresh mount in a week. We also have many fine war horses which could benefit "
+"mounted soldiers, but you have none we can help.\""
+msgstr ""
+"当你走近马厩时，马夫长出现了，牵着一匹漂亮的战马。「这匹骏马将加速你的旅途。"
+"可惜大量骑乘后牠的耐力会下降，你一周后必须回来换马。我们还有许多好的战马可供"
+"骑士使用，但你没有我们能帮助的部队。」"
+
+msgid "The Arena guards turn you away."
+msgstr "竞技场的守卫将你拒之门外。"
+
+msgid ""
+"You have your crew stop up their ears with wax before the sirens' eerie song "
+"has any chance of luring them to a watery grave."
+msgstr ""
+"在海妖诡异的歌声有机会将船员引入葬身之地前，你让他们用蜡堵住耳朵。"
+
+msgid ""
+"As the sirens sing their eerie song, your small, determined army manages to "
+"overcome the urge to dive headlong into the sea."
+msgstr ""
+"海妖唱着诡异的歌声时，你那小而坚决的军队成功克制了一头栽入大海的冲动。"
+
+msgid ""
+"An eerie wailing song emanates from the sirens perched upon the rocks. Many "
+"of your crew fall under its spell, and dive into the water where they drown. "
+"You are now wiser for the visit, and gain %{exp} experience."
+msgstr ""
+"栖息在岩石上的海妖发出诡异的哀歌。许多船员中了咒语，跳入水中溺毙。经此一事你"
+"更加睿智，获得 %{exp} 点经验值。"
+
+msgid ""
+"In a dazzling display of daring, you break into the local jail and free the "
+"hero imprisoned there, who, in return, pledges loyalty to your cause."
+msgstr ""
+"凭借惊人的胆识，你闯入了当地牢狱并释放了被囚禁的英雄，作为回报，他向你效忠。"
+
+msgid ""
+"You already have %{count} heroes, and regretfully must leave the prisoner in "
+"this jail to languish in agony for untold days."
+msgstr ""
+"你已有 %{count} 位英雄，只能遗憾地将囚犯留在牢狱中继续受苦。"
+
+msgid ""
+"You enter a rickety hut and talk to the magician who lives there. He tells "
+"you of places near and far which may aid you in your journeys."
+msgstr ""
+"你进入一间摇摇欲坠的小屋，与住在那里的法师交谈。他告诉你远近各处可能对旅途有"
+"帮助的地点。"
+
+msgid "This eye seems to be intently studying its surroundings."
+msgstr "这只眼睛似乎正专注地观察着周围环境。"
+
+msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
+msgstr "你遇到了一座巨大的人面狮身像。它异常沉默。"
+
+msgid ""
+"\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
+"shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
+"the challenge?\""
+msgstr ""
+"「我有一个谜语要考你，」人面狮身像说。「答对了就有奖赏。答错了就会被吃掉。你"
+"接受挑战吗？」"
+
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+"\n"
+"'"
+msgstr ""
+"人面狮身像向你提出以下谜语:\n"
+"\n"
+"「"
+
+msgid ""
+"sphinx|'\n"
+"\n"
+"Your answer?"
+msgstr ""
+"」\n"
+"\n"
+"你的答案？"
+
+msgid ""
+"\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
+"you with a paw, knocking you to the ground. Another blow makes the world go "
+"black, and you know no more."
+msgstr ""
+"「你猜错了，」人面狮身像微笑着说。牠一掌将你拍倒在地。又一击让世界陷入黑暗，"
+"你再也不知道了。"
+
+msgid ""
+"Looking somewhat disappointed, the Sphinx sighs. \"You've answered my riddle "
+"so here's your reward. Now begone.\""
+msgstr ""
+"人面狮身像看起来有些失望，叹了口气。「你回答了我的谜语，这是你的奖励。现在离"
+"开吧。」"
+
+msgid ""
+"A magical barrier stands tall before you, blocking your way. Runes on the "
+"arch read,\n"
+"\"Speak the key and you may pass.\"\n"
+"As you speak the magic word, the glowing barrier dissolves into nothingness."
+msgstr ""
+"一道高大的魔法屏障挡住你的去路。拱门上的符文写着:\n"
+"「说出通关密语即可通过。」\n"
+"当你说出魔法口令时，发光的屏障化为虚无消散了。"
+
+msgid ""
+"A magical barrier stands tall before you, blocking your way. Runes on the "
+"arch read,\n"
+"\"Speak the key and you may pass.\"\n"
+"You speak, and nothing happens."
+msgstr ""
+"一道高大的魔法屏障挡住你的去路。拱门上的符文写着:\n"
+"「说出通关密语即可通过。」\n"
+"你开口了，但什么都没发生。"
+
+msgid ""
+"You enter the tent and see an old woman gazing into a magic gem. She looks "
+"up and says,\n"
+"\"In my travels, I have learned much in the way of arcane magic. A great "
+"oracle taught me his skill. I have the answer you seek.\""
+msgstr ""
+"你进入帐篷，看到一位老妇人正凝视着一颗魔法宝石。她擡头说道:\n"
+"「在我的旅途中，我学到了许多奥术魔法。一位伟大先知将技艺传授给我。我有你寻找"
+"的答案。」"
+
+msgid ""
+"The sting of your previous encounter still lingers, and you keep your "
+"distance from the intimidating cat until you have regained your courage in "
+"battle."
+msgstr ""
+"上次遭遇的刺痛仍在，你与那只可怕的猫保持距离，直到在战斗中恢复勇气。"
+
+msgid ""
+"You come upon a great cat, purring as it rubs against your leg. Charmed, you "
+"reach down, but it bites you and flees. At least the laughter at your "
+"misfortune lifts your troops' spirits."
+msgstr ""
+"你遇到一只大猫，牠呼噜着蹭你的腿。你着迷地伸手去摸，却被咬了一口，猫随即逃"
+"跑。至少部队因你的糗事而欢笑，士气有所提升。"
+
+msgid "No spell book is present."
+msgstr "目前没有法术书。"
+
+msgid ""
+"This spell costs %{mana} spell points. You have no spell points, so you "
+"cannot cast it."
+msgstr ""
+"此法术需要 %{mana} 点魔法值。你没有魔法值，因此无法施放。"
+
+msgid ""
+"This spell costs %{mana} spell points. You only have %{point} spell points, "
+"so you cannot cast it."
+msgstr ""
+"此法术需要 %{mana} 点魔法值。你只有 %{point} 点魔法值，因此无法施放。"
+
+msgid "The spell was not found."
+msgstr "未找到此法术。"
+
+msgid "Only heroes can cast this spell."
+msgstr "只有英雄能施放此法术。"
+
+msgid "This hero is not able to cast adventure spells."
+msgstr "此英雄无法施放冒险法术。"
+
+msgid "This spell cannot be cast on a boat."
+msgstr "此法术无法在船上施放。"
+
+msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
+msgstr "英雄今天太疲劳无法施放此法术。请明天再试。"
+
+msgid "This spell can only be cast near an ocean."
+msgstr "此法术只能在海洋附近施放。"
+
+msgid ""
+"There are no boats available and no ocean adjacent to the hero where this "
+"spell will work."
+msgstr ""
+"没有可用的船只，英雄附近也没有可让此法术生效的海洋。"
+
+msgid "There are no boats available for this spell."
+msgstr "没有可供此法术使用的船只。"
+
+msgid "There is no ocean adjacent to the hero where this spell will work."
+msgstr "英雄附近没有可让此法术生效的海洋。"
+
+msgid ""
+"You do not own any town or castle that is not currently occupied by a hero. "
+"This spell will have no effect."
+msgstr ""
+"你没有任何未被英雄占据的城镇或城堡。此法术不会有效果。"
+
+msgid "This hero is already in a town, so this spell will have no effect."
+msgstr "此英雄已在城镇中，法术不会有效果。"
+
+msgid ""
+"The nearest town is %{town}.\n"
+"\n"
+"This town is occupied by your hero %{hero}."
+msgstr ""
+"最近的城镇是 %{town}。\n"
+"\n"
+"此城镇被你的英雄 %{hero} 占据。"
+
+msgid "This spell is already in effect."
+msgstr "此法术已在生效中。"
+
+msgid ""
+"No opponent neither has nor can have any hero under their command anymore. "
+"Casting this spell will have no effect."
+msgstr ""
+"没有对手现在或未来会拥有英雄。施放此法术不会有效果。"
+
+msgid ""
+"No opponent has a hero under their command at this time. Casting this spell "
+"will have no effect."
+msgstr ""
+"目前没有对手拥有英雄。施放此法术不会有效果。"
+
+msgid ""
+"You must be within %{count} spaces of a monster for the Visions spell to "
+"work."
+msgstr ""
+"必须在怪物 %{count} 格范围内才能使幻视法术生效。"
+
+msgid ""
+"You must be standing on the entrance to a mine (sawmills and alchemist labs "
+"do not count) to cast this spell."
+msgstr ""
+"必须站在矿场入口 (锯木厂和炼金术士实验室不算) 才能施放此法术。"
+
+msgid "You must first defeat the ghosts guarding the mine to cast this spell."
+msgstr "必须先击败守卫矿场的鬼怪才能施放此法术。"
+
+msgid ""
+"There are already at least as many elementals guarding the mine as this hero "
+"can generate. Casting this spell will have no effect."
+msgstr ""
+"守卫矿场的元素生物已达此英雄能产生的上限。施放此法术不会有效果。"
+
+msgid "%{name} the %{race} (Level %{level})"
+msgstr "%{name}，%{race} (等级 %{level})"
+
+msgid "Random hero (Level %{level})"
+msgstr "随机英雄 (等级 %{level})"
+
+msgid "Random %{race} hero (Level %{level})"
+msgstr "随机 %{race} 英雄 (等级 %{level})"
+
+msgid "Hero class:"
+msgstr "英雄职业："
+
+msgid "Are you sure you want to dismiss this Hero?"
+msgstr "确定要解散此英雄吗？"
+
+msgid "Set custom Experience value. Current value is default."
+msgstr "设定自订经验值。目前为预设值。"
+
+msgid "Change Experience value. Right-click to reset to default value."
+msgstr "变更经验值。右键按一下重置为预设值。"
+
+msgid "View Experience Info"
+msgstr "检视经验值资讯"
+
+msgid "Set custom Spell Points value. Current value is default."
+msgstr "设定自订魔法值。目前为预设值。"
+
+msgid "Change Spell Points value. Right-click to reset to default value."
+msgstr "变更魔法值。右键按一下重置为预设值。"
+
+msgid "Set Spell Points value:"
+msgstr "设定魔法值："
+
+msgid "View Spell Points Info"
+msgstr "检视魔法值资讯"
+
+msgid "Set patrol radius in tiles:"
+msgstr "设定巡逻半径 (格数):"
+
+msgid "Enter hero's name:"
+msgstr "输入英雄名称："
+
+msgid "Click to change class."
+msgstr "按一下变更职业。"
+
+msgid ""
+"'Spread' combat formation spreads the hero's units from the top to the "
+"bottom of the battlefield, with at least one empty space between each unit."
+msgstr ""
+"「分散」阵型将英雄的部队从战场顶部到底部展开，每支部队之间至少保留一格空间。"
+
+msgid ""
+"'Grouped' combat formation bunches the hero's army together in the center of "
+"their side of the battlefield."
+msgstr ""
+"「集中」阵型将英雄的军队集中在战场己方一侧的中央。"
+
+msgid "Exit Hero Screen"
+msgstr "离开英雄画面"
+
+msgid "You cannot dismiss a hero in a castle"
+msgstr "无法在城堡中解散英雄"
+
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
+msgstr "场景禁止解散 %{race} %{name}"
+
+msgid "Dismiss %{name} the %{race}"
+msgstr "解散 %{race} %{name}"
+
+msgid "Show previous hero"
+msgstr "显示上一位英雄"
+
+msgid "Show next hero"
+msgstr "显示下一位英雄"
+
+msgid "Set army combat formation to 'Spread'"
+msgstr "将军队战斗阵型设为「分散」"
+
+msgid "Set army combat formation to 'Grouped'"
+msgstr "将军队战斗阵型设为「集中」"
+
+msgid "Set hero's Artifacts. Right-click to reset Artifact."
+msgstr "设定英雄的神器。右键按一下重置神器。"
+
+msgid "Set hero's Secondary Skills. Right-click to reset skill."
+msgstr "设定英雄的次要技能。右键按一下重置技能。"
+
+msgid "Set hero's Army. Right-click to reset unit."
+msgstr "设定英雄的军队。右键按一下重置单位。"
+
+msgid "Set hero's portrait. Right-click to reset to default."
+msgstr "设定英雄肖像。右键按一下重置为预设。"
+
+msgid "Click to change hero's name. Right-click to reset to default."
+msgstr "按一下变更英雄名称。右键按一下重置为预设。"
+
+msgid "Hero is in patrol mode in %{tiles} tiles radius. Click to disable it."
+msgstr "英雄正在 %{tiles} 格半径范围内巡逻。按一下停用。"
+
+msgid "Click to enable hero's patrol mode."
+msgstr "按一下启用英雄的巡逻模式。"
+
+msgid "Do you want to save the changes made?"
+msgstr "要储存所做的变更吗？"
+
+msgid "Blood Morale"
+msgstr "嗜血士气"
+
+msgid "%{morale} Morale"
+msgstr "%{morale}士气"
+
+msgid "%{luck} Luck"
+msgstr "%{luck}运气"
+
+msgid "Current Luck Modifiers:"
+msgstr "目前运气加成："
+
+msgid "Current Morale Modifiers:"
+msgstr "目前士气加成："
+
+msgid "Entire army is undead, so morale does not apply."
+msgstr "全军皆为亡灵，士气不适用。"
+
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
+msgstr ""
+"目前经验值 %{exp1}。\n"
+" 下一级 %{exp2}。"
+
+msgid "million|M"
+msgstr "M"
+
+msgid "Level %{level}"
+msgstr "等级 %{level}"
+
+msgid ""
+"%{name} currently has %{point} spell points out of a maximum of %{max}. The "
+"maximum number of spell points is 10 times the hero's knowledge. It is "
+"occasionally possible for the hero to have more than their maximum spell "
+"points via special events."
+msgstr ""
+"%{name} 目前有 %{point} 点魔法值，上限为 %{max}。魔法值上限为英雄知识值的 10 "
+"倍。透过特殊事件，英雄偶尔可以拥有超过上限的魔法值。"
+
+msgid "%{name1} meets %{name2}"
+msgstr "%{name1} 遇见 %{name2}"
+
+msgid "hero|Level %{level}"
+msgstr "等级 %{level}"
+
+msgid "Move all artifacts from %{from_hero_name} to %{to_hero_name}."
+msgstr "将所有神器从 %{from_hero_name} 移转至 %{to_hero_name}。"
+
+msgid "Artifact Transfer"
+msgstr "神器移转"
+
+msgid "Swap Artifacts"
+msgstr "交换神器"
+
+msgid "Swap all artifacts between heroes."
+msgstr "交换英雄之间的所有神器。"
+
+msgid "Move army from %{from_hero_name} to %{to_hero_name}."
+msgstr "将军队从 %{from_hero_name} 移动至 %{to_hero_name}。"
+
+msgid "Army Transfer"
+msgstr "军队移转"
+
+msgid "Swap Armies"
+msgstr "交换军队"
+
+msgid "Swap armies between heroes."
+msgstr "交换英雄之间的军队。"
+
+msgid "Enemy heroes are now fully identifiable."
+msgstr "敌方英雄现已可完全辨识。"
+
+msgid "Identify Hero"
+msgstr "辨识英雄"
+
+msgid "Select town to port to."
+msgstr "选择要传送至的城镇。"
+
+msgid "Town Portal"
+msgstr "城镇传送门"
+
+msgid "The creatures are willing to join us!"
+msgstr "这些生物愿意加入我们！"
+
+msgid "All the creatures will join us..."
+msgstr "所有的生物都将加入我们……"
+
+msgid "The creature will join us..."
+msgid_plural "%{count} of the creatures will join us..."
+msgstr[0] "生物将加入我们……"
+
+msgid ""
+"\n"
+" for a fee of %{gold} gold."
+msgstr ""
+"\n"
+"费用为 %{gold} 金币。"
+
+msgid "These weak creatures will surely flee before us."
+msgstr "这些弱小的生物肯定会在我们面前逃跑。"
+
+msgid "I fear these creatures are in the mood for a fight."
+msgstr "恐怕这些生物正准备要战斗。"
+
+msgid "The hero's attack skill is a bonus added to each unit's attack skill."
+msgstr "英雄的攻击技能作为加成加到每支部队的攻击技能上。"
+
+msgid "The hero's defense skill is a bonus added to each unit's defense skill."
+msgstr "英雄的防御技能作为加成加到每支部队的防御技能上。"
+
+msgid "The hero's spell power determines the duration or power of a spell."
+msgstr "英雄的魔法力量决定法术的持续时间或威力。"
+
+msgid ""
+"The hero's knowledge determines how many spell points the hero may have. "
+"Under normal circumstances, a hero is limited to 10 spell points per level "
+"of knowledge."
+msgstr ""
+"英雄的知识决定可拥有多少魔法值。正常情况下，英雄每点知识限制为 10 点魔法值。"
+
+msgid "Current Modifiers:"
+msgstr "目前加成："
+
+msgid "skill|Basic"
+msgstr "基础"
+
+msgid "skill|Advanced"
+msgstr "进阶"
+
+msgid "skill|Expert"
+msgstr "专家"
+
+msgid "Pathfinding"
+msgstr "寻路术"
+
+msgid "Archery"
+msgstr "箭术"
+
+msgid "Logistics"
+msgstr "后勤术"
+
+msgid "Scouting"
+msgstr "侦察术"
+
+msgid "Diplomacy"
+msgstr "外交术"
+
+msgid "Navigation"
+msgstr "航海术"
+
+msgid "Leadership"
+msgstr "领导术"
+
+msgid "Wisdom"
+msgstr "智慧"
+
+msgid "Mysticism"
+msgstr "神秘术"
+
+msgid "Ballistics"
+msgstr "弹道术"
+
+msgid "Eagle Eye"
+msgstr "鹰眼术"
+
+msgid "Necromancy"
+msgstr "亡灵巫术"
+
+msgid "Estates"
+msgstr "产业术"
+
+msgid "Advanced Archery"
+msgstr "进阶箭术"
+
+msgid "Advanced Pathfinding"
+msgstr "进阶寻路术"
+
+msgid "Basic Archery"
+msgstr "基础箭术"
+
+msgid "Basic Pathfinding"
+msgstr "基础寻路术"
+
+msgid "Expert Pathfinding"
+msgstr "专家寻路术"
+
+msgid "Advanced Logistics"
+msgstr "进阶后勤术"
+
+msgid "Basic Logistics"
+msgstr "基础后勤术"
+
+msgid "Basic Scouting"
+msgstr "基础侦察术"
+
+msgid "Expert Archery"
+msgstr "专家箭术"
+
+msgid "Expert Logistics"
+msgstr "专家后勤术"
+
+msgid "Advanced Diplomacy"
+msgstr "进阶外交术"
+
+msgid "Advanced Scouting"
+msgstr "进阶侦察术"
+
+msgid "Basic Diplomacy"
+msgstr "基础外交术"
+
+msgid "Expert Diplomacy"
+msgstr "专家外交术"
+
+msgid "Expert Scouting"
+msgstr "专家侦察术"
+
+msgid "Advanced Leadership"
+msgstr "进阶领导术"
+
+msgid "Advanced Navigation"
+msgstr "进阶航海术"
+
+msgid "Basic Leadership"
+msgstr "基础领导术"
+
+msgid "Basic Navigation"
+msgstr "基础航海术"
+
+msgid "Expert Navigation"
+msgstr "专家航海术"
+
+msgid "Advanced Wisdom"
+msgstr "进阶智慧"
+
+msgid "Basic Mysticism"
+msgstr "基础神秘术"
+
+msgid "Basic Wisdom"
+msgstr "基础智慧"
+
+msgid "Expert Leadership"
+msgstr "专家领导术"
+
+msgid "Expert Wisdom"
+msgstr "专家智慧"
+
+msgid "Advanced Luck"
+msgstr "进阶运气"
+
+msgid "Advanced Mysticism"
+msgstr "进阶神秘术"
+
+msgid "Basic Luck"
+msgstr "基础运气"
+
+msgid "Expert Luck"
+msgstr "专家运气"
+
+msgid "Expert Mysticism"
+msgstr "专家神秘术"
+
+msgid "Advanced Ballistics"
+msgstr "进阶弹道术"
+
+msgid "Advanced Eagle Eye"
+msgstr "进阶鹰眼术"
+
+msgid "Basic Ballistics"
+msgstr "基础弹道术"
+
+msgid "Basic Eagle Eye"
+msgstr "基础鹰眼术"
+
+msgid "Expert Ballistics"
+msgstr "专家弹道术"
+
+msgid "Advanced Necromancy"
+msgstr "进阶亡灵巫术"
+
+msgid "Basic Estates"
+msgstr "基础产业术"
+
+msgid "Basic Necromancy"
+msgstr "基础亡灵巫术"
+
+msgid "Expert Eagle Eye"
+msgstr "专家鹰眼术"
+
+msgid "Expert Necromancy"
+msgstr "专家亡灵巫术"
+
+msgid "Advanced Estates"
+msgstr "进阶产业术"
+
+msgid "Expert Estates"
+msgstr "专家产业术"
+
+msgid ""
+"%{skill} reduces the movement penalty for rough terrain by %{count} percent."
+msgstr ""
+"%{skill} 将崎岖地形的移动惩罚降低 %{count}%。"
+
+msgid "%{skill} eliminates the movement penalty for rough terrain."
+msgstr "%{skill} 消除崎岖地形的移动惩罚。"
+
+msgid ""
+"%{skill} increases the damage done by the hero's range attacking creatures "
+"by %{count} percent, and eliminates the %{penalty} percent penalty when "
+"shooting past obstacles (e.g. castle walls)."
+msgstr ""
+"%{skill} 将英雄远距攻击生物的伤害提升 %{count}%，并消除穿过障碍物（例如城墙）"
+"射击时 %{penalty}% 的惩罚。"
+
+msgid "%{skill} increases the hero's movement points by %{count} percent."
+msgstr "%{skill} 将英雄的移动力提升 %{count}%。"
+
+msgid "%{skill} increases the hero's viewable area by one square."
+msgid_plural "%{skill} increases the hero's viewable area by %{count} squares."
+msgstr[0] "%{skill} 将英雄的可视范围增加一格。"
+
+msgid ""
+"%{skill} allows the hero to negotiate with monsters who are weaker than "
+"their army, and reduces the cost of surrender."
+msgstr ""
+"%{skill} 让英雄能与比自身弱的怪物交涉，并降低投降的费用。"
+
+msgid ""
+"Approximately %{count} percent of the creatures may offer to join the hero."
+msgstr ""
+"约 %{count}% 的生物可能会主动加入英雄。"
+
+msgid "All of the creatures may offer to join the hero."
+msgstr "所有生物都可能主动加入英雄。"
+
+msgid ""
+"The cost of surrender is reduced to %{percent} percent of the total cost of "
+"troops in the army."
+msgstr ""
+"投降费用降为军队部队总成本的 %{percent}%。"
+
+msgid ""
+"%{skill} increases the hero's movement points over water by %{count} percent."
+msgstr ""
+"%{skill} 将英雄的水上移动力提升 %{count}%。"
+
+msgid "%{skill} increases the hero's troops morale by %{count}."
+msgstr "%{skill} 将英雄部队的士气提升 %{count}。"
+
+msgid "%{skill} allows the hero to learn third level spells."
+msgstr "%{skill} 让英雄能学习第三级法术。"
+
+msgid "%{skill} allows the hero to learn fourth level spells."
+msgstr "%{skill} 让英雄能学习第四级法术。"
+
+msgid "%{skill} allows the hero to learn fifth level spells."
+msgstr "%{skill} 让英雄能学习第五级法术。"
+
+msgid "%{skill} regenerates one additional spell point per day to the hero."
+msgid_plural ""
+"%{skill} regenerates %{count} additional spell points per day to the hero."
+msgstr[0] "%{skill} 每日为英雄额外恢复一点魔法值。"
+
+msgid "%{skill} increases the hero's luck by %{count}."
+msgstr "%{skill} 将英雄的运气提升 %{count}。"
+
+msgid ""
+"%{skill} gives the hero's catapult shots a greater chance to hit and do "
+"damage to castle walls."
+msgstr ""
+"%{skill} 让英雄的投石车射击有更高机率命中并破坏城墙。"
+
+msgid ""
+"%{skill} gives the hero's catapult an extra shot, and each shot has a "
+"greater chance to hit and do damage to castle walls."
+msgstr ""
+"%{skill} 让英雄的投石车多一次射击机会，且每次射击有更高机率命中并破坏城墙。"
+
+msgid ""
+"%{skill} gives the hero's catapult an extra shot, and each shot "
+"automatically destroys any wall, except a fortified wall in a Knight castle."
+msgstr ""
+"%{skill} 让英雄的投石车多一次射击机会，且每次射击自动摧毁任何城墙，骑士城堡的"
+"强化城墙除外。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 1st or "
+"2nd level spell that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 让英雄有 %{count}% 的机率学会敌人在战斗中施放的任何一、二级法术。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 3rd "
+"level spell (or below) that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 让英雄有 %{count}% 的机率学会敌人在战斗中施放的任何三级 (含以下) 法"
+"术。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 4th "
+"level spell (or below) that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 让英雄有 %{count}% 的机率学会敌人在战斗中施放的任何四级 (含以下) 法"
+"术。"
+
+msgid ""
+"%{skill} allows %{count} percent of the creatures killed in combat to be "
+"brought back from the dead as Skeletons."
+msgstr ""
+"%{skill} 让战斗中被杀死的生物有 %{count}% 能以骷髅兵的形式复活。"
+
+msgid ""
+"The hero produces %{count} gold pieces per day as tax revenue from estates."
+msgstr ""
+"英雄每日从产业中获得 %{count} 金币的税收。"
+
+msgid "Blue"
+msgstr "蓝色"
+
+msgid "Green"
+msgstr "绿色"
+
+msgid "Red"
+msgstr "红色"
+
+msgid "Yellow"
+msgstr "黄色"
+
+msgid "Orange"
+msgstr "橙色"
+
+msgid "Purple"
+msgstr "紫色"
+
+msgid "barrier|Aqua"
+msgstr "水蓝"
+
+msgid "barrier|Blue"
+msgstr "蓝色"
+
+msgid "barrier|Brown"
+msgstr "棕色"
+
+msgid "barrier|Gold"
+msgstr "金色"
+
+msgid "barrier|Green"
+msgstr "绿色"
+
+msgid "barrier|Orange"
+msgstr "橙色"
+
+msgid "barrier|Purple"
+msgstr "紫色"
+
+msgid "barrier|Red"
+msgstr "红色"
+
+msgid "tent|Aqua"
+msgstr "水蓝"
+
+msgid "tent|Blue"
+msgstr "蓝色"
+
+msgid "tent|Brown"
+msgstr "棕色"
+
+msgid "tent|Gold"
+msgstr "金色"
+
+msgid "tent|Green"
+msgstr "绿色"
+
+msgid "tent|Orange"
+msgstr "橙色"
+
+msgid "tent|Purple"
+msgstr "紫色"
+
+msgid "tent|Red"
+msgstr "红色"
+
+msgid "Experience"
+msgstr "经验值"
+
+msgid ""
+"Experience allows your heroes to gain levels, increasing their primary and "
+"secondary skills."
+msgstr ""
+"经验值让英雄能升级，提升主要和次要技能。"
+
+msgid "Hero/Stats"
+msgstr "英雄/属性"
+
+msgid "Skills"
+msgstr "技能"
+
+msgid "Town/Castle"
+msgstr "城镇/城堡"
+
+msgid "Garrison"
+msgstr "城防部队"
+
+msgid "Gold Per Day:"
+msgstr "每日黄金："
+
+msgid "View Heroes."
+msgstr "检视英雄。"
+
+msgid "Towns/Castles"
+msgstr "城镇/城堡"
+
+msgid "View Towns and Castles."
+msgstr "检视城镇和城堡。"
+
+msgid "luck|Cursed"
+msgstr "被诅咒"
+
+msgid "luck|Awful"
+msgstr "极差"
+
+msgid "luck|Bad"
+msgstr "差"
+
+msgid "luck|Normal"
+msgstr "普通"
+
+msgid "luck|Good"
+msgstr "好"
+
+msgid "luck|Great"
+msgstr "极好"
+
+msgid "luck|Irish"
+msgstr "幸运之极"
+
+msgid ""
+"%{luck-type} luck sometimes falls on the hero's units in combat, causing "
+"their attacks to only do half damage."
+msgstr ""
+"%{luck-type}运气有时会降临在英雄的部队上，使其攻击只造成一半的伤害。"
+
+msgid ""
+"%{luck-type} luck means the hero's units will never get lucky or unlucky "
+"attacks on the enemy."
+msgstr ""
+"%{luck-type} 运气表示英雄的部队在攻击敌人时不会获得好运或厄运效果。"
+
+msgid ""
+"%{luck-type} luck sometimes lets the hero's units get lucky attacks (double "
+"strength) in combat."
+msgstr ""
+"%{luck-type} 运气有时会让英雄的部队在战斗中获得幸运攻击（双倍伤害）。"
+
+msgid "morale|Treason"
+msgstr "叛变"
+
+msgid "morale|Awful"
+msgstr "极差"
+
+msgid "morale|Poor"
+msgstr "差"
+
+msgid "morale|Normal"
+msgstr "普通"
+
+msgid "morale|Good"
+msgstr "好"
+
+msgid "morale|Great"
+msgstr "极好"
+
+msgid "morale|Blood!"
+msgstr "嗜血！"
+
+msgid "%{morale-type} morale may cause the hero's units to freeze in combat."
+msgstr "%{morale-type}士气可能导致英雄的部队在战斗中僵住。"
+
+msgid ""
+"%{morale-type} morale means the hero's units will never be blessed with "
+"extra attacks or freeze in combat."
+msgstr ""
+"%{morale-type}士气表示英雄的部队不会获得额外攻击或在战斗中僵住。"
+
+msgid ""
+"%{morale-type} morale may give the hero's units extra attacks in combat."
+msgstr ""
+"%{morale-type}士气可能让英雄的部队在战斗中获得额外攻击。"
+
+msgid "Blood"
+msgstr "嗜血"
+
+msgid "Knight"
+msgstr "骑士"
+
+msgid "Barbarian"
+msgstr "野蛮人"
+
+msgid "Sorceress"
+msgstr "女巫"
+
+msgid "Warlock"
+msgstr "术士"
+
+msgid "Wizard"
+msgstr "巫师"
+
+msgid "Necromancer"
+msgstr "亡灵法师"
+
+msgid "Multi"
+msgstr "混合"
+
+msgid "doubleLined|Knight"
+msgstr "骑士"
+
+msgid "doubleLined|Barbarian"
+msgstr "野蛮人"
+
+msgid "doubleLined|Sorceress"
+msgstr "女巫"
+
+msgid "doubleLined|Warlock"
+msgstr "术士"
+
+msgid "doubleLined|Wizard"
+msgstr "巫师"
+
+msgid ""
+"doubleLined|Necro-\n"
+"mancer"
+msgstr ""
+"亡灵\n"
+"法师"
+
+msgid "doubleLinedRace|Multi"
+msgstr "混合"
+
+msgid "doubleLinedRace|Random"
+msgstr "随机"
+
+msgid "speed|Standing"
+msgstr "静止"
+
+msgid "speed|Crawling"
+msgstr "极慢"
+
+msgid "speed|Very Slow"
+msgstr "非常慢"
+
+msgid "speed|Slow"
+msgstr "慢"
+
+msgid "speed|Average"
+msgstr "普通"
+
+msgid "speed|Fast"
+msgstr "快"
+
+msgid "speed|Very Fast"
+msgstr "非常快"
+
+msgid "speed|Ultra Fast"
+msgstr "极快"
+
+msgid "speed|Blazing"
+msgstr "疾速"
+
+msgid "speed|Instant"
+msgstr "瞬间"
+
+msgid "Click this button to adjust the level of zoom."
+msgstr "按此按钮调整缩放等级。"
+
+msgid "Zoom"
+msgstr "缩放"
+
+msgid "week|Squirrel"
+msgstr "松鼠"
+
+msgid "week|Rabbit"
+msgstr "兔子"
+
+msgid "week|Gopher"
+msgstr "地鼠"
+
+msgid "week|Badger"
+msgstr "獾"
+
+msgid "week|Rat"
+msgstr "老鼠"
+
+msgid "week|Eagle"
+msgstr "老鹰"
+
+msgid "week|Weasel"
+msgstr "鼬鼠"
+
+msgid "week|Raven"
+msgstr "乌鸦"
+
+msgid "week|Mongoose"
+msgstr "猫鼬"
+
+msgid "week|Dog"
+msgstr "犬"
+
+msgid "week|Aardvark"
+msgstr "食蚁兽"
+
+msgid "week|Lizard"
+msgstr "蜥蜴"
+
+msgid "week|Tortoise"
+msgstr "陆龟"
+
+msgid "week|Hedgehog"
+msgstr "刺猬"
+
+msgid "week|Condor"
+msgstr "秃鹫"
+
+msgid "week|Ant"
+msgstr "蚂蚁"
+
+msgid "week|Grasshopper"
+msgstr "蚱蜢"
+
+msgid "week|Dragonfly"
+msgstr "蜻蜓"
+
+msgid "week|Spider"
+msgstr "蜘蛛"
+
+msgid "week|Butterfly"
+msgstr "蝴蝶"
+
+msgid "week|Bumblebee"
+msgstr "大黄蜂"
+
+msgid "week|Locust"
+msgstr "蝗虫"
+
+msgid "week|Earthworm"
+msgstr "蚯蚓"
+
+msgid "week|Hornet"
+msgstr "胡蜂"
+
+msgid "week|Beetle"
+msgstr "甲虫"
+
+msgid "week|PLAGUE"
+msgstr "瘟疫"
+
+msgid "week|Unnamed"
+msgstr "无名"
+
+msgid "Desert"
+msgstr "沙漠"
+
+msgid "Snow"
+msgstr "雪地"
+
+msgid "Wasteland"
+msgstr "荒地"
+
+msgid "Beach"
+msgstr "沙滩"
+
+msgid "Lava"
+msgstr "岩浆"
+
+msgid "Dirt"
+msgstr "泥土"
+
+msgid "Grass"
+msgstr "草地"
+
+msgid "Ocean"
+msgstr "海洋"
+
+msgid "map_layout|Mirrored"
+msgstr "镜像"
+
+msgid "map_layout|Balanced"
+msgstr "平衡"
+
+msgid "map_layout|Islands"
+msgstr "群岛"
+
+msgid "map_layout|Pyramid"
+msgstr "金字塔"
+
+msgid "map_layout|Quest"
+msgstr "任务"
+
+msgid "resource_density|Scarce"
+msgstr "稀少"
+
+msgid "resource_density|Normal"
+msgstr "正常"
+
+msgid "resource_density|Abundant"
+msgstr "丰富"
+
+msgid "monster_strength|Weak"
+msgstr "弱"
+
+msgid "monster_strength|Normal"
+msgstr "正常"
+
+msgid "monster_strength|Strong"
+msgstr "强"
+
+msgid "monster_strength|Deadly"
+msgstr "致命"
+
+msgid "maps|Small"
+msgstr "小型"
+
+msgid "maps|Medium"
+msgstr "中型"
+
+msgid "maps|Large"
+msgstr "大型"
+
+msgid "maps|Extra Large"
+msgstr "超大"
+
+msgid "maps|Custom Size"
+msgstr "自订大小"
+
+msgid "Ore Mine"
+msgstr "矿石矿场"
+
+msgid "Sulfur Mine"
+msgstr "硫磺矿场"
+
+msgid "Crystal Mine"
+msgstr "水晶矿场"
+
+msgid "Gems Mine"
+msgstr "宝石矿场"
+
+msgid "Gold Mine"
+msgstr "金矿"
+
+msgid "Mine"
+msgstr "矿场"
+
+msgid "Burma shave."
+msgstr "Burma shave."
+
+msgid "Next sign 50 miles."
+msgstr "下个路标 50 英里。"
+
+msgid "See Rock City."
+msgstr "See Rock City."
+
+msgid "This space for rent."
+msgstr "此处招租。"
+
+msgid "No object"
+msgstr "无物件"
+
+msgid "Alchemist Lab"
+msgstr "炼金术士实验室"
+
+msgid "Sign"
+msgstr "路标"
+
+msgid "Buoy"
+msgstr "浮标"
+
+msgid "Skeleton"
+msgstr "骷髅兵"
+
+msgid "Daemon Cave"
+msgstr "恶魔洞穴"
+
+msgid "Treasure Chest"
+msgstr "宝箱"
+
+msgid "Faerie Ring"
+msgstr "妖精之环"
+
+msgid "Campfire"
+msgstr "营火"
+
+msgid "Fountain"
+msgstr "喷泉"
+
+msgid "Gazebo"
+msgstr "凉亭"
+
+msgid "Genie Lamp"
+msgstr "精灵神灯"
+
+msgid "Archer's House"
+msgstr "弓箭手之屋"
+
+msgid "Goblin Hut"
+msgstr "妖怪小屋"
+
+msgid "Dwarf Cottage"
+msgstr "矮人小屋"
+
+msgid "Peasant Hut"
+msgstr "农民小屋"
+
+msgid "Stables"
+msgstr "马厩"
+
+msgid "Alchemist's Tower"
+msgstr "炼金术士之塔"
+
+msgid "Event"
+msgstr "事件"
+
+msgid "Dragon City"
+msgstr "龙族之城"
+
+msgid "Lighthouse"
+msgid_plural "Lighthouses"
+msgstr[0] "灯塔"
+
+msgid "Water Wheel"
+msgid_plural "Water Wheels"
+msgstr[0] "水车"
+
+msgid "Monster"
+msgstr "怪物"
+
+msgid "Obelisk"
+msgstr "方尖碑"
+
+msgid "Oasis"
+msgstr "绿洲"
+
+msgid "Resource"
+msgstr "资源"
+
+msgid "Sawmill"
+msgstr "锯木厂"
+
+msgid "Oracle"
+msgstr "神谕"
+
+msgid "Shrine of the First Circle"
+msgstr "第一环神殿"
+
+msgid "Shipwreck"
+msgstr "沉船"
+
+msgid "Sea Chest"
+msgstr "海中宝箱"
+
+msgid "Desert Tent"
+msgstr "沙漠帐篷"
+
+msgid "Stone Liths"
+msgstr "巨石阵"
+
+msgid "Wagon Camp"
+msgstr "马车营地"
+
+msgid "Hut of the Magi"
+msgstr "法师小屋"
+
+msgid "Whirlpool"
+msgstr "漩涡"
+
+msgid "Windmill"
+msgid_plural "Windmills"
+msgstr[0] "风车"
+
+msgid "Mermaid"
+msgstr "美人鱼"
+
+msgid "Boat"
+msgstr "船"
+
+msgid "Random Ultimate Artifact"
+msgstr "随机终极神器"
+
+msgid "Random Artifact"
+msgstr "随机神器"
+
+msgid "Random Resource"
+msgstr "随机资源"
+
+msgid "Random Monster"
+msgstr "随机怪物"
+
+msgid "Random Town"
+msgstr "随机城镇"
+
+msgid "Random Castle"
+msgstr "随机城堡"
+
+msgid "Eye of the Magi"
+msgstr "法师之眼"
+
+msgid "Random Monster - weak"
+msgstr "随机怪物 - 弱"
+
+msgid "Random Monster - medium"
+msgstr "随机怪物 - 中"
+
+msgid "Random Monster - strong"
+msgstr "随机怪物 - 强"
+
+msgid "Random Monster - very strong"
+msgstr "随机怪物 - 极强"
+
+msgid "Nothing Special"
+msgstr "无特殊物件"
+
+msgid "Mossy Rock"
+msgstr "青苔岩石"
+
+msgid "Watch Tower"
+msgstr "瞭望塔"
+
+msgid "Tree House"
+msgstr "树屋"
+
+msgid "Tree City"
+msgstr "树城"
+
+msgid "Ruins"
+msgstr "遗迹"
+
+msgid "Fort"
+msgstr "堡垒"
+
+msgid "Abandoned Mine"
+msgstr "废弃矿场"
+
+msgid "Sirens"
+msgstr "海妖"
+
+msgid "Standing Stones"
+msgstr "竖石"
+
+msgid "Idol"
+msgstr "偶像"
+
+msgid "Tree of Knowledge"
+msgstr "知识之树"
+
+msgid "Witch Doctor's Hut"
+msgstr "巫医小屋"
+
+msgid "Temple"
+msgstr "神庙"
+
+msgid "Hill Fort"
+msgstr "丘陵堡垒"
+
+msgid "Halfling Hole"
+msgstr "侏儒洞穴"
+
+msgid "Mercenary Camp"
+msgstr "佣兵营地"
+
+msgid "Shrine of the Second Circle"
+msgstr "第二环神殿"
+
+msgid "Shrine of the Third Circle"
+msgstr "第三环神殿"
+
+msgid "City of the Dead"
+msgstr "亡者之城"
+
+msgid "Sphinx"
+msgstr "人面狮身像"
+
+msgid "Wagon"
+msgstr "马车"
+
+msgid "Tar Pit"
+msgstr "焦油坑"
+
+msgid "Artesian Spring"
+msgstr "自流泉"
+
+msgid "Troll Bridge"
+msgstr "索尔之桥"
+
+msgid "Watering Hole"
+msgstr "水源地"
+
+msgid "Witch's Hut"
+msgstr "女巫小屋"
+
+msgid "Xanadu"
+msgstr "世外桃源"
+
+msgid "Lean-To"
+msgstr "棚屋"
+
+msgid "Magellan's Maps"
+msgstr "麦哲伦的海图"
+
+msgid "Flotsam"
+msgstr "漂流物"
+
+msgid "Derelict Ship"
+msgstr "废弃船"
+
+msgid "Shipwreck Survivor"
+msgstr "沉船幸存者"
+
+msgid "Bottle"
+msgstr "瓶子"
+
+msgid "Magic Well"
+msgstr "魔法之井"
+
+msgid "Magic Garden"
+msgid_plural "Magic Gardens"
+msgstr[0] "魔法花园"
+
+msgid "Observation Tower"
+msgstr "观测塔"
+
+msgid "Freeman's Foundry"
+msgstr "自由人铸造厂"
+
+msgid "Reefs"
+msgstr "暗礁"
+
+msgid "Volcano"
+msgstr "火山"
+
+msgid "Flowers"
+msgstr "花丛"
+
+msgid "Rock"
+msgstr "岩石"
+
+msgid "Water Lake"
+msgstr "湖泊"
+
+msgid "Mandrake"
+msgstr "曼德拉草"
+
+msgid "Dead Tree"
+msgstr "枯树"
+
+msgid "Stump"
+msgstr "树桩"
+
+msgid "Crater"
+msgstr "火山口"
+
+msgid "Cactus"
+msgstr "仙人掌"
+
+msgid "Mound"
+msgstr "土丘"
+
+msgid "Dune"
+msgstr "沙丘"
+
+msgid "Lava Pool"
+msgstr "岩浆池"
+
+msgid "Shrub"
+msgstr "灌木"
+
+msgid "Barrow Mounds"
+msgstr "古坟"
+
+msgid "Random Artifact - Treasure"
+msgstr "随机神器 - 宝藏"
+
+msgid "Random Artifact - Minor"
+msgstr "随机神器 - 次要"
+
+msgid "Random Artifact - Major"
+msgstr "随机神器 - 主要"
+
+msgid "Barrier"
+msgstr "屏障"
+
+msgid "Traveller's Tent"
+msgstr "旅人帐篷"
+
+msgid "Jail"
+msgstr "牢狱"
+
+msgid "Fire Summoning Altar"
+msgstr "火焰召唤祭坛"
+
+msgid "Air Summoning Altar"
+msgstr "空气召唤祭坛"
+
+msgid "Earth Summoning Altar"
+msgstr "大地召唤祭坛"
+
+msgid "Water Summoning Altar"
+msgstr "水之召唤祭坛"
+
+msgid "Swampy Lake"
+msgstr "沼泽湖"
+
+msgid "Frozen Lake"
+msgstr "冰冻湖"
+
+msgid "Black Cat"
+msgstr "黑猫"
+
+msgid "Barrel"
+msgstr "木桶"
+
+msgid "randomRace|level 1 creatures"
+msgstr "1 阶生物"
+
+msgid "randomRace|level 2 creatures"
+msgstr "2 阶生物"
+
+msgid "randomRace|level 3 creatures"
+msgstr "3 阶生物"
+
+msgid "randomRace|level 4 creatures"
+msgstr "4 阶生物"
+
+msgid "randomRace|level 5 creatures"
+msgstr "5 阶生物"
+
+msgid "randomRace|level 6 creatures"
+msgstr "6 阶生物"
+
+msgid "Unknown Monsters"
+msgstr "未知怪物"
+
+msgid "Unknown Monster"
+msgstr "未知怪物"
+
+msgid "Peasant"
+msgstr "农民"
+
+msgid "Peasants"
+msgstr "农民"
+
+msgid "Archer"
+msgstr "弓箭手"
+
+msgid "Archers"
+msgstr "弓箭手"
+
+msgid "Ranger"
+msgstr "高级弓箭手"
+
+msgid "Rangers"
+msgstr "高级弓箭手"
+
+msgid "Pikeman"
+msgstr "枪兵"
+
+msgid "Pikemen"
+msgstr "枪兵"
+
+msgid "Veteran Pikeman"
+msgstr "高级枪兵"
+
+msgid "Veteran Pikemen"
+msgstr "高级枪兵"
+
+msgid "Swordsman"
+msgstr "剑客"
+
+msgid "Swordsmen"
+msgstr "剑客"
+
+msgid "Master Swordsman"
+msgstr "高级剑客"
+
+msgid "Master Swordsmen"
+msgstr "高级剑客"
+
+msgid "Cavalries"
+msgstr "骑士"
+
+msgid "Cavalry"
+msgstr "骑士"
+
+msgid "Champion"
+msgstr "高级骑士"
+
+msgid "Champions"
+msgstr "高级骑士"
+
+msgid "Paladin"
+msgstr "武士"
+
+msgid "Paladins"
+msgstr "武士"
+
+msgid "Crusader"
+msgstr "高级武士"
+
+msgid "Crusaders"
+msgstr "高级武士"
+
+msgid "Goblin"
+msgstr "妖怪"
+
+msgid "Goblins"
+msgstr "妖怪"
+
+msgid "Orc"
+msgstr "海怪"
+
+msgid "Orcs"
+msgstr "海怪"
+
+msgid "Orc Chief"
+msgstr "高级海怪"
+
+msgid "Orc Chiefs"
+msgstr "高级海怪"
+
+msgid "Wolf"
+msgstr "狼"
+
+msgid "Wolves"
+msgstr "狼"
+
+msgid "Ogre"
+msgstr "食人魔"
+
+msgid "Ogres"
+msgstr "食人魔"
+
+msgid "Ogre Lord"
+msgstr "高级食人魔"
+
+msgid "Ogre Lords"
+msgstr "高级食人魔"
+
+msgid "Troll"
+msgstr "索尔"
+
+msgid "Trolls"
+msgstr "索尔"
+
+msgid "War Troll"
+msgstr "高级索尔"
+
+msgid "War Trolls"
+msgstr "高级索尔"
+
+msgid "Cyclopes"
+msgstr "独眼巨人"
+
+msgid "Cyclops"
+msgstr "独眼巨人"
+
+msgid "Sprite"
+msgstr "妖精"
+
+msgid "Sprites"
+msgstr "妖精"
+
+msgid "Dwarf"
+msgstr "矮人"
+
+msgid "Dwarves"
+msgstr "矮人"
+
+msgid "Battle Dwarf"
+msgstr "高级矮人"
+
+msgid "Battle Dwarves"
+msgstr "高级矮人"
+
+msgid "Elf"
+msgstr "小精灵"
+
+msgid "Elves"
+msgstr "小精灵"
+
+msgid "Grand Elf"
+msgstr "高级小精灵"
+
+msgid "Grand Elves"
+msgstr "高级小精灵"
+
+msgid "Druid"
+msgstr "德鲁伊"
+
+msgid "Druids"
+msgstr "德鲁伊"
+
+msgid "Greater Druid"
+msgstr "高级德鲁伊"
+
+msgid "Greater Druids"
+msgstr "高级德鲁伊"
+
+msgid "Unicorn"
+msgstr "独角兽"
+
+msgid "Unicorns"
+msgstr "独角兽"
+
+msgid "Phoenix"
+msgstr "凤凰"
+
+msgid "Phoenixes"
+msgstr "凤凰"
+
+msgid "Centaur"
+msgstr "半人马"
+
+msgid "Centaurs"
+msgstr "半人马"
+
+msgid "Gargoyle"
+msgstr "石像鬼"
+
+msgid "Gargoyles"
+msgstr "石像鬼"
+
+msgid "Griffin"
+msgstr "狮鹫"
+
+msgid "Griffins"
+msgstr "狮鹫"
+
+msgid "Minotaur"
+msgstr "牛头怪"
+
+msgid "Minotaurs"
+msgstr "牛头怪"
+
+msgid "Minotaur King"
+msgstr "高级牛头怪"
+
+msgid "Minotaur Kings"
+msgstr "高级牛头怪"
+
+msgid "Hydra"
+msgstr "九头蛇"
+
+msgid "Hydras"
+msgstr "九头蛇"
+
+msgid "Green Dragon"
+msgstr "绿龙"
+
+msgid "Green Dragons"
+msgstr "绿龙"
+
+msgid "Red Dragon"
+msgstr "红龙"
+
+msgid "Red Dragons"
+msgstr "红龙"
+
+msgid "Black Dragon"
+msgstr "黑龙"
+
+msgid "Black Dragons"
+msgstr "黑龙"
+
+msgid "Halfling"
+msgstr "侏儒"
+
+msgid "Halflings"
+msgstr "侏儒"
+
+msgid "Boar"
+msgstr "野猪"
+
+msgid "Boars"
+msgstr "野猪"
+
+msgid "Iron Golem"
+msgstr "机器人"
+
+msgid "Iron Golems"
+msgstr "机器人"
+
+msgid "Steel Golem"
+msgstr "钢铁机器人"
+
+msgid "Steel Golems"
+msgstr "钢铁机器人"
+
+msgid "Roc"
+msgstr "大鹏"
+
+msgid "Rocs"
+msgstr "大鹏"
+
+msgid "Mage"
+msgstr "僧侣"
+
+msgid "Magi"
+msgstr "僧侣"
+
+msgid "Archmage"
+msgstr "高级僧侣"
+
+msgid "Archmagi"
+msgstr "高级僧侣"
+
+msgid "Giant"
+msgstr "泰坦"
+
+msgid "Giants"
+msgstr "泰坦"
+
+msgid "Titan"
+msgstr "高级泰坦"
+
+msgid "Titans"
+msgstr "高级泰坦"
+
+msgid "Skeletons"
+msgstr "骷髅兵"
+
+msgid "Zombie"
+msgstr "僵尸"
+
+msgid "Zombies"
+msgstr "僵尸"
+
+msgid "Mutant Zombie"
+msgstr "高级僵尸"
+
+msgid "Mutant Zombies"
+msgstr "高级僵尸"
+
+msgid "Mummies"
+msgstr "木乃伊"
+
+msgid "Mummy"
+msgstr "木乃伊"
+
+msgid "Royal Mummies"
+msgstr "高级木乃伊"
+
+msgid "Royal Mummy"
+msgstr "高级木乃伊"
+
+msgid "Vampire"
+msgstr "吸血鬼"
+
+msgid "Vampires"
+msgstr "吸血鬼"
+
+msgid "Vampire Lord"
+msgstr "高级吸血鬼"
+
+msgid "Vampire Lords"
+msgstr "高级吸血鬼"
+
+msgid "Lich"
+msgstr "地鬼"
+
+msgid "Liches"
+msgstr "地鬼"
+
+msgid "Power Lich"
+msgstr "高级地鬼"
+
+msgid "Power Liches"
+msgstr "高级地鬼"
+
+msgid "Bone Dragon"
+msgstr "骨龙"
+
+msgid "Bone Dragons"
+msgstr "骨龙"
+
+msgid "Rogue"
+msgstr "盗贼"
+
+msgid "Rogues"
+msgstr "盗贼"
+
+msgid "Nomad"
+msgstr "游牧民"
+
+msgid "Nomads"
+msgstr "游牧民"
+
+msgid "Ghost"
+msgstr "鬼怪"
+
+msgid "Ghosts"
+msgstr "鬼怪"
+
+msgid "Genie"
+msgstr "神怪"
+
+msgid "Genies"
+msgstr "神怪"
+
+msgid "Medusa"
+msgstr "美杜莎"
+
+msgid "Medusas"
+msgstr "美杜莎"
+
+msgid "Earth Elemental"
+msgstr "土元素"
+
+msgid "Earth Elementals"
+msgstr "土元素"
+
+msgid "Air Elemental"
+msgstr "气元素"
+
+msgid "Air Elementals"
+msgstr "气元素"
+
+msgid "Fire Elemental"
+msgstr "火元素"
+
+msgid "Fire Elementals"
+msgstr "火元素"
+
+msgid "Water Elemental"
+msgstr "水元素"
+
+msgid "Water Elementals"
+msgstr "水元素"
+
+msgid "Random Monsters"
+msgstr "随机怪物"
+
+msgid "Random Monster 1"
+msgstr "随机怪物 1"
+
+msgid "Random Monsters 1"
+msgstr "随机怪物 1"
+
+msgid "Random Monster 2"
+msgstr "随机怪物 2"
+
+msgid "Random Monsters 2"
+msgstr "随机怪物 2"
+
+msgid "Random Monster 3"
+msgstr "随机怪物 3"
+
+msgid "Random Monsters 3"
+msgstr "随机怪物 3"
+
+msgid "Random Monster 4"
+msgstr "随机怪物 4"
+
+msgid "Random Monsters 4"
+msgstr "随机怪物 4"
+
+msgid "Double shot"
+msgstr "双重射击"
+
+msgid "2-hex monster"
+msgstr "占两格怪物"
+
+msgid "Double strike"
+msgstr "双重打击"
+
+msgid "Double damage to Undead"
+msgstr "对亡灵双倍伤害"
+
+msgid "% magic resistance"
+msgstr "% 魔法抗性"
+
+msgid "Immune to Mind spells"
+msgstr "免疫心灵法术"
+
+msgid "Immune to Elemental spells"
+msgstr "免疫元素法术"
+
+msgid "Immune to Fire spells"
+msgstr "免疫火焰法术"
+
+msgid "Immune to Cold spells"
+msgstr "免疫冰霜法术"
+
+msgid "Immune to "
+msgstr "免疫 "
+
+msgid "% immunity to %{spell} spell"
+msgstr "% 免疫 %{spell} 法术"
+
+msgid "% damage from Elemental spells"
+msgstr "% 元素法术伤害"
+
+msgid "% damage from %{spell} spell"
+msgstr "% 来自 %{spell} 法术的伤害"
+
+msgid "% chance to Dispel beneficial spells"
+msgstr "% 机率驱散增益法术"
+
+msgid "% chance to Paralyze"
+msgstr "% 机率麻痹"
+
+msgid "% chance to Petrify"
+msgstr "% 机率石化"
+
+msgid "% chance to Blind"
+msgstr "% 机率目盲"
+
+msgid "% chance to Curse"
+msgstr "% 机率诅咒"
+
+msgid "% chance to cast %{spell} spell"
+msgstr "% 机率施放 %{spell} 法术"
+
+msgid "HP regeneration"
+msgstr "生命值再生"
+
+msgid "Two hexes attack"
+msgstr "两格攻击"
+
+msgid "Flyer"
+msgstr "飞行者"
+
+msgid "Unlimited retaliation"
+msgstr "无限反击"
+
+msgid "Attacks all adjacent enemies"
+msgstr "攻击所有相邻敌人"
+
+msgid "No melee penalty"
+msgstr "无近战惩罚"
+
+msgid "Dragon"
+msgstr "龙族"
+
+msgid "Undead"
+msgstr "亡灵"
+
+msgid "No enemy retaliation"
+msgstr "敌人无法反击"
+
+msgid "HP drain"
+msgstr "生命值吸取"
+
+msgid "Cloud attack"
+msgstr "云攻击"
+
+msgid "Decreases enemy's morale by "
+msgstr "降低敌方士气 "
+
+msgid "% chance to halve enemy"
+msgstr "% 机率使敌方减半"
+
+msgid "Soul Eater"
+msgstr "噬魂者"
+
+msgid "Elemental"
+msgstr "元素"
+
+msgid "No Morale"
+msgstr "无士气"
+
+msgid "Earth creature"
+msgstr "土系生物"
+
+msgid "Air creature"
+msgstr "气系生物"
+
+msgid "Fire creature"
+msgstr "火系生物"
+
+msgid "Water creature"
+msgstr "水系生物"
+
+msgid "Double damage from Fire spells"
+msgstr "受火焰法术双倍伤害"
+
+msgid "Double damage from Cold spells"
+msgstr "受冰霜法术双倍伤害"
+
+msgid "Double damage from Earth creatures"
+msgstr "受土系生物双倍伤害"
+
+msgid "Double damage from Air creatures"
+msgstr "受气系生物双倍伤害"
+
+msgid "Double damage from Fire creatures"
+msgstr "受火系生物双倍伤害"
+
+msgid "Double damage from Water creatures"
+msgstr "受水系生物双倍伤害"
+
+msgid "Lightning"
+msgstr "闪电"
+
+msgid "% immunity to "
+msgstr "% 免疫 "
+
+msgid "% damage from "
+msgstr "% 伤害来自 "
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr "三件 Anduran 神器神奇地合而为一。"
+
+msgid "View Spells"
+msgstr "检视法术"
+
+msgid "View %{name} Info"
+msgstr "检视 %{name} 资讯"
+
+msgid "Move %{name}"
+msgstr "移动 %{name}"
+
+msgid "Cannot move the Spellbook"
+msgstr "无法移动法术书"
+
+msgid "This item can't be traded."
+msgstr "此物品无法交易。"
+
+msgid "Invalid Artifact"
+msgstr "无效的神器"
+
+msgid "The %{name} increases the hero's knowledge by %{count}."
+msgstr "%{name} 增加英雄 %{count} 点知识。"
+
+msgid "Ultimate Book of Knowledge"
+msgstr "Ultimate Book of Knowledge"
+
+msgid "The %{name} increases the hero's attack skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 点攻击技能。"
+
+msgid "Ultimate Sword of Dominion"
+msgstr "Ultimate Sword of Dominion"
+
+msgid "The %{name} increases the hero's defense skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 点防御技能。"
+
+msgid "Ultimate Cloak of Protection"
+msgstr "Ultimate Cloak of Protection"
+
+msgid "The %{name} increases the hero's spell power by %{count}."
+msgstr "%{name} 增加英雄 %{count} 点魔法力量。"
+
+msgid "Ultimate Wand of Magic"
+msgstr "Ultimate Wand of Magic"
+
+msgid ""
+"The %{name} increases the hero's attack and defense skills by %{count} each."
+msgstr ""
+"%{name} 各增加英雄 %{count} 点攻击和防御技能。"
+
+msgid "Ultimate Shield"
+msgstr "Ultimate Shield"
+
+msgid ""
+"The %{name} increases the hero's spell power and knowledge by %{count} each."
+msgstr ""
+"%{name} 各增加英雄 %{count} 点魔法力量和知识。"
+
+msgid "Ultimate Staff"
+msgstr "Ultimate Staff"
+
+msgid ""
+"The %{name} increases each of the hero's basic skills by %{count} points."
+msgstr ""
+"%{name} 增加英雄每项基础技能 %{count} 点。"
+
+msgid "Ultimate Crown"
+msgstr "Ultimate Crown"
+
+msgid "Golden Goose"
+msgstr "Golden Goose"
+
+msgid "The %{name} brings in an income of %{count} gold per day."
+msgstr "%{name} 每日带来 %{count} 金币的收入。"
+
+msgid "Arcane Necklace of Magic"
+msgstr "Arcane Necklace of Magic"
+
+msgid ""
+"After rescuing a Sorceress from a cursed tomb, she rewards your heroism with "
+"an exquisite jeweled necklace."
+msgstr ""
+"从被诅咒的坟墓中救出一位女巫后，她以一条精美的珠宝项链酬谢你的英勇。"
+
+msgid "Caster's Bracelet of Magic"
+msgstr "Caster's Bracelet of Magic"
+
+msgid ""
+"While searching through the rubble of a caved-in mine, you free a group of "
+"trapped Dwarves. Grateful, the leader gives you a golden bracelet."
+msgstr ""
+"在搜寻塌陷矿坑的碎石时，你救出了一群被困的矮人。感激之余，首领送给你一只金手"
+"镯。"
+
+msgid "Mage's Ring of Power"
+msgstr "Mage's Ring of Power"
+
+msgid ""
+"A cry of pain leads you to a Centaur, caught in a trap. Upon setting the "
+"creature free, he hands you a small pouch. Emptying the contents, you find a "
+"dazzling jeweled ring."
+msgstr ""
+"一声痛苦的呼喊引导你找到了一只陷入陷阱的半人马。将牠释放后，牠递给你一个小袋"
+"子。倒出内容物后，你发现了一枚耀眼的宝石戒指。"
+
+msgid "Witch's Broach of Magic"
+msgstr "Witch's Broach of Magic"
+
+msgid ""
+"Alongside the remains of a burnt witch lies a beautiful broach, intricately "
+"designed. Approaching the corpse with caution, you add the broach to your "
+"inventory."
+msgstr ""
+"在一具烧焦女巫的遗骸旁，放着一枚设计精美的胸针。你小心地靠近尸体，将胸针收入"
+"囊中。"
+
+msgid "Medal of Valor"
+msgstr "Medal of Valor"
+
+msgid "The %{name} increases the morale of the hero's army by %{count}."
+msgstr "%{name} 增加英雄军队 %{count} 点士气。"
+
+msgid ""
+"Freeing a virtuous maiden from the clutches of an evil overlord, you are "
+"granted a Medal of Valor by the King's herald."
+msgstr ""
+"从邪恶领主的魔爪中救出了一位善良的少女，国王的传令官授予你一枚英勇勋章。"
+
+msgid "Medal of Courage"
+msgstr "Medal of Courage"
+
+msgid ""
+"After saving a young boy from a vicious pack of Wolves, you return him to "
+"his father's manor. The grateful nobleman awards you with a Medal of Courage."
+msgstr ""
+"从凶猛的狼群中救出一个小男孩后，你将他送回父亲的庄园。感激的贵族授予你一枚勇"
+"气勋章。"
+
+msgid "Medal of Honor"
+msgstr "Medal of Honor"
+
+msgid ""
+"After freeing a princess of a neighboring kingdom from the evil clutches of "
+"despicable slavers, she awards you with a Medal of Honor."
+msgstr ""
+"从卑鄙奴隶贩子的魔爪中解救了邻国的公主后，她授予你一枚荣誉勋章。"
+
+msgid "Medal of Distinction"
+msgstr "Medal of Distinction"
+
+msgid ""
+"Ridding the countryside of the hideous Minotaur who made a sport of eating "
+"noblemen's Knights, you are honored with the Medal of Distinction."
+msgstr ""
+"铲除了以吞噬贵族骑士为乐的可怕牛头怪后，你获颁卓越勋章。"
+
+msgid "Fizbin of Misfortune"
+msgstr "Fizbin of Misfortune"
+
+msgid ""
+"The %{name} greatly decreases the morale of the hero's army by %{count}."
+msgstr ""
+"%{name} 大幅降低英雄军队 %{count} 点士气。"
+
+msgid ""
+"You stumble upon a medal lying alongside the empty road. Adding the medal to "
+"your inventory, you become aware that you have acquired the undesirable "
+"Fizbin of Misfortune, greatly decreasing your army's morale."
+msgstr ""
+"你在空旷的路边偶然发现了一枚勋章。将它收入囊中后，你意识到自己获得了不祥的厄"
+"运徽记，大幅降低了军队的士气。"
+
+msgid "Thunder Mace of Dominion"
+msgstr "Thunder Mace of Dominion"
+
+msgid ""
+"During a sudden storm, a bolt of lightning strikes a tree, splitting it. "
+"Inside the tree you find a mysterious mace."
+msgstr ""
+"突如其来的暴风雨中，一道闪电击中了一棵树，将其劈开。你在树干中找到了一把神秘"
+"的权杖。"
+
+msgid "Armored Gauntlets of Protection"
+msgstr "Armored Gauntlets of Protection"
+
+msgid "The %{name} increase the hero's defense skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 点防御技能。"
+
+msgid ""
+"You encounter the infamous Black Knight! After a grueling duel ending in a "
+"draw, the Knight, out of respect, offers you a pair of armored gauntlets."
+msgstr ""
+"你遇到了恶名昭彰的黑骑士！经过一场以平手收场的艰苦决斗，骑士出于敬意送给你一"
+"副装甲护手。"
+
+msgid "Defender Helm of Protection"
+msgstr "Defender Helm of Protection"
+
+msgid ""
+"A glint of golden light catches your eye. Upon further investigation, you "
+"find a golden helm hidden under a bush."
+msgstr ""
+"一道金色光芒吸引了你的注意。仔细调查后，你在灌木下发现了一顶金色头盔。"
+
+msgid "Giant Flail of Dominion"
+msgstr "Giant Flail of Dominion"
+
+msgid ""
+"A clumsy Giant has killed himself with his own flail. Knowing your superior "
+"skill with this weapon, you confidently remove the spectacular flail from "
+"the fallen Giant."
+msgstr ""
+"一个笨拙的巨人被自己的连枷杀死了。深知自己对这种武器驾轻就熟，你自信地从倒下"
+"的巨人身上取下了壮观的连枷。"
+
+msgid "Ballista of Quickness"
+msgstr "Ballista of Quickness"
+
+msgid "The %{name} gives the hero's catapult one extra shot per combat round."
+msgstr "%{name} 让英雄的投石车每回合多一次射击机会。"
+
+msgid ""
+"Walking through the ruins of an ancient walled city, you find the instrument "
+"of the city's destruction, an elaborately crafted ballista."
+msgstr ""
+"穿行于古代城墙城市的废墟中，你找到了摧毁这座城市的工具——一架制作精良的弩砲。"
+
+msgid "Stealth Shield of Protection"
+msgstr "Stealth Shield of Protection"
+
+msgid ""
+"A stone statue of a warrior holds a silver shield. As you remove the shield, "
+"the statue crumbles into dust."
+msgstr ""
+"一尊战士石像手持一面银盾。当你取下盾牌时，石像碎成了尘土。"
+
+msgid "Dragon Sword of Dominion"
+msgstr "Dragon Sword of Dominion"
+
+msgid ""
+"As you are walking along a narrow path, a nearby bush suddenly bursts into "
+"flames. Before your eyes the flames become the image of a beautiful woman. "
+"She holds out a magnificent sword to you."
+msgstr ""
+"你沿着一条狭窄小径行走时，附近的灌木突然燃烧起来。在你眼前，火焰化为一位美丽"
+"女性的形象。她向你递出一把华丽的宝剑。"
+
+msgid "Power Axe of Dominion"
+msgstr "Power Axe of Dominion"
+
+msgid ""
+"You see a silver axe embedded deeply in the ground. After several "
+"unsuccessful attempts by your army to remove the axe, you tightly grip the "
+"handle of the axe and effortlessly pull it free."
+msgstr ""
+"你看到一把深深嵌入地面的银斧。在军队数次尝试拔出失败后，你紧握斧柄，毫不费力"
+"地将其拔出。"
+
+msgid "Divine Breastplate of Protection"
+msgstr "Divine Breastplate of Protection"
+
+msgid ""
+"A gang of Rogues is sifting through the possessions of dead warriors. "
+"Scaring off the scavengers, you note the Rogues had overlooked a beautiful "
+"breastplate."
+msgstr ""
+"一群盗贼正在翻找死去战士的遗物。你赶走了这些拾荒者，注意到盗贼们忽略了一件精"
+"美的胸甲。"
+
+msgid "Minor Scroll of Knowledge"
+msgstr "Minor Scroll of Knowledge"
+
+msgid ""
+"Before you appears a levitating glass case with a scroll, perched upon a bed "
+"of crimson velvet. At your touch, the lid opens and the scroll floats into "
+"your awaiting hands."
+msgstr ""
+"你面前出现了一个漂浮的玻璃箱，放置在深红色天鹅绒上，内有一个卷轴。你一触碰，"
+"盖子便打开，卷轴飘入你等候的双手中。"
+
+msgid "Major Scroll of Knowledge"
+msgstr "Major Scroll of Knowledge"
+
+msgid ""
+"Visiting a local wiseman, you explain the intent of your journey. He reaches "
+"into a sack and withdraws a yellowed scroll and hands it to you."
+msgstr ""
+"拜访当地的智者时，你说明了旅程的目的。他从袋中取出一卷泛黄的卷轴递给你。"
+
+msgid "Superior Scroll of Knowledge"
+msgstr "Superior Scroll of Knowledge"
+
+msgid ""
+"You come across the remains of an ancient Druid. Bones, yellowed with age, "
+"peer from the ragged folds of her robe. Searching the robe, you discover a "
+"scroll hidden in the folds."
+msgstr ""
+"你发现了一位古代德鲁伊的遗骸。泛黄的白骨从破烂的袍褶中露出。搜寻袍子后，你在"
+"褶层中发现了一卷藏匿的卷轴。"
+
+msgid "Foremost Scroll of Knowledge"
+msgstr "Foremost Scroll of Knowledge"
+
+msgid ""
+"Mangled bones, yellowed with age, peer from the ragged folds of a dead "
+"Druid's robe. Searching the robe, you discover a scroll hidden within."
+msgstr ""
+"残破泛黄的白骨从一位已故德鲁伊破烂的袍子中露出。搜寻袍子后，你在其中发现了一"
+"卷藏匿的卷轴。"
+
+msgid "Endless Sack of Gold"
+msgstr "Endless Sack of Gold"
+
+msgid "The %{name} provides the hero with %{count} gold per day."
+msgstr "%{name} 每日为英雄提供 %{count} 金币。"
+
+msgid ""
+"A little leprechaun dances gleefully around a magic sack. Seeing you "
+"approach, he stops in mid-stride. The little man screams and stamps his foot "
+"ferociously, vanishing into thin air. Remembering the old leprechaun saying "
+"'Finders Keepers', you grab the sack and leave."
+msgstr ""
+"一个小矮妖围着一个魔法袋欢快地跳舞。看到你走近，他停下脚步，小矮人尖叫着猛跺"
+"脚，消失得无影无踪。想起那句古老的矮妖格言「捡到就是你的」，你抓起袋子离开"
+"了。"
+
+msgid "Endless Bag of Gold"
+msgstr "Endless Bag of Gold"
+
+msgid ""
+"A noblewoman, separated from her traveling companions, asks for your help. "
+"After escorting her home, she rewards you with a bag filled with gold."
+msgstr ""
+"一位与旅伴走散的贵妇人请求你的帮助。护送她回家后，她以一袋金币作为酬谢。"
+
+msgid "Endless Purse of Gold"
+msgstr "Endless Purse of Gold"
+
+msgid ""
+"In your travels, you find a leather purse filled with gold that once "
+"belonged to a great warrior king who had the ability to transform any "
+"inanimate object into gold."
+msgstr ""
+"旅途中，你找到了一个装满金币的皮革钱包，它曾属于一位拥有将任何无生命物体变成"
+"黄金能力的伟大战士国王。"
+
+msgid "Nomad Boots of Mobility"
+msgstr "Nomad Boots of Mobility"
+
+msgid "The %{name} increase the hero's movement on land."
+msgstr "%{name} 增加英雄的陆上移动力。"
+
+msgid ""
+"A Nomad trader seeks protection from a tribe of Goblins. For your "
+"assistance, he gives you a finely crafted pair of boots made from the "
+"softest leather. Looking closely, you see fascinating ancient carvings "
+"engraved on the leather."
+msgstr ""
+"一位游牧商人请求你保护他免受妖怪部落侵害。作为报答，他送给你一双以最柔软皮"
+"革精制的靴子。仔细观察，你发现皮革上刻有迷人的古代雕纹。"
+
+msgid "Traveler's Boots of Mobility"
+msgstr "Traveler's Boots of Mobility"
+
+msgid ""
+"Discovering a pair of beautifully beaded boots made from the finest and "
+"softest leather, you thank the anonymous donor and add the boots to your "
+"inventory."
+msgstr ""
+"发现一双以最精致柔软的皮革制成、缀满珠饰的靴子，你感谢匿名赠予者并将靴子收入"
+"囊中。"
+
+msgid "Lucky Rabbit's Foot"
+msgstr "Lucky Rabbit's Foot"
+
+msgid "The %{name} increases the luck of the hero's army by %{count}."
+msgstr "%{name} 增加英雄军队 %{count} 点幸运。"
+
+msgid ""
+"A traveling merchant offers you a rabbit's foot, made of gleaming silver "
+"fur, for safe passage. The merchant explains the charm will increase your "
+"luck in combat."
+msgstr ""
+"一位旅行商人以一只闪亮银毛兔脚换取安全通行。商人解释说这个护身符能增加你在战"
+"斗中的运气。"
+
+msgid "Golden Horseshoe"
+msgstr "Golden Horseshoe"
+
+msgid ""
+"An ensnared Unicorn whinnies in fright. Murmuring soothing words, you set "
+"her free. Snorting and stamping her front hoof once, she gallops off. "
+"Looking down you see a golden horseshoe."
+msgstr ""
+"一只被困住的独角兽恐惧地嘶鸣。你轻声安慰着将牠放走。牠喷了口气、前蹄跺地一下"
+"便奔驰而去。你低头发现了一只金色马蹄铁。"
+
+msgid "Gambler's Lucky Coin"
+msgstr "Gambler's Lucky Coin"
+
+msgid ""
+"You have captured a mischievous imp who has been terrorizing the region. In "
+"exchange for his release, he rewards you with a magical coin."
+msgstr ""
+"你捕获了一只一直在恐吓该地区的恶作剧小恶魔。为了换取自由，牠以一枚魔法硬币作"
+"为报答。"
+
+msgid "Four-Leaf Clover"
+msgstr "Four-Leaf Clover"
+
+msgid ""
+"In the middle of a patch of dead and dry vegetation, to your surprise you "
+"find a healthy green four-leaf clover."
+msgstr ""
+"在一片枯死干燥的植被中，你惊喜地发现了一株健康翠绿的四叶草。"
+
+msgid "True Compass of Mobility"
+msgstr "True Compass of Mobility"
+
+msgid "The %{name} increases the hero's movement on land and sea."
+msgstr "%{name} 增加英雄的陆上和海上移动力。"
+
+msgid ""
+"An old man claiming to be an inventor asks you to try his latest invention. "
+"He then hands you a compass."
+msgstr ""
+"一位自称发明家的老人请你试试他的最新发明，然后递给你一个指南针。"
+
+msgid "Sailor's Astrolabe of Mobility"
+msgstr "Sailor's Astrolabe of Mobility"
+
+msgid "The %{name} increases the hero's movement on sea."
+msgstr "%{name} 增加英雄的海上移动力。"
+
+msgid ""
+"An old sea captain is being tortured by Ogres. You save him, and in return "
+"he rewards you with a wondrous instrument to measure the distance of a star."
+msgstr ""
+"一位老海船长正被食人魔折磨。你救了他，作为回报，他送给你一件可以测量星辰距离"
+"的奇妙仪器。"
+
+msgid "Evil Eye"
+msgstr "Evil Eye"
+
+msgid "The %{name} reduces the casting cost of curse spells by half."
+msgstr "%{name} 将诅咒系法术的施放消耗减半。"
+
+msgid ""
+"While venturing into a decrepit hut you find the Skeleton of a long dead "
+"witch. Investigation of the remains reveals a glass eye rolling around "
+"inside an empty skull."
+msgstr ""
+"进入一间破败的小屋时，你发现了一具早已死去的女巫骸骨。调查遗骸时，在空骷髅里"
+"发现了一颗滚动的玻璃眼珠。"
+
+msgid "Enchanted Hourglass"
+msgstr "Enchanted Hourglass"
+
+msgid ""
+"The %{name} extends the duration of all the hero's spells by %{count} turns."
+msgstr ""
+"%{name} 延长英雄所有法术的持续时间 %{count} 回合。"
+
+msgid ""
+"A surprise turn in the landscape finds you in the midst of a grisly scene: "
+"Vultures picking at the aftermath of a terrible battle. Your cursory search "
+"of the remains turns up an enchanted hourglass."
+msgstr ""
+"地形的意外转折使你置身于一幅恐怖的景象中：秃鹰在一场惨烈战斗的残骸中啄食。你"
+"粗略搜寻遗骸，找到了一个魔法沙漏。"
+
+msgid "Gold Watch"
+msgstr "Gold Watch"
+
+msgid "The %{name} doubles the effectiveness of the hero's hypnotize spells."
+msgstr "%{name} 使英雄的催眠术效果加倍。"
+
+msgid ""
+"In reward for helping his cart out of a ditch, a traveling potion salesman "
+"gives you a \"magic\" gold watch. Unbeknownst to him, the watch really is "
+"magical."
+msgstr ""
+"为了答谢你帮他的货车脱离沟渠，一位旅行药剂商人送给你一只「魔法」金表。他自己"
+"都不知道，这只表真的是魔法物品。"
+
+msgid "Skullcap"
+msgstr "Skullcap"
+
+msgid "The %{name} halves the casting cost of all mind influencing spells."
+msgstr "%{name} 将所有精神系法术的施放消耗减半。"
+
+msgid ""
+"A brief stop at an improbable rural inn yields an exchange of money, tales, "
+"and accidentally, luggage. You find a magical skullcap in your new backpack."
+msgstr ""
+"在一间不起眼的乡间旅店短暂停留，交换了金钱、故事，还不小心交换了行李。你在新"
+"背包中发现了一顶魔法骷髅帽。"
+
+msgid "Ice Cloak"
+msgstr "Ice Cloak"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from cold spells."
+msgstr ""
+"%{name} 将英雄部队受到的冰系法术伤害减半。"
+
+msgid ""
+"Responding to the panicked cries of a damsel in distress, you discover a "
+"young woman fleeing from a hungry bear. You slay the beast in the nick of "
+"time, and the grateful Sorceress weaves a magic cloak from the bear's hide."
+msgstr ""
+"回应一位落难少女的惊恐求救，你发现一名年轻女子正在逃离一只饥饿的熊。你及时杀"
+"死了野兽，感激的女巫用熊皮织成了一件魔法斗篷。"
+
+msgid "Fire Cloak"
+msgstr "Fire Cloak"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from fire spells."
+msgstr ""
+"%{name} 将英雄部队受到的火系法术伤害减半。"
+
+msgid ""
+"You've come upon a fight between a Necromancer and a Paladin. The "
+"Necromancer blasts the Paladin with a fire bolt, bringing him to his knees. "
+"Acting quickly, you slay the evil one before the final blow. The grateful "
+"Paladin gives you the fire cloak that saved him."
+msgstr ""
+"你撞见了一场死灵法师与武士的战斗。死灵法师以火焰箭击中武士，将他打跪在"
+"地。你迅速行动，在致命一击前杀死了邪恶者。武士满怀感激，将救命的火焰斗篷送"
+"给你。"
+
+msgid "Lightning Helm"
+msgstr "Lightning Helm"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from lightning "
+"spells."
+msgstr ""
+"%{name} 将英雄部队受到的雷电法术伤害减半。"
+
+msgid ""
+"A traveling tinker in need of supplies offers you a helm with a thunderbolt "
+"design on its top in exchange for food and water. Curious, you accept, and "
+"later find out that the helm is magical."
+msgstr ""
+"一位需要补给的旅行修补匠以顶部有雷电图案的头盔换取食物和水。出于好奇你接受"
+"了，后来发现这顶头盔是魔法物品。"
+
+msgid "Evercold Icicle"
+msgstr "Evercold Icicle"
+
+msgid ""
+"The %{name} causes the hero's cold spells to do %{count} percent more damage "
+"to enemy troops."
+msgstr ""
+"%{name} 使英雄的冰系法术对敌军造成额外 %{count}% 的伤害。"
+
+msgid ""
+"An icicle withstanding the full heat of the noonday sun attracts your "
+"attention. Intrigued, you break it off, and find that it does not melt in "
+"your hand."
+msgstr ""
+"一根在正午烈日下仍不融化的冰柱吸引了你的注意。你好奇地折断它，发现它在手中不"
+"会融化。"
+
+msgid "Everhot Lava Rock"
+msgstr "Everhot Lava Rock"
+
+msgid ""
+"The %{name} causes the hero's fire spells to do %{count} percent more damage "
+"to enemy troops."
+msgstr ""
+"%{name} 使英雄的火系法术对敌军造成额外 %{count}% 的伤害。"
+
+msgid ""
+"Your wanderings bring you into contact with a tribe of ape-like beings using "
+"a magical lava rock that never cools to light their fires. You take pity on "
+"them and teach them to make fire with sticks. Believing you to be a god, the "
+"apes give you their rock."
+msgstr ""
+"你在漫游中遇到了一群类猿生物，牠们正使用一块永不冷却的魔法岩浆石生火。你同情"
+"牠们，教牠们用木棍生火。猿人们相信你是神明，将岩浆石送给了你。"
+
+msgid "Lightning Rod"
+msgstr "Lightning Rod"
+
+msgid ""
+"The %{name} causes the hero's lightning spells to do %{count} percent more "
+"damage to enemy troops."
+msgstr ""
+"%{name} 使英雄的雷电法术对敌军造成额外 %{count}% 的伤害。"
+
+msgid ""
+"While waiting out a storm, a lighting bolt strikes a nearby cottage's "
+"lightning rod, which melts and falls to the ground. The tip of the rod, "
+"however, survives intact and makes your hair stand on end when you touch it. "
+"Hmm..."
+msgstr ""
+"等待暴风雨过去时，一道闪电击中了附近小屋的避雷针，将其融化落地。然而针尖完好"
+"无损，触碰它会让你毛发直竖。嗯……"
+
+msgid "Snake-Ring"
+msgstr "Snake-Ring"
+
+msgid "The %{name} halves the casting cost of all of the hero's bless spells."
+msgstr "%{name} 将英雄所有祝福法术的施放消耗减半。"
+
+msgid ""
+"You've found an oddly shaped ring on the finger of a long dead traveler. The "
+"ring looks like a snake biting its own tail."
+msgstr ""
+"你在一位早已死去的旅人手指上发现了一枚形状奇特的戒指。戒指看起来像一条咬住自"
+"己尾巴的蛇。"
+
+msgid "Ankh"
+msgstr "Ankh"
+
+msgid ""
+"The %{name} doubles the effectiveness of all of the hero's resurrect and "
+"animate spells."
+msgstr ""
+"%{name} 使英雄所有复活和操控亡灵法术的效果加倍。"
+
+msgid ""
+"A fierce windstorm reveals the entrance to a buried tomb. Your investigation "
+"reveals that the tomb has already been looted, but the thieves overlooked an "
+"ankh on a silver chain in the dark."
+msgstr ""
+"一阵猛烈的风暴揭露了一座被埋葬坟墓的入口。你的调查发现坟墓已被洗劫一空，但盗"
+"贼在黑暗中忽略了一条银链上的安卡十字架。"
+
+msgid "Book of Elements"
+msgstr "Book of Elements"
+
+msgid ""
+"The %{name} doubles the effectiveness of all of the hero's summoning spells."
+msgstr ""
+"%{name} 使英雄所有召唤法术的效果加倍。"
+
+msgid ""
+"You come across a conjurer who begs to accompany you and your army awhile "
+"for safety. You agree, and he offers as payment a copy of the book of the "
+"elements."
+msgstr ""
+"你遇到一位恳求随你和你的军队同行以保安全的咒术师。你同意了，他以一本元素之书"
+"的抄本作为报酬。"
+
+msgid "Elemental Ring"
+msgstr "Elemental Ring"
+
+msgid "The %{name} halves the casting cost of all summoning spells."
+msgstr "%{name} 将所有召唤法术的施放消耗减半。"
+
+msgid ""
+"While pausing to rest, you notice a bobcat climbing a short tree to get at a "
+"crow's nest. On impulse, you climb the tree yourself and scare off the cat. "
+"When you look in the nest, you find a collection of shiny stones and a ring."
+msgstr ""
+"休息时，你注意到一只山猫正爬上矮树去抓乌鸦巢。你冲动地自己爬上树赶走了猫。检"
+"视巢穴时，你发现了一堆闪亮的石头和一枚戒指。"
+
+msgid "Holy Pendant"
+msgstr "Holy Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to curse spells."
+msgstr "%{name} 使英雄所有部队免疫诅咒法术。"
+
+msgid ""
+"In your wanderings you come across a hermit living in a small, tidy hut. "
+"Impressed with your mission, he takes time out from his meditations to bless "
+"and give you a charm against curses."
+msgstr ""
+"你在漫游中遇到了一位住在整洁小屋中的隐士。对你的使命印象深刻，他从冥想中抽出"
+"时间为你祝福，并送你一个防御诅咒的护身符。"
+
+msgid "Pendant of Free Will"
+msgstr "Pendant of Free Will"
+
+msgid "The %{name} makes all of the hero's troops immune to hypnotize spells."
+msgstr "%{name} 使英雄所有部队免疫催眠术。"
+
+msgid ""
+"Responding to cries for help, you find river Sprites making a sport of "
+"dunking an old man. Feeling vengeful, you rescue the man and drag a Sprite "
+"onto dry land for awhile. The Sprite, uncomfortable in the air, gives you a "
+"magic pendant to let him go."
+msgstr ""
+"回应呼救声，你发现河精灵正以把一位老人按入水中为乐。你气愤地救了那人，并把一"
+"只精灵拖到岸上。精灵在空气中不舒服，送你一个魔法坠饰以求你放牠走。"
+
+msgid "Pendant of Life"
+msgstr "Pendant of Life"
+
+msgid "The %{name} makes all of the hero's troops immune to death spells."
+msgstr "%{name} 使英雄所有部队免疫死亡法术。"
+
+msgid ""
+"A brief roadside encounter with a small caravan and a game of knucklebones "
+"wins a magic pendant. Its former owner says that it protects from "
+"Necromancers' death spells."
+msgstr ""
+"在路边与一支小商队偶遇，一场掷骨游戏赢得了一个魔法坠饰。前任主人说它能抵御死"
+"灵法师的死亡法术。"
+
+msgid "Serenity Pendant"
+msgstr "Serenity Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to berserk spells."
+msgstr "%{name} 使英雄所有部队免疫狂暴法术。"
+
+msgid ""
+"The sounds of combat draw you to the scene of a fight between an old "
+"Barbarian and an eight-headed Hydra. Your timely intervention swings the "
+"battle in favor of the man, and he rewards you with a pendant he used to use "
+"to calm his mind for battle."
+msgstr ""
+"战斗的声响将你引到一位老蛮族与一只八头九头蛇的战斗现场。你的及时介入扭转了战"
+"局，他以一个曾用来让自己冷静作战的坠饰作为报答。"
+
+msgid "Seeing-eye Pendant"
+msgstr "Seeing-eye Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to blindness spells."
+msgstr "%{name} 使英雄所有部队免疫致盲法术。"
+
+msgid ""
+"You come upon a very old woman, long blind from cataracts and dying alone. "
+"You tend to her final needs and promise a proper burial. Grateful, she gives "
+"you a magic pendant emblazoned with a stylized eye. It lets you see with "
+"your eyes closed."
+msgstr ""
+"你遇到一位非常年迈的老妇人，她因白内障长期失明，独自等死。你照料她最后的需求"
+"并承诺妥善安葬。感激之余，她送你一个刻有风格化眼睛的魔法坠饰，让你闭着眼也能"
+"看见。"
+
+msgid "Kinetic Pendant"
+msgstr "Kinetic Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to paralyze spells."
+msgstr "%{name} 使英雄所有部队免疫麻痹法术。"
+
+msgid ""
+"You come across a golem wearing a glowing pendant and blocking your way. "
+"Acting on a hunch, you cut the pendant from its neck. Deprived of its power "
+"source, the golem breaks down, leaving you with the magical pendant."
+msgstr ""
+"你遇到一个戴着发光坠饰、挡住你去路的魔像。凭直觉行事，你切断了牠脖子上的坠"
+"饰。失去能量来源的魔像随即瓦解，留下魔法坠饰给你。"
+
+msgid "Pendant of Death"
+msgstr "Pendant of Death"
+
+msgid "The %{name} makes all of the hero's troops immune to holy spells."
+msgstr "%{name} 使英雄所有部队免疫神圣法术。"
+
+msgid ""
+"A quick and deadly battle with a Necromancer wins you his magical pendant. "
+"Later, a Wizard tells you that the pendant protects undead under your "
+"control from holy word spells."
+msgstr ""
+"与一位死灵法师的快速致命战斗为你赢得了他的魔法坠饰。之后，一位巫师告诉你这个"
+"坠饰能保护你控制的亡灵免受神圣之语法术的影响。"
+
+msgid "Wand of Negation"
+msgstr "Wand of Negation"
+
+msgid ""
+"The %{name} makes all of the hero's troops immune to dispel magic spells."
+msgstr ""
+"%{name} 使英雄所有部队免疫驱散魔法。"
+
+msgid ""
+"You meet an old Wizard friend of yours traveling in the opposite direction. "
+"He presents  you with a gift: A wand that prevents the use of the dispel "
+"magic spell on your allies."
+msgstr ""
+"你遇到了一位相识的老巫师朋友，他正往反方向旅行。他送给你一份礼物：一根能阻止"
+"敌人对你盟友使用驱散魔法的魔杖。"
+
+msgid "Golden Bow"
+msgstr "Golden Bow"
+
+msgid ""
+"The %{name} eliminates the %{count} percent penalty for the hero's troops "
+"shooting past obstacles (e.g. castle walls)."
+msgstr ""
+"%{name} 消除英雄部队射击穿越障碍物 (如城墙) 时的 %{count}% 惩罚。"
+
+msgid ""
+"A chance meeting with a famous Archer finds you in a game of knucklebones "
+"pitting his bow against your horse. You win."
+msgstr ""
+"偶遇一位著名弓箭手，你们以掷骰子比赛，以他的弓对你的马作为赌注。你赢了。"
+
+msgid "Telescope"
+msgstr "Telescope"
+
+msgid ""
+"The %{name} increases the amount of terrain the hero reveals when "
+"adventuring by %{count} extra square."
+msgstr ""
+"%{name} 使英雄冒险时额外揭露 %{count} 格地形。"
+
+msgid ""
+"A merchant from far away lands trades you a new invention of his people for "
+"traveling supplies. It makes distant objects appear closer, and he calls "
+"it...\n"
+"\n"
+"a telescope."
+msgstr ""
+"一位来自远方的商人以旅行补给换给你他的民族的新发明。它能让远处的物体看起来更"
+"近，他称之为……\n"
+"\n"
+"望远镜。"
+
+msgid "Statesman's Quill"
+msgstr "Statesman's Quill"
+
+msgid ""
+"The %{name} reduces the cost of surrender to %{count} percent of the total "
+"cost of troops the hero has in their army."
+msgstr ""
+"%{name} 将投降费用降低至英雄军队总兵力价值的 %{count}%。"
+
+msgid ""
+"You pause to help a diplomat with a broken axle fix his problem. In "
+"gratitude, he gives you a writing quill with magical properties which he "
+"says will \"help people see things your way\"."
+msgstr ""
+"你停下来帮助一位车轴断裂的外交官解决问题。出于感激，他送你一支具有魔法特性的"
+"鹅毛笔，说它能「帮助别人看到你的观点」。"
+
+msgid "Wizard's Hat"
+msgstr "Wizard's Hat"
+
+msgid ""
+"The %{name} increases the duration of the hero's spells by %{count} turns."
+msgstr ""
+"%{name} 延长英雄法术的持续时间 %{count} 回合。"
+
+msgid ""
+"You see a Wizard fleeing from a Griffin and riding like the wind. The Wizard "
+"opens a portal and rides through, getting his hat knocked off by the edge of "
+"the gate. The Griffin follows; the gate closes. You pick the hat up, dust it "
+"off, and put it on."
+msgstr ""
+"你看到一位巫师骑马疾风般地逃离一只狮鹫。巫师打开一个传送门冲了过去，帽子被门"
+"边撞落。狮鹫跟着进去了，门随即关闭。你捡起帽子，拍掉灰尘，戴在头上。"
+
+msgid "Power Ring"
+msgstr "Power Ring"
+
+msgid "The %{name} returns %{count} extra spell points per day to the hero."
+msgstr "%{name} 每日额外恢复英雄 %{count} 点魔法值。"
+
+msgid ""
+"You find a small tree that closely resembles the great Warlock Carnauth with "
+"a ring around one of its twigs. Scraps of clothing and rotting leather lead "
+"you to suspect that it IS Carnauth, transformed. Since you can't help him, "
+"you take the magic ring."
+msgstr ""
+"你发现一棵小树酷似伟大的术士 Carnauth，其中一根树枝上套着一枚戒指。现场有碎布"
+"和腐烂的皮革，让你怀疑这就是变形后的 Carnauth。既然帮不了他，你取走了魔法戒"
+"指。"
+
+msgid "Ammo Cart"
+msgstr "Ammo Cart"
+
+msgid ""
+"The %{name} provides endless ammunition for all of the hero's troops that "
+"shoot."
+msgstr ""
+"%{name} 为英雄所有远距部队提供无限弹药。"
+
+msgid ""
+"An ammunition cart in the middle of an old battlefield catches your eye. "
+"Inspection shows it to be in good working order, so  you take it along."
+msgstr ""
+"一辆位于旧战场中央的弹药车吸引了你的目光。检查后发现它仍能正常运作，于是你带"
+"上了它。"
+
+msgid "Tax Lien"
+msgstr "Tax Lien"
+
+msgid "The %{name} costs the hero %{count} gold pieces per day."
+msgstr "%{name} 每日消耗英雄 %{count} 金币。"
+
+msgid ""
+"Your big spending habits have earned you a massive tax bill that you can't "
+"hope to pay. The tax man takes pity and agrees to only take 250 gold a day "
+"from your account for life. Check here if you want one dollar to go to the "
+"presidential campaign election fund."
+msgstr ""
+"你挥金如土的习惯为你带来了一张你无法支付的巨额税单。税务官大发慈悲，同意终身"
+"每日只从你的帐户扣除 250 金币。如果你想为总统竞选基金捐一块钱，请在此勾选。"
+
+msgid "Hideous Mask"
+msgstr "Hideous Mask"
+
+msgid "The %{name} prevents all 'wandering' armies from joining the hero."
+msgstr "%{name} 阻止所有流浪军队加入英雄。"
+
+msgid ""
+"Your looting of the grave of Sinfilas Gardolad, the famous shapeshifting "
+"Warlock, unearths his fabled mask. Trembling, you put it on and it twists "
+"your visage into an awful grimace! Oh no! It's actually the hideous mask of "
+"Gromluck Greene, and you are stuck with it."
+msgstr ""
+"你盗掘了著名变形术士 Sinfilas Gardolad 的坟墓，挖出了他传说中的面具。你颤抖地"
+"戴上它，它将你的面容扭曲成可怕的鬼脸！糟糕！这其实是 Gromluck Greene 的丑陋面"
+"具，而且你摘不下来了。"
+
+msgid "Endless Pouch of Sulfur"
+msgstr "Endless Pouch of Sulfur"
+
+msgid "The %{name} provides %{count} unit of sulfur per day."
+msgstr "%{name} 每日提供 %{count} 单位硫磺。"
+
+msgid ""
+"You visit an alchemist who, upon seeing your army, is swayed by the "
+"righteousness of your cause. The newly loyal subject gives you his endless "
+"pouch of sulfur to help with the war effort."
+msgstr ""
+"你拜访了一位炼金术士，他看到你的军队后被你的正义事业所感动。这位新近效忠的臣"
+"民送你无尽硫磺袋，协助你的战事。"
+
+msgid "Endless Vial of Mercury"
+msgstr "Endless Vial of Mercury"
+
+msgid "The %{name} provides %{count} unit of mercury per day."
+msgstr "%{name} 每日提供 %{count} 单位水银。"
+
+msgid ""
+"A brief stop at a hastily abandoned Wizard's tower turns up a magical vial "
+"of mercury that always has a little left on the bottom. Recognizing a "
+"treasure when you see one, you cap it and slip it in your pocket."
+msgstr ""
+"在一座匆忙废弃的巫师塔短暂停留，你发现了一瓶底部永远留有一些水银的魔法瓶。识"
+"宝之人自然不会错过，你盖上瓶盖塞进口袋。"
+
+msgid "Endless Pouch of Gems"
+msgstr "Endless Pouch of Gems"
+
+msgid "The %{name} provides %{count} unit of gems per day."
+msgstr "%{name} 每日提供 %{count} 单位宝石。"
+
+msgid ""
+"A short rainstorm brings forth a rainbow...and you can see the end of it. "
+"Riding quickly, you seize the pot of gold you find there. The leprechaun who "
+"owns it, unable to stop you from taking it, offers an endless pouch of gems "
+"for the return of his gold. You accept."
+msgstr ""
+"一阵短暂的雷阵雨带来了彩虹……你看得到彩虹的尽头。快马加鞭，你夺取了那里的金"
+"罐。拥有它的小矮妖无法阻止你，提议以一个无尽宝石袋换回他的金子。你接受了。"
+
+msgid "Endless Cord of Wood"
+msgstr "Endless Cord of Wood"
+
+msgid "The %{name} provides %{count} unit of wood per day."
+msgstr "%{name} 每日提供 %{count} 单位木材。"
+
+msgid ""
+"Pausing to rest and light a cook fire, you pull wood out of a nearby pile of "
+"dead wood. As you keep pulling wood from the pile, you notice that it "
+"doesn't shrink. You realize to your delight that the wood is enchanted, so "
+"you take it along."
+msgstr ""
+"休息生火时，你从附近的枯木堆中抽取木材。你不断取出木材，却注意到木堆没有减"
+"少。你高兴地意识到这些木材被施了魔法，于是将它带走。"
+
+msgid "Endless Cart of Ore"
+msgstr "Endless Cart of Ore"
+
+msgid "The %{name} provides %{count} unit of ore per day."
+msgstr "%{name} 每日提供 %{count} 单位矿石。"
+
+msgid ""
+"You've found a Goblin weapon smithy making weapons for use against humans. "
+"With a tremendous yell you and your army descend upon their camp and drive "
+"them away. A search finds a magic ore cart that never runs out of iron."
+msgstr ""
+"你发现了一个妖怪武器锻造所，正在制造对付人类的武器。你和军队大喊一声冲进他"
+"们的营地，将他们赶跑。搜寻后发现了一辆永远不会用完铁矿的魔法矿车。"
+
+msgid "Endless Pouch of Crystal"
+msgstr "Endless Pouch of Crystal"
+
+msgid ""
+"Taking shelter from a storm in a small cave, you notice a small patch of "
+"crystal in one corner. Curious, you break a piece off and notice that the "
+"original crystal grows the lost piece back. You decide to stuff the entire "
+"patch into a pouch and take it with you."
+msgstr ""
+"在小洞穴中躲避暴风雨时，你注意到角落有一小片水晶。出于好奇，你折断了一块，发"
+"现原来的水晶长回了缺失的部分。你决定将整片水晶塞进袋子带走。"
+
+msgid "The %{name} provides %{count} unit of crystal per day."
+msgstr "%{name} 每日提供 %{count} 单位水晶。"
+
+msgid "Spiked Helm"
+msgstr "Spiked Helm"
+
+msgid ""
+"Your army is ambushed by a small tribe of wild (and none too bright) Orcs. "
+"You fend them off easily and the survivors flee in all directions. One of "
+"the Orcs was wearing a polished spiked helm. Figuring it will make a good "
+"souvenir, you take it."
+msgstr ""
+"你的军队遭到一个野蛮 (而且不怎么聪明) 的海怪小部落伏击。你轻松击退了他们，幸"
+"存者四散奔逃。其中一个海怪戴着一顶抛光的尖刺头盔。想着它是个不错的纪念品，你"
+"将它取走。"
+
+msgid "Spiked Shield"
+msgstr "Spiked Shield"
+
+msgid ""
+"You come upon a bridge spanning a dry gully. Before you can cross, a Troll "
+"steps out from under the bridge and demands payment before it will permit "
+"you to pass. You refuse, and the Troll charges, forcing you to slay it. You "
+"take its spiked shield as a trophy."
+msgstr ""
+"你来到一座横跨干涸沟壑的桥前。在你过桥之前，一只索尔从桥下走出，要求你付费才"
+"肯放行。你拒绝了，索尔发起冲锋，你被迫将牠斩杀。你取走了牠的尖刺盾牌作为战利"
+"品。"
+
+msgid "White Pearl"
+msgstr "White Pearl"
+
+msgid ""
+"A walk across a dry saltwater lake bed yields an unlikely prize: A white "
+"pearl amidst shattered shells and debris."
+msgstr ""
+"穿越干涸盐湖湖床的途中，你获得了意想不到的奖品：一颗藏在碎裂贝壳和残骸中的白"
+"色珍珠。"
+
+msgid "Black Pearl"
+msgstr "Black Pearl"
+
+msgid ""
+"Rumors of a Griffin of unusual size preying upon the countryside lead you to "
+"its cave lair. A quick, brutal fight dispatches the beast, and a search of "
+"its foul nest turns up a huge black pearl."
+msgstr ""
+"关于一只巨大狮鹫在乡间捕食的传言将你引到了牠的洞穴巢穴。一场快速而残酷的战斗"
+"杀死了野兽。你搜寻牠肮脏的巢穴时，找到了一颗巨大的黑珍珠。"
+
+msgid "Magic Book"
+msgstr "Magic Book"
+
+msgid "The %{name} enables the hero to cast spells."
+msgstr "%{name} 使英雄能够施放法术。"
+
+msgid ""
+"A young man approaches you: \"My Lord, allow me to show you my latest "
+"invention for spreading knowledge!\" You follow the man into his workshop "
+"and immediately observe a large apparatus with levers and cranks. \"This "
+"here is it!\" he says eagerly, \"The Printing Press.\" And before you get to "
+"say a word, he hands you a Magic Book."
+msgstr ""
+"一个年轻人走近你：「大人，让我向您展示我传播知识的最新发明！」你跟着他走进工"
+"坊，立刻看到一台带有拉杆和曲柄的大型装置。「这就是了！」他急切地说，「印刷"
+"机。」你还来不及说话，他就递给你一本魔法书。"
+
+msgid "Victory can be achieved by finding any Ultimate Artifact."
+msgstr "找到任何终极神器即可获胜。"
+
+msgid "Dummy 2"
+msgstr "Dummy 2"
+
+msgid "The reserved artifact."
+msgstr "保留的神器。"
+
+msgid "Dummy 3"
+msgstr "Dummy 3"
+
+msgid "Dummy 4"
+msgstr "Dummy 4"
+
+msgid "Spell Scroll"
+msgstr "Spell Scroll"
+
+msgid ""
+"This %{name} gives the hero the ability to cast the %{spell} spell if the "
+"hero has a Magic Book."
+msgstr ""
+"这个 %{name} 在英雄拥有魔法书的情况下赋予施放 %{spell} 法术的能力。"
+
+msgid ""
+"You find an elaborate container which houses an old vellum scroll. The runes "
+"on the container are very old, and the artistry with which it was put "
+"together is stunning. As you pull the scroll out, you feel imbued with "
+"magical power."
+msgstr ""
+"你找到了一个精致的容器，里面装着一卷古老的羊皮纸卷轴。容器上的符文非常古老，"
+"其工艺令人惊叹。当你抽出卷轴时，你感觉全身充满了魔力。"
+
+msgid "Arm of the Martyr"
+msgstr "Arm of the Martyr"
+
+msgid ""
+"One of the less intelligent members of your party picks up an arm off of the "
+"ground. Despite its missing a body, it is still moving. Your troops find the "
+"dismembered arm repulsive, but you cannot bring yourself to drop it: it "
+"seems to hold some sort of magical power that influences your decision "
+"making."
+msgstr ""
+"你队伍中一位不太聪明的成员从地上捡起了一只手臂。尽管没有身体，它仍在动。你的"
+"部队对这只断臂感到恶心，但你就是放不下它：它似乎拥有某种影响你决策的魔力。"
+
+msgid ""
+"The %{name} increases the hero's spell power by %{count} but adds the undead "
+"morale penalty."
+msgstr ""
+"%{name} 增加英雄 %{count} 点魔法力量，但附加亡灵士气惩罚。"
+
+msgid "Breastplate of Anduran"
+msgstr "Breastplate of Anduran"
+
+msgid "The %{name} increases the hero's defense by %{count}."
+msgstr "%{name} 增加英雄 %{count} 点防御。"
+
+msgid ""
+"You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
+"swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
+"you stand up, you feel a coldness against your skin. Looking down, you find "
+"that you are suddenly wearing a gleaming, ornate breastplate."
+msgstr ""
+"你来到一块告示牌前。上面写着：「此处安息着 Anduran 的遗体。鞠躬宣誓效忠，你将"
+"得到回报。」你照做了。站起身来时，你感觉一阵冰凉贴着皮肤。低头一看，你发现自"
+"己突然穿上了一件闪亮华丽的胸甲。"
+
+msgid "Broach of Shielding"
+msgstr "Broach of Shielding"
+
+msgid ""
+"The %{name} provides %{count} percent protection from Armageddon and "
+"Elemental Storm, but decreases spell power by 2."
+msgstr ""
+"%{name} 提供 %{count}% 的末日审判和元素风暴防护，但降低 2 点魔法力量。"
+
+msgid ""
+"A kindly Sorceress thinks that your army's defenses could use a magical "
+"boost. She offers to enchant the Broach that you wear on your cloak, and you "
+"accept."
+msgstr ""
+"一位善良的女巫认为你军队的防御可以用魔法强化。她提议为你斗篷上的胸针施加附"
+"魔，你接受了。"
+
+msgid "Battle Garb of Anduran"
+msgstr "Battle Garb of Anduran"
+
+msgid ""
+"The %{name} combines the powers of the three Anduran artifacts (+5 to "
+"attack, defense, and spell power). It also provides maximum luck and morale "
+"for the hero's troops and gives the hero the Town Portal spell."
+msgstr ""
+"%{name} 结合了三件 Anduran 神器的力量 (攻击、防御和魔法力量各 +5)。它还为英雄"
+"的部队提供最大幸运和士气，并赋予英雄城镇传送门法术。"
+
+msgid ""
+"Out of pity for a poor peasant, you purchase a chest of old junk they are "
+"hawking for too much gold. Later, as you search through it, you find it "
+"contains the 3 pieces of the legendary battle garb of Anduran!"
+msgstr ""
+"出于对一个贫穷农民的同情，你以过高的价格买下了他们叫卖的一箱旧破烂。后来翻找"
+"时，你发现里面竟包含传说中 Anduran 战甲的 3 个部件！"
+
+msgid "Crystal Ball"
+msgstr "Crystal Ball"
+
+msgid ""
+"The %{name} lets the hero get more specific information about monsters, "
+"enemy heroes, and castles nearby the hero."
+msgstr ""
+"%{name} 让英雄获得附近怪物、敌方英雄和城堡的更详细资讯。"
+
+msgid ""
+"You come upon a caravan of gypsies who are feasting and fortifying their "
+"bodies with mead. They call you forward and say \"If you prove that you can "
+"dance the Rama-Buta, we will reward you.\" You don't know it, but try "
+"anyway. They laugh hysterically, but admire your bravery, giving you a "
+"Crystal Ball."
+msgstr ""
+"你遇到了一支正在饮蜜酒欢宴的吉普赛商队。他们叫你过去说：「如果你能跳 Rama-"
+"Buta 舞，我们就奖赏你。」你不会跳，但还是尝试了。他们笑得前仰后合，但钦佩你的"
+"勇气，送给你一颗水晶球。"
+
+msgid "Heart of Fire"
+msgstr "Heart of Fire"
+
+msgid ""
+"The %{name} provides %{count} percent protection from fire, but doubles the "
+"damage taken from cold."
+msgstr ""
+"%{name} 提供 %{count}% 的火焰防护，但受到的冰系伤害加倍。"
+
+msgid ""
+"You enter a recently burned glade and come upon a Fire Elemental sitting "
+"atop a rock. It looks up, its flaming face contorted in a look of severe "
+"pain. It then tosses a glowing object at you. You put up your hands to block "
+"it, but it passes right through them and sears itself into your chest."
+msgstr ""
+"你进入一片最近烧毁的林间空地，遇到一个坐在岩石上的火元素。牠擡头看你，燃烧的"
+"脸庞扭曲着剧痛的表情。然后牠朝你抛出一个发光的物体。你举起双手阻挡，但它直接"
+"穿过，灼入你的胸膛。"
+
+msgid "Heart of Ice"
+msgstr "Heart of Ice"
+
+msgid ""
+"The %{name} provides %{count} percent protection from cold, but doubles the "
+"damage taken from fire."
+msgstr ""
+"%{name} 提供 %{count}% 的寒冰防护，但受到的火系伤害加倍。"
+
+msgid ""
+"Suddenly, a biting coldness engulfs your body. You seize up, falling from "
+"your horse. The pain subsides, but you still feel as if your chest is "
+"frozen. As you pick yourself up off of the ground, you hear hearty laughter. "
+"You turn around just in time to see a Frost Giant run off into the woods and "
+"disappear."
+msgstr ""
+"突然，刺骨的寒冷吞噬了你的身体。你全身僵硬，从马上摔落。疼痛消退了，但你仍觉"
+"得胸口像是结了冰。当你从地上爬起时，听到了爽朗的笑声。你转过身，恰好看见一个"
+"霜巨人跑入树林中消失了。"
+
+msgid "Helmet of Anduran"
+msgstr "Helmet of Anduran"
+
+msgid ""
+"You spy a gleaming object poking up out of the ground. You send a member of "
+"your party over to investigate. He comes back with a golden helmet in his "
+"hands. You realize that it must be the helmet of the legendary Anduran, the "
+"only man who was known to wear solid gold armor."
+msgstr ""
+"你发现地面上露出一个闪光的物体。你派队员去调查。他带着一顶金色头盔回来。你意"
+"识到这一定是传说中 Anduran 的头盔，他是唯一一位已知穿戴纯金盔甲的人。"
+
+msgid "Holy Hammer"
+msgstr "Holy Hammer"
+
+msgid ""
+"You come upon a battle where a Paladin has been mortally wounded by a group "
+"of Zombies. He asks you to take his hammer and finish what he started. As "
+"you pick it up, it begins to hum, and then everything becomes a blur. The "
+"Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
+msgstr ""
+"你遇到一场战斗，一位武士被一群僵尸重伤。他请你拿起他的锤子完成他的使命。当"
+"你捡起它时，锤子开始嗡鸣，然后一切变得模糊。僵尸们都倒下了，锤子滴着鲜血。你"
+"将它系在腰带上。"
+
+msgid "Legendary Scepter"
+msgstr "Legendary Scepter"
+
+msgid "The %{name} adds %{count} points to all attributes."
+msgstr "%{name} 增加所有属性 %{count} 点。"
+
+msgid ""
+"Upon cresting a small hill, you come upon a ridiculous looking sight. A "
+"Sprite is attempting to carry a Scepter that is almost as big as it is. "
+"Trying not to laugh, you ask, \"Need help?\" The Sprite glares at you and "
+"answers: \"You think this is funny? Fine. You can carry it. I much prefer "
+"flying anyway.\""
+msgstr ""
+"翻过一座小丘，你看到了一幅滑稽的景象。一只精灵正试图搬运一根几乎和牠一样大的"
+"权杖。你忍住笑问道：「需要帮忙吗？」精灵瞪着你回答：「你觉得这很好笑吗？好"
+"吧，你来搬。反正我比较喜欢飞。」"
+
+msgid "Masthead"
+msgstr "Masthead"
+
+msgid ""
+"The %{name} boosts the hero's troops' luck and morale by %{count} each in "
+"sea combat."
+msgstr ""
+"%{name} 在海战中各增加英雄部队 %{count} 点幸运和士气。"
+
+msgid ""
+"An old seaman tells you a tale of an enchanted masthead that he used in his "
+"youth to rally his crew during times of trouble. He then hands you a faded "
+"map that shows where he hid it. After much exploring, you find it stashed "
+"underneath a nearby dock."
+msgstr ""
+"一位老水手向你讲述他年轻时用一个魔法船首像在危难时鼓舞船员的故事。然后他递给"
+"你一张褪色的地图，标示了他藏匿之处。经过一番探索，你在附近的码头下面找到了"
+"它。"
+
+msgid "Sphere of Negation"
+msgstr "Sphere of Negation"
+
+msgid "The %{name} disables all spell casting, for both sides, in combat."
+msgstr "%{name} 在战斗中禁止双方施放任何法术。"
+
+msgid ""
+"You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
+"hands you a tiny sphere. As soon as you grasp it, you feel the magical "
+"energy drain from your limbs..."
+msgstr ""
+"你停下来帮助一个农民抓住逃跑的母马。为表感谢，他递给你一个小球体。你一握住"
+"它，就感觉魔力从四肢流失……"
+
+msgid "Staff of Wizardry"
+msgstr "Staff of Wizardry"
+
+msgid "The %{name} boosts the hero's spell power by %{count}."
+msgstr "%{name} 增加英雄 %{count} 点魔法力量。"
+
+msgid ""
+"While out scaring up game, your troops find a mysterious staff levitating "
+"about three feet off of the ground. They hand it to you, and you notice an "
+"inscription. It reads: \"Brains best brawn and magic beats might. Heed my "
+"words, and you'll win every fight.\""
+msgstr ""
+"在外出驱赶猎物时，你的部队发现了一根在离地三英尺处悬浮的神秘法杖。他们将它交"
+"给你，你注意到上面有铭文写着：「智慧胜过蛮力，魔法克制武力。听从我的话，你将"
+"赢得每场战斗。」"
+
+msgid "Sword Breaker"
+msgstr "Sword Breaker"
+
+msgid "The %{name} increases the hero's defense by %{count} and attack by 1."
+msgstr "%{name} 增加英雄 %{count} 点防御和 1 点攻击。"
+
+msgid ""
+"A former Captain of the Guard admires your quest and gives you the enchanted "
+"Sword Breaker that he relied on during his tour of duty."
+msgstr ""
+"一位前卫队队长钦佩你的壮举，将他在任期间依赖的附魔碎剑器送给你。"
+
+msgid "Sword of Anduran"
+msgstr "Sword of Anduran"
+
+msgid ""
+"A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
+"will slay you where you stand.\" You refuse. The troll grabs the sword "
+"hanging from its belt, screams in pain, and runs away. Picking up the fabled "
+"sword, you give thanks that half-witted Trolls tend to grab the wrong end of "
+"sharp objects."
+msgstr ""
+"一只索尔拦住你说：「付我 5,000 金币，否则 Anduran 之剑会就地斩杀你。」你拒绝"
+"了。索尔抓住挂在腰带上的剑，痛得尖叫着跑掉了。捡起这把传说中的剑，你庆幸愚蠢"
+"的索尔总是抓错锐器的那一端。"
+
+msgid "Spade of Necromancy"
+msgstr "Spade of Necromancy"
+
+msgid "The %{name} gives the hero increased necromancy skill."
+msgstr "%{name} 增强英雄的死灵术技能。"
+
+msgid ""
+"A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
+"you discover it to be the enchanted shovel of the Gravediggers, long thought "
+"lost by mortals."
+msgstr ""
+"附近的土堆中插着一把肮脏的铲子。经过调查，你发现它是掘墓人的魔法铲，长久以来"
+"被凡人认为已失落。"
+
+msgid "spellBonus|selected by user"
+msgstr "使用者选择"
+
+msgid "Wood"
+msgstr "木材"
+
+msgid "Mercury"
+msgstr "水银"
+
+msgid "Ore"
+msgstr "矿石"
+
+msgid "Sulfur"
+msgstr "硫磺"
+
+msgid "Crystal"
+msgstr "水晶"
+
+msgid "Gems"
+msgstr "宝石"
+
+msgid "Gold"
+msgstr "黄金"
+
+msgid ""
+"There are seven resources in Heroes 2, used to build and improves castles, "
+"purchase troops and recruit heroes. Gold is the most common, required for "
+"virtually everything. Wood and ore are used for most buildings. Gems, "
+"Mercury, Sulfur and Crystal are rare magical resources used for the most "
+"powerful creatures and buildings."
+msgstr ""
+"Heroes 2 中有七种资源，用于建造和升级城堡、购买部队和招募英雄。黄金是最常见"
+"的，几乎所有事物都需要。木材和矿石用于大多数建筑。宝石、水银、硫磺和水晶是稀"
+"有的魔法资源，用于最强大的生物和建筑。"
+
+msgid ""
+"Causes a giant fireball to strike the selected area, damaging all nearby "
+"creatures."
+msgstr ""
+"对选定区域发射巨大火球，伤害附近所有生物。"
+
+msgid "Fireball"
+msgstr "火球术"
+
+msgid "Fireblast"
+msgstr "烈焰爆裂"
+
+msgid ""
+"An improved version of fireball, fireblast affects two hexes around the "
+"center point of the spell, rather than one."
+msgstr ""
+"火球术的强化版，烈焰爆裂影响以施法中心为圆心两格范围内的区域，而非一格。"
+
+msgid "Causes a bolt of electrical energy to strike the selected creature."
+msgstr "对选定生物发射一道闪电。"
+
+msgid "Lightning Bolt"
+msgstr "闪电箭"
+
+msgid "Chain Lightning"
+msgstr "连锁闪电"
+
+msgid ""
+"Causes a bolt of electrical energy to strike a selected creature, then "
+"strike the nearest creature with half damage, then strike the NEXT nearest "
+"creature with half again damage, and so on, until it becomes too weak to be "
+"harmful. Warning: This spell can hit your own creatures!"
+msgstr ""
+"对选定生物发射闪电，然后以一半伤害击中最近的生物，再以一半伤害击中下一个最近"
+"的生物，依此类推，直到威力不足以造成伤害。警告：此法术可能击中己方生物！"
+
+msgid "Teleport"
+msgstr "Teleport"
+
+msgid ""
+"Teleports the creature you select to any open position on the battlefield."
+msgstr ""
+"将选定生物传送到战场上任意空位。"
+
+msgid "Cure"
+msgstr "治疗"
+
+msgid ""
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
+msgstr ""
+"移除己方一个单位身上的所有负面法术，并依魔法力量等级每级恢复最多 %{count} 点"
+"生命值。"
+
+msgid "Mass Cure"
+msgstr "群体治疗"
+
+msgid ""
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
+msgstr ""
+"移除己方部队身上的所有负面法术，并依魔法力量等级，每级为每个生物恢复最多 "
+"%{count} 点生命值。"
+
+msgid "Resurrect"
+msgstr "复活术"
+
+msgid "Resurrects creatures from a damaged or dead unit until end of combat."
+msgstr "从受伤或死亡的单位中复活生物，效果持续至战斗结束。"
+
+msgid "Resurrect True"
+msgstr "完全复活"
+
+msgid "Resurrects creatures from a damaged or dead unit permanently."
+msgstr "永久复活受伤或死亡单位中的生物。"
+
+msgid "Haste"
+msgstr "加速术"
+
+msgid "Increases the speed of any creature by %{count}."
+msgstr "增加任意生物 %{count} 点速度。"
+
+msgid "Increases the speed of all of your creatures by %{count}."
+msgstr "增加己方所有生物 %{count} 点速度。"
+
+msgid "Mass Haste"
+msgstr "群体加速"
+
+msgid "Slows target to half movement rate."
+msgstr "将目标的移动速率减半。"
+
+msgid "spell|Slow"
+msgstr "缓速术"
+
+msgid "Mass Slow"
+msgstr "群体缓速"
+
+msgid "Slows all enemies to half movement rate."
+msgstr "将所有敌人的移动速率减半。"
+
+msgid "spell|Blind"
+msgstr "致盲术"
+
+msgid ""
+"Clouds the affected creatures' eyes, preventing them from moving and reduces "
+"the damage when retaliating by %{count} percent."
+msgstr ""
+"蒙蔽受影响生物的双眼，使其无法移动，并降低 %{count}% 的反击伤害。"
+
+msgid "Bless"
+msgstr "祝福"
+
+msgid "Causes the selected creatures to inflict maximum damage."
+msgstr "使选定生物造成最大伤害。"
+
+msgid "Causes all of your units to inflict maximum damage."
+msgstr "使己方所有单位造成最大伤害。"
+
+msgid "Mass Bless"
+msgstr "群体祝福"
+
+msgid "Magically increases the defense skill of the selected creatures."
+msgstr "以魔法增加选定生物的防御技能。"
+
+msgid "Stoneskin"
+msgstr "石肤术"
+
+msgid "Steelskin"
+msgstr "钢肤术"
+
+msgid ""
+"Increases the defense skill of the targeted creatures. This is an improved "
+"version of Stoneskin."
+msgstr ""
+"增加目标生物的防御技能。此为石肤术的强化版。"
+
+msgid "Causes the selected creatures to inflict minimum damage."
+msgstr "使选定生物只能造成最低伤害。"
+
+msgid "Curse"
+msgstr "诅咒"
+
+msgid "Causes all enemy troops to inflict minimum damage."
+msgstr "使所有敌军只能造成最低伤害。"
+
+msgid "Mass Curse"
+msgstr "群体诅咒"
+
+msgid "Damages all undead in the battle."
+msgstr "伤害战斗中所有亡灵。"
+
+msgid "Holy Word"
+msgstr "神圣之语"
+
+msgid ""
+"Damages all undead in the battle. This is an improved version of Holy Word."
+msgstr ""
+"伤害战斗中所有亡灵。此为神圣之语的强化版。"
+
+msgid "Holy Shout"
+msgstr "神圣呐喊"
+
+msgid "Anti-Magic"
+msgstr "反魔法结界"
+
+msgid "Prevents any magic against the selected creatures."
+msgstr "使选定生物免受任何魔法影响。"
+
+msgid "Dispel Magic"
+msgstr "驱散魔法"
+
+msgid "Removes all magic spells from a single target."
+msgstr "移除单一目标身上的所有魔法效果。"
+
+msgid "Mass Dispel"
+msgstr "群体驱散"
+
+msgid "Removes all magic spells from all creatures."
+msgstr "移除所有生物身上的所有魔法效果。"
+
+msgid "Causes a magic arrow to strike the selected target."
+msgstr "对选定目标射出一发魔法飞弹。"
+
+msgid "Magic Arrow"
+msgstr "魔法飞弹"
+
+msgid "Berserker"
+msgstr "Berserker"
+
+msgid "Causes a creature to attack its nearest neighbor."
+msgstr "使一个生物攻击其最近的邻居。"
+
+msgid "Armageddon"
+msgstr "Armageddon"
+
+msgid ""
+"Holy terror strikes the battlefield, causing severe damage to all creatures."
+msgstr ""
+"神圣恐惧降临战场，对所有生物造成严重伤害。"
+
+msgid "Elemental Storm"
+msgstr "元素风暴"
+
+msgid "Magical elements pour down on the battlefield, damaging all creatures."
+msgstr "魔法元素倾泻至战场，伤害所有生物。"
+
+msgid ""
+"A rain of rocks strikes an area of the battlefield, damaging all nearby "
+"creatures."
+msgstr ""
+"石雨袭击战场上的一个区域，伤害附近所有生物。"
+
+msgid "Meteor Shower"
+msgstr "陨石雨"
+
+msgid "Paralyze"
+msgstr "麻痹术"
+
+msgid "The targeted creatures are paralyzed, unable to move or retaliate."
+msgstr "目标生物陷入麻痹，无法移动或反击。"
+
+msgid "Hypnotize"
+msgstr "催眠术"
+
+msgid ""
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
+msgstr ""
+"敌方单一单位生命值低于施法者魔法力量的 %{count} 倍时，即可将其控制。"
+
+msgid "Cold Ray"
+msgstr "寒冰射线"
+
+msgid "Drains body heat from a single enemy unit."
+msgstr "吸取单一敌方单位的体温。"
+
+msgid "Cold Ring"
+msgstr "寒冰之环"
+
+msgid ""
+"Drains body heat from all units surrounding the center point, but not "
+"including the center point."
+msgstr ""
+"吸取中心点周围所有单位的体温，但不影响中心点。"
+
+msgid "Disrupting Ray"
+msgstr "瓦解射线"
+
+msgid "Reduces the defense rating of an enemy unit by three."
+msgstr "降低敌方单位 3 点防御值。"
+
+msgid "Damages all living (non-undead) units in the battle."
+msgstr "伤害战斗中所有活体 (非亡灵) 单位。"
+
+msgid "Death Ripple"
+msgstr "死亡涟漪"
+
+msgid "Death Wave"
+msgstr "死亡波动"
+
+msgid ""
+"Damages all living (non-undead) units in the battle. This spell is an "
+"improved version of Death Ripple."
+msgstr ""
+"伤害战斗中所有活体 (非亡灵) 单位。此为死亡涟漪的强化版。"
+
+msgid "Dragon Slayer"
+msgstr "屠龙术"
+
+msgid "Greatly increases a unit's attack skill vs. Dragons."
+msgstr "大幅增加单位对龙族的攻击技能。"
+
+msgid "Blood Lust"
+msgstr "嗜血术"
+
+msgid "Increases a unit's attack skill."
+msgstr "增加单位的攻击技能。"
+
+msgid "Animate Dead"
+msgstr "操控亡灵"
+
+msgid "Resurrects creatures from a damaged or dead undead unit permanently."
+msgstr "永久复活受伤或死亡的亡灵单位中的生物。"
+
+msgid "Mirror Image"
+msgstr "镜像术"
+
+msgid ""
+"Creates an illusionary unit that duplicates one of your existing units. This "
+"illusionary unit does the same damages as the original, but will vanish if "
+"it takes any damage."
+msgstr ""
+"建立一个复制己方现有单位的幻影。幻影单位造成与原单位相同的伤害，但受到任何伤"
+"害就会消失。"
+
+msgid "Shield"
+msgstr "护盾"
+
+msgid ""
+"Halves damage received from ranged attacks for a single unit. Does not "
+"affect damage received from Turrets or Ballistae."
+msgstr ""
+"将单一单位受到的远距攻击伤害减半。不影响箭塔或弩砲造成的伤害。"
+
+msgid "Mass Shield"
+msgstr "群体护盾"
+
+msgid ""
+"Halves damage received from ranged attacks for all of your units. Does not "
+"affect damage received from Turrets or Ballistae."
+msgstr ""
+"将己方所有单位受到的远距攻击伤害减半。不影响箭塔或弩砲造成的伤害。"
+
+msgid "Summon Earth Elemental"
+msgstr "召唤土元素"
+
+msgid "Summons Earth Elementals to fight for your army."
+msgstr "召唤土元素为你的军队作战。"
+
+msgid "Summon Air Elemental"
+msgstr "召唤气元素"
+
+msgid "Summons Air Elementals to fight for your army."
+msgstr "召唤气元素为你的军队作战。"
+
+msgid "Summon Fire Elemental"
+msgstr "召唤火元素"
+
+msgid "Summons Fire Elementals to fight for your army."
+msgstr "召唤火元素为你的军队作战。"
+
+msgid "Summon Water Elemental"
+msgstr "召唤水元素"
+
+msgid "Summons Water Elementals to fight for your army."
+msgstr "召唤水元素为你的军队作战。"
+
+msgid "Damages castle walls."
+msgstr "破坏城墙。"
+
+msgid "Earthquake"
+msgstr "地震"
+
+msgid "Causes all mines across the land to become visible."
+msgstr "显示大地上所有矿场的位置。"
+
+msgid "View Mines"
+msgstr "探查矿场"
+
+msgid "Causes all resources across the land to become visible."
+msgstr "显示大地上所有资源的位置。"
+
+msgid "View Resources"
+msgstr "探查资源"
+
+msgid "Causes all artifacts across the land to become visible."
+msgstr "显示大地上所有神器的位置。"
+
+msgid "View Artifacts"
+msgstr "探查神器"
+
+msgid "Causes all towns and castles across the land to become visible."
+msgstr "显示大地上所有城镇和城堡的位置。"
+
+msgid "View Towns"
+msgstr "探查城镇"
+
+msgid "Causes all Heroes across the land to become visible."
+msgstr "显示大地上所有英雄的位置。"
+
+msgid "View Heroes"
+msgstr "探查英雄"
+
+msgid "Causes the entire land to become visible."
+msgstr "显示整片大地的全貌。"
+
+msgid "View All"
+msgstr "全域探查"
+
+msgid "Allows the caster to view detailed information on enemy Heroes."
+msgstr "让施法者检视敌方英雄的详细资讯。"
+
+msgid "Summon Boat"
+msgstr "召唤船只"
+
+msgid ""
+"Summons the nearest unoccupied, friendly boat to an adjacent shore location. "
+"A friendly boat is one which you just built or were the most recent player "
+"to occupy."
+msgstr ""
+"召唤最近且无人占用的友方船只到相邻海岸位置。友方船只是你刚建造，或最近由你占"
+"用过的船。"
+
+msgid "Allows the caster to magically transport to a nearby location."
+msgstr "让施法者以魔法传送到附近的位置。"
+
+msgid "Dimension Door"
+msgstr "次元之门"
+
+msgid "Town Gate"
+msgstr "城镇传送门"
+
+msgid ""
+"Returns the caster to the nearest town or castle currently owned. This spell "
+"cannot be cast if the hero is already in a town or a castle."
+msgstr ""
+"将施法者传送至最近的己方城镇或城堡。若英雄已在城镇或城堡中，则无法施放此法"
+"术。"
+
+msgid ""
+"Returns the hero to the town or castle of choice, provided it is controlled "
+"by you."
+msgstr ""
+"将英雄传送至你控制的指定城镇或城堡。"
+
+msgid "Visions"
+msgstr "幻视"
+
+msgid ""
+"Visions predicts the likely outcome of an encounter with a neutral army camp."
+msgstr ""
+"幻视预测与中立军队营地遭遇的可能结果。"
+
+msgid "Haunt"
+msgstr "闹鬼"
+
+msgid ""
+"Haunts a mine you control with Ghosts. This mine stops producing resources. "
+"(If I can't keep it, nobody will!)"
+msgstr ""
+"以鬼怪缠绕你控制的矿场，使该矿场停止生产资源。（如果我留不住，谁也别想要！）"
+
+msgid "Set Earth Guardian"
+msgstr "设立土元素守卫"
+
+msgid "Sets Earth Elementals to guard a mine against enemy armies."
+msgstr "设立土元素守卫矿场以抵御敌军。"
+
+msgid "Set Air Guardian"
+msgstr "设立气元素守卫"
+
+msgid "Sets Air Elementals to guard a mine against enemy armies."
+msgstr "设立气元素守卫矿场以抵御敌军。"
+
+msgid "Set Fire Guardian"
+msgstr "设立火元素守卫"
+
+msgid "Sets Fire Elementals to guard a mine against enemy armies."
+msgstr "设立火元素守卫矿场以抵御敌军。"
+
+msgid "Set Water Guardian"
+msgstr "设立水元素守卫"
+
+msgid "Sets Water Elementals to guard a mine against enemy armies."
+msgstr "设立水元素守卫矿场以抵御敌军。"
+
+msgid "Random Spell"
+msgstr "随机法术"
+
+msgid "Randomly selected spell of any level."
+msgstr "随机选取任意等级的法术。"
+
+msgid "Random 1st Level Spell"
+msgstr "随机 1 级法术"
+
+msgid "Randomly selected 1st level spell."
+msgstr "随机选取 1 级法术。"
+
+msgid "Random 2nd Level Spell"
+msgstr "随机 2 级法术"
+
+msgid "Randomly selected 2nd level spell."
+msgstr "随机选取 2 级法术。"
+
+msgid "Random 3rd Level Spell"
+msgstr "随机 3 级法术"
+
+msgid "Randomly selected 3rd level spell."
+msgstr "随机选取 3 级法术。"
+
+msgid "Random 4th Level Spell"
+msgstr "随机 4 级法术"
+
+msgid "Randomly selected 4th level spell."
+msgstr "随机选取 4 级法术。"
+
+msgid "Random 5th Level Spell"
+msgstr "随机 5 级法术"
+
+msgid "Randomly selected 5th level spell."
+msgstr "随机选取 5 级法术。"
+
+msgid "Petrification"
+msgstr "石化术"
+
+msgid ""
+"Turns the affected creature into stone. A petrified creature receives half "
+"damage from a direct attack."
+msgstr ""
+"将受影响的生物变为石头。石化生物遭受直接攻击时，伤害减半。"
+
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr "你没有魔法书，无法施放法术。"
+
+msgid "No spell to cast."
+msgstr "没有可施放的法术。"
+
+msgid "Your hero has %{sp} spell points remaining out of %{max}."
+msgstr "英雄剩余 %{sp}/%{max} 点魔法值。"
+
+msgid "View Adventure Spells"
+msgstr "检视冒险法术"
+
+msgid "View Combat Spells"
+msgstr "检视战斗法术"
+
+msgid "View previous page"
+msgstr "检视上一页"
+
+msgid "View next page"
+msgstr "检视下一页"
+
+msgid "Close Spellbook"
+msgstr "关闭法术书"
+
+msgid "View %{spell}"
+msgstr "检视 %{spell}"
+
+msgid "This spell does %{damage} points of damage."
+msgstr "此法术造成 %{damage} 点伤害。"
+
+msgid ""
+"This spell summons\n"
+"%{count} %{monster}."
+msgstr ""
+"此法术召唤\n"
+"%{count} 个 %{monster}。"
+
+msgid "This spell restores %{hp} HP."
+msgstr "此法术恢复 %{hp} 点生命值。"
+
+msgid "This spell summons %{count} %{monster} to guard the mine."
+msgstr "此法术召唤 %{count} 个 %{monster} 守卫矿场。"
+
+msgid "The nearest town is %{town}."
+msgstr "最近的城镇是 %{town}。"
+
+msgid "This town is occupied by your hero %{hero}."
+msgstr "此城镇已由你的英雄 %{hero} 驻守。"
+
+msgid ""
+"This spell controls up to\n"
+"%{hp} HP."
+msgstr ""
+"此法术可控制\n"
+"最多 %{hp} 点生命值的单位。"
+
+msgid "The ultimate artifact is really the %{name}."
+msgstr "终极神器其实是 %{name}。"
+
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
+msgstr "终极神器可能在世界的 %{name} 区域找到。"
+
+msgid "north-west"
+msgstr "西北"
+
+msgid "north"
+msgstr "北方"
+
+msgid "north-east"
+msgstr "东北"
+
+msgid "west"
+msgstr "西方"
+
+msgid "center"
+msgstr "中央"
+
+msgid "east"
+msgstr "东方"
+
+msgid "south-west"
+msgstr "西南"
+
+msgid "south"
+msgstr "南方"
+
+msgid "south-east"
+msgstr "东南"
+
+msgid "The truth is out there."
+msgstr "真相就在那里。"
+
+msgid "The dark side is stronger."
+msgstr "黑暗面更为强大。"
+
+msgid "The end of the world is near."
+msgstr "世界末日即将来临。"
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr "杀手领主的骸骨埋藏在竞技场的地基中。"
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr "黑龙随时都能打败泰坦。"
+
+msgid "He told her: Yada yada yada... and then she said: Blah, blah, blah..."
+msgstr "他跟她说：巴拉巴拉巴拉……然后她说：叽哩呱啦……"
+
+msgid "An unknown force is being resurrected..."
+msgstr "一股未知的力量正在复苏……"

--- a/files/lang/zh_TW.po
+++ b/files/lang/zh_TW.po
@@ -1,0 +1,12093 @@
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: fheroes2\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2026-05-31 03:40+0800\n"
+"PO-Revision-Date: 2026-05-31 03:39+0800\n"
+"Last-Translator: fheroes2 team <fhomm2@gmail.com>\n"
+"Language-Team: \n"
+"Language: zh_TW\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=1; plural=0;\n"
+
+msgid "SELECT"
+msgstr "選擇"
+
+msgid "ABOUT"
+msgstr "關於"
+
+msgid "S"
+msgstr "S"
+
+msgid "M"
+msgstr "M"
+
+msgid "L"
+msgstr "L"
+
+msgid "X-L"
+msgstr "X-L"
+
+msgid "ALL"
+msgstr "全部"
+
+msgid "EXIT"
+msgstr "離開"
+
+msgid "smallerButton|EXIT"
+msgstr "離開"
+
+msgid "OKAY"
+msgstr "確定"
+
+msgid "HEROES"
+msgstr "英雄"
+
+msgid ""
+"TOWNS/\n"
+"CASTLES"
+msgstr ""
+"城鎮/\n"
+"城堡"
+
+msgid "CANCEL"
+msgstr "取消"
+
+msgid "ACCEPT"
+msgstr "接受"
+
+msgid "DECLINE"
+msgstr "拒絕"
+
+msgid "LEARN"
+msgstr "學習"
+
+msgid "TRADE"
+msgstr "交易"
+
+msgid "YES"
+msgstr "是"
+
+msgid "NO"
+msgstr "否"
+
+msgid "DISMISS"
+msgstr "解散"
+
+msgid "UPGRADE"
+msgstr "升級"
+
+msgid "GIFT"
+msgstr "贈禮"
+
+msgid "RESTART"
+msgstr "重新開始"
+
+msgid "MAX"
+msgstr "最大"
+
+msgid "MIN"
+msgstr "最小"
+
+msgid ""
+"D\n"
+"I\n"
+"S\n"
+"M\n"
+"I\n"
+"S\n"
+"S"
+msgstr ""
+"解\n"
+"散"
+
+msgid ""
+"E\n"
+"X\n"
+"I\n"
+"T"
+msgstr ""
+"離\n"
+"開"
+
+msgid ""
+"C\n"
+"A\n"
+"M\n"
+"P\n"
+"A\n"
+"I\n"
+"G\n"
+"N"
+msgstr ""
+"戰\n"
+"役"
+
+msgid ""
+"S\n"
+"T\n"
+"A\n"
+"N\n"
+"D\n"
+"A\n"
+"R\n"
+"D"
+msgstr ""
+"標\n"
+"準"
+
+msgid ""
+"NEW\n"
+"GAME"
+msgstr ""
+"新\n"
+"遊戲"
+
+msgid ""
+"LOAD\n"
+"GAME"
+msgstr ""
+"載入\n"
+"遊戲"
+
+msgid ""
+"RESTART\n"
+"GAME"
+msgstr ""
+"重新\n"
+"開始"
+
+msgid ""
+"SAVE\n"
+"GAME"
+msgstr ""
+"儲存\n"
+"遊戲"
+
+msgid ""
+"QUICK\n"
+"SAVE"
+msgstr ""
+"快速\n"
+"存檔"
+
+msgid "QUIT"
+msgstr "結束"
+
+msgid ""
+"START\n"
+"MAP"
+msgstr ""
+"開始\n"
+"地圖"
+
+msgid ""
+"MAIN\n"
+"MENU"
+msgstr ""
+"主\n"
+"選單"
+
+msgid ""
+"NEW\n"
+"MAP"
+msgstr ""
+"新\n"
+"地圖"
+
+msgid ""
+"LOAD\n"
+"MAP"
+msgstr "載入地圖"
+
+msgid ""
+"SAVE\n"
+"MAP"
+msgstr "儲存地圖"
+
+msgid "INFO"
+msgstr "資訊"
+
+msgid ""
+"BATTLE\n"
+"ONLY"
+msgstr "僅限戰鬥"
+
+msgid "SETTINGS"
+msgstr "設定"
+
+msgid ""
+"STANDARD\n"
+"GAME"
+msgstr "標準遊戲"
+
+msgid ""
+"CAMPAIGN\n"
+"GAME"
+msgstr "戰役遊戲"
+
+msgid ""
+"MULTI-\n"
+"PLAYER\n"
+"GAME"
+msgstr "多人遊戲"
+
+msgid "HOT SEAT"
+msgstr "熱座模式"
+
+msgid "2 PLAYERS"
+msgstr "2 位玩家"
+
+msgid "3 PLAYERS"
+msgstr "3 位玩家"
+
+msgid "4 PLAYERS"
+msgstr "4 位玩家"
+
+msgid "5 PLAYERS"
+msgstr "5 位玩家"
+
+msgid "6 PLAYERS"
+msgstr "6 位玩家"
+
+msgid ""
+"ORIGINAL\n"
+"CAMPAIGN"
+msgstr "原版戰役"
+
+msgid ""
+"EXPANSION\n"
+"CAMPAIGN"
+msgstr "資料片戰役"
+
+msgid "editorMainMenu|BACK"
+msgstr "返回"
+
+msgid ""
+"newMap|FROM\n"
+"SCRATCH"
+msgstr ""
+"從頭\n"
+"開始"
+
+msgid "newMap|RANDOM"
+msgstr "隨機"
+
+msgid "DIFFICULTY"
+msgstr "難度"
+
+msgid "VIEW INTRO"
+msgstr "觀看序幕"
+
+msgid "RESET"
+msgstr "重置"
+
+msgid "START"
+msgstr "開始"
+
+msgid ""
+"P\n"
+"A\n"
+"T\n"
+"R\n"
+"O\n"
+"L"
+msgstr ""
+"巡\n"
+"邏"
+
+msgid "army|Few"
+msgstr "班"
+
+msgid "Warrior"
+msgstr "戰士"
+
+msgid "Builder"
+msgstr "建設者"
+
+msgid "Explorer"
+msgstr "探索者"
+
+msgid "None"
+msgstr "無"
+
+msgid ""
+"%{monster}\n"
+"%{range}"
+msgstr ""
+"%{monster}\n"
+"%{range}"
+
+msgid ""
+"A few\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"班"
+
+msgid ""
+"Several\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"排"
+
+msgid ""
+"A pack of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"連"
+
+msgid ""
+"Lots of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"營"
+
+msgid ""
+"A horde of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"團"
+
+msgid ""
+"A throng of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"旅"
+
+msgid ""
+"A swarm of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"師"
+
+msgid ""
+"Zounds...\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"軍"
+
+msgid ""
+"A legion of\n"
+"%{monster}"
+msgstr ""
+"%{monster}\n"
+"集團軍"
+
+msgid "army|Several"
+msgstr "排"
+
+msgid "army|Pack"
+msgstr "連"
+
+msgid "army|Lots"
+msgstr "營"
+
+msgid "army|Horde"
+msgstr "團"
+
+msgid "army|Throng"
+msgstr "旅"
+
+msgid "army|Swarm"
+msgstr "師"
+
+msgid "army|Zounds"
+msgstr "軍"
+
+msgid "army|Legion"
+msgstr "集團軍"
+
+msgid "All %{race} troops +1"
+msgstr "所有 %{race} 部隊 +1"
+
+msgid "NeutralRaceTroops|Neutral"
+msgstr "中立"
+
+msgid "Troops of %{count} alignments -%{penalty}"
+msgstr "%{count} 種陣營的部隊 -%{penalty}"
+
+msgid "Some undead in army -1"
+msgstr "軍隊中有部分亡靈 -1"
+
+msgid ""
+"Default\n"
+"troop"
+msgstr ""
+"預設\n"
+"部隊"
+
+msgid "View %{name}"
+msgstr "檢視 %{name}"
+
+msgid "Move the %{name} "
+msgstr "移動 %{name} "
+
+msgid "Move or right click to redistribute %{name}"
+msgstr "移動或按右鍵重新分配 %{name}"
+
+msgid "Combine %{name} armies"
+msgstr "合併 %{name} 軍隊"
+
+msgid "Exchange %{name2} with %{name}"
+msgstr "交換 %{name2} 與 %{name}"
+
+msgid "Select %{name}"
+msgstr "選擇 %{name}"
+
+msgid "Cannot move last troop"
+msgstr "無法移動最後一支部隊"
+
+msgid "Move the %{name}"
+msgstr "移動 %{name}"
+
+msgid "Set %{monster} Count:"
+msgstr "設定 %{monster} 數量："
+
+msgid "%{name} destroys half the enemy troops!"
+msgid_plural "%{name} destroy half the enemy troops!"
+msgstr[0] "%{name} 摧毀了一半的敵方部隊！"
+
+msgid "%{name} has turned off the auto combat"
+msgstr "%{name} 已關閉自動戰鬥"
+
+msgid "%{name} has turned on the auto combat"
+msgstr "%{name} 已開啟自動戰鬥"
+
+msgid "Spell failed!"
+msgstr "法術失敗！"
+
+msgid ""
+"The Sphere of Negation artifact is in effect for this battle, disabling all "
+"combat spells."
+msgstr ""
+"否定之球神器在此戰鬥中生效，所有戰鬥法術均被封鎖。"
+
+msgid "You cannot cast spells without a commanding hero."
+msgstr "沒有指揮英雄就無法施放法術。"
+
+msgid "You have already cast a spell this round."
+msgstr "本回合已經施放過法術了。"
+
+msgid "That spell will have no effect!"
+msgstr "該法術不會有任何效果！"
+
+msgid "You may only summon one type of elemental per combat."
+msgstr "每場戰鬥只能召喚一種元素生物。"
+
+msgid ""
+"There is no open space adjacent to your hero where you can summon an "
+"Elemental to."
+msgstr ""
+"英雄旁邊沒有空位可以召喚元素生物。"
+
+msgid ""
+"The Moat interrupts any movement through it and reduces the defense skill of "
+"troops present in it by %{count}."
+msgstr ""
+"護城河會中斷經過的一切移動，並將停留其中部隊的防禦技能降低 %{count}。"
+
+msgid "battleAnimation|Speed: %{speed}"
+msgstr "速度：%{speed}"
+
+msgid "battleAnimation|Speed"
+msgstr "速度"
+
+msgid "Interface"
+msgstr "介面"
+
+msgid "Settings"
+msgstr "設定"
+
+msgid "Auto Spell Casting"
+msgstr "自動施法"
+
+msgid "Off"
+msgstr "關閉"
+
+msgid "On"
+msgstr "開啟"
+
+msgid "Set the speed of combat actions and animations."
+msgstr "調整戰鬥動作與動畫的速度。"
+
+msgid "Change the interface settings of the game."
+msgstr "變更遊戲的介面設定。"
+
+msgid "Interface Settings"
+msgstr "介面設定"
+
+msgid ""
+"Toggle whether or not the computer will cast spells for you when auto combat "
+"is on. (Note: This does not affect spell casting for computer players in any "
+"way, nor does it affect quick combat.)"
+msgstr ""
+"切換自動戰鬥時是否由電腦代為施法。（注意：此選項不會影響電腦玩家的施法方式，"
+"也不會影響快速戰鬥。）"
+
+msgid "Audio"
+msgstr "音效"
+
+msgid "Change the audio settings of the game."
+msgstr "變更遊戲的音效設定。"
+
+msgid "Check and configure all the hot keys present in the game."
+msgstr "檢查並調整遊戲中所有的快速鍵。"
+
+msgid "Hot Keys"
+msgstr "快速鍵"
+
+msgid "Exit this menu."
+msgstr "離開此選單。"
+
+msgid "Okay"
+msgstr "確定"
+
+msgid "The enemy has surrendered!"
+msgstr "敵人已投降！"
+
+msgid "Their cowardice costs them %{gold} gold."
+msgstr "怯懦使他們損失了 %{gold} 金幣。"
+
+msgid "The enemy has fled!"
+msgstr "敵人逃跑了！"
+
+msgid "A glorious victory!"
+msgstr "光榮的勝利！"
+
+msgid "For valor in combat, %{name} receives %{exp} experience."
+msgstr "因在戰鬥中英勇表現，%{name} 獲得了 %{exp} 點經驗值。"
+
+msgid "The cowardly %{name} flees from battle."
+msgstr "懦弱的 %{name} 從戰場上逃走了。"
+
+msgid "%{name} surrenders to the enemy, and departs in shame."
+msgstr "%{name} 向敵人投降，羞愧地離去。"
+
+msgid "Your forces suffer a bitter defeat, and %{name} abandons your cause."
+msgstr "軍隊遭受慘敗，%{name} 拋棄了你的陣營。"
+
+msgid "Your forces suffer a bitter defeat."
+msgstr "軍隊遭受了慘敗。"
+
+msgid "Battlefield Casualties"
+msgstr "戰場傷亡"
+
+msgid "Attacker"
+msgstr "進攻方"
+
+msgid "Defender"
+msgstr "防守方"
+
+msgid "Click to leave the battle results."
+msgstr "按一下離開戰鬥結果。"
+
+msgid "Click to restart the battle in manual mode."
+msgstr "按一下以手動模式重新開始戰鬥。"
+
+msgid "Restart"
+msgstr "重新開始"
+
+msgid "You have captured an enemy artifact!"
+msgstr "繳獲了一件敵方神器！"
+
+msgid "As you reach for the %{name}, it mysteriously disappears."
+msgstr "當你伸手去拿 %{name} 時，它神祕地消失了。"
+
+msgid "As your enemy reaches for the %{name}, it mysteriously disappears."
+msgstr "當敵人伸手去拿 %{name} 時，它神祕地消失了。"
+
+msgid "Necromancy!"
+msgstr "亡靈巫術！"
+
+msgid ""
+"Practicing the dark arts of necromancy, you are able to raise %{count} of "
+"the enemy's dead to return under your service as %{monster}."
+msgstr ""
+"藉由施展亡靈巫術的黑暗力量，你復活了 %{count} 具敵方屍體，化為 %{monster} 為"
+"你效力。"
+
+msgid "%{name} the %{race}"
+msgstr "%{name}，%{race}"
+
+msgid "Captain of %{name}"
+msgstr "%{name} 的隊長"
+
+msgid "Attack"
+msgstr "攻擊"
+
+msgid "Defense"
+msgstr "防禦"
+
+msgid "Spell Power"
+msgstr "魔法力量"
+
+msgid "Knowledge"
+msgstr "知識"
+
+msgid "Morale"
+msgstr "士氣"
+
+msgid "Luck"
+msgstr "運氣"
+
+msgid "Spell Points"
+msgstr "魔法值"
+
+msgid "Cast Spell"
+msgstr "施放法術"
+
+msgid "Retreat"
+msgstr "撤退"
+
+msgid "Surrender"
+msgstr "投降"
+
+msgid "Cancel"
+msgstr "取消"
+
+msgid "Hero Screen"
+msgstr "英雄畫面"
+
+msgid "Captain's Options"
+msgstr "隊長選項"
+
+msgid "Hero's Options"
+msgstr "英雄選項"
+
+msgid ""
+"Cast a magical spell. You may only cast one spell per combat round. The "
+"round is reset when every creature has had a turn."
+msgstr ""
+"施放法術。每回合只能施放一個法術，當所有生物都行動過後回合即重置。"
+
+msgid ""
+"Retreat your hero, abandoning your creatures. Your hero will be available "
+"for you to recruit again, however, the hero will have only a novice hero's "
+"forces."
+msgstr ""
+"撤退英雄並拋棄部隊。英雄可重新招募，但只會擁有新手英雄的起始兵力。"
+
+msgid ""
+"Surrendering costs gold. However if you pay the ransom, the hero and all of "
+"his or her surviving creatures will be available to recruit again. The cost "
+"of surrender is half of the total cost of the non-temporary troops remaining "
+"in the army."
+msgstr ""
+"投降需要支付黃金。不過若支付贖金，英雄及其所有倖存部隊均可重新招募。投降費用"
+"為軍隊中所有非臨時部隊總成本的一半。"
+
+msgid "Open Hero Screen to view full information about the hero."
+msgstr "開啟英雄畫面以檢視英雄的完整資訊。"
+
+msgid "Return to the battle."
+msgstr "返回戰鬥。"
+
+msgid "Not enough gold (%{gold})"
+msgstr "黃金不足 (%{gold})"
+
+msgid "%{name} states:"
+msgstr "%{name} 表示："
+
+msgid "Captain of %{name} states:"
+msgstr "%{name} 的隊長表示："
+
+msgid ""
+"\"I will accept your surrender and grant you and your troops safe passage "
+"for the price of %{price} gold.\""
+msgstr ""
+"「我接受你的投降。支付 %{price} 金幣後，你和部隊就能安全離開。」"
+
+msgid "View %{monster} info"
+msgstr "檢視 %{monster} 資訊"
+
+msgid "Fly %{monster} here"
+msgstr "令 %{monster} 飛到此處"
+
+msgid "Move %{monster} here"
+msgstr "移動 %{monster} 到此處"
+
+msgid "Shoot %{monster}"
+msgstr "射擊 %{monster}"
+
+msgid "(1 shot left)"
+msgid_plural "(%{count} shots left)"
+msgstr[0] "(剩餘 1 次射擊)"
+
+msgid "Attack %{monster}"
+msgstr "攻擊 %{monster}"
+
+msgid "Turn %{turn}"
+msgstr "回合 %{turn}"
+
+msgid "Teleport here"
+msgstr "傳送至此"
+
+msgid "Invalid teleport destination"
+msgstr "無效的傳送目的地"
+
+msgid "Cast %{spell} on %{monster}"
+msgstr "對 %{monster} 施放 %{spell}"
+
+msgid "Cast %{spell}"
+msgstr "施放 %{spell}"
+
+msgid "Select spell target"
+msgstr "選擇法術目標"
+
+msgid "Are you sure you want to enable the auto combat mode?"
+msgstr "確定要啟用自動戰鬥模式嗎？"
+
+msgid "Are you sure you want to resolve the battle in the quick combat mode?"
+msgstr "確定要以快速戰鬥模式結算這場戰鬥嗎？"
+
+msgid "View Ballista info"
+msgstr "檢視弩砲資訊"
+
+msgid "Ballista"
+msgstr "弩砲"
+
+msgid "Automatic combat modes"
+msgstr "自動戰鬥模式"
+
+msgid "Automatic Combat Modes"
+msgstr "自動戰鬥模式"
+
+msgid ""
+"Choose between proceeding the combat in auto combat mode or in quick combat "
+"mode."
+msgstr ""
+"請選擇以自動戰鬥模式或快速戰鬥模式繼續戰鬥。"
+
+msgid "Customize system options"
+msgstr "自訂系統選項"
+
+msgid "Allows you to customize the combat screen."
+msgstr "可自訂戰鬥畫面。"
+
+msgid "System Options"
+msgstr "系統選項"
+
+msgid "Skip this unit"
+msgstr "略過此單位"
+
+msgid "Skip"
+msgstr "略過"
+
+msgid ""
+"Skips the current creature. The current creature ends its turn and does not "
+"get to go again until the next round."
+msgstr ""
+"略過目前的生物。該生物結束其回合，直到下一回合才能再次行動。"
+
+msgid "View Captain's options"
+msgstr "檢視隊長選項"
+
+msgid "View Hero's options"
+msgstr "檢視英雄選項"
+
+msgid "View opposing Captain"
+msgstr "檢視對方隊長"
+
+msgid "View opposing Hero"
+msgstr "檢視對方英雄"
+
+msgid "Hide logs"
+msgstr "隱藏記錄"
+
+msgid "Show logs"
+msgstr "顯示記錄"
+
+msgid "Message Bar"
+msgstr "訊息列"
+
+msgid "Shows the results of individual monster's actions."
+msgstr "顯示各怪物的行動結果。"
+
+msgid ""
+"AUTO\n"
+"COMBAT"
+msgstr ""
+"自動\n"
+"戰鬥"
+
+msgid ""
+"QUICK\n"
+"COMBAT"
+msgstr ""
+"快速\n"
+"戰鬥"
+
+msgid "The computer continues the combat for you."
+msgstr "由電腦繼續為你戰鬥。"
+
+msgid ""
+"autoCombat|This can be interrupted at any moment by pressing the Auto Combat "
+"hotkey or the default Cancel key, or by performing a left or right click "
+"anywhere on the game screen."
+msgstr ""
+"可隨時按下自動戰鬥快速鍵、預設取消鍵，或在遊戲畫面任意處左鍵或右鍵按一下來中"
+"斷。"
+
+msgid "Auto Combat"
+msgstr "自動戰鬥"
+
+msgid "The combat is resolved from the current state."
+msgstr "從目前狀態結算戰鬥結果。"
+
+msgid "quickCombat|This cannot be undone."
+msgstr "此操作無法復原。"
+
+msgid "Quick Combat"
+msgstr "快速戰鬥"
+
+msgid "The %{name} skips their turn."
+msgid_plural "The %{name} skip their turn."
+msgstr[0] "%{name} 略過了回合。"
+
+msgid "%{attacker} does %{damage} damage."
+msgid_plural "%{attacker} do %{damage} damage."
+msgstr[0] "%{attacker} 造成了 %{damage} 點傷害。"
+
+msgid "1 creature perishes."
+msgid_plural "%{count} creatures perish."
+msgstr[0] "1 個生物陣亡。"
+
+msgid "1 %{defender} perishes."
+msgid_plural "%{count} %{defender} perish."
+msgstr[0] "1 個 %{defender} 陣亡。"
+
+msgid "1 soul is incorporated."
+msgid_plural "%{count} souls are incorporated."
+msgstr[0] "1 個靈魂被吸收。"
+
+msgid "1 %{unit} is revived."
+msgid_plural "%{count} %{unit} are revived."
+msgstr[0] "1 個 %{unit} 被復活。"
+
+msgid "Moved %{monster}: from [%{src}] to [%{dst}]."
+msgstr "已移動 %{monster}: 從 [%{src}] 到 [%{dst}]。"
+
+msgid "The %{name} resists the spell!"
+msgid_plural "The %{name} resist the spell!"
+msgstr[0] "%{name} 抵抗了法術！"
+
+msgid "%{name} casts %{spell} on the %{troop}."
+msgstr "%{name} 對 %{troop} 施放了 %{spell}。"
+
+msgid "%{name} casts %{spell}."
+msgstr "%{name} 施放了 %{spell}。"
+
+msgid "The %{spell} does %{damage} damage to one undead creature."
+msgstr "%{spell} 對一個亡靈生物造成了 %{damage} 點傷害。"
+
+msgid "The %{spell} does %{damage} damage to all undead creatures."
+msgstr "%{spell} 對所有亡靈生物造成了 %{damage} 點傷害。"
+
+msgid "The %{spell} does %{damage} damage, %{count} creatures perish."
+msgstr "%{spell} 造成了 %{damage} 點傷害，%{count} 個生物陣亡。"
+
+msgid "The %{spell} does %{damage} damage."
+msgstr "%{spell} 造成了 %{damage} 點傷害。"
+
+msgid "The %{spell} does %{damage} damage to one living creature."
+msgstr "%{spell} 對一個活體生物造成了 %{damage} 點傷害。"
+
+msgid "The %{spell} does %{damage} damage to all living creatures."
+msgstr "%{spell} 對所有活體生物造成了 %{damage} 點傷害。"
+
+msgid "The %{attacker}'s attack blinds the %{target}!"
+msgid_plural "The %{attacker}' attack blinds the %{target}!"
+msgstr[0] "%{attacker} 的攻擊使 %{target} 目盲了！"
+
+msgid "The %{attacker}'s gaze turns the %{target} to stone!"
+msgid_plural "The %{attacker}' gaze turns the %{target} to stone!"
+msgstr[0] "%{attacker} 的凝視使 %{target} 石化了！"
+
+msgid "The %{attacker}'s curse falls upon the %{target}!"
+msgid_plural "The %{attacker}' curse falls upon the %{target}!"
+msgstr[0] "%{attacker} 的詛咒降臨在 %{target} 身上！"
+
+msgid "The %{target} is paralyzed by the %{attacker}!"
+msgid_plural "The %{target} are paralyzed by the %{attacker}!"
+msgstr[0] "%{target} 被 %{attacker} 麻痺了！"
+
+msgid "The %{attacker} dispels all good spells on your %{target}!"
+msgid_plural "The %{attacker} dispel all good spells on your %{target}!"
+msgstr[0] "%{attacker} 解除了 %{target} 身上所有的增益法術！"
+
+msgid "The %{attacker} casts %{spell} on the %{target}!"
+msgid_plural "The %{attacker} cast %{spell} on the %{target}!"
+msgstr[0] "%{attacker} 對 %{target} 施放了 %{spell}！"
+
+msgid "Bad luck descends on the %{attacker}."
+msgstr "厄運降臨在 %{attacker} 身上。"
+
+msgid "Good luck shines on the %{attacker}."
+msgstr "好運眷顧了 %{attacker}。"
+
+msgid "High morale enables the %{monster} to attack again."
+msgstr "高昂士氣使 %{monster} 得以再次攻擊。"
+
+msgid "Low morale causes the %{monster} to freeze in panic."
+msgstr "低落士氣使 %{monster} 因恐慌而僵住。"
+
+msgid "%{tower} does %{damage} damage."
+msgstr "%{tower} 造成了 %{damage} 點傷害。"
+
+msgid "The mirror image is created."
+msgstr "鏡像已建立。"
+
+msgid "The mirror image is destroyed!"
+msgstr "鏡像被摧毀了！"
+
+msgid "Are you sure you want to interrupt the auto combat mode?"
+msgstr "確定要中斷自動戰鬥模式嗎？"
+
+msgid "Error"
+msgstr "錯誤"
+
+msgid "No spells to cast."
+msgstr "沒有可施放的法術。"
+
+msgid "Are you sure you want to retreat?"
+msgstr "確定要撤退嗎？"
+
+msgid "Retreat disabled"
+msgstr "撤退已停用"
+
+msgid "Surrender disabled"
+msgstr "投降已停用"
+
+msgid "Damage: %{max}"
+msgstr "傷害：%{max}"
+
+msgid "Damage: %{min} - %{max}"
+msgstr "傷害：%{min} - %{max}"
+
+msgid "Perish: %{max}"
+msgstr "陣亡：%{max}"
+
+msgid "Perish: %{min} - %{max}"
+msgstr "陣亡：%{min} - %{max}"
+
+msgid "battle_turn_order|Top"
+msgstr "頂部"
+
+msgid "battle_turn_order|Bottom"
+msgstr "底部"
+
+msgid "Turn Order"
+msgstr "行動順序"
+
+msgid "Grid"
+msgstr "格線"
+
+msgid "Damage Info"
+msgstr "傷害資訊"
+
+msgid "Shadow Movement"
+msgstr "移動陰影"
+
+msgid "Shadow Cursor"
+msgstr "游標陰影"
+
+msgid "Movement Area"
+msgstr "移動範圍"
+
+msgid "Toggle to display the turn order during the battle."
+msgstr "切換是否在戰鬥中顯示行動順序。"
+
+msgid ""
+"Toggle the hex grid on or off. The hex grid always underlies movement, even "
+"if turned off. This switch only determines if the grid is visible."
+msgstr ""
+"切換六角格線的顯示。格線始終作為移動的基礎存在，此開關僅決定是否顯示格線。"
+
+msgid "Toggle to display damage information during the battle."
+msgstr "切換是否在戰鬥中顯示傷害資訊。"
+
+msgid ""
+"Toggle on or off shadows showing where your creatures can move and attack."
+msgstr ""
+"切換是否顯示生物可移動和攻擊範圍的陰影。"
+
+msgid ""
+"Toggle on or off a shadow showing the current hex location of the mouse "
+"cursor."
+msgstr ""
+"切換是否顯示滑鼠游標目前所在六角格的陰影。"
+
+msgid "Toggle showing the movement area of a highlighted creature on or off."
+msgstr "切換是否顯示選取生物的移動範圍。"
+
+msgid ""
+"Through eagle-eyed observation, %{name} is able to learn the magic spell "
+"%{spell}."
+msgstr ""
+"憑藉敏銳的觀察力，%{name} 學會了魔法 %{spell}。"
+
+msgid "Human"
+msgstr "人類"
+
+msgid "Terrain"
+msgstr "地形"
+
+msgid "Battle Only"
+msgstr "僅限戰鬥"
+
+msgid "Start"
+msgstr "開始"
+
+msgid "Start the battle."
+msgstr "開始戰鬥。"
+
+msgid "Exit"
+msgstr "離開"
+
+msgid "Reset"
+msgstr "重置"
+
+msgid "Reset to default settings."
+msgstr "重置為預設設定。"
+
+msgid ""
+"The battle will take place on a randomly selected terrain. Click to change "
+"the terrain type."
+msgstr ""
+"戰鬥將在隨機選取的地形上進行。按一下可變更地形類型。"
+
+msgid ""
+"The battle will take place on %{terrain-type} terrain. Click to change the "
+"terrain type."
+msgstr ""
+"戰鬥將在 %{terrain-type} 地形上進行。按一下可變更地形類型。"
+
+msgid "Please select another hero."
+msgstr "請選擇另一位英雄。"
+
+msgid "Click to select a hero."
+msgstr "按一下選擇一位英雄。"
+
+msgid "Hero"
+msgstr "英雄"
+
+msgid ""
+"If this checkbox is checked, the defending hero is going be human-controlled."
+msgstr ""
+"勾選此選項後，防守方英雄將由人類玩家控制。"
+
+msgid "%{race1} %{name1} vs %{race2} %{name2}"
+msgstr "%{race1} %{name1} 對 %{race2} %{name2}"
+
+msgid "Monsters"
+msgstr "怪物"
+
+msgid "N/A"
+msgstr "不適用"
+
+msgid "Left Turret"
+msgstr "左箭塔"
+
+msgid "Right Turret"
+msgstr "右箭塔"
+
+msgid "The %{name} fires with the strength of %{count} Archers"
+msgstr "%{name} 以 %{count} 名弓箭手的力量進行射擊"
+
+msgid "each with a +%{attack} bonus to their attack skill."
+msgstr "每位均有 +%{attack} 的攻擊技能加成。"
+
+msgid "The %{name} is destroyed."
+msgstr "%{name} 被摧毀了。"
+
+msgid "%{count} %{name} rises from the dead!"
+msgid_plural "%{count} %{name} rise from the dead!"
+msgstr[0] "%{count} 個 %{name} 從死亡中復活了！"
+
+msgid "Dwarven Alliance"
+msgstr "矮人聯盟"
+
+msgid "Sorceress Guild"
+msgstr "女巫公會"
+
+msgid "Necromancer Guild"
+msgstr "亡靈法師公會"
+
+msgid "Ogre Alliance"
+msgstr "食人魔聯盟"
+
+msgid "Dwarfbane"
+msgstr "矮人剋星"
+
+msgid "Dragon Alliance"
+msgstr "巨龍聯盟"
+
+msgid "Elven Alliance"
+msgstr "精靈聯盟"
+
+msgid "Kraeger defeated"
+msgstr "Kraeger 被擊敗"
+
+msgid "Wayward Son"
+msgstr "離家之子"
+
+msgid "Uncle Ivan"
+msgstr "Ivan 叔叔"
+
+msgid "Annexation"
+msgstr "併吞"
+
+msgid "Force of Arms"
+msgstr "武力征服"
+
+msgid "Save the Dwarves"
+msgstr "拯救矮人"
+
+msgid "Carator Mines"
+msgstr "Carator 礦場"
+
+msgid "Turning Point"
+msgstr "轉捩點"
+
+msgid "scenarioName|Defender"
+msgstr "守衛者"
+
+msgid "Corlagon's Defense"
+msgstr "Corlagon 的防線"
+
+msgid "The Crown"
+msgstr "王冠"
+
+msgid "The Gauntlet"
+msgstr "護手"
+
+msgid "Betrayal"
+msgstr "背叛"
+
+msgid "Final Justice"
+msgstr "最終審判"
+
+msgid ""
+"Roland needs you to defeat the lords near his castle to begin his war of "
+"rebellion against his brother. They are not allied with each other, so they "
+"will spend most of their time fighting with one another. Victory is yours "
+"when you have defeated all of their castles and heroes."
+msgstr ""
+"Roland 需要你擊敗城堡附近的領主，以展開他對抗其兄弟的叛亂戰爭。他們彼此並未結"
+"盟，所以大部分時間會自相殘殺。擊敗所有敵方城堡和英雄即可獲勝。"
+
+msgid ""
+"The local lords refuse to swear allegiance to Roland, and must be subdued. "
+"They are wealthy and powerful, so be prepared for a tough fight. Capture all "
+"enemy castles to win."
+msgstr ""
+"當地領主拒絕向 Roland 效忠，必須加以鎮壓。他們富有且強大，請做好艱苦戰鬥的準"
+"備。佔領所有敵方城堡即可獲勝。"
+
+msgid ""
+"Your task is to defend the Dwarves against Archibald's forces. Capture all "
+"of the enemy towns and castles to win, and be sure not to lose all of the "
+"dwarf towns at once, or the enemy will have won."
+msgstr ""
+"你的任務是保護矮人免受 Archibald 軍隊的侵害。佔領所有敵方城鎮和城堡即可獲勝，"
+"但不可同時失去所有矮人城鎮，否則敵人就贏了。"
+
+msgid ""
+"You will face four allied enemies in a straightforward fight for resources "
+"and treasure. Capture all of the enemy castles for victory."
+msgstr ""
+"你將面對四個結盟的敵人，在一場直截了當的資源與寶藏爭奪中作戰。佔領所有敵方城"
+"堡即可獲勝。"
+
+msgid ""
+"Your enemies are allied against you and start close by, so be ready to come "
+"out fighting. You will need to own all four castles in this small valley to "
+"win."
+msgstr ""
+"敵人結盟對抗你且起始位置很近，請做好戰鬥準備。必須佔領這個小山谷中的所有四座"
+"城堡才能獲勝。"
+
+msgid ""
+"The Sorceress' guild of Noraston has requested Roland's aid against an "
+"attack from Archibald's allies. Capture all of the enemy castles to win, and "
+"don't lose Noraston, or you'll lose the scenario. (Hint: There is an enemy "
+"castle on an island in the ocean.)"
+msgstr ""
+"Noraston 的女巫公會請求 Roland 援助，對抗 Archibald 盟友的進攻。佔領所有敵方"
+"城堡即可獲勝，不可失去 Noraston，否則場景失敗。（提示：海洋中的島嶼上有一座敵"
+"方城堡。）"
+
+msgid ""
+"Gather as large an army as possible and capture the enemy castle within 8 "
+"weeks. You are opposed by only one enemy, but must travel a long way to get "
+"to the enemy castle. Any troops you have in your army at the end of this "
+"scenario will be with you in the final battle."
+msgstr ""
+"盡可能集結大軍，在 8 週內佔領敵方城堡。你只面對一個敵人，但必須長途跋涉才能到"
+"達敵方城堡。此場景結束時軍隊中的所有部隊將伴隨你進入最終決戰。"
+
+msgid ""
+"Find the Crown before Archibald's heroes find it. Roland will need the Crown "
+"for the final battle against Archibald."
+msgstr ""
+"在 Archibald 的英雄之前找到王冠。Roland 需要王冠來進行對 Archibald 的最終決"
+"戰。"
+
+msgid ""
+"Three allied enemies stand before you and victory, including Lord Corlagon. "
+"Roland is in a castle to the northwest, and you will lose if he falls to the "
+"enemy. Remember that capturing Lord Corlagon will ensure that he will not "
+"fight against you in the final scenario."
+msgstr ""
+"三個結盟的敵人擋在你與勝利之間，其中包括 Lord Corlagon。Roland 位於西北方的城"
+"堡；如果他落入敵手，你就輸了。記住，俘獲 Lord Corlagon 可確保他不會在最終場景"
+"中與你為敵。"
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Archibald to end the war!"
+msgstr ""
+"這是最終決戰。你和敵人都武裝到牙齒，所有人都結盟對抗你。俘獲 Archibald 即可結"
+"束戰爭！"
+
+msgid ""
+"Switching sides leaves you with three castles against the enemy's one. This "
+"battle will be the easiest one you will face for the rest of the war..."
+"traitor."
+msgstr ""
+"叛變後你擁有三座城堡對抗敵方的一座。這將是這場戰爭中你面對最簡單的戰鬥……叛"
+"徒。"
+
+msgid "Barbarian Wars"
+msgstr "野蠻人之戰"
+
+msgid "First Blood"
+msgstr "初戰"
+
+msgid "Necromancers"
+msgstr "亡靈法師們"
+
+msgid "Slay the Dwarves"
+msgstr "屠殺矮人"
+
+msgid "Country Lords"
+msgstr "鄉間領主"
+
+msgid "Dragon Master"
+msgstr "龍族大師"
+
+msgid "Rebellion"
+msgstr "叛亂"
+
+msgid "Apocalypse"
+msgstr "天啟"
+
+msgid "Greater Glory"
+msgstr "更大的榮耀"
+
+msgid ""
+"King Archibald requires you to defeat the three enemies in this region. They "
+"are not allied with one another, so they will spend most of their energy "
+"fighting amongst themselves. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+"Archibald 國王要求你擊敗此地區的三個敵人。他們彼此並未結盟，所以大部分精力會"
+"花在自相殘殺上。當你佔領所有敵方城堡且不再有敵方英雄時即獲勝。"
+
+msgid ""
+"You must unify the barbarian tribes of the north by conquering them. As in "
+"the previous mission, the enemy is not allied against you, but they have "
+"more resources at their disposal. You will win when you own all of the enemy "
+"castles and there are no more heroes left to fight."
+msgstr ""
+"你必須征服並統一北方的野蠻人部族。如同前一個任務，敵人並未結盟對抗你，但他們"
+"擁有更多資源。當你佔領所有敵方城堡且不再有敵方英雄時即獲勝。"
+
+msgid ""
+"Do-gooder wizards have taken the Necromancers' castle. You must retake it to "
+"achieve victory. Remember that while you start with a powerful army, you "
+"have no castle and must take one within 7 days, or lose this battle. (Hint: "
+"The nearest castle is to the southeast.)"
+msgstr ""
+"自以為正義的巫師奪取了亡靈法師的城堡。你必須奪回它才能獲勝。記住，雖然你開局"
+"擁有強大的軍隊，但沒有城堡，必須在 7 天內攻佔一座，否則戰敗。（提示：最近的城"
+"堡在東南方。）"
+
+msgid ""
+"The dwarves need conquering before they can interfere in King Archibald's "
+"plans. Roland's forces have more than one hero and many towns to start with, "
+"so be ready for attack from multiple directions. You must capture all of the "
+"enemy towns and castles to claim victory."
+msgstr ""
+"在矮人干涉 Archibald 國王的計畫之前必須先征服他們。Roland 的軍隊有多位英雄和"
+"許多城鎮，請做好多方向進攻的準備。必須佔領所有敵方城鎮和城堡才能獲勝。"
+
+msgid ""
+"You must put down a peasant revolt led by Roland's forces. All are allied "
+"against you, but you have Lord Corlagon, an experienced hero, to help you. "
+"Capture all enemy castles to win."
+msgstr ""
+"你必須鎮壓由 Roland 軍隊領導的農民起義。所有人都結盟對抗你，但你有經驗豐富的"
+"英雄 Lord Corlagon 助陣。佔領所有敵方城堡即可獲勝。"
+
+msgid ""
+"There are two enemies allied against you in this mission. Both are well "
+"armed and seek to evict you from their island. Avoid them and capture Dragon "
+"City to win."
+msgstr ""
+"此任務中有兩個結盟的敵人對抗你。他們都裝備精良，想將你逐出島嶼。避開他們並佔"
+"領龍族之城即可獲勝。"
+
+msgid ""
+"Your orders are to conquer the country lords that have sworn to serve "
+"Roland. All of the enemy castles are unified against you. Since you start "
+"without a castle, you must hurry to capture one before the end of the week. "
+"Capture all enemy castles for victory."
+msgstr ""
+"你的命令是征服宣誓效忠 Roland 的鄉間領主。所有敵方城堡都團結對抗你。由於你開"
+"局沒有城堡，必須趕在本週結束前攻佔一座。佔領所有敵方城堡即可獲勝。"
+
+msgid ""
+"Find the Crown before Roland's heroes find it. Archibald will need the Crown "
+"for the final battle against Roland."
+msgstr ""
+"在 Roland 的英雄之前找到王冠。Archibald 需要王冠來進行對 Roland 的最終決戰。"
+
+msgid ""
+"This is the final battle. Both you and your enemy are armed to the teeth, "
+"and all are allied against you. Capture Roland to win the war, and be sure "
+"not to lose Archibald in the fight!"
+msgstr ""
+"這是最終決戰。你和敵人都武裝到牙齒，所有人都結盟對抗你。俘獲 Roland 即可贏得"
+"戰爭，但不可在戰鬥中失去 Archibald！"
+
+msgid "Arrow's Flight"
+msgstr "箭矢之途"
+
+msgid "Island of Chaos"
+msgstr "混沌之島"
+
+msgid "The Abyss"
+msgstr "深淵"
+
+msgid "Uprising"
+msgstr "起義"
+
+msgid "Aurora Borealis"
+msgstr "極光"
+
+msgid "Betrayal's End"
+msgstr "背叛的終結"
+
+msgid "Corruption's Heart"
+msgstr "腐敗之心"
+
+msgid "The Giant's Pass"
+msgstr "巨人之關"
+
+msgid ""
+"Subdue the unruly local lords in order to provide the Empire with facilities "
+"to operate in this region."
+msgstr ""
+"鎮壓不服從的當地領主，為帝國在此地區的運作提供設施。"
+
+msgid ""
+"Eliminate all opposition in this area. Then the first piece of the artifact "
+"will be yours."
+msgstr ""
+"消滅此區域的所有反對勢力，接著你就能取得神器的第一塊碎片。"
+
+msgid ""
+"The sorceresses to the northeast are rebelling! For the good of the empire "
+"you must quash their feeble uprising on your way to the mountains."
+msgstr ""
+"東北方的女巫們正在叛亂！為了帝國的利益，你必須在前往山區的途中鎮壓她們微弱的"
+"起義。"
+
+msgid ""
+"Having prepared for your arrival, Kraeger has arranged for a force of "
+"necromancers to thwart your quest. You must capture the castle of Scabsdale "
+"before the first day of the third week, or the Necromancers will be too "
+"strong for you."
+msgstr ""
+"Kraeger 已為你的到來做好準備，安排了一支亡靈法師部隊阻撓你的任務。你必須在第"
+"三週的第一天之前攻佔 Scabsdale 城堡，否則亡靈法師將強大到無法對抗。"
+
+msgid ""
+"The barbarian despot in this area is, as yet, ignorant of your presence. "
+"Quickly, build up your forces before you are discovered and attacked! Secure "
+"the region by subduing all enemy forces."
+msgstr ""
+"此地區的野蠻人暴君尚未察覺你的存在。趕緊在被發現和遭受攻擊之前增強實力！鎮壓"
+"所有敵方勢力以確保此地區的安全。"
+
+msgid ""
+"The Empire is weak in this region. You will be unable to completely subdue "
+"all forces in this area, so take what you can before reprisal strikes. "
+"Remember, your true goal is to claim the Helmet of Anduran."
+msgstr ""
+"帝國在此地區很薄弱。你無法完全鎮壓此地所有勢力，所以在報復來臨之前盡可能掠"
+"奪。記住，你的真正目標是奪取 Anduran 頭盔。"
+
+msgid "For the good of the Empire, eliminate Kraeger."
+msgstr "為了帝國的利益，消滅 Kraeger。"
+
+msgid ""
+"At last, you have the opportunity and the facilities to rid the Empire of "
+"the necromancer's evil. Eradicate them completely, and you will be sung as a "
+"hero for all time."
+msgstr ""
+"終於，你有了機會和設施來為帝國剷除亡靈法師的邪惡。徹底消滅他們，你將被世代傳"
+"頌為英雄。"
+
+msgid "Border Towns"
+msgstr "邊境城鎮"
+
+msgid "Conquer and Unify"
+msgstr "征服與統一"
+
+msgid "Crazy Uncle Ivan"
+msgstr "瘋狂的 Ivan 叔叔"
+
+msgid "The Wayward Son"
+msgstr "離家之子"
+
+msgid "Ivory Gates"
+msgstr "象牙之門"
+
+msgid "The Elven Lands"
+msgstr "精靈之地"
+
+msgid "The Epic Battle"
+msgstr "史詩之戰"
+
+msgid "The Southern War"
+msgstr "南方戰爭"
+
+msgid ""
+"Conquer and unite all the enemy tribes. Don't lose the hero Jarkonas, the "
+"forefather of all descendants."
+msgstr ""
+"征服並統一所有敵對部族。不可失去英雄 Jarkonas，他是所有後裔的始祖。"
+
+msgid ""
+"Your rival, the Kingdom of Harondale, is attacking weak towns on your "
+"border! Recover from their first strike and crush them completely!"
+msgstr ""
+"你的宿敵 Harondale 王國正在進攻邊境上的薄弱城鎮！從他們的首波攻擊中恢復，並徹"
+"底擊潰他們！"
+
+msgid ""
+"Find your wayward son Joseph who is rumored to be living in the desolate "
+"lands. Do it before the first day of the third month or it will be of no "
+"help to your family."
+msgstr ""
+"找到你離家出走的兒子 Joseph，傳聞他住在荒涼之地。在第三個月的第一天之前完成此"
+"事，否則對你的家族毫無幫助。"
+
+msgid ""
+"Rescue your crazy uncle Ivan. Find him before the first day of the fourth "
+"month or it will be of no help to your kingdom."
+msgstr ""
+"拯救你瘋狂的 Ivan 叔叔。在第四個月的第一天之前找到他，否則對王國毫無幫助。"
+
+msgid ""
+"Destroy the barbarians who are attacking the southern border of your "
+"kingdom! Recover your fallen towns, and then invade the jungle kingdom. "
+"Leave no enemy standing."
+msgstr ""
+"摧毀正在進攻王國南部邊境的野蠻人！收復失去的城鎮，然後入侵叢林王國。不留任何"
+"敵人。"
+
+msgid "Retake the castle of Ivory Gates, which has fallen due to treachery."
+msgstr "奪回因叛變而淪陷的象牙之門城堡。"
+
+msgid ""
+"Gain the favor of the elves. They will not allow trees to be chopped down, "
+"so we will send you wood every 2 weeks. You must complete your mission "
+"before the first day of the seventh month, or the kingdom will surely fall."
+msgstr ""
+"贏得精靈的好感。他們不允許砍伐樹木，所以我們每兩週會送你木材。你必須在第七個"
+"月的第一天之前完成任務，否則王國必將淪陷。"
+
+msgid ""
+"This is the final battle against your rival kingdom of Harondale. Eliminate "
+"everyone, and don't lose the hero Jarkonas VI."
+msgstr ""
+"這是對宿敵 Harondale 王國的最終決戰。消滅所有敵人，不可失去英雄 Jarkonas VI。"
+
+msgid "Fount of Wizardry"
+msgstr "巫術之泉"
+
+msgid "Power's End"
+msgstr "力量的終結"
+
+msgid "The Eternal Scrolls"
+msgstr "永恆卷軸"
+
+msgid "The Shrouded Isles"
+msgstr "迷霧群島"
+
+msgid ""
+"Your mission is to vanquish the warring mages in the magical Shrouded Isles. "
+"The completion of this task will give you a fighting chance against your "
+"rivals."
+msgstr ""
+"你的任務是消滅迷霧群島上交戰中的法師。完成此任務將使你有機會對抗勁敵。"
+
+msgid ""
+"The location of the great library has been discovered! You must make your "
+"way to it, and reclaim the city of Chronos in which it lies."
+msgstr ""
+"大圖書館的位置已被發現！你必須前往該處，奪回它所在的 Chronos 城。"
+
+msgid ""
+"Find the Orb of negation, which is said to be buried in this land. There are "
+"clues inscribed on stone obelisks which will help lead you to your prize. "
+"Find the Orb before the first day of the sixth month, or your rivals will "
+"surely have gotten to the fount before you."
+msgstr ""
+"找到傳說中埋藏在此地的否定之球。石碑上刻有線索，能引導你找到寶物。在第六個月"
+"的第一天之前找到它，否則你的對手肯定會搶先到達泉源。"
+
+msgid ""
+"You must take control of the castle of Magic, where the fount of wizardry "
+"lies. Do this and your victory will be supreme."
+msgstr ""
+"你必須奪取魔法城堡——巫術之泉所在之地。完成此任務，你的勝利將是至高無上的。"
+
+msgid "Blood is Thicker"
+msgstr "血濃於水"
+
+msgid "King and Country"
+msgstr "國王與國家"
+
+msgid "Pirate Isles"
+msgstr "海盜群島"
+
+msgid "Stranded"
+msgstr "擱淺"
+
+msgid ""
+"Capture the town on the island off the southeast shore in order to construct "
+"a boat and travel back towards the mainland. Do not lose the hero Gallavant."
+msgstr ""
+"佔領東南海岸外島嶼上的城鎮，以建造船隻返回大陸。不可失去英雄 Gallavant。"
+
+msgid ""
+"Find and defeat Martine, the pirate leader, who resides in Pirates Cove. Do "
+"not lose Gallavant or your quest will be over."
+msgstr ""
+"找到並擊敗海盜首領 Martine，他藏身在海盜灣。不可失去 Gallavant，否則任務就結"
+"束了。"
+
+msgid ""
+"Eliminate all the other forces who oppose the rule of Lord Alberon. "
+"Gallavant must not die."
+msgstr ""
+"消滅所有反對 Alberon 領主統治的勢力。Gallavant 不可戰死。"
+
+msgid ""
+"Overthrow the entrenched monarchy of Lord Alberon, and claim all the land in "
+"your name. Gallavant must not die."
+msgstr ""
+"推翻 Alberon 領主根深柢固的統治，以你的名義佔領所有土地。Gallavant 不可戰死。"
+
+msgid " bane"
+msgstr "剋星"
+
+msgid " alliance"
+msgstr "聯盟"
+
+msgid "Carry-over forces"
+msgstr "延續兵力"
+
+msgid " bonus"
+msgstr "加成"
+
+msgid " defeated"
+msgstr "被擊敗"
+
+msgid " will always run away from your army."
+msgstr "會永遠逃離你的軍隊。"
+
+msgid " will be willing to join your army."
+msgstr "會願意加入你的軍隊。"
+
+msgid "\"%{artifact}\" artifact will be carried over in the campaign."
+msgstr "神器「%{artifact}」將延續至戰役中。"
+
+msgid "The army will be carried over in the campaign."
+msgstr "軍隊將延續至戰役中。"
+
+msgid "The kingdom will have +%{count} %{resource} each day."
+msgstr "王國每日將額外獲得 +%{count} %{resource}。"
+
+msgid "The \"%{spell}\" spell will be carried over in the campaign."
+msgstr "「%{spell}」法術將延續至戰役中。"
+
+msgid "%{hero} can be hired during scenarios."
+msgstr "%{hero} 可在場景中招募。"
+
+msgid "%{hero} has been defeated and will not appear in subsequent scenarios."
+msgstr "%{hero} 已被擊敗，不會出現在後續場景中。"
+
+msgid "The dwarves recognize their allies and gladly join your forces."
+msgstr "矮人認出了盟友，欣然加入你的隊伍。"
+
+msgid "The ogres recognize you as the Dwarfbane and lumber over to join you."
+msgstr "食人魔認出你是矮人剋星，笨重地走來加入你。"
+
+msgid ""
+"The dragons, snarling and growling, agree to join forces with you, their "
+"'Ally'."
+msgstr ""
+"巨龍們咆哮嘶吼著，同意與牠們的「盟友」你併肩作戰。"
+
+msgid ""
+"As you approach the group of elves, their leader calls them all to "
+"attention. He shouts to them, \"Who of you is brave enough to join this "
+"fearless ally of ours?\" The group explodes with cheers as they run to join "
+"your ranks."
+msgstr ""
+"當你接近精靈群時，他們的首領召集所有人注意。他對他們喊道：「你們誰夠勇敢，願"
+"意加入我們這位無畏的盟友？」人群爆發出歡呼聲，紛紛跑來加入你的隊伍。"
+
+msgid ""
+"The dwarves hail you, \"Any friend of Roland is a friend of ours. You may "
+"pass.\""
+msgstr ""
+"矮人向你致意：「凡是 Roland 的朋友，都是我們的朋友。請通行吧。」"
+
+msgid ""
+"The ogres give you a grunt of recognition, \"Archibald's allies may pass.\""
+msgstr ""
+"食人魔發出認可的咕噥聲：「Archibald 的盟友可以通行。」"
+
+msgid ""
+"The dragons see you and call out. \"Our alliance with Archibald compels us "
+"to join you. Unfortunately you have no room. A pity!\" They quickly scatter."
+msgstr ""
+"巨龍們看到你並呼喊：「我們與 Archibald 的聯盟迫使我們加入你，但很遺憾你沒有空"
+"位，太可惜了！」牠們很快四散離去。"
+
+msgid ""
+"The elves stand at attention as you approach. Their leader calls to you and "
+"says, \"Let us not impede your progress, ally! Move on, and may victory be "
+"yours.\""
+msgstr ""
+"精靈們在你接近時立正站好。他們的首領對你喊道：「讓我們不要阻礙盟友的進展！請"
+"繼續前進，願勝利屬於你。」"
+
+msgid "\"The Dwarfbane!!!!, run for your lives.\""
+msgstr "「矮人剋星！！！！快逃命吧。」"
+
+msgid "campaignBonus|Animate Dead"
+msgstr "操控亡靈"
+
+msgid "campaignBonus|Chain Lightning"
+msgstr "連鎖閃電"
+
+msgid "campaignBonus|Fireblast"
+msgstr "烈焰爆裂"
+
+msgid "campaignBonus|Mass Curse"
+msgstr "群體詛咒"
+
+msgid "campaignBonus|Mass Haste"
+msgstr "群體加速"
+
+msgid "campaignBonus|Mirror Image"
+msgstr "鏡像術"
+
+msgid "campaignBonus|Resurrect"
+msgstr "復活術"
+
+msgid "campaignBonus|Steelskin"
+msgstr "鋼膚術"
+
+msgid "campaignBonus|Summon Earth"
+msgstr "召喚土元素"
+
+msgid "campaignBonus|View Heroes"
+msgstr "探查英雄"
+
+msgid "campaignBonus|Ballista"
+msgstr "弩砲"
+
+msgid "campaignBonus|Black Pearl"
+msgstr "Black Pearl"
+
+msgid "campaignBonus|Caster's Bracelet"
+msgstr "Caster's Bracelet of Magic"
+
+msgid "campaignBonus|Defender Helm"
+msgstr "Defender Helm of Protection"
+
+msgid "campaignBonus|Breastplate"
+msgstr "Breastplate of Anduran"
+
+msgid "campaignBonus|Dragon Sword"
+msgstr "Dragon Sword of Dominion"
+
+msgid "campaignBonus|Fizbin Medal"
+msgstr "Fizbin of Misfortune"
+
+msgid "campaignBonus|Foremost Scroll"
+msgstr "Foremost Scroll of Knowledge"
+
+msgid "campaignBonus|Gauntlets"
+msgstr "Armored Gauntlets of Protection"
+
+msgid "campaignBonus|Hideous Mask"
+msgstr "Hideous Mask"
+
+msgid "campaignBonus|Mage's Ring"
+msgstr "Mage's Ring of Power"
+
+msgid "campaignBonus|Major Scroll"
+msgstr "Major Scroll of Knowledge"
+
+msgid "campaignBonus|Medal of Honor"
+msgstr "Medal of Honor"
+
+msgid "campaignBonus|Medal of Valor"
+msgstr "Medal of Valor"
+
+msgid "campaignBonus|Minor Scroll"
+msgstr "Minor Scroll of Knowledge"
+
+msgid "campaignBonus|Nomad Boots"
+msgstr "Nomad Boots of Mobility"
+
+msgid "campaignBonus|Power Axe"
+msgstr "Power Axe of Dominion"
+
+msgid "campaignBonus|Spiked Shield"
+msgstr "Spiked Shield"
+
+msgid "campaignBonus|Stealth Shield"
+msgstr "Stealth Shield of Protection"
+
+msgid "campaignBonus|Tax Lien"
+msgstr "Tax Lien"
+
+msgid "campaignBonus|Thunder Mace"
+msgstr "Thunder Mace of Dominion"
+
+msgid "campaignBonus|Traveler's Boots"
+msgstr "Traveler's Boots of Mobility"
+
+msgid "campaignBonus|White Pearl"
+msgstr "White Pearl"
+
+msgid "campaignBonus|Basic Archery"
+msgstr "基礎箭術"
+
+msgid "campaignBonus|Advanced Archery"
+msgstr "進階箭術"
+
+msgid "campaignBonus|Expert Archery"
+msgstr "專家箭術"
+
+msgid "campaignBonus|Basic Ballistics"
+msgstr "基礎彈道術"
+
+msgid "campaignBonus|Advanced Ballistics"
+msgstr "進階彈道術"
+
+msgid "campaignBonus|Expert Ballistics"
+msgstr "專家彈道術"
+
+msgid "campaignBonus|Basic Diplomacy"
+msgstr "基礎外交術"
+
+msgid "campaignBonus|Advanced Diplomacy"
+msgstr "進階外交術"
+
+msgid "campaignBonus|Expert Diplomacy"
+msgstr "專家外交術"
+
+msgid "campaignBonus|Basic Eagle Eye"
+msgstr "基礎鷹眼術"
+
+msgid "campaignBonus|Advanced Eagle Eye"
+msgstr "進階鷹眼術"
+
+msgid "campaignBonus|Expert Eagle Eye"
+msgstr "專家鷹眼術"
+
+msgid "campaignBonus|Basic Estates"
+msgstr "基礎產業術"
+
+msgid "campaignBonus|Advanced Estates"
+msgstr "進階產業術"
+
+msgid "campaignBonus|Expert Estates"
+msgstr "專家產業術"
+
+msgid "campaignBonus|Basic Leadership"
+msgstr "基礎領導術"
+
+msgid "campaignBonus|Advanced Leadership"
+msgstr "進階領導術"
+
+msgid "campaignBonus|Expert Leadership"
+msgstr "專家領導術"
+
+msgid "campaignBonus|Basic Logistics"
+msgstr "基礎後勤術"
+
+msgid "campaignBonus|Advanced Logistics"
+msgstr "進階後勤術"
+
+msgid "campaignBonus|Expert Logistics"
+msgstr "專家後勤術"
+
+msgid "campaignBonus|Basic Luck"
+msgstr "基礎運氣"
+
+msgid "campaignBonus|Advanced Luck"
+msgstr "進階運氣"
+
+msgid "campaignBonus|Expert Luck"
+msgstr "專家運氣"
+
+msgid "campaignBonus|Basic Mysticism"
+msgstr "基礎神祕術"
+
+msgid "campaignBonus|Advanced Mysticism"
+msgstr "進階神祕術"
+
+msgid "campaignBonus|Expert Mysticism"
+msgstr "專家神祕術"
+
+msgid "campaignBonus|Basic Navigation"
+msgstr "基礎航海術"
+
+msgid "campaignBonus|Advanced Navigation"
+msgstr "進階航海術"
+
+msgid "campaignBonus|Expert Navigation"
+msgstr "專家航海術"
+
+msgid "campaignBonus|Basic Necromancy"
+msgstr "基礎亡靈巫術"
+
+msgid "campaignBonus|Advanced Necromancy"
+msgstr "進階亡靈巫術"
+
+msgid "campaignBonus|Expert Necromancy"
+msgstr "專家亡靈巫術"
+
+msgid "campaignBonus|Basic Pathfinding"
+msgstr "基礎尋路術"
+
+msgid "campaignBonus|Advanced Pathfinding"
+msgstr "進階尋路術"
+
+msgid "campaignBonus|Expert Pathfinding"
+msgstr "專家尋路術"
+
+msgid "campaignBonus|Basic Scouting"
+msgstr "基礎偵察術"
+
+msgid "campaignBonus|Advanced Scouting"
+msgstr "進階偵察術"
+
+msgid "campaignBonus|Expert Scouting"
+msgstr "專家偵察術"
+
+msgid "campaignBonus|Basic Wisdom"
+msgstr "基礎智慧"
+
+msgid "campaignBonus|Advanced Wisdom"
+msgstr "進階智慧"
+
+msgid "campaignBonus|Expert Wisdom"
+msgstr "專家智慧"
+
+msgid ""
+"The main hero will have the \"%{artifact}\" artifact at the start of the "
+"scenario."
+msgstr ""
+"主英雄在場景開始時將擁有「%{artifact}」神器。"
+
+msgid ""
+"The kingdom will receive %{amount} additional %{resource} at the start of "
+"the scenario."
+msgstr ""
+"王國在場景開始時將額外獲得 %{amount} %{resource}。"
+
+msgid ""
+"The kingdom will have %{amount} less %{resource} at the start of the "
+"scenario."
+msgstr ""
+"王國在場景開始時將減少 %{amount} %{resource}。"
+
+msgid ""
+"The main hero will have %{count} %{monster} at the start of the scenario."
+msgstr ""
+"主英雄在場景開始時將擁有 %{count} 個 %{monster}。"
+
+msgid ""
+"The main hero will have the \"%{spell}\" spell at the start of the scenario."
+msgstr ""
+"主英雄在場景開始時將擁有「%{spell}」法術。"
+
+msgid "The starting alignment of the scenario will be %{race}."
+msgstr "此場景的起始陣營將是 %{race}。"
+
+msgid ""
+"The main hero will receive a +%{count} to their %{skill} at the start of the "
+"scenario."
+msgstr ""
+"主英雄在場景開始時其 %{skill} 將獲得 +%{count} 加成。"
+
+msgid "The main hero will have %{skill} at the start of the scenario."
+msgstr "主英雄在場景開始時將擁有 %{skill}。"
+
+msgid "Roland"
+msgstr "Roland"
+
+msgid "Archibald"
+msgstr "Archibald"
+
+msgid "Price of Loyalty"
+msgstr "忠誠的代價"
+
+msgid "Voyage Home"
+msgstr "歸鄉之旅"
+
+msgid "Wizard's Isle"
+msgstr "巫師之島"
+
+msgid "Descendants"
+msgstr "後裔"
+
+msgid "Cannot build. You have already built here today."
+msgstr "無法建造，今日已經建造過了。"
+
+msgid "For this action it is necessary to build a castle first."
+msgstr "此操作需要先建造城堡。"
+
+msgid "The %{building} produces %{monster}."
+msgstr "%{building} 生產 %{monster}。"
+
+msgid "Requires:"
+msgstr "需求："
+
+msgid "Exit this menu without doing anything."
+msgstr "離開此選單，不進行任何操作。"
+
+msgid "Cannot build %{name}. The castle is too far away from an ocean."
+msgstr "無法建造 %{name}，城堡離海洋太遠。"
+
+msgid "This building has been disabled."
+msgstr "此建築已被停用。"
+
+msgid "Cannot afford the %{name}."
+msgstr "無法負擔 %{name} 的費用。"
+
+msgid "The %{name} is already built."
+msgstr "%{name} 已經建造完成。"
+
+msgid "Cannot build the %{name}."
+msgstr "無法建造 %{name}。"
+
+msgid "Build %{name}."
+msgstr "建造 %{name}。"
+
+msgid "Blackridge"
+msgstr "Blackridge"
+
+msgid "Hillstone"
+msgstr "Hillstone"
+
+msgid "Pinehurst"
+msgstr "Pinehurst"
+
+msgid "Whiteshield"
+msgstr "Whiteshield"
+
+msgid "Woodhaven"
+msgstr "Woodhaven"
+
+msgid "Blackwind"
+msgstr "Blackwind"
+
+msgid "Bloodreign"
+msgstr "Bloodreign"
+
+msgid "Dragontooth"
+msgstr "Dragontooth"
+
+msgid "Greywind"
+msgstr "Greywind"
+
+msgid "Portsmith"
+msgstr "Portsmith"
+
+msgid "Atlantium"
+msgstr "Atlantium"
+
+msgid "Middle Gate"
+msgstr "Middle Gate"
+
+msgid "Sansobar"
+msgstr "Sansobar"
+
+msgid "Tundara"
+msgstr "Tundara"
+
+msgid "Vulcania"
+msgstr "Vulcania"
+
+msgid "Baywatch"
+msgstr "Baywatch"
+
+msgid "Fountainhead"
+msgstr "Fountainhead"
+
+msgid "Vertigo"
+msgstr "Vertigo"
+
+msgid "Wildabar"
+msgstr "Wildabar"
+
+msgid "Winterkill"
+msgstr "Winterkill"
+
+msgid "Brindamoor"
+msgstr "Brindamoor"
+
+msgid "Lakeside"
+msgstr "Lakeside"
+
+msgid "Nightshadow"
+msgstr "Nightshadow"
+
+msgid "Olympus"
+msgstr "Olympus"
+
+msgid "Sandcaster"
+msgstr "Sandcaster"
+
+msgid "Alamar"
+msgstr "Alamar"
+
+msgid "Burlock"
+msgstr "Burlock"
+
+msgid "Dragadune"
+msgstr "Dragadune"
+
+msgid "Kalindra"
+msgstr "Kalindra"
+
+msgid "Xabran"
+msgstr "Xabran"
+
+msgid "Algary"
+msgstr "Algary"
+
+msgid "Basenji"
+msgstr "Basenji"
+
+msgid "Blackfang"
+msgstr "Blackfang"
+
+msgid "New Dawn"
+msgstr "New Dawn"
+
+msgid "Sorpigal"
+msgstr "Sorpigal"
+
+msgid "Avone"
+msgstr "Avone"
+
+msgid "Big Oak"
+msgstr "Big Oak"
+
+msgid "Chandler"
+msgstr "Chandler"
+
+msgid "Erliquin"
+msgstr "Erliquin"
+
+msgid "Hampshire"
+msgstr "Hampshire"
+
+msgid "Antioch"
+msgstr "Antioch"
+
+msgid "Avalon"
+msgstr "Avalon"
+
+msgid "Roc Haven"
+msgstr "Roc Haven"
+
+msgid "South Mill"
+msgstr "South Mill"
+
+msgid "Weed Patch"
+msgstr "Weed Patch"
+
+msgid "Brownston"
+msgstr "Brownston"
+
+msgid "Hilltop"
+msgstr "Hilltop"
+
+msgid "Weddington"
+msgstr "Weddington"
+
+msgid "Westfork"
+msgstr "Westfork"
+
+msgid "Whittingham"
+msgstr "Whittingham"
+
+msgid "Cathcart"
+msgstr "Cathcart"
+
+msgid "Elk's Head"
+msgstr "Elk's Head"
+
+msgid "Roscomon"
+msgstr "Roscomon"
+
+msgid "Sherman"
+msgstr "Sherman"
+
+msgid "Yorksford"
+msgstr "Yorksford"
+
+msgid "Blackburn"
+msgstr "Blackburn"
+
+msgid "Blacksford"
+msgstr "Blacksford"
+
+msgid "Burton"
+msgstr "Burton"
+
+msgid "Pig's Eye"
+msgstr "Pig's Eye"
+
+msgid "Viper's Nest"
+msgstr "Viper's Nest"
+
+msgid "Fenton"
+msgstr "Fenton"
+
+msgid "Lankershire"
+msgstr "Lankershire"
+
+msgid "Lombard"
+msgstr "Lombard"
+
+msgid "Timberhill"
+msgstr "Timberhill"
+
+msgid "Troy"
+msgstr "Troy"
+
+msgid "Forder Oaks"
+msgstr "Forder Oaks"
+
+msgid "Meramec"
+msgstr "Meramec"
+
+msgid "Quick Silver"
+msgstr "Quick Silver"
+
+msgid "Westmoor"
+msgstr "Westmoor"
+
+msgid "Willow"
+msgstr "Willow"
+
+msgid "Corackston"
+msgstr "Corackston"
+
+msgid "Sheltemburg"
+msgstr "Sheltemburg"
+
+msgid "Cannot recruit - you already have a Hero in this town."
+msgstr "無法招募——此城鎮中已有英雄。"
+
+msgid "Cannot recruit - you have too many Heroes."
+msgstr "無法招募——英雄數量已達上限。"
+
+msgid "Cannot afford a Hero."
+msgstr "無法負擔英雄的招募費用。"
+
+msgid "There is no room in the garrison for this army."
+msgstr "城防部隊中沒有空間容納此軍隊。"
+
+msgid "Fortifications"
+msgstr "防禦工事"
+
+msgid "Farm"
+msgstr "農場"
+
+msgid "Thatched Hut"
+msgstr "茅草屋"
+
+msgid "Archery Range"
+msgstr "射箭場"
+
+msgid "Upg. Archery Range"
+msgstr "進階射箭場"
+
+msgid "Blacksmith"
+msgstr "鐵匠鋪"
+
+msgid "Upg. Blacksmith"
+msgstr "進階鐵匠鋪"
+
+msgid "Armory"
+msgstr "兵器庫"
+
+msgid "Upg. Armory"
+msgstr "進階兵器庫"
+
+msgid "Jousting Arena"
+msgstr "馬上比武場"
+
+msgid "Upg. Jousting Arena"
+msgstr "進階馬上比武場"
+
+msgid "Cathedral"
+msgstr "大教堂"
+
+msgid "Upg. Cathedral"
+msgstr "進階大教堂"
+
+msgid "Coliseum"
+msgstr "競技場"
+
+msgid "Garbage Heap"
+msgstr "垃圾堆"
+
+msgid "Hut"
+msgstr "小屋"
+
+msgid "Stick Hut"
+msgstr "木棍屋"
+
+msgid "Upg. Stick Hut"
+msgstr "進階木棍屋"
+
+msgid "Den"
+msgstr "獸穴"
+
+msgid "Adobe"
+msgstr "土坯屋"
+
+msgid "Upg. Adobe"
+msgstr "進階土坯屋"
+
+msgid "Bridge"
+msgstr "橋樑"
+
+msgid "Upg. Bridge"
+msgstr "進階橋樑"
+
+msgid "Pyramid"
+msgstr "金字塔"
+
+msgid "Rainbow"
+msgstr "彩虹"
+
+msgid "Crystal Garden"
+msgstr "水晶花園"
+
+msgid "Treehouse"
+msgstr "樹屋"
+
+msgid "Cottage"
+msgstr "小木屋"
+
+msgid "Upg. Cottage"
+msgstr "進階小木屋"
+
+msgid "Stonehenge"
+msgstr "巨石陣"
+
+msgid "Upg. Stonehenge"
+msgstr "進階巨石陣"
+
+msgid "Fenced Meadow"
+msgstr "圍籬草地"
+
+msgid "sorceress|Red Tower"
+msgstr "紅塔"
+
+msgid "Dungeon"
+msgstr "地牢"
+
+msgid "Waterfall"
+msgstr "瀑布"
+
+msgid "Cave"
+msgstr "洞穴"
+
+msgid "Crypt"
+msgstr "墓穴"
+
+msgid "Nest"
+msgstr "巢穴"
+
+msgid "Maze"
+msgstr "迷宮"
+
+msgid "Upg. Maze"
+msgstr "進階迷宮"
+
+msgid "Swamp"
+msgstr "沼澤"
+
+msgid "Green Tower"
+msgstr "綠塔"
+
+msgid "warlock|Red Tower"
+msgstr "紅塔"
+
+msgid "Black Tower"
+msgstr "黑塔"
+
+msgid "Library"
+msgstr "圖書館"
+
+msgid "Orchard"
+msgstr "果園"
+
+msgid "Habitat"
+msgstr "棲息地"
+
+msgid "Pen"
+msgstr "圍欄"
+
+msgid "Foundry"
+msgstr "鑄造廠"
+
+msgid "Upg. Foundry"
+msgstr "進階鑄造廠"
+
+msgid "Cliff Nest"
+msgstr "懸崖巢穴"
+
+msgid "Ivory Tower"
+msgstr "象牙塔"
+
+msgid "Upg. Ivory Tower"
+msgstr "進階象牙塔"
+
+msgid "Cloud Castle"
+msgstr "雲端城堡"
+
+msgid "Upg. Cloud Castle"
+msgstr "進階雲端城堡"
+
+msgid "Storm"
+msgstr "風暴"
+
+msgid "Skull Pile"
+msgstr "骷髏堆"
+
+msgid "Excavation"
+msgstr "發掘地"
+
+msgid "Graveyard"
+msgstr "墓地"
+
+msgid "Upg. Graveyard"
+msgstr "進階墓地"
+
+msgid "Upg. Pyramid"
+msgstr "進階金字塔"
+
+msgid "Mansion"
+msgstr "宅邸"
+
+msgid "Upg. Mansion"
+msgstr "進階宅邸"
+
+msgid "Mausoleum"
+msgstr "陵寢"
+
+msgid "Upg. Mausoleum"
+msgstr "進階陵寢"
+
+msgid "Laboratory"
+msgstr "實驗室"
+
+msgid "Shrine"
+msgstr "神殿"
+
+msgid "Special"
+msgstr "特殊"
+
+msgid "Horde Building"
+msgstr "增產建築"
+
+msgid "Dwelling 1"
+msgstr "住所 1"
+
+msgid "Dwelling 2"
+msgstr "住所 2"
+
+msgid "Upg. Dwelling 2"
+msgstr "進階住所 2"
+
+msgid "Dwelling 3"
+msgstr "住所 3"
+
+msgid "Upg. Dwelling 3"
+msgstr "進階住所 3"
+
+msgid "Dwelling 4"
+msgstr "住所 4"
+
+msgid "Upg. Dwelling 4"
+msgstr "進階住所 4"
+
+msgid "Dwelling 5"
+msgstr "住所 5"
+
+msgid "Upg. Dwelling 5"
+msgstr "進階住所 5"
+
+msgid "Dwelling 6"
+msgstr "住所 6"
+
+msgid "Upg. Dwelling 6"
+msgstr "進階住所 6"
+
+msgid "2x Upg. Dwelling 6"
+msgstr "二階住所 6"
+
+msgid ""
+"The Fortifications increase the toughness of the walls, increasing the "
+"number of turns it takes to knock them down."
+msgstr ""
+"防禦工事增強城牆的堅固程度，增加擊倒城牆所需的回合數。"
+
+msgid "The Farm increases production of Peasants by %{count} per week."
+msgstr "農場每週增加 %{count} 個農民的產量。"
+
+msgid ""
+"The Coliseum provides inspiring spectacles to defending troops, raising "
+"their morale by two during combat."
+msgstr ""
+"競技場為守軍提供鼓舞人心的表演，在戰鬥中將士氣提升 2 點。"
+
+msgid "The Garbage Heap increases production of Goblins by %{count} per week."
+msgstr "垃圾堆每週增加 %{count} 個哥布林的產量。"
+
+msgid "The Rainbow increases the luck of the defending units by two."
+msgstr "彩虹將守軍的運氣提升 2 點。"
+
+msgid ""
+"The Crystal Garden increases production of Sprites by %{count} per week."
+msgstr ""
+"水晶花園每週增加 %{count} 個精靈的產量。"
+
+msgid "The Dungeon increases the income of the town by %{count} gold per day."
+msgstr "地牢每日增加城鎮 %{count} 金幣的收入。"
+
+msgid "The Waterfall increases production of Centaurs by %{count} per week."
+msgstr "瀑布每週增加 %{count} 個半人馬的產量。"
+
+msgid ""
+"The Library increases the number of spells in the Guild by one for each "
+"level of the guild."
+msgstr ""
+"圖書館讓公會每個等級多增加一個法術。"
+
+msgid "The Orchard increases production of Halflings by %{count} per week."
+msgstr "果園每週增加 %{count} 個半身人的產量。"
+
+msgid "The Storm adds +2 to the power of spells of a defending spell caster."
+msgstr "風暴為防守方施法者的法術力量增加 +2。"
+
+msgid "The Skull Pile increases production of Skeletons by %{count} per week."
+msgstr "骷髏堆每週增加 %{count} 個骷髏兵的產量。"
+
+msgid "The Special building gives a specific bonus to the chosen castle type."
+msgstr "特殊建築為所選城堡類型提供特定加成。"
+
+msgid ""
+"The Horde Building increases the growth rate of the level 1 creatures by 8 "
+"per week."
+msgstr ""
+"增產建築每週增加 8 個一階生物的產量。"
+
+msgid "Thieves' Guild"
+msgstr "盜賊公會"
+
+msgid "Tavern"
+msgstr "酒館"
+
+msgid "Shipyard"
+msgstr "造船廠"
+
+msgid "Well"
+msgstr "水井"
+
+msgid "Statue"
+msgstr "雕像"
+
+msgid "Marketplace"
+msgstr "市場"
+
+msgid "Moat"
+msgstr "護城河"
+
+msgid "Castle"
+msgstr "城堡"
+
+msgid "Tent"
+msgstr "帳篷"
+
+msgid "Captain's Quarters"
+msgstr "隊長營房"
+
+msgid "Mage Guild, Level 1"
+msgstr "法師公會，等級 1"
+
+msgid "Mage Guild, Level 2"
+msgstr "法師公會，等級 2"
+
+msgid "Mage Guild, Level 3"
+msgstr "法師公會，等級 3"
+
+msgid "Mage Guild, Level 4"
+msgstr "法師公會，等級 4"
+
+msgid "Mage Guild, Level 5"
+msgstr "法師公會，等級 5"
+
+msgid ""
+"The Shrine increases the necromancy skill of all your necromancers by 10 "
+"percent."
+msgstr ""
+"神殿使所有亡靈法師的亡靈巫術技能提升 10%。"
+
+msgid ""
+"The Thieves' Guild provides information on enemy players. Thieves' Guilds "
+"can also provide scouting information on enemy towns. Additional Guilds "
+"provide more information."
+msgstr ""
+"盜賊公會提供敵方玩家的情報。盜賊公會也能提供敵方城鎮的偵察資訊。擁有越多公會"
+"可獲得越多情報。"
+
+msgid "The Tavern increases morale for troops defending the castle."
+msgstr "酒館提升防守城堡部隊的士氣。"
+
+msgid "The Shipyard allows ships to be built."
+msgstr "造船廠可建造船隻。"
+
+msgid ""
+"The Well increases the growth rate of all dwellings by %{count} creatures "
+"per week."
+msgstr ""
+"水井每週增加所有住所 %{count} 個生物的產量。"
+
+msgid "The Statue increases the town's income by %{count} gold per day."
+msgstr "雕像每日增加城鎮 %{count} 金幣的收入。"
+
+msgid "The Left Turret provides extra firepower during castle combat."
+msgstr "左箭塔在城堡戰鬥中提供額外火力。"
+
+msgid "The Right Turret provides extra firepower during castle combat."
+msgstr "右箭塔在城堡戰鬥中提供額外火力。"
+
+msgid ""
+"The Marketplace can be used to convert one type of resource into another. "
+"The more marketplaces you control, the better the exchange rate."
+msgstr ""
+"市場可用來轉換資源類型。控制的市場越多，兌換比率越好。"
+
+msgid ""
+"The Moat slows and weakens attacking units. Any walking unit entering the "
+"moat must end its turn there and can only move within the moat one hex at a "
+"time. Any creature present in the moat will have its defense skill reduced "
+"by %{count}."
+msgstr ""
+"護城河會減緩和削弱進攻的部隊。任何步行單位進入護城河後必須在該處結束回合，且"
+"每次只能在河中移動一格。停留在護城河中的所有生物防禦技能將降低 %{count}。"
+
+msgid ""
+"The Castle improves the town's defense and increases its income to %{count} "
+"gold per day."
+msgstr ""
+"城堡改善城鎮的防禦，並將收入增加至每日 %{count} 金幣。"
+
+msgid ""
+"The Tent provides workers to build a castle, provided the materials and the "
+"gold are available."
+msgstr ""
+"帳篷提供工人來建造城堡，前提是有足夠的材料和黃金。"
+
+msgid ""
+"The Captain's Quarters provides a captain to assist in the castle's defense "
+"when no hero is present."
+msgstr ""
+"隊長營房在沒有英雄駐守時提供一名隊長協助城堡防禦。"
+
+msgid ""
+"The Mage Guild allows heroes to learn spells and replenish their spell "
+"points."
+msgstr ""
+"法師公會讓英雄學習法術並補充魔法值。"
+
+msgid "Recruit %{name}"
+msgstr "招募 %{name}"
+
+msgid "Month: %{month}, Week: %{week}, Day: %{day}"
+msgstr "月：%{month}，週：%{week}，日：%{day}"
+
+msgid ""
+"You must purchase a spell book to use the mage guild, but you currently have "
+"no room for a spell book. Try giving one of your artifacts to another hero."
+msgstr ""
+"必須購買法術書才能使用法師公會，但目前沒有空間放置法術書。嘗試將一件神器轉交"
+"給其他英雄。"
+
+msgid "Exit Castle"
+msgstr "離開城堡"
+
+msgid "Exit Town"
+msgstr "離開城鎮"
+
+msgid "Show Income"
+msgstr "顯示收入"
+
+msgid "Show previous town"
+msgstr "顯示上一個城鎮"
+
+msgid "Show next town"
+msgstr "顯示下一個城鎮"
+
+msgid "View Hero"
+msgstr "檢視英雄"
+
+msgid "Click to show the next town."
+msgstr "按一下顯示下一個城鎮。"
+
+msgid "Click to show the previous town."
+msgstr "按一下顯示上一個城鎮。"
+
+msgid "This town may not be upgraded to a castle."
+msgstr "此城鎮無法升級為城堡。"
+
+msgid "Town"
+msgstr "城鎮"
+
+msgid "The above spells are available here."
+msgstr "以上法術在此處可用。"
+
+msgid "The spells the hero can learn have been added to their book."
+msgstr "英雄可學習的法術已加入其法術書。"
+
+msgid "Exit Mage Guild"
+msgstr "離開法師公會"
+
+msgid "A generous tip for the barkeep yields the following rumor:"
+msgstr "給酒保一筆大方的小費後得到了以下傳言："
+
+msgid "Recruit Hero"
+msgstr "招募英雄"
+
+msgid "%{name} is a level %{value} %{race} "
+msgstr "%{name} 是等級 %{value} 的 %{race} "
+
+msgid "with %{count} artifacts."
+msgstr "擁有 %{count} 件神器。"
+
+msgid "with 1 artifact."
+msgstr "擁有 1 件神器。"
+
+msgid "without artifacts."
+msgstr "沒有神器。"
+
+msgid "Recruit %{name} the %{race}"
+msgstr "招募 %{race} %{name}"
+
+msgid ""
+"'Spread' combat formation spreads the castle's units from the top to the "
+"bottom of the battlefield, with at least one empty space between each unit."
+msgstr ""
+"「分散」陣型將城堡的部隊從戰場頂部到底部展開，每支部隊之間至少保留一格空間。"
+
+msgid ""
+"'Grouped' combat formation bunches the castle's units together in the center "
+"of the castle's side of the battlefield."
+msgstr ""
+"「集中」陣型將城堡的部隊集中在戰場己方一側的中央。"
+
+msgid "Castle Options. Month: %{month}, Week: %{week}, Day: %{day}"
+msgstr "城堡選項。月：%{month}，週：%{week}，日：%{day}"
+
+msgid "Set garrison combat formation to 'Spread'"
+msgstr "將城防戰鬥陣型設為「分散」"
+
+msgid "Set garrison combat formation to 'Grouped'"
+msgstr "將城防戰鬥陣型設為「集中」"
+
+msgid "Exit Castle Options"
+msgstr "離開城堡選項"
+
+msgid "Spread Formation"
+msgstr "分散陣型"
+
+msgid "Grouped Formation"
+msgstr "集中陣型"
+
+msgid "Not enough resources to recruit creatures."
+msgstr "資源不足，無法招募生物。"
+
+msgid "You are unable to recruit at this time, your ranks are full."
+msgstr "目前無法招募，部隊已滿編。"
+
+msgid "No creatures available for purchase."
+msgstr "沒有可招募的生物。"
+
+msgid "Recruit Creatures"
+msgstr "招募生物"
+
+msgid "Hire all creatures in the town."
+msgstr "招募城鎮中的所有生物。"
+
+msgid "Max"
+msgstr "最大"
+
+msgid "Available"
+msgstr "可用"
+
+msgid "Town Population Information and Statistics"
+msgstr "城鎮人口資訊與統計"
+
+msgid "Damage"
+msgstr "傷害"
+
+msgid "HP"
+msgstr "生命值"
+
+msgid "Speed"
+msgstr "速度"
+
+msgid "Growth"
+msgstr "成長"
+
+msgid "week"
+msgstr "週"
+
+msgid "View World"
+msgstr "檢視世界"
+
+msgid "View the entire world."
+msgstr "檢視整個世界。"
+
+msgid "Puzzle"
+msgstr "拼圖"
+
+msgid "View the obelisk puzzle."
+msgstr "檢視方尖碑拼圖。"
+
+msgid "Scenario Information"
+msgstr "場景資訊"
+
+msgid "View information on the scenario you are currently playing."
+msgstr "檢視目前正在進行的場景資訊。"
+
+msgid "Dig for the Ultimate Artifact."
+msgstr "挖掘終極神器。"
+
+msgid "Digging"
+msgstr "挖掘"
+
+msgid "Arena"
+msgstr "競技場"
+
+msgid ""
+"You enter the arena and face a pack of vicious lions. You handily defeat "
+"them, to the wild cheers of the crowd. Impressed by your skill, the aged "
+"trainer of gladiators agrees to train you in a skill of your choice."
+msgstr ""
+"你進入競技場面對一群兇猛的獅子。你輕鬆擊敗了牠們，觀眾瘋狂歡呼。角鬥士訓練師"
+"年事已高，十分欣賞你的技術，同意讓你選擇一項技能接受訓練。"
+
+msgid "Attack Skill"
+msgstr "攻擊技能"
+
+msgid "Defense Skill"
+msgstr "防禦技能"
+
+msgid "Shots"
+msgstr "射擊次數"
+
+msgid "Shots Left"
+msgstr "剩餘射擊次數"
+
+msgid "Hit Points"
+msgstr "生命值"
+
+msgid "Hit Points Left"
+msgstr "剩餘生命值"
+
+msgid "You can't afford to upgrade your troops!"
+msgstr "無法負擔部隊的升級費用！"
+
+msgid ""
+"Your troops can be upgraded, but it will cost you dearly. Do you wish to "
+"upgrade them?"
+msgstr ""
+"部隊可以升級，但費用不菲。確定要升級嗎？"
+
+msgid "Are you sure you want to dismiss this army?"
+msgstr "確定要解散此軍隊嗎？"
+
+msgid "Upgrade"
+msgstr "升級"
+
+msgid "Upgrade your troops."
+msgstr "升級部隊。"
+
+msgid "Dismiss"
+msgstr "解散"
+
+msgid "Dismiss this army."
+msgstr "解散此軍隊。"
+
+msgid ""
+"A group of %{monster} with a desire for greater glory wish to join you.\n"
+"Do you accept?"
+msgstr ""
+"一群 %{monster} 渴望更偉大的榮耀，希望加入你的隊伍。\n"
+"是否接受？"
+
+msgid "Followers"
+msgstr "追隨者"
+
+msgid ""
+"The %{monster} is swayed by your diplomatic tongue, and offers to join your "
+"army for the sum of %{gold} gold.\n"
+"Do you accept?"
+msgstr ""
+"%{monster} 被你的外交辭令打動，願意以 %{gold} 金幣加入你的軍隊。\n"
+"是否接受？"
+
+msgid ""
+"The creatures are swayed by your diplomatic\n"
+"tongue, and make you an offer:\n"
+"\n"
+msgstr ""
+"這些生物被你的外交辭令打動，\n"
+"向你提出了一個條件:\n"
+"\n"
+
+msgid ""
+"%{offer} of the %{total} %{monster} will join your army, and the rest will "
+"leave you alone, for the sum of %{gold} gold.\n"
+"Do you accept?"
+msgstr ""
+"%{total} 個 %{monster} 中有 %{offer} 個願意加入你的軍隊，其餘的則會離開，費用"
+"為 %{gold} 金幣。\n"
+"是否接受？"
+
+msgid ""
+"All %{offer} of the %{monster} will join your army for the sum of %{gold} "
+"gold.\n"
+"Do you accept?"
+msgstr ""
+"全部 %{offer} 個 %{monster} 願意以 %{gold} 金幣加入你的軍隊。\n"
+"是否接受？"
+
+msgid "(Rate: %{percent})"
+msgstr "(比率：%{percent})"
+
+msgid "off"
+msgstr "關閉"
+
+msgid "Music"
+msgstr "音樂"
+
+msgid "Effects"
+msgstr "音效"
+
+msgid "MIDI"
+msgstr "MIDI"
+
+msgid "MIDI Expansion"
+msgstr "MIDI 擴充"
+
+msgid "External"
+msgstr "外部"
+
+msgid "Music Type"
+msgstr "音樂類型"
+
+msgid "3D Audio"
+msgstr "3D 音效"
+
+msgid "Toggle ambient music level."
+msgstr "調整環境音樂音量。"
+
+msgid "Toggle foreground sounds level."
+msgstr "調整前景音效音量。"
+
+msgid "Change the type of music."
+msgstr "變更音樂類型。"
+
+msgid "Toggle the 3D effect of foreground sounds."
+msgstr "切換前景音效的 3D 效果。"
+
+msgid "Build a new ship:"
+msgstr "建造新船："
+
+msgid "Resource cost:"
+msgstr "資源花費："
+
+msgid "Total: "
+msgstr "總計："
+
+msgid "Need: "
+msgstr "需要："
+
+msgid "Restart Game"
+msgstr "重新開始遊戲"
+
+msgid "There was an issue during saving."
+msgstr "儲存時發生問題。"
+
+msgid "New Game"
+msgstr "新遊戲"
+
+msgid "Start a single or multi-player game."
+msgstr "開始單人或多人遊戲。"
+
+msgid "Load Game"
+msgstr "載入遊戲"
+
+msgid "Load a previously saved game."
+msgstr "載入先前儲存的遊戲。"
+
+msgid "Restart the scenario."
+msgstr "重新開始此場景。"
+
+msgid "Save Game"
+msgstr "儲存遊戲"
+
+msgid "Save the current game."
+msgstr "儲存目前的遊戲。"
+
+msgid "Quick Save"
+msgstr "快速存檔"
+
+msgid "Save the current game without name selection."
+msgstr "不選擇名稱直接儲存目前的遊戲。"
+
+msgid "Quit"
+msgstr "結束"
+
+msgid "Quit out of Heroes of Might and Magic II."
+msgstr "結束 Heroes of Might and Magic II。"
+
+msgid "Change the language of the game."
+msgstr "變更遊戲的語言。"
+
+msgid "Select Game Language"
+msgstr "選擇遊戲語言"
+
+msgid "Change the graphics settings of the game."
+msgstr "變更遊戲的圖形設定。"
+
+msgid "Graphics"
+msgstr "圖形"
+
+msgid "Mouse Cursor"
+msgstr "滑鼠游標"
+
+msgid "Toggle colored cursor on or off. This is only an aesthetic choice."
+msgstr "切換彩色游標的開關。這僅為視覺偏好設定。"
+
+msgid "Interface Type"
+msgstr "介面類型"
+
+msgid "Toggle the type of interface you want to use."
+msgstr "切換要使用的介面類型。"
+
+msgid "Text Support"
+msgstr "文字輔助"
+
+msgid ""
+"Toggle text support mode to output extra information about windows and "
+"events in the game."
+msgstr ""
+"切換文字輔助模式，以輸出關於遊戲視窗和事件的額外資訊。"
+
+msgid ""
+"Map\n"
+"Difficulty"
+msgstr ""
+"地圖\n"
+"難度"
+
+msgid ""
+"Game\n"
+"Difficulty"
+msgstr ""
+"遊戲\n"
+"難度"
+
+msgid "Rating"
+msgstr "評分"
+
+msgid "Map Size"
+msgstr "地圖大小"
+
+msgid "Opponents"
+msgstr "對手"
+
+msgid "Class"
+msgstr "職業"
+
+msgid ""
+"Victory\n"
+"Conditions"
+msgstr ""
+"勝利\n"
+"條件"
+
+msgid ""
+"Loss\n"
+"Conditions"
+msgstr ""
+"失敗\n"
+"條件"
+
+msgid "About"
+msgstr "關於"
+
+msgid "Click to read notes from the map creator."
+msgstr "按一下閱讀地圖製作者的備註。"
+
+msgid "Map Description"
+msgstr "地圖描述"
+
+msgid "First select recipients!"
+msgstr "請先選擇收禮對象！"
+
+msgid "You cannot select %{resource}!"
+msgstr "無法選擇 %{resource}！"
+
+msgid "Set %{resource-type} Count"
+msgstr "設定 %{resource-type} 數量"
+
+msgid "Select Recipients"
+msgstr "選擇收禮對象"
+
+msgid "Your Funds"
+msgstr "你的資金"
+
+msgid "Planned Gift"
+msgstr "計畫贈禮"
+
+msgid "Gift from %{name}"
+msgstr "來自 %{name} 的贈禮"
+
+msgid "Resolution"
+msgstr "解析度"
+
+msgid "Fullscreen"
+msgstr "全螢幕"
+
+msgid "window|Mode"
+msgstr "視窗模式"
+
+msgid "Windowed"
+msgstr "視窗化"
+
+msgid "V-Sync"
+msgstr "垂直同步"
+
+msgid "FPS"
+msgstr "FPS"
+
+msgid "System Info"
+msgstr "系統資訊"
+
+msgid "Nearest"
+msgstr "鄰近取樣"
+
+msgid "Screen Scaling Type"
+msgstr "螢幕縮放類型"
+
+msgid "Linear"
+msgstr "線性"
+
+msgid "Change the resolution of the game."
+msgstr "變更遊戲的解析度。"
+
+msgid "Select Game Resolution"
+msgstr "選擇遊戲解析度"
+
+msgid "Toggle between fullscreen and windowed modes."
+msgstr "切換全螢幕與視窗模式。"
+
+msgid ""
+"Toggle the type of screen scaling you want to use. Linear scaling makes the "
+"resized screen image blurry while nearest scaling preserves the sharpness of "
+"the original game. The nearest scaling looks best on integer scales, for "
+"example 2.0x or 3.0x."
+msgstr ""
+"切換要使用的螢幕縮放類型。線性縮放會使畫面模糊，而鄰近取樣則保留原始遊戲的清"
+"晰度。鄰近取樣在整數倍率 (如 2.0x 或 3.0x) 下效果最佳。"
+
+msgid ""
+"The V-Sync option can be enabled to resolve flickering issues on some "
+"monitors."
+msgstr ""
+"可啟用垂直同步選項來解決某些螢幕上的閃爍問題。"
+
+msgid "Show extra information such as FPS and current time."
+msgstr "顯示額外資訊，例如 FPS 和目前時間。"
+
+msgid "Hotkey: "
+msgstr "快速鍵： "
+
+msgid "Category: "
+msgstr "分類："
+
+msgid "Event: "
+msgstr "事件："
+
+msgid "Hot Keys:"
+msgstr "快速鍵："
+
+msgid "Hide"
+msgstr "隱藏"
+
+msgid "Show"
+msgstr "顯示"
+
+msgid "Army Estimation"
+msgstr "軍隊估算"
+
+msgid "Canonical"
+msgstr "正規"
+
+msgid "Numeric"
+msgstr "數值"
+
+msgid "Toggle interface visibility."
+msgstr "切換介面可見度。"
+
+msgid "Scroll Speed"
+msgstr "捲動速度"
+
+msgid "Sets the speed at which you scroll the window."
+msgstr "調整視窗捲動的速度。"
+
+msgid ""
+"Toggle how army sizes are displayed when right-clicking armies on the "
+"adventure map. \n"
+"\n"
+"Canonical: Army sizes are shown as descriptive text (e.g. \"Few\").\n"
+"\n"
+"Numeric: Army sizes are shown as numeric ranges (e.g. \"1-4\")."
+msgstr ""
+"切換在冒險地圖上右鍵按一下軍隊時的顯示方式。\n"
+"\n"
+"正規：軍隊數量以描述性文字顯示 (例如「少量」)。\n"
+"\n"
+"數值：軍隊數量以數字範圍顯示 (例如「1-4」)。"
+
+msgid "Select Game Language:"
+msgstr "選擇遊戲語言："
+
+msgid "Select Language:"
+msgstr "選擇語言："
+
+msgid "Click to choose the selected language."
+msgstr "按一下選擇所選的語言。"
+
+msgid "%{name} has gained a level."
+msgstr "%{name} 升級了。"
+
+msgid "%{skill} +1"
+msgstr "%{skill} +1"
+
+msgid "You have learned %{skill}."
+msgstr "學會了 %{skill}。"
+
+msgid ""
+"%{name} has gained a level.\n"
+"\n"
+"%{skill} +1"
+msgstr ""
+"%{name} 升級了。\n"
+"\n"
+"%{skill} +1"
+
+msgid ""
+"You may learn either:\n"
+"%{skill1}\n"
+"or\n"
+"%{skill2}"
+msgstr ""
+"可以學習以下其一:\n"
+"%{skill1}\n"
+"或\n"
+"%{skill2}"
+
+msgid "Learn %{secondary-skill}"
+msgstr "學習 %{secondary-skill}"
+
+msgid "n/a"
+msgstr "不適用"
+
+msgid ""
+"Please inspect our fine wares. If you feel like offering a trade, click on "
+"the items you wish to trade with and for."
+msgstr ""
+"請瀏覽我們的精美商品。若有意交易，請按一下要交易的物品。"
+
+msgid ""
+"You have received quite a bargain. I expect to make no profit on the deal. "
+"Can I interest you in any of my other wares?"
+msgstr ""
+"你得到了相當划算的交易，我預計不會有任何利潤。還對我的其他商品感興趣嗎？"
+
+msgid "I can offer you %{count} for 1 unit of %{resfrom}."
+msgstr "可以提供 %{count} 換取 1 單位的 %{resfrom}。"
+
+msgid "I can offer you 1 unit of %{resto} for %{count} units of %{resfrom}."
+msgstr "可以提供 1 單位的 %{resto} 換取 %{count} 單位的 %{resfrom}。"
+
+msgid "Min"
+msgstr "最小"
+
+msgid "Qty to trade"
+msgstr "交易數量"
+
+msgid "Trading Post"
+msgstr "交易站"
+
+msgid "Your Resources"
+msgstr "你的資源"
+
+msgid "Available Trades"
+msgstr "可用交易"
+
+msgid "guarded by %{count} %{monster}"
+msgstr "由 %{count} 個 %{monster} 守衛"
+
+msgid "guarded by "
+msgstr "守衛者："
+
+msgid "(available: %{count})"
+msgstr "(可用：%{count})"
+
+msgid "(empty)"
+msgstr "(空)"
+
+msgid "already learned"
+msgstr "已學會"
+
+msgid "treeOfKnowledge|free"
+msgstr "免費"
+
+msgid "already claimed"
+msgstr "已領取"
+
+msgid "not claimed"
+msgstr "未領取"
+
+msgid "already knows this skill"
+msgstr "已知曉此技能"
+
+msgid "already has max skills"
+msgstr "技能數已滿"
+
+msgid "(already visited)"
+msgstr "(已造訪)"
+
+msgid "(not visited)"
+msgstr "(未造訪)"
+
+msgid "%{color} Barrier"
+msgstr "%{color}屏障"
+
+msgid "(tent visited)"
+msgstr "(帳篷已造訪)"
+
+msgid "%{color} Tent"
+msgstr "%{color}帳篷"
+
+msgid "Road"
+msgstr "道路"
+
+msgid "(digging ok)"
+msgstr "(可挖掘)"
+
+msgid "(no digging)"
+msgstr "(無法挖掘)"
+
+msgid "penalty: %{cost}"
+msgstr "懲罰：%{cost}"
+
+msgid "Defenders:"
+msgstr "守衛者："
+
+msgid "Unknown"
+msgstr "未知"
+
+msgid "heroQuickInfo|(Level %{level})"
+msgstr "(等級 %{level})"
+
+msgid "Attack:"
+msgstr "攻擊："
+
+msgid "Defense:"
+msgstr "防禦："
+
+msgid "Spell Power:"
+msgstr "魔法力量："
+
+msgid "Knowledge:"
+msgstr "知識："
+
+msgid "Spell Points:"
+msgstr "魔法值："
+
+msgid "Move Points:"
+msgstr "移動力："
+
+msgid "Uncharted Territory"
+msgstr "未探索區域"
+
+msgid "Random Map Generator"
+msgstr "隨機地圖產生器"
+
+msgid "rmg|Player count:"
+msgstr "玩家數量："
+
+msgid "rmg|Map layout:"
+msgstr "地圖佈局："
+
+msgid "rmg|Water percentage:"
+msgstr "水域百分比："
+
+msgid "rmg|Monster strength:"
+msgstr "怪物強度："
+
+msgid "rmg|Resource availability:"
+msgstr "資源可用性："
+
+msgid "rmg|Map seed:"
+msgstr "地圖種子碼："
+
+msgid "Click to generate a new map."
+msgstr "按一下產生新地圖。"
+
+msgid "Return to the previous menu."
+msgstr "返回上一個選單。"
+
+msgid "Cost per troop:"
+msgstr "每支部隊花費："
+
+msgid "Available: %{count}"
+msgstr "可用：%{count}"
+
+msgid "Number to buy:"
+msgstr "購買數量："
+
+msgid "Recruit selected monsters."
+msgstr "招募選取的怪物。"
+
+msgid "Select maximum monsters to be recruited."
+msgstr "選擇最大招募數量。"
+
+msgid "Select only 1 monster to be recruited."
+msgstr "選擇僅招募 1 個怪物。"
+
+msgid "Select this game resolution."
+msgstr "選擇此遊戲解析度。"
+
+msgid ""
+"Selecting this resolution will set a resolution that is scaled from the "
+"original resolution (%{resolution}) by multiplying it with the number in the "
+"brackets (%{scale}).\n"
+"\n"
+"A resolution with a clean integer number (2.0x, 3.0x etc.) will usually look "
+"better because the pixels are upscaled evenly in both horizontal and "
+"vertical directions."
+msgstr ""
+"選擇此解析度將以原始解析度 (%{resolution}) 乘以括號中的數字 (%{scale}) 來設"
+"定。\n"
+"\n"
+"使用整數倍率 (2.0x、3.0x 等) 的解析度通常看起來更好，因為畫素在水平和垂直方向"
+"上均勻放大。"
+
+msgid "Select Game Resolution:"
+msgstr "選擇遊戲解析度："
+
+msgid "Click to apply the selected resolution."
+msgstr "按一下套用選取的解析度。"
+
+msgid "Click to select the maximum amount."
+msgstr "按一下選擇最大數量。"
+
+msgid "Click to select the minimum amount."
+msgstr "按一下選擇最小數量。"
+
+msgid "Click to apply the entered number."
+msgstr "按一下套用輸入的數字。"
+
+msgid "Click to apply the entered text."
+msgstr "按一下套用輸入的文字。"
+
+msgid "Click to open the Virtual Keyboard dialog."
+msgstr "按一下開啟虛擬鍵盤對話方塊。"
+
+msgid "Open Virtual Keyboard"
+msgstr "開啟虛擬鍵盤"
+
+msgid "How many creatures do you wish to move?"
+msgstr "要移動多少生物？"
+
+msgid "Select how many units to separate into:"
+msgstr "選擇要分出多少單位："
+
+msgid "Map: "
+msgstr "地圖："
+
+msgid ""
+"\n"
+"\n"
+"Month: "
+msgstr ""
+"\n"
+"\n"
+"月："
+
+msgid ", Week: "
+msgstr "，週："
+
+msgid ", Day: "
+msgstr "，日："
+
+msgid ""
+"\n"
+"\n"
+"Location: "
+msgstr ""
+"\n"
+"\n"
+"位置："
+
+msgid "saveLoadDialog|Name"
+msgstr "名稱"
+
+msgid "saveLoadDialog|Date"
+msgstr "日期"
+
+msgid "Are you sure you want to delete file:"
+msgstr "確定要刪除此檔案嗎："
+
+msgid "Warning"
+msgstr "警告"
+
+msgid "Click to save the current game."
+msgstr "按一下儲存目前的遊戲。"
+
+msgid "Click to load a previously saved game."
+msgstr "按一下載入先前儲存的遊戲。"
+
+msgid "Click here if you wish to sort save files by their name."
+msgstr "按此處以依名稱排序存檔。"
+
+msgid "Sort by Name"
+msgstr "依名稱排序"
+
+msgid ""
+"Click here if you you wish to sort save files by their last modified date."
+msgstr ""
+"按此處以依修改日期排序存檔。"
+
+msgid "Sort by Date"
+msgstr "依日期排序"
+
+msgid "File to Save:"
+msgstr "儲存檔案："
+
+msgid "File to Load:"
+msgstr "載入檔案："
+
+msgid "Terrain object"
+msgstr "地形物件"
+
+msgid "There is nothing to select from."
+msgstr "沒有可選擇的選項。"
+
+msgid "There are no castles to select from."
+msgstr "沒有可選擇的城堡。"
+
+msgid "Accept the choice made."
+msgstr "確認所做的選擇。"
+
+msgid "Click to enable all items."
+msgstr "按一下啟用所有選項。"
+
+msgid "Enable All Items"
+msgstr "啟用所有選項"
+
+msgid "Click to disable all items."
+msgstr "按一下停用所有選項。"
+
+msgid "Disable All Items"
+msgstr "停用所有選項"
+
+msgid "There are no secondary skills to select from."
+msgstr "沒有可選擇的次要技能。"
+
+msgid "Select Skill:"
+msgstr "選擇技能："
+
+msgid "There are no spells to select."
+msgstr "沒有可選擇的法術。"
+
+msgid "Select Spell:"
+msgstr "選擇法術："
+
+msgid "There are no artifacts to select from."
+msgstr "沒有可選擇的神器。"
+
+msgid "Select Artifact:"
+msgstr "選擇神器："
+
+msgid "There are no monsters to select from."
+msgstr "沒有可選擇的怪物。"
+
+msgid "Select Monster:"
+msgstr "選擇怪物："
+
+msgid "There are no heroes to select from."
+msgstr "沒有可選擇的英雄。"
+
+msgid "Select Hero:"
+msgstr "選擇英雄："
+
+msgid "Select Monsters:"
+msgstr "選擇怪物："
+
+msgid "Select Artifacts:"
+msgstr "選擇神器："
+
+msgid "race|Random"
+msgstr "隨機"
+
+msgid "Click to start placing the selected hero."
+msgstr "按一下開始放置選取的英雄。"
+
+msgid "%{color} %{race}"
+msgstr "%{color} %{race}"
+
+msgid "You will place"
+msgstr "你將放置"
+
+msgid "Click to select this class."
+msgstr "按一下選擇此職業。"
+
+msgid "Click to select this color."
+msgstr "按一下選擇此顏色。"
+
+msgid "Select Treasure:"
+msgstr "選擇寶藏："
+
+msgid "Select Ocean Object:"
+msgstr "選擇海洋物件："
+
+msgid "Castle/town placing:"
+msgstr "城堡/城鎮放置："
+
+msgid "doubleLinedRace|Neutral"
+msgstr "中立"
+
+msgid "TOWN"
+msgstr "城鎮"
+
+msgid "CASTLE"
+msgstr "城堡"
+
+msgid "Click to start placing the selected castle/town."
+msgstr "按一下開始放置選取的城堡/城鎮。"
+
+msgid "Click to select town placing."
+msgstr "按一下選擇城鎮放置。"
+
+msgid "Click to select castle placing."
+msgstr "按一下選擇城堡放置。"
+
+msgid "%{color} %{race} %{townOrCastle}"
+msgstr "%{color} %{race} %{townOrCastle}"
+
+msgid "race|Neutral"
+msgstr "中立"
+
+msgid "Select Dwelling:"
+msgstr "選擇住所："
+
+msgid "Select Landscape Object:"
+msgstr "選擇地景物件："
+
+msgid "Mine placing:"
+msgstr "礦場放置："
+
+msgid ""
+"Resource\n"
+"type:"
+msgstr ""
+"資源\n"
+"類型："
+
+msgid "%{mineName} appearance:"
+msgstr "%{mineName} 外觀："
+
+msgid "Click to select the color."
+msgstr "按一下選擇顏色。"
+
+msgid "Click to select %{object} as the resource generator to be placed."
+msgstr "按一下選擇 %{object} 作為要放置的資源產生器。"
+
+msgid "Select Mountain Object:"
+msgstr "選擇山脈物件："
+
+msgid "Select Rock Object:"
+msgstr "選擇岩石物件："
+
+msgid "Select Tree Object:"
+msgstr "選擇樹木物件："
+
+msgid "Select Power Up Object:"
+msgstr "選擇增強物件："
+
+msgid "Select Adventure Object:"
+msgstr "選擇冒險物件："
+
+msgid "Select color:"
+msgstr "選擇顏色："
+
+msgid "Players Icon"
+msgstr "玩家圖示"
+
+msgid ""
+"Indicates how many players total are in the scenario. Any positions not "
+"occupied by human players will be occupied by computer players."
+msgstr ""
+"顯示場景中的總玩家數。未被人類玩家佔據的位置將由電腦玩家佔據。"
+
+msgid ""
+"Indicates whether the map\n"
+"is small (36 x 36), medium\n"
+"(72 x 72), large (108 x 108),\n"
+"or extra large (144 x 144)."
+msgstr ""
+"顯示地圖大小是\n"
+"小型 (36 x 36)、中型\n"
+"(72 x 72)、大型 (108 x 108)\n"
+"或超大型 (144 x 144)。"
+
+msgid "Size Icon"
+msgstr "大小圖示"
+
+msgid "The Succession Wars"
+msgstr "繼位戰爭"
+
+msgid "The Price of Loyalty"
+msgstr "忠誠的代價"
+
+msgid "Resurrection"
+msgstr "復甦"
+
+msgid "This map is made for \"%{game-version}\" version of the game."
+msgstr "此地圖是為遊戲的「%{game-version}」版本製作的。"
+
+msgid "Map Type"
+msgstr "地圖類型"
+
+msgid "Map Type:\n"
+msgstr "地圖類型:\n"
+
+msgid ""
+"\n"
+"\n"
+"Supported languages:\n"
+msgstr ""
+"\n"
+"\n"
+"支援的語言:\n"
+
+msgid "Lose all your heroes and towns."
+msgstr "失去所有英雄和城鎮。"
+
+msgid "Lose a specific town."
+msgstr "失去特定城鎮。"
+
+msgid "Lose a specific hero."
+msgstr "失去特定英雄。"
+
+msgid "Run out of time. Fail to win by a certain point."
+msgstr "時間耗盡，未能在期限前獲勝。"
+
+msgid "Loss Condition"
+msgstr "失敗條件"
+
+msgid "Defeat all enemy heroes and towns."
+msgstr "擊敗所有敵方英雄和城鎮。"
+
+msgid "Capture a specific town."
+msgstr "佔領特定城鎮。"
+
+msgid "Defeat a specific hero."
+msgstr "擊敗特定英雄。"
+
+msgid "Find a specific artifact."
+msgstr "找到特定神器。"
+
+msgid "Your side must defeat the opposing side."
+msgstr "必須擊敗對方。"
+
+msgid "Accumulate a large amount of gold."
+msgstr "累積大量黃金。"
+
+msgid "Victory Condition"
+msgstr "勝利條件"
+
+msgid "Map difficulty:"
+msgstr "地圖難度："
+
+msgid "N"
+msgstr "N"
+
+msgid "Are you sure you want to delete the map:"
+msgstr "確定要刪除此地圖嗎："
+
+msgid "No maps exist at that size."
+msgstr "沒有該大小的地圖。"
+
+msgid "Small Maps"
+msgstr "小型地圖"
+
+msgid "View only maps of size small (36 x 36)."
+msgstr "僅顯示小型 (36 x 36) 地圖。"
+
+msgid "Medium Maps"
+msgstr "中型地圖"
+
+msgid "View only maps of size medium (72 x 72)."
+msgstr "僅顯示中型 (72 x 72) 地圖。"
+
+msgid "Large Maps"
+msgstr "大型地圖"
+
+msgid "View only maps of size large (108 x 108)."
+msgstr "僅顯示大型 (108 x 108) 地圖。"
+
+msgid "Extra Large Maps"
+msgstr "超大地圖"
+
+msgid "View only maps of size extra large (144 x 144)."
+msgstr "僅顯示超大型 (144 x 144) 地圖。"
+
+msgid "All Maps"
+msgstr "所有地圖"
+
+msgid "View all maps, regardless of size."
+msgstr "顯示所有地圖，不限大小。"
+
+msgid "Selected Name"
+msgstr "選取的名稱"
+
+msgid "The name of the currently selected map."
+msgstr "目前選取地圖的名稱。"
+
+msgid "Selected Map Difficulty"
+msgstr "選取地圖的難度"
+
+msgid ""
+"The map difficulty of the currently selected map. The map difficulty is "
+"determined by the scenario designer. More difficult maps might include more "
+"or stronger enemies, fewer resources, or other special conditions making "
+"things tougher for the human player."
+msgstr ""
+"目前選取地圖的難度。地圖難度由場景設計者決定。地圖難度越高，敵人可能越多或越"
+"強、資源越少，或出現其他對人類玩家不利的特殊條件。"
+
+msgid "Selected Map Description"
+msgstr "選取地圖的描述"
+
+msgid "Jump"
+msgstr "跳躍"
+
+msgid "Hero Speed"
+msgstr "英雄速度"
+
+msgid "Don't Show"
+msgstr "不顯示"
+
+msgid "Enemy Speed"
+msgstr "敵方速度"
+
+msgid "Auto Resolve"
+msgstr "自動結算"
+
+msgid "Auto, No Spells"
+msgstr "自動，無法術"
+
+msgid "Battles"
+msgstr "戰鬥"
+
+msgid "combatMode|Manual"
+msgstr "手動"
+
+msgid "Change the speed at which your heroes move on the main screen."
+msgstr "變更英雄在主畫面上的移動速度。"
+
+msgid ""
+"Sets the speed that computer heroes move at. You can also elect not to view "
+"computer movement at all."
+msgstr ""
+"設定電腦英雄的移動速度。也可以選擇完全不顯示電腦的移動。"
+
+msgid "Toggle instant battle mode."
+msgstr "切換即時戰鬥模式。"
+
+msgid "Att."
+msgstr "攻"
+
+msgid "Def."
+msgstr "防"
+
+msgid "Power"
+msgstr "力量"
+
+msgid "Knowl"
+msgstr "知識"
+
+msgid "1st"
+msgstr "第一"
+
+msgid "2nd"
+msgstr "第二"
+
+msgid "3rd"
+msgstr "第三"
+
+msgid "4th"
+msgstr "第四"
+
+msgid "5th"
+msgstr "第五"
+
+msgid "6th"
+msgstr "第六"
+
+msgid "Oracle: Player Rankings"
+msgstr "神諭：玩家排名"
+
+msgid "Thieves' Guild: Player Rankings"
+msgstr "盜賊公會：玩家排名"
+
+msgid "Number of Towns:"
+msgstr "城鎮數："
+
+msgid "Number of Castles:"
+msgstr "城堡數："
+
+msgid "Number of Heroes:"
+msgstr "英雄數："
+
+msgid "Gold in Treasury:"
+msgstr "國庫黃金："
+
+msgid "Wood & Ore:"
+msgstr "木材與礦石："
+
+msgid "Gems, Cr, Slf & Mer:"
+msgstr "寶石、水晶、硫磺與水銀："
+
+msgid "Obelisks Found:"
+msgstr "已發現方尖碑："
+
+msgid "Artifacts:"
+msgstr "神器："
+
+msgid "Total Army Strength:"
+msgstr "軍隊總戰力："
+
+msgid "Income:"
+msgstr "收入："
+
+msgid "Best Hero:"
+msgstr "最佳英雄："
+
+msgid "Best Hero Stats:"
+msgstr "最佳英雄屬性："
+
+msgid "Personality:"
+msgstr "性格："
+
+msgid "Best Monster:"
+msgstr "最強怪物："
+
+msgid "Random Castle Name"
+msgstr "隨機城堡名稱"
+
+msgid "Random Town Name"
+msgstr "隨機城鎮名稱"
+
+msgid "BANNED SPELLS"
+msgstr "停用法術"
+
+msgid "Click to accept the changes made."
+msgstr "按一下接受所做的變更。"
+
+msgid "Exit this dialog, discarding the changes made."
+msgstr "離開此對話方塊，放棄所做的變更。"
+
+msgid "Click to ban spells from appearing in the Mage Guild."
+msgstr "按一下禁止法術出現在法師公會中。"
+
+msgid "Banned Spells"
+msgstr "停用法術"
+
+msgid "Select spells that will appear in the Mage Guild."
+msgstr "選擇將出現在法師公會中的法術。"
+
+msgid "SET SPELLS"
+msgstr "設定法術"
+
+msgid "Allow Castle build"
+msgstr "允許建造城堡"
+
+msgid "Default Buildings"
+msgstr "預設建築"
+
+msgid "RESTRICT"
+msgstr "限制"
+
+msgid "Default Army"
+msgstr "預設軍隊"
+
+msgid "Castle Army"
+msgstr "城堡軍隊"
+
+msgid "Town Army"
+msgstr "城鎮軍隊"
+
+msgid "You have unsaved changes. Do you wish to proceed?"
+msgstr "有未儲存的變更。確定要繼續嗎？"
+
+msgid "Click to change the Castle name."
+msgstr "按一下變更城堡名稱。"
+
+msgid "Enter Castle name:"
+msgstr "輸入城堡名稱："
+
+msgid "Reset the Castle name."
+msgstr "重置城堡名稱。"
+
+msgid "Allow to build a castle in this town."
+msgstr "允許在此城鎮建造城堡。"
+
+msgid "Toggle the use of default buildings. Custom buildings will be reset!"
+msgstr "切換使用預設建築。自訂建築將被重置！"
+
+msgid "Toggle building construction restriction mode."
+msgstr "切換建築建造限制模式。"
+
+msgid "Restrict Building Construction"
+msgstr "限制建築建造"
+
+msgid "Use default defenders army."
+msgstr "使用預設守軍。"
+
+msgid "Reset the army."
+msgstr "重置軍隊。"
+
+msgid "Set custom Castle Army."
+msgstr "設定自訂城堡軍隊。"
+
+msgid "Set spells to appear in the Mage Guild."
+msgstr "設定出現在法師公會中的法術。"
+
+msgid "Set Spells"
+msgstr "設定法術"
+
+msgid "Castle Settings"
+msgstr "城堡設定"
+
+msgid "Message Text:"
+msgstr "訊息文字："
+
+msgid "Reward:"
+msgstr "獎勵："
+
+msgid "Player colors allowed to get event:"
+msgstr "允許取得事件的玩家顏色："
+
+msgid "Computer colors allowed to get event:"
+msgstr "允許取得事件的電腦顏色："
+
+msgid "First day of occurrence:"
+msgstr "首次發生日："
+
+msgid "Repeat period (days):"
+msgstr "重複週期 (天):"
+
+msgid "Allow %{color} human player to get event"
+msgstr "允許 %{color} 人類玩家取得事件"
+
+msgid ""
+"If this checkbox is checked, this event will trigger for the %{color} player "
+"if they are controlled by a human."
+msgstr ""
+"勾選此選項且 %{color} 玩家由人類控制時，此事件就會觸發。"
+
+msgid "Allow %{color} computer player to get event"
+msgstr "允許 %{color} 電腦玩家取得事件"
+
+msgid ""
+"If this checkbox is checked, this event will trigger for the %{color} player "
+"if they are controlled by a computer."
+msgstr ""
+"勾選此選項且 %{color} 玩家由電腦控制時，此事件就會觸發。"
+
+msgid "Set %{resource-type} Count:"
+msgstr "設定 %{resource-type} 數量："
+
+msgid "Message:"
+msgstr "訊息："
+
+msgid "Click to save the Event properties."
+msgstr "按一下儲存事件屬性。"
+
+msgid "No resources will be given as a reward."
+msgstr "不會給予任何資源作為獎勵。"
+
+msgid "Resources"
+msgstr "資源"
+
+msgid "Resources will be given as a reward."
+msgstr "將給予資源作為獎勵。"
+
+msgid "Click here to change the event message."
+msgstr "按此處變更事件訊息。"
+
+msgid "Event Message Text"
+msgstr "事件訊息文字"
+
+msgid "Day: %{day}"
+msgstr "日：%{day}"
+
+msgid "Daily events:"
+msgstr "每日事件："
+
+msgid "Click to save the events."
+msgstr "按一下儲存事件。"
+
+msgid "Add Event"
+msgstr "新增事件"
+
+msgid "Add an additional event."
+msgstr "新增額外的事件。"
+
+msgid "Edit Event"
+msgstr "編輯事件"
+
+msgid "Edit an existing event."
+msgstr "編輯既有的事件。"
+
+msgid "Delete Event"
+msgstr "刪除事件"
+
+msgid "Delete an existing event."
+msgstr "刪除既有的事件。"
+
+msgid "Effects:"
+msgstr "效果："
+
+msgid "Conditions:"
+msgstr "條件："
+
+msgid "Cancel event after first visit"
+msgstr "首次造訪後取消事件"
+
+msgid "Computer colors allowed to get the event:"
+msgstr "允許取得事件的電腦顏色："
+
+msgid "Set Experience value:"
+msgstr "設定經驗值："
+
+msgid "Artifact"
+msgstr "神器"
+
+msgid "No artifact will be given by the event."
+msgstr "此事件不會給予任何神器。"
+
+msgid "Delete Artifact"
+msgstr "刪除神器"
+
+msgid "Delete an artifact from the event."
+msgstr "從事件中刪除神器。"
+
+msgid "No Secondary Skill will be given by the event."
+msgstr "此事件不會給予任何次要技能。"
+
+msgid "Secondary Skill"
+msgstr "次要技能"
+
+msgid "Delete Secondary Skill"
+msgstr "刪除次要技能"
+
+msgid "Delete the Secondary Skill from the event."
+msgstr "從事件中刪除次要技能。"
+
+msgid "No resources will be part of this event."
+msgstr "此事件不包含任何資源。"
+
+msgid "These resources will be a part of the event."
+msgstr "這些資源將成為事件的一部分。"
+
+msgid ""
+"If this checkbox is checked, the event will trigger only once. If not "
+"checked, the event will trigger every time one of the specified players "
+"crosses the event tile."
+msgstr ""
+"勾選此選項後，事件只會觸發一次。若未勾選，每次指定的玩家經過事件格時都會觸"
+"發。"
+
+msgid "Click to make selection."
+msgstr "按一下進行選擇。"
+
+msgid "%{objects} cannot be placed on water."
+msgstr "%{objects} 無法放置在水上。"
+
+msgid ""
+"The Ultimate Artifact can only be placed on terrain where digging is "
+"possible."
+msgstr ""
+"終極神器只能放置在可挖掘的地形上。"
+
+msgid "%{objects} must be placed on water."
+msgstr "%{objects} 必須放置在水上。"
+
+msgid "Action objects cannot be placed outside the map."
+msgstr "動作物件無法放置在地圖外。"
+
+msgid "Action objects must be placed on clear tiles."
+msgstr "動作物件必須放置在空白格上。"
+
+msgid "A maximum of %{count} %{objects} can be placed on the map."
+msgstr "地圖上最多可放置 %{count} 個 %{objects}。"
+
+msgid "Not able to generate a map with given parameters."
+msgstr "無法以指定參數產生地圖。"
+
+msgid ""
+"Do you wish to return to the game's Main Menu? All unsaved changes will be "
+"lost."
+msgstr ""
+"確定要返回遊戲主選單嗎？所有未儲存的變更將會遺失。"
+
+msgid "Editor"
+msgstr "編輯器"
+
+msgid ""
+"Are you sure you want to load a new map? (Any unsaved changes to the current "
+"map will be lost.)"
+msgstr ""
+"確定要載入新地圖嗎？（目前地圖所有未儲存的變更將會遺失。）"
+
+msgid ""
+"Are you sure you want to create a new map? (Any unsaved changes to the "
+"current map will be lost.)"
+msgstr ""
+"確定要建立新地圖嗎？（目前地圖所有未儲存的變更將會遺失。）"
+
+msgid "Main Menu"
+msgstr "主選單"
+
+msgid ""
+"Do you wish to return to the game's Main Menu? (Any unsaved changes to the "
+"current map will be lost.)"
+msgstr ""
+"確定要返回遊戲主選單嗎？（目前地圖所有未儲存的變更將會遺失。）"
+
+msgid "Unsaved Changes"
+msgstr "未儲存的變更"
+
+msgid ""
+"This map has either terrain changes, undo history or has not yet been saved "
+"to a file.\n"
+"\n"
+"Do you wish to save the current map?"
+msgstr ""
+"此地圖有地形變更、復原歷史紀錄或尚未儲存至檔案。\n"
+"\n"
+"是否要儲存目前的地圖？"
+
+msgid "Unplayable Map"
+msgstr "無法遊玩的地圖"
+
+msgid ""
+"This map is not playable. You need at least one human player for the map to "
+"be playable."
+msgstr ""
+"此地圖無法遊玩。至少需要一位人類玩家才能遊玩。"
+
+msgid "Start Map"
+msgstr "開始地圖"
+
+msgid ""
+"Do you wish to leave the Editor and start the map? (Any unsaved changes to "
+"the current map will be lost.)"
+msgstr ""
+"確定要離開編輯器並開始地圖嗎？（目前地圖所有未儲存的變更將會遺失。）"
+
+msgid "Create a new map from scratch."
+msgstr "從頭建立新地圖。"
+
+msgid "New Map"
+msgstr "新地圖"
+
+msgid "Load Map"
+msgstr "載入地圖"
+
+msgid "Load an existing map."
+msgstr "載入既有的地圖。"
+
+msgid "Save Map"
+msgstr "儲存地圖"
+
+msgid "Save the current map."
+msgstr "儲存目前的地圖。"
+
+msgid "Quit out of the map editor."
+msgstr "離開地圖編輯器。"
+
+msgid "Return to the game's Main Menu."
+msgstr "返回遊戲主選單。"
+
+msgid "Leave the Editor and play the map in the Standard Game mode."
+msgstr "離開編輯器，以標準遊戲模式遊玩此地圖。"
+
+msgid "Input %{object} text:"
+msgstr "輸入 %{object} 文字："
+
+msgid "Set Random Ultimate Artifact Radius:"
+msgstr "設定隨機終極神器半徑："
+
+msgid "%{object} has no properties to change."
+msgstr "%{object} 沒有可變更的屬性。"
+
+msgid "This artifact"
+msgstr "此神器"
+
+msgid "The total number of obelisks is %{count}."
+msgstr "方尖碑總數為 %{count}。"
+
+msgid "There are no players on the map, so no one can own this object."
+msgstr "地圖上沒有玩家，因此無人可擁有此物件。"
+
+msgid "Roads"
+msgstr "道路"
+
+msgid "Streams"
+msgstr "溪流"
+
+msgid ""
+"A maximum of %{count} heroes including jailed heroes can be placed on the "
+"map."
+msgstr ""
+"地圖上最多可放置 %{count} 位英雄（含被囚禁的英雄）。"
+
+msgid ""
+"A maximum of %{count} heroes of the same color can be placed on the map."
+msgstr ""
+"地圖上最多可放置 %{count} 位相同顏色的英雄。"
+
+msgid "Failed to update player information."
+msgstr "更新玩家資訊失敗。"
+
+msgid "Only one Random Ultimate Artifact can be placed on the map."
+msgstr "地圖上只能放置一個隨機終極神器。"
+
+msgid "A maximum of %{count} obelisks can be placed on the map."
+msgstr "地圖上最多可放置 %{count} 座方尖碑。"
+
+msgid "The same object exists on the tile."
+msgstr "此格上已存在相同的物件。"
+
+msgid "The map is corrupted."
+msgstr "地圖已損壞。"
+
+msgid "Unable to locate data directory to save the map."
+msgstr "無法找到儲存地圖的資料目錄。"
+
+msgid "Unable to create a directory to save the map."
+msgstr "無法建立儲存地圖的目錄。"
+
+msgid "Unable to locate a directory to save the map."
+msgstr "無法找到儲存地圖的目錄。"
+
+msgid "Are you sure you want to overwrite the existing map?"
+msgstr "確定要覆寫既有的地圖嗎？"
+
+msgid "Map saved to: "
+msgstr "地圖已儲存至："
+
+msgid "Failed to save the map."
+msgstr "地圖儲存失敗。"
+
+msgid "Used to place %{object}."
+msgstr "用於放置 %{object}。"
+
+msgid "Select object type"
+msgstr "選擇物件類型"
+
+msgid ""
+"Click here to\n"
+"select a monster."
+msgstr ""
+"按此處\n"
+"選擇怪物。"
+
+msgid ""
+"Click here to\n"
+"select another monster."
+msgstr ""
+"按此處\n"
+"選擇另一個怪物。"
+
+msgid "Erase"
+msgstr "清除"
+
+msgid "Mountains"
+msgstr "山脈"
+
+msgid "Rocks"
+msgstr "岩石"
+
+msgid "Trees"
+msgstr "樹木"
+
+msgid "Water Objects"
+msgstr "水域物件"
+
+msgid "Miscellaneous"
+msgstr "雜項"
+
+msgid "Artifacts"
+msgstr "神器"
+
+msgid "Dwellings"
+msgstr "住所"
+
+msgid "Mines"
+msgstr "礦場"
+
+msgid "Power-ups"
+msgstr "增強物件"
+
+msgid "Treasures"
+msgstr "寶藏"
+
+msgid "Heroes"
+msgstr "英雄"
+
+msgid "Towns"
+msgstr "城鎮"
+
+msgid "editorDetailMode|Edit"
+msgstr "編輯"
+
+msgid "editorDetailMode|Move"
+msgstr "移動"
+
+msgid "editorDetailMode|Copy"
+msgstr "複製"
+
+msgid "editorErasure|Mountains"
+msgstr "山脈"
+
+msgid "editorErasure|Rocks"
+msgstr "岩石"
+
+msgid "editorErasure|Trees"
+msgstr "樹木"
+
+msgid "editorErasure|Miscellaneous and Water landscape objects"
+msgstr "雜項與水域地景物件"
+
+msgid "editorErasure|Adventure non pickable objects"
+msgstr "不可拾取的冒險物件"
+
+msgid "editorErasure|Castles"
+msgstr "城堡"
+
+msgid "editorErasure|Adventure pickable objects"
+msgstr "可拾取的冒險物件"
+
+msgid "editorErasure|Monsters"
+msgstr "怪物"
+
+msgid "editorErasure|Heroes"
+msgstr "英雄"
+
+msgid "editorErasure|Roads"
+msgstr "道路"
+
+msgid "editorErasure|Streams"
+msgstr "溪流"
+
+msgid ""
+"Draws terrain in\n"
+"%{size} by %{size} square increments."
+msgstr ""
+"以 %{size} x %{size} 格為單位\n"
+"繪製地形。"
+
+msgid ""
+"Erases objects in\n"
+"%{size} by %{size} square increments."
+msgstr ""
+"以 %{size} x %{size} 格為單位\n"
+"清除物件。"
+
+msgid "Small Brush"
+msgstr "小筆刷"
+
+msgid "Medium Brush"
+msgstr "中筆刷"
+
+msgid "Large Brush"
+msgstr "大筆刷"
+
+msgid "Area Fill"
+msgstr "區域填充"
+
+msgid "Used to click and drag for filling in large areas."
+msgstr "按住並拖曳以填充大範圍區域。"
+
+msgid "Clear Area"
+msgstr "清除區域"
+
+msgid "Used to click and drag for clearing large areas."
+msgstr "按住並拖曳以清除大範圍區域。"
+
+msgid ""
+"Costs %{rate} times normal movement for all heroes. (Pathfinding reduces or "
+"eliminates the penalty.)"
+msgstr ""
+"所有英雄經過時需消耗正常移動力的 %{rate} 倍。（尋路技能可降低或消除此懲罰。）"
+
+msgid "Traversable only by boat."
+msgstr "只能以船隻通行。"
+
+msgid "No special modifiers."
+msgstr "無特殊修飾。"
+
+msgid "Edit objects on the Adventure Map."
+msgstr "編輯冒險地圖上的物件。"
+
+msgid "Move objects on the Adventure Map."
+msgstr "移動冒險地圖上的物件。"
+
+msgid "Copy objects on the Adventure Map."
+msgstr "複製冒險地圖上的物件。"
+
+msgid "Toggle the erasure of %{type} objects."
+msgstr "切換 %{type} 物件的清除。"
+
+msgid ""
+"Objects of this type will be deleted with the Erase tool. Left-click here to "
+"deselect this type. Press and hold this button to deselect all other object "
+"types."
+msgstr ""
+"此類型的物件將被清除工具刪除。左鍵按一下此處取消選取此類型。長按此按鈕取消選"
+"取所有其他物件類型。"
+
+msgid ""
+"Objects of this type will NOT be deleted with the Erase tool. Left-click "
+"here to select this type. Press and hold this button to select all other "
+"object types."
+msgstr ""
+"此類型的物件不會被清除工具刪除。左鍵按一下此處選取此類型。長按此按鈕選取所有"
+"其他物件類型。"
+
+msgid "Terrain Mode"
+msgstr "地形模式"
+
+msgid "Used to draw the underlying grass, dirt, water, etc. on the map."
+msgstr "用於在地圖上繪製草地、泥土、水域等基礎地形。"
+
+msgid "Landscape Objects Mode"
+msgstr "地景物件模式"
+
+msgid ""
+"Used to place landscape objects (mountains, rocks, trees, etc.) on the map."
+msgstr ""
+"用於在地圖上放置地景物件（山脈、岩石、樹木等）。"
+
+msgid "Detail Mode"
+msgstr "細節模式"
+
+msgid "Used for moving or customizing objects."
+msgstr "用於移動或自訂物件。"
+
+msgid "Adventure Objects Mode"
+msgstr "冒險物件模式"
+
+msgid ""
+"Used to place adventure objects (artifacts, dwellings, mines, treasures, "
+"etc.) on the map."
+msgstr ""
+"用於在地圖上放置冒險物件（神器、住所、礦場、寶藏等）。"
+
+msgid "Kingdom Objects Mode"
+msgstr "王國物件模式"
+
+msgid "Used to place kingdom objects (towns, castles and heroes) on the map."
+msgstr "用於在地圖上放置王國物件 (城鎮、城堡和英雄)。"
+
+msgid "Monsters Mode"
+msgstr "怪物模式"
+
+msgid "Used to place monsters on the map."
+msgstr "用於在地圖上放置怪物。"
+
+msgid "Allows you to draw streams by clicking and dragging."
+msgstr "按住並拖曳以繪製溪流。"
+
+msgid "Stream Mode"
+msgstr "溪流模式"
+
+msgid "Allows you to draw roads by clicking and dragging."
+msgstr "按住並拖曳以繪製道路。"
+
+msgid "Road Mode"
+msgstr "道路模式"
+
+msgid "Erase Mode"
+msgstr "清除模式"
+
+msgid "Used to erase objects from the map."
+msgstr "用於清除地圖上的物件。"
+
+msgid "Change between zoom and normal view."
+msgstr "切換縮放與正常檢視。"
+
+msgid "Magnify"
+msgstr "放大"
+
+msgid "Undo"
+msgstr "復原"
+
+msgid "Undo your last action."
+msgstr "復原上一個動作。"
+
+msgid "Redo"
+msgstr "重做"
+
+msgid "Redo the last undone action."
+msgstr "重做上一個復原的動作。"
+
+msgid "Edit map title, description, and other general information."
+msgstr "編輯地圖示題、描述和其他一般資訊。"
+
+msgid "Specifications"
+msgstr "規格"
+
+msgid "File Options"
+msgstr "檔案選項"
+
+msgid ""
+"Open the file options menu, where you can save or load maps, or quit out of "
+"the editor."
+msgstr ""
+"開啟檔案選項選單，可儲存或載入地圖，或離開編輯器。"
+
+msgid "View the editor system options, which let you customize the editor."
+msgstr "檢視編輯器系統選項，可自訂編輯器。"
+
+msgid "Supported languages:"
+msgstr "支援的語言："
+
+msgid "Language"
+msgstr "語言"
+
+msgid "This language already exists in the list."
+msgstr "此語言已存在於列表中。"
+
+msgid "A map should have at least one language."
+msgstr "地圖至少應有一種語言。"
+
+msgid "Click to apply changes."
+msgstr "按一下套用變更。"
+
+msgid "Add Language"
+msgstr "新增語言"
+
+msgid "Add an additional language."
+msgstr "新增額外的語言。"
+
+msgid "Delete Language"
+msgstr "刪除語言"
+
+msgid "Delete an existing language."
+msgstr "刪除既有的語言。"
+
+msgid "Failed to generate a random map with given parameters."
+msgstr "無法以指定參數產生隨機地圖。"
+
+msgid ""
+"Create a new map, either from scratch or using the random map generator."
+msgstr ""
+"建立新地圖，可從頭開始或使用隨機地圖產生器。"
+
+msgid "Exit the Editor and return to the game's Main Menu."
+msgstr "離開編輯器並返回遊戲主選單。"
+
+msgid "From Scratch"
+msgstr "從頭開始"
+
+msgid "Start from scratch with a blank map."
+msgstr "從空白地圖開始。"
+
+msgid "Create a randomly generated map."
+msgstr "建立隨機產生的地圖。"
+
+msgid "Random"
+msgstr "隨機"
+
+msgid "Back"
+msgstr "返回"
+
+msgid "Return to the Editor's main menu options."
+msgstr "返回編輯器主選單。"
+
+msgid ""
+"Generate a random map that is %{size} squares wide and %{size} squares high."
+msgstr ""
+"產生一張 %{size} x %{size} 格的隨機地圖。"
+
+msgid "Create a map that is %{size} squares wide and %{size} squares high."
+msgstr "建立一張 %{size} x %{size} 格的地圖。"
+
+msgid "Return to the previous menu options."
+msgstr "返回上一個選單。"
+
+msgid "No maps available!"
+msgstr "沒有可用的地圖！"
+
+msgid "[%{pos}]: %{race} hero"
+msgstr "[%{pos}]: %{race} 英雄"
+
+msgid "[%{pos}]: %{name}, %{race} hero"
+msgstr "[%{pos}]: %{name}，%{race} 英雄"
+
+msgid "[%{pos}]: %{race} castle"
+msgstr "[%{pos}]: %{race} 城堡"
+
+msgid "[%{pos}]: %{race} town"
+msgstr "[%{pos}]: %{race} 城鎮"
+
+msgid "[%{pos}]: %{name}, %{race} castle"
+msgstr "[%{pos}]: %{name}，%{race} 城堡"
+
+msgid "[%{pos}]: %{name}, %{race} town"
+msgstr "[%{pos}]: %{name}，%{race} 城鎮"
+
+msgid "None."
+msgstr "無。"
+
+msgid "One side defeats the other."
+msgstr "一方擊敗另一方。"
+
+msgid "Accumulate gold."
+msgstr "累積黃金。"
+
+msgid "Run out of time."
+msgstr "時間耗盡。"
+
+msgid "alliance|1st"
+msgstr "第一"
+
+msgid "alliance|2nd"
+msgstr "第二"
+
+msgid "alliance|3rd"
+msgstr "第三"
+
+msgid "alliance|4th"
+msgstr "第四"
+
+msgid "alliance|5th"
+msgstr "第五"
+
+msgid "Special Loss Condition"
+msgstr "特殊失敗條件"
+
+msgid "Special Victory Condition"
+msgstr "特殊勝利條件"
+
+msgid "Allow standard victory conditions"
+msgstr "允許標準勝利條件"
+
+msgid "Allow this condition also for AI"
+msgstr "同時允許 AI 使用此條件"
+
+msgid "Set alliances:"
+msgstr "設定聯盟："
+
+msgid "{%number} alliance: "
+msgstr "第 {%number} 聯盟："
+
+msgid "Gold:"
+msgstr "黃金："
+
+msgid "Select a Town to capture to achieve victory"
+msgstr "選擇要佔領以獲勝的城鎮"
+
+msgid "Click here to change the town needed to capture to achieve victory."
+msgstr "按此處變更需要佔領以獲勝的城鎮。"
+
+msgid "Select a Hero to defeat to achieve victory"
+msgstr "選擇要擊敗以獲勝的英雄"
+
+msgid "Click here to change the hero needed to defeat to achieve victory."
+msgstr "按此處變更需要擊敗以獲勝的英雄。"
+
+msgid "Put %{color} player in the %{alliance} alliance"
+msgstr "將 %{color} 玩家加入第 %{alliance} 聯盟"
+
+msgid ""
+"If this checkbox is checked, the %{color} player will be in the %{alliance} "
+"alliance."
+msgstr ""
+"勾選此選項後，%{color} 玩家將加入第 %{alliance} 聯盟。"
+
+msgid "Days:"
+msgstr "天數："
+
+msgid "Select a Town to lose to suffer defeat"
+msgstr "選擇失去即落敗的城鎮"
+
+msgid "Click here to change the town whose loss would mean defeat."
+msgstr "按此處變更失去即落敗的城鎮。"
+
+msgid "Select a Hero to lose to suffer defeat"
+msgstr "選擇失去即落敗的英雄"
+
+msgid "Click here to change the hero whose loss would mean defeat."
+msgstr "按此處變更失去即落敗的英雄。"
+
+msgid "Map Difficulty"
+msgstr "地圖難度"
+
+msgid "RUMORS"
+msgstr "謠言"
+
+msgid "EVENTS"
+msgstr "事件"
+
+msgid "LANGUAGE"
+msgstr "語言"
+
+msgid "map|ABOUT"
+msgstr "關於"
+
+msgid "Change Map Name:"
+msgstr "變更地圖名稱："
+
+msgid "Change Map Description:"
+msgstr "變更地圖描述："
+
+msgid "map|About"
+msgstr "關於"
+
+msgid "Click to edit custom rumors."
+msgstr "按一下編輯自訂謠言。"
+
+msgid "Rumors"
+msgstr "謠言"
+
+msgid "Click to edit daily events."
+msgstr "按一下編輯每日事件。"
+
+msgid "Events"
+msgstr "事件"
+
+msgid "Click to change the language of the map."
+msgstr "按一下變更地圖語言。"
+
+msgid ""
+"Click to edit notes from the map creator. These notes are optional and do "
+"not appear during gameplay."
+msgstr ""
+"按一下編輯地圖製作者備註。此備註為選填，不會在遊玩時顯示。"
+
+msgid "Click to change your map name."
+msgstr "按一下變更地圖名稱。"
+
+msgid "Map Name"
+msgstr "地圖名稱"
+
+msgid "Click to change the description of the current map."
+msgstr "按一下變更目前地圖的描述。"
+
+msgid "Click to change the victory condition of the current map."
+msgstr "按一下變更目前地圖的勝利條件。"
+
+msgid "Click to change the loss condition of the current map."
+msgstr "按一下變更目前地圖的失敗條件。"
+
+msgid "Indicates the player types in the scenario. Click to change."
+msgstr "顯示場景中的玩家類型。按一下可變更。"
+
+msgid "Player Type"
+msgstr "玩家類型"
+
+msgid ""
+"Click to set map difficulty. More difficult maps might include more or "
+"stronger enemies, fewer resources, or other special conditions making things "
+"tougher for the human player."
+msgstr ""
+"按一下設定地圖難度。地圖難度越高，敵人可能越多或越強、資源越少，或出現其他對"
+"人類玩家不利的特殊條件。"
+
+msgid ""
+"editor|%{object}\n"
+"(%{color} player)"
+msgstr ""
+"%{object}\n"
+"(%{color}玩家)"
+
+msgid "editor|%{count} %{resource}"
+msgstr "%{count} %{resource}"
+
+msgid "Animation"
+msgstr "動畫"
+
+msgid "Passability"
+msgstr "通行性"
+
+msgid "Toggle animation of the objects."
+msgstr "切換物件的動畫。"
+
+msgid "Toggle display of objects' passability."
+msgstr "切換物件通行性的顯示。"
+
+msgid "Rumors:"
+msgstr "謠言："
+
+msgid "Rumor:"
+msgstr "謠言："
+
+msgid "Rumor"
+msgstr "謠言"
+
+msgid "This rumor already exists in the list."
+msgstr "此謠言已存在於列表中。"
+
+msgid "Click to save the rumors."
+msgstr "按一下儲存謠言。"
+
+msgid "Add Rumor"
+msgstr "新增謠言"
+
+msgid "Add an additional rumor."
+msgstr "新增額外的謠言。"
+
+msgid "Edit Rumor"
+msgstr "編輯謠言"
+
+msgid "Edit an existing rumor."
+msgstr "編輯既有的謠言。"
+
+msgid "Delete Rumor"
+msgstr "刪除謠言"
+
+msgid "Delete an existing rumor."
+msgstr "刪除既有的謠言。"
+
+msgid ""
+"\n"
+"\n"
+"Language:\n"
+msgstr ""
+"\n"
+"\n"
+"語言:\n"
+
+msgid ""
+"\n"
+"\n"
+"Size: "
+msgstr ""
+"\n"
+"\n"
+"大小："
+
+msgid ""
+"\n"
+"\n"
+"Description: "
+msgstr ""
+"\n"
+"\n"
+"描述："
+
+msgid "Save Map:"
+msgstr "儲存地圖："
+
+msgid "Click to save the current map."
+msgstr "按一下儲存目前的地圖。"
+
+msgid "Click to enable all secondary skills."
+msgstr "按一下啟用所有次要技能。"
+
+msgid "Enable All Secondary Skills"
+msgstr "啟用所有次要技能"
+
+msgid "Click to disable all secondary skills."
+msgstr "按一下停用所有次要技能。"
+
+msgid "Disable All Secondary Skills"
+msgstr "停用所有次要技能"
+
+msgid "Click to show only level %{level} spells."
+msgstr "按一下僅顯示等級 %{level} 法術。"
+
+msgid "Spells level"
+msgstr "法術等級"
+
+msgid "Click to enable all spells."
+msgstr "按一下啟用所有法術。"
+
+msgid "Enable All Spells"
+msgstr "啟用所有法術"
+
+msgid "Click to disable all spells."
+msgstr "按一下停用所有法術。"
+
+msgid "Disable All Spells"
+msgstr "停用所有法術"
+
+msgid "Riddle:"
+msgstr "謎語："
+
+msgid "Answers:"
+msgstr "答案："
+
+msgid "Answer:"
+msgstr "答案："
+
+msgid "Answer"
+msgstr "答案"
+
+msgid "This answer exists in the list."
+msgstr "此答案已存在於列表中。"
+
+msgid "Click to save the Sphinx properties."
+msgstr "按一下儲存人面獅身像屬性。"
+
+msgid "Add Answer"
+msgstr "新增答案"
+
+msgid "Add an additional answer for the question."
+msgstr "為問題新增額外的答案。"
+
+msgid "Edit Answer"
+msgstr "編輯答案"
+
+msgid "Edit an existing answer for the question."
+msgstr "編輯既有的答案。"
+
+msgid "Delete Answer"
+msgstr "刪除答案"
+
+msgid "Delete an existing answer for the question."
+msgstr "刪除既有的答案。"
+
+msgid "Riddle"
+msgstr "謎語"
+
+msgid "No artifact will be given as a reward."
+msgstr "不會給予任何神器作為獎勵。"
+
+msgid "Delete an artifact from the reward."
+msgstr "從獎勵中刪除神器。"
+
+msgid "Day: %{day} Week: %{week} Month: %{month}"
+msgstr "日：%{day} 週：%{week} 月：%{month}"
+
+msgid "difficulty|Easy"
+msgstr "簡單"
+
+msgid "difficulty|Normal"
+msgstr "普通"
+
+msgid "difficulty|Hard"
+msgstr "困難"
+
+msgid "difficulty|Expert"
+msgstr "專家"
+
+msgid "difficulty|Impossible"
+msgstr "不可能"
+
+msgid "and more..."
+msgstr "以及更多……"
+
+msgid "Easy"
+msgstr "簡單"
+
+msgid "Normal"
+msgstr "普通"
+
+msgid "Hard"
+msgstr "困難"
+
+msgid "Campaign Difficulty"
+msgstr "戰役難度"
+
+msgid ""
+"Choose this difficulty to experience the game's story with less challenge. "
+"The AI will be weaker than at Normal difficulty."
+msgstr ""
+"選擇此難度以較輕鬆的方式體驗遊戲劇情。AI 將比普通難度更弱。"
+
+msgid ""
+"Choose this difficulty to experience the campaign as per the original design."
+msgstr ""
+"選擇此難度以原始設計體驗戰役。"
+
+msgid ""
+"Choose this difficulty if you want more challenge. The AI will be stronger "
+"than at Normal difficulty."
+msgstr ""
+"想要更多挑戰時，請選擇此難度。AI 會比普通難度更強。"
+
+msgid ""
+"Congratulations!\n"
+"\n"
+"Days: %{days}\n"
+msgstr ""
+"恭喜！\n"
+"\n"
+"天數：%{days}\n"
+
+msgid ""
+"\n"
+"Difficulty: %{difficulty}\n"
+"\n"
+msgstr ""
+"\n"
+"難度：%{difficulty}\n"
+"\n"
+
+msgid ""
+"Score: %{score}\n"
+"\n"
+"Rating:\n"
+"%{rating}"
+msgstr ""
+"分數：%{score}\n"
+"\n"
+"評價:\n"
+"%{rating}"
+
+msgid "Start the selected scenario."
+msgstr "開始選取的場景。"
+
+msgid "View Intro"
+msgstr "觀看序幕"
+
+msgid "View the intro video for the current state of the campaign."
+msgstr "觀看目前戰役狀態的序幕影片。"
+
+msgid ""
+"Select the campaign difficulty. This can be changed at any point during the "
+"campaign. However, the final score will be calculated based solely on the "
+"lowest difficulty of a completed scenario during the campaign."
+msgstr ""
+"選擇戰役難度。可在戰役中隨時變更。但最終分數將僅依據戰役中已完成場景的最低難"
+"度計算。"
+
+msgid "Restart the current scenario."
+msgstr "重新開始目前的場景。"
+
+msgid "Difficulty"
+msgstr "難度"
+
+msgid ""
+"You have changed the campaign difficulty. The final high score will be "
+"calculated based solely on the lowest difficulty level for a completed "
+"scenario during the campaign. Do you want to proceed?"
+msgstr ""
+"你已變更了戰役難度。最終最高分將僅依據戰役中已完成場景的最低難度等級計算。確"
+"定要繼續嗎？"
+
+msgid "Are you sure you want to restart this scenario?"
+msgstr "確定要重新開始此場景嗎？"
+
+msgid "Campaign Scenario loading failure"
+msgstr "戰役場景載入失敗"
+
+msgid "Please make sure that campaign files are correct and present."
+msgstr "請確認戰役檔案正確且存在。"
+
+msgid "Days spent"
+msgstr "所花天數"
+
+msgid "The number of days spent on this campaign."
+msgstr "在此戰役所花費的天數。"
+
+msgid "Scenario Title"
+msgstr "場景標題"
+
+msgid "Project Coordination and Core Development"
+msgstr "專案統籌與核心開發"
+
+msgid "Development"
+msgstr "開發"
+
+msgid "Visit us at"
+msgstr "造訪我們"
+
+msgid "QA and Support"
+msgstr "品質保證與技術支援"
+
+msgid "Dev and Support"
+msgstr "開發與技術支援"
+
+msgid "Special Thanks to"
+msgstr "特別感謝"
+
+msgid "and all the people who have helped make the project possible!"
+msgstr "以及所有協助讓這個專案成真的人們！"
+
+msgid "Support us at"
+msgstr "贊助我們"
+
+msgid "local-donation-platform|https://www.patreon.com/fheroes2"
+msgstr "https://www.patreon.com/fheroes2"
+
+msgid "Connect with us at"
+msgstr "聯絡我們"
+
+msgid "local-social-network|https://www.facebook.com/groups/fheroes2"
+msgstr "https://www.facebook.com/groups/fheroes2"
+
+msgid "Need help with the game?"
+msgstr "需要遊戲協助嗎？"
+
+msgid "Original project before 0.7"
+msgstr "0.7 版之前的原始專案"
+
+msgid "Heroes of Might and Magic II: The Succession Wars team"
+msgstr "Heroes of Might and Magic II: The Succession Wars 團隊"
+
+msgid "Designed and Directed"
+msgstr "設計與監製"
+
+msgid "Programming and Design"
+msgstr "程式設計與設計"
+
+msgid "Executive Producer"
+msgstr "執行製作人"
+
+msgid "Producer"
+msgstr "製作人"
+
+msgid "Additional Design"
+msgstr "額周邊裝置計"
+
+msgid "Additional Programming"
+msgstr "額外程式設計"
+
+msgid "Musical Production"
+msgstr "音樂製作"
+
+msgid "Music and Sound Design"
+msgstr "音樂與聲音設計"
+
+msgid "Vocalists"
+msgstr "歌手"
+
+msgid "Art Director"
+msgstr "藝術總監"
+
+msgid "Assistant Art Director"
+msgstr "助理藝術總監"
+
+msgid "Artists"
+msgstr "美術設計師"
+
+msgid "QA Manager"
+msgstr "品質保證經理"
+
+msgid "QA"
+msgstr "品質保證"
+
+msgid "Writing"
+msgstr "文案撰寫"
+
+msgid "Manual and Helpfile"
+msgstr "手冊與說明檔"
+
+msgid "Scenarios"
+msgstr "場景設計"
+
+msgid "Heroes of Might and Magic II: The Price of Loyalty team"
+msgstr "Heroes of Might and Magic II: The Price of Loyalty 團隊"
+
+msgid "Design Lead"
+msgstr "首席設計師"
+
+msgid "Designers"
+msgstr "設計師"
+
+msgid "Programming Lead"
+msgstr "首席程式設計師"
+
+msgid "Art Lead"
+msgstr "首席美術設計師"
+
+msgid "Playtesters"
+msgstr "遊戲測試員"
+
+msgid "Designer"
+msgstr "設計師"
+
+msgid "Producers"
+msgstr "製作人"
+
+msgid "QA Managers"
+msgstr "品質保證經理"
+
+msgid "Sound Design"
+msgstr "聲音設計"
+
+msgid "Town Themes"
+msgstr "城鎮主題音樂"
+
+msgid "Alto Sax"
+msgstr "中音薩克斯風"
+
+msgid "Harpsichord and Piano"
+msgstr "大鍵琴與鋼琴"
+
+msgid "Basso Vocal"
+msgstr "低音聲樂"
+
+msgid "Soprano Vocal"
+msgstr "女高音聲樂"
+
+msgid "Recorded at %{recordingStudio}"
+msgstr "錄製於 %{recordingStudio}"
+
+msgid "credits|Manual"
+msgstr "手冊"
+
+msgid "German Consultant"
+msgstr "德文顧問"
+
+msgid "Map Designers"
+msgstr "地圖設計師"
+
+msgid "Package Design"
+msgstr "包裝設計"
+
+msgid "To exit fheroes2, press the Home button or swipe up."
+msgstr "若要離開 fheroes2，請按主畫面按鈕或向上滑動。"
+
+msgid "Are you sure you want to quit?"
+msgstr "確定要結束嗎？"
+
+msgid "High Scores"
+msgstr "最高分"
+
+msgid "Your Name"
+msgstr "你的名稱"
+
+msgid "Unknown Hero"
+msgstr "無名英雄"
+
+msgid "Standard"
+msgstr "標準"
+
+msgid "View High Scores for Standard Maps."
+msgstr "檢視標準地圖的最高分排行榜。"
+
+msgid "Campaign"
+msgstr "戰役"
+
+msgid "View High Scores for Campaigns."
+msgstr "檢視戰役的最高分排行榜。"
+
+msgid "hotkey|default okay event"
+msgstr "預設確認事件"
+
+msgid "hotkey|default cancel event"
+msgstr "預設取消事件"
+
+msgid "hotkey|default left"
+msgstr "預設向左"
+
+msgid "hotkey|default right"
+msgstr "預設向右"
+
+msgid "hotkey|default up"
+msgstr "預設向上"
+
+msgid "hotkey|default down"
+msgstr "預設向下"
+
+msgid "hotkey|toggle fullscreen"
+msgstr "切換全螢幕"
+
+msgid "hotkey|toggle text support mode"
+msgstr "切換文字輔助模式"
+
+msgid "hotkey|toggle developer mode"
+msgstr "切換開發者模式"
+
+msgid "hotkey|quit"
+msgstr "結束"
+
+msgid "hotkey|new game"
+msgstr "新遊戲"
+
+msgid "hotkey|load game"
+msgstr "載入遊戲"
+
+msgid "hotkey|high scores"
+msgstr "最高分"
+
+msgid "hotkey|credits"
+msgstr "製作名單"
+
+msgid "hotkey|standard game"
+msgstr "標準遊戲"
+
+msgid "hotkey|campaign game"
+msgstr "戰役遊戲"
+
+msgid "hotkey|multi-player game"
+msgstr "多人遊戲"
+
+msgid "hotkey|settings"
+msgstr "設定"
+
+msgid "hotkey|select map"
+msgstr "選擇地圖"
+
+msgid "hotkey|select small map size"
+msgstr "選擇小型地圖"
+
+msgid "hotkey|select medium map size"
+msgstr "選擇中型地圖"
+
+msgid "hotkey|select large map size"
+msgstr "選擇大型地圖"
+
+msgid "hotkey|select extra large map size"
+msgstr "選擇超大型地圖"
+
+msgid "hotkey|select all map sizes"
+msgstr "選擇所有地圖大小"
+
+msgid "hotkey|hot seat game"
+msgstr "熱座遊戲"
+
+msgid "hotkey|battle only game"
+msgstr "僅限戰鬥遊戲"
+
+msgid "hotkey|choose the original campaign"
+msgstr "選擇原版戰役"
+
+msgid "hotkey|choose the expansion campaign"
+msgstr "選擇資料片戰役"
+
+msgid "hotkey|map editor main menu"
+msgstr "地圖編輯器主選單"
+
+msgid "hotkey|new map menu"
+msgstr "新地圖選單"
+
+msgid "hotkey|load map menu"
+msgstr "載入地圖選單"
+
+msgid "hotkey|new map from scratch"
+msgstr "從頭建立新地圖"
+
+msgid "hotkey|new random map"
+msgstr "新隨機地圖"
+
+msgid "hotkey|undo last action"
+msgstr "復原上一個動作"
+
+msgid "hotkey|redo last action"
+msgstr "重做上一個動作"
+
+msgid "hotkey|open game main menu"
+msgstr "開啟遊戲主選單"
+
+msgid "hotkey|toggle passability"
+msgstr "切換通行性"
+
+msgid "hotkey|re-generate random map"
+msgstr "重新產生隨機地圖"
+
+msgid "hotkey|re-configure random map"
+msgstr "重新設定隨機地圖"
+
+msgid "hotkey|output all text"
+msgstr "輸出所有文字"
+
+msgid "hotkey|roland campaign"
+msgstr "Roland 戰役"
+
+msgid "hotkey|archibald campaign"
+msgstr "Archibald 戰役"
+
+msgid "hotkey|price of loyalty campaign"
+msgstr "忠誠的代價戰役"
+
+msgid "hotkey|voyage home campaign"
+msgstr "歸鄉之旅戰役"
+
+msgid "hotkey|wizard's isle campaign"
+msgstr "巫師之島戰役"
+
+msgid "hotkey|descendants campaign"
+msgstr "後裔戰役"
+
+msgid "hotkey|select first campaign bonus"
+msgstr "選擇第一項戰役獎勵"
+
+msgid "hotkey|select second campaign bonus"
+msgstr "選擇第二項戰役獎勵"
+
+msgid "hotkey|select third campaign bonus"
+msgstr "選擇第三項戰役獎勵"
+
+msgid "hotkey|view campaign intro"
+msgstr "觀看戰役序幕"
+
+msgid "hotkey|select campaign difficulty"
+msgstr "選擇戰役難度"
+
+msgid "hotkey|restart campaign scenario"
+msgstr "重新開始戰役場景"
+
+msgid "hotkey|world map left"
+msgstr "世界地圖向左"
+
+msgid "hotkey|world map right"
+msgstr "世界地圖向右"
+
+msgid "hotkey|world map up"
+msgstr "世界地圖向上"
+
+msgid "hotkey|world map down"
+msgstr "世界地圖向下"
+
+msgid "hotkey|world map up left"
+msgstr "世界地圖左上"
+
+msgid "hotkey|world map up right"
+msgstr "世界地圖右上"
+
+msgid "hotkey|world map down left"
+msgstr "世界地圖左下"
+
+msgid "hotkey|world map down right"
+msgstr "世界地圖右下"
+
+msgid "hotkey|save game"
+msgstr "儲存遊戲"
+
+msgid "hotkey|quick save"
+msgstr "快速存檔"
+
+msgid "hotkey|next hero"
+msgstr "下一位英雄"
+
+msgid "hotkey|change to hero under cursor"
+msgstr "切換至游標下的英雄"
+
+msgid "hotkey|hold and left click to move hero portrait to top of list"
+msgstr "按住並左鍵按一下以將英雄肖像移至列表頂端"
+
+msgid "hotkey|start hero movement"
+msgstr "開始英雄移動"
+
+msgid "hotkey|cast adventure spell"
+msgstr "施放冒險法術"
+
+msgid "hotkey|put hero to sleep"
+msgstr "讓英雄休息"
+
+msgid "hotkey|next town"
+msgstr "下一座城鎮"
+
+msgid "hotkey|end turn"
+msgstr "結束回合"
+
+msgid "hotkey|file options"
+msgstr "檔案選項"
+
+msgid "hotkey|adventure options"
+msgstr "冒險選項"
+
+msgid "hotkey|puzzle map"
+msgstr "拼圖地圖"
+
+msgid "hotkey|scenario information"
+msgstr "場景資訊"
+
+msgid "hotkey|dig for artifact"
+msgstr "挖掘神器"
+
+msgid "hotkey|view world"
+msgstr "檢視世界"
+
+msgid "hotkey|kingdom summary"
+msgstr "王國摘要"
+
+msgid "hotkey|default action"
+msgstr "預設動作"
+
+msgid "hotkey|open focus"
+msgstr "開啟焦點"
+
+msgid "hotkey|system options"
+msgstr "系統選項"
+
+msgid "hotkey|scroll left"
+msgstr "向左捲動"
+
+msgid "hotkey|scroll right"
+msgstr "向右捲動"
+
+msgid "hotkey|scroll up"
+msgstr "向上捲動"
+
+msgid "hotkey|scroll down"
+msgstr "向下捲動"
+
+msgid "hotkey|toggle control panel"
+msgstr "切換控制台"
+
+msgid "hotkey|toggle radar"
+msgstr "切換雷達"
+
+msgid "hotkey|toggle buttons"
+msgstr "切換按鈕"
+
+msgid "hotkey|toggle status"
+msgstr "切換狀態"
+
+msgid "hotkey|toggle icons"
+msgstr "切換圖示"
+
+msgid "hotkey|transfer control to ai"
+msgstr "將控制權移轉給 AI"
+
+msgid "hotkey|retreat from battle"
+msgstr "從戰鬥中撤退"
+
+msgid "hotkey|surrender during battle"
+msgstr "在戰鬥中投降"
+
+msgid "hotkey|toggle auto combat mode"
+msgstr "切換自動戰鬥模式"
+
+msgid "hotkey|quick combat"
+msgstr "快速戰鬥"
+
+msgid "hotkey|battle options"
+msgstr "戰鬥選項"
+
+msgid "hotkey|skip turn in battle"
+msgstr "在戰鬥中略過回合"
+
+msgid "hotkey|cast battle spell"
+msgstr "施放戰鬥法術"
+
+msgid "hotkey|toggle display of battle turn order"
+msgstr "切換戰鬥行動順序顯示"
+
+msgid "hotkey|dwelling level 1"
+msgstr "住所等級 1"
+
+msgid "hotkey|dwelling level 2"
+msgstr "住所等級 2"
+
+msgid "hotkey|dwelling level 3"
+msgstr "住所等級 3"
+
+msgid "hotkey|dwelling level 4"
+msgstr "住所等級 4"
+
+msgid "hotkey|dwelling level 5"
+msgstr "住所等級 5"
+
+msgid "hotkey|dwelling level 6"
+msgstr "住所等級 6"
+
+msgid "hotkey|well"
+msgstr "水井"
+
+msgid "hotkey|marketplace"
+msgstr "市場"
+
+msgid "hotkey|mage guild"
+msgstr "法師公會"
+
+msgid "hotkey|shipyard"
+msgstr "造船廠"
+
+msgid "hotkey|thieves guild"
+msgstr "盜賊公會"
+
+msgid "hotkey|tavern"
+msgstr "酒館"
+
+msgid "hotkey|construction screen"
+msgstr "建造畫面"
+
+msgid "hotkey|buy all monsters in well"
+msgstr "從水井購買所有怪物"
+
+msgid "hotkey|merge troops with hero"
+msgstr "合併部隊至英雄"
+
+msgid "hotkey|merge troops with garrison"
+msgstr "合併部隊至城防"
+
+msgid "hotkey|split stack by half"
+msgstr "將部隊分為一半"
+
+msgid "hotkey|split stack by one"
+msgstr "將部隊分出一個"
+
+msgid "hotkey|join stacks"
+msgstr "合併部隊"
+
+msgid "hotkey|upgrade troop"
+msgstr "升級部隊"
+
+msgid "hotkey|dismiss hero or troop"
+msgstr "解散英雄或部隊"
+
+msgid "hotkey|exchange all troops"
+msgstr "交換所有部隊"
+
+msgid ""
+"Do you want to regain control from AI? The effect will take place only on "
+"the next turn."
+msgstr ""
+"確定要從 AI 奪回控制權嗎？效果將在下一回合生效。"
+
+msgid ""
+"Do you want to transfer control from you to the AI? The effect will take "
+"place only on the next turn."
+msgstr ""
+"確定要將控制權移轉給 AI 嗎？效果將在下一回合生效。"
+
+msgid "Default Actions"
+msgstr "預設操作"
+
+msgid "Global Actions"
+msgstr "全域操作"
+
+msgid "World Map"
+msgstr "世界地圖"
+
+msgid "Battle Screen"
+msgstr "戰鬥畫面"
+
+msgid "Town Screen"
+msgstr "城鎮畫面"
+
+msgid "Army Actions"
+msgstr "軍隊操作"
+
+msgid "The save file is corrupted."
+msgstr "存檔已損壞。"
+
+msgid "Unsupported save format: "
+msgstr "不支援的存檔格式："
+
+msgid "Current game version: "
+msgstr "目前遊戲版本："
+
+msgid "Last supported version: "
+msgstr "最後支援的版本："
+
+msgid "This file contains a save with an invalid game type."
+msgstr "此檔案包含無效遊戲類型的存檔。"
+
+msgid ""
+"This save file requires \"The Price of Loyalty\" game assets, but they have "
+"not been provided to the engine."
+msgstr ""
+"此存檔需要「The Price of Loyalty」遊戲資源，但尚未提供給引擎。"
+
+msgid "This saved game is localized to '"
+msgstr "此存檔的語系為「"
+
+msgid "' language, but the current language of the game is '"
+msgstr "」，但目前遊戲的語言為「"
+
+msgid "No save files to load."
+msgstr "沒有可載入的存檔。"
+
+msgid "A single player game playing out a single map."
+msgstr "在單一地圖上進行的單人遊戲。"
+
+msgid "Standard Game"
+msgstr "標準遊戲"
+
+msgid "A single player game playing through a series of maps."
+msgstr "依序遊玩一系列地圖的單人遊戲。"
+
+msgid "Campaign Game"
+msgstr "戰役遊戲"
+
+msgid "Multi-Player Game"
+msgstr "多人遊戲"
+
+msgid ""
+"A multi-player game, with several human players completing against each "
+"other on a single map."
+msgstr ""
+"多人遊戲，多位人類玩家在同一張地圖上彼此競爭。"
+
+msgid "Hot Seat"
+msgstr "熱座模式"
+
+msgid ""
+"Play a Hot Seat game, where 2 to 6 players play around the same computer, "
+"switching into the 'Hot Seat' when it is their turn."
+msgstr ""
+"進行熱座遊戲，2 至 6 位玩家在同一台電腦上輪流遊玩。"
+
+msgid "Cancel back to the main menu."
+msgstr "取消並返回主選單。"
+
+msgid "fheroes2 Resurrection Team presents"
+msgstr "fheroes2 Resurrection Team 獻上"
+
+msgid "Welcome to Heroes of Might and Magic II powered by fheroes2 engine!"
+msgstr "歡迎遊玩由 fheroes2 引擎驅動的 Heroes of Might and Magic II！"
+
+msgid ""
+"\n"
+"\n"
+"To simulate a right-click with a touch to get info on various items, you "
+"need to first touch and keep touching on the item of interest and then touch "
+"anywhere else on the screen. While holding the second finger, you can remove "
+"the first one from the screen and keep viewing the information on the item."
+msgstr ""
+"\n"
+"\n"
+"想以觸控方式模擬右鍵取得各種物件的資訊，請先觸碰並按住想檢視的物件，然後再觸"
+"碰螢幕上的其他位置。按住第二根手指的同時，可以移開第一根手指並繼續檢視該物件"
+"的資訊。"
+
+msgid ""
+"\n"
+"\n"
+"Before starting the game, please select a game resolution."
+msgstr ""
+"\n"
+"\n"
+"開始遊戲前，請先選擇遊戲解析度。"
+
+msgid "Greetings!"
+msgstr "歡迎！"
+
+msgid "Quit Heroes of Might and Magic II and return to the operating system."
+msgstr "結束 Heroes of Might and Magic II 並返回作業系統。"
+
+msgid "Credits"
+msgstr "製作名單"
+
+msgid "View the credits screen."
+msgstr "檢視製作名單。"
+
+msgid "View the high scores screen."
+msgstr "檢視最高分排行榜。"
+
+msgid "Create new or modify existing maps."
+msgstr "建立新地圖或修改既有地圖。"
+
+msgid "Change language, resolution and settings of the game."
+msgstr "變更遊戲的語言、解析度和設定。"
+
+msgid "Game Settings"
+msgstr "遊戲設定"
+
+msgid ""
+"The required video files for the campaign selection window are missing. "
+"Please make sure that all necessary files are present in the system."
+msgstr ""
+"戰役選擇視窗所需的影片檔案遺失，請確認所有必要檔案已存在於系統中。"
+
+msgid "Loading video. Please wait..."
+msgstr "正在載入影片，請稍候……"
+
+msgid ""
+"fheroes2 needs data files from the original Heroes of Might and Magic II to "
+"operate. You appear to be using the demo version of Heroes of Might and "
+"Magic II for this purpose. Please note that only one scenario will be "
+"available in this setup."
+msgstr ""
+"fheroes2 需要原版 Heroes of Might and Magic II 的資料檔案才能執行。你似乎正在"
+"使用 Heroes of Might and Magic II 的試玩版。請注意在此設定下只有一個場景可"
+"用。"
+
+msgid ""
+"A multi-player game, with several human players competing against each other "
+"on a single map."
+msgstr ""
+"多人遊戲，多位人類玩家在同一張地圖上彼此競爭。"
+
+msgid "Setup and play a battle without loading any map."
+msgstr "直接開始一場戰鬥，無須載入地圖。"
+
+msgid "2 Players"
+msgstr "2 位玩家"
+
+msgid ""
+"Play with 2 human players, and optionally, up to 4 additional computer "
+"players."
+msgstr ""
+"以 2 位人類玩家遊玩，可選擇加入最多 4 位電腦玩家。"
+
+msgid "3 Players"
+msgstr "3 位玩家"
+
+msgid ""
+"Play with 3 human players, and optionally, up to 3 additional computer "
+"players."
+msgstr ""
+"以 3 位人類玩家遊玩，可選擇加入最多 3 位電腦玩家。"
+
+msgid "4 Players"
+msgstr "4 位玩家"
+
+msgid ""
+"Play with 4 human players, and optionally, up to 2 additional computer "
+"players."
+msgstr ""
+"以 4 位人類玩家遊玩，可選擇加入最多 2 位電腦玩家。"
+
+msgid "5 Players"
+msgstr "5 位玩家"
+
+msgid ""
+"Play with 5 human players, and optionally, up to 1 additional computer "
+"player."
+msgstr ""
+"以 5 位人類玩家遊玩，可選擇加入最多 1 位電腦玩家。"
+
+msgid "6 Players"
+msgstr "6 位玩家"
+
+msgid "Play with 6 human players."
+msgstr "以 6 位人類玩家遊玩。"
+
+msgid "Original Campaign"
+msgstr "原版戰役"
+
+msgid ""
+"Either Roland's or Archibald's campaign from the original Heroes of Might "
+"and Magic II."
+msgstr ""
+"原版 Heroes of Might and Magic II 中 Roland 或 Archibald 的戰役。"
+
+msgid "Expansion Campaign"
+msgstr "資料片戰役"
+
+msgid "One of the four new campaigns from the Price of Loyalty expansion set."
+msgstr "Price of Loyalty 資料片中四個新戰役之一。"
+
+msgid ""
+"Play a Hot Seat game, where 2 to 6 players play on the same device, "
+"switching into the 'Hot Seat' when it is their turn."
+msgstr ""
+"進行熱座遊戲，2 至 6 位玩家在同一台裝置上輪流遊玩。"
+
+msgid "Dragon city has fallen! You are now the Master of the Dragons."
+msgstr "龍族之城已經淪陷！你現在是龍族之主了。"
+
+msgid ""
+"You captured %{name}!\n"
+"You are victorious."
+msgstr ""
+"佔領了 %{name}！\n"
+"你獲得了勝利。"
+
+msgid ""
+"You have captured the enemy hero %{name}!\n"
+"Your quest is complete."
+msgstr ""
+"俘獲了敵方英雄 %{name}！\n"
+"任務完成。"
+
+msgid ""
+"You have found the %{name}.\n"
+"Your quest is complete."
+msgstr ""
+"找到了 %{name}。\n"
+"任務完成。"
+
+msgid "Ultimate Artifact"
+msgstr "終極神器"
+
+msgid ""
+"The enemy is beaten.\n"
+"Your side has triumphed!"
+msgstr ""
+"敵人被擊敗了。\n"
+"你方獲得了勝利！"
+
+msgid ""
+"You have built up over %{count} gold in your treasury.\n"
+"All enemies bow before your wealth and power."
+msgstr ""
+"國庫已累積超過 %{count} 金幣。\n"
+"所有敵人在你的財富與力量面前俯首稱臣。"
+
+msgid "Victory!"
+msgstr "勝利！"
+
+msgid ""
+"The enemy has captured %{name}!\n"
+"They are triumphant."
+msgstr ""
+"敵人佔領了 %{name}！\n"
+"他們獲得了勝利。"
+
+msgid ""
+"The enemy has found the %{name}.\n"
+"Your quest is a failure."
+msgstr ""
+"敵人找到了 %{name}。\n"
+"任務失敗。"
+
+msgid ""
+"The enemy has built up over %{count} gold in his treasury.\n"
+"You must bow done in defeat before his wealth and power."
+msgstr ""
+"敵人的國庫已累積超過 %{count} 金幣。\n"
+"你必須在其財富與力量面前認輸。"
+
+msgid "You have been eliminated from the game!!!"
+msgstr "你已被淘汰出局！！！"
+
+msgid ""
+"You have lost the hero %{name}.\n"
+"Your quest is over."
+msgstr ""
+"失去了英雄 %{name}。\n"
+"任務結束。"
+
+msgid ""
+"You have failed to complete your quest in time.\n"
+"All is lost."
+msgstr ""
+"未能在時限內完成任務。\n"
+"一切都完了。"
+
+msgid "Defeat!"
+msgstr "戰敗！"
+
+msgid ""
+"Base score: %{score}\n"
+"Difficulty: %{difficulty}\n"
+"\n"
+msgstr ""
+"基礎分數：%{score}\n"
+"難度：%{difficulty}\n"
+"\n"
+
+msgid "Defeat all enemy heroes and capture all enemy towns and castles."
+msgstr "擊敗所有敵方英雄，並佔領所有敵方城鎮和城堡。"
+
+msgid "Your side defeats the opposing side."
+msgstr "你方擊敗了對方。"
+
+msgid "Run out of time. (Fail to win by a certain point.)"
+msgstr "時間耗盡。(未能在期限前獲勝。)"
+
+msgid "You must defeat the enemy %{enemies}."
+msgid_plural "You must defeat the enemy alliance of %{enemies}."
+msgstr[0] "必須擊敗敵方 %{enemies}。"
+
+msgid ""
+"The alliance consisting of %{allies} and you must defeat the enemy "
+"%{enemies}."
+msgid_plural ""
+"The alliance consisting of %{allies} and you must defeat the enemy alliance "
+"of %{enemies}."
+msgstr[0] ""
+"由 %{allies} 和你組成的聯盟必須擊敗敵方 %{enemies}。"
+
+msgid "Capture the castle '%{name}'."
+msgstr "佔領城堡「%{name}」。"
+
+msgid "Capture the town '%{name}'."
+msgstr "佔領城鎮「%{name}」。"
+
+msgid "Defeat the hero '%{name}'."
+msgstr "擊敗英雄「%{name}」。"
+
+msgid "Find the ultimate artifact."
+msgstr "找到終極神器。"
+
+msgid "Find the '%{name}' artifact."
+msgstr "找到神器「%{name}」。"
+
+msgid "Accumulate %{count} gold."
+msgstr "累積 %{count} 金幣。"
+
+msgid ""
+", or you may win by defeating all enemy heroes and capturing all enemy towns "
+"and castles."
+msgstr ""
+"，或者也可以擊敗所有敵方英雄並佔領所有敵方城鎮和城堡來獲勝。"
+
+msgid "Lose the castle '%{name}'."
+msgstr "失去城堡「%{name}」。"
+
+msgid "Lose the town '%{name}'."
+msgstr "失去城鎮「%{name}」。"
+
+msgid "Lose the hero: %{name}."
+msgstr "失去英雄：%{name}。"
+
+msgid "Fail to win by the end of month %{month}, week %{week}, day %{day}."
+msgstr "未能在第 %{month} 月第 %{week} 週第 %{day} 日結束前獲勝。"
+
+msgid "%{color} player has been vanquished!"
+msgstr "%{color}玩家已被消滅！"
+
+msgid "Major Event!"
+msgstr "重大事件！"
+
+msgid "Scenario:"
+msgstr "場景："
+
+msgid "Game Difficulty:"
+msgstr "遊戲難度："
+
+msgid "Opponents:"
+msgstr "對手："
+
+msgid "Class:"
+msgstr "職業："
+
+msgid "Rating %{rating}%"
+msgstr "評分 %{rating}%"
+
+msgid "Click here to select which scenario to play."
+msgstr "按此處選擇要遊玩的場景。"
+
+msgid "Scenario"
+msgstr "場景"
+
+msgid "Game Difficulty"
+msgstr "遊戲難度"
+
+msgid ""
+"This lets you change the starting difficulty at which you will play. Higher "
+"difficulty levels start you off with fewer resources, and at the higher "
+"settings, give extra resources to the computer."
+msgstr ""
+"可變更遊玩的起始難度。難度等級越高，開局資源就越少；在更高的設定下，電腦還會"
+"獲得額外資源。"
+
+msgid "Difficulty Rating"
+msgstr "難度評分"
+
+msgid ""
+"The difficulty rating reflects a combination of various settings for your "
+"game. This number will be applied to your final score."
+msgstr ""
+"難度評分反映了遊戲各項設定的綜合評估，此數值將計入最終分數。"
+
+msgid "Click to accept these settings and start a new game."
+msgstr "按一下接受這些設定並開始新遊戲。"
+
+msgid "Click to return to the main menu."
+msgstr "按一下返回主選單。"
+
+msgid "The map is corrupted or doesn't exist."
+msgstr "地圖已損壞或不存在。"
+
+msgid "Astrologers proclaim the Month of the %{name}."
+msgstr "占星師宣布這是 %{name} 之月。"
+
+msgid "New Month!"
+msgstr "新的月份！"
+
+msgid "Astrologers proclaim the Week of the %{name}."
+msgstr "占星師宣布這是 %{name} 之週。"
+
+msgid "New Week!"
+msgstr "新的一週！"
+
+msgid "After regular growth, the population of %{monster} is doubled!"
+msgstr "正常增長後，%{monster} 的族群數量翻倍！"
+
+msgid ""
+"After regular growth, the population of %{monster} increases by %{count} "
+"percent!"
+msgid_plural ""
+"After regular growth, the population of %{monster} increases by %{count} "
+"percent!"
+msgstr[0] ""
+"正常增長後，%{monster} 的族群數量增加 %{count}%！"
+
+msgid "%{monster} growth +%{count}."
+msgstr "%{monster} 增長 +%{count}。"
+
+msgid "All populations are halved."
+msgstr "所有生物族群減半。"
+
+msgid "All dwellings increase population."
+msgstr "所有住所增加族群數量。"
+
+msgid "Beware!"
+msgstr "小心！"
+
+msgid ""
+"%{color} player, this is your last day to capture a town, or you will be "
+"banished from this land."
+msgstr ""
+"%{color}玩家，這是佔領城鎮的最後一天，否則將被放逐。"
+
+msgid ""
+"%{color} player, you only have %{day} days left to capture a town, or you "
+"will be banished from this land."
+msgstr ""
+"%{color}玩家，僅剩 %{day} 天可以佔領城鎮，否則將被放逐。"
+
+msgid "%{color} player's turn."
+msgstr "%{color}玩家的回合。"
+
+msgid ""
+"%{color} player, you have lost your last town. If you do not conquer another "
+"town in the next week, you will be eliminated."
+msgstr ""
+"%{color}玩家，你失去了最後一座城鎮。若未能在下週內攻佔另一座城鎮，將被淘汰。"
+
+msgid ""
+"%{color} player, your heroes abandon you, and you are banished from this "
+"land."
+msgstr ""
+"%{color}玩家，英雄們拋棄了你，你被放逐出這片土地。"
+
+msgid "Lord Kilburn"
+msgstr "Lord Kilburn"
+
+msgid "Tsabu"
+msgstr "Tsabu"
+
+msgid "Sir Galant"
+msgstr "Sir Galant"
+
+msgid "Thundax"
+msgstr "Thundax"
+
+msgid "Lord Haart"
+msgstr "Lord Haart"
+
+msgid "Ariel"
+msgstr "Ariel"
+
+msgid "Rebecca"
+msgstr "Rebecca"
+
+msgid "Sandro"
+msgstr "Sandro"
+
+msgid "Crodo"
+msgstr "Crodo"
+
+msgid "Barock"
+msgstr "Barock"
+
+msgid "Antoine"
+msgstr "Antoine"
+
+msgid "Astra"
+msgstr "Astra"
+
+msgid "Agar"
+msgstr "Agar"
+
+msgid "Vatawna"
+msgstr "Vatawna"
+
+msgid "Vesper"
+msgstr "Vesper"
+
+msgid "Ambrose"
+msgstr "Ambrose"
+
+msgid "Troyan"
+msgstr "Troyan"
+
+msgid "Jojosh"
+msgstr "Jojosh"
+
+msgid "Wrathmont"
+msgstr "Wrathmont"
+
+msgid "Maximus"
+msgstr "Maximus"
+
+msgid "Next Hero"
+msgstr "下一位英雄"
+
+msgid "Select the next Hero."
+msgstr "選擇下一位英雄。"
+
+msgid "Hero Movement"
+msgstr "英雄移動"
+
+msgid ""
+"Start the Hero's movement along the current path or re-visit the object "
+"occupied by the Hero. Press and hold this button to reset the Hero's path."
+msgstr ""
+"沿目前路徑開始英雄的移動，或重新造訪英雄所在的物件。長按此按鈕可重置英雄的路"
+"徑。"
+
+msgid "Kingdom Summary"
+msgstr "王國摘要"
+
+msgid "View a summary of your Kingdom."
+msgstr "檢視王國摘要。"
+
+msgid "Cast an adventure spell."
+msgstr "施放冒險法術。"
+
+msgid "End Turn"
+msgstr "結束回合"
+
+msgid "End your turn and let the computer take its turn."
+msgstr "結束你的回合，讓電腦行動。"
+
+msgid "Adventure Options"
+msgstr "冒險選項"
+
+msgid "Bring up the adventure options menu."
+msgstr "開啟冒險選項選單。"
+
+msgid ""
+"Bring up the file options menu, allowing you to load, save, start a new game "
+"or quit."
+msgstr ""
+"開啟檔案選項選單，可載入、儲存、開始新遊戲或結束。"
+
+msgid "Bring up the system options menu, allowing you to customize your game."
+msgstr "開啟系統選項選單，以自訂遊戲。"
+
+msgid "Hero Movement Points"
+msgstr "英雄移動力"
+
+msgid ""
+"The hero's army cannot move anymore today. The movement points will be "
+"refilled tomorrow after you end your turn."
+msgstr ""
+"英雄的軍隊今日已無法繼續移動。結束回合後，明天移動力將會恢復。"
+
+msgid ""
+"One or more heroes may still move, are you sure you want to end your turn?"
+msgstr ""
+"仍有英雄可以移動，確定要結束回合嗎？"
+
+msgid "Are you sure you want to restart? (Your current game will be lost.)"
+msgstr "確定要重新開始嗎？(目前的遊戲進度將會遺失。)"
+
+msgid "Are you sure you want to overwrite the save with this name?"
+msgstr "確定要覆寫此名稱的存檔嗎？"
+
+msgid "Game saved successfully."
+msgstr "遊戲儲存成功。"
+
+msgid ""
+"Are you sure you want to load a new game? (Your current game will be lost.)"
+msgstr ""
+"確定要載入新遊戲嗎？（目前的遊戲進度將會遺失。）"
+
+msgid "Try looking on land!!!"
+msgstr "試試在陸地上尋找！！！"
+
+msgid ""
+"Searching for the Ultimate Artifact is fruitless. Your hero could not carry "
+"it even if he found it - all his artifact slots are full."
+msgstr ""
+"搜尋終極神器毫無結果。即使找到也無法攜帶——英雄的神器欄位已滿。"
+
+msgid "Digging for artifacts requires a whole day, try again tomorrow."
+msgstr "挖掘神器需要一整天的時間，請明天再試。"
+
+msgid ""
+"After spending many hours digging here, you have uncovered the %{artifact}."
+msgstr ""
+"經過數小時的挖掘，你發現了 %{artifact}。"
+
+msgid "Congratulations!"
+msgstr "恭喜！"
+
+msgid "Nothing here. Where could it be?"
+msgstr "這裡什麼都沒有。它會在哪裡呢？"
+
+msgid "Try searching on clear ground."
+msgstr "試試在空地上搜尋。"
+
+msgid "A miniature view of the known world. Left click to move viewing area."
+msgstr "已知世界的縮圖。左鍵按一下移動檢視區域。"
+
+msgid "Month: %{month} Week: %{week}"
+msgstr "月：%{month} 週：%{week}"
+
+msgid ""
+"You find a small\n"
+"quantity of %{resource}."
+msgstr ""
+"你發現了少量\n"
+"%{resource}。"
+
+msgid "Status Window"
+msgstr "狀態視窗"
+
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date."
+msgstr ""
+"此視窗顯示英雄或王國的狀態資訊及日期。"
+
+msgid ""
+"This window provides information on the status of your hero or kingdom, and "
+"shows the date. Left click here to cycle through these windows."
+msgstr ""
+"此視窗顯示英雄或王國的狀態資訊及日期。左鍵按一下可切換不同視窗。"
+
+msgid ""
+"This lets you change player starting positions and colors. A particular "
+"color will always start in a particular location. Some positions may only be "
+"played by a computer player or only by a human player."
+msgstr ""
+"可變更玩家的起始位置和顏色。特定顏色將始終在特定位置開始。某些位置只能由電腦"
+"玩家或人類玩家使用。"
+
+msgid ""
+"This lets you change the class of a player. Classes are not always "
+"changeable. Depending on the scenario, a player may receive additional towns "
+"and/or heroes not of their primary alignment."
+msgstr ""
+"可變更玩家的職業。職業並非總是可變更的。根據場景，玩家可能會獲得非其主要陣營"
+"的額外城鎮和/或英雄。"
+
+msgid "Handicap"
+msgstr "讓分"
+
+msgid ""
+"This lets you change the handicap of a particular player. Only human players "
+"may have a handicap. Handicapped players start with fewer resources and earn "
+"15 or 30% fewer resources per turn for mild and severe handicaps, "
+"respectively."
+msgstr ""
+"可變更特定玩家的讓分。只有人類玩家可設定讓分。有讓分的玩家以較少資源開局，輕"
+"度和重度讓分分別每回合減少 15% 或 30% 的資源收入。"
+
+msgid "%{color} player"
+msgstr "%{color}玩家"
+
+msgid "No Handicap"
+msgstr "無讓分"
+
+msgid ""
+"No special restrictions on starting resources and resource income per turn."
+msgstr ""
+"起始資源與每回合資源收入無特殊限制。"
+
+msgid "Mild Handicap"
+msgstr "輕度讓分"
+
+msgid ""
+"Players with mild handicap start with fewer resources and earn 15% fewer "
+"resources per turn."
+msgstr ""
+"輕度讓分的玩家以較少資源開局，且每回合收入減少 15%。"
+
+msgid "Severe Handicap"
+msgstr "重度讓分"
+
+msgid ""
+"Players with severe handicap start with fewer resources and earn 30% fewer "
+"resources per turn."
+msgstr ""
+"重度讓分的玩家以較少資源開局，且每回合收入減少 30%。"
+
+msgid ""
+"Default\n"
+"value"
+msgstr ""
+"預設\n"
+"數值"
+
+msgid "Set %{skill} Skill:"
+msgstr "設定 %{skill} 技能："
+
+msgid "Set %{skill} base value. Right-click to reset all skills to default."
+msgstr "設定 %{skill} 基礎值。右鍵按一下可將所有技能重置為預設。"
+
+msgid "View %{skill} Info"
+msgstr "檢視 %{skill} 資訊"
+
+msgid ""
+"Default\n"
+"skill"
+msgstr ""
+"預設\n"
+"技能"
+
+msgid "The available values range from %{min} to %{max}."
+msgstr "可用數值範圍為 %{min} 至 %{max}。"
+
+msgid "Uppercase"
+msgstr "大寫"
+
+msgid "Click to switch to uppercase letters."
+msgstr "按一下切換為大寫字母。"
+
+msgid "Keyboard|123"
+msgstr "123"
+
+msgid "Keyboard type"
+msgstr "鍵盤類型"
+
+msgid "Click to switch between keyboard types."
+msgstr "按一下切換鍵盤類型。"
+
+msgid "Keyboard|SPACE"
+msgstr "空格"
+
+msgid "Change language"
+msgstr "切換語言"
+
+msgid "Click to switch between languages."
+msgstr "按一下切換語言。"
+
+msgid "Backspace"
+msgstr "退格"
+
+msgid "Click to remove characters."
+msgstr "按一下刪除字元。"
+
+msgid "Lowercase"
+msgstr "小寫"
+
+msgid "Click to switch to lowercase letters."
+msgstr "按一下切換為小寫字母。"
+
+msgid "Keyboard|ABC"
+msgstr "ABC"
+
+msgid "Swap sign"
+msgstr "正負號切換"
+
+msgid "Click to switch between signed and unsigned numbers."
+msgstr "按一下切換正負數。"
+
+msgid "The entered value is invalid."
+msgstr "輸入的數值無效。"
+
+msgid ""
+"The entered value is out of range.\n"
+"It should be not less than %{minValue} and not more than %{maxValue}."
+msgstr ""
+"輸入的數值超出範圍。\n"
+"應不小於 %{minValue} 且不大於 %{maxValue}。"
+
+msgid "Kingdom Income"
+msgstr "王國收入"
+
+msgid "Kingdom Income per day."
+msgstr "王國每日收入。"
+
+msgid "For every lighthouse controlled, your ships will move further each day."
+msgstr "每控制一座燈塔，船隻每日可移動更遠。"
+
+msgid "English"
+msgstr "英文"
+
+msgid "French"
+msgstr "法文"
+
+msgid "Polish"
+msgstr "波蘭文"
+
+msgid "German"
+msgstr "德文"
+
+msgid "Russian"
+msgstr "俄文"
+
+msgid "Italian"
+msgstr "義大利文"
+
+msgid "Czech"
+msgstr "捷克文"
+
+msgid "Norwegian"
+msgstr "挪威文"
+
+msgid "Belarusian"
+msgstr "白俄羅斯文"
+
+msgid "Bulgarian"
+msgstr "保加利亞文"
+
+msgid "Ukrainian"
+msgstr "烏克蘭文"
+
+msgid "Romanian"
+msgstr "羅馬尼亞文"
+
+msgid "Spanish"
+msgstr "西班牙文"
+
+msgid "Swedish"
+msgstr "瑞典文"
+
+msgid "Portuguese"
+msgstr "葡萄牙文"
+
+msgid "Turkish"
+msgstr "土耳其文"
+
+msgid "Dutch"
+msgstr "荷蘭文"
+
+msgid "Hungarian"
+msgstr "匈牙利文"
+
+msgid "Danish"
+msgstr "丹麥文"
+
+msgid "Slovak"
+msgstr "斯洛伐克文"
+
+msgid "Vietnamese"
+msgstr "越南文"
+
+msgid "Greek"
+msgstr "希臘文"
+
+msgid "Esperanto"
+msgstr "世界語"
+
+msgid "Simplified Chinese"
+msgstr "簡體中文"
+
+msgid "Traditional Chinese"
+msgstr "繁體中文"
+
+msgid "Slow"
+msgstr "慢"
+
+msgid "Fast"
+msgstr "快"
+
+msgid "Very Fast"
+msgstr "非常快"
+
+msgid "Dynamic"
+msgstr "動態"
+
+msgid "Good"
+msgstr "善良"
+
+msgid "Evil"
+msgstr "邪惡"
+
+msgid "Black & White"
+msgstr "黑白"
+
+msgid "Color"
+msgstr "彩色"
+
+msgid "Configure"
+msgstr "設定"
+
+msgid ", FPS: "
+msgstr ", FPS: "
+
+msgid "Ector"
+msgstr "Ector"
+
+msgid "Gwenneth"
+msgstr "Gwenneth"
+
+msgid "Sir Gallant"
+msgstr "Sir Gallant"
+
+msgid "Tyro"
+msgstr "Tyro"
+
+msgid "Dimitry"
+msgstr "Dimitry"
+
+msgid "Ruby"
+msgstr "Ruby"
+
+msgid "Crag Hack"
+msgstr "Crag Hack"
+
+msgid "Fineous"
+msgstr "Fineous"
+
+msgid "Jaclyn"
+msgstr "Jaclyn"
+
+msgid "Jezebel"
+msgstr "Jezebel"
+
+msgid "Atlas"
+msgstr "Atlas"
+
+msgid "Ergon"
+msgstr "Ergon"
+
+msgid "Gem"
+msgstr "Gem"
+
+msgid "Natasha"
+msgstr "Natasha"
+
+msgid "Carlawn"
+msgstr "Carlawn"
+
+msgid "Luna"
+msgstr "Luna"
+
+msgid "Arie"
+msgstr "Arie"
+
+msgid "Barok"
+msgstr "Barok"
+
+msgid "Kastore"
+msgstr "Kastore"
+
+msgid "Falagar"
+msgstr "Falagar"
+
+msgid "Dawn"
+msgstr "Dawn"
+
+msgid "Flint"
+msgstr "Flint"
+
+msgid "Halon"
+msgstr "Halon"
+
+msgid "Myra"
+msgstr "Myra"
+
+msgid "Myrini"
+msgstr "Myrini"
+
+msgid "Wilfrey"
+msgstr "Wilfrey"
+
+msgid "Mandigal"
+msgstr "Mandigal"
+
+msgid "Sarakin"
+msgstr "Sarakin"
+
+msgid "Charity"
+msgstr "Charity"
+
+msgid "Darlana"
+msgstr "Darlana"
+
+msgid "Ranloo"
+msgstr "Ranloo"
+
+msgid "Rialdo"
+msgstr "Rialdo"
+
+msgid "Zam"
+msgstr "Zam"
+
+msgid "Zom"
+msgstr "Zom"
+
+msgid "Celia"
+msgstr "Celia"
+
+msgid "Roxana"
+msgstr "Roxana"
+
+msgid "Lord Corlagon"
+msgstr "Lord Corlagon"
+
+msgid "Lord Halton"
+msgstr "Lord Halton"
+
+msgid "Sister Eliza"
+msgstr "Sister Eliza"
+
+msgid "Brother Brax"
+msgstr "Brother Brax"
+
+msgid "Dainwin"
+msgstr "Dainwin"
+
+msgid "Gallavant"
+msgstr "Gallavant"
+
+msgid "Joseph"
+msgstr "Joseph"
+
+msgid "Mog"
+msgstr "Mog"
+
+msgid "Solmyr"
+msgstr "Solmyr"
+
+msgid "Ceallach"
+msgstr "Ceallach"
+
+msgid "Drakonia"
+msgstr "Drakonia"
+
+msgid "Elderian"
+msgstr "Elderian"
+
+msgid "Jarkonas"
+msgstr "Jarkonas"
+
+msgid "Martine"
+msgstr "Martine"
+
+msgid "shipAndGraveyard|%{object} robber"
+msgstr "%{object}強盜"
+
+msgid "pyramid|%{object} raided"
+msgstr "%{object}已被搜刮"
+
+msgid " gives you maximum morale"
+msgstr "給予你最高士氣"
+
+msgid " gives you maximum luck"
+msgstr "給予你最高運氣"
+
+msgid "You cannot have multiple spell books."
+msgstr "不能擁有多本法術書。"
+
+msgid "You cannot pick up this artifact, you already have a full load!"
+msgstr "無法拾取此神器，神器欄位已滿！"
+
+msgid "To cast spells, you must first buy a spell book for %{gold} gold."
+msgstr "要施放法術，必須先花 %{gold} 金幣購買法術書。"
+
+msgid "Unfortunately, you seem to be a little short of cash at the moment."
+msgstr "很遺憾，你目前似乎資金不足。"
+
+msgid "Do you wish to buy one?"
+msgstr "要購買一本嗎？"
+
+msgid "%{count} / day"
+msgstr "%{count} / 日"
+
+msgid "one"
+msgstr "一"
+
+msgid "two"
+msgstr "二"
+
+msgid "A whirlpool engulfs your ship. Some of your army has fallen overboard."
+msgstr "漩渦吞沒了你的船。部分軍隊落入水中。"
+
+msgid "Insulted by your refusal of their offer, the monsters attack!"
+msgstr "怪物因你拒絕牠們的提議而惱怒，發動了攻擊！"
+
+msgid ""
+"The %{monster}, awed by the power of your forces, begin to scatter.\n"
+"Do you wish to pursue and engage them?"
+msgstr ""
+"%{monster} 被你的軍隊力量震懾，開始四散逃離。\n"
+"是否要追擊？"
+
+msgid "Ransacking an enemy camp, you discover a hidden cache of treasures."
+msgstr "搜刮敵方營地時，你發現了一處隱藏的寶藏。"
+
+msgid ""
+"Your ship bumps into a barrel drifting at sea. Inside, you discover a stash "
+"of lost treasure."
+msgstr ""
+"你的船撞上了一個在海上漂流的木桶。裡面發現了一批遺落的寶藏。"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I have been working very hard to provide you with these resources, "
+"come back next week for more.\""
+msgstr ""
+"磨坊管理員宣布:\n"
+"「大人，我一直努力為您提供這些資源，請下週再來取用。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I am sorry, there are no resources currently available. Please try "
+"again next week.\""
+msgstr ""
+"磨坊管理員宣布:\n"
+"「大人，很抱歉，目前沒有可用的資源。請下週再來。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I have been working very hard to provide you with this gold, come "
+"back next week for more.\""
+msgstr ""
+"磨坊管理員宣布:\n"
+"「大人，我一直努力為您準備黃金，請下週再來取用。」"
+
+msgid ""
+"The keeper of the mill announces:\n"
+"\"Milord, I am sorry, there is no gold currently available. Please try again "
+"next week.\""
+msgstr ""
+"磨坊管理員宣布:\n"
+"「大人，很抱歉，目前沒有可用的黃金。請下週再來。」"
+
+msgid ""
+"You've found an abandoned lean-to.\n"
+"Poking about, you discover some resources hidden nearby."
+msgstr ""
+"你發現了一間廢棄的棚屋。\n"
+"四處翻找後，發現附近藏有一些資源。"
+
+msgid "The lean-to is long abandoned. There is nothing of value here."
+msgstr "棚屋早已荒廢，這裡沒有任何有價值的東西。"
+
+msgid ""
+"You catch a leprechaun foolishly sleeping amidst a cluster of magic "
+"mushrooms.\n"
+"In exchange for his freedom, he guides you to a small pot filled with "
+"precious things."
+msgstr ""
+"你發現一個妖精愚蠢地睡在一叢魔法蘑菇中間。\n"
+"為了換取自由，他帶你去了一個裝滿珍貴物品的小罐子。"
+
+msgid ""
+"You've found a magic garden, the kind of place that leprechauns and faeries "
+"like to cavort in, but there is no one here today.\n"
+"Perhaps you should try again next week."
+msgstr ""
+"你發現了一座魔法花園，是妖精和仙子喜歡嬉戲的地方，但今天這裡空無一人。\n"
+"或許下週再來試試。"
+
+msgid "You come upon the remains of an unfortunate adventurer."
+msgstr "你發現了一位不幸冒險者的遺骸。"
+
+msgid "Treasure"
+msgstr "寶藏"
+
+msgid "Searching through the tattered clothing, you find the %{artifact}."
+msgstr "翻找破舊的衣物時，你發現了 %{artifact}。"
+
+msgid "Searching through the tattered clothing, you find nothing."
+msgstr "翻找破舊的衣物，什麼都沒找到。"
+
+msgid ""
+"You come across an old wagon left by a trader who didn't quite make it to "
+"safe terrain."
+msgstr ""
+"你發現一輛舊馬車；留下它的商人沒能抵達安全地帶。"
+
+msgid "Unfortunately, others have found it first, and the wagon is empty."
+msgstr "很遺憾，其他人已捷足先登，馬車是空的。"
+
+msgid "Searching inside, you find the %{artifact}."
+msgstr "在裡面搜尋，你發現了 %{artifact}。"
+
+msgid "Inside, you find some of the wagon's cargo still intact."
+msgstr "在裡面，你發現了一些馬車貨物仍完好無損。"
+
+msgid "You search through the flotsam, and find some wood and some gold."
+msgstr "你翻找漂流物，發現了一些木材和黃金。"
+
+msgid "You search through the flotsam, and find some wood."
+msgstr "你翻找漂流物，發現了一些木材。"
+
+msgid "You search through the flotsam, but find nothing."
+msgstr "你翻找了漂流物，但什麼都沒找到。"
+
+msgid "Shrine of the 1st Circle"
+msgstr "第一環神殿"
+
+msgid ""
+"You come across a small shrine attended by a group of novice acolytes.\n"
+"In exchange for your protection, they agree to teach you a simple spell - "
+"'%{spell}'."
+msgstr ""
+"你偶然發現一座由一群見習僧侶看管的小神殿。\n"
+"為了換取你的保護，他們同意教你一個簡單的法術——「%{spell}」。"
+
+msgid "Shrine of the 2nd Circle"
+msgstr "第二環神殿"
+
+msgid ""
+"You come across an ornate shrine attended by a group of rotund friars.\n"
+"In exchange for your protection, they agree to teach you a spell - "
+"'%{spell}'."
+msgstr ""
+"你偶然發現一座由一群圓胖修士看管的華麗神殿。\n"
+"為了換取你的保護，他們同意教你一個法術——「%{spell}」。"
+
+msgid "Shrine of the 3rd Circle"
+msgstr "第三環神殿"
+
+msgid ""
+"You come across a lavish shrine attended by a group of high priests.\n"
+"In exchange for your protection, they agree to teach you a sophisticated "
+"spell - '%{spell}'."
+msgstr ""
+"你偶然發現一座由一群大祭司看管的奢華神殿。\n"
+"為了換取你的保護，他們同意教你一個高深法術——「%{spell}」。"
+
+msgid ""
+"\n"
+"Unfortunately, you do not have the wisdom to understand the spell, and you "
+"are unable to learn it."
+msgstr ""
+"\n"
+"很遺憾，你沒有足夠的智慧來理解此法術，無法學會它。"
+
+msgid ""
+"\n"
+"Unfortunately, you already have knowledge of this spell, so there is nothing "
+"more for them to teach you."
+msgstr ""
+"\n"
+"很遺憾，你已知曉此法術，他們無法再教你更多了。"
+
+msgid ""
+"\n"
+"Unfortunately, you have no Magic Book to record the spell with."
+msgstr ""
+"\n"
+"很遺憾，你沒有法術書來記錄此法術。"
+
+msgid ""
+"You approach the hut and observe a witch inside studying an ancient tome on "
+"%{skill}.\n"
+"\n"
+msgstr ""
+"你走近小屋，看到裡面有一位女巫正在研讀一本關於 %{skill} 的古老典籍。\n"
+"\n"
+
+msgid ""
+"As you approach, she turns and focuses her one glass eye on you.\n"
+"\"You already know everything you deserve to learn!\" the witch screeches. "
+"\"NOW GET OUT OF MY HOUSE!\""
+msgstr ""
+"當你走近時，她轉過身用她的玻璃眼瞪著你。\n"
+"「你已經知道了所有你該學的東西！」女巫尖叫道。「立刻滾出我的房子！」"
+
+msgid ""
+"As you approach, she turns and speaks.\n"
+"\"You already know that which I would teach you. I can help you no further.\""
+msgstr ""
+"當你走近時，她轉過身說道。\n"
+"「你已經知道我要教的東西了。我無法再幫助你。」"
+
+msgid ""
+"An ancient and immortal witch living in a hut with bird's legs for stilts "
+"teaches you %{skill} for her own inscrutable purposes."
+msgstr ""
+"一位住在以鳥腿為支柱小屋中的古老不朽女巫，為了她不可測的目的教導了你 "
+"%{skill}。"
+
+msgid "As you drink the sweet water, you gain luck for your next battle."
+msgstr "喝下甘甜的泉水後，你的下一場戰鬥將獲得好運加成。"
+
+msgid "You drink from the enchanted fountain, but nothing happens."
+msgstr "你從施了魔法的噴泉中飲水，但什麼都沒發生。"
+
+msgid "You enter the faerie ring, but nothing happens."
+msgstr "你進入了妖精之環，但什麼都沒發生。"
+
+msgid ""
+"Upon entering the mystical faerie ring, your army gains luck for its next "
+"battle."
+msgstr ""
+"進入神祕的妖精之環後，軍隊在下一場戰鬥中將獲得好運加成。"
+
+msgid ""
+"You've found an ancient and weathered stone idol.\n"
+"It is supposed to grant luck to visitors, but since the stars are already "
+"smiling upon you, it does nothing."
+msgstr ""
+"你發現了一座古老且風化的石偶像。\n"
+"據說它能賜予造訪者好運，但由於幸運之星已經眷顧你了，所以毫無效果。"
+
+msgid ""
+"You've found an ancient and weathered stone idol.\n"
+"Kissing it is supposed to be lucky, so you do. The stone is very cold to the "
+"touch."
+msgstr ""
+"你發現了一座古老且風化的石偶像。\n"
+"據說親吻它會帶來好運，於是你照做了。石頭觸感非常冰冷。"
+
+msgid "The mermaids silently entice you to return later and be blessed again."
+msgstr "美人魚靜靜地引誘你稍後再來接受祝福。"
+
+msgid ""
+"The magical, soothing beauty of the Mermaids reaches you and your crew.\n"
+"Just for a moment, you forget your worries and bask in the beauty of the "
+"moment.\n"
+"The mermaids' charms bless you with increased luck for your next combat."
+msgstr ""
+"美人魚那神奇而撫慰人心的美麗觸及你和你的船員。\n"
+"短暫的一刻，你忘卻了煩憂，沉浸在美好之中。\n"
+"美人魚的魅力為你的下一場戰鬥賜予好運加成。"
+
+msgid ""
+"You come upon the pyramid of a great and ancient king.\n"
+"You are tempted to search it for treasure, but all the old stories warn of "
+"fearful curses and undead guardians.\n"
+"Will you search?"
+msgstr ""
+"你來到了一位偉大古代國王的金字塔前。\n"
+"你很想搜尋寶藏，但所有古老的故事都警告著可怕的詛咒和亡靈守衛。\n"
+"要搜尋嗎？"
+
+msgid ""
+"Upon defeating the monsters, you decipher an ancient glyph on the wall, "
+"telling the secret of the spell - '"
+msgstr ""
+"擊敗怪物後，你破譯了牆上的古老銘文，得知了法術的奧祕——「"
+
+msgid "Unfortunately, you have no Magic Book to record the spell with."
+msgstr "很遺憾，你沒有法術書來記錄此法術。"
+
+msgid ""
+"Unfortunately, you do not have the wisdom to understand the spell, and you "
+"are unable to learn it."
+msgstr ""
+"很遺憾，你沒有足夠的智慧來理解此法術，無法學會它。"
+
+msgid ""
+"You come upon the pyramid of a great and ancient king.\n"
+"Routine exploration reveals that the pyramid is completely empty."
+msgstr ""
+"你來到了一位偉大古代國王的金字塔前。\n"
+"例行探索後發現金字塔完全是空的。"
+
+msgid ""
+"A drink at the well is supposed to restore your spell points, but you are "
+"already at maximum."
+msgstr ""
+"在井中飲水據說能恢復魔法值，但你的魔法值已經是滿的了。"
+
+msgid "A second drink at the well in one day will not help you."
+msgstr "一天內在井中第二次飲水不會有幫助。"
+
+msgid "A drink from the well has restored your spell points to maximum."
+msgstr "井中的一口水已將你的魔法值恢復至最大值。"
+
+msgid ""
+"\"I'm sorry sir,\" The leader of the soldiers says, \"but you already know "
+"everything we have to teach.\""
+msgstr ""
+"「抱歉，大人，」士兵的首領說道，「但你已經知道我們能教的一切了。」"
+
+msgid "The soldiers living in the fort teach you a few new defensive tricks."
+msgstr "駐守堡壘的士兵教了你一些新的防禦技巧。"
+
+msgid ""
+"You've come upon a mercenary camp practicing their tactics. \"You're too "
+"advanced for us,\" the mercenary captain says. \"We can teach nothing more.\""
+msgstr ""
+"你偶然來到一個正在練習戰術的傭兵營地。「你太強了，」傭兵隊長說道。「我們沒什"
+"麼能教你的了。」"
+
+msgid ""
+"You've come upon a mercenary camp practicing their tactics. The mercenaries "
+"welcome you and your troops and invite you to train with them."
+msgstr ""
+"你偶然來到一個正在練習戰術的傭兵營地。傭兵們歡迎你和你的部隊，邀請你們一起訓"
+"練。"
+
+msgid "\"Go 'way!\", the witch doctor barks, \"you know all I know.\""
+msgstr "「走開！」巫醫吠道，「你已經知道我所知的一切了。」"
+
+msgid ""
+"An Orcish witch doctor living in the hut deepens your knowledge of magic by "
+"showing you how to cast stones, read portents, and decipher the intricacies "
+"of chicken entrails."
+msgstr ""
+"住在小屋裡的獸人巫醫向你展示如何投石占卜、解讀預兆和辨析雞內臟的複雜紋理，加"
+"深了你的魔法知識。"
+
+msgid ""
+"You've found a group of Druids worshipping at one of their strange stone "
+"edifices. Silently, the Druids turn you away, indicating they have nothing "
+"new to teach you."
+msgstr ""
+"你發現一群德魯伊正在其中一座奇異的石造建築前膜拜。德魯伊們默默將你拒之門外，"
+"示意他們沒有新東西可教你。"
+
+msgid ""
+"You've found a group of Druids worshipping at one of their strange stone "
+"edifices. Silently, they teach you new ways to cast spells."
+msgstr ""
+"你發現一群德魯伊正在其中一座奇異的石造建築前膜拜。他們默默教你施法的新方式。"
+
+msgid ""
+"You tentatively approach the burial ground of ancient warriors. Do you want "
+"to search the graves?"
+msgstr ""
+"你試探性地走向古代戰士的墓地。要搜尋墳墓嗎？"
+
+msgid ""
+"You spend several hours searching the graves and find nothing. Such a "
+"despicable act reduces your army's morale."
+msgstr ""
+"你花了數小時搜尋墳墓卻一無所獲。這種卑劣行為讓軍隊士氣下降。"
+
+msgid "Upon defeating the Zombies you search the graves and find something!"
+msgstr "擊敗殭屍後你搜尋了墳墓並找到了些東西！"
+
+msgid ""
+"The rotting hulk of a great pirate ship creaks eerily as it is pushed "
+"against the rocks. Do you wish to search the shipwreck?"
+msgstr ""
+"一艘巨大海盜船腐爛的殘骸被推靠在岩石上，發出詭異的嘎吱聲。要搜尋沉船嗎？"
+
+msgid ""
+"You spend several hours sifting through the debris and find nothing. Such a "
+"despicable act reduces your army's morale."
+msgstr ""
+"你花了數小時翻找殘骸卻一無所獲。這種卑劣行為讓軍隊士氣下降。"
+
+msgid ""
+"Upon defeating the Ghosts you sift through the debris and find something!"
+msgstr ""
+"擊敗幽靈後你篩查了殘骸並找到了些東西！"
+
+msgid ""
+"The rotting hulk of a great pirate ship creaks eerily as it is pushed "
+"against the rocks. Do you wish to search the ship?"
+msgstr ""
+"一艘巨大海盜船腐爛的殘骸被推靠在岩石上，發出詭異的嘎吱聲。要搜尋船隻嗎？"
+
+msgid ""
+"Upon defeating the Skeletons you sift through the debris and find something!"
+msgstr ""
+"擊敗骷髏兵後你篩查了殘骸並找到了些東西！"
+
+msgid "Your men spot a navigational buoy, confirming that you are on course."
+msgstr "你的船員發現了一個航標，確認航線正確。"
+
+msgid ""
+"Your men spot a navigational buoy, confirming that you are on course and "
+"increasing their morale."
+msgstr ""
+"你的船員發現了一個航標，確認航線正確，提振了士氣。"
+
+msgid ""
+"The drink at the oasis is refreshing, but offers no further benefit. The "
+"oasis might help again if you fought a battle first."
+msgstr ""
+"綠洲的水很清爽，但沒有額外效果。先打完一場仗後綠洲可能會再次生效。"
+
+msgid ""
+"A drink at the oasis fills your troops with strength and lifts their "
+"spirits. You can travel a bit further today."
+msgstr ""
+"在綠洲飲水使部隊充滿力量、精神振奮。今天可以多走一段路。"
+
+msgid ""
+"The drink at the watering hole is refreshing, but offers no further benefit. "
+"The watering hole might help again if you fought a battle first."
+msgstr ""
+"水源地的水很清爽，但沒有額外效果。先打完一場仗後水源地可能會再次生效。"
+
+msgid ""
+"A drink at the watering hole fills your troops with strength and lifts their "
+"spirits. You can travel a bit further today."
+msgstr ""
+"在水源地飲水使部隊充滿力量、精神振奮。今天可以多走一段路。"
+
+msgid ""
+"It doesn't help to pray twice before a battle. Come back after you've fought."
+msgstr ""
+"戰鬥前祈禱兩次沒有幫助。打完仗再回來吧。"
+
+msgid "A visit and a prayer at the temple raises the morale of your troops."
+msgstr "在神廟中造訪並祈禱提升了部隊的士氣。"
+
+msgid ""
+"An old Knight appears on the steps of the gazebo. \"I am sorry, my liege, I "
+"have taught you all I can.\""
+msgstr ""
+"一位年邁的騎士出現在涼亭的臺階上。「很抱歉，主公，我已經把能教的都教了。」"
+
+msgid ""
+"An old Knight appears on the steps of the gazebo. \"My liege, I will teach "
+"you all that I know to aid you in your travels.\""
+msgstr ""
+"一位年邁的騎士出現在涼亭的臺階上。「主公，我將傾囊相授，助你旅途順利。」"
+
+msgid ""
+"You've pulled a shipwreck survivor from certain death in an unforgiving "
+"ocean. Grateful, he says, \"I would give you an artifact as a reward, but "
+"you're all full.\""
+msgstr ""
+"你從無情的大海中救出了一位沉船倖存者。他感激地說：「我想給你一件神器作為回"
+"報，但你的神器欄位已滿了。」"
+
+msgid ""
+"You've pulled a shipwreck survivor from certain death in an unforgiving "
+"ocean. Grateful, he rewards you for your act of kindness by giving you the "
+"%{art}."
+msgstr ""
+"你從無情的大海中救出了一位沉船倖存者。他感激你的善舉，將 %{art} 送給你作為回"
+"報。"
+
+msgid "A leprechaun offers you the %{art} for the small price of %{gold} Gold."
+msgstr "一個妖精以 %{gold} 金幣的低價向你兜售 %{art}。"
+
+msgid ""
+"A leprechaun offers you the %{art} for the small price of %{gold} Gold and "
+"%{count} %{res}."
+msgstr ""
+"一個妖精以 %{gold} 金幣加 %{count} %{res} 的低價向你兜售 %{art}。"
+
+msgid "Do you wish to buy this artifact?"
+msgstr "要購買此神器嗎？"
+
+msgid ""
+"You try to pay the leprechaun, but realize that you can't afford it. The "
+"leprechaun stamps his foot and ignores you."
+msgstr ""
+"你想付錢給妖精，但發現負擔不起。妖精跺了跺腳，不理你了。"
+
+msgid ""
+"Insulted by your refusal of his generous offer, the leprechaun stamps his "
+"foot and ignores you."
+msgstr ""
+"妖精因你拒絕他慷慨的提議而受辱，跺了跺腳不理你了。"
+
+msgid "You've found the artifact: "
+msgstr "你找到了神器："
+
+msgid ""
+"You've found the humble dwelling of a withered hermit. The hermit tells you "
+"that he is willing to give the %{art} to the first wise person he meets."
+msgstr ""
+"你發現了一位枯槁隱士的簡陋居所。隱士告訴你，他願意將 %{art} 送給第一位遇到的"
+"有智慧者。"
+
+msgid ""
+"You've come across the spartan quarters of a retired soldier. The soldier "
+"tells you that he is willing to pass on the %{art} to the first true leader "
+"he meets."
+msgstr ""
+"你偶然發現一位退役士兵的簡樸住處。士兵告訴你，他願意將 %{art} 傳給第一位遇到"
+"的真正領袖。"
+
+msgid ""
+"You've encountered a strange person with a hat and an owl on it. He tells "
+"you that he is willing to give %{art} if you have %{skill}."
+msgstr ""
+"你遇到了一個戴著帽子、上面有隻貓頭鷹的奇人。他告訴你，若你擁有 %{skill}，他願"
+"意給你 %{art}。"
+
+msgid ""
+"You come upon an ancient artifact. As you reach for it, a pack of Rogues "
+"leap out of the brush to guard their stolen loot."
+msgstr ""
+"你發現了一件古老的神器。正當你伸手去拿時，一群盜賊從灌木叢中跳出，守衛他們偷"
+"來的贓物。"
+
+msgid ""
+"Through a clearing you observe an ancient artifact. Unfortunately, it's "
+"guarded by a nearby %{monster}. Do you want to fight the %{monster} for the "
+"artifact?"
+msgstr ""
+"隔著一片空地，你看到一件古老的神器。不幸的是，旁邊有 %{monster} 守衛。要為了"
+"神器與 %{monster} 戰鬥嗎？"
+
+msgid "Victorious, you take your prize, the %{art}."
+msgstr "你取得了勝利，拿走了獎品 %{art}。"
+
+msgid ""
+"Discretion is the better part of valor, and you decide to avoid this fight "
+"for today."
+msgstr ""
+"慎重是勇氣的一部分，你決定今天不打這場仗。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it, "
+"only to find it empty."
+msgstr ""
+"花了數小時從海中撈出寶箱後打開一看，裡面竟然是空的。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it "
+"and find %{gold} gold and the %{art}."
+msgstr ""
+"花了數小時從海中撈出寶箱後打開，發現了 %{gold} 金幣和 %{art}。"
+
+msgid ""
+"After spending hours trying to fish the chest out of the sea, you open it "
+"and find %{gold} gold pieces."
+msgstr ""
+"花了數小時從海中撈出寶箱後打開，發現了 %{gold} 金幣。"
+
+msgid ""
+"After scouring the area, you fall upon a hidden treasure cache. You may take "
+"the gold or distribute the gold to the peasants for experience. Do you wish "
+"to keep the gold?"
+msgstr ""
+"搜尋此區域後，你發現了一處隱藏的寶藏。你可以拿走黃金，或將黃金分給農民以換取"
+"經驗值。要保留黃金嗎？"
+
+msgid ""
+"After scouring the area, you fall upon a hidden chest, containing the "
+"ancient artifact %{art}."
+msgstr ""
+"搜尋此區域後，你發現了一個隱藏的寶箱，裡面裝有古老的神器 %{art}。"
+
+msgid ""
+"You stumble upon a dented and tarnished lamp lodged deep in the earth. Do "
+"you wish to rub the lamp?"
+msgstr ""
+"你偶然發現一盞凹凸不平、鏽蝕的神燈深埋在地下。要擦拭神燈嗎？"
+
+msgid ""
+"You have taken control of the local Alchemist shop. It will provide you with "
+"%{count} unit of Mercury per day."
+msgstr ""
+"你取得了當地煉金術士商店的控制權。每日將提供 %{count} 單位的水銀。"
+
+msgid ""
+"You gain control of a sawmill. It will provide you with %{count} units of "
+"wood per day."
+msgstr ""
+"你取得了一座鋸木廠的控制權。每日將提供 %{count} 單位的木材。"
+
+msgid ""
+"You gain control of an ore mine. It will provide you with %{count} units of "
+"ore per day."
+msgstr ""
+"你取得了一座礦石礦場的控制權。每日將提供 %{count} 單位的礦石。"
+
+msgid ""
+"You gain control of a sulfur mine. It will provide you with %{count} unit of "
+"sulfur per day."
+msgstr ""
+"你取得了一座硫磺礦場的控制權。每日將提供 %{count} 單位的硫磺。"
+
+msgid ""
+"You gain control of a crystal mine. It will provide you with %{count} unit "
+"of crystal per day."
+msgstr ""
+"你取得了一座水晶礦場的控制權。每日將提供 %{count} 單位的水晶。"
+
+msgid ""
+"You gain control of a gem mine. It will provide you with %{count} unit of "
+"gems per day."
+msgstr ""
+"你取得了一座寶石礦場的控制權。每日將提供 %{count} 單位的寶石。"
+
+msgid ""
+"You gain control of a gold mine. It will provide you with %{count} gold per "
+"day."
+msgstr ""
+"你取得了一座金礦的控制權。每日將提供 %{count} 金幣。"
+
+msgid ""
+"The lighthouse is now under your control, and all of your ships will now "
+"move further each day."
+msgstr ""
+"燈塔現已在你的控制之下，所有船隻每日可移動更遠。"
+
+msgid "You gain control of a %{name}."
+msgstr "你取得了 %{name} 的控制權。"
+
+msgid ""
+"You come upon an abandoned gold mine. The mine appears to be haunted. Do you "
+"wish to enter?"
+msgstr ""
+"你發現了一座廢棄金礦。礦場似乎鬧鬼。要進入嗎？"
+
+msgid "You beat the Ghosts and are able to restore the mine to production."
+msgstr "你擊敗了幽靈，得以恢復礦場的生產。"
+
+msgid ""
+"A group of %{monster} with a desire for greater glory wish to join you. Do "
+"you accept?"
+msgstr ""
+"一群渴望更偉大榮耀的 %{monster} 希望加入你。是否接受？"
+
+msgid "As you approach the dwelling, you notice that there is no one here."
+msgstr "當你接近住所時，發現這裡空無一人。"
+
+msgid ""
+"You search the ruins, but the Medusas that used to live here are gone. "
+"Perhaps there will be more next week."
+msgstr ""
+"你搜尋了遺跡，但曾住在這裡的美杜莎已經離開。或許下週會有更多。"
+
+msgid ""
+"You've found some Medusas living in the ruins. They are willing to join your "
+"army for a price. Do you want to recruit Medusas?"
+msgstr ""
+"你在遺跡中發現了一些美杜莎。她們願意以一定代價加入你的軍隊。要招募美杜莎嗎？"
+
+msgid ""
+"You've found a Sprite Tree City. Unfortunately, none of the Sprites living "
+"there wish to join an army. Maybe next week."
+msgstr ""
+"你發現了一座精靈樹城。可惜，住在那裡的精靈都不想加入軍隊。也許下週吧。"
+
+msgid ""
+"Some of the Sprites living in the tree city are willing to join your army "
+"for a price. Do you want to recruit Sprites?"
+msgstr ""
+"住在樹城中的一些精靈願意以一定代價加入你的軍隊。要招募精靈嗎？"
+
+msgid ""
+"A colorful Rogues' wagon stands empty here. Perhaps more Rogues will be here "
+"later."
+msgstr ""
+"一輛色彩繽紛的盜賊馬車空置在此。也許稍後會有更多盜賊出現。"
+
+msgid ""
+"Distant sounds of music and laughter draw you to a colorful wagon housing "
+"Rogues. Do you wish to have any Rogues join your army?"
+msgstr ""
+"遠方傳來的音樂和笑聲將你引到一輛色彩繽紛的盜賊馬車旁。要讓盜賊加入你的軍隊"
+"嗎？"
+
+msgid ""
+"A group of tattered tents, billowing in the sandy wind, beckons you. The "
+"tents are unoccupied. Perhaps more Nomads will be here later."
+msgstr ""
+"一群在沙風中飄動的破舊帳篷向你招手。帳篷空無一人，也許稍後會有更多遊牧民出"
+"現。"
+
+msgid ""
+"A group of tattered tents, billowing in the sandy wind, beckons you. Do you "
+"wish to have any Nomads join you during your travels?"
+msgstr ""
+"一群在沙風中飄動的破舊帳篷向你招手。要讓遊牧民在旅途中加入你嗎？"
+
+msgid "The pit of mud bubbles for a minute and then lies still."
+msgstr "泥坑冒了一分鐘的泡，然後歸於平靜。"
+
+msgid ""
+"As you approach the bubbling pit of mud, creatures begin to climb out and "
+"position themselves around it. In unison they say: \"Mother Earth would like "
+"to offer you a few of her troops. Do you want to recruit Earth Elementals?\""
+msgstr ""
+"當你走近冒泡的泥坑時，生物開始從中爬出並圍繞著它。他們齊聲說道：「大地之母願"
+"意提供一些部隊給你。要招募土元素嗎？」"
+
+msgid "You enter the structure of white stone pillars, and find nothing."
+msgstr "你進入了白色石柱建築，什麼都沒找到。"
+
+msgid ""
+"White stone pillars support a roof that rises up to the sky. As you enter "
+"the structure, the dead air of the outside gives way to a whirling gust that "
+"almost pushes you back out. The air current materializes into a barely "
+"visible form. The creature asks, in what can only be described as a loud "
+"whisper: \"Why have you come? Are you here to call upon the forces of the "
+"air?\""
+msgstr ""
+"白色石柱撐起一座直入雲霄的屋頂。進入建築時，外面死寂的空氣消失了，一股旋風幾"
+"乎把你推回去。氣流凝聚成一個幾乎看不見的形體。那生物以只能形容為低沉耳語的聲"
+"音問道：「你為何而來？是要召喚空氣的力量嗎？」"
+
+msgid "No Fire Elementals approach you from the lava pool."
+msgstr "沒有火元素從岩漿池中靠近你。"
+
+msgid ""
+"Beneath a structure that serves to hold in heat, Fire Elementals move about "
+"in a fiery pool of molten lava. A group of them approach you and offer their "
+"services. Would you like to recruit Fire Elementals?"
+msgstr ""
+"在一座蓄熱建築下方，火元素在熾熱的岩漿池中活動。一群火元素走近你並提供服務。"
+"要招募火元素嗎？"
+
+msgid "A face forms in the water for a moment, and then is gone."
+msgstr "水面上短暫地浮現出一張臉，隨即消失。"
+
+msgid ""
+"Crystalline structures cast shadows over a small reflective pool of water. "
+"You peer into the pool, and a face that is not your own peers back. It asks: "
+"\"Would you like to call upon the powers of water?\""
+msgstr ""
+"水晶結構在一個小型反射水池上投下陰影。你凝視池中，一張不屬於你的面孔回望著"
+"你。它問道：「你想召喚水的力量嗎？」"
+
+msgid "This burial site is deathly still."
+msgstr "這片墓地死寂一片。"
+
+msgid ""
+"Restless spirits of long dead warriors seeking their final resting place "
+"offer to join you in hopes of finding peace. Do you wish to recruit ghosts?"
+msgstr ""
+"早已亡故的不安戰士靈魂尋找最終安息之地，願意加入你以期得到安寧。要招募幽靈"
+"嗎？"
+
+msgid ""
+"The City of the Dead is empty of life, and empty of unlife as well. Perhaps "
+"some undead will move in next week."
+msgstr ""
+"亡者之城既無生者，也無亡靈。或許下週會有亡靈進駐。"
+
+msgid ""
+"Some Liches living here are willing to join your army for a price. Do you "
+"want to recruit Liches?"
+msgstr ""
+"住在此處的一些巫妖願意以一定代價加入你的軍隊。要招募巫妖嗎？"
+
+msgid ""
+"You've found the ruins of an ancient city, now inhabited solely by the "
+"undead. Will you search?"
+msgstr ""
+"你發現了一座古城遺跡，如今只有亡靈棲息。要搜尋嗎？"
+
+msgid ""
+"Some of the surviving Liches are impressed by your victory over their "
+"fellows, and offer to join you for a price. Do you want to recruit Liches?"
+msgstr ""
+"倖存的一些巫妖對你戰勝他們的同伴印象深刻，願意以一定代價加入你。要招募巫妖"
+"嗎？"
+
+msgid ""
+"You've found one of those bridges that Trolls are so fond of living under, "
+"but there are none here. Perhaps there will be some next week."
+msgstr ""
+"你找到了一座巨魔最愛棲息其下的橋，但這裡一個都沒有。也許下週會有。"
+
+msgid ""
+"Some Trolls living under a bridge are willing to join your army, but for a "
+"price. Do you want to recruit Trolls?"
+msgstr ""
+"住在橋下的一些巨魔願意以一定代價加入你的軍隊。要招募巨魔嗎？"
+
+msgid "Trolls living under the bridge challenge you. Will you fight them?"
+msgstr "住在橋下的巨魔向你挑戰。要戰鬥嗎？"
+
+msgid ""
+"A few Trolls remain, cowering under the bridge. They approach you and offer "
+"to join your forces as mercenaries. Do you want to buy any Trolls?"
+msgstr ""
+"幾個巨魔畏縮在橋下。他們走近你，提議以傭兵身分加入你的隊伍。要購買巨魔嗎？"
+
+msgid ""
+"The Dragon city has no Dragons willing to join you this week. Perhaps a "
+"Dragon will become available next week."
+msgstr ""
+"龍族之城本週沒有願意加入你的巨龍。也許下週會有。"
+
+msgid ""
+"The Dragon city is willing to offer some Dragons for your army for a price. "
+"Do you wish to recruit Dragons?"
+msgstr ""
+"龍族之城願意以一定代價為你的軍隊提供巨龍。要招募巨龍嗎？"
+
+msgid ""
+"You stand before the Dragon City, a place off-limits to mere humans. Do you "
+"wish to violate this rule and challenge the Dragons to a fight?"
+msgstr ""
+"你站在龍族之城前，這是凡人禁止踏入之地。要違反此規則向巨龍發起挑戰嗎？"
+
+msgid ""
+"Having defeated the Dragon champions, the city's leaders agree to supply "
+"some Dragons to your army for a price. Do you wish to recruit Dragons?"
+msgstr ""
+"擊敗龍族勇士後，城市首領同意讓你的軍隊付費招募巨龍。要招募巨龍嗎？"
+
+msgid "From the observation tower, you are able to see distant lands."
+msgstr "從觀測塔上，你可以看到遠方的土地。"
+
+msgid ""
+"The spring only refills once a week, and someone's already been here this "
+"week."
+msgstr ""
+"泉水每週只補充一次，本週已有人來過了。"
+
+msgid ""
+"A drink at the spring is supposed to give you twice your normal spell "
+"points, but you are already at that level."
+msgstr ""
+"泉水據說能給予你雙倍的正常魔法值，但你已經達到那個水平了。"
+
+msgid ""
+"A drink from the spring fills your blood with magic! You have twice your "
+"normal spell points in reserve."
+msgstr ""
+"泉水中的一口飲料讓你的血液充滿魔力！你的魔法值儲備達到正常值的兩倍。"
+
+msgid ""
+"Recognizing you, the butler refuses to admit you. \"The master,\" he says, "
+"\"will not see the same student twice.\""
+msgstr ""
+"管家認出了你，拒絕讓你入內。「主人，」他說，「不會見同一個學生兩次。」"
+
+msgid ""
+"The butler admits you to see the master of the house. He trains you in the "
+"four skills a hero should know."
+msgstr ""
+"管家允許你謁見主人。他訓練你英雄應知的四項技能。"
+
+msgid ""
+"The butler opens the door and looks you up and down. \"You are neither "
+"famous nor diplomatic enough to be admitted to see my master,\" he sniffs. "
+"\"Come back when you think yourself worthy.\""
+msgstr ""
+"管家打開門，上下打量著你。「你既不夠出名也不夠圓滑，不配覲見我的主人，」他哼"
+"了一聲。「覺得自己配的時候再來吧。」"
+
+msgid " and "
+msgstr "和"
+
+msgid ""
+"All of the %{monsters} you have in your army have been trained by the battle "
+"masters of the fort. Your army now contains %{monsters2}."
+msgstr ""
+"你軍隊中所有的 %{monsters} 已經被堡壘的戰鬥大師訓練過了。軍隊現在包含 "
+"%{monsters2}。"
+
+msgid ""
+"An unusual alliance of Ogres, Orcs, and Dwarves offer to train (upgrade) any "
+"such troops brought to them. Unfortunately, you have none with you."
+msgstr ""
+"食人魔、獸人和矮人的罕見聯盟願意訓練 (升級) 帶來的相關部隊。可惜，你沒有攜帶"
+"任何適用部隊。"
+
+msgid "All of your %{monsters} have been upgraded into %{monsters2}."
+msgstr "你所有的 %{monsters} 已升級為 %{monsters2}。"
+
+msgid ""
+"A blacksmith working at the foundry offers to convert all Pikemen and "
+"Swordsmen's weapons brought to him from iron to steel. He also says that he "
+"knows a process that will convert Iron Golems into Steel Golems. "
+"Unfortunately, you have none of these troops in your army, so he can't help "
+"you."
+msgstr ""
+"在鑄造廠工作的鐵匠願意將所有送來的槍兵和劍士的武器從鐵轉換為鋼。他還說他知道"
+"將鐵魔像轉換為鋼魔像的方法。可惜，你的軍隊中沒有這些部隊，他幫不了你。"
+
+msgid ""
+"The captain looks at you with surprise and says:\n"
+"\"You already have all the maps I know about. Let me fish in peace now.\""
+msgstr ""
+"船長驚訝地看著你說道:\n"
+"「你已經有了我知道的所有海圖。現在讓我安靜地釣魚吧。」"
+
+msgid ""
+"A retired captain living on this refurbished fishing platform offers to sell "
+"you maps of the sea he made in his younger days for 1,000 gold. Do you wish "
+"to buy the maps?"
+msgstr ""
+"一位住在這個翻修過的釣魚平台上的退休船長，願意以 1,000 金幣賣給你他年輕時繪製"
+"的海圖。要購買嗎？"
+
+msgid ""
+"The captain sighs. \"You don't have enough money, eh? You can't expect me to "
+"give my maps away for free!\""
+msgstr ""
+"船長嘆了口氣。「你沒有足夠的錢嗎？總不能指望我免費送你海圖吧！」"
+
+msgid ""
+"You come upon an obelisk made from a type of stone you have never seen "
+"before. Staring at it intensely, the smooth surface suddenly changes to an "
+"inscription. The inscription is a piece of a lost ancient map. Quickly you "
+"copy down the piece and the inscription vanishes as abruptly as it appeared."
+msgstr ""
+"你發現了一座由前所未見的石材製成的方尖碑。你凝視著它，光滑的表面突然變成了銘"
+"文。銘文是一份失落古地圖的碎片。你迅速抄錄下來，銘文便如同出現時一樣突然消失"
+"了。"
+
+msgid "You have already been to this obelisk."
+msgstr "你已經來過這座方尖碑了。"
+
+msgid ""
+"Upon your approach, the tree opens its eyes in delight. \"It is good to see "
+"you, my student. I hope my teachings have helped you.\""
+msgstr ""
+"當你走近時，樹木高興地睜開了眼睛。「很高興見到你，我的學生。希望我的教導對你"
+"有所幫助。」"
+
+msgid ""
+"Upon your approach, the tree opens its eyes in delight. \"Ahh, an "
+"adventurer! Allow me to teach you a little of what I have learned over the "
+"ages.\""
+msgstr ""
+"當你走近時，樹木高興地睜開了眼睛。「啊，一位冒險者！讓我教你一點我歷經數個世"
+"紀學到的知識。」"
+
+msgid "Upon your approach, the tree opens its eyes in delight."
+msgstr "當你走近時，樹木高興地睜開了眼睛。"
+
+msgid ""
+"\"Ahh, an adventurer! I will be happy to teach you a little of what I have "
+"learned over the ages for a mere %{count} %{res}.\""
+msgstr ""
+"「啊，一位冒險者！我很樂意以僅僅 %{count} %{res} 教你一點我歷經數個世紀學到的"
+"知識。」"
+
+msgid "(Just bury it around my roots.)"
+msgstr "(只要埋在我的根部周圍就好。)"
+
+msgid "Tears brim in the eyes of the tree."
+msgstr "淚水湧上了樹木的眼眶。"
+
+msgid "\"I need %{count} %{res}.\""
+msgstr "「我需要 %{count} %{res}。」"
+
+msgid "it whispers. (sniff) \"Well, come back when you can pay me.\""
+msgstr "它低語道。(抽泣) 「好吧，付得起的時候再來吧。」"
+
+msgid ""
+"Nestled among the trees sits a blind seer. After you explain the intent of "
+"your journey, the seer activates his crystal ball, allowing you to see the "
+"strengths and weaknesses of your opponents."
+msgstr ""
+"一位盲眼先知隱居在樹林間。在你說明旅程的目的後，先知啟動了水晶球，讓你看見對"
+"手的優勢和弱點。"
+
+msgid ""
+"The entrance to the cave is dark, and a foul, sulfurous smell issues from "
+"the cave mouth. Will you enter?"
+msgstr ""
+"洞穴入口一片漆黑，洞口散發著惡臭的硫磺味。要進入嗎？"
+
+msgid "Except for evidence of a terrible battle, the cave is empty."
+msgstr "除了一場慘烈戰鬥的痕跡外，洞穴是空的。"
+
+msgid ""
+"You find a powerful and grotesque Demon in the cave. \"Today,\" it rasps, "
+"\"you will fight and surely die. But I will give you a choice of deaths. You "
+"may fight me, or you may fight my servants. Do you prefer to fight my "
+"servants?\""
+msgstr ""
+"你在洞穴中發現了一個強大而猙獰的惡魔。「今天，」牠嘶啞地說，「你將戰鬥並必然"
+"死亡。但我給你選擇死法的機會。你可以和我打，或和我的僕從打。你想和我的僕從打"
+"嗎？」"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and receive %{exp} experience points."
+msgstr ""
+"惡魔發出挑戰的尖叫，並且發動攻擊！經過一場短暫而拚死的戰鬥，你殺死了怪物並獲"
+"得 %{exp} 點經驗值。"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and receive %{exp} experience points and "
+"%{count} gold."
+msgstr ""
+"惡魔發出挑戰的尖叫，並且發動攻擊！經過一場短暫而拚死的戰鬥，你殺死了怪物並獲"
+"得 %{exp} 點經驗值和 %{count} 金幣。"
+
+msgid ""
+"The Demon screams its challenge and attacks! After a short, desperate "
+"battle, you slay the monster and find the %{art} in the back of the cave."
+msgstr ""
+"惡魔發出挑戰的尖叫，並且發動攻擊！經過一場短暫而拚死的戰鬥，你殺死了怪物並在"
+"洞穴深處找到了 %{art}。"
+
+msgid ""
+"Seeing that you do not have %{count} gold, the demon slashes you with its "
+"claws, and the last thing you see is a red haze."
+msgstr ""
+"看到你沒有 %{count} 金幣，惡魔用爪子劈向你，你最後看到的是一片紅色迷霧。"
+
+msgid ""
+"The Demon leaps upon you and has its claws at your throat before you can "
+"even draw your sword. \"Your life is mine,\" it says. \"I will sell it back "
+"to you for %{count} gold.\""
+msgstr ""
+"惡魔撲向你，在你拔劍之前就已把爪子抵在你的喉嚨上。「你的命是我的了，」牠說。"
+"「我願意以 %{count} 金幣把它賣還給你。」"
+
+msgid ""
+"Upon defeating the daemon's servants, you find a hidden cache with %{count} "
+"gold."
+msgstr ""
+"擊敗惡魔的僕從後，你找到了一處藏有 %{count} 金幣的隱密寶藏。"
+
+msgid ""
+"As you enter the Alchemist's Tower, a hobbled, graying man in a brown cloak "
+"makes his way towards you."
+msgstr ""
+"進入煉金術士之塔時，一位披著棕色斗篷、蹣跚而行的灰髮老人向你走來。"
+
+msgid "He checks your pack, and sees that you have 1 cursed item."
+msgid_plural ""
+"He checks your pack, and sees that you have %{count} cursed items."
+msgstr[0] "他檢查了你的背包，發現你有 1 件被詛咒的物品。"
+
+msgid "For %{gold} gold, the alchemist will remove it for you. Do you pay?"
+msgid_plural ""
+"For %{gold} gold, the alchemist will remove them for you. Do you pay?"
+msgstr[0] "煉金術士願意以 %{gold} 金幣為你移除它。要付費嗎？"
+
+msgid ""
+"After you consent to pay the requested amount of gold, the alchemist grabs "
+"the cursed artifact and throws it into his magical cauldron."
+msgid_plural ""
+"After you consent to pay the requested amount of gold, the alchemist grabs "
+"all cursed artifacts and throws them into his magical cauldron."
+msgstr[0] ""
+"你同意支付要求的金額後，煉金術士抓起受詛咒的神器，扔進他的魔法大鍋中。"
+
+msgid ""
+"You hear a voice from behind the locked door, \"You don't have enough gold "
+"to pay for my services.\""
+msgstr ""
+"你聽到鎖著的門後傳來聲音：「你的黃金不足，付不起我的服務費。」"
+
+msgid ""
+"You hear a voice from high above in the tower, \"Go away! I can't help you!\""
+msgstr ""
+"你聽到塔頂傳來聲音：「走開！我幫不了你！」"
+
+msgid ""
+"The head groom speaks to you, \"That is a fine looking horse you have. I am "
+"afraid we can give you no better, but the horses your cavalry are riding "
+"look to be of poor breeding stock. We have many trained war horses which "
+"would aid your riders greatly. I insist you take them.\""
+msgstr ""
+"馬夫長對你說：「你有一匹漂亮的好馬。恐怕我們無法給你更好的，但你騎兵的坐騎看"
+"起來血統不佳。我們有許多訓練有素的戰馬可以大大幫助你的騎手。我堅持讓你帶走牠"
+"們。」"
+
+msgid ""
+"As you approach the stables, the head groom appears, leading a fine looking "
+"war horse. \"This steed will help speed you in your travels. Alas, he will "
+"grow tired in a week. You must also let me give better horses to your "
+"mounted soldiers, their horses look shoddy and weak.\""
+msgstr ""
+"當你走近馬廄時，馬夫長出現了，牽著一匹漂亮的戰馬。「這匹駿馬將加速你的旅途。"
+"可惜牠一週後會疲勞。你也必須讓我給你的騎兵更好的坐騎，他們的馬看起來劣質又虛"
+"弱。」"
+
+msgid ""
+"The head groom approaches you and speaks, \"You already have a fine horse, "
+"and have no inexperienced cavalry which might make use of our trained war "
+"horses.\""
+msgstr ""
+"馬夫長走近你說道：「你已經有一匹好馬了，而且沒有需要我們訓練戰馬的新手騎"
+"兵。」"
+
+msgid ""
+"As you approach the stables, the head groom appears, leading a fine looking "
+"war horse. \"This steed will help speed you in your travels. Alas, his "
+"endurance will wane with a lot of heavy riding, and you must return for a "
+"fresh mount in a week. We also have many fine war horses which could benefit "
+"mounted soldiers, but you have none we can help.\""
+msgstr ""
+"當你走近馬廄時，馬夫長出現了，牽著一匹漂亮的戰馬。「這匹駿馬將加速你的旅途。"
+"可惜大量騎乘後牠的耐力會下降，你一週後必須回來換馬。我們還有許多好的戰馬可供"
+"騎兵使用，但你沒有我們能幫助的部隊。」"
+
+msgid "The Arena guards turn you away."
+msgstr "競技場的守衛將你拒之門外。"
+
+msgid ""
+"You have your crew stop up their ears with wax before the sirens' eerie song "
+"has any chance of luring them to a watery grave."
+msgstr ""
+"在海妖詭異的歌聲有機會將船員引入葬身之地前，你讓他們用蠟堵住耳朵。"
+
+msgid ""
+"As the sirens sing their eerie song, your small, determined army manages to "
+"overcome the urge to dive headlong into the sea."
+msgstr ""
+"海妖唱著詭異的歌聲時，你那小而堅決的軍隊成功克制了一頭栽入大海的衝動。"
+
+msgid ""
+"An eerie wailing song emanates from the sirens perched upon the rocks. Many "
+"of your crew fall under its spell, and dive into the water where they drown. "
+"You are now wiser for the visit, and gain %{exp} experience."
+msgstr ""
+"棲息在岩石上的海妖發出詭異的哀歌。許多船員中了咒語，跳入水中溺斃。經此一事你"
+"更加睿智，獲得 %{exp} 點經驗值。"
+
+msgid ""
+"In a dazzling display of daring, you break into the local jail and free the "
+"hero imprisoned there, who, in return, pledges loyalty to your cause."
+msgstr ""
+"憑藉驚人的膽識，你闖入了當地牢獄並釋放了被囚禁的英雄，作為回報，他向你效忠。"
+
+msgid ""
+"You already have %{count} heroes, and regretfully must leave the prisoner in "
+"this jail to languish in agony for untold days."
+msgstr ""
+"你已有 %{count} 位英雄，只能遺憾地將囚犯留在牢獄中繼續受苦。"
+
+msgid ""
+"You enter a rickety hut and talk to the magician who lives there. He tells "
+"you of places near and far which may aid you in your journeys."
+msgstr ""
+"你進入一間搖搖欲墜的小屋，與住在那裡的法師交談。他告訴你遠近各處可能對旅途有"
+"幫助的地點。"
+
+msgid "This eye seems to be intently studying its surroundings."
+msgstr "這隻眼睛似乎正專注地觀察著周圍環境。"
+
+msgid "You come across a giant Sphinx. The Sphinx remains strangely quiet."
+msgstr "你遇到了一座巨大的人面獅身像。它異常沉默。"
+
+msgid ""
+"\"I have a riddle for you,\" the Sphinx says. \"Answer correctly, and you "
+"shall be rewarded. Answer incorrectly, and you shall be eaten. Do you accept "
+"the challenge?\""
+msgstr ""
+"「我有一個謎語要考你，」人面獅身像說。「答對了就有獎賞。答錯了就會被吃掉。你"
+"接受挑戰嗎？」"
+
+msgid ""
+"The Sphinx asks you the following riddle:\n"
+"\n"
+"'"
+msgstr ""
+"人面獅身像向你提出以下謎語:\n"
+"\n"
+"「"
+
+msgid ""
+"sphinx|'\n"
+"\n"
+"Your answer?"
+msgstr ""
+"」\n"
+"\n"
+"你的答案？"
+
+msgid ""
+"\"You guessed incorrectly,\" the Sphinx says, smiling. The Sphinx swipes at "
+"you with a paw, knocking you to the ground. Another blow makes the world go "
+"black, and you know no more."
+msgstr ""
+"「你猜錯了，」人面獅身像微笑著說。牠一掌將你拍倒在地。又一擊讓世界陷入黑暗，"
+"你再也不知道了。"
+
+msgid ""
+"Looking somewhat disappointed, the Sphinx sighs. \"You've answered my riddle "
+"so here's your reward. Now begone.\""
+msgstr ""
+"人面獅身像看起來有些失望，嘆了口氣。「你回答了我的謎語，這是你的獎勵。現在離"
+"開吧。」"
+
+msgid ""
+"A magical barrier stands tall before you, blocking your way. Runes on the "
+"arch read,\n"
+"\"Speak the key and you may pass.\"\n"
+"As you speak the magic word, the glowing barrier dissolves into nothingness."
+msgstr ""
+"一道高大的魔法屏障擋住你的去路。拱門上的符文寫著:\n"
+"「說出通關密語即可通過。」\n"
+"當你說出魔法口令時，發光的屏障化為虛無消散了。"
+
+msgid ""
+"A magical barrier stands tall before you, blocking your way. Runes on the "
+"arch read,\n"
+"\"Speak the key and you may pass.\"\n"
+"You speak, and nothing happens."
+msgstr ""
+"一道高大的魔法屏障擋住你的去路。拱門上的符文寫著:\n"
+"「說出通關密語即可通過。」\n"
+"你開口了，但什麼都沒發生。"
+
+msgid ""
+"You enter the tent and see an old woman gazing into a magic gem. She looks "
+"up and says,\n"
+"\"In my travels, I have learned much in the way of arcane magic. A great "
+"oracle taught me his skill. I have the answer you seek.\""
+msgstr ""
+"你進入帳篷，看到一位老婦人正凝視著一顆魔法寶石。她抬頭說道:\n"
+"「在我的旅途中，我學到了許多奧術魔法。一位偉大先知將技藝傳授給我。我有你尋找"
+"的答案。」"
+
+msgid ""
+"The sting of your previous encounter still lingers, and you keep your "
+"distance from the intimidating cat until you have regained your courage in "
+"battle."
+msgstr ""
+"上次遭遇的刺痛仍在，你與那隻可怕的貓保持距離，直到在戰鬥中恢復勇氣。"
+
+msgid ""
+"You come upon a great cat, purring as it rubs against your leg. Charmed, you "
+"reach down, but it bites you and flees. At least the laughter at your "
+"misfortune lifts your troops' spirits."
+msgstr ""
+"你遇到一隻大貓，牠呼嚕著蹭你的腿。你著迷地伸手去摸，卻被咬了一口，貓隨即逃"
+"跑。至少部隊因你的糗事而歡笑，士氣有所提升。"
+
+msgid "No spell book is present."
+msgstr "目前沒有法術書。"
+
+msgid ""
+"This spell costs %{mana} spell points. You have no spell points, so you "
+"cannot cast it."
+msgstr ""
+"此法術需要 %{mana} 點魔法值。你沒有魔法值，因此無法施放。"
+
+msgid ""
+"This spell costs %{mana} spell points. You only have %{point} spell points, "
+"so you cannot cast it."
+msgstr ""
+"此法術需要 %{mana} 點魔法值。你只有 %{point} 點魔法值，因此無法施放。"
+
+msgid "The spell was not found."
+msgstr "未找到此法術。"
+
+msgid "Only heroes can cast this spell."
+msgstr "只有英雄能施放此法術。"
+
+msgid "This hero is not able to cast adventure spells."
+msgstr "此英雄無法施放冒險法術。"
+
+msgid "This spell cannot be cast on a boat."
+msgstr "此法術無法在船上施放。"
+
+msgid "Your hero is too tired to cast this spell today. Try again tomorrow."
+msgstr "英雄今天太疲勞無法施放此法術。請明天再試。"
+
+msgid "This spell can only be cast near an ocean."
+msgstr "此法術只能在海洋附近施放。"
+
+msgid ""
+"There are no boats available and no ocean adjacent to the hero where this "
+"spell will work."
+msgstr ""
+"沒有可用的船隻，英雄附近也沒有可讓此法術生效的海洋。"
+
+msgid "There are no boats available for this spell."
+msgstr "沒有可供此法術使用的船隻。"
+
+msgid "There is no ocean adjacent to the hero where this spell will work."
+msgstr "英雄附近沒有可讓此法術生效的海洋。"
+
+msgid ""
+"You do not own any town or castle that is not currently occupied by a hero. "
+"This spell will have no effect."
+msgstr ""
+"你沒有任何未被英雄佔據的城鎮或城堡。此法術不會有效果。"
+
+msgid "This hero is already in a town, so this spell will have no effect."
+msgstr "此英雄已在城鎮中，法術不會有效果。"
+
+msgid ""
+"The nearest town is %{town}.\n"
+"\n"
+"This town is occupied by your hero %{hero}."
+msgstr ""
+"最近的城鎮是 %{town}。\n"
+"\n"
+"此城鎮被你的英雄 %{hero} 佔據。"
+
+msgid "This spell is already in effect."
+msgstr "此法術已在生效中。"
+
+msgid ""
+"No opponent neither has nor can have any hero under their command anymore. "
+"Casting this spell will have no effect."
+msgstr ""
+"沒有對手現在或未來會擁有英雄。施放此法術不會有效果。"
+
+msgid ""
+"No opponent has a hero under their command at this time. Casting this spell "
+"will have no effect."
+msgstr ""
+"目前沒有對手擁有英雄。施放此法術不會有效果。"
+
+msgid ""
+"You must be within %{count} spaces of a monster for the Visions spell to "
+"work."
+msgstr ""
+"必須在怪物 %{count} 格範圍內才能使幻視法術生效。"
+
+msgid ""
+"You must be standing on the entrance to a mine (sawmills and alchemist labs "
+"do not count) to cast this spell."
+msgstr ""
+"必須站在礦場入口 (鋸木廠和煉金術士實驗室不算) 才能施放此法術。"
+
+msgid "You must first defeat the ghosts guarding the mine to cast this spell."
+msgstr "必須先擊敗守衛礦場的幽靈才能施放此法術。"
+
+msgid ""
+"There are already at least as many elementals guarding the mine as this hero "
+"can generate. Casting this spell will have no effect."
+msgstr ""
+"守衛礦場的元素生物已達此英雄能產生的上限。施放此法術不會有效果。"
+
+msgid "%{name} the %{race} (Level %{level})"
+msgstr "%{name}，%{race} (等級 %{level})"
+
+msgid "Random hero (Level %{level})"
+msgstr "隨機英雄 (等級 %{level})"
+
+msgid "Random %{race} hero (Level %{level})"
+msgstr "隨機 %{race} 英雄 (等級 %{level})"
+
+msgid "Hero class:"
+msgstr "英雄職業："
+
+msgid "Are you sure you want to dismiss this Hero?"
+msgstr "確定要解散此英雄嗎？"
+
+msgid "Set custom Experience value. Current value is default."
+msgstr "設定自訂經驗值。目前為預設值。"
+
+msgid "Change Experience value. Right-click to reset to default value."
+msgstr "變更經驗值。右鍵按一下重置為預設值。"
+
+msgid "View Experience Info"
+msgstr "檢視經驗值資訊"
+
+msgid "Set custom Spell Points value. Current value is default."
+msgstr "設定自訂魔法值。目前為預設值。"
+
+msgid "Change Spell Points value. Right-click to reset to default value."
+msgstr "變更魔法值。右鍵按一下重置為預設值。"
+
+msgid "Set Spell Points value:"
+msgstr "設定魔法值："
+
+msgid "View Spell Points Info"
+msgstr "檢視魔法值資訊"
+
+msgid "Set patrol radius in tiles:"
+msgstr "設定巡邏半徑 (格數):"
+
+msgid "Enter hero's name:"
+msgstr "輸入英雄名稱："
+
+msgid "Click to change class."
+msgstr "按一下變更職業。"
+
+msgid ""
+"'Spread' combat formation spreads the hero's units from the top to the "
+"bottom of the battlefield, with at least one empty space between each unit."
+msgstr ""
+"「分散」陣型將英雄的部隊從戰場頂部到底部展開，每支部隊之間至少保留一格空間。"
+
+msgid ""
+"'Grouped' combat formation bunches the hero's army together in the center of "
+"their side of the battlefield."
+msgstr ""
+"「集中」陣型將英雄的軍隊集中在戰場己方一側的中央。"
+
+msgid "Exit Hero Screen"
+msgstr "離開英雄畫面"
+
+msgid "You cannot dismiss a hero in a castle"
+msgstr "無法在城堡中解散英雄"
+
+msgid "Dismissal of %{name} the %{race} is prohibited by scenario"
+msgstr "場景禁止解散 %{race} %{name}"
+
+msgid "Dismiss %{name} the %{race}"
+msgstr "解散 %{race} %{name}"
+
+msgid "Show previous hero"
+msgstr "顯示上一位英雄"
+
+msgid "Show next hero"
+msgstr "顯示下一位英雄"
+
+msgid "Set army combat formation to 'Spread'"
+msgstr "將軍隊戰鬥陣型設為「分散」"
+
+msgid "Set army combat formation to 'Grouped'"
+msgstr "將軍隊戰鬥陣型設為「集中」"
+
+msgid "Set hero's Artifacts. Right-click to reset Artifact."
+msgstr "設定英雄的神器。右鍵按一下重置神器。"
+
+msgid "Set hero's Secondary Skills. Right-click to reset skill."
+msgstr "設定英雄的次要技能。右鍵按一下重置技能。"
+
+msgid "Set hero's Army. Right-click to reset unit."
+msgstr "設定英雄的軍隊。右鍵按一下重置單位。"
+
+msgid "Set hero's portrait. Right-click to reset to default."
+msgstr "設定英雄肖像。右鍵按一下重置為預設。"
+
+msgid "Click to change hero's name. Right-click to reset to default."
+msgstr "按一下變更英雄名稱。右鍵按一下重置為預設。"
+
+msgid "Hero is in patrol mode in %{tiles} tiles radius. Click to disable it."
+msgstr "英雄正在 %{tiles} 格半徑範圍內巡邏。按一下停用。"
+
+msgid "Click to enable hero's patrol mode."
+msgstr "按一下啟用英雄的巡邏模式。"
+
+msgid "Do you want to save the changes made?"
+msgstr "要儲存所做的變更嗎？"
+
+msgid "Blood Morale"
+msgstr "嗜血士氣"
+
+msgid "%{morale} Morale"
+msgstr "%{morale}士氣"
+
+msgid "%{luck} Luck"
+msgstr "%{luck}運氣"
+
+msgid "Current Luck Modifiers:"
+msgstr "目前運氣加成："
+
+msgid "Current Morale Modifiers:"
+msgstr "目前士氣加成："
+
+msgid "Entire army is undead, so morale does not apply."
+msgstr "全軍皆為亡靈，士氣不適用。"
+
+msgid ""
+"Current experience %{exp1}.\n"
+" Next level %{exp2}."
+msgstr ""
+"目前經驗值 %{exp1}。\n"
+" 下一級 %{exp2}。"
+
+msgid "million|M"
+msgstr "M"
+
+msgid "Level %{level}"
+msgstr "等級 %{level}"
+
+msgid ""
+"%{name} currently has %{point} spell points out of a maximum of %{max}. The "
+"maximum number of spell points is 10 times the hero's knowledge. It is "
+"occasionally possible for the hero to have more than their maximum spell "
+"points via special events."
+msgstr ""
+"%{name} 目前有 %{point} 點魔法值，上限為 %{max}。魔法值上限為英雄知識值的 10 "
+"倍。透過特殊事件，英雄偶爾可以擁有超過上限的魔法值。"
+
+msgid "%{name1} meets %{name2}"
+msgstr "%{name1} 遇見 %{name2}"
+
+msgid "hero|Level %{level}"
+msgstr "等級 %{level}"
+
+msgid "Move all artifacts from %{from_hero_name} to %{to_hero_name}."
+msgstr "將所有神器從 %{from_hero_name} 移轉至 %{to_hero_name}。"
+
+msgid "Artifact Transfer"
+msgstr "神器移轉"
+
+msgid "Swap Artifacts"
+msgstr "交換神器"
+
+msgid "Swap all artifacts between heroes."
+msgstr "交換英雄之間的所有神器。"
+
+msgid "Move army from %{from_hero_name} to %{to_hero_name}."
+msgstr "將軍隊從 %{from_hero_name} 移動至 %{to_hero_name}。"
+
+msgid "Army Transfer"
+msgstr "軍隊移轉"
+
+msgid "Swap Armies"
+msgstr "交換軍隊"
+
+msgid "Swap armies between heroes."
+msgstr "交換英雄之間的軍隊。"
+
+msgid "Enemy heroes are now fully identifiable."
+msgstr "敵方英雄現已可完全辨識。"
+
+msgid "Identify Hero"
+msgstr "辨識英雄"
+
+msgid "Select town to port to."
+msgstr "選擇要傳送至的城鎮。"
+
+msgid "Town Portal"
+msgstr "城鎮傳送門"
+
+msgid "The creatures are willing to join us!"
+msgstr "這些生物願意加入我們！"
+
+msgid "All the creatures will join us..."
+msgstr "所有的生物都將加入我們……"
+
+msgid "The creature will join us..."
+msgid_plural "%{count} of the creatures will join us..."
+msgstr[0] "生物將加入我們……"
+
+msgid ""
+"\n"
+" for a fee of %{gold} gold."
+msgstr ""
+"\n"
+"費用為 %{gold} 金幣。"
+
+msgid "These weak creatures will surely flee before us."
+msgstr "這些弱小的生物肯定會在我們面前逃跑。"
+
+msgid "I fear these creatures are in the mood for a fight."
+msgstr "恐怕這些生物正準備要戰鬥。"
+
+msgid "The hero's attack skill is a bonus added to each unit's attack skill."
+msgstr "英雄的攻擊技能作為加成加到每支部隊的攻擊技能上。"
+
+msgid "The hero's defense skill is a bonus added to each unit's defense skill."
+msgstr "英雄的防禦技能作為加成加到每支部隊的防禦技能上。"
+
+msgid "The hero's spell power determines the duration or power of a spell."
+msgstr "英雄的魔法力量決定法術的持續時間或威力。"
+
+msgid ""
+"The hero's knowledge determines how many spell points the hero may have. "
+"Under normal circumstances, a hero is limited to 10 spell points per level "
+"of knowledge."
+msgstr ""
+"英雄的知識決定可擁有多少魔法值。正常情況下，英雄每點知識限制為 10 點魔法值。"
+
+msgid "Current Modifiers:"
+msgstr "目前加成："
+
+msgid "skill|Basic"
+msgstr "基礎"
+
+msgid "skill|Advanced"
+msgstr "進階"
+
+msgid "skill|Expert"
+msgstr "專家"
+
+msgid "Pathfinding"
+msgstr "尋路術"
+
+msgid "Archery"
+msgstr "箭術"
+
+msgid "Logistics"
+msgstr "後勤術"
+
+msgid "Scouting"
+msgstr "偵察術"
+
+msgid "Diplomacy"
+msgstr "外交術"
+
+msgid "Navigation"
+msgstr "航海術"
+
+msgid "Leadership"
+msgstr "領導術"
+
+msgid "Wisdom"
+msgstr "智慧"
+
+msgid "Mysticism"
+msgstr "神祕術"
+
+msgid "Ballistics"
+msgstr "彈道術"
+
+msgid "Eagle Eye"
+msgstr "鷹眼術"
+
+msgid "Necromancy"
+msgstr "亡靈巫術"
+
+msgid "Estates"
+msgstr "產業術"
+
+msgid "Advanced Archery"
+msgstr "進階箭術"
+
+msgid "Advanced Pathfinding"
+msgstr "進階尋路術"
+
+msgid "Basic Archery"
+msgstr "基礎箭術"
+
+msgid "Basic Pathfinding"
+msgstr "基礎尋路術"
+
+msgid "Expert Pathfinding"
+msgstr "專家尋路術"
+
+msgid "Advanced Logistics"
+msgstr "進階後勤術"
+
+msgid "Basic Logistics"
+msgstr "基礎後勤術"
+
+msgid "Basic Scouting"
+msgstr "基礎偵察術"
+
+msgid "Expert Archery"
+msgstr "專家箭術"
+
+msgid "Expert Logistics"
+msgstr "專家後勤術"
+
+msgid "Advanced Diplomacy"
+msgstr "進階外交術"
+
+msgid "Advanced Scouting"
+msgstr "進階偵察術"
+
+msgid "Basic Diplomacy"
+msgstr "基礎外交術"
+
+msgid "Expert Diplomacy"
+msgstr "專家外交術"
+
+msgid "Expert Scouting"
+msgstr "專家偵察術"
+
+msgid "Advanced Leadership"
+msgstr "進階領導術"
+
+msgid "Advanced Navigation"
+msgstr "進階航海術"
+
+msgid "Basic Leadership"
+msgstr "基礎領導術"
+
+msgid "Basic Navigation"
+msgstr "基礎航海術"
+
+msgid "Expert Navigation"
+msgstr "專家航海術"
+
+msgid "Advanced Wisdom"
+msgstr "進階智慧"
+
+msgid "Basic Mysticism"
+msgstr "基礎神祕術"
+
+msgid "Basic Wisdom"
+msgstr "基礎智慧"
+
+msgid "Expert Leadership"
+msgstr "專家領導術"
+
+msgid "Expert Wisdom"
+msgstr "專家智慧"
+
+msgid "Advanced Luck"
+msgstr "進階運氣"
+
+msgid "Advanced Mysticism"
+msgstr "進階神祕術"
+
+msgid "Basic Luck"
+msgstr "基礎運氣"
+
+msgid "Expert Luck"
+msgstr "專家運氣"
+
+msgid "Expert Mysticism"
+msgstr "專家神祕術"
+
+msgid "Advanced Ballistics"
+msgstr "進階彈道術"
+
+msgid "Advanced Eagle Eye"
+msgstr "進階鷹眼術"
+
+msgid "Basic Ballistics"
+msgstr "基礎彈道術"
+
+msgid "Basic Eagle Eye"
+msgstr "基礎鷹眼術"
+
+msgid "Expert Ballistics"
+msgstr "專家彈道術"
+
+msgid "Advanced Necromancy"
+msgstr "進階亡靈巫術"
+
+msgid "Basic Estates"
+msgstr "基礎產業術"
+
+msgid "Basic Necromancy"
+msgstr "基礎亡靈巫術"
+
+msgid "Expert Eagle Eye"
+msgstr "專家鷹眼術"
+
+msgid "Expert Necromancy"
+msgstr "專家亡靈巫術"
+
+msgid "Advanced Estates"
+msgstr "進階產業術"
+
+msgid "Expert Estates"
+msgstr "專家產業術"
+
+msgid ""
+"%{skill} reduces the movement penalty for rough terrain by %{count} percent."
+msgstr ""
+"%{skill} 將崎嶇地形的移動懲罰降低 %{count}%。"
+
+msgid "%{skill} eliminates the movement penalty for rough terrain."
+msgstr "%{skill} 消除崎嶇地形的移動懲罰。"
+
+msgid ""
+"%{skill} increases the damage done by the hero's range attacking creatures "
+"by %{count} percent, and eliminates the %{penalty} percent penalty when "
+"shooting past obstacles (e.g. castle walls)."
+msgstr ""
+"%{skill} 將英雄遠距攻擊生物的傷害提升 %{count}%，並消除穿過障礙物（例如城牆）"
+"射擊時 %{penalty}% 的懲罰。"
+
+msgid "%{skill} increases the hero's movement points by %{count} percent."
+msgstr "%{skill} 將英雄的移動力提升 %{count}%。"
+
+msgid "%{skill} increases the hero's viewable area by one square."
+msgid_plural "%{skill} increases the hero's viewable area by %{count} squares."
+msgstr[0] "%{skill} 將英雄的可視範圍增加一格。"
+
+msgid ""
+"%{skill} allows the hero to negotiate with monsters who are weaker than "
+"their army, and reduces the cost of surrender."
+msgstr ""
+"%{skill} 讓英雄能與比自身弱的怪物交涉，並降低投降的費用。"
+
+msgid ""
+"Approximately %{count} percent of the creatures may offer to join the hero."
+msgstr ""
+"約 %{count}% 的生物可能會主動加入英雄。"
+
+msgid "All of the creatures may offer to join the hero."
+msgstr "所有生物都可能主動加入英雄。"
+
+msgid ""
+"The cost of surrender is reduced to %{percent} percent of the total cost of "
+"troops in the army."
+msgstr ""
+"投降費用降為軍隊部隊總成本的 %{percent}%。"
+
+msgid ""
+"%{skill} increases the hero's movement points over water by %{count} percent."
+msgstr ""
+"%{skill} 將英雄的水上移動力提升 %{count}%。"
+
+msgid "%{skill} increases the hero's troops morale by %{count}."
+msgstr "%{skill} 將英雄部隊的士氣提升 %{count}。"
+
+msgid "%{skill} allows the hero to learn third level spells."
+msgstr "%{skill} 讓英雄能學習第三級法術。"
+
+msgid "%{skill} allows the hero to learn fourth level spells."
+msgstr "%{skill} 讓英雄能學習第四級法術。"
+
+msgid "%{skill} allows the hero to learn fifth level spells."
+msgstr "%{skill} 讓英雄能學習第五級法術。"
+
+msgid "%{skill} regenerates one additional spell point per day to the hero."
+msgid_plural ""
+"%{skill} regenerates %{count} additional spell points per day to the hero."
+msgstr[0] "%{skill} 每日為英雄額外恢復一點魔法值。"
+
+msgid "%{skill} increases the hero's luck by %{count}."
+msgstr "%{skill} 將英雄的運氣提升 %{count}。"
+
+msgid ""
+"%{skill} gives the hero's catapult shots a greater chance to hit and do "
+"damage to castle walls."
+msgstr ""
+"%{skill} 讓英雄的投石車射擊有更高機率命中並破壞城牆。"
+
+msgid ""
+"%{skill} gives the hero's catapult an extra shot, and each shot has a "
+"greater chance to hit and do damage to castle walls."
+msgstr ""
+"%{skill} 讓英雄的投石車多一次射擊機會，且每次射擊有更高機率命中並破壞城牆。"
+
+msgid ""
+"%{skill} gives the hero's catapult an extra shot, and each shot "
+"automatically destroys any wall, except a fortified wall in a Knight castle."
+msgstr ""
+"%{skill} 讓英雄的投石車多一次射擊機會，且每次射擊自動摧毀任何城牆，騎士城堡的"
+"強化城牆除外。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 1st or "
+"2nd level spell that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 讓英雄有 %{count}% 的機率學會敵人在戰鬥中施放的任何一、二級法術。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 3rd "
+"level spell (or below) that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 讓英雄有 %{count}% 的機率學會敵人在戰鬥中施放的任何三級 (含以下) 法"
+"術。"
+
+msgid ""
+"%{skill} gives the hero a %{count} percent chance to learn any given 4th "
+"level spell (or below) that was cast by an enemy during combat."
+msgstr ""
+"%{skill} 讓英雄有 %{count}% 的機率學會敵人在戰鬥中施放的任何四級 (含以下) 法"
+"術。"
+
+msgid ""
+"%{skill} allows %{count} percent of the creatures killed in combat to be "
+"brought back from the dead as Skeletons."
+msgstr ""
+"%{skill} 讓戰鬥中被殺死的生物有 %{count}% 能以骷髏兵的形式復活。"
+
+msgid ""
+"The hero produces %{count} gold pieces per day as tax revenue from estates."
+msgstr ""
+"英雄每日從產業中獲得 %{count} 金幣的稅收。"
+
+msgid "Blue"
+msgstr "藍色"
+
+msgid "Green"
+msgstr "綠色"
+
+msgid "Red"
+msgstr "紅色"
+
+msgid "Yellow"
+msgstr "黃色"
+
+msgid "Orange"
+msgstr "橙色"
+
+msgid "Purple"
+msgstr "紫色"
+
+msgid "barrier|Aqua"
+msgstr "水藍"
+
+msgid "barrier|Blue"
+msgstr "藍色"
+
+msgid "barrier|Brown"
+msgstr "棕色"
+
+msgid "barrier|Gold"
+msgstr "金色"
+
+msgid "barrier|Green"
+msgstr "綠色"
+
+msgid "barrier|Orange"
+msgstr "橙色"
+
+msgid "barrier|Purple"
+msgstr "紫色"
+
+msgid "barrier|Red"
+msgstr "紅色"
+
+msgid "tent|Aqua"
+msgstr "水藍"
+
+msgid "tent|Blue"
+msgstr "藍色"
+
+msgid "tent|Brown"
+msgstr "棕色"
+
+msgid "tent|Gold"
+msgstr "金色"
+
+msgid "tent|Green"
+msgstr "綠色"
+
+msgid "tent|Orange"
+msgstr "橙色"
+
+msgid "tent|Purple"
+msgstr "紫色"
+
+msgid "tent|Red"
+msgstr "紅色"
+
+msgid "Experience"
+msgstr "經驗值"
+
+msgid ""
+"Experience allows your heroes to gain levels, increasing their primary and "
+"secondary skills."
+msgstr ""
+"經驗值讓英雄能升級，提升主要和次要技能。"
+
+msgid "Hero/Stats"
+msgstr "英雄/屬性"
+
+msgid "Skills"
+msgstr "技能"
+
+msgid "Town/Castle"
+msgstr "城鎮/城堡"
+
+msgid "Garrison"
+msgstr "城防部隊"
+
+msgid "Gold Per Day:"
+msgstr "每日黃金："
+
+msgid "View Heroes."
+msgstr "檢視英雄。"
+
+msgid "Towns/Castles"
+msgstr "城鎮/城堡"
+
+msgid "View Towns and Castles."
+msgstr "檢視城鎮和城堡。"
+
+msgid "luck|Cursed"
+msgstr "被詛咒"
+
+msgid "luck|Awful"
+msgstr "極差"
+
+msgid "luck|Bad"
+msgstr "差"
+
+msgid "luck|Normal"
+msgstr "普通"
+
+msgid "luck|Good"
+msgstr "好"
+
+msgid "luck|Great"
+msgstr "極好"
+
+msgid "luck|Irish"
+msgstr "幸運之極"
+
+msgid ""
+"%{luck-type} luck sometimes falls on the hero's units in combat, causing "
+"their attacks to only do half damage."
+msgstr ""
+"%{luck-type}運氣有時會降臨在英雄的部隊上，使其攻擊只造成一半的傷害。"
+
+msgid ""
+"%{luck-type} luck means the hero's units will never get lucky or unlucky "
+"attacks on the enemy."
+msgstr ""
+"%{luck-type} 運氣表示英雄的部隊在攻擊敵人時不會獲得好運或厄運效果。"
+
+msgid ""
+"%{luck-type} luck sometimes lets the hero's units get lucky attacks (double "
+"strength) in combat."
+msgstr ""
+"%{luck-type} 運氣有時會讓英雄的部隊在戰鬥中獲得幸運攻擊（雙倍傷害）。"
+
+msgid "morale|Treason"
+msgstr "叛變"
+
+msgid "morale|Awful"
+msgstr "極差"
+
+msgid "morale|Poor"
+msgstr "差"
+
+msgid "morale|Normal"
+msgstr "普通"
+
+msgid "morale|Good"
+msgstr "好"
+
+msgid "morale|Great"
+msgstr "極好"
+
+msgid "morale|Blood!"
+msgstr "嗜血！"
+
+msgid "%{morale-type} morale may cause the hero's units to freeze in combat."
+msgstr "%{morale-type}士氣可能導致英雄的部隊在戰鬥中僵住。"
+
+msgid ""
+"%{morale-type} morale means the hero's units will never be blessed with "
+"extra attacks or freeze in combat."
+msgstr ""
+"%{morale-type}士氣表示英雄的部隊不會獲得額外攻擊或在戰鬥中僵住。"
+
+msgid ""
+"%{morale-type} morale may give the hero's units extra attacks in combat."
+msgstr ""
+"%{morale-type}士氣可能讓英雄的部隊在戰鬥中獲得額外攻擊。"
+
+msgid "Blood"
+msgstr "嗜血"
+
+msgid "Knight"
+msgstr "騎士"
+
+msgid "Barbarian"
+msgstr "野蠻人"
+
+msgid "Sorceress"
+msgstr "女巫"
+
+msgid "Warlock"
+msgstr "術士"
+
+msgid "Wizard"
+msgstr "巫師"
+
+msgid "Necromancer"
+msgstr "亡靈法師"
+
+msgid "Multi"
+msgstr "混合"
+
+msgid "doubleLined|Knight"
+msgstr "騎士"
+
+msgid "doubleLined|Barbarian"
+msgstr "野蠻人"
+
+msgid "doubleLined|Sorceress"
+msgstr "女巫"
+
+msgid "doubleLined|Warlock"
+msgstr "術士"
+
+msgid "doubleLined|Wizard"
+msgstr "巫師"
+
+msgid ""
+"doubleLined|Necro-\n"
+"mancer"
+msgstr ""
+"亡靈\n"
+"法師"
+
+msgid "doubleLinedRace|Multi"
+msgstr "混合"
+
+msgid "doubleLinedRace|Random"
+msgstr "隨機"
+
+msgid "speed|Standing"
+msgstr "靜止"
+
+msgid "speed|Crawling"
+msgstr "極慢"
+
+msgid "speed|Very Slow"
+msgstr "非常慢"
+
+msgid "speed|Slow"
+msgstr "慢"
+
+msgid "speed|Average"
+msgstr "普通"
+
+msgid "speed|Fast"
+msgstr "快"
+
+msgid "speed|Very Fast"
+msgstr "非常快"
+
+msgid "speed|Ultra Fast"
+msgstr "極快"
+
+msgid "speed|Blazing"
+msgstr "疾速"
+
+msgid "speed|Instant"
+msgstr "瞬間"
+
+msgid "Click this button to adjust the level of zoom."
+msgstr "按此按鈕調整縮放等級。"
+
+msgid "Zoom"
+msgstr "縮放"
+
+msgid "week|Squirrel"
+msgstr "松鼠"
+
+msgid "week|Rabbit"
+msgstr "兔子"
+
+msgid "week|Gopher"
+msgstr "地鼠"
+
+msgid "week|Badger"
+msgstr "獾"
+
+msgid "week|Rat"
+msgstr "老鼠"
+
+msgid "week|Eagle"
+msgstr "老鷹"
+
+msgid "week|Weasel"
+msgstr "鼬鼠"
+
+msgid "week|Raven"
+msgstr "烏鴉"
+
+msgid "week|Mongoose"
+msgstr "貓鼬"
+
+msgid "week|Dog"
+msgstr "犬"
+
+msgid "week|Aardvark"
+msgstr "食蟻獸"
+
+msgid "week|Lizard"
+msgstr "蜥蜴"
+
+msgid "week|Tortoise"
+msgstr "陸龜"
+
+msgid "week|Hedgehog"
+msgstr "刺蝟"
+
+msgid "week|Condor"
+msgstr "禿鷲"
+
+msgid "week|Ant"
+msgstr "螞蟻"
+
+msgid "week|Grasshopper"
+msgstr "蚱蜢"
+
+msgid "week|Dragonfly"
+msgstr "蜻蜓"
+
+msgid "week|Spider"
+msgstr "蜘蛛"
+
+msgid "week|Butterfly"
+msgstr "蝴蝶"
+
+msgid "week|Bumblebee"
+msgstr "大黃蜂"
+
+msgid "week|Locust"
+msgstr "蝗蟲"
+
+msgid "week|Earthworm"
+msgstr "蚯蚓"
+
+msgid "week|Hornet"
+msgstr "胡蜂"
+
+msgid "week|Beetle"
+msgstr "甲蟲"
+
+msgid "week|PLAGUE"
+msgstr "瘟疫"
+
+msgid "week|Unnamed"
+msgstr "無名"
+
+msgid "Desert"
+msgstr "沙漠"
+
+msgid "Snow"
+msgstr "雪地"
+
+msgid "Wasteland"
+msgstr "荒地"
+
+msgid "Beach"
+msgstr "沙灘"
+
+msgid "Lava"
+msgstr "岩漿"
+
+msgid "Dirt"
+msgstr "泥土"
+
+msgid "Grass"
+msgstr "草地"
+
+msgid "Ocean"
+msgstr "海洋"
+
+msgid "map_layout|Mirrored"
+msgstr "鏡像"
+
+msgid "map_layout|Balanced"
+msgstr "平衡"
+
+msgid "map_layout|Islands"
+msgstr "群島"
+
+msgid "map_layout|Pyramid"
+msgstr "金字塔"
+
+msgid "map_layout|Quest"
+msgstr "任務"
+
+msgid "resource_density|Scarce"
+msgstr "稀少"
+
+msgid "resource_density|Normal"
+msgstr "正常"
+
+msgid "resource_density|Abundant"
+msgstr "豐富"
+
+msgid "monster_strength|Weak"
+msgstr "弱"
+
+msgid "monster_strength|Normal"
+msgstr "正常"
+
+msgid "monster_strength|Strong"
+msgstr "強"
+
+msgid "monster_strength|Deadly"
+msgstr "致命"
+
+msgid "maps|Small"
+msgstr "小型"
+
+msgid "maps|Medium"
+msgstr "中型"
+
+msgid "maps|Large"
+msgstr "大型"
+
+msgid "maps|Extra Large"
+msgstr "超大"
+
+msgid "maps|Custom Size"
+msgstr "自訂大小"
+
+msgid "Ore Mine"
+msgstr "礦石礦場"
+
+msgid "Sulfur Mine"
+msgstr "硫磺礦場"
+
+msgid "Crystal Mine"
+msgstr "水晶礦場"
+
+msgid "Gems Mine"
+msgstr "寶石礦場"
+
+msgid "Gold Mine"
+msgstr "金礦"
+
+msgid "Mine"
+msgstr "礦場"
+
+msgid "Burma shave."
+msgstr "Burma shave."
+
+msgid "Next sign 50 miles."
+msgstr "下個路標 50 英里。"
+
+msgid "See Rock City."
+msgstr "See Rock City."
+
+msgid "This space for rent."
+msgstr "此處招租。"
+
+msgid "No object"
+msgstr "無物件"
+
+msgid "Alchemist Lab"
+msgstr "煉金術士實驗室"
+
+msgid "Sign"
+msgstr "路標"
+
+msgid "Buoy"
+msgstr "浮標"
+
+msgid "Skeleton"
+msgstr "骷髏"
+
+msgid "Daemon Cave"
+msgstr "惡魔洞穴"
+
+msgid "Treasure Chest"
+msgstr "寶箱"
+
+msgid "Faerie Ring"
+msgstr "妖精之環"
+
+msgid "Campfire"
+msgstr "營火"
+
+msgid "Fountain"
+msgstr "噴泉"
+
+msgid "Gazebo"
+msgstr "涼亭"
+
+msgid "Genie Lamp"
+msgstr "精靈神燈"
+
+msgid "Archer's House"
+msgstr "弓箭手之屋"
+
+msgid "Goblin Hut"
+msgstr "哥布林小屋"
+
+msgid "Dwarf Cottage"
+msgstr "矮人小屋"
+
+msgid "Peasant Hut"
+msgstr "農民小屋"
+
+msgid "Stables"
+msgstr "馬廄"
+
+msgid "Alchemist's Tower"
+msgstr "煉金術士之塔"
+
+msgid "Event"
+msgstr "事件"
+
+msgid "Dragon City"
+msgstr "龍族之城"
+
+msgid "Lighthouse"
+msgid_plural "Lighthouses"
+msgstr[0] "燈塔"
+
+msgid "Water Wheel"
+msgid_plural "Water Wheels"
+msgstr[0] "水車"
+
+msgid "Monster"
+msgstr "怪物"
+
+msgid "Obelisk"
+msgstr "方尖碑"
+
+msgid "Oasis"
+msgstr "綠洲"
+
+msgid "Resource"
+msgstr "資源"
+
+msgid "Sawmill"
+msgstr "鋸木廠"
+
+msgid "Oracle"
+msgstr "神諭"
+
+msgid "Shrine of the First Circle"
+msgstr "第一環神殿"
+
+msgid "Shipwreck"
+msgstr "沉船"
+
+msgid "Sea Chest"
+msgstr "海中寶箱"
+
+msgid "Desert Tent"
+msgstr "沙漠帳篷"
+
+msgid "Stone Liths"
+msgstr "巨石陣"
+
+msgid "Wagon Camp"
+msgstr "馬車營地"
+
+msgid "Hut of the Magi"
+msgstr "法師小屋"
+
+msgid "Whirlpool"
+msgstr "漩渦"
+
+msgid "Windmill"
+msgid_plural "Windmills"
+msgstr[0] "風車"
+
+msgid "Mermaid"
+msgstr "美人魚"
+
+msgid "Boat"
+msgstr "船"
+
+msgid "Random Ultimate Artifact"
+msgstr "隨機終極神器"
+
+msgid "Random Artifact"
+msgstr "隨機神器"
+
+msgid "Random Resource"
+msgstr "隨機資源"
+
+msgid "Random Monster"
+msgstr "隨機怪物"
+
+msgid "Random Town"
+msgstr "隨機城鎮"
+
+msgid "Random Castle"
+msgstr "隨機城堡"
+
+msgid "Eye of the Magi"
+msgstr "法師之眼"
+
+msgid "Random Monster - weak"
+msgstr "隨機怪物 - 弱"
+
+msgid "Random Monster - medium"
+msgstr "隨機怪物 - 中"
+
+msgid "Random Monster - strong"
+msgstr "隨機怪物 - 強"
+
+msgid "Random Monster - very strong"
+msgstr "隨機怪物 - 極強"
+
+msgid "Nothing Special"
+msgstr "無特殊物件"
+
+msgid "Mossy Rock"
+msgstr "青苔岩石"
+
+msgid "Watch Tower"
+msgstr "瞭望塔"
+
+msgid "Tree House"
+msgstr "樹屋"
+
+msgid "Tree City"
+msgstr "樹城"
+
+msgid "Ruins"
+msgstr "遺跡"
+
+msgid "Fort"
+msgstr "堡壘"
+
+msgid "Abandoned Mine"
+msgstr "廢棄礦場"
+
+msgid "Sirens"
+msgstr "海妖"
+
+msgid "Standing Stones"
+msgstr "豎石"
+
+msgid "Idol"
+msgstr "偶像"
+
+msgid "Tree of Knowledge"
+msgstr "知識之樹"
+
+msgid "Witch Doctor's Hut"
+msgstr "巫醫小屋"
+
+msgid "Temple"
+msgstr "神廟"
+
+msgid "Hill Fort"
+msgstr "丘陵堡壘"
+
+msgid "Halfling Hole"
+msgstr "半身人洞穴"
+
+msgid "Mercenary Camp"
+msgstr "傭兵營地"
+
+msgid "Shrine of the Second Circle"
+msgstr "第二環神殿"
+
+msgid "Shrine of the Third Circle"
+msgstr "第三環神殿"
+
+msgid "City of the Dead"
+msgstr "亡者之城"
+
+msgid "Sphinx"
+msgstr "人面獅身像"
+
+msgid "Wagon"
+msgstr "馬車"
+
+msgid "Tar Pit"
+msgstr "焦油坑"
+
+msgid "Artesian Spring"
+msgstr "自流泉"
+
+msgid "Troll Bridge"
+msgstr "巨魔之橋"
+
+msgid "Watering Hole"
+msgstr "水源地"
+
+msgid "Witch's Hut"
+msgstr "女巫小屋"
+
+msgid "Xanadu"
+msgstr "世外桃源"
+
+msgid "Lean-To"
+msgstr "棚屋"
+
+msgid "Magellan's Maps"
+msgstr "麥哲倫的海圖"
+
+msgid "Flotsam"
+msgstr "漂流物"
+
+msgid "Derelict Ship"
+msgstr "廢棄船"
+
+msgid "Shipwreck Survivor"
+msgstr "沉船倖存者"
+
+msgid "Bottle"
+msgstr "瓶子"
+
+msgid "Magic Well"
+msgstr "魔法之井"
+
+msgid "Magic Garden"
+msgid_plural "Magic Gardens"
+msgstr[0] "魔法花園"
+
+msgid "Observation Tower"
+msgstr "觀測塔"
+
+msgid "Freeman's Foundry"
+msgstr "自由人鑄造廠"
+
+msgid "Reefs"
+msgstr "暗礁"
+
+msgid "Volcano"
+msgstr "火山"
+
+msgid "Flowers"
+msgstr "花叢"
+
+msgid "Rock"
+msgstr "岩石"
+
+msgid "Water Lake"
+msgstr "湖泊"
+
+msgid "Mandrake"
+msgstr "曼德拉草"
+
+msgid "Dead Tree"
+msgstr "枯樹"
+
+msgid "Stump"
+msgstr "樹樁"
+
+msgid "Crater"
+msgstr "火山口"
+
+msgid "Cactus"
+msgstr "仙人掌"
+
+msgid "Mound"
+msgstr "土丘"
+
+msgid "Dune"
+msgstr "沙丘"
+
+msgid "Lava Pool"
+msgstr "岩漿池"
+
+msgid "Shrub"
+msgstr "灌木"
+
+msgid "Barrow Mounds"
+msgstr "古墳"
+
+msgid "Random Artifact - Treasure"
+msgstr "隨機神器 - 寶藏"
+
+msgid "Random Artifact - Minor"
+msgstr "隨機神器 - 次要"
+
+msgid "Random Artifact - Major"
+msgstr "隨機神器 - 主要"
+
+msgid "Barrier"
+msgstr "屏障"
+
+msgid "Traveller's Tent"
+msgstr "旅人帳篷"
+
+msgid "Jail"
+msgstr "牢獄"
+
+msgid "Fire Summoning Altar"
+msgstr "火焰召喚祭壇"
+
+msgid "Air Summoning Altar"
+msgstr "空氣召喚祭壇"
+
+msgid "Earth Summoning Altar"
+msgstr "大地召喚祭壇"
+
+msgid "Water Summoning Altar"
+msgstr "水之召喚祭壇"
+
+msgid "Swampy Lake"
+msgstr "沼澤湖"
+
+msgid "Frozen Lake"
+msgstr "冰凍湖"
+
+msgid "Black Cat"
+msgstr "黑貓"
+
+msgid "Barrel"
+msgstr "木桶"
+
+msgid "randomRace|level 1 creatures"
+msgstr "1 階生物"
+
+msgid "randomRace|level 2 creatures"
+msgstr "2 階生物"
+
+msgid "randomRace|level 3 creatures"
+msgstr "3 階生物"
+
+msgid "randomRace|level 4 creatures"
+msgstr "4 階生物"
+
+msgid "randomRace|level 5 creatures"
+msgstr "5 階生物"
+
+msgid "randomRace|level 6 creatures"
+msgstr "6 階生物"
+
+msgid "Unknown Monsters"
+msgstr "未知怪物"
+
+msgid "Unknown Monster"
+msgstr "未知怪物"
+
+msgid "Peasant"
+msgstr "農民"
+
+msgid "Peasants"
+msgstr "農民"
+
+msgid "Archer"
+msgstr "弓箭手"
+
+msgid "Archers"
+msgstr "弓箭手"
+
+msgid "Ranger"
+msgstr "遊俠"
+
+msgid "Rangers"
+msgstr "遊俠"
+
+msgid "Pikeman"
+msgstr "槍兵"
+
+msgid "Pikemen"
+msgstr "槍兵"
+
+msgid "Veteran Pikeman"
+msgstr "老練槍兵"
+
+msgid "Veteran Pikemen"
+msgstr "老練槍兵"
+
+msgid "Swordsman"
+msgstr "劍士"
+
+msgid "Swordsmen"
+msgstr "劍士"
+
+msgid "Master Swordsman"
+msgstr "劍術大師"
+
+msgid "Master Swordsmen"
+msgstr "劍術大師"
+
+msgid "Cavalries"
+msgstr "騎兵"
+
+msgid "Cavalry"
+msgstr "騎兵"
+
+msgid "Champion"
+msgstr "勇士"
+
+msgid "Champions"
+msgstr "勇士"
+
+msgid "Paladin"
+msgstr "聖騎士"
+
+msgid "Paladins"
+msgstr "聖騎士"
+
+msgid "Crusader"
+msgstr "十字軍"
+
+msgid "Crusaders"
+msgstr "十字軍"
+
+msgid "Goblin"
+msgstr "哥布林"
+
+msgid "Goblins"
+msgstr "哥布林"
+
+msgid "Orc"
+msgstr "獸人"
+
+msgid "Orcs"
+msgstr "獸人"
+
+msgid "Orc Chief"
+msgstr "獸人首領"
+
+msgid "Orc Chiefs"
+msgstr "獸人首領"
+
+msgid "Wolf"
+msgstr "狼"
+
+msgid "Wolves"
+msgstr "狼"
+
+msgid "Ogre"
+msgstr "食人魔"
+
+msgid "Ogres"
+msgstr "食人魔"
+
+msgid "Ogre Lord"
+msgstr "食人魔領主"
+
+msgid "Ogre Lords"
+msgstr "食人魔領主"
+
+msgid "Troll"
+msgstr "巨魔"
+
+msgid "Trolls"
+msgstr "巨魔"
+
+msgid "War Troll"
+msgstr "戰爭巨魔"
+
+msgid "War Trolls"
+msgstr "戰爭巨魔"
+
+msgid "Cyclopes"
+msgstr "獨眼巨人"
+
+msgid "Cyclops"
+msgstr "獨眼巨人"
+
+msgid "Sprite"
+msgstr "精靈"
+
+msgid "Sprites"
+msgstr "精靈"
+
+msgid "Dwarf"
+msgstr "矮人"
+
+msgid "Dwarves"
+msgstr "矮人"
+
+msgid "Battle Dwarf"
+msgstr "戰鬥矮人"
+
+msgid "Battle Dwarves"
+msgstr "戰鬥矮人"
+
+msgid "Elf"
+msgstr "精靈弓手"
+
+msgid "Elves"
+msgstr "精靈弓手"
+
+msgid "Grand Elf"
+msgstr "大精靈弓手"
+
+msgid "Grand Elves"
+msgstr "大精靈弓手"
+
+msgid "Druid"
+msgstr "德魯伊"
+
+msgid "Druids"
+msgstr "德魯伊"
+
+msgid "Greater Druid"
+msgstr "高階德魯伊"
+
+msgid "Greater Druids"
+msgstr "高階德魯伊"
+
+msgid "Unicorn"
+msgstr "獨角獸"
+
+msgid "Unicorns"
+msgstr "獨角獸"
+
+msgid "Phoenix"
+msgstr "鳳凰"
+
+msgid "Phoenixes"
+msgstr "鳳凰"
+
+msgid "Centaur"
+msgstr "半人馬"
+
+msgid "Centaurs"
+msgstr "半人馬"
+
+msgid "Gargoyle"
+msgstr "石像鬼"
+
+msgid "Gargoyles"
+msgstr "石像鬼"
+
+msgid "Griffin"
+msgstr "獅鷲"
+
+msgid "Griffins"
+msgstr "獅鷲"
+
+msgid "Minotaur"
+msgstr "牛頭怪"
+
+msgid "Minotaurs"
+msgstr "牛頭怪"
+
+msgid "Minotaur King"
+msgstr "牛頭怪之王"
+
+msgid "Minotaur Kings"
+msgstr "牛頭怪之王"
+
+msgid "Hydra"
+msgstr "九頭蛇"
+
+msgid "Hydras"
+msgstr "九頭蛇"
+
+msgid "Green Dragon"
+msgstr "綠龍"
+
+msgid "Green Dragons"
+msgstr "綠龍"
+
+msgid "Red Dragon"
+msgstr "紅龍"
+
+msgid "Red Dragons"
+msgstr "紅龍"
+
+msgid "Black Dragon"
+msgstr "黑龍"
+
+msgid "Black Dragons"
+msgstr "黑龍"
+
+msgid "Halfling"
+msgstr "半身人"
+
+msgid "Halflings"
+msgstr "半身人"
+
+msgid "Boar"
+msgstr "野豬"
+
+msgid "Boars"
+msgstr "野豬"
+
+msgid "Iron Golem"
+msgstr "鐵魔像"
+
+msgid "Iron Golems"
+msgstr "鐵魔像"
+
+msgid "Steel Golem"
+msgstr "鋼魔像"
+
+msgid "Steel Golems"
+msgstr "鋼魔像"
+
+msgid "Roc"
+msgstr "大鵬"
+
+msgid "Rocs"
+msgstr "大鵬"
+
+msgid "Mage"
+msgstr "法師"
+
+msgid "Magi"
+msgstr "法師"
+
+msgid "Archmage"
+msgstr "大法師"
+
+msgid "Archmagi"
+msgstr "大法師"
+
+msgid "Giant"
+msgstr "巨人"
+
+msgid "Giants"
+msgstr "巨人"
+
+msgid "Titan"
+msgstr "泰坦"
+
+msgid "Titans"
+msgstr "泰坦"
+
+msgid "Skeletons"
+msgstr "骷髏兵"
+
+msgid "Zombie"
+msgstr "殭屍"
+
+msgid "Zombies"
+msgstr "殭屍"
+
+msgid "Mutant Zombie"
+msgstr "變異殭屍"
+
+msgid "Mutant Zombies"
+msgstr "變異殭屍"
+
+msgid "Mummies"
+msgstr "木乃伊"
+
+msgid "Mummy"
+msgstr "木乃伊"
+
+msgid "Royal Mummies"
+msgstr "皇家木乃伊"
+
+msgid "Royal Mummy"
+msgstr "皇家木乃伊"
+
+msgid "Vampire"
+msgstr "吸血鬼"
+
+msgid "Vampires"
+msgstr "吸血鬼"
+
+msgid "Vampire Lord"
+msgstr "吸血鬼領主"
+
+msgid "Vampire Lords"
+msgstr "吸血鬼領主"
+
+msgid "Lich"
+msgstr "巫妖"
+
+msgid "Liches"
+msgstr "巫妖"
+
+msgid "Power Lich"
+msgstr "強力巫妖"
+
+msgid "Power Liches"
+msgstr "強力巫妖"
+
+msgid "Bone Dragon"
+msgstr "骨龍"
+
+msgid "Bone Dragons"
+msgstr "骨龍"
+
+msgid "Rogue"
+msgstr "盜賊"
+
+msgid "Rogues"
+msgstr "盜賊"
+
+msgid "Nomad"
+msgstr "遊牧民"
+
+msgid "Nomads"
+msgstr "遊牧民"
+
+msgid "Ghost"
+msgstr "幽靈"
+
+msgid "Ghosts"
+msgstr "幽靈"
+
+msgid "Genie"
+msgstr "精怪"
+
+msgid "Genies"
+msgstr "精怪"
+
+msgid "Medusa"
+msgstr "美杜莎"
+
+msgid "Medusas"
+msgstr "美杜莎"
+
+msgid "Earth Elemental"
+msgstr "土元素"
+
+msgid "Earth Elementals"
+msgstr "土元素"
+
+msgid "Air Elemental"
+msgstr "風元素"
+
+msgid "Air Elementals"
+msgstr "風元素"
+
+msgid "Fire Elemental"
+msgstr "火元素"
+
+msgid "Fire Elementals"
+msgstr "火元素"
+
+msgid "Water Elemental"
+msgstr "水元素"
+
+msgid "Water Elementals"
+msgstr "水元素"
+
+msgid "Random Monsters"
+msgstr "隨機怪物"
+
+msgid "Random Monster 1"
+msgstr "隨機怪物 1"
+
+msgid "Random Monsters 1"
+msgstr "隨機怪物 1"
+
+msgid "Random Monster 2"
+msgstr "隨機怪物 2"
+
+msgid "Random Monsters 2"
+msgstr "隨機怪物 2"
+
+msgid "Random Monster 3"
+msgstr "隨機怪物 3"
+
+msgid "Random Monsters 3"
+msgstr "隨機怪物 3"
+
+msgid "Random Monster 4"
+msgstr "隨機怪物 4"
+
+msgid "Random Monsters 4"
+msgstr "隨機怪物 4"
+
+msgid "Double shot"
+msgstr "雙重射擊"
+
+msgid "2-hex monster"
+msgstr "佔兩格怪物"
+
+msgid "Double strike"
+msgstr "雙重打擊"
+
+msgid "Double damage to Undead"
+msgstr "對亡靈雙倍傷害"
+
+msgid "% magic resistance"
+msgstr "% 魔法抗性"
+
+msgid "Immune to Mind spells"
+msgstr "免疫心靈法術"
+
+msgid "Immune to Elemental spells"
+msgstr "免疫元素法術"
+
+msgid "Immune to Fire spells"
+msgstr "免疫火焰法術"
+
+msgid "Immune to Cold spells"
+msgstr "免疫冰霜法術"
+
+msgid "Immune to "
+msgstr "免疫 "
+
+msgid "% immunity to %{spell} spell"
+msgstr "% 免疫 %{spell} 法術"
+
+msgid "% damage from Elemental spells"
+msgstr "% 元素法術傷害"
+
+msgid "% damage from %{spell} spell"
+msgstr "% 來自 %{spell} 法術的傷害"
+
+msgid "% chance to Dispel beneficial spells"
+msgstr "% 機率驅散增益法術"
+
+msgid "% chance to Paralyze"
+msgstr "% 機率麻痺"
+
+msgid "% chance to Petrify"
+msgstr "% 機率石化"
+
+msgid "% chance to Blind"
+msgstr "% 機率目盲"
+
+msgid "% chance to Curse"
+msgstr "% 機率詛咒"
+
+msgid "% chance to cast %{spell} spell"
+msgstr "% 機率施放 %{spell} 法術"
+
+msgid "HP regeneration"
+msgstr "生命值再生"
+
+msgid "Two hexes attack"
+msgstr "兩格攻擊"
+
+msgid "Flyer"
+msgstr "飛行者"
+
+msgid "Unlimited retaliation"
+msgstr "無限反擊"
+
+msgid "Attacks all adjacent enemies"
+msgstr "攻擊所有相鄰敵人"
+
+msgid "No melee penalty"
+msgstr "無近戰懲罰"
+
+msgid "Dragon"
+msgstr "龍族"
+
+msgid "Undead"
+msgstr "亡靈"
+
+msgid "No enemy retaliation"
+msgstr "敵人無法反擊"
+
+msgid "HP drain"
+msgstr "生命值吸取"
+
+msgid "Cloud attack"
+msgstr "雲攻擊"
+
+msgid "Decreases enemy's morale by "
+msgstr "降低敵方士氣 "
+
+msgid "% chance to halve enemy"
+msgstr "% 機率使敵方減半"
+
+msgid "Soul Eater"
+msgstr "噬魂者"
+
+msgid "Elemental"
+msgstr "元素"
+
+msgid "No Morale"
+msgstr "無士氣"
+
+msgid "Earth creature"
+msgstr "土系生物"
+
+msgid "Air creature"
+msgstr "氣系生物"
+
+msgid "Fire creature"
+msgstr "火系生物"
+
+msgid "Water creature"
+msgstr "水系生物"
+
+msgid "Double damage from Fire spells"
+msgstr "受火焰法術雙倍傷害"
+
+msgid "Double damage from Cold spells"
+msgstr "受冰霜法術雙倍傷害"
+
+msgid "Double damage from Earth creatures"
+msgstr "受土系生物雙倍傷害"
+
+msgid "Double damage from Air creatures"
+msgstr "受氣系生物雙倍傷害"
+
+msgid "Double damage from Fire creatures"
+msgstr "受火系生物雙倍傷害"
+
+msgid "Double damage from Water creatures"
+msgstr "受水系生物雙倍傷害"
+
+msgid "Lightning"
+msgstr "閃電"
+
+msgid "% immunity to "
+msgstr "% 免疫 "
+
+msgid "% damage from "
+msgstr "% 傷害來自 "
+
+msgid "The three Anduran artifacts magically combine into one."
+msgstr "三件 Anduran 神器神奇地合而為一。"
+
+msgid "View Spells"
+msgstr "檢視法術"
+
+msgid "View %{name} Info"
+msgstr "檢視 %{name} 資訊"
+
+msgid "Move %{name}"
+msgstr "移動 %{name}"
+
+msgid "Cannot move the Spellbook"
+msgstr "無法移動法術書"
+
+msgid "This item can't be traded."
+msgstr "此物品無法交易。"
+
+msgid "Invalid Artifact"
+msgstr "無效的神器"
+
+msgid "The %{name} increases the hero's knowledge by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點知識。"
+
+msgid "Ultimate Book of Knowledge"
+msgstr "Ultimate Book of Knowledge"
+
+msgid "The %{name} increases the hero's attack skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點攻擊技能。"
+
+msgid "Ultimate Sword of Dominion"
+msgstr "Ultimate Sword of Dominion"
+
+msgid "The %{name} increases the hero's defense skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點防禦技能。"
+
+msgid "Ultimate Cloak of Protection"
+msgstr "Ultimate Cloak of Protection"
+
+msgid "The %{name} increases the hero's spell power by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點魔法力量。"
+
+msgid "Ultimate Wand of Magic"
+msgstr "Ultimate Wand of Magic"
+
+msgid ""
+"The %{name} increases the hero's attack and defense skills by %{count} each."
+msgstr ""
+"%{name} 各增加英雄 %{count} 點攻擊和防禦技能。"
+
+msgid "Ultimate Shield"
+msgstr "Ultimate Shield"
+
+msgid ""
+"The %{name} increases the hero's spell power and knowledge by %{count} each."
+msgstr ""
+"%{name} 各增加英雄 %{count} 點魔法力量和知識。"
+
+msgid "Ultimate Staff"
+msgstr "Ultimate Staff"
+
+msgid ""
+"The %{name} increases each of the hero's basic skills by %{count} points."
+msgstr ""
+"%{name} 增加英雄每項基礎技能 %{count} 點。"
+
+msgid "Ultimate Crown"
+msgstr "Ultimate Crown"
+
+msgid "Golden Goose"
+msgstr "Golden Goose"
+
+msgid "The %{name} brings in an income of %{count} gold per day."
+msgstr "%{name} 每日帶來 %{count} 金幣的收入。"
+
+msgid "Arcane Necklace of Magic"
+msgstr "Arcane Necklace of Magic"
+
+msgid ""
+"After rescuing a Sorceress from a cursed tomb, she rewards your heroism with "
+"an exquisite jeweled necklace."
+msgstr ""
+"從被詛咒的墳墓中救出一位女巫後，她以一條精美的珠寶項鍊酬謝你的英勇。"
+
+msgid "Caster's Bracelet of Magic"
+msgstr "Caster's Bracelet of Magic"
+
+msgid ""
+"While searching through the rubble of a caved-in mine, you free a group of "
+"trapped Dwarves. Grateful, the leader gives you a golden bracelet."
+msgstr ""
+"在搜尋塌陷礦坑的碎石時，你救出了一群被困的矮人。感激之餘，首領送給你一只金手"
+"鐲。"
+
+msgid "Mage's Ring of Power"
+msgstr "Mage's Ring of Power"
+
+msgid ""
+"A cry of pain leads you to a Centaur, caught in a trap. Upon setting the "
+"creature free, he hands you a small pouch. Emptying the contents, you find a "
+"dazzling jeweled ring."
+msgstr ""
+"一聲痛苦的呼喊引導你找到了一隻陷入陷阱的半人馬。將牠釋放後，牠遞給你一個小袋"
+"子。倒出內容物後，你發現了一枚耀眼的寶石戒指。"
+
+msgid "Witch's Broach of Magic"
+msgstr "Witch's Broach of Magic"
+
+msgid ""
+"Alongside the remains of a burnt witch lies a beautiful broach, intricately "
+"designed. Approaching the corpse with caution, you add the broach to your "
+"inventory."
+msgstr ""
+"在一具燒焦女巫的遺骸旁，放著一枚設計精美的胸針。你小心地靠近屍體，將胸針收入"
+"囊中。"
+
+msgid "Medal of Valor"
+msgstr "Medal of Valor"
+
+msgid "The %{name} increases the morale of the hero's army by %{count}."
+msgstr "%{name} 增加英雄軍隊 %{count} 點士氣。"
+
+msgid ""
+"Freeing a virtuous maiden from the clutches of an evil overlord, you are "
+"granted a Medal of Valor by the King's herald."
+msgstr ""
+"從邪惡領主的魔爪中救出了一位善良的少女，國王的傳令官授予你一枚英勇勳章。"
+
+msgid "Medal of Courage"
+msgstr "Medal of Courage"
+
+msgid ""
+"After saving a young boy from a vicious pack of Wolves, you return him to "
+"his father's manor. The grateful nobleman awards you with a Medal of Courage."
+msgstr ""
+"從兇猛的狼群中救出一個小男孩後，你將他送回父親的莊園。感激的貴族授予你一枚勇"
+"氣勳章。"
+
+msgid "Medal of Honor"
+msgstr "Medal of Honor"
+
+msgid ""
+"After freeing a princess of a neighboring kingdom from the evil clutches of "
+"despicable slavers, she awards you with a Medal of Honor."
+msgstr ""
+"從卑鄙奴隸販子的魔爪中解救了鄰國的公主後，她授予你一枚榮譽勳章。"
+
+msgid "Medal of Distinction"
+msgstr "Medal of Distinction"
+
+msgid ""
+"Ridding the countryside of the hideous Minotaur who made a sport of eating "
+"noblemen's Knights, you are honored with the Medal of Distinction."
+msgstr ""
+"剷除了以吞噬貴族騎士為樂的可怕牛頭怪後，你獲頒卓越勳章。"
+
+msgid "Fizbin of Misfortune"
+msgstr "Fizbin of Misfortune"
+
+msgid ""
+"The %{name} greatly decreases the morale of the hero's army by %{count}."
+msgstr ""
+"%{name} 大幅降低英雄軍隊 %{count} 點士氣。"
+
+msgid ""
+"You stumble upon a medal lying alongside the empty road. Adding the medal to "
+"your inventory, you become aware that you have acquired the undesirable "
+"Fizbin of Misfortune, greatly decreasing your army's morale."
+msgstr ""
+"你在空曠的路邊偶然發現了一枚勳章。將它收入囊中後，你意識到自己獲得了不祥的厄"
+"運徽記，大幅降低了軍隊的士氣。"
+
+msgid "Thunder Mace of Dominion"
+msgstr "Thunder Mace of Dominion"
+
+msgid ""
+"During a sudden storm, a bolt of lightning strikes a tree, splitting it. "
+"Inside the tree you find a mysterious mace."
+msgstr ""
+"突如其來的暴風雨中，一道閃電擊中了一棵樹，將其劈開。你在樹幹中找到了一把神秘"
+"的權杖。"
+
+msgid "Armored Gauntlets of Protection"
+msgstr "Armored Gauntlets of Protection"
+
+msgid "The %{name} increase the hero's defense skill by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點防禦技能。"
+
+msgid ""
+"You encounter the infamous Black Knight! After a grueling duel ending in a "
+"draw, the Knight, out of respect, offers you a pair of armored gauntlets."
+msgstr ""
+"你遇到了惡名昭彰的黑騎士！經過一場以平手收場的艱苦決鬥，騎士出於敬意送給你一"
+"副裝甲護手。"
+
+msgid "Defender Helm of Protection"
+msgstr "Defender Helm of Protection"
+
+msgid ""
+"A glint of golden light catches your eye. Upon further investigation, you "
+"find a golden helm hidden under a bush."
+msgstr ""
+"一道金色光芒吸引了你的注意。仔細調查後，你在灌木下發現了一頂金色頭盔。"
+
+msgid "Giant Flail of Dominion"
+msgstr "Giant Flail of Dominion"
+
+msgid ""
+"A clumsy Giant has killed himself with his own flail. Knowing your superior "
+"skill with this weapon, you confidently remove the spectacular flail from "
+"the fallen Giant."
+msgstr ""
+"一個笨拙的巨人被自己的連枷殺死了。深知自己對這種武器駕輕就熟，你自信地從倒下"
+"的巨人身上取下了壯觀的連枷。"
+
+msgid "Ballista of Quickness"
+msgstr "Ballista of Quickness"
+
+msgid "The %{name} gives the hero's catapult one extra shot per combat round."
+msgstr "%{name} 讓英雄的投石車每回合多一次射擊機會。"
+
+msgid ""
+"Walking through the ruins of an ancient walled city, you find the instrument "
+"of the city's destruction, an elaborately crafted ballista."
+msgstr ""
+"穿行於古代城牆城市的廢墟中，你找到了摧毀這座城市的工具——一架製作精良的弩砲。"
+
+msgid "Stealth Shield of Protection"
+msgstr "Stealth Shield of Protection"
+
+msgid ""
+"A stone statue of a warrior holds a silver shield. As you remove the shield, "
+"the statue crumbles into dust."
+msgstr ""
+"一尊戰士石像手持一面銀盾。當你取下盾牌時，石像碎成了塵土。"
+
+msgid "Dragon Sword of Dominion"
+msgstr "Dragon Sword of Dominion"
+
+msgid ""
+"As you are walking along a narrow path, a nearby bush suddenly bursts into "
+"flames. Before your eyes the flames become the image of a beautiful woman. "
+"She holds out a magnificent sword to you."
+msgstr ""
+"你沿著一條狹窄小徑行走時，附近的灌木突然燃燒起來。在你眼前，火焰化為一位美麗"
+"女性的形象。她向你遞出一把華麗的寶劍。"
+
+msgid "Power Axe of Dominion"
+msgstr "Power Axe of Dominion"
+
+msgid ""
+"You see a silver axe embedded deeply in the ground. After several "
+"unsuccessful attempts by your army to remove the axe, you tightly grip the "
+"handle of the axe and effortlessly pull it free."
+msgstr ""
+"你看到一把深深嵌入地面的銀斧。在軍隊數次嘗試拔出失敗後，你緊握斧柄，毫不費力"
+"地將其拔出。"
+
+msgid "Divine Breastplate of Protection"
+msgstr "Divine Breastplate of Protection"
+
+msgid ""
+"A gang of Rogues is sifting through the possessions of dead warriors. "
+"Scaring off the scavengers, you note the Rogues had overlooked a beautiful "
+"breastplate."
+msgstr ""
+"一群盜賊正在翻找死去戰士的遺物。你趕走了這些拾荒者，注意到盜賊們忽略了一件精"
+"美的胸甲。"
+
+msgid "Minor Scroll of Knowledge"
+msgstr "Minor Scroll of Knowledge"
+
+msgid ""
+"Before you appears a levitating glass case with a scroll, perched upon a bed "
+"of crimson velvet. At your touch, the lid opens and the scroll floats into "
+"your awaiting hands."
+msgstr ""
+"你面前出現了一個漂浮的玻璃箱，放置在深紅色天鵝絨上，內有一個捲軸。你一觸碰，"
+"蓋子便打開，捲軸飄入你等候的雙手中。"
+
+msgid "Major Scroll of Knowledge"
+msgstr "Major Scroll of Knowledge"
+
+msgid ""
+"Visiting a local wiseman, you explain the intent of your journey. He reaches "
+"into a sack and withdraws a yellowed scroll and hands it to you."
+msgstr ""
+"拜訪當地的智者時，你說明了旅程的目的。他從袋中取出一卷泛黃的捲軸遞給你。"
+
+msgid "Superior Scroll of Knowledge"
+msgstr "Superior Scroll of Knowledge"
+
+msgid ""
+"You come across the remains of an ancient Druid. Bones, yellowed with age, "
+"peer from the ragged folds of her robe. Searching the robe, you discover a "
+"scroll hidden in the folds."
+msgstr ""
+"你發現了一位古代德魯伊的遺骸。泛黃的白骨從破爛的袍褶中露出。搜尋袍子後，你在"
+"褶層中發現了一卷藏匿的捲軸。"
+
+msgid "Foremost Scroll of Knowledge"
+msgstr "Foremost Scroll of Knowledge"
+
+msgid ""
+"Mangled bones, yellowed with age, peer from the ragged folds of a dead "
+"Druid's robe. Searching the robe, you discover a scroll hidden within."
+msgstr ""
+"殘破泛黃的白骨從一位已故德魯伊破爛的袍子中露出。搜尋袍子後，你在其中發現了一"
+"卷藏匿的捲軸。"
+
+msgid "Endless Sack of Gold"
+msgstr "Endless Sack of Gold"
+
+msgid "The %{name} provides the hero with %{count} gold per day."
+msgstr "%{name} 每日為英雄提供 %{count} 金幣。"
+
+msgid ""
+"A little leprechaun dances gleefully around a magic sack. Seeing you "
+"approach, he stops in mid-stride. The little man screams and stamps his foot "
+"ferociously, vanishing into thin air. Remembering the old leprechaun saying "
+"'Finders Keepers', you grab the sack and leave."
+msgstr ""
+"一個小矮妖圍著一個魔法袋歡快地跳舞。看到你走近，他停下腳步，小矮人尖叫著猛跺"
+"腳，消失得無影無蹤。想起那句古老的矮妖格言「撿到就是你的」，你抓起袋子離開"
+"了。"
+
+msgid "Endless Bag of Gold"
+msgstr "Endless Bag of Gold"
+
+msgid ""
+"A noblewoman, separated from her traveling companions, asks for your help. "
+"After escorting her home, she rewards you with a bag filled with gold."
+msgstr ""
+"一位與旅伴走散的貴婦人請求你的幫助。護送她回家後，她以一袋金幣作為酬謝。"
+
+msgid "Endless Purse of Gold"
+msgstr "Endless Purse of Gold"
+
+msgid ""
+"In your travels, you find a leather purse filled with gold that once "
+"belonged to a great warrior king who had the ability to transform any "
+"inanimate object into gold."
+msgstr ""
+"旅途中，你找到了一個裝滿金幣的皮革錢包，它曾屬於一位擁有將任何無生命物體變成"
+"黃金能力的偉大戰士國王。"
+
+msgid "Nomad Boots of Mobility"
+msgstr "Nomad Boots of Mobility"
+
+msgid "The %{name} increase the hero's movement on land."
+msgstr "%{name} 增加英雄的陸上移動力。"
+
+msgid ""
+"A Nomad trader seeks protection from a tribe of Goblins. For your "
+"assistance, he gives you a finely crafted pair of boots made from the "
+"softest leather. Looking closely, you see fascinating ancient carvings "
+"engraved on the leather."
+msgstr ""
+"一位遊牧商人請求你保護他免受哥布林部落侵害。作為報答，他送給你一雙以最柔軟皮"
+"革精製的靴子。仔細觀察，你發現皮革上刻有迷人的古代雕紋。"
+
+msgid "Traveler's Boots of Mobility"
+msgstr "Traveler's Boots of Mobility"
+
+msgid ""
+"Discovering a pair of beautifully beaded boots made from the finest and "
+"softest leather, you thank the anonymous donor and add the boots to your "
+"inventory."
+msgstr ""
+"發現一雙以最精緻柔軟的皮革製成、綴滿珠飾的靴子，你感謝匿名贈予者並將靴子收入"
+"囊中。"
+
+msgid "Lucky Rabbit's Foot"
+msgstr "Lucky Rabbit's Foot"
+
+msgid "The %{name} increases the luck of the hero's army by %{count}."
+msgstr "%{name} 增加英雄軍隊 %{count} 點幸運。"
+
+msgid ""
+"A traveling merchant offers you a rabbit's foot, made of gleaming silver "
+"fur, for safe passage. The merchant explains the charm will increase your "
+"luck in combat."
+msgstr ""
+"一位旅行商人以一隻閃亮銀毛兔腳換取安全通行。商人解釋說這個護身符能增加你在戰"
+"鬥中的運氣。"
+
+msgid "Golden Horseshoe"
+msgstr "Golden Horseshoe"
+
+msgid ""
+"An ensnared Unicorn whinnies in fright. Murmuring soothing words, you set "
+"her free. Snorting and stamping her front hoof once, she gallops off. "
+"Looking down you see a golden horseshoe."
+msgstr ""
+"一隻被困住的獨角獸恐懼地嘶鳴。你輕聲安慰著將牠放走。牠噴了口氣、前蹄跺地一下"
+"便奔馳而去。你低頭發現了一隻金色馬蹄鐵。"
+
+msgid "Gambler's Lucky Coin"
+msgstr "Gambler's Lucky Coin"
+
+msgid ""
+"You have captured a mischievous imp who has been terrorizing the region. In "
+"exchange for his release, he rewards you with a magical coin."
+msgstr ""
+"你捕獲了一隻一直在恐嚇該地區的惡作劇小惡魔。為了換取自由，牠以一枚魔法硬幣作"
+"為報答。"
+
+msgid "Four-Leaf Clover"
+msgstr "Four-Leaf Clover"
+
+msgid ""
+"In the middle of a patch of dead and dry vegetation, to your surprise you "
+"find a healthy green four-leaf clover."
+msgstr ""
+"在一片枯死乾燥的植被中，你驚喜地發現了一株健康翠綠的四葉草。"
+
+msgid "True Compass of Mobility"
+msgstr "True Compass of Mobility"
+
+msgid "The %{name} increases the hero's movement on land and sea."
+msgstr "%{name} 增加英雄的陸上和海上移動力。"
+
+msgid ""
+"An old man claiming to be an inventor asks you to try his latest invention. "
+"He then hands you a compass."
+msgstr ""
+"一位自稱發明家的老人請你試試他的最新發明，然後遞給你一個指南針。"
+
+msgid "Sailor's Astrolabe of Mobility"
+msgstr "Sailor's Astrolabe of Mobility"
+
+msgid "The %{name} increases the hero's movement on sea."
+msgstr "%{name} 增加英雄的海上移動力。"
+
+msgid ""
+"An old sea captain is being tortured by Ogres. You save him, and in return "
+"he rewards you with a wondrous instrument to measure the distance of a star."
+msgstr ""
+"一位老海船長正被食人魔折磨。你救了他，作為回報，他送給你一件可以測量星辰距離"
+"的奇妙儀器。"
+
+msgid "Evil Eye"
+msgstr "Evil Eye"
+
+msgid "The %{name} reduces the casting cost of curse spells by half."
+msgstr "%{name} 將詛咒系法術的施放消耗減半。"
+
+msgid ""
+"While venturing into a decrepit hut you find the Skeleton of a long dead "
+"witch. Investigation of the remains reveals a glass eye rolling around "
+"inside an empty skull."
+msgstr ""
+"進入一間破敗的小屋時，你發現了一具早已死去的女巫骸骨。調查遺骸時，在空骷髏裡"
+"發現了一顆滾動的玻璃眼珠。"
+
+msgid "Enchanted Hourglass"
+msgstr "Enchanted Hourglass"
+
+msgid ""
+"The %{name} extends the duration of all the hero's spells by %{count} turns."
+msgstr ""
+"%{name} 延長英雄所有法術的持續時間 %{count} 回合。"
+
+msgid ""
+"A surprise turn in the landscape finds you in the midst of a grisly scene: "
+"Vultures picking at the aftermath of a terrible battle. Your cursory search "
+"of the remains turns up an enchanted hourglass."
+msgstr ""
+"地形的意外轉折使你置身於一幅恐怖的景象中：禿鷹在一場慘烈戰鬥的殘骸中啄食。你"
+"粗略搜尋遺骸，找到了一個魔法沙漏。"
+
+msgid "Gold Watch"
+msgstr "Gold Watch"
+
+msgid "The %{name} doubles the effectiveness of the hero's hypnotize spells."
+msgstr "%{name} 使英雄的催眠術效果加倍。"
+
+msgid ""
+"In reward for helping his cart out of a ditch, a traveling potion salesman "
+"gives you a \"magic\" gold watch. Unbeknownst to him, the watch really is "
+"magical."
+msgstr ""
+"為了答謝你幫他的貨車脫離溝渠，一位旅行藥劑商人送給你一隻「魔法」金錶。他自己"
+"都不知道，這隻錶真的是魔法物品。"
+
+msgid "Skullcap"
+msgstr "Skullcap"
+
+msgid "The %{name} halves the casting cost of all mind influencing spells."
+msgstr "%{name} 將所有精神系法術的施放消耗減半。"
+
+msgid ""
+"A brief stop at an improbable rural inn yields an exchange of money, tales, "
+"and accidentally, luggage. You find a magical skullcap in your new backpack."
+msgstr ""
+"在一間不起眼的鄉間旅店短暫停留，交換了金錢、故事，還不小心交換了行李。你在新"
+"背包中發現了一頂魔法骷髏帽。"
+
+msgid "Ice Cloak"
+msgstr "Ice Cloak"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from cold spells."
+msgstr ""
+"%{name} 將英雄部隊受到的冰系法術傷害減半。"
+
+msgid ""
+"Responding to the panicked cries of a damsel in distress, you discover a "
+"young woman fleeing from a hungry bear. You slay the beast in the nick of "
+"time, and the grateful Sorceress weaves a magic cloak from the bear's hide."
+msgstr ""
+"回應一位落難少女的驚恐求救，你發現一名年輕女子正在逃離一隻飢餓的熊。你及時殺"
+"死了野獸，感激的女巫用熊皮織成了一件魔法斗篷。"
+
+msgid "Fire Cloak"
+msgstr "Fire Cloak"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from fire spells."
+msgstr ""
+"%{name} 將英雄部隊受到的火系法術傷害減半。"
+
+msgid ""
+"You've come upon a fight between a Necromancer and a Paladin. The "
+"Necromancer blasts the Paladin with a fire bolt, bringing him to his knees. "
+"Acting quickly, you slay the evil one before the final blow. The grateful "
+"Paladin gives you the fire cloak that saved him."
+msgstr ""
+"你撞見了一場死靈法師與聖騎士的戰鬥。死靈法師以火焰箭擊中聖騎士，將他打跪在"
+"地。你迅速行動，在致命一擊前殺死了邪惡者。聖騎士滿懷感激，將救命的火焰斗篷送"
+"給你。"
+
+msgid "Lightning Helm"
+msgstr "Lightning Helm"
+
+msgid ""
+"The %{name} halves all damage the hero's troops receive from lightning "
+"spells."
+msgstr ""
+"%{name} 將英雄部隊受到的雷電法術傷害減半。"
+
+msgid ""
+"A traveling tinker in need of supplies offers you a helm with a thunderbolt "
+"design on its top in exchange for food and water. Curious, you accept, and "
+"later find out that the helm is magical."
+msgstr ""
+"一位需要補給的旅行修補匠以頂部有雷電圖案的頭盔換取食物和水。出於好奇你接受"
+"了，後來發現這頂頭盔是魔法物品。"
+
+msgid "Evercold Icicle"
+msgstr "Evercold Icicle"
+
+msgid ""
+"The %{name} causes the hero's cold spells to do %{count} percent more damage "
+"to enemy troops."
+msgstr ""
+"%{name} 使英雄的冰系法術對敵軍造成額外 %{count}% 的傷害。"
+
+msgid ""
+"An icicle withstanding the full heat of the noonday sun attracts your "
+"attention. Intrigued, you break it off, and find that it does not melt in "
+"your hand."
+msgstr ""
+"一根在正午烈日下仍不融化的冰柱吸引了你的注意。你好奇地折斷它，發現它在手中不"
+"會融化。"
+
+msgid "Everhot Lava Rock"
+msgstr "Everhot Lava Rock"
+
+msgid ""
+"The %{name} causes the hero's fire spells to do %{count} percent more damage "
+"to enemy troops."
+msgstr ""
+"%{name} 使英雄的火系法術對敵軍造成額外 %{count}% 的傷害。"
+
+msgid ""
+"Your wanderings bring you into contact with a tribe of ape-like beings using "
+"a magical lava rock that never cools to light their fires. You take pity on "
+"them and teach them to make fire with sticks. Believing you to be a god, the "
+"apes give you their rock."
+msgstr ""
+"你在漫遊中遇到了一群類猿生物，牠們正使用一塊永不冷卻的魔法岩漿石生火。你同情"
+"牠們，教牠們用木棍生火。猿人們相信你是神明，將岩漿石送給了你。"
+
+msgid "Lightning Rod"
+msgstr "Lightning Rod"
+
+msgid ""
+"The %{name} causes the hero's lightning spells to do %{count} percent more "
+"damage to enemy troops."
+msgstr ""
+"%{name} 使英雄的雷電法術對敵軍造成額外 %{count}% 的傷害。"
+
+msgid ""
+"While waiting out a storm, a lighting bolt strikes a nearby cottage's "
+"lightning rod, which melts and falls to the ground. The tip of the rod, "
+"however, survives intact and makes your hair stand on end when you touch it. "
+"Hmm..."
+msgstr ""
+"等待暴風雨過去時，一道閃電擊中了附近小屋的避雷針，將其融化落地。然而針尖完好"
+"無損，觸碰它會讓你毛髮直豎。嗯……"
+
+msgid "Snake-Ring"
+msgstr "Snake-Ring"
+
+msgid "The %{name} halves the casting cost of all of the hero's bless spells."
+msgstr "%{name} 將英雄所有祝福法術的施放消耗減半。"
+
+msgid ""
+"You've found an oddly shaped ring on the finger of a long dead traveler. The "
+"ring looks like a snake biting its own tail."
+msgstr ""
+"你在一位早已死去的旅人手指上發現了一枚形狀奇特的戒指。戒指看起來像一條咬住自"
+"己尾巴的蛇。"
+
+msgid "Ankh"
+msgstr "Ankh"
+
+msgid ""
+"The %{name} doubles the effectiveness of all of the hero's resurrect and "
+"animate spells."
+msgstr ""
+"%{name} 使英雄所有復活和操控亡靈法術的效果加倍。"
+
+msgid ""
+"A fierce windstorm reveals the entrance to a buried tomb. Your investigation "
+"reveals that the tomb has already been looted, but the thieves overlooked an "
+"ankh on a silver chain in the dark."
+msgstr ""
+"一陣猛烈的風暴揭露了一座被埋葬墳墓的入口。你的調查發現墳墓已被洗劫一空，但盜"
+"賊在黑暗中忽略了一條銀鏈上的安卡十字架。"
+
+msgid "Book of Elements"
+msgstr "Book of Elements"
+
+msgid ""
+"The %{name} doubles the effectiveness of all of the hero's summoning spells."
+msgstr ""
+"%{name} 使英雄所有召喚法術的效果加倍。"
+
+msgid ""
+"You come across a conjurer who begs to accompany you and your army awhile "
+"for safety. You agree, and he offers as payment a copy of the book of the "
+"elements."
+msgstr ""
+"你遇到一位懇求隨你和你的軍隊同行以保安全的咒術師。你同意了，他以一本元素之書"
+"的抄本作為報酬。"
+
+msgid "Elemental Ring"
+msgstr "Elemental Ring"
+
+msgid "The %{name} halves the casting cost of all summoning spells."
+msgstr "%{name} 將所有召喚法術的施放消耗減半。"
+
+msgid ""
+"While pausing to rest, you notice a bobcat climbing a short tree to get at a "
+"crow's nest. On impulse, you climb the tree yourself and scare off the cat. "
+"When you look in the nest, you find a collection of shiny stones and a ring."
+msgstr ""
+"休息時，你注意到一隻山貓正爬上矮樹去抓烏鴉巢。你衝動地自己爬上樹趕走了貓。檢"
+"視巢穴時，你發現了一堆閃亮的石頭和一枚戒指。"
+
+msgid "Holy Pendant"
+msgstr "Holy Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to curse spells."
+msgstr "%{name} 使英雄所有部隊免疫詛咒法術。"
+
+msgid ""
+"In your wanderings you come across a hermit living in a small, tidy hut. "
+"Impressed with your mission, he takes time out from his meditations to bless "
+"and give you a charm against curses."
+msgstr ""
+"你在漫遊中遇到了一位住在整潔小屋中的隱士。對你的使命印象深刻，他從冥想中抽出"
+"時間為你祝福，並送你一個防禦詛咒的護身符。"
+
+msgid "Pendant of Free Will"
+msgstr "Pendant of Free Will"
+
+msgid "The %{name} makes all of the hero's troops immune to hypnotize spells."
+msgstr "%{name} 使英雄所有部隊免疫催眠術。"
+
+msgid ""
+"Responding to cries for help, you find river Sprites making a sport of "
+"dunking an old man. Feeling vengeful, you rescue the man and drag a Sprite "
+"onto dry land for awhile. The Sprite, uncomfortable in the air, gives you a "
+"magic pendant to let him go."
+msgstr ""
+"回應呼救聲，你發現河精靈正以把一位老人按入水中為樂。你氣憤地救了那人，並把一"
+"隻精靈拖到岸上。精靈在空氣中不舒服，送你一個魔法墜飾以求你放牠走。"
+
+msgid "Pendant of Life"
+msgstr "Pendant of Life"
+
+msgid "The %{name} makes all of the hero's troops immune to death spells."
+msgstr "%{name} 使英雄所有部隊免疫死亡法術。"
+
+msgid ""
+"A brief roadside encounter with a small caravan and a game of knucklebones "
+"wins a magic pendant. Its former owner says that it protects from "
+"Necromancers' death spells."
+msgstr ""
+"在路邊與一支小商隊偶遇，一場擲骨遊戲贏得了一個魔法墜飾。前任主人說它能抵禦死"
+"靈法師的死亡法術。"
+
+msgid "Serenity Pendant"
+msgstr "Serenity Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to berserk spells."
+msgstr "%{name} 使英雄所有部隊免疫狂暴法術。"
+
+msgid ""
+"The sounds of combat draw you to the scene of a fight between an old "
+"Barbarian and an eight-headed Hydra. Your timely intervention swings the "
+"battle in favor of the man, and he rewards you with a pendant he used to use "
+"to calm his mind for battle."
+msgstr ""
+"戰鬥的聲響將你引到一位老蠻族與一隻八頭九頭蛇的戰鬥現場。你的及時介入扭轉了戰"
+"局，他以一個曾用來讓自己冷靜作戰的墜飾作為報答。"
+
+msgid "Seeing-eye Pendant"
+msgstr "Seeing-eye Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to blindness spells."
+msgstr "%{name} 使英雄所有部隊免疫致盲法術。"
+
+msgid ""
+"You come upon a very old woman, long blind from cataracts and dying alone. "
+"You tend to her final needs and promise a proper burial. Grateful, she gives "
+"you a magic pendant emblazoned with a stylized eye. It lets you see with "
+"your eyes closed."
+msgstr ""
+"你遇到一位非常年邁的老婦人，她因白內障長期失明，獨自等死。你照料她最後的需求"
+"並承諾妥善安葬。感激之餘，她送你一個刻有風格化眼睛的魔法墜飾，讓你閉著眼也能"
+"看見。"
+
+msgid "Kinetic Pendant"
+msgstr "Kinetic Pendant"
+
+msgid "The %{name} makes all of the hero's troops immune to paralyze spells."
+msgstr "%{name} 使英雄所有部隊免疫麻痺法術。"
+
+msgid ""
+"You come across a golem wearing a glowing pendant and blocking your way. "
+"Acting on a hunch, you cut the pendant from its neck. Deprived of its power "
+"source, the golem breaks down, leaving you with the magical pendant."
+msgstr ""
+"你遇到一個戴著發光墜飾、擋住你去路的魔像。憑直覺行事，你切斷了牠脖子上的墜"
+"飾。失去能量來源的魔像隨即瓦解，留下魔法墜飾給你。"
+
+msgid "Pendant of Death"
+msgstr "Pendant of Death"
+
+msgid "The %{name} makes all of the hero's troops immune to holy spells."
+msgstr "%{name} 使英雄所有部隊免疫神聖法術。"
+
+msgid ""
+"A quick and deadly battle with a Necromancer wins you his magical pendant. "
+"Later, a Wizard tells you that the pendant protects undead under your "
+"control from holy word spells."
+msgstr ""
+"與一位死靈法師的快速致命戰鬥為你贏得了他的魔法墜飾。之後，一位巫師告訴你這個"
+"墜飾能保護你控制的亡靈免受神聖之語法術的影響。"
+
+msgid "Wand of Negation"
+msgstr "Wand of Negation"
+
+msgid ""
+"The %{name} makes all of the hero's troops immune to dispel magic spells."
+msgstr ""
+"%{name} 使英雄所有部隊免疫驅散魔法。"
+
+msgid ""
+"You meet an old Wizard friend of yours traveling in the opposite direction. "
+"He presents  you with a gift: A wand that prevents the use of the dispel "
+"magic spell on your allies."
+msgstr ""
+"你遇到了一位相識的老巫師朋友，他正往反方向旅行。他送給你一份禮物：一根能阻止"
+"敵人對你盟友使用驅散魔法的魔杖。"
+
+msgid "Golden Bow"
+msgstr "Golden Bow"
+
+msgid ""
+"The %{name} eliminates the %{count} percent penalty for the hero's troops "
+"shooting past obstacles (e.g. castle walls)."
+msgstr ""
+"%{name} 消除英雄部隊射擊穿越障礙物 (如城牆) 時的 %{count}% 懲罰。"
+
+msgid ""
+"A chance meeting with a famous Archer finds you in a game of knucklebones "
+"pitting his bow against your horse. You win."
+msgstr ""
+"偶遇一位著名弓箭手，你們以擲骰子比賽，以他的弓對你的馬作為賭注。你贏了。"
+
+msgid "Telescope"
+msgstr "Telescope"
+
+msgid ""
+"The %{name} increases the amount of terrain the hero reveals when "
+"adventuring by %{count} extra square."
+msgstr ""
+"%{name} 使英雄冒險時額外揭露 %{count} 格地形。"
+
+msgid ""
+"A merchant from far away lands trades you a new invention of his people for "
+"traveling supplies. It makes distant objects appear closer, and he calls "
+"it...\n"
+"\n"
+"a telescope."
+msgstr ""
+"一位來自遠方的商人以旅行補給換給你他的民族的新發明。它能讓遠處的物體看起來更"
+"近，他稱之為……\n"
+"\n"
+"望遠鏡。"
+
+msgid "Statesman's Quill"
+msgstr "Statesman's Quill"
+
+msgid ""
+"The %{name} reduces the cost of surrender to %{count} percent of the total "
+"cost of troops the hero has in their army."
+msgstr ""
+"%{name} 將投降費用降低至英雄軍隊總兵力價值的 %{count}%。"
+
+msgid ""
+"You pause to help a diplomat with a broken axle fix his problem. In "
+"gratitude, he gives you a writing quill with magical properties which he "
+"says will \"help people see things your way\"."
+msgstr ""
+"你停下來幫助一位車軸斷裂的外交官解決問題。出於感激，他送你一支具有魔法特性的"
+"鵝毛筆，說它能「幫助別人看到你的觀點」。"
+
+msgid "Wizard's Hat"
+msgstr "Wizard's Hat"
+
+msgid ""
+"The %{name} increases the duration of the hero's spells by %{count} turns."
+msgstr ""
+"%{name} 延長英雄法術的持續時間 %{count} 回合。"
+
+msgid ""
+"You see a Wizard fleeing from a Griffin and riding like the wind. The Wizard "
+"opens a portal and rides through, getting his hat knocked off by the edge of "
+"the gate. The Griffin follows; the gate closes. You pick the hat up, dust it "
+"off, and put it on."
+msgstr ""
+"你看到一位巫師騎馬疾風般地逃離一隻獅鷲。巫師打開一個傳送門衝了過去，帽子被門"
+"邊撞落。獅鷲跟著進去了，門隨即關閉。你撿起帽子，拍掉灰塵，戴在頭上。"
+
+msgid "Power Ring"
+msgstr "Power Ring"
+
+msgid "The %{name} returns %{count} extra spell points per day to the hero."
+msgstr "%{name} 每日額外恢復英雄 %{count} 點魔法值。"
+
+msgid ""
+"You find a small tree that closely resembles the great Warlock Carnauth with "
+"a ring around one of its twigs. Scraps of clothing and rotting leather lead "
+"you to suspect that it IS Carnauth, transformed. Since you can't help him, "
+"you take the magic ring."
+msgstr ""
+"你發現一棵小樹酷似偉大的術士 Carnauth，其中一根樹枝上套著一枚戒指。現場有碎布"
+"和腐爛的皮革，讓你懷疑這就是變形後的 Carnauth。既然幫不了他，你取走了魔法戒"
+"指。"
+
+msgid "Ammo Cart"
+msgstr "Ammo Cart"
+
+msgid ""
+"The %{name} provides endless ammunition for all of the hero's troops that "
+"shoot."
+msgstr ""
+"%{name} 為英雄所有遠距部隊提供無限彈藥。"
+
+msgid ""
+"An ammunition cart in the middle of an old battlefield catches your eye. "
+"Inspection shows it to be in good working order, so  you take it along."
+msgstr ""
+"一輛位於舊戰場中央的彈藥車吸引了你的目光。檢查後發現它仍能正常運作，於是你帶"
+"上了它。"
+
+msgid "Tax Lien"
+msgstr "Tax Lien"
+
+msgid "The %{name} costs the hero %{count} gold pieces per day."
+msgstr "%{name} 每日消耗英雄 %{count} 金幣。"
+
+msgid ""
+"Your big spending habits have earned you a massive tax bill that you can't "
+"hope to pay. The tax man takes pity and agrees to only take 250 gold a day "
+"from your account for life. Check here if you want one dollar to go to the "
+"presidential campaign election fund."
+msgstr ""
+"你揮金如土的習慣為你帶來了一張你無法支付的巨額稅單。稅務官大發慈悲，同意終身"
+"每日只從你的帳戶扣除 250 金幣。如果你想為總統競選基金捐一塊錢，請在此勾選。"
+
+msgid "Hideous Mask"
+msgstr "Hideous Mask"
+
+msgid "The %{name} prevents all 'wandering' armies from joining the hero."
+msgstr "%{name} 阻止所有流浪軍隊加入英雄。"
+
+msgid ""
+"Your looting of the grave of Sinfilas Gardolad, the famous shapeshifting "
+"Warlock, unearths his fabled mask. Trembling, you put it on and it twists "
+"your visage into an awful grimace! Oh no! It's actually the hideous mask of "
+"Gromluck Greene, and you are stuck with it."
+msgstr ""
+"你盜掘了著名變形術士 Sinfilas Gardolad 的墳墓，挖出了他傳說中的面具。你顫抖地"
+"戴上它，它將你的面容扭曲成可怕的鬼臉！糟糕！這其實是 Gromluck Greene 的醜陋面"
+"具，而且你摘不下來了。"
+
+msgid "Endless Pouch of Sulfur"
+msgstr "Endless Pouch of Sulfur"
+
+msgid "The %{name} provides %{count} unit of sulfur per day."
+msgstr "%{name} 每日提供 %{count} 單位硫磺。"
+
+msgid ""
+"You visit an alchemist who, upon seeing your army, is swayed by the "
+"righteousness of your cause. The newly loyal subject gives you his endless "
+"pouch of sulfur to help with the war effort."
+msgstr ""
+"你拜訪了一位煉金術士，他看到你的軍隊後被你的正義事業所感動。這位新近效忠的臣"
+"民送你無盡硫磺袋，協助你的戰事。"
+
+msgid "Endless Vial of Mercury"
+msgstr "Endless Vial of Mercury"
+
+msgid "The %{name} provides %{count} unit of mercury per day."
+msgstr "%{name} 每日提供 %{count} 單位水銀。"
+
+msgid ""
+"A brief stop at a hastily abandoned Wizard's tower turns up a magical vial "
+"of mercury that always has a little left on the bottom. Recognizing a "
+"treasure when you see one, you cap it and slip it in your pocket."
+msgstr ""
+"在一座匆忙廢棄的巫師塔短暫停留，你發現了一瓶底部永遠留有一些水銀的魔法瓶。識"
+"寶之人自然不會錯過，你蓋上瓶蓋塞進口袋。"
+
+msgid "Endless Pouch of Gems"
+msgstr "Endless Pouch of Gems"
+
+msgid "The %{name} provides %{count} unit of gems per day."
+msgstr "%{name} 每日提供 %{count} 單位寶石。"
+
+msgid ""
+"A short rainstorm brings forth a rainbow...and you can see the end of it. "
+"Riding quickly, you seize the pot of gold you find there. The leprechaun who "
+"owns it, unable to stop you from taking it, offers an endless pouch of gems "
+"for the return of his gold. You accept."
+msgstr ""
+"一陣短暫的雷陣雨帶來了彩虹……你看得到彩虹的盡頭。快馬加鞭，你奪取了那裡的金"
+"罐。擁有它的小矮妖無法阻止你，提議以一個無盡寶石袋換回他的金子。你接受了。"
+
+msgid "Endless Cord of Wood"
+msgstr "Endless Cord of Wood"
+
+msgid "The %{name} provides %{count} unit of wood per day."
+msgstr "%{name} 每日提供 %{count} 單位木材。"
+
+msgid ""
+"Pausing to rest and light a cook fire, you pull wood out of a nearby pile of "
+"dead wood. As you keep pulling wood from the pile, you notice that it "
+"doesn't shrink. You realize to your delight that the wood is enchanted, so "
+"you take it along."
+msgstr ""
+"休息生火時，你從附近的枯木堆中抽取木材。你不斷取出木材，卻注意到木堆沒有減"
+"少。你高興地意識到這些木材被施了魔法，於是將它帶走。"
+
+msgid "Endless Cart of Ore"
+msgstr "Endless Cart of Ore"
+
+msgid "The %{name} provides %{count} unit of ore per day."
+msgstr "%{name} 每日提供 %{count} 單位礦石。"
+
+msgid ""
+"You've found a Goblin weapon smithy making weapons for use against humans. "
+"With a tremendous yell you and your army descend upon their camp and drive "
+"them away. A search finds a magic ore cart that never runs out of iron."
+msgstr ""
+"你發現了一個哥布林武器鍛造所，正在製造對付人類的武器。你和軍隊大喊一聲衝進他"
+"們的營地，將他們趕跑。搜尋後發現了一輛永遠不會用完鐵礦的魔法礦車。"
+
+msgid "Endless Pouch of Crystal"
+msgstr "Endless Pouch of Crystal"
+
+msgid ""
+"Taking shelter from a storm in a small cave, you notice a small patch of "
+"crystal in one corner. Curious, you break a piece off and notice that the "
+"original crystal grows the lost piece back. You decide to stuff the entire "
+"patch into a pouch and take it with you."
+msgstr ""
+"在小洞穴中躲避暴風雨時，你注意到角落有一小片水晶。出於好奇，你折斷了一塊，發"
+"現原來的水晶長回了缺失的部分。你決定將整片水晶塞進袋子帶走。"
+
+msgid "The %{name} provides %{count} unit of crystal per day."
+msgstr "%{name} 每日提供 %{count} 單位水晶。"
+
+msgid "Spiked Helm"
+msgstr "Spiked Helm"
+
+msgid ""
+"Your army is ambushed by a small tribe of wild (and none too bright) Orcs. "
+"You fend them off easily and the survivors flee in all directions. One of "
+"the Orcs was wearing a polished spiked helm. Figuring it will make a good "
+"souvenir, you take it."
+msgstr ""
+"你的軍隊遭到一個野蠻 (而且不怎麼聰明) 的獸人小部落伏擊。你輕鬆擊退了他們，倖"
+"存者四散奔逃。其中一個獸人戴著一頂拋光的尖刺頭盔。想著它是個不錯的紀念品，你"
+"將它取走。"
+
+msgid "Spiked Shield"
+msgstr "Spiked Shield"
+
+msgid ""
+"You come upon a bridge spanning a dry gully. Before you can cross, a Troll "
+"steps out from under the bridge and demands payment before it will permit "
+"you to pass. You refuse, and the Troll charges, forcing you to slay it. You "
+"take its spiked shield as a trophy."
+msgstr ""
+"你來到一座橫跨乾涸溝壑的橋前。在你過橋之前，一隻巨魔從橋下走出，要求你付費才"
+"肯放行。你拒絕了，巨魔發起衝鋒，你被迫將牠斬殺。你取走了牠的尖刺盾牌作為戰利"
+"品。"
+
+msgid "White Pearl"
+msgstr "White Pearl"
+
+msgid ""
+"A walk across a dry saltwater lake bed yields an unlikely prize: A white "
+"pearl amidst shattered shells and debris."
+msgstr ""
+"穿越乾涸鹽湖湖床的途中，你獲得了意想不到的獎品：一顆藏在碎裂貝殼和殘骸中的白"
+"色珍珠。"
+
+msgid "Black Pearl"
+msgstr "Black Pearl"
+
+msgid ""
+"Rumors of a Griffin of unusual size preying upon the countryside lead you to "
+"its cave lair. A quick, brutal fight dispatches the beast, and a search of "
+"its foul nest turns up a huge black pearl."
+msgstr ""
+"關於一隻巨大獅鷲在鄉間捕食的傳言將你引到了牠的洞穴巢穴。一場快速而殘酷的戰鬥"
+"殺死了野獸。你搜尋牠骯髒的巢穴時，找到了一顆巨大的黑珍珠。"
+
+msgid "Magic Book"
+msgstr "Magic Book"
+
+msgid "The %{name} enables the hero to cast spells."
+msgstr "%{name} 使英雄能夠施放法術。"
+
+msgid ""
+"A young man approaches you: \"My Lord, allow me to show you my latest "
+"invention for spreading knowledge!\" You follow the man into his workshop "
+"and immediately observe a large apparatus with levers and cranks. \"This "
+"here is it!\" he says eagerly, \"The Printing Press.\" And before you get to "
+"say a word, he hands you a Magic Book."
+msgstr ""
+"一個年輕人走近你：「大人，讓我向您展示我傳播知識的最新發明！」你跟著他走進工"
+"坊，立刻看到一台帶有拉桿和曲柄的大型裝置。「這就是了！」他急切地說，「印刷"
+"機。」你還來不及說話，他就遞給你一本魔法書。"
+
+msgid "Victory can be achieved by finding any Ultimate Artifact."
+msgstr "找到任何終極神器即可獲勝。"
+
+msgid "Dummy 2"
+msgstr "Dummy 2"
+
+msgid "The reserved artifact."
+msgstr "保留的神器。"
+
+msgid "Dummy 3"
+msgstr "Dummy 3"
+
+msgid "Dummy 4"
+msgstr "Dummy 4"
+
+msgid "Spell Scroll"
+msgstr "Spell Scroll"
+
+msgid ""
+"This %{name} gives the hero the ability to cast the %{spell} spell if the "
+"hero has a Magic Book."
+msgstr ""
+"這個 %{name} 在英雄擁有魔法書的情況下賦予施放 %{spell} 法術的能力。"
+
+msgid ""
+"You find an elaborate container which houses an old vellum scroll. The runes "
+"on the container are very old, and the artistry with which it was put "
+"together is stunning. As you pull the scroll out, you feel imbued with "
+"magical power."
+msgstr ""
+"你找到了一個精緻的容器，裡面裝著一卷古老的羊皮紙捲軸。容器上的符文非常古老，"
+"其工藝令人驚嘆。當你抽出捲軸時，你感覺全身充滿了魔力。"
+
+msgid "Arm of the Martyr"
+msgstr "Arm of the Martyr"
+
+msgid ""
+"One of the less intelligent members of your party picks up an arm off of the "
+"ground. Despite its missing a body, it is still moving. Your troops find the "
+"dismembered arm repulsive, but you cannot bring yourself to drop it: it "
+"seems to hold some sort of magical power that influences your decision "
+"making."
+msgstr ""
+"你隊伍中一位不太聰明的成員從地上撿起了一隻手臂。儘管沒有身體，它仍在動。你的"
+"部隊對這隻斷臂感到噁心，但你就是放不下它：它似乎擁有某種影響你決策的魔力。"
+
+msgid ""
+"The %{name} increases the hero's spell power by %{count} but adds the undead "
+"morale penalty."
+msgstr ""
+"%{name} 增加英雄 %{count} 點魔法力量，但附加亡靈士氣懲罰。"
+
+msgid "Breastplate of Anduran"
+msgstr "Breastplate of Anduran"
+
+msgid "The %{name} increases the hero's defense by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點防禦。"
+
+msgid ""
+"You come upon a sign. It reads: \"Here lies the body of Anduran. Bow and "
+"swear fealty, and you shall be rewarded.\" You decide to do as it says. As "
+"you stand up, you feel a coldness against your skin. Looking down, you find "
+"that you are suddenly wearing a gleaming, ornate breastplate."
+msgstr ""
+"你來到一塊告示牌前。上面寫著：「此處安息著 Anduran 的遺體。鞠躬宣誓效忠，你將"
+"得到回報。」你照做了。站起身來時，你感覺一陣冰涼貼著皮膚。低頭一看，你發現自"
+"己突然穿上了一件閃亮華麗的胸甲。"
+
+msgid "Broach of Shielding"
+msgstr "Broach of Shielding"
+
+msgid ""
+"The %{name} provides %{count} percent protection from Armageddon and "
+"Elemental Storm, but decreases spell power by 2."
+msgstr ""
+"%{name} 提供 %{count}% 的末日審判和元素風暴防護，但降低 2 點魔法力量。"
+
+msgid ""
+"A kindly Sorceress thinks that your army's defenses could use a magical "
+"boost. She offers to enchant the Broach that you wear on your cloak, and you "
+"accept."
+msgstr ""
+"一位善良的女巫認為你軍隊的防禦可以用魔法強化。她提議為你斗篷上的胸針施加附"
+"魔，你接受了。"
+
+msgid "Battle Garb of Anduran"
+msgstr "Battle Garb of Anduran"
+
+msgid ""
+"The %{name} combines the powers of the three Anduran artifacts (+5 to "
+"attack, defense, and spell power). It also provides maximum luck and morale "
+"for the hero's troops and gives the hero the Town Portal spell."
+msgstr ""
+"%{name} 結合了三件 Anduran 神器的力量 (攻擊、防禦和魔法力量各 +5)。它還為英雄"
+"的部隊提供最大幸運和士氣，並賦予英雄城鎮傳送門法術。"
+
+msgid ""
+"Out of pity for a poor peasant, you purchase a chest of old junk they are "
+"hawking for too much gold. Later, as you search through it, you find it "
+"contains the 3 pieces of the legendary battle garb of Anduran!"
+msgstr ""
+"出於對一個貧窮農民的同情，你以過高的價格買下了他們叫賣的一箱舊破爛。後來翻找"
+"時，你發現裡面竟包含傳說中 Anduran 戰甲的 3 個部件！"
+
+msgid "Crystal Ball"
+msgstr "Crystal Ball"
+
+msgid ""
+"The %{name} lets the hero get more specific information about monsters, "
+"enemy heroes, and castles nearby the hero."
+msgstr ""
+"%{name} 讓英雄獲得附近怪物、敵方英雄和城堡的更詳細資訊。"
+
+msgid ""
+"You come upon a caravan of gypsies who are feasting and fortifying their "
+"bodies with mead. They call you forward and say \"If you prove that you can "
+"dance the Rama-Buta, we will reward you.\" You don't know it, but try "
+"anyway. They laugh hysterically, but admire your bravery, giving you a "
+"Crystal Ball."
+msgstr ""
+"你遇到了一支正在飲蜜酒歡宴的吉普賽商隊。他們叫你過去說：「如果你能跳 Rama-"
+"Buta 舞，我們就獎賞你。」你不會跳，但還是嘗試了。他們笑得前仰後合，但欽佩你的"
+"勇氣，送給你一顆水晶球。"
+
+msgid "Heart of Fire"
+msgstr "Heart of Fire"
+
+msgid ""
+"The %{name} provides %{count} percent protection from fire, but doubles the "
+"damage taken from cold."
+msgstr ""
+"%{name} 提供 %{count}% 的火焰防護，但受到的冰系傷害加倍。"
+
+msgid ""
+"You enter a recently burned glade and come upon a Fire Elemental sitting "
+"atop a rock. It looks up, its flaming face contorted in a look of severe "
+"pain. It then tosses a glowing object at you. You put up your hands to block "
+"it, but it passes right through them and sears itself into your chest."
+msgstr ""
+"你進入一片最近燒毀的林間空地，遇到一個坐在岩石上的火元素。牠抬頭看你，燃燒的"
+"臉龐扭曲著劇痛的表情。然後牠朝你拋出一個發光的物體。你舉起雙手阻擋，但它直接"
+"穿過，灼入你的胸膛。"
+
+msgid "Heart of Ice"
+msgstr "Heart of Ice"
+
+msgid ""
+"The %{name} provides %{count} percent protection from cold, but doubles the "
+"damage taken from fire."
+msgstr ""
+"%{name} 提供 %{count}% 的寒冰防護，但受到的火系傷害加倍。"
+
+msgid ""
+"Suddenly, a biting coldness engulfs your body. You seize up, falling from "
+"your horse. The pain subsides, but you still feel as if your chest is "
+"frozen. As you pick yourself up off of the ground, you hear hearty laughter. "
+"You turn around just in time to see a Frost Giant run off into the woods and "
+"disappear."
+msgstr ""
+"突然，刺骨的寒冷吞噬了你的身體。你全身僵硬，從馬上摔落。疼痛消退了，但你仍覺"
+"得胸口像是結了冰。當你從地上爬起時，聽到了爽朗的笑聲。你轉過身，恰好看見一個"
+"霜巨人跑入樹林中消失了。"
+
+msgid "Helmet of Anduran"
+msgstr "Helmet of Anduran"
+
+msgid ""
+"You spy a gleaming object poking up out of the ground. You send a member of "
+"your party over to investigate. He comes back with a golden helmet in his "
+"hands. You realize that it must be the helmet of the legendary Anduran, the "
+"only man who was known to wear solid gold armor."
+msgstr ""
+"你發現地面上露出一個閃光的物體。你派隊員去調查。他帶著一頂金色頭盔回來。你意"
+"識到這一定是傳說中 Anduran 的頭盔，他是唯一一位已知穿戴純金盔甲的人。"
+
+msgid "Holy Hammer"
+msgstr "Holy Hammer"
+
+msgid ""
+"You come upon a battle where a Paladin has been mortally wounded by a group "
+"of Zombies. He asks you to take his hammer and finish what he started. As "
+"you pick it up, it begins to hum, and then everything becomes a blur. The "
+"Zombies lie dead, the hammer dripping with blood. You strap it to your belt."
+msgstr ""
+"你遇到一場戰鬥，一位聖騎士被一群殭屍重傷。他請你拿起他的錘子完成他的使命。當"
+"你撿起它時，錘子開始嗡鳴，然後一切變得模糊。殭屍們都倒下了，錘子滴著鮮血。你"
+"將它繫在腰帶上。"
+
+msgid "Legendary Scepter"
+msgstr "Legendary Scepter"
+
+msgid "The %{name} adds %{count} points to all attributes."
+msgstr "%{name} 增加所有屬性 %{count} 點。"
+
+msgid ""
+"Upon cresting a small hill, you come upon a ridiculous looking sight. A "
+"Sprite is attempting to carry a Scepter that is almost as big as it is. "
+"Trying not to laugh, you ask, \"Need help?\" The Sprite glares at you and "
+"answers: \"You think this is funny? Fine. You can carry it. I much prefer "
+"flying anyway.\""
+msgstr ""
+"翻過一座小丘，你看到了一幅滑稽的景象。一隻精靈正試圖搬運一根幾乎和牠一樣大的"
+"權杖。你忍住笑問道：「需要幫忙嗎？」精靈瞪著你回答：「你覺得這很好笑嗎？好"
+"吧，你來搬。反正我比較喜歡飛。」"
+
+msgid "Masthead"
+msgstr "Masthead"
+
+msgid ""
+"The %{name} boosts the hero's troops' luck and morale by %{count} each in "
+"sea combat."
+msgstr ""
+"%{name} 在海戰中各增加英雄部隊 %{count} 點幸運和士氣。"
+
+msgid ""
+"An old seaman tells you a tale of an enchanted masthead that he used in his "
+"youth to rally his crew during times of trouble. He then hands you a faded "
+"map that shows where he hid it. After much exploring, you find it stashed "
+"underneath a nearby dock."
+msgstr ""
+"一位老水手向你講述他年輕時用一個魔法船首像在危難時鼓舞船員的故事。然後他遞給"
+"你一張褪色的地圖，標示了他藏匿之處。經過一番探索，你在附近的碼頭下面找到了"
+"它。"
+
+msgid "Sphere of Negation"
+msgstr "Sphere of Negation"
+
+msgid "The %{name} disables all spell casting, for both sides, in combat."
+msgstr "%{name} 在戰鬥中禁止雙方施放任何法術。"
+
+msgid ""
+"You stop to help a Peasant catch a runaway mare. To show his gratitude, he "
+"hands you a tiny sphere. As soon as you grasp it, you feel the magical "
+"energy drain from your limbs..."
+msgstr ""
+"你停下來幫助一個農民抓住逃跑的母馬。為表感謝，他遞給你一個小球體。你一握住"
+"它，就感覺魔力從四肢流失……"
+
+msgid "Staff of Wizardry"
+msgstr "Staff of Wizardry"
+
+msgid "The %{name} boosts the hero's spell power by %{count}."
+msgstr "%{name} 增加英雄 %{count} 點魔法力量。"
+
+msgid ""
+"While out scaring up game, your troops find a mysterious staff levitating "
+"about three feet off of the ground. They hand it to you, and you notice an "
+"inscription. It reads: \"Brains best brawn and magic beats might. Heed my "
+"words, and you'll win every fight.\""
+msgstr ""
+"在外出驅趕獵物時，你的部隊發現了一根在離地三英尺處懸浮的神秘法杖。他們將它交"
+"給你，你注意到上面有銘文寫著：「智慧勝過蠻力，魔法克制武力。聽從我的話，你將"
+"贏得每場戰鬥。」"
+
+msgid "Sword Breaker"
+msgstr "Sword Breaker"
+
+msgid "The %{name} increases the hero's defense by %{count} and attack by 1."
+msgstr "%{name} 增加英雄 %{count} 點防禦和 1 點攻擊。"
+
+msgid ""
+"A former Captain of the Guard admires your quest and gives you the enchanted "
+"Sword Breaker that he relied on during his tour of duty."
+msgstr ""
+"一位前衛隊隊長欽佩你的壯舉，將他在任期間依賴的附魔碎劍器送給你。"
+
+msgid "Sword of Anduran"
+msgstr "Sword of Anduran"
+
+msgid ""
+"A Troll stops you and says: \"Pay me 5,000 gold, or the Sword of Anduran "
+"will slay you where you stand.\" You refuse. The troll grabs the sword "
+"hanging from its belt, screams in pain, and runs away. Picking up the fabled "
+"sword, you give thanks that half-witted Trolls tend to grab the wrong end of "
+"sharp objects."
+msgstr ""
+"一隻巨魔攔住你說：「付我 5,000 金幣，否則 Anduran 之劍會就地斬殺你。」你拒絕"
+"了。巨魔抓住掛在腰帶上的劍，痛得尖叫著跑掉了。撿起這把傳說中的劍，你慶幸愚蠢"
+"的巨魔總是抓錯銳器的那一端。"
+
+msgid "Spade of Necromancy"
+msgstr "Spade of Necromancy"
+
+msgid "The %{name} gives the hero increased necromancy skill."
+msgstr "%{name} 增強英雄的死靈術技能。"
+
+msgid ""
+"A dirty shovel has been thrust into a dirt mound nearby. Upon investigation, "
+"you discover it to be the enchanted shovel of the Gravediggers, long thought "
+"lost by mortals."
+msgstr ""
+"附近的土堆中插著一把骯髒的鏟子。經過調查，你發現它是掘墓人的魔法鏟，長久以來"
+"被凡人認為已失落。"
+
+msgid "spellBonus|selected by user"
+msgstr "使用者選擇"
+
+msgid "Wood"
+msgstr "木材"
+
+msgid "Mercury"
+msgstr "水銀"
+
+msgid "Ore"
+msgstr "礦石"
+
+msgid "Sulfur"
+msgstr "硫磺"
+
+msgid "Crystal"
+msgstr "水晶"
+
+msgid "Gems"
+msgstr "寶石"
+
+msgid "Gold"
+msgstr "黃金"
+
+msgid ""
+"There are seven resources in Heroes 2, used to build and improves castles, "
+"purchase troops and recruit heroes. Gold is the most common, required for "
+"virtually everything. Wood and ore are used for most buildings. Gems, "
+"Mercury, Sulfur and Crystal are rare magical resources used for the most "
+"powerful creatures and buildings."
+msgstr ""
+"Heroes 2 中有七種資源，用於建造和升級城堡、購買部隊和招募英雄。黃金是最常見"
+"的，幾乎所有事物都需要。木材和礦石用於大多數建築。寶石、水銀、硫磺和水晶是稀"
+"有的魔法資源，用於最強大的生物和建築。"
+
+msgid ""
+"Causes a giant fireball to strike the selected area, damaging all nearby "
+"creatures."
+msgstr ""
+"對選定區域發射巨大火球，傷害附近所有生物。"
+
+msgid "Fireball"
+msgstr "火球術"
+
+msgid "Fireblast"
+msgstr "烈焰爆裂"
+
+msgid ""
+"An improved version of fireball, fireblast affects two hexes around the "
+"center point of the spell, rather than one."
+msgstr ""
+"火球術的強化版，烈焰爆裂影響以施法中心為圓心兩格範圍內的區域，而非一格。"
+
+msgid "Causes a bolt of electrical energy to strike the selected creature."
+msgstr "對選定生物發射一道閃電。"
+
+msgid "Lightning Bolt"
+msgstr "閃電箭"
+
+msgid "Chain Lightning"
+msgstr "連鎖閃電"
+
+msgid ""
+"Causes a bolt of electrical energy to strike a selected creature, then "
+"strike the nearest creature with half damage, then strike the NEXT nearest "
+"creature with half again damage, and so on, until it becomes too weak to be "
+"harmful. Warning: This spell can hit your own creatures!"
+msgstr ""
+"對選定生物發射閃電，然後以一半傷害擊中最近的生物，再以一半傷害擊中下一個最近"
+"的生物，依此類推，直到威力不足以造成傷害。警告：此法術可能擊中己方生物！"
+
+msgid "Teleport"
+msgstr "Teleport"
+
+msgid ""
+"Teleports the creature you select to any open position on the battlefield."
+msgstr ""
+"將選定生物傳送到戰場上任意空位。"
+
+msgid "Cure"
+msgstr "治療"
+
+msgid ""
+"Removes all negative spells cast upon one of your units, and restores up to "
+"%{count} HP per level of spell power."
+msgstr ""
+"移除己方一個單位身上的所有負面法術，並依魔法力量等級每級恢復最多 %{count} 點"
+"生命值。"
+
+msgid "Mass Cure"
+msgstr "群體治療"
+
+msgid ""
+"Removes all negative spells cast upon your forces, and restores up to "
+"%{count} HP per level of spell power, per creature."
+msgstr ""
+"移除己方部隊身上的所有負面法術，並依魔法力量等級，每級為每個生物恢復最多 "
+"%{count} 點生命值。"
+
+msgid "Resurrect"
+msgstr "復活術"
+
+msgid "Resurrects creatures from a damaged or dead unit until end of combat."
+msgstr "從受傷或死亡的單位中復活生物，效果持續至戰鬥結束。"
+
+msgid "Resurrect True"
+msgstr "完全復活"
+
+msgid "Resurrects creatures from a damaged or dead unit permanently."
+msgstr "永久復活受傷或死亡單位中的生物。"
+
+msgid "Haste"
+msgstr "加速術"
+
+msgid "Increases the speed of any creature by %{count}."
+msgstr "增加任意生物 %{count} 點速度。"
+
+msgid "Increases the speed of all of your creatures by %{count}."
+msgstr "增加己方所有生物 %{count} 點速度。"
+
+msgid "Mass Haste"
+msgstr "群體加速"
+
+msgid "Slows target to half movement rate."
+msgstr "將目標的移動速率減半。"
+
+msgid "spell|Slow"
+msgstr "緩速術"
+
+msgid "Mass Slow"
+msgstr "群體緩速"
+
+msgid "Slows all enemies to half movement rate."
+msgstr "將所有敵人的移動速率減半。"
+
+msgid "spell|Blind"
+msgstr "致盲術"
+
+msgid ""
+"Clouds the affected creatures' eyes, preventing them from moving and reduces "
+"the damage when retaliating by %{count} percent."
+msgstr ""
+"蒙蔽受影響生物的雙眼，使其無法移動，並降低 %{count}% 的反擊傷害。"
+
+msgid "Bless"
+msgstr "祝福"
+
+msgid "Causes the selected creatures to inflict maximum damage."
+msgstr "使選定生物造成最大傷害。"
+
+msgid "Causes all of your units to inflict maximum damage."
+msgstr "使己方所有單位造成最大傷害。"
+
+msgid "Mass Bless"
+msgstr "群體祝福"
+
+msgid "Magically increases the defense skill of the selected creatures."
+msgstr "以魔法增加選定生物的防禦技能。"
+
+msgid "Stoneskin"
+msgstr "石膚術"
+
+msgid "Steelskin"
+msgstr "鋼膚術"
+
+msgid ""
+"Increases the defense skill of the targeted creatures. This is an improved "
+"version of Stoneskin."
+msgstr ""
+"增加目標生物的防禦技能。此為石膚術的強化版。"
+
+msgid "Causes the selected creatures to inflict minimum damage."
+msgstr "使選定生物只能造成最低傷害。"
+
+msgid "Curse"
+msgstr "詛咒"
+
+msgid "Causes all enemy troops to inflict minimum damage."
+msgstr "使所有敵軍只能造成最低傷害。"
+
+msgid "Mass Curse"
+msgstr "群體詛咒"
+
+msgid "Damages all undead in the battle."
+msgstr "傷害戰鬥中所有亡靈。"
+
+msgid "Holy Word"
+msgstr "神聖之語"
+
+msgid ""
+"Damages all undead in the battle. This is an improved version of Holy Word."
+msgstr ""
+"傷害戰鬥中所有亡靈。此為神聖之語的強化版。"
+
+msgid "Holy Shout"
+msgstr "神聖吶喊"
+
+msgid "Anti-Magic"
+msgstr "反魔法結界"
+
+msgid "Prevents any magic against the selected creatures."
+msgstr "使選定生物免受任何魔法影響。"
+
+msgid "Dispel Magic"
+msgstr "驅散魔法"
+
+msgid "Removes all magic spells from a single target."
+msgstr "移除單一目標身上的所有魔法效果。"
+
+msgid "Mass Dispel"
+msgstr "群體驅散"
+
+msgid "Removes all magic spells from all creatures."
+msgstr "移除所有生物身上的所有魔法效果。"
+
+msgid "Causes a magic arrow to strike the selected target."
+msgstr "對選定目標射出一發魔法飛彈。"
+
+msgid "Magic Arrow"
+msgstr "魔法飛彈"
+
+msgid "Berserker"
+msgstr "Berserker"
+
+msgid "Causes a creature to attack its nearest neighbor."
+msgstr "使一個生物攻擊其最近的鄰居。"
+
+msgid "Armageddon"
+msgstr "Armageddon"
+
+msgid ""
+"Holy terror strikes the battlefield, causing severe damage to all creatures."
+msgstr ""
+"神聖恐懼降臨戰場，對所有生物造成嚴重傷害。"
+
+msgid "Elemental Storm"
+msgstr "元素風暴"
+
+msgid "Magical elements pour down on the battlefield, damaging all creatures."
+msgstr "魔法元素傾瀉至戰場，傷害所有生物。"
+
+msgid ""
+"A rain of rocks strikes an area of the battlefield, damaging all nearby "
+"creatures."
+msgstr ""
+"石雨襲擊戰場上的一個區域，傷害附近所有生物。"
+
+msgid "Meteor Shower"
+msgstr "隕石雨"
+
+msgid "Paralyze"
+msgstr "麻痺術"
+
+msgid "The targeted creatures are paralyzed, unable to move or retaliate."
+msgstr "目標生物陷入麻痺，無法移動或反擊。"
+
+msgid "Hypnotize"
+msgstr "催眠術"
+
+msgid ""
+"Brings a single enemy unit under your control if its hits are less than "
+"%{count} times the caster's spell power."
+msgstr ""
+"敵方單一單位生命值低於施法者魔法力量的 %{count} 倍時，即可將其控制。"
+
+msgid "Cold Ray"
+msgstr "寒冰射線"
+
+msgid "Drains body heat from a single enemy unit."
+msgstr "吸取單一敵方單位的體溫。"
+
+msgid "Cold Ring"
+msgstr "寒冰之環"
+
+msgid ""
+"Drains body heat from all units surrounding the center point, but not "
+"including the center point."
+msgstr ""
+"吸取中心點周圍所有單位的體溫，但不影響中心點。"
+
+msgid "Disrupting Ray"
+msgstr "瓦解射線"
+
+msgid "Reduces the defense rating of an enemy unit by three."
+msgstr "降低敵方單位 3 點防禦值。"
+
+msgid "Damages all living (non-undead) units in the battle."
+msgstr "傷害戰鬥中所有活體 (非亡靈) 單位。"
+
+msgid "Death Ripple"
+msgstr "死亡漣漪"
+
+msgid "Death Wave"
+msgstr "死亡波動"
+
+msgid ""
+"Damages all living (non-undead) units in the battle. This spell is an "
+"improved version of Death Ripple."
+msgstr ""
+"傷害戰鬥中所有活體 (非亡靈) 單位。此為死亡漣漪的強化版。"
+
+msgid "Dragon Slayer"
+msgstr "屠龍術"
+
+msgid "Greatly increases a unit's attack skill vs. Dragons."
+msgstr "大幅增加單位對龍族的攻擊技能。"
+
+msgid "Blood Lust"
+msgstr "嗜血術"
+
+msgid "Increases a unit's attack skill."
+msgstr "增加單位的攻擊技能。"
+
+msgid "Animate Dead"
+msgstr "操控亡靈"
+
+msgid "Resurrects creatures from a damaged or dead undead unit permanently."
+msgstr "永久復活受傷或死亡的亡靈單位中的生物。"
+
+msgid "Mirror Image"
+msgstr "鏡像術"
+
+msgid ""
+"Creates an illusionary unit that duplicates one of your existing units. This "
+"illusionary unit does the same damages as the original, but will vanish if "
+"it takes any damage."
+msgstr ""
+"建立一個複製己方現有單位的幻影。幻影單位造成與原單位相同的傷害，但受到任何傷"
+"害就會消失。"
+
+msgid "Shield"
+msgstr "護盾"
+
+msgid ""
+"Halves damage received from ranged attacks for a single unit. Does not "
+"affect damage received from Turrets or Ballistae."
+msgstr ""
+"將單一單位受到的遠距攻擊傷害減半。不影響箭塔或弩砲造成的傷害。"
+
+msgid "Mass Shield"
+msgstr "群體護盾"
+
+msgid ""
+"Halves damage received from ranged attacks for all of your units. Does not "
+"affect damage received from Turrets or Ballistae."
+msgstr ""
+"將己方所有單位受到的遠距攻擊傷害減半。不影響箭塔或弩砲造成的傷害。"
+
+msgid "Summon Earth Elemental"
+msgstr "召喚土元素"
+
+msgid "Summons Earth Elementals to fight for your army."
+msgstr "召喚土元素為你的軍隊作戰。"
+
+msgid "Summon Air Elemental"
+msgstr "召喚風元素"
+
+msgid "Summons Air Elementals to fight for your army."
+msgstr "召喚風元素為你的軍隊作戰。"
+
+msgid "Summon Fire Elemental"
+msgstr "召喚火元素"
+
+msgid "Summons Fire Elementals to fight for your army."
+msgstr "召喚火元素為你的軍隊作戰。"
+
+msgid "Summon Water Elemental"
+msgstr "召喚水元素"
+
+msgid "Summons Water Elementals to fight for your army."
+msgstr "召喚水元素為你的軍隊作戰。"
+
+msgid "Damages castle walls."
+msgstr "破壞城牆。"
+
+msgid "Earthquake"
+msgstr "地震"
+
+msgid "Causes all mines across the land to become visible."
+msgstr "顯示大地上所有礦場的位置。"
+
+msgid "View Mines"
+msgstr "探查礦場"
+
+msgid "Causes all resources across the land to become visible."
+msgstr "顯示大地上所有資源的位置。"
+
+msgid "View Resources"
+msgstr "探查資源"
+
+msgid "Causes all artifacts across the land to become visible."
+msgstr "顯示大地上所有神器的位置。"
+
+msgid "View Artifacts"
+msgstr "探查神器"
+
+msgid "Causes all towns and castles across the land to become visible."
+msgstr "顯示大地上所有城鎮和城堡的位置。"
+
+msgid "View Towns"
+msgstr "探查城鎮"
+
+msgid "Causes all Heroes across the land to become visible."
+msgstr "顯示大地上所有英雄的位置。"
+
+msgid "View Heroes"
+msgstr "探查英雄"
+
+msgid "Causes the entire land to become visible."
+msgstr "顯示整片大地的全貌。"
+
+msgid "View All"
+msgstr "全域探查"
+
+msgid "Allows the caster to view detailed information on enemy Heroes."
+msgstr "讓施法者檢視敵方英雄的詳細資訊。"
+
+msgid "Summon Boat"
+msgstr "召喚船隻"
+
+msgid ""
+"Summons the nearest unoccupied, friendly boat to an adjacent shore location. "
+"A friendly boat is one which you just built or were the most recent player "
+"to occupy."
+msgstr ""
+"召喚最近且無人佔用的友方船隻到相鄰海岸位置。友方船隻是你剛建造，或最近由你佔"
+"用過的船。"
+
+msgid "Allows the caster to magically transport to a nearby location."
+msgstr "讓施法者以魔法傳送到附近的位置。"
+
+msgid "Dimension Door"
+msgstr "次元之門"
+
+msgid "Town Gate"
+msgstr "城鎮傳送門"
+
+msgid ""
+"Returns the caster to the nearest town or castle currently owned. This spell "
+"cannot be cast if the hero is already in a town or a castle."
+msgstr ""
+"將施法者傳送至最近的己方城鎮或城堡。若英雄已在城鎮或城堡中，則無法施放此法"
+"術。"
+
+msgid ""
+"Returns the hero to the town or castle of choice, provided it is controlled "
+"by you."
+msgstr ""
+"將英雄傳送至你控制的指定城鎮或城堡。"
+
+msgid "Visions"
+msgstr "幻視"
+
+msgid ""
+"Visions predicts the likely outcome of an encounter with a neutral army camp."
+msgstr ""
+"幻視預測與中立軍隊營地遭遇的可能結果。"
+
+msgid "Haunt"
+msgstr "鬧鬼"
+
+msgid ""
+"Haunts a mine you control with Ghosts. This mine stops producing resources. "
+"(If I can't keep it, nobody will!)"
+msgstr ""
+"以幽靈纏繞你控制的礦場，使該礦場停止生產資源。（如果我留不住，誰也別想要！）"
+
+msgid "Set Earth Guardian"
+msgstr "設立土元素守衛"
+
+msgid "Sets Earth Elementals to guard a mine against enemy armies."
+msgstr "設立土元素守衛礦場以抵禦敵軍。"
+
+msgid "Set Air Guardian"
+msgstr "設立風元素守衛"
+
+msgid "Sets Air Elementals to guard a mine against enemy armies."
+msgstr "設立風元素守衛礦場以抵禦敵軍。"
+
+msgid "Set Fire Guardian"
+msgstr "設立火元素守衛"
+
+msgid "Sets Fire Elementals to guard a mine against enemy armies."
+msgstr "設立火元素守衛礦場以抵禦敵軍。"
+
+msgid "Set Water Guardian"
+msgstr "設立水元素守衛"
+
+msgid "Sets Water Elementals to guard a mine against enemy armies."
+msgstr "設立水元素守衛礦場以抵禦敵軍。"
+
+msgid "Random Spell"
+msgstr "隨機法術"
+
+msgid "Randomly selected spell of any level."
+msgstr "隨機選取任意等級的法術。"
+
+msgid "Random 1st Level Spell"
+msgstr "隨機 1 級法術"
+
+msgid "Randomly selected 1st level spell."
+msgstr "隨機選取 1 級法術。"
+
+msgid "Random 2nd Level Spell"
+msgstr "隨機 2 級法術"
+
+msgid "Randomly selected 2nd level spell."
+msgstr "隨機選取 2 級法術。"
+
+msgid "Random 3rd Level Spell"
+msgstr "隨機 3 級法術"
+
+msgid "Randomly selected 3rd level spell."
+msgstr "隨機選取 3 級法術。"
+
+msgid "Random 4th Level Spell"
+msgstr "隨機 4 級法術"
+
+msgid "Randomly selected 4th level spell."
+msgstr "隨機選取 4 級法術。"
+
+msgid "Random 5th Level Spell"
+msgstr "隨機 5 級法術"
+
+msgid "Randomly selected 5th level spell."
+msgstr "隨機選取 5 級法術。"
+
+msgid "Petrification"
+msgstr "石化術"
+
+msgid ""
+"Turns the affected creature into stone. A petrified creature receives half "
+"damage from a direct attack."
+msgstr ""
+"將受影響的生物變為石頭。石化生物遭受直接攻擊時，傷害減半。"
+
+msgid "You have no Magic Book, so you cannot cast a spell."
+msgstr "你沒有魔法書，無法施放法術。"
+
+msgid "No spell to cast."
+msgstr "沒有可施放的法術。"
+
+msgid "Your hero has %{sp} spell points remaining out of %{max}."
+msgstr "英雄剩餘 %{sp}/%{max} 點魔法值。"
+
+msgid "View Adventure Spells"
+msgstr "檢視冒險法術"
+
+msgid "View Combat Spells"
+msgstr "檢視戰鬥法術"
+
+msgid "View previous page"
+msgstr "檢視上一頁"
+
+msgid "View next page"
+msgstr "檢視下一頁"
+
+msgid "Close Spellbook"
+msgstr "關閉法術書"
+
+msgid "View %{spell}"
+msgstr "檢視 %{spell}"
+
+msgid "This spell does %{damage} points of damage."
+msgstr "此法術造成 %{damage} 點傷害。"
+
+msgid ""
+"This spell summons\n"
+"%{count} %{monster}."
+msgstr ""
+"此法術召喚\n"
+"%{count} 個 %{monster}。"
+
+msgid "This spell restores %{hp} HP."
+msgstr "此法術恢復 %{hp} 點生命值。"
+
+msgid "This spell summons %{count} %{monster} to guard the mine."
+msgstr "此法術召喚 %{count} 個 %{monster} 守衛礦場。"
+
+msgid "The nearest town is %{town}."
+msgstr "最近的城鎮是 %{town}。"
+
+msgid "This town is occupied by your hero %{hero}."
+msgstr "此城鎮已由你的英雄 %{hero} 駐守。"
+
+msgid ""
+"This spell controls up to\n"
+"%{hp} HP."
+msgstr ""
+"此法術可控制\n"
+"最多 %{hp} 點生命值的單位。"
+
+msgid "The ultimate artifact is really the %{name}."
+msgstr "終極神器其實是 %{name}。"
+
+msgid "The ultimate artifact may be found in the %{name} regions of the world."
+msgstr "終極神器可能在世界的 %{name} 區域找到。"
+
+msgid "north-west"
+msgstr "西北"
+
+msgid "north"
+msgstr "北方"
+
+msgid "north-east"
+msgstr "東北"
+
+msgid "west"
+msgstr "西方"
+
+msgid "center"
+msgstr "中央"
+
+msgid "east"
+msgstr "東方"
+
+msgid "south-west"
+msgstr "西南"
+
+msgid "south"
+msgstr "南方"
+
+msgid "south-east"
+msgstr "東南"
+
+msgid "The truth is out there."
+msgstr "真相就在那裡。"
+
+msgid "The dark side is stronger."
+msgstr "黑暗面更為強大。"
+
+msgid "The end of the world is near."
+msgstr "世界末日即將來臨。"
+
+msgid "The bones of Lord Slayer are buried in the foundation of the arena."
+msgstr "殺手領主的骸骨埋藏在競技場的地基中。"
+
+msgid "A Black Dragon will take out a Titan any day of the week."
+msgstr "黑龍隨時都能打敗泰坦。"
+
+msgid "He told her: Yada yada yada... and then she said: Blah, blah, blah..."
+msgstr "他跟她說：巴拉巴拉巴拉……然後她說：嘰哩呱啦……"
+
+msgid "An unknown force is being resurrected..."
+msgstr "一股未知的力量正在復甦……"

--- a/src/dist/Makefile
+++ b/src/dist/Makefile
@@ -40,7 +40,6 @@ CPPFLAGS := $(CPPFLAGS)
 LDFLAGS := $(LDFLAGS) -pthread
 # Flags for additional libraries
 LDLIBS := $(LDLIBS)
-
 ifdef FHEROES2_WITH_DEBUG
 CCFLAGS := $(CCFLAGS) -O0 -g
 else
@@ -86,6 +85,19 @@ endif
 
 include Makefile.$(PLATFORM)
 
+SDL_TTF_AVAILABLE := $(shell pkg-config --exists SDL2_ttf 2>/dev/null && echo yes)
+ifeq ($(origin FHEROES2_WITH_CJK_TEXT),undefined)
+ifneq ($(SDL_TTF_AVAILABLE),)
+FHEROES2_WITH_CJK_TEXT := 1
+endif
+endif
+CJK_TEXT_ENABLED :=
+ifneq ($(FHEROES2_WITH_CJK_TEXT),0)
+ifdef FHEROES2_WITH_CJK_TEXT
+CJK_TEXT_ENABLED := 1
+endif
+endif
+
 #
 # Build options for third-party libraries
 #
@@ -116,6 +128,12 @@ endif
 ifdef FHEROES2_WITH_IMAGE
 CCFLAGS := $(CCFLAGS) -DWITH_IMAGE
 endif
+ifdef CJK_TEXT_ENABLED
+CCFLAGS := $(CCFLAGS) -DWITH_CJK_TEXT
+endif
+ifdef FHEROES2_WITH_ICONV
+CCFLAGS := $(CCFLAGS) -DWITH_ICONV
+endif
 ifdef FHEROES2_DATA
 CCFLAGS := $(CCFLAGS) -DFHEROES2_DATA="$(FHEROES2_DATA)"
 endif
@@ -135,12 +153,21 @@ endif
 # SDL-related build options
 #
 
+ifdef CJK_TEXT_ENABLED
+ifeq ($(SDL_TTF_AVAILABLE),)
+$(error FHEROES2_WITH_CJK_TEXT requires SDL2_ttf development files discoverable by pkg-config)
+endif
+endif
+
 # SDL_FLAGS can already be defined in a platform-specific Makefile
 ifeq ($(origin SDL_FLAGS),undefined)
 SDL_FLAGS := $(shell sdl2-config --cflags)
 
 ifdef FHEROES2_WITH_IMAGE
 SDL_FLAGS := $(SDL_FLAGS) $(shell libpng-config --cflags)
+endif
+ifdef CJK_TEXT_ENABLED
+SDL_FLAGS := $(SDL_FLAGS) $(shell pkg-config --cflags SDL2_ttf)
 endif
 endif
 
@@ -151,9 +178,16 @@ SDL_LIBS := -lSDL2_mixer $(shell sdl2-config --libs)
 ifdef FHEROES2_WITH_IMAGE
 SDL_LIBS := $(SDL_LIBS) -lSDL2_image $(shell libpng-config --libs)
 endif
+ifdef CJK_TEXT_ENABLED
+SDL_LIBS := $(SDL_LIBS) $(shell pkg-config --libs SDL2_ttf)
+endif
 endif
 
 CCFLAGS := $(CCFLAGS) $(SDL_FLAGS)
+ifdef FHEROES2_WITH_ICONV
+CCFLAGS := $(CCFLAGS) $(ICONV_FLAGS)
+LIBS := $(LIBS) $(ICONV_LIBS)
+endif
 LIBS := $(SDL_LIBS) $(LIBS)
 
 export CC CXX AR CCFLAGS CFLAGS CXXFLAGS CPPFLAGS LDFLAGS LIBS TARGET

--- a/src/dist/Makefile.bsd
+++ b/src/dist/Makefile.bsd
@@ -21,3 +21,7 @@
 AR := ar
 CXX := g++
 LDFLAGS := $(LDFLAGS) -L/usr/local/lib
+
+ifdef FHEROES2_WITH_ICONV
+ICONV_LIBS ?= -liconv
+endif

--- a/src/dist/Makefile.osx
+++ b/src/dist/Makefile.osx
@@ -28,3 +28,7 @@ ifdef FHEROES2_MACOS_APP_BUNDLE
 CCFLAGS := $(CCFLAGS) -DMACOS_APP_BUNDLE
 LDFLAGS := $(LDFLAGS) -framework CoreFoundation
 endif
+
+ifdef FHEROES2_WITH_ICONV
+ICONV_LIBS ?= -liconv
+endif

--- a/src/engine/translations.cpp
+++ b/src/engine/translations.cpp
@@ -168,7 +168,9 @@ namespace
         LOCALE_SV,
         LOCALE_TR,
         LOCALE_UK,
-        LOCALE_VI
+        LOCALE_VI,
+        LOCALE_ZH_CN,
+        LOCALE_ZH_TW
     };
 
     LocaleType langToLocale( const std::string_view langName )
@@ -286,7 +288,18 @@ namespace
                                                                                   { "ukrainian", LocaleType::LOCALE_UK },
                                                                                   // Vietnamese
                                                                                   { "vi", LocaleType::LOCALE_VI },
-                                                                                  { "vietnamese", LocaleType::LOCALE_VI } };
+                                                                                  { "vietnamese", LocaleType::LOCALE_VI },
+                                                                                  // Simplified Chinese
+                                                                                  { "zh_CN", LocaleType::LOCALE_ZH_CN },
+                                                                                  { "zh_cn", LocaleType::LOCALE_ZH_CN },
+                                                                                  { "zh-cn", LocaleType::LOCALE_ZH_CN },
+                                                                                  { "simplified chinese", LocaleType::LOCALE_ZH_CN },
+                                                                                  { "chinese simplified", LocaleType::LOCALE_ZH_CN },
+                                                                                  // Traditional Chinese
+                                                                                  { "zh_TW", LocaleType::LOCALE_ZH_TW },
+                                                                                  { "zh_tw", LocaleType::LOCALE_ZH_TW },
+                                                                                  { "zh-tw", LocaleType::LOCALE_ZH_TW },
+                                                                                  { "traditional chinese", LocaleType::LOCALE_ZH_TW } };
 
         const auto iter = langLocale.find( langName );
         if ( iter == langLocale.end() ) {
@@ -634,6 +647,9 @@ const char * Translation::ngettext( const char * str, const char * plural, const
 {
     if ( current ) {
         switch ( current->getLocale() ) {
+        case LocaleType::LOCALE_ZH_CN:
+        case LocaleType::LOCALE_ZH_TW:
+            return current->ngettext( str, 0 );
         case LocaleType::LOCALE_AF:
         case LocaleType::LOCALE_BG:
         case LocaleType::LOCALE_DA:

--- a/src/fheroes2/CMakeLists.txt
+++ b/src/fheroes2/CMakeLists.txt
@@ -112,3 +112,13 @@ target_link_libraries(
 	engine
 	${USE_SDL_VERSION}::${USE_SDL_VERSION}main
 	)
+
+if(FHEROES2_CJK_TEXT_AVAILABLE)
+	target_compile_definitions(fheroes2 PRIVATE WITH_CJK_TEXT)
+	target_link_libraries(fheroes2 ${USE_SDL_VERSION}_ttf::${USE_SDL_VERSION}_ttf)
+endif(FHEROES2_CJK_TEXT_AVAILABLE)
+
+if(Iconv_FOUND)
+	target_compile_definitions(fheroes2 PRIVATE WITH_ICONV)
+	target_link_libraries(fheroes2 Iconv::Iconv)
+endif(Iconv_FOUND)

--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -217,7 +217,9 @@ void Dialog::GameInfo()
 
         if ( isCreatorInfoPresent ) {
             if ( le.MouseClickLeft( buttonAbout.area() ) ) {
-                fheroes2::showStandardTextMessage( _( "About" ), mapInfo.creatorNotes, Dialog::OK );
+                const fheroes2::Text header( _( "About" ), fheroes2::FontType::normalYellow() );
+                const fheroes2::Text body( mapInfo.creatorNotes, fheroes2::FontType::normalWhite(), mapLanguage );
+                fheroes2::showMessage( header, body, Dialog::OK );
             }
             else if ( le.isMouseRightButtonPressedInArea( buttonAbout.area() ) ) {
                 fheroes2::showStandardTextMessage( _( "About" ), _( "Click to read notes from the map creator." ), Dialog::ZERO );

--- a/src/fheroes2/dialog/dialog_language_selection.cpp
+++ b/src/fheroes2/dialog/dialog_language_selection.cpp
@@ -275,6 +275,20 @@ namespace
 
         display.render( background.totalArea() );
 
+        const auto updateChosenLanguage = [&chosenLanguage, isGameLanguage, &conf]( const fheroes2::SupportedLanguage newChosenLanguage ) {
+            if ( newChosenLanguage == chosenLanguage ) {
+                return false;
+            }
+
+            chosenLanguage = newChosenLanguage;
+
+            if ( isGameLanguage ) {
+                conf.setGameLanguage( fheroes2::getLanguageAbbreviation( chosenLanguage ) );
+            }
+
+            return true;
+        };
+
         LocalEvent & le = LocalEvent::Get();
         while ( le.HandleEvents() ) {
             if ( buttonOk.isEnabled() ) {
@@ -290,6 +304,8 @@ namespace
             const int listId = listBox.getCurrentId();
             listBox.QueueEventProcessing();
             const bool needRedraw = listId != listBox.getCurrentId();
+            // A double-click also confirms the selected row, so commit the row before returning.
+            const bool isLanguageChanged = needRedraw && updateChosenLanguage( listBox.GetCurrent() );
 
             if ( ( buttonOk.isEnabled() && le.MouseClickLeft( buttonOk.area() ) ) || Game::HotKeyPressEvent( Game::HotKeyEvent::DEFAULT_OKAY )
                  || listBox.isDoubleClicked() ) {
@@ -311,21 +327,12 @@ namespace
                 continue;
             }
 
-            if ( needRedraw ) {
-                const fheroes2::SupportedLanguage newChosenLanguage = listBox.GetCurrent();
-                if ( newChosenLanguage != chosenLanguage ) {
-                    chosenLanguage = newChosenLanguage;
-
-                    if ( isGameLanguage ) {
-                        conf.setGameLanguage( fheroes2::getLanguageAbbreviation( chosenLanguage ) );
-                    }
-
-                    titleBackground.restore();
-                    selectedLangBackground.restore();
-                    redrawDialogInfo( listRoi, chosenLanguage, isGameLanguage );
-                    buttonsBackground.restore();
-                    background.renderOkayCancelButtons( buttonOk, buttonCancel );
-                }
+            if ( isLanguageChanged ) {
+                titleBackground.restore();
+                selectedLangBackground.restore();
+                redrawDialogInfo( listRoi, chosenLanguage, isGameLanguage );
+                buttonsBackground.restore();
+                background.renderOkayCancelButtons( buttonOk, buttonCancel );
             }
 
             listBox.Redraw( chosenLanguage );
@@ -349,6 +356,9 @@ namespace fheroes2
 
         if ( languages.size() == 1 ) {
             Settings::Get().setGameLanguage( fheroes2::getLanguageAbbreviation( languages.front() ) );
+            if ( isGameLanguage ) {
+                Settings::Get().Save( Settings::configFileName );
+            }
             return languages.front();
         }
 
@@ -366,6 +376,12 @@ namespace fheroes2
             }
 
             return currentLanguage;
+        }
+
+        if ( isGameLanguage ) {
+            Settings & conf = Settings::Get();
+            conf.setGameLanguage( fheroes2::getLanguageAbbreviation( chosenLanguage ) );
+            conf.Save( Settings::configFileName );
         }
 
         return chosenLanguage;

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -80,6 +80,7 @@
 #include "settings.h"
 #include "system.h"
 #include "timing.h"
+#include "ui_text.h"
 #include "ui_tool.h"
 #include "zzlib.h"
 
@@ -216,6 +217,10 @@ namespace
 
         ~DisplayInitializer()
         {
+            // Release CJK font resources (and shut SDL_ttf down) here, while SDL is still alive: this initializer
+            // outlives CoreInitializer, which owns SDL_Quit.
+            fheroes2::releaseCjkTextResources();
+
             fheroes2::RenderProcessor::instance().unregisterRenderers();
 
             fheroes2::Display & display = fheroes2::Display::instance();

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -865,8 +865,8 @@ namespace fheroes2
         const int32_t textHeight = releasedText.height( textAreaWidth );
         assert( textHeight > 0 );
 
-        // Add extra y-margin for multi-lined texts on normal buttons.
-        if ( ( emptyButtonIcnID == ICN::EMPTY_EVIL_BUTTON || emptyButtonIcnID == ICN::EMPTY_GOOD_BUTTON ) && textHeight > 17 ) {
+        // Add extra vertical padding only for real multi-line captions.
+        if ( ( emptyButtonIcnID == ICN::EMPTY_EVIL_BUTTON || emptyButtonIcnID == ICN::EMPTY_GOOD_BUTTON ) && releasedText.rows( textAreaWidth ) > 1 ) {
             textAreaMargins.y += 16;
         }
         const int32_t borderedTextHeight = textHeight + textAreaMargins.y;
@@ -932,12 +932,14 @@ namespace fheroes2
         const int32_t finalWidth = std::clamp( maxWidth + 6, minWidth, maxAllowedWidth );
 
         int32_t maxHeight = 0;
+        bool hasMultiLineText = false;
         for ( const auto & text : buttonTexts ) {
             maxHeight = std::max( maxHeight, text.height( finalWidth ) );
+            hasMultiLineText = hasMultiLineText || text.rows( finalWidth ) > 1;
         }
 
-        // Add extra vertical margin depending on how many lines of text there are.
-        if ( maxHeight > getFontHeight( buttonFontType.size ) ) {
+        // Use taller buttons only for real multi-line captions.
+        if ( hasMultiLineText ) {
             const int32_t maxAllowedHeight = 200;
             maxHeight = std::clamp<int32_t>( maxHeight, 56, maxAllowedHeight );
         }

--- a/src/fheroes2/gui/ui_font.cpp
+++ b/src/fheroes2/gui/ui_font.cpp
@@ -6788,6 +6788,10 @@ namespace fheroes2
         case CodePage::ISO8859_3:
             generateISO8859_3Alphabet( icnVsSprite );
             break;
+        case CodePage::UTF8:
+            // UTF-8 languages such as Traditional Chinese are rendered through the runtime fallback font path.
+            // Keep the restored base alphabet for ASCII characters and avoid forcing it into an 8-bit code page.
+            break;
         default:
             // Add new code page generation code!
             assert( 0 );
@@ -6813,6 +6817,7 @@ namespace fheroes2
 
         switch ( codePage ) {
         case CodePage::ASCII:
+        case CodePage::UTF8:
             // Do nothing since the ASCII is the base font.
             break;
         case CodePage::CP1250:

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -35,6 +35,7 @@
 #include "settings.h"
 #include "tools.h"
 #include "translations.h"
+#include "ui_text.h"
 
 namespace
 {
@@ -69,7 +70,20 @@ namespace
             { "sk", fheroes2::SupportedLanguage::Slovak },     { "slovak", fheroes2::SupportedLanguage::Slovak },
             { "vi", fheroes2::SupportedLanguage::Vietnamese }, { "vietnamese", fheroes2::SupportedLanguage::Vietnamese },
             { "el", fheroes2::SupportedLanguage::Greek },      { "greek", fheroes2::SupportedLanguage::Greek },
-            { "eo", fheroes2::SupportedLanguage::Esperanto },  { "esperanto", fheroes2::SupportedLanguage::Esperanto } };
+            { "eo", fheroes2::SupportedLanguage::Esperanto },  { "esperanto", fheroes2::SupportedLanguage::Esperanto },
+            { "zh_cn", fheroes2::SupportedLanguage::SimplifiedChinese },
+            { "zh-cn", fheroes2::SupportedLanguage::SimplifiedChinese },
+            { "simplified chinese", fheroes2::SupportedLanguage::SimplifiedChinese },
+            { "chinese simplified", fheroes2::SupportedLanguage::SimplifiedChinese },
+            { "zh_tw", fheroes2::SupportedLanguage::TraditionalChinese },
+            { "zh-tw", fheroes2::SupportedLanguage::TraditionalChinese },
+            { "traditional chinese", fheroes2::SupportedLanguage::TraditionalChinese },
+            { "chinese traditional", fheroes2::SupportedLanguage::TraditionalChinese } };
+
+    bool isChineseLanguage( const fheroes2::SupportedLanguage language )
+    {
+        return language == fheroes2::SupportedLanguage::SimplifiedChinese || language == fheroes2::SupportedLanguage::TraditionalChinese;
+    }
 }
 
 namespace fheroes2
@@ -111,13 +125,22 @@ namespace fheroes2
         return *language;
     }
 
+    bool isLanguageSupportedForRendering( const SupportedLanguage language )
+    {
+        if ( !isChineseLanguage( language ) ) {
+            return true;
+        }
+
+        return fheroes2::isCjkTextRenderingAvailable();
+    }
+
     std::vector<SupportedLanguage> getSupportedLanguages()
     {
         // We need to group languages by code pages to avoid recreating font related resources while switching languages.
         std::map<CodePage, std::vector<SupportedLanguage>> supportedLanguges;
 
         const SupportedLanguage resourceLanguage = getResourceLanguage();
-        if ( resourceLanguage != SupportedLanguage::English ) {
+        if ( resourceLanguage != SupportedLanguage::English && isLanguageSupportedForRendering( resourceLanguage ) ) {
             supportedLanguges[getCodePage( resourceLanguage )].emplace_back( resourceLanguage );
         }
 
@@ -128,10 +151,11 @@ namespace fheroes2
                                                              SupportedLanguage::Swedish,    SupportedLanguage::Turkish,    SupportedLanguage::Dutch,
                                                              SupportedLanguage::Hungarian,  SupportedLanguage::Czech,      SupportedLanguage::Danish,
                                                              SupportedLanguage::Slovak,     SupportedLanguage::Vietnamese, SupportedLanguage::Greek,
-                                                             SupportedLanguage::Esperanto };
+                                                             SupportedLanguage::Esperanto,  SupportedLanguage::SimplifiedChinese,
+                                                             SupportedLanguage::TraditionalChinese };
 
         for ( const SupportedLanguage language : possibleLanguages ) {
-            if ( language != resourceLanguage ) {
+            if ( language != resourceLanguage && isLanguageSupportedForRendering( language ) ) {
                 supportedLanguges[getCodePage( language )].emplace_back( language );
             }
         }
@@ -208,6 +232,10 @@ namespace fheroes2
             return _( "Greek" );
         case SupportedLanguage::Esperanto:
             return _( "Esperanto" );
+        case SupportedLanguage::SimplifiedChinese:
+            return _( "Simplified Chinese" );
+        case SupportedLanguage::TraditionalChinese:
+            return _( "Traditional Chinese" );
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );
@@ -264,6 +292,10 @@ namespace fheroes2
             return "el";
         case SupportedLanguage::Esperanto:
             return "eo";
+        case SupportedLanguage::SimplifiedChinese:
+            return "zh_CN";
+        case SupportedLanguage::TraditionalChinese:
+            return "zh_TW";
         default:
             // Did you add a new language? Please add the code to handle it.
             assert( 0 );
@@ -312,7 +344,8 @@ namespace fheroes2
 
     SupportedLanguage getCurrentLanguage()
     {
-        return fheroes2::getLanguageFromAbbreviation( Settings::Get().getGameLanguage() );
+        const SupportedLanguage language = fheroes2::getLanguageFromAbbreviation( Settings::Get().getGameLanguage() );
+        return isLanguageSupportedForRendering( language ) ? language : SupportedLanguage::English;
     }
 
     CodePage getCodePage( const SupportedLanguage language )
@@ -350,6 +383,9 @@ namespace fheroes2
             return CodePage::ISO8859_16;
         case SupportedLanguage::Esperanto:
             return CodePage::ISO8859_3;
+        case SupportedLanguage::SimplifiedChinese:
+        case SupportedLanguage::TraditionalChinese:
+            return CodePage::UTF8;
         default:
             // Add new language handling code!
             assert( 0 );

--- a/src/fheroes2/gui/ui_language.h
+++ b/src/fheroes2/gui/ui_language.h
@@ -48,6 +48,9 @@ namespace fheroes2
     // This function returns an array of supported languages. If the array contains only one language it must be English.
     std::vector<SupportedLanguage> getSupportedLanguages();
 
+    // Returns true if the current build and runtime resources can display this language.
+    bool isLanguageSupportedForRendering( const SupportedLanguage language );
+
     // Return name of the language. Call this function only within the scope of LanguageSwitcher object.
     const char * getLanguageName( const SupportedLanguage language );
 

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -21,15 +21,46 @@
 #include "ui_text.h"
 
 #include <algorithm>
+#include <array>
 #include <cassert>
 #include <cstddef>
+#include <cctype>
 #include <cstdlib>
 #include <map>
 #include <memory>
 #include <numeric>
+#include <string>
+#include <utility>
+#include <vector>
+
+#if defined( WITH_CJK_TEXT )
+#include <filesystem>
+#include <set>
+#include <system_error>
+
+#if defined( __GNUC__ )
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wswitch-default"
+#endif
+
+#include <SDL_ttf.h>
+
+#if SDL_TTF_VERSION_ATLEAST( 2, 0, 18 )
+#define FHEROES2_SDL_TTF_HAS_32BIT_GLYPHS
+#endif
+
+#if defined( __GNUC__ )
+#pragma GCC diagnostic pop
+#endif
+#endif
 
 #include "agg_image.h"
+#include "game_language.h"
 #include "icn.h"
+#include "logging.h"
+#include "settings.h"
+#include "system.h"
 #include "ui_language.h"
 
 namespace
@@ -55,6 +86,1462 @@ namespace
     }
 
     const fheroes2::Sprite errorImage;
+
+    constexpr uint32_t unicodeReplacementGlyph{ 0x25A1 };
+
+    struct Utf8Character
+    {
+        uint32_t codePoint{ 0 };
+        size_t byteOffset{ 0 };
+        size_t byteCount{ 0 };
+    };
+
+    bool isCjkCodePoint( const uint32_t codePoint )
+    {
+        return ( codePoint >= 0x3400 && codePoint <= 0x4DBF ) || ( codePoint >= 0x4E00 && codePoint <= 0x9FFF )
+               || ( codePoint >= 0xF900 && codePoint <= 0xFAFF ) || ( codePoint >= 0x3040 && codePoint <= 0x30FF )
+               || ( codePoint >= 0x3100 && codePoint <= 0x312F ) || ( codePoint >= 0x20000 && codePoint <= 0x2A6DF )
+               || ( codePoint >= 0x2A700 && codePoint <= 0x2B73F ) || ( codePoint >= 0x2B740 && codePoint <= 0x2B81F )
+               || ( codePoint >= 0x2B820 && codePoint <= 0x2EBEF ) || ( codePoint >= 0x2F800 && codePoint <= 0x2FA1F )
+               || ( codePoint >= 0x30000 && codePoint <= 0x323AF );
+    }
+
+    bool decodeUtf8( const std::string_view text, std::vector<Utf8Character> & output, bool & hasNonAscii )
+    {
+        output.clear();
+        hasNonAscii = false;
+
+        bool isValid = true;
+
+        for ( size_t offset = 0; offset < text.size(); ) {
+            const auto firstByte = static_cast<uint8_t>( text[offset] );
+            uint32_t codePoint = unicodeReplacementGlyph;
+            size_t byteCount = 1;
+            bool isSequenceValid = true;
+
+            if ( firstByte < 0x80 ) {
+                codePoint = firstByte;
+            }
+            else if ( ( firstByte & 0xE0 ) == 0xC0 && offset + 1 < text.size() ) {
+                const auto secondByte = static_cast<uint8_t>( text[offset + 1] );
+                isSequenceValid = ( secondByte & 0xC0 ) == 0x80;
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x1F ) << 6 ) | static_cast<uint32_t>( secondByte & 0x3F );
+                byteCount = 2;
+
+                if ( codePoint < 0x80 ) {
+                    isSequenceValid = false;
+                }
+            }
+            else if ( ( firstByte & 0xF0 ) == 0xE0 && offset + 2 < text.size() ) {
+                const auto secondByte = static_cast<uint8_t>( text[offset + 1] );
+                const auto thirdByte = static_cast<uint8_t>( text[offset + 2] );
+                isSequenceValid = ( ( secondByte & 0xC0 ) == 0x80 ) && ( ( thirdByte & 0xC0 ) == 0x80 );
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x0F ) << 12 ) | ( static_cast<uint32_t>( secondByte & 0x3F ) << 6 )
+                            | static_cast<uint32_t>( thirdByte & 0x3F );
+                byteCount = 3;
+
+                if ( codePoint < 0x800 || ( codePoint >= 0xD800 && codePoint <= 0xDFFF ) ) {
+                    isSequenceValid = false;
+                }
+            }
+            else if ( ( firstByte & 0xF8 ) == 0xF0 && offset + 3 < text.size() ) {
+                const auto secondByte = static_cast<uint8_t>( text[offset + 1] );
+                const auto thirdByte = static_cast<uint8_t>( text[offset + 2] );
+                const auto fourthByte = static_cast<uint8_t>( text[offset + 3] );
+                isSequenceValid
+                    = ( ( secondByte & 0xC0 ) == 0x80 ) && ( ( thirdByte & 0xC0 ) == 0x80 ) && ( ( fourthByte & 0xC0 ) == 0x80 );
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x07 ) << 18 ) | ( static_cast<uint32_t>( secondByte & 0x3F ) << 12 )
+                            | ( static_cast<uint32_t>( thirdByte & 0x3F ) << 6 ) | static_cast<uint32_t>( fourthByte & 0x3F );
+                byteCount = 4;
+
+                if ( codePoint < 0x10000 || codePoint > 0x10FFFF ) {
+                    isSequenceValid = false;
+                }
+            }
+            else {
+                isSequenceValid = false;
+            }
+
+            if ( firstByte >= 0x80 ) {
+                hasNonAscii = true;
+            }
+
+            if ( !isSequenceValid ) {
+                isValid = false;
+                codePoint = unicodeReplacementGlyph;
+                byteCount = 1;
+            }
+
+            output.push_back( { codePoint, offset, byteCount } );
+            offset += byteCount;
+        }
+
+        return isValid;
+    }
+
+    bool isChineseLanguage( const fheroes2::SupportedLanguage language )
+    {
+        return language == fheroes2::SupportedLanguage::SimplifiedChinese || language == fheroes2::SupportedLanguage::TraditionalChinese;
+    }
+
+    bool hasHighBitByte( const std::string_view text )
+    {
+        return std::any_of( text.begin(), text.end(), []( const char character ) { return static_cast<uint8_t>( character ) >= 0x80; } );
+    }
+
+    bool isUnicodeTextCandidate( const std::string_view text, const std::optional<fheroes2::SupportedLanguage> & language )
+    {
+        if ( text.empty() ) {
+            return false;
+        }
+
+        // Pure ASCII text (the vast majority of rendered strings) can never be a CJK candidate.
+        // Skip the full UTF-8 decode and its allocation in that very common case.
+        if ( !hasHighBitByte( text ) ) {
+            return false;
+        }
+
+        std::vector<Utf8Character> characters;
+        bool hasNonAscii = false;
+        if ( !decodeUtf8( text, characters, hasNonAscii ) || !hasNonAscii ) {
+            return false;
+        }
+
+        const fheroes2::SupportedLanguage textLanguage = language.value_or( fheroes2::getCurrentLanguage() );
+        if ( isChineseLanguage( textLanguage ) ) {
+            return true;
+        }
+
+        return std::any_of( characters.begin(), characters.end(), []( const Utf8Character & character ) { return isCjkCodePoint( character.codePoint ); } );
+    }
+
+    void removeLastUtf8Character( std::string & text )
+    {
+        if ( text.empty() ) {
+            return;
+        }
+
+        size_t newSize = text.size() - 1;
+        while ( newSize > 0 && ( static_cast<uint8_t>( text[newSize] ) & 0xC0 ) == 0x80 ) {
+            --newSize;
+        }
+
+        text.resize( newSize );
+    }
+
+#if defined( WITH_CJK_TEXT )
+    // Button captions are part of low-resolution assets and need dedicated CJK font tuning.
+    bool isButtonFontSize( const fheroes2::FontSize fontSize )
+    {
+        return fontSize == fheroes2::FontSize::BUTTON_RELEASED || fontSize == fheroes2::FontSize::BUTTON_PRESSED;
+    }
+
+    bool isUnicodeLineSeparator( const uint32_t codePoint )
+    {
+        return codePoint == '\n';
+    }
+
+    bool isUnicodeSpace( const uint32_t codePoint )
+    {
+        return codePoint == ' ' || codePoint == '\t' || codePoint == 0x3000;
+    }
+
+    bool isCjkPunctuation( const uint32_t codePoint )
+    {
+        return ( codePoint >= 0x3000 && codePoint <= 0x303F ) || ( codePoint >= 0xFF00 && codePoint <= 0xFFEF );
+    }
+
+    bool isLineStartProhibitedPunctuation( const uint32_t codePoint )
+    {
+        switch ( codePoint ) {
+        case 0x3001: // Ideographic comma.
+        case 0x3002: // Ideographic full stop.
+        case 0xFF0C: // Fullwidth comma.
+        case 0xFF0E: // Fullwidth full stop.
+        case 0xFF1A: // Fullwidth colon.
+        case 0xFF1B: // Fullwidth semicolon.
+        case 0xFF01: // Fullwidth exclamation mark.
+        case 0xFF1F: // Fullwidth question mark.
+        case 0xFF09: // Fullwidth right parenthesis.
+        case 0xFF3D: // Fullwidth right square bracket.
+        case 0xFF5D: // Fullwidth right curly bracket.
+        case 0x3009: // Right angle bracket.
+        case 0x300B: // Right double angle bracket.
+        case 0x300D: // Right corner bracket.
+        case 0x300F: // Right white corner bracket.
+        case 0x3011: // Right black lenticular bracket.
+        case 0x3015: // Right tortoise shell bracket.
+        case 0x3017: // Right white lenticular bracket.
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    bool isUnicodeBreakAllowedAfter( const uint32_t currentCodePoint, const uint32_t nextCodePoint )
+    {
+        if ( isUnicodeSpace( currentCodePoint ) || currentCodePoint == '-' ) {
+            return true;
+        }
+
+        if ( isCjkCodePoint( currentCodePoint ) || isCjkPunctuation( currentCodePoint ) ) {
+            return !isLineStartProhibitedPunctuation( nextCodePoint );
+        }
+
+        return false;
+    }
+
+    int32_t getFallbackSpaceWidth( const fheroes2::FontSize fontSize )
+    {
+        switch ( fontSize ) {
+        case fheroes2::FontSize::SMALL:
+            return 4;
+        case fheroes2::FontSize::NORMAL:
+            return 6;
+        case fheroes2::FontSize::LARGE:
+        case fheroes2::FontSize::BUTTON_RELEASED:
+        case fheroes2::FontSize::BUTTON_PRESSED:
+            return 8;
+        default:
+            assert( 0 );
+            break;
+        }
+
+        return 0;
+    }
+
+    constexpr uint32_t unicodeQuestionMark{ '?' };
+
+    struct GlyphCacheKey
+    {
+        fheroes2::FontSize size{ fheroes2::FontSize::NORMAL };
+        fheroes2::FontColor color{ fheroes2::FontColor::WHITE };
+        size_t fontIndex{ 0 };
+        uint32_t codePoint{ 0 };
+        uint32_t renderableCodePoint{ 0 };
+
+        bool operator<( const GlyphCacheKey & other ) const
+        {
+            if ( size != other.size ) {
+                return static_cast<uint8_t>( size ) < static_cast<uint8_t>( other.size );
+            }
+
+            if ( color != other.color ) {
+                return static_cast<uint8_t>( color ) < static_cast<uint8_t>( other.color );
+            }
+
+            if ( fontIndex != other.fontIndex ) {
+                return fontIndex < other.fontIndex;
+            }
+
+            if ( codePoint != other.codePoint ) {
+                return codePoint < other.codePoint;
+            }
+
+            return renderableCodePoint < other.renderableCodePoint;
+        }
+    };
+
+    struct FontCacheKey
+    {
+        size_t fontIndex{ 0 };
+        fheroes2::FontSize size{ fheroes2::FontSize::NORMAL };
+
+        bool operator<( const FontCacheKey & other ) const
+        {
+            if ( fontIndex != other.fontIndex ) {
+                return fontIndex < other.fontIndex;
+            }
+
+            return static_cast<uint8_t>( size ) < static_cast<uint8_t>( other.size );
+        }
+    };
+
+    struct RenderableGlyph
+    {
+        size_t fontIndex{ static_cast<size_t>( -1 ) };
+        uint32_t codePoint{ 0 };
+        bool isValid{ false };
+    };
+
+    struct CjkGlyph
+    {
+        fheroes2::Sprite sprite;
+        int32_t advance{ 0 };
+    };
+
+    struct TtfFontDeleter
+    {
+        void operator()( TTF_Font * font ) const
+        {
+            if ( font != nullptr ) {
+                TTF_CloseFont( font );
+            }
+        }
+    };
+
+    std::string toLowerAscii( std::string str )
+    {
+        std::transform( str.begin(), str.end(), str.begin(), []( const unsigned char c ) { return static_cast<char>( std::tolower( c ) ); } );
+        return str;
+    }
+
+    bool hasFontExtension( const std::string & fileName )
+    {
+        const std::string lowerName = toLowerAscii( fileName );
+
+        return lowerName.size() > 4
+               && ( lowerName.compare( lowerName.size() - 4, 4, ".ttf" ) == 0 || lowerName.compare( lowerName.size() - 4, 4, ".ttc" ) == 0
+                    || lowerName.compare( lowerName.size() - 4, 4, ".otf" ) == 0 );
+    }
+
+    int32_t getCjkFontNamePriority( const std::string & fileName )
+    {
+        const std::string lowerName = toLowerAscii( fileName );
+
+        if ( lowerName.find( "serif" ) != std::string::npos ) {
+            return 3;
+        }
+
+        if ( lowerName.find( "noto" ) != std::string::npos || lowerName.find( "sourcehan" ) != std::string::npos
+             || lowerName.find( "source han" ) != std::string::npos || lowerName.find( "wqy" ) != std::string::npos
+             || lowerName.find( "wenquanyi" ) != std::string::npos ) {
+            return 0;
+        }
+
+        if ( lowerName.find( "msjh" ) != std::string::npos || lowerName.find( "msyh" ) != std::string::npos || lowerName.find( "simhei" ) != std::string::npos
+             || lowerName.find( "deng" ) != std::string::npos || lowerName.find( "pingfang" ) != std::string::npos
+             || lowerName.find( "hiragino" ) != std::string::npos || lowerName.find( "heiti" ) != std::string::npos ) {
+            return 1;
+        }
+
+        if ( lowerName.find( "mingliu" ) != std::string::npos || lowerName.find( "simsun" ) != std::string::npos ) {
+            return 2;
+        }
+
+        return 5;
+    }
+
+    // Button labels have limited space, so prefer fonts that fit compact UI controls.
+    int32_t getCjkButtonFontNamePriority( const std::string & fileName )
+    {
+        const std::string lowerName = toLowerAscii( fileName );
+
+        if ( lowerName.find( "kaiti" ) != std::string::npos || lowerName.find( "stkaiti" ) != std::string::npos || lowerName.find( "ukai" ) != std::string::npos
+             || lowerName.find( " kai" ) != std::string::npos || lowerName.find( "-kai" ) != std::string::npos ) {
+            return 0;
+        }
+
+        if ( lowerName.find( "mingliu" ) != std::string::npos || lowerName.find( "simsun" ) != std::string::npos || lowerName.find( "songti" ) != std::string::npos
+             || lowerName.find( "sourcehanserif" ) != std::string::npos || lowerName.find( "source han serif" ) != std::string::npos
+             || lowerName.find( "notoserif" ) != std::string::npos || lowerName.find( "noto serif" ) != std::string::npos
+             || lowerName.find( "uming" ) != std::string::npos || lowerName.find( "serif" ) != std::string::npos ) {
+            return 1;
+        }
+
+        return 2;
+    }
+
+    bool isPreferredCjkFontName( const std::string & fileName )
+    {
+        return getCjkFontNamePriority( fileName ) < 5;
+    }
+
+    const std::vector<std::string> & getKnownCjkFontFileNames()
+    {
+        static const std::vector<std::string> fontNames{ "NotoSansCJK-Regular.ttc",     "NotoSansCJKtc-Regular.otf", "NotoSansTC-Regular.otf",
+                                                         "NotoSansSC-Regular.otf",      "SourceHanSans-Regular.ttc", "SourceHanSansTC-Regular.otf",
+                                                         "SourceHanSansCN-Regular.otf", "wqy-microhei.ttc",          "wqy-zenhei.ttc",
+                                                         "msjh.ttc",                    "msyh.ttc",                  "simhei.ttf",
+                                                         "mingliu.ttc",                 "simsun.ttc",                "Songti.ttc",
+                                                         "Kaiti.ttc",                   "Hiragino Sans GB.ttc",      "PingFang.ttc",
+                                                         "STHeiti Medium.ttc",          "STHeiti Light.ttc",
+                                                         "Arial Unicode.ttf",           "NotoSerifCJK-Regular.ttc",  "NotoSerifTC-Regular.otf",
+                                                         "SourceHanSerifTC-Regular.otf" };
+
+        return fontNames;
+    }
+
+    void appendFontPathIfExists( std::vector<std::string> & fontPaths, const std::string & path )
+    {
+        if ( path.empty() || !System::IsFile( path ) ) {
+            return;
+        }
+
+        if ( std::find( fontPaths.begin(), fontPaths.end(), path ) == fontPaths.end() ) {
+            fontPaths.emplace_back( path );
+        }
+    }
+
+    void appendFontPathsByPriority( std::vector<std::string> & fontPaths, std::vector<std::string> candidatePaths )
+    {
+        std::sort( candidatePaths.begin(), candidatePaths.end(), []( const std::string & lhs, const std::string & rhs ) {
+            const int32_t leftPriority = getCjkFontNamePriority( lhs );
+            const int32_t rightPriority = getCjkFontNamePriority( rhs );
+            if ( leftPriority != rightPriority ) {
+                return leftPriority < rightPriority;
+            }
+
+            return toLowerAscii( lhs ) < toLowerAscii( rhs );
+        } );
+
+        for ( const std::string & candidatePath : candidatePaths ) {
+            appendFontPathIfExists( fontPaths, candidatePath );
+        }
+    }
+
+    void appendKnownFontsInDirectory( std::vector<std::string> & fontPaths, const std::string & directory )
+    {
+        if ( !System::IsDirectory( directory ) ) {
+            return;
+        }
+
+        for ( const std::string & fontName : getKnownCjkFontFileNames() ) {
+            appendFontPathIfExists( fontPaths, System::concatPath( directory, fontName ) );
+        }
+    }
+
+    void appendFontsInDirectory( std::vector<std::string> & fontPaths, const std::string & directory, const bool requirePreferredName )
+    {
+        if ( !System::IsDirectory( directory ) ) {
+            return;
+        }
+
+        std::vector<std::string> candidatePaths;
+        std::error_code ec;
+        for ( const std::filesystem::directory_entry & entry : std::filesystem::directory_iterator( directory, ec ) ) {
+            if ( !entry.is_regular_file( ec ) ) {
+                continue;
+            }
+
+            const std::string fileName = System::fsPathToString( entry.path().filename() );
+            if ( !hasFontExtension( fileName ) || ( requirePreferredName && !isPreferredCjkFontName( fileName ) ) ) {
+                continue;
+            }
+
+            candidatePaths.emplace_back( System::fsPathToString( entry.path() ) );
+        }
+
+        appendFontPathsByPriority( fontPaths, std::move( candidatePaths ) );
+    }
+
+    void appendPortableCjkFontPaths( std::vector<std::string> & fontPaths )
+    {
+        for ( const std::string & rootDir : Settings::GetRootDirs() ) {
+            for ( const std::string & fontDirectoryName : { std::string( "files/fonts" ), std::string( "fonts" ), std::string( "Fonts" ) } ) {
+                const std::string fontDirectory = System::concatPath( rootDir, fontDirectoryName );
+
+                appendKnownFontsInDirectory( fontPaths, fontDirectory );
+                appendFontsInDirectory( fontPaths, fontDirectory, false );
+            }
+        }
+    }
+
+    std::vector<std::string> findCjkFontPaths()
+    {
+        std::vector<std::string> fontPaths;
+
+        const std::string & configuredFontPath = Settings::Get().getCjkFontPath();
+        if ( !configuredFontPath.empty() ) {
+            if ( System::IsFile( configuredFontPath ) ) {
+                appendFontPathIfExists( fontPaths, configuredFontPath );
+            }
+            else {
+                ERROR_LOG( "Configured CJK font file was not found: " << configuredFontPath )
+            }
+        }
+
+        appendPortableCjkFontPaths( fontPaths );
+
+#if defined( _WIN32 )
+        for ( const std::string & fontPath : { std::string( "C:/Windows/Fonts/msjh.ttc" ), std::string( "C:/Windows/Fonts/msjhbd.ttc" ),
+                                               std::string( "C:/Windows/Fonts/msyh.ttc" ), std::string( "C:/Windows/Fonts/msyhbd.ttc" ),
+                                               std::string( "C:/Windows/Fonts/simhei.ttf" ), std::string( "C:/Windows/Fonts/mingliu.ttc" ),
+                                               std::string( "C:/Windows/Fonts/simsun.ttc" ) } ) {
+            appendFontPathIfExists( fontPaths, fontPath );
+        }
+#elif defined( __APPLE__ ) && !defined( __IPHONEOS__ )
+        for ( const std::string & fontPath : { std::string( "/System/Library/Fonts/Hiragino Sans GB.ttc" ),
+                                               std::string( "/System/Library/Fonts/Supplemental/Hiragino Sans GB.ttc" ),
+                                               std::string( "/System/Library/Fonts/STHeiti Light.ttc" ),
+                                               std::string( "/System/Library/Fonts/Supplemental/STHeiti Light.ttc" ),
+                                               std::string( "/System/Library/Fonts/Supplemental/Songti.ttc" ),
+                                               std::string( "/System/Library/Fonts/Supplemental/Kaiti.ttc" ),
+                                               std::string( "/System/Library/Fonts/Supplemental/Arial Unicode.ttf" ),
+                                               std::string( "/System/Library/Fonts/PingFang.ttc" ) } ) {
+            appendFontPathIfExists( fontPaths, fontPath );
+        }
+#elif defined( __linux__ ) && !defined( ANDROID )
+        for ( const std::string & fontPath :
+              { std::string( "/usr/share/fonts/opentype/noto/NotoSansCJK-Regular.ttc" ),
+                std::string( "/usr/share/fonts/opentype/noto/NotoSansCJKtc-Regular.otf" ),
+                std::string( "/usr/share/fonts/opentype/noto/NotoSansTC-Regular.otf" ),
+                std::string( "/usr/share/fonts/opentype/noto/NotoSansSC-Regular.otf" ),
+                std::string( "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc" ),
+                std::string( "/usr/share/fonts/opentype/source-han-sans/SourceHanSans-Regular.ttc" ),
+                std::string( "/usr/share/fonts/opentype/source-han-sans/SourceHanSansTC-Regular.otf" ),
+                std::string( "/usr/share/fonts/opentype/source-han-sans/SourceHanSansCN-Regular.otf" ),
+                std::string( "/usr/share/fonts/truetype/wqy/wqy-microhei.ttc" ),
+                std::string( "/usr/share/fonts/truetype/wqy/wqy-zenhei.ttc" ),
+                std::string( "/usr/share/fonts/wenquanyi/wqy-microhei/wqy-microhei.ttc" ),
+                std::string( "/usr/share/fonts/wenquanyi/wqy-zenhei/wqy-zenhei.ttc" ) } ) {
+            appendFontPathIfExists( fontPaths, fontPath );
+        }
+
+        auto appendPreferredFontsRecursively = []( std::vector<std::string> & fontPaths, const std::string & directory ) {
+            if ( !System::IsDirectory( directory ) ) {
+                return;
+            }
+
+            std::vector<std::string> candidatePaths;
+            std::error_code ec;
+            for ( const std::filesystem::directory_entry & entry : std::filesystem::recursive_directory_iterator( directory, ec ) ) {
+                if ( !entry.is_regular_file( ec ) ) {
+                    continue;
+                }
+
+                const std::string fileName = System::fsPathToString( entry.path().filename() );
+                if ( hasFontExtension( fileName ) && isPreferredCjkFontName( fileName ) ) {
+                    candidatePaths.emplace_back( System::fsPathToString( entry.path() ) );
+                }
+            }
+
+            appendFontPathsByPriority( fontPaths, std::move( candidatePaths ) );
+        };
+
+        std::vector<std::string> linuxFontDirectories{ "/usr/share/fonts", "/usr/local/share/fonts" };
+        if ( const char * homePath = getenv( "HOME" ); homePath != nullptr ) {
+            linuxFontDirectories.emplace_back( System::concatPath( System::concatPath( homePath, ".local" ), "share/fonts" ) );
+        }
+
+        for ( const std::string & fontDirectory : linuxFontDirectories ) {
+            appendPreferredFontsRecursively( fontPaths, fontDirectory );
+        }
+#endif
+
+        return fontPaths;
+    }
+
+    // Map game font slots to CJK TTF pixel sizes so CJK text fits the low-resolution UI.
+    int32_t getTtfPixelSize( const fheroes2::FontSize fontSize )
+    {
+        switch ( fontSize ) {
+        case fheroes2::FontSize::SMALL:
+            return 10;
+        case fheroes2::FontSize::NORMAL:
+            return 13;
+        case fheroes2::FontSize::LARGE:
+            return 24;
+        case fheroes2::FontSize::BUTTON_RELEASED:
+        case fheroes2::FontSize::BUTTON_PRESSED:
+            return 14;
+        default:
+            assert( 0 );
+            break;
+        }
+
+        return 16;
+    }
+
+    uint8_t getCjkGlyphOutlineColor( const fheroes2::FontType fontType )
+    {
+        if ( fontType.size == fheroes2::FontSize::BUTTON_RELEASED || fontType.size == fheroes2::FontSize::BUTTON_PRESSED ) {
+            return 10;
+        }
+
+        return 0;
+    }
+
+    // Non-button white CJK glyphs keep the original white-to-gray brightness ramp.
+    uint8_t getWhiteCjkGlyphColor( const uint8_t alpha )
+    {
+        if ( alpha > 224 ) {
+            return 10;
+        }
+        if ( alpha > 184 ) {
+            return 12;
+        }
+        if ( alpha > 144 ) {
+            return 14;
+        }
+        if ( alpha > 104 ) {
+            return 16;
+        }
+
+        return 21;
+    }
+
+    // Non-button yellow CJK glyphs use the main yellow and golden palette range.
+    uint8_t getYellowCjkGlyphColor( const uint8_t alpha )
+    {
+        if ( alpha > 224 ) {
+            return 219;
+        }
+        if ( alpha > 184 ) {
+            return 115;
+        }
+        if ( alpha > 144 ) {
+            return 117;
+        }
+        if ( alpha > 104 ) {
+            return 118;
+        }
+
+        return 120;
+    }
+
+    // Non-button gray CJK glyphs keep the disabled-state look without near-black edges.
+    uint8_t getGrayCjkGlyphColor( const uint8_t alpha )
+    {
+        if ( alpha > 224 ) {
+            return 17;
+        }
+        if ( alpha > 184 ) {
+            return 19;
+        }
+        if ( alpha > 144 ) {
+            return 21;
+        }
+        if ( alpha > 104 ) {
+            return 23;
+        }
+
+        return 25;
+    }
+
+    // Button glyphs need harder pixel edges, so filter more TTF antialiasing.
+    uint8_t getCjkGlyphAlphaThreshold( const fheroes2::FontType fontType )
+    {
+        return isButtonFontSize( fontType.size ) ? 128 : 72;
+    }
+
+    // CJK button captions keep a small extra advance to avoid cramped horizontal text.
+    int32_t getCjkGlyphExtraAdvance( const fheroes2::FontType fontType, const uint32_t codePoint )
+    {
+        return isButtonFontSize( fontType.size ) && isCjkCodePoint( codePoint ) ? 2 : 0;
+    }
+
+    // Map SDL_ttf antialiasing alpha to the game palette while preserving button colors.
+    uint8_t getCjkGlyphColor( const fheroes2::FontType fontType, const uint8_t alpha )
+    {
+        if ( fontType.size == fheroes2::FontSize::BUTTON_RELEASED ) {
+            return fontType.color == fheroes2::FontColor::GRAY ? 30 : 56;
+        }
+
+        if ( fontType.size == fheroes2::FontSize::BUTTON_PRESSED ) {
+            return fontType.color == fheroes2::FontColor::GRAY ? 36 : 62;
+        }
+
+        switch ( fontType.color ) {
+        case fheroes2::FontColor::YELLOW:
+        case fheroes2::FontColor::GOLDEN_GRADIENT:
+            return getYellowCjkGlyphColor( alpha );
+        case fheroes2::FontColor::GRAY:
+            return getGrayCjkGlyphColor( alpha );
+        case fheroes2::FontColor::WHITE:
+        case fheroes2::FontColor::SILVER_GRADIENT:
+            return getWhiteCjkGlyphColor( alpha );
+        default:
+            assert( 0 );
+            break;
+        }
+
+        return 36;
+    }
+
+    uint8_t getSurfaceAlpha( const SDL_Surface & surface, const int32_t x, const int32_t y )
+    {
+        // Glyphs are always produced by TTF_RenderGlyph(32)_Blended, which yields a 32-bit ARGB surface.
+        assert( surface.format->BytesPerPixel == 4 );
+
+        const auto * pixel = static_cast<const uint8_t *>( surface.pixels ) + y * surface.pitch + x * surface.format->BytesPerPixel;
+        const uint32_t pixelValue = *reinterpret_cast<const uint32_t *>( pixel );
+
+        uint8_t red = 0;
+        uint8_t green = 0;
+        uint8_t blue = 0;
+        uint8_t alpha = 0;
+        SDL_GetRGBA( pixelValue, surface.format, &red, &green, &blue, &alpha );
+
+        return alpha;
+    }
+
+    // Some CJK glyph bounding boxes sit low, so use a stable anchor for vertical placement.
+    int32_t getCjkGlyphVerticalOffset( TTF_Font * font, const uint32_t codePoint, const int32_t maxY, const int32_t paddingTop )
+    {
+        int32_t anchorMaxY = maxY;
+        if ( isCjkCodePoint( codePoint ) || isCjkPunctuation( codePoint ) ) {
+            anchorMaxY = std::max( anchorMaxY, TTF_FontAscent( font ) - 2 );
+        }
+
+        return TTF_FontAscent( font ) - anchorMaxY - paddingTop;
+    }
+
+    void addCjkButtonOffsetContour( fheroes2::Sprite & input, const fheroes2::Point & contourOffset, const uint8_t colorId )
+    {
+        if ( input.empty() || input.singleLayer() || contourOffset.x > 0 || contourOffset.y < 0 || ( -contourOffset.x >= input.width() )
+             || ( contourOffset.y >= input.height() ) ) {
+            return;
+        }
+
+        fheroes2::Sprite output = input;
+
+        const int32_t imageWidth = output.width();
+        const int32_t width = imageWidth + contourOffset.x;
+        const int32_t height = output.height() - contourOffset.y;
+
+        const int32_t offsetY = imageWidth * contourOffset.y;
+        uint8_t * imageOutY = output.image() + offsetY;
+        const uint8_t * transformInY = input.transform() - contourOffset.x;
+        uint8_t * transformOutY = output.transform() + offsetY;
+        const uint8_t * transformOutYEnd = transformOutY + imageWidth * height;
+
+        for ( ; transformOutY != transformOutYEnd; transformInY += imageWidth, transformOutY += imageWidth, imageOutY += imageWidth ) {
+            uint8_t * imageOutX = imageOutY;
+            const uint8_t * transformInX = transformInY;
+            uint8_t * transformOutX = transformOutY;
+            const uint8_t * transformOutXEnd = transformOutX + width;
+
+            for ( ; transformOutX != transformOutXEnd; ++transformInX, ++transformOutX, ++imageOutX ) {
+                if ( *transformOutX == 1 && ( *transformInX == 0 || ( *( transformInX + contourOffset.x ) == 0 && *( transformInX + offsetY ) == 0 ) ) ) {
+                    *imageOutX = colorId;
+                    *transformOutX = 0;
+                }
+            }
+        }
+
+        input = std::move( output );
+    }
+
+    // CJK strokes are denser than bitmap Latin glyphs; button states use minimal effects.
+    void applyCjkButtonGlyphEffects( fheroes2::Sprite & glyph, const fheroes2::FontType fontType )
+    {
+        if ( !isButtonFontSize( fontType.size ) ) {
+            fheroes2::updateShadow( glyph, { -1, fontType.size == fheroes2::FontSize::SMALL ? 1 : 2 }, 2, false );
+            return;
+        }
+
+        if ( fontType.size == fheroes2::FontSize::BUTTON_RELEASED ) {
+            fheroes2::updateShadow( glyph, { 1, -1 }, 2, true );
+            addCjkButtonOffsetContour( glyph, { -1, 1 }, getCjkGlyphOutlineColor( fontType ) );
+            return;
+        }
+
+        fheroes2::updateShadow( glyph, { 1, -1 }, 2, true );
+        fheroes2::updateShadow( glyph, { -1, 1 }, 7, true );
+    }
+
+    class CjkFontRenderer
+    {
+    public:
+        // Initialize SDL_ttf and build a font chain for per-glyph fallback.
+        bool isReady()
+        {
+            if ( _initializationAttempted ) {
+                return _isReady;
+            }
+
+            _initializationAttempted = true;
+
+            if ( TTF_WasInit() == 0 && TTF_Init() != 0 ) {
+                ERROR_LOG( "Unable to initialize SDL_ttf for CJK text rendering: " << TTF_GetError() )
+                return false;
+            }
+
+            _fontPaths = findCjkFontPaths();
+            if ( _fontPaths.empty() ) {
+                ERROR_LOG( "CJK font was not found. Set cjk_font_path or place a CJK TTF/TTC/OTF font under files/fonts/." )
+                return false;
+            }
+
+            _isReady = true;
+            DEBUG_LOG( DBG_GAME, DBG_INFO, "Using CJK font chain with " << _fontPaths.size() << " entries. Primary font: " << _fontPaths.front() )
+
+            return true;
+        }
+
+        int32_t getLineHeight( const fheroes2::FontSize fontSize )
+        {
+            if ( isButtonFontSize( fontSize ) ) {
+                return fheroes2::getFontHeight( fontSize );
+            }
+
+            for ( const size_t fontIndex : getFontSearchOrder( fontSize ) ) {
+                if ( TTF_Font * font = getFont( fontIndex, fontSize ); font != nullptr ) {
+                    return std::max( fheroes2::getFontHeight( fontSize ), TTF_FontLineSkip( font ) );
+                }
+            }
+
+            return fheroes2::getFontHeight( fontSize );
+        }
+
+        int32_t getSpaceWidth( const fheroes2::FontSize fontSize )
+        {
+            for ( const size_t fontIndex : getFontSearchOrder( fontSize ) ) {
+                TTF_Font * font = getFont( fontIndex, fontSize );
+                if ( font == nullptr ) {
+                    continue;
+                }
+
+                int minX = 0;
+                int maxX = 0;
+                int minY = 0;
+                int maxY = 0;
+                int advance = 0;
+                if ( getGlyphMetrics( font, ' ', &minX, &maxX, &minY, &maxY, &advance ) && advance > 0 ) {
+                    return advance;
+                }
+            }
+
+            return getFallbackSpaceWidth( fontSize );
+        }
+
+        const CjkGlyph & getGlyph( const fheroes2::FontType fontType, const uint32_t codePoint )
+        {
+            const RenderableGlyph renderableGlyph = getRenderableGlyph( fontType.size, codePoint );
+            const GlyphCacheKey key{ fontType.size, fontType.color, renderableGlyph.fontIndex, codePoint, renderableGlyph.codePoint };
+            if ( const auto iter = _glyphCache.find( key ); iter != _glyphCache.end() ) {
+                return iter->second;
+            }
+
+            // The full CJK repertoire across several font sizes and colors would let the cache grow without bound.
+            // Glyphs are cheap to rebuild and have a high reuse rate, so a coarse flush keeps memory in check without
+            // the bookkeeping of an LRU. The returned reference is consumed immediately by the caller, so clearing
+            // before the insertion below is safe.
+            if ( _glyphCache.size() >= glyphCacheLimit ) {
+                _glyphCache.clear();
+                _missingGlyphs.clear();
+            }
+
+            auto [iter, inserted] = _glyphCache.emplace( key, buildGlyph( fontType, codePoint, renderableGlyph ) );
+            (void)inserted;
+            assert( inserted );
+
+            return iter->second;
+        }
+
+        // Drop all cached fonts and glyphs and shut SDL_ttf down. Must run while SDL is still alive.
+        void release()
+        {
+            _glyphCache.clear();
+            _missingGlyphs.clear();
+            _fonts.clear();
+
+            if ( TTF_WasInit() != 0 ) {
+                TTF_Quit();
+            }
+
+            _initializationAttempted = false;
+            _isReady = false;
+        }
+
+    private:
+        using TtfFontPtr = std::unique_ptr<TTF_Font, TtfFontDeleter>;
+
+        std::vector<size_t> getFontSearchOrder( const fheroes2::FontSize fontSize ) const
+        {
+            std::vector<size_t> order( _fontPaths.size() );
+            std::iota( order.begin(), order.end(), size_t{ 0 } );
+
+            if ( !isButtonFontSize( fontSize ) ) {
+                return order;
+            }
+
+            const std::string & configuredFontPath = Settings::Get().getCjkFontPath();
+            std::stable_sort( order.begin(), order.end(), [this, &configuredFontPath]( const size_t lhs, const size_t rhs ) {
+                const bool isLeftConfigured = !configuredFontPath.empty() && _fontPaths[lhs] == configuredFontPath;
+                const bool isRightConfigured = !configuredFontPath.empty() && _fontPaths[rhs] == configuredFontPath;
+                if ( isLeftConfigured != isRightConfigured ) {
+                    return isLeftConfigured;
+                }
+
+                const int32_t leftPriority = getCjkButtonFontNamePriority( _fontPaths[lhs] );
+                const int32_t rightPriority = getCjkButtonFontNamePriority( _fontPaths[rhs] );
+                if ( leftPriority != rightPriority ) {
+                    return leftPriority < rightPriority;
+                }
+
+                return lhs < rhs;
+            } );
+
+            return order;
+        }
+
+        TTF_Font * getFont( const size_t fontIndex, const fheroes2::FontSize fontSize )
+        {
+            if ( !isReady() || fontIndex >= _fontPaths.size() ) {
+                return nullptr;
+            }
+
+            const FontCacheKey key{ fontIndex, fontSize };
+            auto [iter, inserted] = _fonts.try_emplace( key );
+            if ( inserted ) {
+                iter->second.reset( TTF_OpenFont( _fontPaths[fontIndex].c_str(), getTtfPixelSize( fontSize ) ) );
+                if ( !iter->second ) {
+                    ERROR_LOG( "Unable to open CJK font " << _fontPaths[fontIndex] << ": " << TTF_GetError() )
+                }
+                else {
+                    // Text keeps normal hinting, while button glyphs snap harder to the pixel grid.
+                    TTF_SetFontHinting( iter->second.get(), isButtonFontSize( fontSize ) ? TTF_HINTING_MONO : TTF_HINTING_NORMAL );
+                }
+            }
+
+            return iter->second.get();
+        }
+
+        bool isGlyphProvided( TTF_Font * font, const uint32_t codePoint ) const
+        {
+            if ( font == nullptr ) {
+                return false;
+            }
+
+#if defined( FHEROES2_SDL_TTF_HAS_32BIT_GLYPHS )
+            return TTF_GlyphIsProvided32( font, codePoint ) != 0;
+#else
+            return codePoint <= 0xFFFF && TTF_GlyphIsProvided( font, static_cast<Uint16>( codePoint ) ) != 0;
+#endif
+        }
+
+        bool getGlyphMetrics( TTF_Font * font, const uint32_t codePoint, int * minX, int * maxX, int * minY, int * maxY, int * advance ) const
+        {
+            if ( font == nullptr ) {
+                return false;
+            }
+
+#if defined( FHEROES2_SDL_TTF_HAS_32BIT_GLYPHS )
+            return TTF_GlyphMetrics32( font, codePoint, minX, maxX, minY, maxY, advance ) == 0;
+#else
+            return codePoint <= 0xFFFF && TTF_GlyphMetrics( font, static_cast<Uint16>( codePoint ), minX, maxX, minY, maxY, advance ) == 0;
+#endif
+        }
+
+        SDL_Surface * renderGlyph( TTF_Font * font, const uint32_t codePoint, const SDL_Color color ) const
+        {
+            if ( font == nullptr ) {
+                return nullptr;
+            }
+
+#if defined( FHEROES2_SDL_TTF_HAS_32BIT_GLYPHS )
+            return TTF_RenderGlyph32_Blended( font, codePoint, color );
+#else
+            if ( codePoint > 0xFFFF ) {
+                return nullptr;
+            }
+
+            return TTF_RenderGlyph_Blended( font, static_cast<Uint16>( codePoint ), color );
+#endif
+        }
+
+        RenderableGlyph getRenderableGlyph( const fheroes2::FontSize fontSize, const uint32_t codePoint )
+        {
+            // Try the original code point across the font chain before falling back.
+            for ( const size_t fontIndex : getFontSearchOrder( fontSize ) ) {
+                if ( isGlyphProvided( getFont( fontIndex, fontSize ), codePoint ) ) {
+                    return { fontIndex, codePoint, true };
+                }
+            }
+
+            if ( _missingGlyphs.insert( codePoint ).second ) {
+                ERROR_LOG( "CJK font chain does not provide glyph for Unicode code point " << codePoint << ". A fallback glyph will be used." )
+            }
+
+            for ( const uint32_t fallbackCodePoint : { unicodeReplacementGlyph, unicodeQuestionMark } ) {
+                for ( const size_t fontIndex : getFontSearchOrder( fontSize ) ) {
+                    if ( isGlyphProvided( getFont( fontIndex, fontSize ), fallbackCodePoint ) ) {
+                        return { fontIndex, fallbackCodePoint, true };
+                    }
+                }
+            }
+
+            return {};
+        }
+
+        CjkGlyph buildGlyph( const fheroes2::FontType fontType, const uint32_t codePoint, const RenderableGlyph renderableGlyph )
+        {
+            CjkGlyph glyph;
+
+            if ( isUnicodeSpace( codePoint ) ) {
+                glyph.advance = getSpaceWidth( fontType.size );
+                return glyph;
+            }
+
+            if ( isUnicodeLineSeparator( codePoint ) ) {
+                return glyph;
+            }
+
+            TTF_Font * font = getFont( renderableGlyph.fontIndex, fontType.size );
+            if ( font == nullptr || !renderableGlyph.isValid ) {
+                glyph.advance = getFallbackSpaceWidth( fontType.size );
+                return glyph;
+            }
+
+            int minX = 0;
+            int maxX = 0;
+            int minY = 0;
+            int maxY = 0;
+            int advance = 0;
+            if ( !getGlyphMetrics( font, renderableGlyph.codePoint, &minX, &maxX, &minY, &maxY, &advance ) || advance <= 0 ) {
+                advance = getFallbackSpaceWidth( fontType.size );
+            }
+
+            const SDL_Color color{ 255, 255, 255, 255 };
+            std::unique_ptr<SDL_Surface, decltype( &SDL_FreeSurface )> surface( renderGlyph( font, renderableGlyph.codePoint, color ), SDL_FreeSurface );
+            if ( !surface ) {
+                ERROR_LOG( "Unable to render CJK glyph " << codePoint << ": " << TTF_GetError() )
+                glyph.advance = advance;
+                return glyph;
+            }
+
+            const int32_t paddingLeft = 2;
+            const int32_t paddingTop = isButtonFontSize( fontType.size ) ? 2 : 1;
+            const int32_t paddingRight = 2;
+            const int32_t paddingBottom = 3;
+
+            glyph.sprite.resize( surface->w + paddingLeft + paddingRight, surface->h + paddingTop + paddingBottom );
+            glyph.sprite.reset();
+
+            if ( SDL_MUSTLOCK( surface.get() ) && SDL_LockSurface( surface.get() ) != 0 ) {
+                ERROR_LOG( "Unable to lock CJK glyph surface: " << SDL_GetError() )
+                glyph.advance = advance;
+                return glyph;
+            }
+
+            for ( int32_t y = 0; y < surface->h; ++y ) {
+                for ( int32_t x = 0; x < surface->w; ++x ) {
+                    const uint8_t alpha = getSurfaceAlpha( *surface, x, y );
+                    if ( alpha <= getCjkGlyphAlphaThreshold( fontType ) ) {
+                        continue;
+                    }
+
+                    const int32_t outputX = x + paddingLeft;
+                    const int32_t outputY = y + paddingTop;
+                    const int32_t outputOffset = outputY * glyph.sprite.width() + outputX;
+
+                    glyph.sprite.image()[outputOffset] = getCjkGlyphColor( fontType, alpha );
+                    glyph.sprite.transform()[outputOffset] = 0;
+                }
+            }
+
+            if ( SDL_MUSTLOCK( surface.get() ) ) {
+                SDL_UnlockSurface( surface.get() );
+            }
+
+            glyph.sprite.setPosition( minX - paddingLeft, getCjkGlyphVerticalOffset( font, codePoint, maxY, paddingTop ) );
+            applyCjkButtonGlyphEffects( glyph.sprite, fontType );
+
+            glyph.advance = advance + getCjkGlyphExtraAdvance( fontType, codePoint );
+            return glyph;
+        }
+
+        // Upper bound for the glyph cache. Sized to comfortably hold a full screen of distinct CJK characters across
+        // the handful of font size and color combinations used in the UI, while bounding worst-case memory growth.
+        static constexpr size_t glyphCacheLimit{ 4096 };
+
+        std::vector<std::string> _fontPaths;
+        std::map<FontCacheKey, TtfFontPtr> _fonts;
+        std::map<GlyphCacheKey, CjkGlyph> _glyphCache;
+        std::set<uint32_t> _missingGlyphs;
+        bool _initializationAttempted{ false };
+        bool _isReady{ false };
+    };
+
+    CjkFontRenderer & getCjkFontRenderer()
+    {
+        static CjkFontRenderer renderer;
+        return renderer;
+    }
+
+    bool shouldUseUnicodeTextPath( const std::string_view text, const std::optional<fheroes2::SupportedLanguage> & language, const fheroes2::FontType fontType )
+    {
+        (void)fontType;
+
+        return isUnicodeTextCandidate( text, language ) && getCjkFontRenderer().isReady();
+    }
+
+    // The Unicode path still uses the original bitmap font for ASCII characters.
+    bool isBitmapFontCodePoint( const uint32_t codePoint, const fheroes2::FontCharHandler & charHandler )
+    {
+        return codePoint <= 0x7F && charHandler.isAvailable( static_cast<uint8_t>( codePoint ) );
+    }
+
+    void mergeTextArea( fheroes2::Rect & area, bool & hasArea, const fheroes2::Rect & glyphArea )
+    {
+        if ( hasArea ) {
+            const int32_t left = std::min( area.x, glyphArea.x );
+            const int32_t top = std::min( area.y, glyphArea.y );
+            const int32_t right = std::max( area.x + area.width, glyphArea.x + glyphArea.width );
+            const int32_t bottom = std::max( area.y + area.height, glyphArea.y + glyphArea.height );
+            area = { left, top, right - left, bottom - top };
+            return;
+        }
+
+        area = glyphArea;
+        hasArea = true;
+    }
+
+    int32_t getUnicodeCodePointWidth( const fheroes2::FontType fontType, const uint32_t codePoint, const fheroes2::FontCharHandler & charHandler )
+    {
+        if ( isBitmapFontCodePoint( codePoint, charHandler ) ) {
+            return charHandler.getWidth( static_cast<uint8_t>( codePoint ) );
+        }
+
+        if ( isUnicodeLineSeparator( codePoint ) ) {
+            return 0;
+        }
+
+        if ( isUnicodeSpace( codePoint ) ) {
+            return getCjkFontRenderer().getSpaceWidth( fontType.size );
+        }
+
+        return getCjkFontRenderer().getGlyph( fontType, codePoint ).advance;
+    }
+
+    int32_t renderBitmapCodePoint( const uint32_t codePoint, const int32_t x, const int32_t y, fheroes2::Image & output, const fheroes2::Rect & imageRoi,
+                                   const fheroes2::FontCharHandler & charHandler )
+    {
+        const auto character = static_cast<uint8_t>( codePoint );
+        if ( isSpaceChar( character ) ) {
+            return x + charHandler.getWidth( character );
+        }
+
+        if ( isLineSeparator( character ) ) {
+            return x;
+        }
+
+        const fheroes2::Sprite & charSprite = charHandler.getSprite( character );
+        const fheroes2::Rect charRoi{ x + charSprite.x(), y + charSprite.y(), charSprite.width(), charSprite.height() };
+        const fheroes2::Rect overlappedRoi = imageRoi ^ charRoi;
+
+        fheroes2::Blit( charSprite, overlappedRoi.x - charRoi.x, overlappedRoi.y - charRoi.y, output, overlappedRoi.x, overlappedRoi.y, overlappedRoi.width,
+                        overlappedRoi.height );
+
+        return x + charHandler.getWidth( character );
+    }
+
+    int32_t getUnicodeFontHeight( const fheroes2::FontSize fontSize )
+    {
+        return getCjkFontRenderer().getLineHeight( fontSize );
+    }
+
+    int32_t getUnicodeLineWidth( const std::string_view text, const fheroes2::FontType fontType, const bool keepTrailingSpaces )
+    {
+        std::vector<Utf8Character> characters;
+        bool hasNonAscii = false;
+        decodeUtf8( text, characters, hasNonAscii );
+        const fheroes2::FontCharHandler charHandler( fontType );
+
+        int32_t width = 0;
+        int32_t trailingSpaceWidth = 0;
+
+        for ( const Utf8Character & character : characters ) {
+            const int32_t characterWidth = getUnicodeCodePointWidth( fontType, character.codePoint, charHandler );
+            if ( isUnicodeSpace( character.codePoint ) ) {
+                trailingSpaceWidth += characterWidth;
+                width += keepTrailingSpaces ? characterWidth : 0;
+            }
+            else if ( !isUnicodeLineSeparator( character.codePoint ) ) {
+                if ( !keepTrailingSpaces ) {
+                    width += trailingSpaceWidth;
+                    trailingSpaceWidth = 0;
+                }
+                width += characterWidth;
+            }
+        }
+
+        return width;
+    }
+
+    int32_t getUnicodeMaxByteCount( const std::string_view text, const fheroes2::FontType fontType, const int32_t maxWidth )
+    {
+        std::vector<Utf8Character> characters;
+        bool hasNonAscii = false;
+        decodeUtf8( text, characters, hasNonAscii );
+        const fheroes2::FontCharHandler charHandler( fontType );
+
+        int32_t width = 0;
+        for ( const Utf8Character & character : characters ) {
+            width += getUnicodeCodePointWidth( fontType, character.codePoint, charHandler );
+            if ( width > maxWidth ) {
+                return static_cast<int32_t>( character.byteOffset );
+            }
+        }
+
+        return static_cast<int32_t>( text.size() );
+    }
+
+    int32_t getUnicodeMaxWordWidth( const std::string_view text, const fheroes2::FontType fontType )
+    {
+        std::vector<Utf8Character> characters;
+        bool hasNonAscii = false;
+        decodeUtf8( text, characters, hasNonAscii );
+        const fheroes2::FontCharHandler charHandler( fontType );
+
+        int32_t maxWidth = 1;
+        int32_t width = 0;
+
+        for ( size_t i = 0; i < characters.size(); ++i ) {
+            const Utf8Character & character = characters[i];
+            const uint32_t nextCodePoint = ( i + 1 < characters.size() ) ? characters[i + 1].codePoint : 0;
+
+            if ( isUnicodeSpace( character.codePoint ) || isUnicodeLineSeparator( character.codePoint ) ) {
+                maxWidth = std::max( maxWidth, width == 0 ? getUnicodeCodePointWidth( fontType, character.codePoint, charHandler ) : width );
+                width = 0;
+                continue;
+            }
+
+            width += getUnicodeCodePointWidth( fontType, character.codePoint, charHandler );
+            if ( isUnicodeBreakAllowedAfter( character.codePoint, nextCodePoint ) ) {
+                maxWidth = std::max( maxWidth, width );
+                width = 0;
+            }
+        }
+
+        return std::max( maxWidth, width );
+    }
+
+    fheroes2::Rect getUnicodeTextLineArea( const std::string_view text, const fheroes2::FontType fontType )
+    {
+        std::vector<Utf8Character> characters;
+        bool hasNonAscii = false;
+        decodeUtf8( text, characters, hasNonAscii );
+        const fheroes2::FontCharHandler charHandler( fontType );
+
+        fheroes2::Rect area;
+        bool hasArea = false;
+        int32_t offsetX = 0;
+
+        for ( const Utf8Character & character : characters ) {
+            if ( isBitmapFontCodePoint( character.codePoint, charHandler ) ) {
+                const auto asciiCharacter = static_cast<uint8_t>( character.codePoint );
+                if ( !isSpaceChar( asciiCharacter ) && !isLineSeparator( asciiCharacter ) ) {
+                    const fheroes2::Sprite & sprite = charHandler.getSprite( asciiCharacter );
+                    mergeTextArea( area, hasArea, { offsetX + sprite.x(), sprite.y(), sprite.width(), sprite.height() } );
+                }
+
+                offsetX += charHandler.getWidth( asciiCharacter );
+                continue;
+            }
+
+            if ( isUnicodeSpace( character.codePoint ) ) {
+                offsetX += getUnicodeCodePointWidth( fontType, character.codePoint, charHandler );
+                continue;
+            }
+
+            if ( isUnicodeLineSeparator( character.codePoint ) ) {
+                continue;
+            }
+
+            const CjkGlyph & glyph = getCjkFontRenderer().getGlyph( fontType, character.codePoint );
+            const fheroes2::Sprite & sprite = glyph.sprite;
+
+            if ( !sprite.empty() ) {
+                const fheroes2::Rect glyphArea{ offsetX + sprite.x(), sprite.y(), sprite.width(), sprite.height() };
+                mergeTextArea( area, hasArea, glyphArea );
+            }
+
+            offsetX += glyph.advance;
+        }
+
+        if ( !hasArea ) {
+            area.width = offsetX;
+            area.height = getUnicodeFontHeight( fontType.size );
+        }
+
+        return area;
+    }
+
+    int32_t renderUnicodeSingleLine( const std::string_view text, const int32_t x, const int32_t y, fheroes2::Image & output, const fheroes2::Rect & imageRoi,
+                                     const fheroes2::FontType fontType )
+    {
+        assert( !output.empty() );
+
+        std::vector<Utf8Character> characters;
+        bool hasNonAscii = false;
+        decodeUtf8( text, characters, hasNonAscii );
+        const fheroes2::FontCharHandler charHandler( fontType );
+
+        int32_t offsetX = x;
+
+        for ( const Utf8Character & character : characters ) {
+            if ( isBitmapFontCodePoint( character.codePoint, charHandler ) ) {
+                offsetX = renderBitmapCodePoint( character.codePoint, offsetX, y, output, imageRoi, charHandler );
+                continue;
+            }
+
+            if ( isUnicodeSpace( character.codePoint ) ) {
+                offsetX += getUnicodeCodePointWidth( fontType, character.codePoint, charHandler );
+                continue;
+            }
+
+            if ( isUnicodeLineSeparator( character.codePoint ) ) {
+                continue;
+            }
+
+            const CjkGlyph & glyph = getCjkFontRenderer().getGlyph( fontType, character.codePoint );
+            const fheroes2::Sprite & sprite = glyph.sprite;
+
+            if ( !sprite.empty() ) {
+                const fheroes2::Rect charRoi{ offsetX + sprite.x(), y + sprite.y(), sprite.width(), sprite.height() };
+                const fheroes2::Rect overlappedRoi = imageRoi ^ charRoi;
+
+                fheroes2::Blit( sprite, overlappedRoi.x - charRoi.x, overlappedRoi.y - charRoi.y, output, overlappedRoi.x, overlappedRoi.y, overlappedRoi.width,
+                                overlappedRoi.height );
+            }
+
+            offsetX += glyph.advance;
+        }
+
+        return offsetX;
+    }
+
+    void getUnicodeTextLineInfos( std::vector<fheroes2::TextLineInfo> & textLineInfos, const std::string_view text, const fheroes2::FontType fontType,
+                                  const int32_t maxWidth, const int32_t rowHeight, const bool keepLineTrailingSpaces, const bool keepTextTrailingSpaces )
+    {
+        std::vector<Utf8Character> characters;
+        bool hasNonAscii = false;
+        decodeUtf8( text, characters, hasNonAscii );
+        const fheroes2::FontCharHandler charHandler( fontType );
+
+        const int32_t firstLineOffsetX = textLineInfos.empty() ? 0 : textLineInfos.back().lineWidth;
+        int32_t offsetX = firstLineOffsetX;
+        int32_t offsetY = textLineInfos.empty() ? 0 : textLineInfos.back().offsetY;
+
+        if ( maxWidth < 1 ) {
+            const int32_t lineWidth = firstLineOffsetX + getUnicodeLineWidth( text, fontType, keepLineTrailingSpaces || keepTextTrailingSpaces );
+            textLineInfos.emplace_back( firstLineOffsetX, offsetY, lineWidth, static_cast<int32_t>( text.size() ) );
+            return;
+        }
+
+        size_t lineStartIndex = 0;
+        size_t characterIndex = 0;
+        int32_t lineWidth = firstLineOffsetX;
+        int32_t trailingSpaceWidth = 0;
+        size_t lastBreakIndex = std::string_view::npos;
+        int32_t lastBreakWidth = 0;
+
+        auto appendLine = [&]( const size_t endIndex, const int32_t width ) {
+            const size_t lineStartByte = lineStartIndex < characters.size() ? characters[lineStartIndex].byteOffset : text.size();
+            const size_t lineEndByte = endIndex < characters.size() ? characters[endIndex].byteOffset : text.size();
+            textLineInfos.emplace_back( offsetX, offsetY, width, static_cast<int32_t>( lineEndByte - lineStartByte ) );
+
+            offsetX = 0;
+            offsetY += rowHeight;
+            lineStartIndex = endIndex;
+            characterIndex = endIndex;
+            lineWidth = 0;
+            trailingSpaceWidth = 0;
+            lastBreakIndex = std::string_view::npos;
+            lastBreakWidth = 0;
+        };
+
+        while ( characterIndex < characters.size() ) {
+            const Utf8Character & character = characters[characterIndex];
+
+            if ( isUnicodeLineSeparator( character.codePoint ) ) {
+                const int32_t width = keepLineTrailingSpaces ? lineWidth : lineWidth - trailingSpaceWidth;
+                appendLine( characterIndex + 1, width );
+                continue;
+            }
+
+            const int32_t characterWidth = getUnicodeCodePointWidth( fontType, character.codePoint, charHandler );
+
+            if ( lineWidth != 0 && lineWidth + characterWidth > maxWidth ) {
+                if ( lastBreakIndex != std::string_view::npos && lastBreakIndex > lineStartIndex ) {
+                    appendLine( lastBreakIndex, lastBreakWidth );
+                    continue;
+                }
+
+                if ( characterIndex > lineStartIndex ) {
+                    appendLine( characterIndex, keepLineTrailingSpaces ? lineWidth : lineWidth - trailingSpaceWidth );
+                    continue;
+                }
+            }
+
+            lineWidth += characterWidth;
+
+            if ( isUnicodeSpace( character.codePoint ) ) {
+                trailingSpaceWidth += characterWidth;
+            }
+            else {
+                trailingSpaceWidth = 0;
+            }
+
+            const uint32_t nextCodePoint = ( characterIndex + 1 < characters.size() ) ? characters[characterIndex + 1].codePoint : 0;
+            if ( isUnicodeBreakAllowedAfter( character.codePoint, nextCodePoint ) ) {
+                lastBreakIndex = characterIndex + 1;
+                lastBreakWidth = keepLineTrailingSpaces ? lineWidth : lineWidth - trailingSpaceWidth;
+            }
+
+            ++characterIndex;
+        }
+
+        const int32_t finalWidth = ( keepLineTrailingSpaces || keepTextTrailingSpaces ) ? lineWidth : lineWidth - trailingSpaceWidth;
+        textLineInfos.emplace_back( offsetX, offsetY, finalWidth, static_cast<int32_t>( text.size() - ( lineStartIndex < characters.size() ? characters[lineStartIndex].byteOffset : text.size() ) ) );
+    }
+#else
+    bool shouldUseUnicodeTextPath( const std::string_view text, const std::optional<fheroes2::SupportedLanguage> & language, const fheroes2::FontType fontType )
+    {
+        (void)fontType;
+
+        if ( isUnicodeTextCandidate( text, language ) ) {
+            static bool isLogged = false;
+            if ( !isLogged ) {
+                ERROR_LOG( "UTF-8 CJK text rendering is disabled because the game was built without SDL_ttf support." )
+                isLogged = true;
+            }
+        }
+
+        return false;
+    }
+
+    int32_t getUnicodeFontHeight( const fheroes2::FontSize fontSize )
+    {
+        return fheroes2::getFontHeight( fontSize );
+    }
+
+    int32_t getUnicodeLineWidth( const std::string_view, const fheroes2::FontType, const bool )
+    {
+        return 0;
+    }
+
+    int32_t getUnicodeMaxByteCount( const std::string_view, const fheroes2::FontType, const int32_t )
+    {
+        return 0;
+    }
+
+    int32_t getUnicodeMaxWordWidth( const std::string_view, const fheroes2::FontType )
+    {
+        return 1;
+    }
+
+    fheroes2::Rect getUnicodeTextLineArea( const std::string_view, const fheroes2::FontType )
+    {
+        return {};
+    }
+
+    int32_t renderUnicodeSingleLine( const std::string_view, const int32_t x, const int32_t, fheroes2::Image &, const fheroes2::Rect &, const fheroes2::FontType )
+    {
+        return x;
+    }
+
+    void getUnicodeTextLineInfos( std::vector<fheroes2::TextLineInfo> &, const std::string_view, const fheroes2::FontType, const int32_t, const int32_t, const bool,
+                                  const bool )
+    {
+        // Do nothing.
+    }
+#endif
+
+    int32_t getUnicodeTextVerticalOffset( const fheroes2::FontType fontType )
+    {
+#if defined( WITH_CJK_TEXT )
+        // Button labels use bitmap-style vertical placement, while TTF CJK glyphs sit lower by default.
+        return isButtonFontSize( fontType.size ) ? -1 : 0;
+#else
+        (void)fontType;
+
+        return 0;
+#endif
+    }
 
     const fheroes2::Sprite & getChar( const uint8_t character, const fheroes2::FontType & fontType )
     {
@@ -351,6 +1838,10 @@ namespace fheroes2
     int32_t Text::width() const
     {
         const auto languageSwitcher = getLanguageSwitcher( *this );
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            return getUnicodeLineWidth( _text, _fontType, _keepLineTrailingSpaces );
+        }
+
         const FontCharHandler charHandler( _fontType );
 
         return getLineWidth( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), charHandler, _keepLineTrailingSpaces );
@@ -360,6 +1851,10 @@ namespace fheroes2
     int32_t Text::height() const
     {
         const auto languageSwitcher = getLanguageSwitcher( *this );
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            return getUnicodeFontHeight( _fontType.size );
+        }
+
         return getFontHeight( _fontType.size );
     }
 
@@ -371,6 +1866,7 @@ namespace fheroes2
 
         const auto languageSwitcher = getLanguageSwitcher( *this );
         const int32_t fontHeight = height();
+        const bool useUnicodeTextPath = shouldUseUnicodeTextPath( _text, _language, _fontType );
 
         std::vector<TextLineInfo> lineInfos;
         _getTextLineInfos( lineInfos, maxWidth, fontHeight, false );
@@ -387,7 +1883,8 @@ namespace fheroes2
         }
 
         // This is a multi-line message. Optimize it to fit the text evenly to the same number of lines.
-        int32_t startWidth = getMaxWordWidth( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), _fontType );
+        int32_t startWidth = useUnicodeTextPath ? getUnicodeMaxWordWidth( _text, _fontType )
+                                                : getMaxWordWidth( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), _fontType );
         int32_t endWidth = maxWidth;
 
         while ( startWidth + 1 < endWidth ) {
@@ -441,6 +1938,10 @@ namespace fheroes2
         }
 
         const auto languageSwitcher = getLanguageSwitcher( *this );
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            return getUnicodeTextLineArea( _text, _fontType );
+        }
+
         const FontCharHandler charHandler( _fontType );
 
         return getTextLineArea( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), charHandler );
@@ -454,6 +1955,11 @@ namespace fheroes2
         }
 
         const auto languageSwitcher = getLanguageSwitcher( *this );
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            renderUnicodeSingleLine( _text, x, y + getUnicodeTextVerticalOffset( _fontType ), output, imageRoi, _fontType );
+            return;
+        }
+
         const FontCharHandler charHandler( _fontType );
 
         renderSingleLine( reinterpret_cast<const uint8_t *>( _text.data() ), static_cast<int32_t>( _text.size() ), x, y, output, imageRoi, charHandler );
@@ -472,6 +1978,7 @@ namespace fheroes2
         }
 
         const auto languageSwitcher = getLanguageSwitcher( *this );
+        const bool useUnicodeTextPath = shouldUseUnicodeTextPath( _text, _language, _fontType );
 
         std::vector<TextLineInfo> lineInfos;
         _getTextLineInfos( lineInfos, maxWidth, height(), false );
@@ -485,7 +1992,13 @@ namespace fheroes2
                 // TODO: Implement text alignment setting to allow multi-line left aligned text for editor's warning messages.
                 const int32_t offsetX = info.offsetX + ( maxWidth - info.lineWidth ) / 2;
 
-                renderSingleLine( data, info.characterCount, x + offsetX, y + info.offsetY, output, imageRoi, charHandler );
+                if ( useUnicodeTextPath ) {
+                    renderUnicodeSingleLine( std::string_view( reinterpret_cast<const char *>( data ), static_cast<size_t>( info.characterCount ) ), x + offsetX,
+                                             y + info.offsetY + getUnicodeTextVerticalOffset( _fontType ), output, imageRoi, _fontType );
+                }
+                else {
+                    renderSingleLine( data, info.characterCount, x + offsetX, y + info.offsetY, output, imageRoi, charHandler );
+                }
             }
 
             data += info.characterCount;
@@ -505,6 +2018,17 @@ namespace fheroes2
         }
 
         const auto languageSwitcher = getLanguageSwitcher( *this );
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            const int32_t originalTextWidth = getUnicodeLineWidth( _text, _fontType, _keepLineTrailingSpaces );
+            if ( originalTextWidth <= maxWidth ) {
+                return;
+            }
+
+            _text.resize( getUnicodeMaxByteCount( _text, _fontType, maxWidth - getTruncationSymbolWidth( _fontType ) ) );
+            _text += truncationSymbol;
+            return;
+        }
+
         const FontCharHandler charHandler( _fontType );
 
         const int32_t originalTextWidth
@@ -534,6 +2058,7 @@ namespace fheroes2
         }
 
         const auto languageSwitcher = getLanguageSwitcher( *this );
+        const bool useUnicodeTextPath = shouldUseUnicodeTextPath( _text, _language, _fontType );
         const FontCharHandler charHandler( _fontType );
 
         if ( height( maxWidth ) <= maxHeight ) {
@@ -542,7 +2067,12 @@ namespace fheroes2
         }
 
         while ( !_text.empty() && ( height( maxWidth ) > maxHeight ) ) {
-            _text.pop_back();
+            if ( useUnicodeTextPath ) {
+                removeLastUtf8Character( _text );
+            }
+            else {
+                _text.pop_back();
+            }
         }
 
         // We need to add truncation symbol.
@@ -553,7 +2083,12 @@ namespace fheroes2
                 _text.pop_back();
             }
 
-            _text.pop_back();
+            if ( useUnicodeTextPath ) {
+                removeLastUtf8Character( _text );
+            }
+            else {
+                _text.pop_back();
+            }
 
             _text += truncationSymbol;
         }
@@ -562,6 +2097,11 @@ namespace fheroes2
     void Text::_getTextLineInfos( std::vector<TextLineInfo> & textLineInfos, const int32_t maxWidth, const int32_t rowHeight, const bool keepTextTrailingSpaces ) const
     {
         assert( !_text.empty() );
+
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            getUnicodeTextLineInfos( textLineInfos, _text, _fontType, maxWidth, rowHeight, _keepLineTrailingSpaces, keepTextTrailingSpaces );
+            return;
+        }
 
         const uint8_t * data = reinterpret_cast<const uint8_t *>( _text.data() );
 
@@ -711,6 +2251,23 @@ namespace fheroes2
         }
 
         const auto langugeSwitcher = getLanguageSwitcher( *this );
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            const std::string_view visibleText( _text.data() + _visibleTextBeginPos, static_cast<size_t>( _visibleTextLength ) );
+            const int32_t textWidth = getUnicodeLineWidth( visibleText, _fontType, _keepLineTrailingSpaces );
+
+            const bool isTextTruncatedAtBegin = ( _visibleTextBeginPos != 0 );
+            const bool isTextTruncatedAtEnd = ( _visibleTextLength + _visibleTextBeginPos < static_cast<int32_t>( _text.size() ) );
+
+            if ( isTextTruncatedAtBegin && isTextTruncatedAtEnd ) {
+                return textWidth + 2 * getTruncationSymbolWidth( _fontType );
+            }
+            if ( isTextTruncatedAtBegin || isTextTruncatedAtEnd ) {
+                return textWidth + getTruncationSymbolWidth( _fontType );
+            }
+
+            return textWidth;
+        }
+
         const FontCharHandler charHandler( _fontType );
 
         const int32_t textWidth
@@ -742,6 +2299,26 @@ namespace fheroes2
         }
 
         const auto langugeSwitcher = getLanguageSwitcher( *this );
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            int32_t offsetX = x;
+
+            if ( _visibleTextBeginPos != 0 ) {
+                offsetX = renderUnicodeSingleLine( truncationSymbol, x, y, output, imageRoi, _fontType );
+            }
+
+            offsetX = renderUnicodeSingleLine( std::string_view( _text.data() + _visibleTextBeginPos,
+                                                                 _visibleTextLength == 0
+                                                                     ? static_cast<size_t>( static_cast<int32_t>( _text.size() ) - _visibleTextBeginPos )
+                                                                     : static_cast<size_t>( _visibleTextLength ) ),
+                                               offsetX, y, output, imageRoi, _fontType );
+
+            if ( _visibleTextLength + _visibleTextBeginPos < static_cast<int32_t>( _text.size() ) ) {
+                renderUnicodeSingleLine( truncationSymbol, offsetX, y, output, imageRoi, _fontType );
+            }
+
+            return;
+        }
+
         const FontCharHandler charHandler( _fontType );
 
         int32_t offsetX = x;
@@ -834,6 +2411,19 @@ namespace fheroes2
         }
 
         const auto langugeSwitcher = getLanguageSwitcher( *this );
+        if ( shouldUseUnicodeTextPath( _text, _language, _fontType ) ) {
+            _visibleTextBeginPos = 0;
+            _visibleTextLength = static_cast<int32_t>( _text.size() );
+
+            const int32_t originalTextWidth = getUnicodeLineWidth( _text, _fontType, true );
+            if ( originalTextWidth < maxWidth ) {
+                return;
+            }
+
+            _visibleTextLength = getUnicodeMaxByteCount( _text, _fontType, maxWidth - getTruncationSymbolWidth( _fontType ) );
+            return;
+        }
+
         const FontCharHandler charHandler( _fontType );
         const uint8_t * textData = reinterpret_cast<const uint8_t *>( _text.data() );
         _visibleTextLength = static_cast<int32_t>( _text.size() );
@@ -1198,11 +2788,18 @@ namespace fheroes2
         int32_t offsetX = x;
         for ( const Text & text : _texts ) {
             const auto languageSwitcher = getLanguageSwitcher( text );
-            const int32_t fontHeight = getFontHeight( text._fontType.size );
-            const FontCharHandler charHandler( text._fontType );
+            const bool useUnicodeTextPath = shouldUseUnicodeTextPath( text._text, text._language, text._fontType );
+            const int32_t fontHeight = useUnicodeTextPath ? getUnicodeFontHeight( text._fontType.size ) : getFontHeight( text._fontType.size );
 
-            offsetX = renderSingleLine( reinterpret_cast<const uint8_t *>( text._text.data() ), static_cast<int32_t>( text._text.size() ), offsetX,
-                                        y + ( maxFontHeight - fontHeight ) / 2, output, imageRoi, charHandler );
+            if ( useUnicodeTextPath ) {
+                offsetX = renderUnicodeSingleLine( text._text, offsetX, y + ( maxFontHeight - fontHeight ) / 2 + getUnicodeTextVerticalOffset( text._fontType ),
+                                                   output, imageRoi, text._fontType );
+            }
+            else {
+                const FontCharHandler charHandler( text._fontType );
+                offsetX = renderSingleLine( reinterpret_cast<const uint8_t *>( text._text.data() ), static_cast<int32_t>( text._text.size() ), offsetX,
+                                            y + ( maxFontHeight - fontHeight ) / 2, output, imageRoi, charHandler );
+            }
         }
     }
 
@@ -1247,13 +2844,21 @@ namespace fheroes2
 
             const uint8_t * dataEnd = data + singleText._text.size();
 
+            const bool useUnicodeTextPath = shouldUseUnicodeTextPath( singleText._text, singleText._language, singleText._fontType );
             const FontCharHandler charHandler( singleText._fontType );
 
             while ( data < dataEnd ) {
                 if ( infoIter->characterCount > 0 ) {
                     const int32_t offsetX = x + ( maxWidth > 0 ? ( maxWidth - *widthIter ) / 2 : 0 );
 
-                    renderSingleLine( data, infoIter->characterCount, offsetX + infoIter->offsetX, y + infoIter->offsetY, output, imageRoi, charHandler );
+                    if ( useUnicodeTextPath ) {
+                        renderUnicodeSingleLine( std::string_view( reinterpret_cast<const char *>( data ), static_cast<size_t>( infoIter->characterCount ) ),
+                                                 offsetX + infoIter->offsetX, y + infoIter->offsetY + getUnicodeTextVerticalOffset( singleText._fontType ), output,
+                                                 imageRoi, singleText._fontType );
+                    }
+                    else {
+                        renderSingleLine( data, infoIter->characterCount, offsetX + infoIter->offsetX, y + infoIter->offsetY, output, imageRoi, charHandler );
+                    }
                 }
 
                 data += infoIter->characterCount;
@@ -1273,10 +2878,13 @@ namespace fheroes2
         for ( size_t i = 0; i < _texts.size(); ++i ) {
             const auto languageSwitcher = getLanguageSwitcher( _texts[i] );
 
+            const bool useUnicodeTextPath = shouldUseUnicodeTextPath( _texts[i]._text, _texts[i]._language, _texts[i]._fontType );
             const FontCharHandler charHandler( _texts[i]._fontType );
 
-            const int32_t originalTextWidth
-                = getLineWidth( reinterpret_cast<const uint8_t *>( _texts[i]._text.data() ), static_cast<int32_t>( _texts[i]._text.size() ), charHandler, true );
+            const int32_t originalTextWidth = useUnicodeTextPath
+                                                  ? getUnicodeLineWidth( _texts[i]._text, _texts[i]._fontType, true )
+                                                  : getLineWidth( reinterpret_cast<const uint8_t *>( _texts[i]._text.data() ),
+                                                                  static_cast<int32_t>( _texts[i]._text.size() ), charHandler, true );
 
             if ( ( i + 1 == _texts.size() ) && originalTextWidth <= widthLeft ) {
                 // This is the last text and all texts fit the given width.
@@ -1288,8 +2896,10 @@ namespace fheroes2
             if ( originalTextWidth > correctedWidthLeft ) {
                 // The text does not fit the given width.
 
-                const int32_t maxCharacterCount = getMaxCharacterCount( reinterpret_cast<const uint8_t *>( _texts[i]._text.data() ),
-                                                                        static_cast<int32_t>( _texts[i]._text.size() ), charHandler, correctedWidthLeft );
+                const int32_t maxCharacterCount
+                    = useUnicodeTextPath ? getUnicodeMaxByteCount( _texts[i]._text, _texts[i]._fontType, correctedWidthLeft )
+                                         : getMaxCharacterCount( reinterpret_cast<const uint8_t *>( _texts[i]._text.data() ),
+                                                                 static_cast<int32_t>( _texts[i]._text.size() ), charHandler, correctedWidthLeft );
 
                 // Remove the characters that do not fit the given width.
                 _texts[i]._text.resize( maxCharacterCount );
@@ -1401,13 +3011,39 @@ namespace fheroes2
             return true;
         }
 
+        if ( shouldUseUnicodeTextPath( text, std::nullopt, fontType ) ) {
+            return true;
+        }
+
         const FontCharHandler charHandler( fontType );
 
         return std::all_of( text.begin(), text.end(), [&charHandler]( const int8_t character ) { return charHandler.isAvailable( character ); } );
     }
 
+    bool isCjkTextRenderingAvailable()
+    {
+#if defined( WITH_CJK_TEXT )
+        return getCjkFontRenderer().isReady();
+#else
+        return false;
+#endif
+    }
+
+    void releaseCjkTextResources()
+    {
+#if defined( WITH_CJK_TEXT )
+        // Release the fonts and shut SDL_ttf down explicitly so that it happens while SDL is still alive,
+        // instead of relying on the destruction order of the function-local renderer singleton at program exit.
+        getCjkFontRenderer().release();
+#endif
+    }
+
     int32_t getTruncationSymbolWidth( const FontType fontType )
     {
+        if ( shouldUseUnicodeTextPath( truncationSymbol, std::nullopt, fontType ) ) {
+            return getUnicodeLineWidth( truncationSymbol, fontType, true );
+        }
+
         // Symbol width depends on font size and not on its color.
         static std::map<FontSize, int32_t> truncationSymbolWidth;
 

--- a/src/fheroes2/gui/ui_text.h
+++ b/src/fheroes2/gui/ui_text.h
@@ -415,6 +415,12 @@ namespace fheroes2
     // This function is usually useful for text generation on buttons as button font is a separate set of sprites.
     bool isFontAvailable( const std::string_view text, const FontType fontType );
 
+    // Returns true if UTF-8 CJK text rendering has both SDL_ttf support and a usable font.
+    bool isCjkTextRenderingAvailable();
+
+    // Releases all CJK font resources and shuts SDL_ttf down. Call this during engine shutdown, before SDL_Quit.
+    void releaseCjkTextResources();
+
     // This function will return the width in pixels of the truncation symbol for the given font type.
     int32_t getTruncationSymbolWidth( const FontType fontType );
 

--- a/src/fheroes2/maps/maps_fileinfo.cpp
+++ b/src/fheroes2/maps/maps_fileinfo.cpp
@@ -44,6 +44,7 @@
 #include "map_format_info.h"
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"
+#include "maps_text.h"
 #include "mp2.h"
 #include "mp2_helper.h"
 #include "race.h"
@@ -326,9 +327,10 @@ bool Maps::FileInfo::readMP2Map( std::string filePath, const bool isForEditor )
         }
     }
 
+    // MP2 maps do not store a reliable text language, so decoding falls back to the current UI language.
     // Map name
     fs.seek( 58 );
-    name = fs.getString( mapNameLength );
+    name = Maps::decodeLegacyChineseTextForDisplay( fs.getString( mapNameLength ) );
     if ( name.empty() ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Map " << filename << " does not contain a name." )
         return false;
@@ -336,7 +338,7 @@ bool Maps::FileInfo::readMP2Map( std::string filePath, const bool isForEditor )
 
     // Map description
     fs.seek( 118 );
-    description = fs.getString( mapDescriptionLength );
+    description = Maps::decodeLegacyChineseTextForDisplay( fs.getString( mapDescriptionLength ) );
 
     // Alliances of kingdoms
     if ( victoryConditionType == VICTORY_DEFEAT_OTHER_SIDE && !skipUnionSetup ) {
@@ -426,8 +428,9 @@ bool Maps::FileInfo::loadResurrectionMap( const Map_Format::BaseMapFormat & map,
     width = static_cast<uint16_t>( map.width );
     height = static_cast<uint16_t>( map.width );
 
-    name = map.name;
-    description = map.description;
+    // FH2 maps carry the selected map language, which can guide legacy text decoding when needed.
+    name = Maps::decodeLegacyChineseTextForDisplay( map.name, map.mainLanguage );
+    description = Maps::decodeLegacyChineseTextForDisplay( map.description, map.mainLanguage );
 
     assert( ( map.availablePlayerColors & map.humanPlayerColors ) == map.humanPlayerColors );
     assert( ( map.availablePlayerColors & map.computerPlayerColors ) == map.computerPlayerColors );
@@ -534,7 +537,7 @@ bool Maps::FileInfo::loadResurrectionMap( const Map_Format::BaseMapFormat & map,
         translations.emplace_back( language );
     }
 
-    creatorNotes = map.creatorNotes;
+    creatorNotes = Maps::decodeLegacyChineseTextForDisplay( map.creatorNotes, map.mainLanguage );
 
     return true;
 }

--- a/src/fheroes2/maps/maps_objects.cpp
+++ b/src/fheroes2/maps/maps_objects.cpp
@@ -32,6 +32,7 @@
 #include "color.h"
 #include "game_io.h"
 #include "logging.h"
+#include "maps_text.h"
 #include "mp2.h"
 #include "rand.h"
 #include "save_format_version.h"
@@ -156,7 +157,7 @@ void MapEvent::LoadFromMP2( const int32_t index, const std::vector<uint8_t> & da
         colors |= PlayerColor::PURPLE;
     }
 
-    message = dataStream.getString();
+    message = Maps::decodeLegacyChineseTextForDisplay( dataStream.getString() );
 
     setUIDAndIndex( index );
 
@@ -249,7 +250,7 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
 
     // Get all possible answers.
     for ( uint32_t i = 0; i < 8; ++i ) {
-        const std::string answer = dataStream.getString( 13 );
+        const std::string answer = Maps::decodeLegacyChineseTextForDisplay( dataStream.getString( 13 ) );
 
         if ( answerCount > 0 ) {
             --answerCount;
@@ -259,7 +260,7 @@ void MapSphinx::LoadFromMP2( const int32_t tileIndex, const std::vector<uint8_t>
         }
     }
 
-    riddle = dataStream.getString();
+    riddle = Maps::decodeLegacyChineseTextForDisplay( dataStream.getString() );
     if ( riddle.empty() ) {
         DEBUG_LOG( DBG_GAME, DBG_WARN, "Sphinx at tile index " << tileIndex << " does not have questions. Marking it as visited." )
         return;
@@ -301,7 +302,7 @@ void MapSign::LoadFromMP2( const int32_t mapIndex, const std::vector<uint8_t> & 
 
     ROStreamBuf dataStream( data );
     dataStream.skip( 9 );
-    message.text = dataStream.getString();
+    message.text = Maps::decodeLegacyChineseTextForDisplay( dataStream.getString() );
 
     if ( message.text.empty() ) {
         setDefaultMessage();

--- a/src/fheroes2/maps/maps_text.cpp
+++ b/src/fheroes2/maps/maps_text.cpp
@@ -1,0 +1,313 @@
+/***************************************************************************
+ *   fheroes2: https://github.com/ihhub/fheroes2                           *
+ *   Copyright (C) 2026                                                    *
+ *                                                                         *
+ *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
+ *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ *   This program is distributed in the hope that it will be useful,       *
+ *   but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ *   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the         *
+ *   GNU General Public License for more details.                          *
+ *                                                                         *
+ *   You should have received a copy of the GNU General Public License     *
+ *   along with this program; if not, write to the                         *
+ *   Free Software Foundation, Inc.,                                       *
+ *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
+ ***************************************************************************/
+
+#include "maps_text.h"
+
+#include <algorithm>
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#if defined( _WIN32 )
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#elif defined( WITH_ICONV )
+#include <iconv.h>
+#endif
+
+#include "logging.h"
+#include "ui_language.h"
+
+namespace
+{
+    enum class LegacyChineseEncoding : uint8_t
+    {
+        GBK,
+        Big5
+    };
+
+    bool hasHighBitByte( const std::string_view text )
+    {
+        return std::any_of( text.begin(), text.end(), []( const char character ) { return static_cast<uint8_t>( character ) >= 0x80; } );
+    }
+
+    bool isValidUtf8( const std::string_view text, bool & hasNonAscii )
+    {
+        hasNonAscii = false;
+
+        for ( size_t offset = 0; offset < text.size(); ) {
+            const auto firstByte = static_cast<uint8_t>( text[offset] );
+            uint32_t codePoint = 0;
+            size_t byteCount = 1;
+
+            if ( firstByte < 0x80 ) {
+                ++offset;
+                continue;
+            }
+
+            hasNonAscii = true;
+
+            if ( ( firstByte & 0xE0 ) == 0xC0 && offset + 1 < text.size() ) {
+                const auto secondByte = static_cast<uint8_t>( text[offset + 1] );
+                if ( ( secondByte & 0xC0 ) != 0x80 ) {
+                    return false;
+                }
+
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x1F ) << 6 ) | static_cast<uint32_t>( secondByte & 0x3F );
+                byteCount = 2;
+                if ( codePoint < 0x80 ) {
+                    return false;
+                }
+            }
+            else if ( ( firstByte & 0xF0 ) == 0xE0 && offset + 2 < text.size() ) {
+                const auto secondByte = static_cast<uint8_t>( text[offset + 1] );
+                const auto thirdByte = static_cast<uint8_t>( text[offset + 2] );
+                if ( ( secondByte & 0xC0 ) != 0x80 || ( thirdByte & 0xC0 ) != 0x80 ) {
+                    return false;
+                }
+
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x0F ) << 12 ) | ( static_cast<uint32_t>( secondByte & 0x3F ) << 6 )
+                            | static_cast<uint32_t>( thirdByte & 0x3F );
+                byteCount = 3;
+                if ( codePoint < 0x800 || ( codePoint >= 0xD800 && codePoint <= 0xDFFF ) ) {
+                    return false;
+                }
+            }
+            else if ( ( firstByte & 0xF8 ) == 0xF0 && offset + 3 < text.size() ) {
+                const auto secondByte = static_cast<uint8_t>( text[offset + 1] );
+                const auto thirdByte = static_cast<uint8_t>( text[offset + 2] );
+                const auto fourthByte = static_cast<uint8_t>( text[offset + 3] );
+                if ( ( secondByte & 0xC0 ) != 0x80 || ( thirdByte & 0xC0 ) != 0x80 || ( fourthByte & 0xC0 ) != 0x80 ) {
+                    return false;
+                }
+
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x07 ) << 18 ) | ( static_cast<uint32_t>( secondByte & 0x3F ) << 12 )
+                            | ( static_cast<uint32_t>( thirdByte & 0x3F ) << 6 ) | static_cast<uint32_t>( fourthByte & 0x3F );
+                byteCount = 4;
+                if ( codePoint < 0x10000 || codePoint > 0x10FFFF ) {
+                    return false;
+                }
+            }
+            else {
+                return false;
+            }
+
+            offset += byteCount;
+        }
+
+        return true;
+    }
+
+    bool isCjkCodePoint( const uint32_t codePoint )
+    {
+        return ( codePoint >= 0x3400 && codePoint <= 0x4DBF ) || ( codePoint >= 0x4E00 && codePoint <= 0x9FFF )
+               || ( codePoint >= 0xF900 && codePoint <= 0xFAFF ) || ( codePoint >= 0x20000 && codePoint <= 0x2EBEF )
+               || ( codePoint >= 0x30000 && codePoint <= 0x323AF );
+    }
+
+    bool isCjkPunctuation( const uint32_t codePoint )
+    {
+        return ( codePoint >= 0x3000 && codePoint <= 0x303F ) || ( codePoint >= 0xFF00 && codePoint <= 0xFFEF );
+    }
+
+    struct Utf8Score
+    {
+        size_t cjkCount{ 0 };
+        size_t cjkPunctuationCount{ 0 };
+        size_t nonAsciiCount{ 0 };
+    };
+
+    Utf8Score getUtf8Score( const std::string_view text )
+    {
+        Utf8Score score;
+
+        for ( size_t offset = 0; offset < text.size(); ) {
+            const auto firstByte = static_cast<uint8_t>( text[offset] );
+            uint32_t codePoint = firstByte;
+            size_t byteCount = 1;
+
+            if ( firstByte < 0x80 ) {
+                ++offset;
+                continue;
+            }
+
+            if ( ( firstByte & 0xE0 ) == 0xC0 ) {
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x1F ) << 6 ) | static_cast<uint32_t>( static_cast<uint8_t>( text[offset + 1] ) & 0x3F );
+                byteCount = 2;
+            }
+            else if ( ( firstByte & 0xF0 ) == 0xE0 ) {
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x0F ) << 12 )
+                            | ( static_cast<uint32_t>( static_cast<uint8_t>( text[offset + 1] ) & 0x3F ) << 6 )
+                            | static_cast<uint32_t>( static_cast<uint8_t>( text[offset + 2] ) & 0x3F );
+                byteCount = 3;
+            }
+            else {
+                codePoint = ( static_cast<uint32_t>( firstByte & 0x07 ) << 18 )
+                            | ( static_cast<uint32_t>( static_cast<uint8_t>( text[offset + 1] ) & 0x3F ) << 12 )
+                            | ( static_cast<uint32_t>( static_cast<uint8_t>( text[offset + 2] ) & 0x3F ) << 6 )
+                            | static_cast<uint32_t>( static_cast<uint8_t>( text[offset + 3] ) & 0x3F );
+                byteCount = 4;
+            }
+
+            ++score.nonAsciiCount;
+            if ( isCjkCodePoint( codePoint ) ) {
+                ++score.cjkCount;
+            }
+            else if ( isCjkPunctuation( codePoint ) ) {
+                ++score.cjkPunctuationCount;
+            }
+
+            offset += byteCount;
+        }
+
+        return score;
+    }
+
+#if defined( _WIN32 )
+    std::optional<std::string> convertToUtf8( const std::string_view text, const LegacyChineseEncoding encoding )
+    {
+        const UINT codePage = encoding == LegacyChineseEncoding::GBK ? 936 : 950;
+        const auto inputSize = static_cast<int>( text.size() );
+
+        const int wideSize = MultiByteToWideChar( codePage, MB_ERR_INVALID_CHARS, text.data(), inputSize, nullptr, 0 );
+        if ( wideSize <= 0 ) {
+            return std::nullopt;
+        }
+
+        std::wstring wideText( static_cast<size_t>( wideSize ), L'\0' );
+        if ( MultiByteToWideChar( codePage, MB_ERR_INVALID_CHARS, text.data(), inputSize, wideText.data(), wideSize ) != wideSize ) {
+            return std::nullopt;
+        }
+
+        const int utf8Size = WideCharToMultiByte( CP_UTF8, WC_ERR_INVALID_CHARS, wideText.data(), wideSize, nullptr, 0, nullptr, nullptr );
+        if ( utf8Size <= 0 ) {
+            return std::nullopt;
+        }
+
+        std::string output( static_cast<size_t>( utf8Size ), '\0' );
+        if ( WideCharToMultiByte( CP_UTF8, WC_ERR_INVALID_CHARS, wideText.data(), wideSize, output.data(), utf8Size, nullptr, nullptr ) != utf8Size ) {
+            return std::nullopt;
+        }
+
+        return output;
+    }
+#elif defined( WITH_ICONV )
+    const char * getEncodingName( const LegacyChineseEncoding encoding )
+    {
+        return encoding == LegacyChineseEncoding::GBK ? "GBK" : "BIG5";
+    }
+
+    std::optional<std::string> convertToUtf8( const std::string_view text, const LegacyChineseEncoding encoding )
+    {
+        iconv_t converter = iconv_open( "UTF-8", getEncodingName( encoding ) );
+        if ( converter == reinterpret_cast<iconv_t>( -1 ) ) {
+            return std::nullopt;
+        }
+
+        std::string output( text.size() * 4 + 4, '\0' );
+        char * inputBuffer = const_cast<char *>( text.data() );
+        size_t inputBytesLeft = text.size();
+        char * outputBuffer = output.data();
+        size_t outputBytesLeft = output.size();
+
+        const size_t result = iconv( converter, &inputBuffer, &inputBytesLeft, &outputBuffer, &outputBytesLeft );
+        iconv_close( converter );
+
+        if ( result == static_cast<size_t>( -1 ) || inputBytesLeft != 0 ) {
+            return std::nullopt;
+        }
+
+        output.resize( output.size() - outputBytesLeft );
+        return output;
+    }
+#else
+    std::optional<std::string> convertToUtf8( const std::string_view, const LegacyChineseEncoding )
+    {
+        return std::nullopt;
+    }
+#endif
+
+    bool shouldAttemptLegacyChineseDecode( const std::optional<fheroes2::SupportedLanguage> language )
+    {
+        const fheroes2::SupportedLanguage targetLanguage = language.value_or( fheroes2::getCurrentLanguage() );
+
+        return targetLanguage == fheroes2::SupportedLanguage::SimplifiedChinese || targetLanguage == fheroes2::SupportedLanguage::TraditionalChinese;
+    }
+
+    bool isLikelyChineseText( const std::string_view text )
+    {
+        bool hasNonAscii = false;
+        if ( !isValidUtf8( text, hasNonAscii ) || !hasNonAscii ) {
+            return false;
+        }
+
+        const Utf8Score score = getUtf8Score( text );
+        return score.cjkCount > 0 && ( score.cjkCount + score.cjkPunctuationCount ) * 2 >= score.nonAsciiCount;
+    }
+
+    void logDecodeFailureOnce()
+    {
+        static bool isLogged = false;
+        if ( isLogged ) {
+            return;
+        }
+
+        DEBUG_LOG( DBG_GAME, DBG_WARN, "Unable to decode a legacy Chinese map text as GBK or Big5. The original bytes will be displayed." )
+        isLogged = true;
+    }
+}
+
+namespace Maps
+{
+    std::string decodeLegacyChineseTextForDisplay( std::string text, const std::optional<fheroes2::SupportedLanguage> language )
+    {
+        bool hasNonAscii = false;
+        if ( text.empty() || isValidUtf8( text, hasNonAscii ) || !hasHighBitByte( text ) ) {
+            return text;
+        }
+
+        if ( !shouldAttemptLegacyChineseDecode( language ) ) {
+            return text;
+        }
+
+        const fheroes2::SupportedLanguage targetLanguage = language.value_or( fheroes2::getCurrentLanguage() );
+        const std::array<LegacyChineseEncoding, 2> encodings = targetLanguage == fheroes2::SupportedLanguage::TraditionalChinese
+                                                                  ? std::array<LegacyChineseEncoding, 2>{ LegacyChineseEncoding::Big5, LegacyChineseEncoding::GBK }
+                                                                  : std::array<LegacyChineseEncoding, 2>{ LegacyChineseEncoding::GBK, LegacyChineseEncoding::Big5 };
+
+        for ( const LegacyChineseEncoding encoding : encodings ) {
+            std::optional<std::string> convertedText = convertToUtf8( text, encoding );
+            if ( convertedText && isLikelyChineseText( *convertedText ) ) {
+                return std::move( *convertedText );
+            }
+        }
+
+        logDecodeFailureOnce();
+        return text;
+    }
+}

--- a/src/fheroes2/maps/maps_text.h
+++ b/src/fheroes2/maps/maps_text.h
@@ -1,6 +1,9 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2026                                             *
+ *   Copyright (C) 2026                                                    *
+ *                                                                         *
+ *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
+ *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *
@@ -20,53 +23,13 @@
 
 #pragma once
 
-#include <cstdint>
+#include <optional>
+#include <string>
 
-namespace fheroes2
+#include "game_language.h"
+
+namespace Maps
 {
-    enum class SupportedLanguage : uint8_t
-    {
-        English = 0, // default language for all versions of the game.
-        French, // GOG version
-        Polish, // GOG version
-        German, // GOG version
-        Russian, // Buka and XXI Vek versions
-        Italian, // Rare version?
-        Czech, // Local release occurred in 2002 by CD Projekt
-        Spanish, // Published by Proein. Only Succession Wars
-
-        // All languages listed below are original to fheroes2.
-        Belarusian,
-        Bulgarian,
-        Danish,
-        Dutch,
-        Esperanto,
-        Greek,
-        Hungarian,
-        Norwegian,
-        Portuguese,
-        Romanian,
-        Slovak,
-        Swedish,
-        Turkish,
-        Ukrainian,
-        Vietnamese,
-        SimplifiedChinese,
-        TraditionalChinese
-    };
-
-    enum class CodePage : uint8_t
-    {
-        NONE,
-        ASCII,
-        CP1250,
-        CP1251,
-        CP1252,
-        CP1253,
-        CP1254,
-        CP1258,
-        ISO8859_16,
-        ISO8859_3,
-        UTF8,
-    };
+    // Convert legacy GBK/Big5 Chinese map text to UTF-8 when the language context allows it.
+    std::string decodeLegacyChineseTextForDisplay( std::string text, const std::optional<fheroes2::SupportedLanguage> language = std::nullopt );
 }

--- a/src/fheroes2/system/settings.cpp
+++ b/src/fheroes2/system/settings.cpp
@@ -172,6 +172,13 @@ bool Settings::Read( const std::string & filePath )
         _gameLanguage = sval;
     }
 
+    // Optional CJK fallback font path. The file is not bundled by default, so users may point to
+    // a redistributable font or to a local system font without copying it into the repository.
+    sval = config.StrParams( "cjk_font_path" );
+    if ( !sval.empty() ) {
+        _cjkFontPath = sval;
+    }
+
     // music source
     _musicType = MUSIC_EXTERNAL;
     sval = config.StrParams( "music" );
@@ -548,6 +555,9 @@ std::string Settings::String() const
     os << std::endl << "# Game language (an empty value means English)" << std::endl;
     os << "lang = " << _gameLanguage << std::endl;
 
+    os << std::endl << "# Optional CJK font file path for UTF-8 languages such as zh_CN and zh_TW" << std::endl;
+    os << "cjk_font_path = " << _cjkFontPath << std::endl;
+
     os << std::endl << "# Controller pointer speed: 0 - 100" << std::endl;
     os << "controller pointer speed = " << _controllerPointerSpeed << std::endl;
 
@@ -605,9 +615,15 @@ void Settings::setCurrentMapInfo( Maps::FileInfo fi )
 
 bool Settings::setGameLanguage( const std::string & language )
 {
-    fheroes2::updateAlphabet( language );
+    fheroes2::SupportedLanguage supportedLanguage = fheroes2::getLanguageFromAbbreviation( language );
+    if ( !fheroes2::isLanguageSupportedForRendering( supportedLanguage ) ) {
+        supportedLanguage = fheroes2::SupportedLanguage::English;
+    }
+    const std::string languageToSet = fheroes2::getLanguageAbbreviation( supportedLanguage );
 
-    _gameLanguage = language;
+    fheroes2::updateAlphabet( languageToSet );
+
+    _gameLanguage = languageToSet;
 
     if ( _gameLanguage.empty() ) {
         Translation::reset();
@@ -615,7 +631,7 @@ bool Settings::setGameLanguage( const std::string & language )
     }
 
     // First, let's see if the translation for the requested language is already cached
-    if ( const auto [isCached, isSet] = Translation::setLanguage( language ); isCached ) {
+    if ( const auto [isCached, isSet] = Translation::setLanguage( _gameLanguage ); isCached ) {
         return isSet;
     }
 
@@ -631,7 +647,7 @@ bool Settings::setGameLanguage( const std::string & language )
     }
 
     // If the translation for this language could not be loaded, it will still remain in the cache as invalid
-    return Translation::setLanguage( language, translations.empty() ? std::string_view{} : translations.back() );
+    return Translation::setLanguage( _gameLanguage, translations.empty() ? std::string_view{} : translations.back() );
 }
 
 void Settings::setEditorAnimation( const bool enable )

--- a/src/fheroes2/system/settings.h
+++ b/src/fheroes2/system/settings.h
@@ -156,6 +156,11 @@ public:
         return _loadedFileLanguage;
     }
 
+    const std::string & getCjkFontPath() const
+    {
+        return _cjkFontPath;
+    }
+
     const fheroes2::Point & PosRadar() const
     {
         return pos_radr;
@@ -447,6 +452,7 @@ private:
     std::string _programPath;
 
     std::string _gameLanguage;
+    std::string _cjkFontPath;
     // Not saved in the config file or savefile
     std::string _loadedFileLanguage;
 

--- a/src/fheroes2/world/world.cpp
+++ b/src/fheroes2/world/world.cpp
@@ -47,6 +47,7 @@
 #include "logging.h"
 #include "maps_fileinfo.h"
 #include "maps_objects.h"
+#include "maps_text.h"
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"
 #include "mp2.h"
@@ -1633,7 +1634,7 @@ void EventDate::LoadFromMP2( const std::vector<uint8_t> & data )
         colors |= PlayerColor::PURPLE;
     }
 
-    message = dataStream.getString();
+    message = Maps::decodeLegacyChineseTextForDisplay( dataStream.getString() );
 
     DEBUG_LOG( DBG_GAME, DBG_INFO, "A timed event which occurs at day " << firstOccurrenceDay << " contains a message: " << message )
 }

--- a/src/fheroes2/world/world_loadmap.cpp
+++ b/src/fheroes2/world/world_loadmap.cpp
@@ -55,6 +55,7 @@
 #include "maps.h"
 #include "maps_fileinfo.h"
 #include "maps_objects.h"
+#include "maps_text.h"
 #include "maps_tiles.h"
 #include "maps_tiles_helper.h"
 #include "math_base.h"
@@ -671,7 +672,7 @@ bool World::LoadMapMP2( const std::string & filename, const bool isOriginalMp2Fi
                 //
                 // - string
                 //    Null terminated string of the rumor.
-                std::string rumor( reinterpret_cast<const char *>( pblock.data() ) + 8 );
+                std::string rumor = Maps::decodeLegacyChineseTextForDisplay( reinterpret_cast<const char *>( pblock.data() ) + 8 );
 
                 if ( !rumor.empty() ) {
                     _customRumors.emplace_back( std::move( rumor ) );
@@ -719,16 +720,23 @@ bool World::loadResurrectionMap( const std::string & filename )
         return false;
     }
 
+    fheroes2::SupportedLanguage loadedMapLanguage = map.mainLanguage;
     const auto currentLanguage = fheroes2::getCurrentLanguage();
-    if ( !Maps::loadTranslation( map, currentLanguage ) ) {
+    if ( Maps::loadTranslation( map, currentLanguage ) ) {
+        loadedMapLanguage = currentLanguage;
+    }
+    else {
         // The current game language is not supported by the map.
         // Try to set the default language - English.
         // Even if it fails, the first language of the map is going to be used.
         if ( currentLanguage != fheroes2::SupportedLanguage::English ) {
-            Maps::loadTranslation( map, fheroes2::SupportedLanguage::English );
+            if ( Maps::loadTranslation( map, fheroes2::SupportedLanguage::English ) ) {
+                loadedMapLanguage = fheroes2::SupportedLanguage::English;
+            }
         }
     }
 
+    // FH2 map text uses the language that was loaded for gameplay.
     width = map.width;
     height = map.width;
 
@@ -966,7 +974,7 @@ bool World::loadResurrectionMap( const std::string & filename )
 
                     eventObject->isComputerPlayerAllowed = ( computerColors != 0 );
                     eventObject->colors = humanColors | computerColors;
-                    eventObject->message = std::move( eventInfo.message );
+                    eventObject->message = Maps::decodeLegacyChineseTextForDisplay( std::move( eventInfo.message ), loadedMapLanguage );
                     eventObject->isSingleTimeEvent = !eventInfo.isRecurringEvent;
                     eventObject->secondarySkill = { eventInfo.secondarySkill, eventInfo.secondarySkillLevel };
                     eventObject->experience = eventInfo.experience;
@@ -1028,13 +1036,13 @@ bool World::loadResurrectionMap( const std::string & filename )
                     auto & signInfo = map.signMetadata[object.id];
 
                     auto signObject = std::make_unique<MapSign>();
-                    signObject->message.text = std::move( signInfo.message );
+                    signObject->message.text = Maps::decodeLegacyChineseTextForDisplay( std::move( signInfo.message ), loadedMapLanguage );
                     signObject->setUIDAndIndex( static_cast<int32_t>( tileId ) );
                     if ( signObject->message.text.empty() ) {
                         signObject->setDefaultMessage();
                     }
                     else {
-                        signObject->message.language = map.mainLanguage;
+                        signObject->message.language = loadedMapLanguage;
                     }
 
                     map_objects.add( std::move( signObject ) );
@@ -1050,11 +1058,11 @@ bool World::loadResurrectionMap( const std::string & filename )
                     auto & sphinxInfo = map.sphinxMetadata[object.id];
 
                     auto sphinxObject = std::make_unique<MapSphinx>();
-                    sphinxObject->riddle = std::move( sphinxInfo.riddle );
+                    sphinxObject->riddle = Maps::decodeLegacyChineseTextForDisplay( std::move( sphinxInfo.riddle ), loadedMapLanguage );
 
                     for ( auto & answer : sphinxInfo.answers ) {
                         if ( !answer.empty() ) {
-                            sphinxObject->answers.push_back( std::move( answer ) );
+                            sphinxObject->answers.push_back( Maps::decodeLegacyChineseTextForDisplay( std::move( answer ), loadedMapLanguage ) );
                         }
                         else {
                             // How is it even possible?
@@ -1126,13 +1134,13 @@ bool World::loadResurrectionMap( const std::string & filename )
                     auto & signInfo = map.signMetadata[object.id];
 
                     auto signObject = std::make_unique<MapSign>();
-                    signObject->message.text = std::move( signInfo.message );
+                    signObject->message.text = Maps::decodeLegacyChineseTextForDisplay( std::move( signInfo.message ), loadedMapLanguage );
                     signObject->setUIDAndIndex( static_cast<int32_t>( tileId ) );
                     if ( signObject->message.text.empty() ) {
                         signObject->setDefaultMessage();
                     }
                     else {
-                        signObject->message.language = map.mainLanguage;
+                        signObject->message.language = loadedMapLanguage;
                     }
 
                     map_objects.add( std::move( signObject ) );
@@ -1341,7 +1349,7 @@ bool World::loadResurrectionMap( const std::string & filename )
         // TODO: modify EventDate structure to have more flexibility.
         auto & newEvent = vec_eventsday.emplace_back();
 
-        newEvent.message = std::move( event.message );
+        newEvent.message = Maps::decodeLegacyChineseTextForDisplay( std::move( event.message ), loadedMapLanguage );
         newEvent.colors = ( humanColors | computerColors );
         newEvent.isApplicableForAIPlayers = ( computerColors != 0 );
 
@@ -1353,7 +1361,7 @@ bool World::loadResurrectionMap( const std::string & filename )
     // Load rumors.
     for ( auto & rumor : map.rumors ) {
         if ( !rumor.empty() ) {
-            _customRumors.emplace_back( std::move( rumor ) );
+            _customRumors.emplace_back( Maps::decodeLegacyChineseTextForDisplay( std::move( rumor ), loadedMapLanguage ) );
         }
     }
 


### PR DESCRIPTION
## Summary

This PR adds Simplified Chinese and Traditional Chinese support, including SDL2_ttf-based CJK text rendering and legacy Chinese map text decoding.

## Changes

- Added zh_CN and zh_TW translations.
- Added CJK text rendering support through SDL2_ttf.
- Added legacy Chinese map text decoding for non-UTF-8 GBK and Big5 map strings.
- Uses map language metadata when it is available, and falls back to the current UI language for original MP2 maps that do not provide reliable language metadata.
- Keeps valid UTF-8 map text unchanged.
- Keeps Chinese fonts out of the repository while preserving the files/fonts resource path so builders can bundle their own CJK-capable fonts.
- Aligns CMake and classic Makefile support for CJK rendering and optional iconv-based decoding.
- Keeps platform-specific build behavior conservative so unsupported platforms are not forced to link iconv or SDL2_ttf unexpectedly.

## Testing

- git diff --check
- make -C files/lang zh_TW.mo
- make -C src/dist FHEROES2_WITH_CJK_TEXT=0
- make -C src/dist
- cmake -S . -B build -DMACOS_APP_BUNDLE=ON -DCMAKE_BUILD_TYPE=Release
- cmake --build build -j8

## Notes

No Chinese font file is bundled in this PR. A CJK-capable .ttf, .ttc, or .otf font can be provided by builders through files/fonts or by using the configured CJK font path.