### PR TITLE
Fix invalid assertion for battle troops

### DIFF
--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -259,7 +259,7 @@ uint32_t Battle::Unit::GetHitPointsLeft() const
 uint32_t Battle::Unit::GetMissingHitPoints() const
 {
     const uint32_t totalHitPoints = _maxCount * Monster::GetHitPoints();
-    assert( totalHitPoints > _hitPoints );
+    assert( totalHitPoints >= _hitPoints );
     return totalHitPoints - _hitPoints;
 }
 


### PR DESCRIPTION
This method could return 0 if the monster hasn't taken any hits.

close #10890