### PR TITLE
Code preparation for widening windows

### DIFF
--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog.h
+++ b/src/fheroes2/dialog/dialog.h
@@ -137,11 +137,11 @@ namespace Dialog
     // Displays a dialog box informing that an artifact set has been assembled
     void ArtifactSetAssembled( const ArtifactSetData & artifactSetData );
 
-    class NonFixedFrameBox
+    class ResizableFrameBox
     {
     public:
-        explicit NonFixedFrameBox( int height = 0, int startYPos = -1, bool showButtons = false );
-        virtual ~NonFixedFrameBox();
+        explicit ResizableFrameBox( int width, int height, int startYPos, const bool showButtons );
+        virtual ~ResizableFrameBox();
 
         const fheroes2::Rect & GetArea() const
         {
@@ -162,11 +162,11 @@ namespace Dialog
         int32_t _middleFragmentHeight;
     };
 
-    class FrameBox : public NonFixedFrameBox
+    class FrameBox final : public ResizableFrameBox
     {
     public:
         explicit FrameBox( int height, bool buttons = false )
-            : Dialog::NonFixedFrameBox( height, -1, buttons )
+            : Dialog::ResizableFrameBox( fheroes2::boxAreaWidthPx, height, -1, buttons )
         {
             // Do nothing.
         }

--- a/src/fheroes2/dialog/dialog_box.cpp
+++ b/src/fheroes2/dialog/dialog_box.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -34,9 +34,10 @@
 
 namespace
 {
-    const int32_t windowWidth = 288; // this is measured value
-    const int32_t buttonHeight = 40;
-    const int32_t activeAreaHeight = 35;
+    constexpr int32_t offsetFromBorder{ 6 };
+    constexpr int32_t windowWidth = fheroes2::boxAreaWidthPx + ( fheroes2::borderWidthPx + offsetFromBorder ) * 2;
+    constexpr int32_t buttonHeight = 40;
+    constexpr int32_t activeAreaHeight = 35;
 
     int32_t topHeight( const bool isEvilInterface )
     {
@@ -91,12 +92,19 @@ namespace
     }
 }
 
-Dialog::NonFixedFrameBox::NonFixedFrameBox( int height, int startYPos, bool showButtons )
+Dialog::ResizableFrameBox::ResizableFrameBox( int width, int height, int startYPos, const bool showButtons )
     : _middleFragmentCount( 0 )
     , _middleFragmentHeight( 0 )
 {
-    if ( showButtons )
+    if ( showButtons ) {
         height += buttonHeight;
+    }
+
+    // TODO: add support for wider windows.
+    if ( width != fheroes2::boxAreaWidthPx ) {
+        // We don't generate windows narrower than the original game.
+        width = fheroes2::boxAreaWidthPx;
+    }
 
     const bool evil = Settings::Get().isEvilInterfaceEnabled();
     _middleFragmentCount = ( height <= 2 * activeAreaHeight ? 0 : 1 + ( height - 2 * activeAreaHeight ) / activeAreaHeight );
@@ -118,13 +126,13 @@ Dialog::NonFixedFrameBox::NonFixedFrameBox( int height, int startYPos, bool show
 
     _restorer.reset( new fheroes2::ImageRestorer( display, _position.x, _position.y, overallWidth( evil ), height_top_bottom + _middleFragmentHeight ) );
 
-    area.x = _position.x + ( windowWidth - fheroes2::boxAreaWidthPx ) / 2 + leftSideOffset;
+    area.x = _position.x + ( windowWidth - area.width ) / 2 + leftSideOffset;
     area.y = _position.y + ( topHeight( evil ) - activeAreaHeight );
 
     redraw();
 }
 
-void Dialog::NonFixedFrameBox::redraw()
+void Dialog::ResizableFrameBox::redraw()
 {
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int buybuild = isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD;
@@ -170,14 +178,14 @@ void Dialog::NonFixedFrameBox::redraw()
     fheroes2::Blit( part2, display, _position.x + overallLeftWidth, _position.y );
 }
 
-Dialog::NonFixedFrameBox::~NonFixedFrameBox()
+Dialog::ResizableFrameBox::~ResizableFrameBox()
 {
     _restorer->restore();
 
     fheroes2::Display::instance().render( _restorer->rect() );
 }
 
-int32_t Dialog::NonFixedFrameBox::getButtonAreaHeight()
+int32_t Dialog::ResizableFrameBox::getButtonAreaHeight()
 {
     return buttonHeight;
 }

--- a/src/fheroes2/dialog/dialog_box.cpp
+++ b/src/fheroes2/dialog/dialog_box.cpp
@@ -55,13 +55,13 @@ namespace
     {
         const int icnId = isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD;
 
-        const fheroes2::Sprite & image3 = fheroes2::AGG::GetICN( icnId, 3 );
         const fheroes2::Sprite & image4 = fheroes2::AGG::GetICN( icnId, 4 );
         const fheroes2::Sprite & image5 = fheroes2::AGG::GetICN( icnId, 5 );
+        const fheroes2::Sprite & image6 = fheroes2::AGG::GetICN( icnId, 6 );
 
-        int32_t widthLeft = image3.width();
-        widthLeft = std::max( widthLeft, image4.width() );
+        int32_t widthLeft = image4.width();
         widthLeft = std::max( widthLeft, image5.width() );
+        widthLeft = std::max( widthLeft, image6.width() );
 
         return widthLeft;
     }
@@ -139,29 +139,26 @@ void Dialog::ResizableFrameBox::redraw()
 
     const int32_t overallLeftWidth = leftWidth( isEvilInterface );
 
-    // right-top
-    const fheroes2::Sprite & part0 = fheroes2::AGG::GetICN( buybuild, 0 );
-    // left-top
-    const fheroes2::Sprite & part4 = fheroes2::AGG::GetICN( buybuild, 4 );
+    const fheroes2::Sprite & rightTop = fheroes2::AGG::GetICN( buybuild, 0 );
+    const fheroes2::Sprite & leftTop = fheroes2::AGG::GetICN( buybuild, 4 );
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    fheroes2::Blit( part4, display, _position.x + overallLeftWidth - part4.width(), _position.y );
-    fheroes2::Blit( part0, display, _position.x + overallLeftWidth, _position.y );
+    fheroes2::Blit( leftTop, display, _position.x + overallLeftWidth - leftTop.width(), _position.y );
+    fheroes2::Blit( rightTop, display, _position.x + overallLeftWidth, _position.y );
 
-    _position.y += part4.height();
+    _position.y += leftTop.height();
 
     const int32_t posBeforeMiddle = _position.y;
     int32_t middleLeftHeight = _middleFragmentHeight;
     for ( uint32_t i = 0; i < _middleFragmentCount; ++i ) {
         const int32_t chunkHeight = middleLeftHeight >= activeAreaHeight ? activeAreaHeight : middleLeftHeight;
-        // left-middle
-        const fheroes2::Sprite & sl = fheroes2::AGG::GetICN( buybuild, 5 );
-        fheroes2::Blit( sl, 0, 10, display, _position.x + overallLeftWidth - sl.width(), _position.y, sl.width(), chunkHeight );
 
-        // right-middle
-        const fheroes2::Sprite & sr = fheroes2::AGG::GetICN( buybuild, 1 );
-        fheroes2::Blit( sr, 0, 10, display, _position.x + overallLeftWidth, _position.y, sr.width(), chunkHeight );
+        const fheroes2::Sprite & leftMiddle = fheroes2::AGG::GetICN( buybuild, 5 );
+        fheroes2::Blit( leftMiddle, 0, 10, display, _position.x + overallLeftWidth - leftMiddle.width(), _position.y, leftMiddle.width(), chunkHeight );
+
+        const fheroes2::Sprite & rightMiddle = fheroes2::AGG::GetICN( buybuild, 1 );
+        fheroes2::Blit( rightMiddle, 0, 10, display, _position.x + overallLeftWidth, _position.y, rightMiddle.width(), chunkHeight );
 
         middleLeftHeight -= chunkHeight;
         _position.y += chunkHeight;
@@ -169,13 +166,11 @@ void Dialog::ResizableFrameBox::redraw()
 
     _position.y = posBeforeMiddle + _middleFragmentHeight;
 
-    // right-bottom
-    const fheroes2::Sprite & part2 = fheroes2::AGG::GetICN( buybuild, 2 );
-    // left-bottom
-    const fheroes2::Sprite & part6 = fheroes2::AGG::GetICN( buybuild, 6 );
+    const fheroes2::Sprite & rightBottom = fheroes2::AGG::GetICN( buybuild, 2 );
+    const fheroes2::Sprite & leftBottom = fheroes2::AGG::GetICN( buybuild, 6 );
 
-    fheroes2::Blit( part6, display, _position.x + overallLeftWidth - part6.width(), _position.y );
-    fheroes2::Blit( part2, display, _position.x + overallLeftWidth, _position.y );
+    fheroes2::Blit( leftBottom, display, _position.x + overallLeftWidth - leftBottom.width(), _position.y );
+    fheroes2::Blit( rightBottom, display, _position.x + overallLeftWidth, _position.y );
 }
 
 Dialog::ResizableFrameBox::~ResizableFrameBox()

--- a/src/fheroes2/dialog/dialog_box.cpp
+++ b/src/fheroes2/dialog/dialog_box.cpp
@@ -111,7 +111,7 @@ Dialog::ResizableFrameBox::ResizableFrameBox( int width, int height, int startYP
     _middleFragmentHeight = height <= 2 * activeAreaHeight ? 0 : height - 2 * activeAreaHeight;
     const int32_t height_top_bottom = topHeight( evil ) + bottomHeight( evil );
 
-    area.width = fheroes2::boxAreaWidthPx;
+    area.width = width;
     area.height = activeAreaHeight + activeAreaHeight + _middleFragmentHeight;
 
     fheroes2::Display & display = fheroes2::Display::instance();

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -481,7 +481,7 @@ int Dialog::ArmySplitTroop( const int32_t freeSlots, const int32_t redistributeM
     const int boxHeight = freeSlots > 1 ? 63 + spacer + titleHeight + bodyHeight : 45;
     const int boxYPosition = defaultYPosition + ( ( display.height() - fheroes2::Display::DEFAULT_HEIGHT ) / 2 ) - boxHeight;
 
-    const NonFixedFrameBox box( boxHeight, boxYPosition, true );
+    const ResizableFrameBox box( fheroes2::boxAreaWidthPx, boxHeight, boxYPosition, true );
 
     const fheroes2::Rect & pos = box.GetArea();
     const int center = pos.x + pos.width / 2;


### PR DESCRIPTION
relates to #9946

Also, fix a bug where we calculate left part using invalid image width resulting in a bigger image restorer size. Therefore, now we utilize less memory for it!