### PR TITLE
Do not do extra rendering for the same radar position on a popup window event

### DIFF
--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -84,22 +84,29 @@ namespace
         COUT( info )
     }
 
-    class RadarUpdater
+    class RadarUpdater final
     {
     public:
         RadarUpdater( const bool performUpdate, const fheroes2::Point & updatedPosition, const fheroes2::Rect & areaToRestore )
             : _performUpdate( performUpdate )
-            , _updatedPosition( updatedPosition )
             , _prevPosition( Interface::AdventureMap::Get().getGameArea().getCurrentCenterInPixels() )
-            , _restorer( fheroes2::Display::instance(), areaToRestore.x, areaToRestore.y, areaToRestore.width, areaToRestore.height )
+            , _restorer( fheroes2::Display::instance(), 0, 0, 0, 0 )
         {
-            if ( !_performUpdate || _updatedPosition == _prevPosition ) {
+            if ( !_performUpdate ) {
+                // Nothing to do. Don't waste resources for rendering.
                 return;
             }
 
             Interface::AdventureMap & iface = Interface::AdventureMap::Get();
-
             iface.getGameArea().SetCenter( updatedPosition );
+            if ( iface.getGameArea().getCurrentCenterInPixels() == _prevPosition ) {
+                // The position hasn't changed. Don't render anything.
+                _performUpdate = false;
+                return;
+            }
+
+            _restorer.update( areaToRestore.x, areaToRestore.y, areaToRestore.width, areaToRestore.height );
+
             iface.redraw( Interface::REDRAW_RADAR_CURSOR );
 
             _restorer.restore();
@@ -107,7 +114,7 @@ namespace
 
         void restore()
         {
-            if ( !_performUpdate || _updatedPosition == _prevPosition ) {
+            if ( !_performUpdate ) {
                 return;
             }
 
@@ -120,8 +127,7 @@ namespace
         }
 
     private:
-        const bool _performUpdate;
-        const fheroes2::Point _updatedPosition;
+        bool _performUpdate;
         const fheroes2::Point _prevPosition;
         fheroes2::ImageRestorer _restorer;
     };


### PR DESCRIPTION
The previous logic was incorrect: the condition `_updatedPosition == _prevPosition` was always **false** because the first value was in tiles while the second one was in pixels.

Also, we were rendering for no reason if no updates. Not anymore.