### PR TITLE
Remove the old code which was a temporary workaround

### DIFF
--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -31,7 +31,6 @@
 #include <map>
 #include <set>
 #include <sstream>
-#include <string_view>
 #include <type_traits>
 #include <utility>
 

--- a/src/fheroes2/game/game_hotkeys.cpp
+++ b/src/fheroes2/game/game_hotkeys.cpp
@@ -456,22 +456,7 @@ void Game::HotKeysLoad( const std::string & filename )
                 const char * eventName = Translation::getNonTranslated( hotKeyEventInfo[eventId].name );
                 std::string value = config.StrParams( eventName );
                 if ( value.empty() ) {
-                    // TODO: remove this temporary workaround
-                    if ( eventName == std::string_view( "toggle auto combat mode" ) ) {
-                        value = config.StrParams( "toggle battle auto mode" );
-                        if ( value.empty() ) {
-                            continue;
-                        }
-                    }
-                    else if ( eventName == std::string_view( "quick combat" ) ) {
-                        value = config.StrParams( "finish the battle in auto mode" );
-                        if ( value.empty() ) {
-                            continue;
-                        }
-                    }
-                    else {
-                        continue;
-                    }
+                    continue;
                 }
 
                 value = StringUpper( value );


### PR DESCRIPTION
relates to #9180

The change was introduced for 1.1.6 release which is 11 releases in the past. Enough time has passed since then.