### PR TITLE
Make "Visions" spell and "Crystal Ball" artifact be much more user-friendly and useful

### DIFF
--- a/src/engine/serialize.h
+++ b/src/engine/serialize.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2012 by Andrey Afletdinov <fheroes2@gmail.com>          *
@@ -33,6 +33,7 @@
 #include <map>
 #include <memory>
 #include <optional>
+#include <set>
 #include <string>
 #include <string_view>
 #include <type_traits>
@@ -246,6 +247,22 @@ public:
         return *this;
     }
 
+    template <class Type>
+    IStreamBase & operator>>( std::set<Type> & v )
+    {
+        const uint32_t size = get32();
+
+        v.clear();
+
+        for ( uint32_t i = 0; i < size; ++i ) {
+            Type temp;
+            *this >> temp;
+            v.emplace( std::move( temp ) );
+        }
+
+        return *this;
+    }
+
     template <class Type1, class Type2>
     IStreamBase & operator>>( std::map<Type1, Type2> & v )
     {
@@ -361,6 +378,16 @@ public:
 
     template <class Type>
     OStreamBase & operator<<( const std::list<Type> & v )
+    {
+        put32( static_cast<uint32_t>( v.size() ) );
+
+        std::for_each( v.begin(), v.end(), [this]( const auto & item ) { *this << item; } );
+
+        return *this;
+    }
+
+    template <class Type1, class Type2>
+    OStreamBase & operator<<( const std::set<Type1, Type2> & v )
     {
         put32( static_cast<uint32_t>( v.size() ) );
 

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -455,11 +455,17 @@ namespace
             return showGuardiansInfo( tile, playerColor == getColorFromTile( tile ) );
         }
 
-        const Kingdom & kingdom = world.GetKingdom( playerColor );
+        Kingdom & kingdom = world.GetKingdom( playerColor );
 
         switch ( objectType ) {
-        case MP2::OBJ_MONSTER:
-            return showMonsterInfo( tile, kingdom.IsTileVisibleFromCrystalBall( tile.GetIndex() ) || kingdom.isMonsterUnderVisionSpell( tile.GetIndex() ) );
+        case MP2::OBJ_MONSTER: {
+            const bool isVisibleFromCrystalBall{ kingdom.IsTileVisibleFromCrystalBall( tile.GetIndex() ) };
+            if ( isVisibleFromCrystalBall ) {
+                kingdom.addMonsterUnderVisionSpell( tile.GetIndex() );
+            }
+
+            return showMonsterInfo( tile, isVisibleFromCrystalBall || kingdom.isMonsterUnderVisionSpell( tile.GetIndex() ) );
+        }
 
         case MP2::OBJ_COAST:
         case MP2::OBJ_EVENT:

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -459,7 +459,7 @@ namespace
 
         switch ( objectType ) {
         case MP2::OBJ_MONSTER:
-            return showMonsterInfo( tile, kingdom.IsTileVisibleFromCrystalBall( tile.GetIndex() ) );
+            return showMonsterInfo( tile, kingdom.IsTileVisibleFromCrystalBall( tile.GetIndex() ) || kingdom.isMonsterUnderVisionSpell( tile.GetIndex() ) );
 
         case MP2::OBJ_COAST:
         case MP2::OBJ_EVENT:

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -316,7 +316,7 @@ namespace
             }
 
             fheroes2::MonsterDialogElement monsterUI( troop );
-            std::vector<const fheroes2::DialogElement *> uiElements{ &monsterUI };
+            const std::vector<const fheroes2::DialogElement *> uiElements{ &monsterUI };
 
             fheroes2::showStandardTextMessage( hdr, msg, Dialog::OK, uiElements );
         }

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -315,7 +315,10 @@ namespace
                 break;
             }
 
-            fheroes2::showStandardTextMessage( hdr, msg, Dialog::OK );
+            fheroes2::MonsterDialogElement monsterUI( troop );
+            std::vector<const fheroes2::DialogElement *> uiElements{ &monsterUI };
+
+            fheroes2::showStandardTextMessage( hdr, msg, Dialog::OK, uiElements );
         }
 
         hero.SetModes( Heroes::VISIONS );

--- a/src/fheroes2/heroes/heroes_spell.cpp
+++ b/src/fheroes2/heroes/heroes_spell.cpp
@@ -273,6 +273,8 @@ namespace
 
         assert( !monsters.empty() );
 
+        hero.GetKingdom().addMonstersUnderVisionSpell( monsters );
+
         for ( const int32_t monsterIndex : monsters ) {
             const Maps::Tile & tile = world.getTile( monsterIndex );
 

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -216,6 +216,9 @@ void Kingdom::ActionNewDay()
 
     // Reset the effect of the "Identify Hero" spell
     ResetModes( IDENTIFYHERO );
+
+    // Reset all monsters under Vision spell.
+    _monstersUnderVision = {};
 }
 
 void Kingdom::ActionNewDayResourceUpdate( const std::function<void( const EventDate & event, const Funds & funds )> & displayEventDialog )
@@ -901,7 +904,8 @@ Cost Kingdom::_getKingdomStartingResources( const int difficulty ) const
 OStreamBase & operator<<( OStreamBase & stream, const Kingdom & kingdom )
 {
     return stream << kingdom.modes << kingdom._color << kingdom.resource << kingdom.lost_town_days << kingdom.castles << kingdom.heroes << kingdom.recruits
-                  << kingdom.visit_object << kingdom.puzzle_maps << kingdom._visitedTentsColors << kingdom._topCastleInKingdomView << kingdom._topHeroInKingdomView;
+                  << kingdom.visit_object << kingdom.puzzle_maps << kingdom._visitedTentsColors << kingdom._topCastleInKingdomView << kingdom._topHeroInKingdomView
+                  << kingdom._monstersUnderVision;
 }
 
 IStreamBase & operator>>( IStreamBase & stream, Kingdom & kingdom )
@@ -927,7 +931,17 @@ IStreamBase & operator>>( IStreamBase & stream, Kingdom & kingdom )
         stream >> dummy;
     }
 
-    return stream >> kingdom._topCastleInKingdomView >> kingdom._topHeroInKingdomView;
+    stream >> kingdom._topCastleInKingdomView >> kingdom._topHeroInKingdomView;
+
+    static_assert( LAST_SUPPORTED_FORMAT_VERSION < FORMAT_VERSION_1180_RELEASE, "Remove the logic below." );
+    if ( Game::GetVersionOfCurrentSaveFile() < FORMAT_VERSION_1180_RELEASE ) {
+        kingdom._monstersUnderVision = {};
+    }
+    else {
+        stream >> kingdom._monstersUnderVision;
+    }
+
+    return stream;
 }
 
 OStreamBase & operator<<( OStreamBase & stream, const Kingdoms & obj )

--- a/src/fheroes2/kingdom/kingdom.cpp
+++ b/src/fheroes2/kingdom/kingdom.cpp
@@ -25,6 +25,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <initializer_list>
 #include <ostream>
 #include <string>
 #include <vector>

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -236,6 +236,18 @@ public:
     // bonus (for example, a Crystal Ball)
     bool IsTileVisibleFromCrystalBall( const int32_t dest ) const;
 
+    void addMonstersUnderVisionSpell( const std::vector<int32_t> & monsters )
+    {
+        for ( const int32_t monsterIndex : monsters ) {
+            _monstersUnderVision.emplace( monsterIndex );
+        }
+    }
+
+    bool isMonsterUnderVisionSpell( const int32_t monsterIndex ) const
+    {
+        return _monstersUnderVision.count( monsterIndex ) > 0;
+    }
+
     static uint32_t GetMaxHeroes();
 
 private:
@@ -262,6 +274,10 @@ private:
     // Used to remember which item was selected in Kingdom View dialog.
     int32_t _topCastleInKingdomView{ -1 };
     int32_t _topHeroInKingdomView{ -1 };
+
+    // A set of monsters under Vision spell.
+    // This list is going to be cleared every day for now.
+    std::set<int32_t> _monstersUnderVision;
 };
 
 class Kingdoms

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -244,6 +244,11 @@ public:
         }
     }
 
+    void addMonsterUnderVisionSpell( const int32_t monsterIndex )
+    {
+        _monstersUnderVision.emplace( monsterIndex );
+    }
+
     bool isMonsterUnderVisionSpell( const int32_t monsterIndex ) const
     {
         return _monstersUnderVision.count( monsterIndex ) > 0;

--- a/src/fheroes2/kingdom/kingdom.h
+++ b/src/fheroes2/kingdom/kingdom.h
@@ -29,6 +29,7 @@
 #include <functional>
 #include <list>
 #include <set>
+#include <vector>
 
 #include "bitmodes.h"
 #include "castle.h"

--- a/src/fheroes2/system/save_format_version.h
+++ b/src/fheroes2/system/save_format_version.h
@@ -27,6 +27,7 @@ enum SaveFileFormat : uint16_t
     // !!! IMPORTANT !!!
     // If you're adding a new version you must assign it to CURRENT_FORMAT_VERSION located at the bottom.
     // If you're removing an old version you must assign the oldest available to LAST_SUPPORTED_FORMAT_VERSION located at the bottom.
+    FORMAT_VERSION_1180_RELEASE = 10034,
     FORMAT_VERSION_1150_RELEASE = 10033,
     FORMAT_VERSION_1111_RELEASE = 10032,
     FORMAT_VERSION_1109_RELEASE = 10031,
@@ -54,5 +55,5 @@ enum SaveFileFormat : uint16_t
 
     LAST_SUPPORTED_FORMAT_VERSION = FORMAT_VERSION_1005_RELEASE,
 
-    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1150_RELEASE
+    CURRENT_FORMAT_VERSION = FORMAT_VERSION_1180_RELEASE
 };


### PR DESCRIPTION
- make "Visions" spell to be much more useful for players: once the spell is casted the whole kingdom will know the number of monsters for the duration of the current turn. This information is reset upon the next turn. Such improvement does **not** add any new abilities to the spell but makes it much more user-friendly since remembering multiple number of neutral monsters is hard;
- when a hero with "Crystal Ball" artifact checks any monster this information persists for the same duration of the current turn;
- interactive monster images for "Visions" spell were added to dialogs.

https://github.com/user-attachments/assets/698360d5-d874-43f2-8673-acd629968f2a