### PR TITLE
Exclude binary files from SonarCloud analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,8 +18,8 @@ sonar.sources=.
 #sonar.sourceEncoding=UTF-8
 
 # List of files completely excluded from the analysis.
-sonar.exclusions=src/thirdparty/**/*,
-				 files/timidity/instruments/**/*.pat
+sonar.exclusions=src/thirdparty/**/*, \
+				 files/timidity/instruments/*.pat
 
 # List of issues to ignore.
 sonar.issue.ignore.multicriteria=cppS106ForTools,webPageWithoutTitleCheckForDefaultLayout

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,7 +19,9 @@ sonar.sources=.
 
 # List of files completely excluded from the analysis.
 sonar.exclusions=src/thirdparty/**/*, \
-				 files/timidity/instruments/*.pat
+				 files/timidity/instruments/*.pat, \
+				 maps/*.fh2m, \
+				 android/app/src/main/res/**/*.png
 
 # List of issues to ignore.
 sonar.issue.ignore.multicriteria=cppS106ForTools,webPageWithoutTitleCheckForDefaultLayout

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -20,8 +20,11 @@ sonar.sources=.
 # List of files completely excluded from the analysis.
 sonar.exclusions=src/thirdparty/**/*, \
 				 files/timidity/instruments/*.pat, \
+				 files/soundfonts/fheroes2.sf3, \
 				 maps/*.fh2m, \
-				 android/app/src/main/res/**/*.png
+				 **/*.png, \
+				 docs/assets/fonts/*.woff2, \
+				 docs/images/screenshots/*.webp
 
 # List of issues to ignore.
 sonar.issue.ignore.multicriteria=cppS106ForTools,webPageWithoutTitleCheckForDefaultLayout

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,16 +18,20 @@ sonar.sources=.
 #sonar.sourceEncoding=UTF-8
 
 # List of files completely excluded from the analysis.
-sonar.exclusions=src/thirdparty/**/*, \
-				 files/timidity/instruments/*.pat, \
-				 files/soundfonts/fheroes2.sf3, \
-				 files/data/*.h2d, \
-				 maps/*.fh2m, \
-				 **/*.png, \
-				 **/*.jpg, \
-				 **/*.jpeg, \
+sonar.exclusions=android/gradle/wrapper/gradle-wrapper.jar, \
 				 docs/assets/fonts/**/*.woff2, \
-				 docs/images/screenshots/*.webp
+				 docs/images/screenshots/*.webp, \
+				 docs/images/*.ico, \
+				 files/data/*.h2d, \
+				 files/soundfonts/fheroes2.sf3, \
+				 files/timidity/instruments/*.pat, \
+				 maps/*.fh2m, \
+				 src/resources/*.icns, \
+				 src/resources/*.ico, \
+				 src/thirdparty/**/*, \
+				 **/*.png, \
+				 **/*.jpeg, \
+				 **/*.jpg
 
 # List of issues to ignore.
 sonar.issue.ignore.multicriteria=cppS106ForTools,webPageWithoutTitleCheckForDefaultLayout

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -21,9 +21,12 @@ sonar.sources=.
 sonar.exclusions=src/thirdparty/**/*, \
 				 files/timidity/instruments/*.pat, \
 				 files/soundfonts/fheroes2.sf3, \
+				 files/data/*.h2d, \
 				 maps/*.fh2m, \
 				 **/*.png, \
-				 docs/assets/fonts/*.woff2, \
+				 **/*.jpg, \
+				 **/*.jpeg, \
+				 docs/assets/fonts/**/*.woff2, \
 				 docs/images/screenshots/*.webp
 
 # List of issues to ignore.

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,8 @@ sonar.sources=.
 #sonar.sourceEncoding=UTF-8
 
 # List of files completely excluded from the analysis.
-sonar.exclusions=src/thirdparty/**/*
+sonar.exclusions=src/thirdparty/**/*,
+				 files/timidity/instruments/*.pat
 
 # List of issues to ignore.
 sonar.issue.ignore.multicriteria=cppS106ForTools,webPageWithoutTitleCheckForDefaultLayout

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,7 +19,7 @@ sonar.sources=.
 
 # List of files completely excluded from the analysis.
 sonar.exclusions=src/thirdparty/**/*,
-				 files/timidity/instruments/*.pat
+				 files/timidity/instruments/**/*.pat
 
 # List of issues to ignore.
 sonar.issue.ignore.multicriteria=cppS106ForTools,webPageWithoutTitleCheckForDefaultLayout


### PR DESCRIPTION
They generate UTF-8 related warnings and affect the performance of the analysis.