### PR TITLE
Rename fheroes2::AGG into Assets namespace

### DIFF
--- a/VisualStudio/fheroes2/sources.props
+++ b/VisualStudio/fheroes2/sources.props
@@ -28,7 +28,6 @@
     <ClCompile Include="src\engine\translations.cpp" />
     <ClCompile Include="src\engine\zzlib.cpp" />
     <ClCompile Include="src\fheroes2\agg\agg.cpp" />
-    <ClCompile Include="src\fheroes2\agg\agg_image.cpp" />
     <ClCompile Include="src\fheroes2\agg\bin_info.cpp" />
     <ClCompile Include="src\fheroes2\agg\icn.cpp" />
     <ClCompile Include="src\fheroes2\agg\m82.cpp" />
@@ -130,6 +129,7 @@
     <ClCompile Include="src\fheroes2\game\difficulty.cpp" />
     <ClCompile Include="src\fheroes2\game\fheroes2.cpp" />
     <ClCompile Include="src\fheroes2\game\game.cpp" />
+    <ClCompile Include="src\fheroes2\game\game_assets.cpp" />
     <ClCompile Include="src\fheroes2\game\game_auto_playtest.cpp" />
     <ClCompile Include="src\fheroes2\game\game_campaign.cpp" />
     <ClCompile Include="src\fheroes2\game\game_credits.cpp" />
@@ -278,7 +278,6 @@
     <ClInclude Include="src\engine\translations.h" />
     <ClInclude Include="src\engine\zzlib.h" />
     <ClInclude Include="src\fheroes2\agg\agg.h" />
-    <ClInclude Include="src\fheroes2\agg\agg_image.h" />
     <ClInclude Include="src\fheroes2\agg\bin_info.h" />
     <ClInclude Include="src\fheroes2\agg\icn.h" />
     <ClInclude Include="src\fheroes2\agg\m82.h" />
@@ -352,6 +351,7 @@
     <ClInclude Include="src\fheroes2\editor\history_manager.h" />
     <ClInclude Include="src\fheroes2\game\difficulty.h" />
     <ClInclude Include="src\fheroes2\game\game.h" />
+    <ClInclude Include="src\fheroes2\game\game_assets.h" />
     <ClInclude Include="src\fheroes2\game\game_auto_playtest.h" />
     <ClInclude Include="src\fheroes2\game\game_credits.h" />
     <ClInclude Include="src\fheroes2\game\game_delays.h" />

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -29,12 +29,12 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_troop.h"
 #include "castle.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes_base.h"
 #include "icn.h"
@@ -187,7 +187,7 @@ namespace
 }
 
 ArmyBar::ArmyBar( Army * ptr, const bool miniSprites, const bool readOnly, const bool isEditMode /* false */, const bool saveLastTroop /* true */ )
-    : spcursor( fheroes2::AGG::GetICN( ICN::STRIP, 1 ) )
+    : spcursor( Assets::getImage( ICN::STRIP, 1 ) )
     , use_mini_sprite( miniSprites )
     , read_only( readOnly )
     , can_change( isEditMode )
@@ -196,7 +196,7 @@ ArmyBar::ArmyBar( Army * ptr, const bool miniSprites, const bool readOnly, const
     if ( use_mini_sprite )
         SetBackground( { 43, 43 }, fheroes2::GetColorId( 0, 45, 0 ) );
     else {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::STRIP, 2 );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::STRIP, 2 );
         setSingleItemSize( { sprite.width(), sprite.height() } );
     }
 
@@ -251,14 +251,14 @@ void ArmyBar::RedrawBackground( const fheroes2::Rect & pos, fheroes2::Image & ds
     else {
         if ( can_change && !_saveLastTroop && _army->GetOccupiedSlotCount() == 0 ) {
             // If none of army's slot is set within the Editor, then a default army will be applied at the game start.
-            fheroes2::ApplyPalette( fheroes2::AGG::GetICN( ICN::STRIP, 2 ), 0, 0, dstsf, pos.x, pos.y, pos.width, pos.height,
+            fheroes2::ApplyPalette( Assets::getImage( ICN::STRIP, 2 ), 0, 0, dstsf, pos.x, pos.y, pos.width, pos.height,
                                     PAL::GetPalette( PAL::PaletteType::DARKENING ) );
 
             const fheroes2::Text text( _( "Default\ntroop" ), fheroes2::FontType::normalWhite() );
             text.drawInRoi( pos.x, pos.y + pos.height / 2 - 17, pos.width, dstsf, pos );
         }
         else {
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::STRIP, 2 ), 0, 0, dstsf, pos );
+            fheroes2::Copy( Assets::getImage( ICN::STRIP, 2 ), 0, 0, dstsf, pos );
         }
     }
 }
@@ -273,7 +273,7 @@ void ArmyBar::RedrawItem( ArmyTroop & troop, const fheroes2::Rect & pos, bool se
     const fheroes2::Text text( std::to_string( troop.GetCount() ), use_mini_sprite ? fheroes2::FontType::smallWhite() : fheroes2::FontType::normalWhite() );
 
     if ( use_mini_sprite ) {
-        const fheroes2::Sprite & mons32 = fheroes2::AGG::GetICN( ICN::MONS32, troop.GetSpriteIndex() );
+        const fheroes2::Sprite & mons32 = Assets::getImage( ICN::MONS32, troop.GetSpriteIndex() );
         fheroes2::Rect srcrt( 0, 0, mons32.width(), mons32.height() );
 
         if ( mons32.width() > pos.width ) {

--- a/src/fheroes2/army/army_bar.cpp
+++ b/src/fheroes2/army/army_bar.cpp
@@ -251,8 +251,7 @@ void ArmyBar::RedrawBackground( const fheroes2::Rect & pos, fheroes2::Image & ds
     else {
         if ( can_change && !_saveLastTroop && _army->GetOccupiedSlotCount() == 0 ) {
             // If none of army's slot is set within the Editor, then a default army will be applied at the game start.
-            fheroes2::ApplyPalette( Assets::getImage( ICN::STRIP, 2 ), 0, 0, dstsf, pos.x, pos.y, pos.width, pos.height,
-                                    PAL::GetPalette( PAL::PaletteType::DARKENING ) );
+            fheroes2::ApplyPalette( Assets::getImage( ICN::STRIP, 2 ), 0, 0, dstsf, pos.x, pos.y, pos.width, pos.height, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
 
             const fheroes2::Text text( _( "Default\ntroop" ), fheroes2::FontType::normalWhite() );
             text.drawInRoi( pos.x, pos.y + pos.height / 2 - 17, pos.width, dstsf, pos );

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -25,10 +25,10 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_troop.h"
 #include "game.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "ui_text.h"
@@ -97,7 +97,7 @@ void fheroes2::drawMiniMonsters( const Troops & troops, int32_t cx, const int32_
             }
         }
 
-        const fheroes2::Sprite & monster = fheroes2::AGG::GetICN( ICN::MONS32, troop->GetSpriteIndex() );
+        const fheroes2::Sprite & monster = Assets::getImage( ICN::MONS32, troop->GetSpriteIndex() );
         const fheroes2::Text text( std::move( monstersCountRepresentation ), fheroes2::FontType::smallWhite() );
 
         const int32_t posX = isRightToLeftRender ? ( cx + static_cast<int32_t>( chunk * ( count - 1 ) ) ) : ( cx - static_cast<int32_t>( chunk * count ) );

--- a/src/fheroes2/army/army_ui_helper.cpp
+++ b/src/fheroes2/army/army_ui_helper.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2023                                             *
+ *   Copyright (C) 2021 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/battle/battle_dialogs.cpp
+++ b/src/fheroes2/battle/battle_dialogs.cpp
@@ -29,7 +29,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army.h"
 #include "artifact.h"
 #include "audio.h"
@@ -45,6 +44,7 @@
 #include "dialog_audio.h"
 #include "dialog_hotkeys.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
@@ -181,8 +181,8 @@ namespace
     void setupAnimation( fheroes2::Display & display, const fheroes2::Rect & animationRoi, LoopedAnimationSequence & sequence )
     {
         sequence.push( ICN::WINCMBT, true ); // needs specific for battle summary
-        const fheroes2::Sprite & sequenceBase = fheroes2::AGG::GetICN( sequence.id(), 0 );
-        const fheroes2::Sprite & sequenceStart = fheroes2::AGG::GetICN( sequence.id(), 1 );
+        const fheroes2::Sprite & sequenceBase = Assets::getImage( sequence.id(), 0 );
+        const fheroes2::Sprite & sequenceStart = Assets::getImage( sequence.id(), 1 );
         Copy( sequenceBase, 0, 0, display, animationRoi.x, animationRoi.y, sequenceBase.width(), sequenceBase.height() );
         fheroes2::Blit( sequenceStart, display, animationRoi.x + sequenceStart.x(), animationRoi.y + sequenceStart.y() );
     }
@@ -192,11 +192,11 @@ namespace
         if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_DIALOG_DELAY ) && !sequence.nextFrame() ) {
             if ( lastSequence != sequence.id() ) {
                 lastSequence = sequence.id();
-                const fheroes2::Sprite & base = fheroes2::AGG::GetICN( lastSequence, 0 );
+                const fheroes2::Sprite & base = Assets::getImage( lastSequence, 0 );
 
                 Copy( base, 0, 0, display, animationRoi.x + base.x(), animationRoi.y + base.y(), base.width(), base.height() );
             }
-            const fheroes2::Sprite & sequenceCurrent = fheroes2::AGG::GetICN( sequence.id(), sequence.frameId() );
+            const fheroes2::Sprite & sequenceCurrent = Assets::getImage( sequence.id(), sequence.frameId() );
 
             fheroes2::Blit( sequenceCurrent, display, animationRoi.x + sequenceCurrent.x(), animationRoi.y + sequenceCurrent.y() );
             display.render( animationRoi );
@@ -237,14 +237,14 @@ namespace
             speedIcnIndex = 1;
         }
 
-        const fheroes2::Sprite & speedIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, speedIcnIndex );
+        const fheroes2::Sprite & speedIcon = Assets::getImage( ICN::CSPANEL, speedIcnIndex );
         fheroes2::drawOption( optionRoi, speedIcon, _( "battleAnimation|Speed" ), std::move( str ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 
     void drawInterfaceSettings( const fheroes2::Rect & optionRoi )
     {
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-        const fheroes2::Sprite & interfaceThemeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isEvilInterface ? 17 : 16 );
+        const fheroes2::Sprite & interfaceThemeIcon = Assets::getImage( ICN::SPANEL, isEvilInterface ? 17 : 16 );
 
         fheroes2::drawOption( optionRoi, interfaceThemeIcon, _( "Interface" ), _( "Settings" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
@@ -252,7 +252,7 @@ namespace
     void drawAutoSpellCasting( const fheroes2::Rect & optionRoi )
     {
         const bool isBattleAudoSpellCastEnabled = Settings::Get().BattleAutoSpellcast();
-        const fheroes2::Sprite & battleAutoSpellCastIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isBattleAudoSpellCastEnabled ? 7 : 6 );
+        const fheroes2::Sprite & battleAutoSpellCastIcon = Assets::getImage( ICN::CSPANEL, isBattleAudoSpellCastEnabled ? 7 : 6 );
         fheroes2::drawOption( optionRoi, battleAutoSpellCastIcon, _( "Auto Spell Casting" ), isBattleAudoSpellCastEnabled ? _( "On" ) : _( "Off" ),
                               fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
@@ -491,7 +491,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
-    const fheroes2::Sprite & originalBorderImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE, 0 );
+    const fheroes2::Sprite & originalBorderImage = Assets::getImage( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE, 0 );
     const fheroes2::Rect animationBorderRoi{ 43, 32, 231, 133 };
 
     const fheroes2::Rect & roi( background.activeArea() );
@@ -688,7 +688,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
 
         background.renderButton( buttonOk, buttonOkICN, 0, 1, { 0, buttonVerticalMargin }, fheroes2::StandardWindow::Padding::BOTTOM_CENTER );
 
-        const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::WINLOSEB, 0 );
+        const fheroes2::Sprite & border = Assets::getImage( ICN::WINLOSEB, 0 );
         const fheroes2::Rect artifactArea( summaryRoi.x + ( summaryRoi.width - border.width() ) / 2, casualtiesOffsetY + 38, border.width(), border.height() );
         Copy( border, 0, 0, display, artifactArea.x, artifactArea.y, artifactArea.width, artifactArea.height );
 
@@ -748,7 +748,7 @@ bool Battle::Arena::DialogBattleSummary( const Result & res, const std::vector<A
                     needHeaderRedraw = true;
                 }
 
-                const fheroes2::Sprite & artifact = fheroes2::AGG::GetICN( ICN::ARTIFACT, art.IndexSprite64() );
+                const fheroes2::Sprite & artifact = Assets::getImage( ICN::ARTIFACT, art.IndexSprite64() );
                 Copy( artifact, 0, 0, display, artifactArea.x + 8, artifactArea.y + 8, artifact.width(), artifact.height() );
 
                 artifactName.restore();
@@ -793,7 +793,7 @@ void Battle::Arena::DialogBattleNecromancy( const uint32_t raiseCount )
 
     // Animation border
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-    const fheroes2::Sprite & originalBorderImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE, 0 );
+    const fheroes2::Sprite & originalBorderImage = Assets::getImage( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE, 0 );
     const fheroes2::Rect animationBorderRoi{ 43, 32, 231, 133 };
 
     const fheroes2::Rect & roi( background.activeArea() );
@@ -819,7 +819,7 @@ void Battle::Arena::DialogBattleNecromancy( const uint32_t raiseCount )
     const int32_t messageWidth = roi.width - 22;
     messageBox.draw( roi.x + 11, yOffset, messageWidth, display );
 
-    const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( ICN::MONS32, mons.GetSpriteIndex() );
+    const fheroes2::Sprite & monsterSprite = Assets::getImage( ICN::MONS32, mons.GetSpriteIndex() );
     yOffset += messageBox.height( messageWidth ) + monsterSprite.height() - 2;
     fheroes2::Blit( monsterSprite, display, ( display.width() - monsterSprite.width() ) / 2, yOffset );
 
@@ -861,7 +861,7 @@ int Battle::Arena::DialogBattleHero( HeroBase & hero, const bool buttons, Status
 
     const PlayerColor currentColor = GetCurrentColor();
     const bool readonly = ( currentColor != hero.GetColor() || !buttons );
-    const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( ( conf.isEvilInterfaceEnabled() ? ICN::VGENBKGE : ICN::VGENBKG ), 0 );
+    const fheroes2::Sprite & dialog = Assets::getImage( ( conf.isEvilInterfaceEnabled() ? ICN::VGENBKGE : ICN::VGENBKG ), 0 );
 
     const fheroes2::Point dialogShadow( 15, 15 );
 
@@ -881,7 +881,7 @@ int Battle::Arena::DialogBattleHero( HeroBase & hero, const bool buttons, Status
 
     hero.PortraitRedraw( pos_rt.x + 12, pos_rt.y + 42, PORT_BIG, display );
     const int col = ( PlayerColor::NONE == hero.GetColor() ? 1 : Color::GetIndex( hero.GetColor() ) + 1 );
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::VIEWGEN, col ), display, pos_rt.x + 133, pos_rt.y + 36 );
+    fheroes2::Blit( Assets::getImage( ICN::VIEWGEN, col ), display, pos_rt.x + 133, pos_rt.y + 36 );
 
     std::string str = hero.isCaptain() ? _( "Captain of %{name}" ) : _( "%{name} the %{race}" );
     StringReplace( str, "%{name}", hero.GetName() );
@@ -1102,7 +1102,7 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdo
 
     const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
-    const fheroes2::Sprite & dialog = fheroes2::AGG::GetICN( isEvilInterface ? ICN::SURDRBKE : ICN::SURDRBKG, 0 );
+    const fheroes2::Sprite & dialog = Assets::getImage( isEvilInterface ? ICN::SURDRBKE : ICN::SURDRBKG, 0 );
 
     fheroes2::Rect pos_rt( ( display.width() - dialog.width() + 16 ) / 2, ( display.height() - dialog.height() + 16 ) / 2, dialog.width(), dialog.height() );
 
@@ -1113,13 +1113,13 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdo
     const int icnMarket = isEvilInterface ? ICN::EVIL_MARKET_BUTTON : ICN::GOOD_MARKET_BUTTON;
 
     fheroes2::ButtonSprite btnAccept
-        = fheroes2::makeButtonWithShadow( pos_rt.x + 91, pos_rt.y + 152, fheroes2::AGG::GetICN( icnAccept, 0 ), fheroes2::AGG::GetICN( icnAccept, 1 ), display );
+        = fheroes2::makeButtonWithShadow( pos_rt.x + 91, pos_rt.y + 152, Assets::getImage( icnAccept, 0 ), Assets::getImage( icnAccept, 1 ), display );
 
     fheroes2::ButtonSprite btnDecline
-        = fheroes2::makeButtonWithShadow( pos_rt.x + 295, pos_rt.y + 152, fheroes2::AGG::GetICN( icnDecline, 0 ), fheroes2::AGG::GetICN( icnDecline, 1 ), display );
+        = fheroes2::makeButtonWithShadow( pos_rt.x + 295, pos_rt.y + 152, Assets::getImage( icnDecline, 0 ), Assets::getImage( icnDecline, 1 ), display );
 
-    fheroes2::ButtonSprite btnMarket = fheroes2::makeButtonWithShadow( pos_rt.x + ( pos_rt.width - 16 ) / 2, pos_rt.y + 145, fheroes2::AGG::GetICN( icnMarket, 0 ),
-                                                                       fheroes2::AGG::GetICN( icnMarket, 1 ), display );
+    fheroes2::ButtonSprite btnMarket = fheroes2::makeButtonWithShadow( pos_rt.x + ( pos_rt.width - 16 ) / 2, pos_rt.y + 145, Assets::getImage( icnMarket, 0 ),
+                                                                       Assets::getImage( icnMarket, 1 ), display );
 
     if ( !kingdom.AllowPayment( Funds( Resource::GOLD, cost ) ) ) {
         btnAccept.disable();
@@ -1152,7 +1152,7 @@ bool Battle::DialogBattleSurrender( const HeroBase & hero, uint32_t cost, Kingdo
     };
 
     const int icn = isEvilInterface ? ICN::SURRENDE : ICN::SURRENDR;
-    const fheroes2::Sprite & window = fheroes2::AGG::GetICN( icn, 4 );
+    const fheroes2::Sprite & window = Assets::getImage( icn, 4 );
     fheroes2::Blit( window, display, pos_rt.x + 55, pos_rt.y + 32 );
     hero.PortraitRedraw( pos_rt.x + 60, pos_rt.y + 38, PORT_BIG, display );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -6828,7 +6828,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const int32_t dst, cons
 
     AudioManager::PlaySound( m82 );
 
-    uint32_t frameCount = Assets::getImageCount( icn );
+    const uint32_t frameCount = Assets::getImageCount( icn );
 
     const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -37,7 +37,6 @@
 #include <set>
 #include <type_traits>
 
-#include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "battle.h" // IWYU pragma: associated
@@ -53,6 +52,7 @@
 #include "bin_info.h"
 #include "castle.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "ground.h"
 #include "heroes_base.h"
@@ -266,7 +266,7 @@ namespace
         rainbow.reset();
 
         // Get the original good luck sprite, since it has a rainbow image which will be used to get line.
-        const fheroes2::Sprite & luckSprite = fheroes2::AGG::GetICN( ICN::EXPMRL, 0 );
+        const fheroes2::Sprite & luckSprite = Assets::getImage( ICN::EXPMRL, 0 );
 
         // Get a single rainbow line from the center of the luckSprite.
         fheroes2::Image croppedRainbow;
@@ -306,14 +306,14 @@ namespace
 
     int32_t GetAbsoluteICNHeight( int icnId )
     {
-        const uint32_t frameCount = fheroes2::AGG::GetICNCount( icnId );
+        const uint32_t frameCount = Assets::getImageCount( icnId );
         if ( frameCount == 0 ) {
             return 0;
         }
 
         int32_t height = 0;
         for ( uint32_t i = 0; i < frameCount; ++i ) {
-            const int32_t offset = -fheroes2::AGG::GetICN( icnId, i ).y();
+            const int32_t offset = -Assets::getImage( icnId, i ).y();
             if ( offset > height ) {
                 height = offset;
             }
@@ -327,7 +327,7 @@ namespace
         const fheroes2::Rect & pos = target.GetRectPosition();
 
         // Get the sprite for the first frame, so its center won't shift if the creature is animating (instead of target.GetFrame()).
-        const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.animation.firstFrame() );
+        const fheroes2::Sprite & unitSprite = Assets::getImage( target.GetMonsterSprite(), target.animation.firstFrame() );
 
         // Bottom-left corner (default) position with spell offset applied
         fheroes2::Point result( pos.x + spellSprite.x(), pos.y + pos.height + cellYOffset + spellSprite.y() );
@@ -461,7 +461,7 @@ namespace
 
     fheroes2::Image DrawHexagon( const uint8_t colorId )
     {
-        const fheroes2::Sprite & originalGrid = fheroes2::AGG::GetICN( ICN::CMBTMISC, 0 );
+        const fheroes2::Sprite & originalGrid = Assets::getImage( ICN::CMBTMISC, 0 );
 
         // Move hexagon by 1 pixel down to match the original game's grid.
         fheroes2::Image hexagonSprite( originalGrid.width(), originalGrid.height() + 1 );
@@ -828,7 +828,7 @@ namespace Battle
 
             setScrollBarArea( { ax + 5, buttonPgUpArea.y + buttonPgUpArea.height + 3, 12, _scrollbarSliderAreaLength } );
 
-            const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( ICN::DROPLISL, 13 );
+            const fheroes2::Sprite & originalSlider = Assets::getImage( ICN::DROPLISL, 13 );
             fheroes2::Image scrollbarSlider
                 = fheroes2::generateScrollbarSlider( originalSlider, false, _scrollbarSliderAreaLength, VisibleItemCount(), static_cast<int32_t>( _messages.size() ),
                                                      { 0, 0, originalSlider.width(), 4 }, { 0, 4, originalSlider.width(), 8 } );
@@ -896,7 +896,7 @@ namespace Battle
             SetListContent( _messages );
 
             // Update the scrollbar image.
-            const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( ICN::DROPLISL, 13 );
+            const fheroes2::Sprite & originalSlider = Assets::getImage( ICN::DROPLISL, 13 );
             fheroes2::Image scrollbarSlider
                 = fheroes2::generateScrollbarSlider( originalSlider, false, _scrollbarSliderAreaLength, VisibleItemCount(), static_cast<int32_t>( _messages.size() ),
                                                      { 0, 0, originalSlider.width(), 4 }, { 0, 4, originalSlider.width(), 8 } );
@@ -922,15 +922,15 @@ namespace Battle
             const int32_t ah = buttonPgDnAreaY - buttonPgUpBottom;
 
             const fheroes2::Rect & borderRect = _border.GetRect();
-            Dialog::FrameBorder::RenderOther( fheroes2::AGG::GetICN( ICN::TEXTBAK2, 0 ), borderRect );
+            Dialog::FrameBorder::RenderOther( Assets::getImage( ICN::TEXTBAK2, 0 ), borderRect );
 
-            const fheroes2::Sprite & sp3 = fheroes2::AGG::GetICN( ICN::DROPLISL, 11 );
+            const fheroes2::Sprite & sp3 = Assets::getImage( ICN::DROPLISL, 11 );
             for ( int32_t i = 0; i < ( ah / sp3.height() ); ++i ) {
                 fheroes2::Copy( sp3, 0, 0, display, ax, buttonPgUpBottom + ( sp3.height() * i ), sp3.width(), sp3.height() );
             }
 
-            const fheroes2::Sprite & sp1 = fheroes2::AGG::GetICN( ICN::DROPLISL, 10 );
-            const fheroes2::Sprite & sp2 = fheroes2::AGG::GetICN( ICN::DROPLISL, 12 );
+            const fheroes2::Sprite & sp1 = Assets::getImage( ICN::DROPLISL, 10 );
+            const fheroes2::Sprite & sp2 = Assets::getImage( ICN::DROPLISL, 12 );
 
             fheroes2::Copy( sp1, 0, 0, display, ax, buttonPgUpBottom, sp1.width(), sp1.height() );
             fheroes2::Copy( sp2, 0, 0, display, ax, buttonPgDnAreaY - sp2.height(), sp2.width(), sp2.height() );
@@ -1016,7 +1016,7 @@ Battle::OpponentSprite::OpponentSprite( const fheroes2::Rect & area, HeroBase * 
         break;
     }
 
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( _heroIcnId, _currentAnim.getFrame() );
+    const fheroes2::Sprite & sprite = Assets::getImage( _heroIcnId, _currentAnim.getFrame() );
 
     _area.width = sprite.width();
     _area.height = sprite.height();
@@ -1091,7 +1091,7 @@ fheroes2::Point Battle::OpponentSprite::GetCastPosition() const
 
 void Battle::OpponentSprite::Redraw( fheroes2::Image & dst ) const
 {
-    const fheroes2::Sprite & hero = fheroes2::AGG::GetICN( _heroIcnId, _currentAnim.getFrame() );
+    const fheroes2::Sprite & hero = Assets::getImage( _heroIcnId, _currentAnim.getFrame() );
 
     fheroes2::Point offset( _offset );
     if ( _heroBase->isCaptain() ) {
@@ -1136,8 +1136,8 @@ bool Battle::OpponentSprite::updateAnimationState()
 }
 
 Battle::Status::Status()
-    : _upperBackground( fheroes2::AGG::GetICN( ICN::TEXTBAR, 8 ) )
-    , _lowerBackground( fheroes2::AGG::GetICN( ICN::TEXTBAR, 9 ) )
+    : _upperBackground( Assets::getImage( ICN::TEXTBAR, 8 ) )
+    , _lowerBackground( Assets::getImage( ICN::TEXTBAR, 9 ) )
 {
     width = _upperBackground.width();
     height = _upperBackground.height() + _lowerBackground.height();
@@ -1222,11 +1222,11 @@ bool Battle::TurnOrder::queueEventProcessing( Interface & interface, std::string
 void Battle::TurnOrder::_redrawUnit( const fheroes2::Rect & pos, const Battle::Unit & unit, const bool revert, const uint8_t unitColor, fheroes2::Image & output )
 {
     // Render background.
-    const fheroes2::Sprite & backgroundOriginal = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+    const fheroes2::Sprite & backgroundOriginal = Assets::getImage( ICN::SWAPWIN, 0 );
     fheroes2::Copy( backgroundOriginal, 37, 268, output, pos.x + 1, pos.y + 1, pos.width - 2, pos.height - 2 );
 
     // Draw a monster's sprite.
-    const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( ICN::MONS32, unit.GetSpriteIndex() );
+    const fheroes2::Sprite & monsterSprite = Assets::getImage( ICN::MONS32, unit.GetSpriteIndex() );
     const int32_t monsterSpriteHeight = monsterSprite.height();
     if ( unit.Modes( Battle::CAP_MIRRORIMAGE ) ) {
         fheroes2::Sprite mirroredMonster = monsterSprite;
@@ -1859,7 +1859,7 @@ void Battle::Interface::RedrawArmies()
             // Render the overlay sprite for units in current cell row above all units in this and upper rows.
             for ( const Battle::UnitSpellEffectInfo * overlaySprite : troopOverlaySpriteBeforeWall ) {
                 assert( overlaySprite->icnId != ICN::UNKNOWN );
-                const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( overlaySprite->icnId, overlaySprite->icnIndex );
+                const fheroes2::Sprite & spellSprite = Assets::getImage( overlaySprite->icnId, overlaySprite->icnIndex );
                 fheroes2::Blit( spellSprite, _mainSurface, overlaySprite->position.x, overlaySprite->position.y, overlaySprite->isReflectedImage );
             }
 
@@ -1888,7 +1888,7 @@ void Battle::Interface::RedrawArmies()
             // Render the overlay sprite for units in current cell row above all units in this and upper rows.
             for ( const Battle::UnitSpellEffectInfo * overlaySprite : troopOverlaySpriteAfterWall ) {
                 assert( overlaySprite->icnId != ICN::UNKNOWN );
-                const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( overlaySprite->icnId, overlaySprite->icnIndex );
+                const fheroes2::Sprite & spellSprite = Assets::getImage( overlaySprite->icnId, overlaySprite->icnIndex );
                 fheroes2::Blit( spellSprite, _mainSurface, overlaySprite->position.x, overlaySprite->position.y, overlaySprite->isReflectedImage );
             }
         }
@@ -1959,7 +1959,7 @@ void Battle::Interface::RedrawArmies()
             // Render the overlay sprite for units in current cell row above all units in this and upper rows.
             for ( const Battle::UnitSpellEffectInfo * overlaySprite : troopOverlaySprite ) {
                 assert( overlaySprite->icnId != ICN::UNKNOWN );
-                const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( overlaySprite->icnId, overlaySprite->icnIndex );
+                const fheroes2::Sprite & spellSprite = Assets::getImage( overlaySprite->icnId, overlaySprite->icnIndex );
                 fheroes2::Blit( spellSprite, _mainSurface, overlaySprite->position.x, overlaySprite->position.y, overlaySprite->isReflectedImage );
             }
         }
@@ -2009,14 +2009,14 @@ void Battle::Interface::RedrawOpponentsFlags()
 
     if ( _attackingOpponent ) {
         const int icn = getFlagIcn( arena.getAttackingForce().GetColor() );
-        const fheroes2::Sprite & flag = fheroes2::AGG::GetICN( icn, ICN::getAnimatedIcnIndex( icn, 0, _flagAnimationFrameIndex ) );
+        const fheroes2::Sprite & flag = Assets::getImage( icn, ICN::getAnimatedIcnIndex( icn, 0, _flagAnimationFrameIndex ) );
         fheroes2::Blit( flag, _mainSurface, _attackingOpponent->Offset().x + OpponentSprite::LEFT_HERO_X_OFFSET + flag.x(),
                         _attackingOpponent->Offset().y + OpponentSprite::LEFT_HERO_Y_OFFSET + flag.y() );
     }
 
     if ( _defendingOpponent ) {
         const int icn = getFlagIcn( arena.getDefendingForce().GetColor() );
-        const fheroes2::Sprite & flag = fheroes2::AGG::GetICN( icn, ICN::getAnimatedIcnIndex( icn, 0, _flagAnimationFrameIndex ) );
+        const fheroes2::Sprite & flag = Assets::getImage( icn, ICN::getAnimatedIcnIndex( icn, 0, _flagAnimationFrameIndex ) );
         fheroes2::Blit( flag, _mainSurface,
                         _defendingOpponent->Offset().x + fheroes2::Display::DEFAULT_WIDTH - OpponentSprite::RIGHT_HERO_X_OFFSET - ( flag.x() + flag.width() ),
                         _defendingOpponent->Offset().y + OpponentSprite::RIGHT_HERO_Y_OFFSET + flag.y(), true );
@@ -2027,7 +2027,7 @@ void Battle::Interface::RedrawTroopSprite( const Unit & unit )
 {
     const bool isCurrentMonsterAction = ( _currentUnit == &unit && _spriteInsteadCurrentUnit != nullptr );
 
-    const fheroes2::Sprite & monsterSprite = isCurrentMonsterAction ? *_spriteInsteadCurrentUnit : fheroes2::AGG::GetICN( unit.GetMonsterSprite(), unit.GetFrame() );
+    const fheroes2::Sprite & monsterSprite = isCurrentMonsterAction ? *_spriteInsteadCurrentUnit : Assets::getImage( unit.GetMonsterSprite(), unit.GetFrame() );
 
     fheroes2::Point drawnPosition;
 
@@ -2200,7 +2200,7 @@ bool Battle::Interface::_drawTroopSpriteWithMoatMask( const Unit & unit, const f
 void Battle::Interface::RedrawTroopCount( const Unit & unit )
 {
     const fheroes2::Rect & rt = unit.GetRectPosition();
-    const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::TEXTBAR, GetIndexIndicator( unit ) );
+    const fheroes2::Sprite & bar = Assets::getImage( ICN::TEXTBAR, GetIndexIndicator( unit ) );
     const bool isReflected = unit.isReflect();
 
     const int32_t monsterIndex = unit.GetHeadIndex();
@@ -2235,7 +2235,7 @@ void Battle::Interface::RedrawCover()
             spriteIndex = _bridgeAnimation.currentFrameId;
         }
 
-        const fheroes2::Sprite & bridgeImage = fheroes2::AGG::GetICN( ICN::getCastleIcnId( Arena::GetCastle()->GetRace() ), spriteIndex );
+        const fheroes2::Sprite & bridgeImage = Assets::getImage( ICN::getCastleIcnId( Arena::GetCastle()->GetRace() ), spriteIndex );
         fheroes2::Blit( bridgeImage, _mainSurface, bridgeImage.x(), bridgeImage.y() );
     }
 
@@ -2435,19 +2435,19 @@ void Battle::Interface::_redrawBattleGround()
 {
     // Battlefield background image.
     if ( _battleGroundIcn != ICN::UNKNOWN ) {
-        const fheroes2::Sprite & cbkg = fheroes2::AGG::GetICN( _battleGroundIcn, 0 );
+        const fheroes2::Sprite & cbkg = Assets::getImage( _battleGroundIcn, 0 );
         fheroes2::Copy( cbkg, _battleGround );
     }
 
     // Objects near the left and right borders of the Battlefield.
     if ( _borderObjectsIcn != ICN::UNKNOWN ) {
-        const fheroes2::Sprite & frng = fheroes2::AGG::GetICN( _borderObjectsIcn, 0 );
+        const fheroes2::Sprite & frng = Assets::getImage( _borderObjectsIcn, 0 );
         fheroes2::Blit( frng, _battleGround, frng.x(), frng.y() );
     }
 
     // Big obstacles in the center of the Battlefield.
     if ( arena.GetICNCovr() != ICN::UNKNOWN ) {
-        const fheroes2::Sprite & cover = fheroes2::AGG::GetICN( arena.GetICNCovr(), 0 );
+        const fheroes2::Sprite & cover = Assets::getImage( arena.GetICNCovr(), 0 );
         fheroes2::Blit( cover, _battleGround, cover.x(), cover.y() );
     }
 
@@ -2481,12 +2481,12 @@ void Battle::Interface::_redrawBattleGround()
             break;
         }
 
-        const fheroes2::Sprite & castleBackground = fheroes2::AGG::GetICN( castleBackgroundIcnId, 1 );
+        const fheroes2::Sprite & castleBackground = Assets::getImage( castleBackgroundIcnId, 1 );
         fheroes2::Blit( castleBackground, _battleGround, castleBackground.x(), castleBackground.y() );
 
         // Moat.
         if ( castle->isBuild( BUILD_MOAT ) ) {
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MOATWHOL, 0 );
+            const fheroes2::Sprite & sprite = Assets::getImage( ICN::MOATWHOL, 0 );
             fheroes2::Blit( sprite, _battleGround, sprite.x(), sprite.y() );
         }
     }
@@ -2507,7 +2507,7 @@ void Battle::Interface::_redrawBattleGround()
 
     // Castle top wall.
     if ( castle != nullptr ) {
-        const fheroes2::Sprite & sprite2 = fheroes2::AGG::GetICN( castleBackgroundIcnId, castle->isFortificationBuilt() ? 4 : 3 );
+        const fheroes2::Sprite & sprite2 = Assets::getImage( castleBackgroundIcnId, castle->isFortificationBuilt() ? 4 : 3 );
         fheroes2::Blit( sprite2, _battleGround, sprite2.x(), sprite2.y() );
     }
 }
@@ -2602,14 +2602,14 @@ void Battle::Interface::RedrawCastle( const Castle & castle, const int32_t cellI
     const int castleIcnId = ICN::getCastleIcnId( castle.GetRace() );
 
     if ( Arena::CATAPULT_POS == cellId ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CATAPULT, catapult_frame );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::CATAPULT, catapult_frame );
         fheroes2::Blit( sprite, _mainSurface, 22 + sprite.x(), 390 + sprite.y() );
     }
     else if ( Arena::CASTLE_GATE_POS == cellId ) {
         const Bridge * bridge = Arena::GetBridge();
         assert( bridge != nullptr );
         if ( bridge != nullptr && !bridge->isDestroyed() ) {
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( castleIcnId, 4 );
+            const fheroes2::Sprite & sprite = Assets::getImage( castleIcnId, 4 );
             fheroes2::Blit( sprite, _mainSurface, sprite.x(), sprite.y() );
         }
     }
@@ -2668,7 +2668,7 @@ void Battle::Interface::RedrawCastle( const Castle & castle, const int32_t cellI
             }
         }
 
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( castleIcnId, index );
+        const fheroes2::Sprite & sprite = Assets::getImage( castleIcnId, index );
         fheroes2::Blit( sprite, _mainSurface, sprite.x(), sprite.y() );
     }
     else if ( Arena::CASTLE_TOP_ARCHER_TOWER_POS == cellId ) {
@@ -2683,7 +2683,7 @@ void Battle::Interface::RedrawCastle( const Castle & castle, const int32_t cellI
             index = 19;
         }
 
-        const fheroes2::Sprite & towerSprite = fheroes2::AGG::GetICN( castleIcnId, index );
+        const fheroes2::Sprite & towerSprite = Assets::getImage( castleIcnId, index );
         fheroes2::Blit( towerSprite, _mainSurface, 443 + towerSprite.x(), 153 + towerSprite.y() );
     }
     else if ( Arena::CASTLE_BOTTOM_ARCHER_TOWER_POS == cellId ) {
@@ -2698,24 +2698,24 @@ void Battle::Interface::RedrawCastle( const Castle & castle, const int32_t cellI
             index = 19;
         }
 
-        const fheroes2::Sprite & towerSprite = fheroes2::AGG::GetICN( castleIcnId, index );
+        const fheroes2::Sprite & towerSprite = Assets::getImage( castleIcnId, index );
         fheroes2::Blit( towerSprite, _mainSurface, 443 + towerSprite.x(), 405 + towerSprite.y() );
     }
     else if ( Arena::CASTLE_TOP_GATE_TOWER_POS == cellId ) {
         const int index = ( Board::GetCell( cellId )->GetObject() == 1 ) ? 19 : 17;
-        const fheroes2::Sprite & towerSprite = fheroes2::AGG::GetICN( castleIcnId, index );
+        const fheroes2::Sprite & towerSprite = Assets::getImage( castleIcnId, index );
         fheroes2::Blit( towerSprite, _mainSurface, 399 + towerSprite.x(), 237 + towerSprite.y() );
     }
     else if ( Arena::CASTLE_BOTTOM_GATE_TOWER_POS == cellId ) {
         const int index = ( Board::GetCell( cellId )->GetObject() == 1 ) ? 19 : 17;
-        const fheroes2::Sprite & towerSprite = fheroes2::AGG::GetICN( castleIcnId, index );
+        const fheroes2::Sprite & towerSprite = Assets::getImage( castleIcnId, index );
         fheroes2::Blit( towerSprite, _mainSurface, 399 + towerSprite.x(), 321 + towerSprite.y() );
     }
 }
 
 void Battle::Interface::RedrawCastleMainTower( const Castle & castle )
 {
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::getCastleIcnId( castle.GetRace() ), ( Arena::GetTower( TowerType::TWR_CENTER )->isValid() ? 20 : 26 ) );
+    const fheroes2::Sprite & sprite = Assets::getImage( ICN::getCastleIcnId( castle.GetRace() ), ( Arena::GetTower( TowerType::TWR_CENTER )->isValid() ? 20 : 26 ) );
 
     fheroes2::Blit( sprite, _mainSurface, sprite.x(), sprite.y() );
 }
@@ -2748,7 +2748,7 @@ void Battle::Interface::_redrawGroundObjects( const int32_t cellId )
         return;
     }
 
-    const fheroes2::Sprite & objectSprite = fheroes2::AGG::GetICN( objectIcnId, 0 );
+    const fheroes2::Sprite & objectSprite = Assets::getImage( objectIcnId, 0 );
     const fheroes2::Rect & pt = cell->GetPos();
     fheroes2::Blit( objectSprite, _battleGround, pt.x + pt.width / 2 + objectSprite.x(), pt.y + pt.height + objectSprite.y() + cellYOffset );
 }
@@ -2859,7 +2859,7 @@ void Battle::Interface::_redrawHighObjects( const int32_t cellId )
         return;
     }
 
-    const fheroes2::Sprite & objectSprite = fheroes2::AGG::GetICN( objectIcnId, 0 );
+    const fheroes2::Sprite & objectSprite = Assets::getImage( objectIcnId, 0 );
     const fheroes2::Rect & pt = cell->GetPos();
     fheroes2::Blit( objectSprite, _mainSurface, pt.x + pt.width / 2 + objectSprite.x(), pt.y + pt.height + objectSprite.y() + cellYOffset );
 }
@@ -3982,7 +3982,7 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
         fheroes2::delayforMs( Game::ApplyBattleSpeed( 115 ) );
     }
     else {
-        missile = fheroes2::AGG::GetICN( static_cast<int>( Monster::GetMissileICN( monsterID ) ),
+        missile = Assets::getImage( static_cast<int>( Monster::GetMissileICN( monsterID ) ),
                                          static_cast<uint32_t>( Bin_Info::GetMonsterInfo( monsterID ).getProjectileID( angle ) ) );
 
         // The projectile has to hit the target but not go through it so its end position is shifted in the direction to the shooter.
@@ -4071,7 +4071,7 @@ void Battle::Interface::RedrawActionAttackPart1( Unit & attacker, const Unit & d
             Game::AnimateResetDelay( Game::DelayType::CUSTOM_BATTLE_UNIT_MOVEMENT_DELAY );
         }
 
-        const fheroes2::Sprite & attackerSprite = fheroes2::AGG::GetICN( attacker.GetMonsterSprite(), attacker.GetFrame() );
+        const fheroes2::Sprite & attackerSprite = Assets::getImage( attacker.GetMonsterSprite(), attacker.GetFrame() );
         const fheroes2::Point attackerPos = GetTroopPosition( attacker, attackerSprite );
 
         // For shooter position we need bottom center position of rear tile
@@ -4288,7 +4288,7 @@ void Battle::Interface::_redrawActionWincesKills( const TargetsInfo & targets, U
     SetHeroAnimationReactionToTroopDeath( deathColor );
 
     uint32_t lichCloudFrame = 0;
-    const uint32_t lichCloudMaxFrame = fheroes2::AGG::GetICNCount( ICN::LICHCLOD );
+    const uint32_t lichCloudMaxFrame = Assets::getImageCount( ICN::LICHCLOD );
     // Wince animation under the Lich cloud, second part: the frame number after which the target animation will be switched to 'WNCE_UP'.
     const uint32_t wnceUpStartFrame = 1;
     // Wince animation under the Lich cloud, third part: the frame number after which the target animation will be switched to 'WNCE_DOWN'.
@@ -4312,7 +4312,7 @@ void Battle::Interface::_redrawActionWincesKills( const TargetsInfo & targets, U
 
         // Render a Lich cloud above the target unit if it is a Lich attack and if the cloud animation is not already finished.
         if ( drawLichCloud && lichCloudFrame < lichCloudMaxFrame ) {
-            const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( ICN::LICHCLOD, lichCloudFrame );
+            const fheroes2::Sprite & spellSprite = Assets::getImage( ICN::LICHCLOD, lichCloudFrame );
             const fheroes2::Point & pos = CalculateSpellPosition( *defender, ICN::LICHCLOD, spellSprite );
             fheroes2::Blit( spellSprite, _mainSurface, pos.x, pos.y, false );
             ++lichCloudFrame;
@@ -5356,7 +5356,7 @@ void Battle::Interface::RedrawActionLuck( const Unit & unit )
                 RedrawPartialStart();
 
                 if ( frameId < frameLimit ) {
-                    const fheroes2::Sprite & luckSprite = fheroes2::AGG::GetICN( ICN::CLOUDLUK, frameId );
+                    const fheroes2::Sprite & luckSprite = Assets::getImage( ICN::CLOUDLUK, frameId );
                     fheroes2::Blit( luckSprite, _mainSurface, offsetX + luckSprite.x(), offsetY + luckSprite.y() );
 
                     ++frameId;
@@ -5498,7 +5498,7 @@ void Battle::Interface::RedrawActionCatapultPart1( const CastleDefenseStructure 
     std::vector<fheroes2::Point>::const_iterator pnt = points.begin();
 
     uint32_t boulderFrameId = 0;
-    const uint32_t boulderFramesCount = fheroes2::AGG::GetICNCount( ICN::BOULDER );
+    const uint32_t boulderFramesCount = Assets::getImageCount( ICN::BOULDER );
 
     allDelays.front() = Game::DelayType::BATTLE_CATAPULT_BOULDER_DELAY;
 
@@ -5510,7 +5510,7 @@ void Battle::Interface::RedrawActionCatapultPart1( const CastleDefenseStructure 
                 ++catapult_frame;
 
             RedrawPartialStart();
-            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::BOULDER, boulderFrameId ), _mainSurface, pnt->x, pnt->y );
+            fheroes2::Blit( Assets::getImage( ICN::BOULDER, boulderFrameId ), _mainSurface, pnt->x, pnt->y );
             RedrawPartialFinish();
             ++pnt;
             ++boulderFrameId;
@@ -5527,7 +5527,7 @@ void Battle::Interface::RedrawActionCatapultPart1( const CastleDefenseStructure 
     const int32_t icn = isHit ? ICN::LICHCLOD : ICN::SMALCLOD;
     uint32_t frame = 0;
     // If the building is hit, end the animation on the 5th frame to change the building state (when the smoke cloud is largest).
-    uint32_t maxFrame = isHit ? castleBuildingDestroyFrame : fheroes2::AGG::GetICNCount( icn );
+    uint32_t maxFrame = isHit ? castleBuildingDestroyFrame : Assets::getImageCount( icn );
     const bool isBridgeDestroyed = isHit && ( catapultTarget == CastleDefenseStructure::BRIDGE );
     // If the bridge is destroyed - prepare parameters for the second smoke cloud.
     if ( isBridgeDestroyed ) {
@@ -5547,10 +5547,10 @@ void Battle::Interface::RedrawActionCatapultPart1( const CastleDefenseStructure 
             RedrawPartialStart();
             // Start animation of the second smoke cloud only for the bridge and after 2 frames of the first smoke cloud.
             if ( isBridgeDestroyed && frame >= bridgeDestroySmokeDelay ) {
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, frame - bridgeDestroySmokeDelay );
+                const fheroes2::Sprite & sprite = Assets::getImage( icn, frame - bridgeDestroySmokeDelay );
                 fheroes2::Blit( sprite, _mainSurface, pt1.x + sprite.x(), pt1.y + sprite.y() );
             }
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, frame );
+            const fheroes2::Sprite & sprite = Assets::getImage( icn, frame );
             fheroes2::Blit( sprite, _mainSurface, pt2.x + sprite.x(), pt2.y + sprite.y() );
             RedrawPartialFinish();
 
@@ -5573,7 +5573,7 @@ void Battle::Interface::RedrawActionCatapultPart2( const CastleDefenseStructure 
     // Continue the smoke cloud animation from the 6th frame.
     const int32_t icnId = ICN::LICHCLOD;
     uint32_t frame = castleBuildingDestroyFrame;
-    const uint32_t maxFrame = fheroes2::AGG::GetICNCount( icnId );
+    const uint32_t maxFrame = Assets::getImageCount( icnId );
     uint32_t maxAnimationFrame = maxFrame;
     const bool isBridgeDestroyed = ( catapultTarget == CastleDefenseStructure::BRIDGE );
     // If the bridge is destroyed - prepare parameters for the second smoke cloud.
@@ -5596,12 +5596,12 @@ void Battle::Interface::RedrawActionCatapultPart2( const CastleDefenseStructure 
             RedrawPartialStart();
             // Draw animation of the second smoke cloud only for the bridge.
             if ( isBridgeDestroyed ) {
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icnId, frame - bridgeDestroySmokeDelay );
+                const fheroes2::Sprite & sprite = Assets::getImage( icnId, frame - bridgeDestroySmokeDelay );
                 fheroes2::Blit( sprite, _mainSurface, pt2.x + sprite.x(), pt2.y + sprite.y() );
             }
             // Don't draw the smoke cloud after its animation has ended (in case the second smoke cloud is still animating).
             if ( frame <= maxFrame ) {
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icnId, frame );
+                const fheroes2::Sprite & sprite = Assets::getImage( icnId, frame );
                 fheroes2::Blit( sprite, _mainSurface, pt1.x + sprite.x(), pt1.y + sprite.y() );
             }
             RedrawPartialFinish();
@@ -5639,7 +5639,7 @@ void Battle::Interface::_redrawActionTeleportSpell( Unit & target, const int32_t
     // Hide the counter.
     target.SwitchAnimation( Monster_Info::STAND_STILL );
 
-    const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
+    const fheroes2::Sprite & unitSprite = Assets::getImage( target.GetMonsterSprite(), target.GetFrame() );
     fheroes2::Sprite rippleSprite;
     _spriteInsteadCurrentUnit = &rippleSprite;
     const int32_t spriteHeight = unitSprite.height();
@@ -5799,7 +5799,7 @@ void Battle::Interface::redrawActionMirrorImageSpell( const HeroBase & caster, c
     _currentUnit = &mirrorUnit;
 
     // Set custom sprite for mirrored unit to hide its contour and to have ability to change sprite position.
-    fheroes2::Sprite mirrorUnitSprite = fheroes2::AGG::GetICN( originalUnit.GetMonsterSprite(), originalUnit.GetFrame() );
+    fheroes2::Sprite mirrorUnitSprite = Assets::getImage( originalUnit.GetMonsterSprite(), originalUnit.GetFrame() );
     _spriteInsteadCurrentUnit = &mirrorUnitSprite;
 
     // Don't highlight the cursor position.
@@ -5966,13 +5966,13 @@ void Battle::Interface::_redrawLightningOnTargets( const std::vector<fheroes2::P
     fheroes2::delayforMs( 100 );
 
     uint32_t frame = 0;
-    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < fheroes2::AGG::GetICNCount( ICN::SPARKS ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < Assets::getImageCount( ICN::SPARKS ) ) {
         _checkGlobalEvents( le );
 
         if ( ( frame == 0 ) || Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY ) ) {
             RedrawPartialStart();
 
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::SPARKS, frame );
+            const fheroes2::Sprite & sprite = Assets::getImage( ICN::SPARKS, frame );
             const int32_t spriteWidth = sprite.width();
 
             for ( size_t i = 1; i < points.size(); ++i ) {
@@ -6020,7 +6020,7 @@ void Battle::Interface::_redrawActionBloodLustSpell( const Unit & target )
 {
     LocalEvent & le = LocalEvent::Get();
 
-    const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
+    const fheroes2::Sprite & unitSprite = Assets::getImage( target.GetMonsterSprite(), target.GetFrame() );
 
     fheroes2::Sprite bloodlustEffect( unitSprite );
     fheroes2::ApplyPalette( bloodlustEffect, PAL::GetPalette( PAL::PaletteType::RED ) );
@@ -6075,7 +6075,7 @@ void Battle::Interface::_redrawActionStoneSpell( const Unit & target )
 {
     LocalEvent & le = LocalEvent::Get();
 
-    const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
+    const fheroes2::Sprite & unitSprite = Assets::getImage( target.GetMonsterSprite(), target.GetFrame() );
 
     fheroes2::Sprite stoneEffect( unitSprite );
     fheroes2::ApplyPalette( stoneEffect, PAL::GetPalette( PAL::PaletteType::GRAY ) );
@@ -6191,7 +6191,7 @@ void Battle::Interface::_redrawRaySpell( const Unit & target, const int spellICN
     const fheroes2::Point targetPos = target.GetCenterPoint();
 
     const std::vector<fheroes2::Point> path = getLinePoints( startingPos, targetPos, size );
-    const uint32_t spriteCount = fheroes2::AGG::GetICNCount( spellICN );
+    const uint32_t spriteCount = Assets::getImageCount( spellICN );
 
     cursor.SetThemes( Cursor::WAR_POINTER );
     AudioManager::PlaySound( spellSound );
@@ -6205,7 +6205,7 @@ void Battle::Interface::_redrawRaySpell( const Unit & target, const int spellICN
 
         if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_DISRUPTING_DELAY ) ) {
             const uint32_t frame = static_cast<uint32_t>( i * spriteCount / path.size() ); // it's safe to do such as i <= path.size()
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( spellICN, frame );
+            const fheroes2::Sprite & sprite = Assets::getImage( spellICN, frame );
             fheroes2::Blit( sprite, _mainSurface, path[i].x - sprite.width() / 2, path[i].y - sprite.height() / 2 );
             RedrawPartialFinish();
             ++i;
@@ -6223,7 +6223,7 @@ void Battle::Interface::_redrawActionDisruptingRaySpell( Unit & target )
     target.SwitchAnimation( Monster_Info::STAND_STILL );
 
     // Part 2 - ripple effect
-    const fheroes2::Sprite & unitSprite = fheroes2::AGG::GetICN( target.GetMonsterSprite(), target.GetFrame() );
+    const fheroes2::Sprite & unitSprite = Assets::getImage( target.GetMonsterSprite(), target.GetFrame() );
     fheroes2::Sprite rippleSprite;
     _spriteInsteadCurrentUnit = &rippleSprite;
 
@@ -6373,15 +6373,15 @@ void Battle::Interface::_redrawActionColdRingSpell( const int32_t dst, const Tar
 
     Game::passAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY );
 
-    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < fheroes2::AGG::GetICNCount( icn ) ) {
+    while ( le.HandleEvents( Game::isDelayNeeded( allDelays ) ) && frame < Assets::getImageCount( icn ) ) {
         _checkGlobalEvents( le );
 
         if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             RedrawPartialStart();
 
-            const fheroes2::Sprite & sprite1 = fheroes2::AGG::GetICN( icn, frame );
+            const fheroes2::Sprite & sprite1 = Assets::getImage( icn, frame );
             fheroes2::Blit( sprite1, _mainSurface, center.x + center.width / 2 + sprite1.x(), center.y + center.height / 2 + sprite1.y() );
-            const fheroes2::Sprite & sprite2 = fheroes2::AGG::GetICN( icn, frame );
+            const fheroes2::Sprite & sprite2 = Assets::getImage( icn, frame );
             fheroes2::Blit( sprite2, _mainSurface, center.x + center.width / 2 - sprite2.width() - sprite2.x(), center.y + center.height / 2 + sprite2.y(), true );
             RedrawPartialFinish();
 
@@ -6490,12 +6490,12 @@ void Battle::Interface::_redrawActionElementalStormSpell( const TargetsInfo & ta
     const int icn = ICN::STORM;
     const int m82 = M82::FromSpell( Spell::ELEMENTALSTORM );
     const int spriteSize = 54;
-    const uint32_t icnCount = fheroes2::AGG::GetICNCount( icn );
+    const uint32_t icnCount = Assets::getImageCount( icn );
 
     std::vector<fheroes2::Sprite> spriteCache;
     spriteCache.reserve( icnCount );
     for ( uint32_t i = 0; i < icnCount; ++i ) {
-        spriteCache.push_back( fheroes2::AGG::GetICN( icn, i ) );
+        spriteCache.push_back( Assets::getImage( icn, i ) );
     }
 
     Cursor::Get().SetThemes( Cursor::WAR_POINTER );
@@ -6679,7 +6679,7 @@ void Battle::Interface::redrawActionEarthquakeSpellPart1( const HeroBase & caste
 
     // Draw buildings demolition clouds.
     const int icn = ICN::LICHCLOD;
-    const uint32_t maxFrame = fheroes2::AGG::GetICNCount( icn ) / 2;
+    const uint32_t maxFrame = Assets::getImageCount( icn ) / 2;
     frame = 0;
 
     AudioManager::PlaySound( M82::CATSND02 );
@@ -6706,11 +6706,11 @@ void Battle::Interface::redrawActionEarthquakeSpellPart1( const HeroBase & caste
 
                 if ( target == CastleDefenseStructure::BRIDGE && frame >= bridgeDestroySmokeDelay ) {
                     // When a bridge is demolished, there is one additional smoke explosion at the point where the bridge falls.
-                    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, frame - bridgeDestroySmokeDelay );
+                    const fheroes2::Sprite & sprite = Assets::getImage( icn, frame - bridgeDestroySmokeDelay );
                     fheroes2::Blit( sprite, _mainSurface, pt2.x + bridgeDestroySmokeOffset.x + sprite.x(), pt2.y + bridgeDestroySmokeOffset.y + sprite.y() );
                 }
 
-                const fheroes2::Sprite & spriteCloud = fheroes2::AGG::GetICN( icn, frame );
+                const fheroes2::Sprite & spriteCloud = Assets::getImage( icn, frame );
                 fheroes2::Blit( spriteCloud, _mainSurface, pt2.x + spriteCloud.x(), pt2.y + spriteCloud.y() );
             }
 
@@ -6729,7 +6729,7 @@ void Battle::Interface::redrawActionEarthquakeSpellPart2( const std::vector<Cast
 
     LocalEvent & le = LocalEvent::Get();
     const int icn = ICN::LICHCLOD;
-    uint32_t maxFrame = fheroes2::AGG::GetICNCount( icn );
+    uint32_t maxFrame = Assets::getImageCount( icn );
     uint32_t frame = maxFrame / 2;
 
     const bool isBridgeDestroyed
@@ -6757,11 +6757,11 @@ void Battle::Interface::redrawActionEarthquakeSpellPart2( const std::vector<Cast
 
                 if ( target == CastleDefenseStructure::BRIDGE ) {
                     // When a bridge is demolished, there is one additional smoke explosion at the point where the bridge falls.
-                    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, frame - bridgeDestroySmokeDelay + 1 );
+                    const fheroes2::Sprite & sprite = Assets::getImage( icn, frame - bridgeDestroySmokeDelay + 1 );
                     fheroes2::Blit( sprite, _mainSurface, pt2.x + bridgeDestroySmokeOffset.x + sprite.x(), pt2.y + bridgeDestroySmokeOffset.y + sprite.y() );
                 }
 
-                const fheroes2::Sprite & spriteCloud = fheroes2::AGG::GetICN( icn, frame );
+                const fheroes2::Sprite & spriteCloud = Assets::getImage( icn, frame );
                 fheroes2::Blit( spriteCloud, _mainSurface, pt2.x + spriteCloud.x(), pt2.y + spriteCloud.y() );
             }
 
@@ -6828,7 +6828,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const int32_t dst, cons
 
     AudioManager::PlaySound( m82 );
 
-    uint32_t frameCount = fheroes2::AGG::GetICNCount( icn );
+    uint32_t frameCount = Assets::getImageCount( icn );
 
     const std::vector<Game::DelayType> allDelays = _mergeWithCommonAnimationsDelays( { Game::DelayType::BATTLE_SPELL_DELAY } );
 
@@ -6840,7 +6840,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const int32_t dst, cons
         if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             RedrawPartialStart();
 
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, frame );
+            const fheroes2::Sprite & sprite = Assets::getImage( icn, frame );
             fheroes2::Blit( sprite, _mainSurface, center.x + center.width / 2 + sprite.x(), center.y + center.height / 2 + sprite.y() );
             RedrawPartialFinish();
 
@@ -6928,7 +6928,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const TargetsInfo & tar
     size_t overlaySpriteCount = _unitSpellEffectInfos.size();
     _unitSpellEffectInfos.reserve( overlaySpriteCount + targets.size() );
 
-    const fheroes2::Sprite & initialSpellSprite = fheroes2::AGG::GetICN( icn, 0 );
+    const fheroes2::Sprite & initialSpellSprite = Assets::getImage( icn, 0 );
 
     for ( const Battle::TargetInfo & target : targets ) {
         if ( target.defender ) {
@@ -6943,7 +6943,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const TargetsInfo & tar
 
     // Set the defender wince animation state.
     bool isDefenderAnimating = wnce;
-    const uint32_t maxFrame = fheroes2::AGG::GetICNCount( icn );
+    const uint32_t maxFrame = Assets::getImageCount( icn );
     uint32_t frame = 0;
 
     // Wait for previously set and not passed delays before rendering a new frame.
@@ -6959,7 +6959,7 @@ void Battle::Interface::RedrawTargetsWithFrameAnimation( const TargetsInfo & tar
         if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             if ( frame < maxFrame ) {
                 std::vector<Battle::UnitSpellEffectInfo>::iterator overlaySpriteIter = overlaySpriteBegin;
-                const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( icn, frame );
+                const fheroes2::Sprite & spellSprite = Assets::getImage( icn, frame );
 
                 for ( const Battle::TargetInfo & target : targets ) {
                     if ( target.defender ) {
@@ -7053,12 +7053,12 @@ void Battle::Interface::RedrawTroopWithFrameAnimation( Unit & unit, const int ic
 
     UnitSpellEffectInfo & unitSpellEffectInfo = _unitSpellEffectInfos.back();
     // Set position for the initial spell sprite.
-    unitSpellEffectInfo.position = CalculateSpellPosition( unit, icn, fheroes2::AGG::GetICN( icn, 0 ) );
+    unitSpellEffectInfo.position = CalculateSpellPosition( unit, icn, Assets::getImage( icn, 0 ) );
 
     // Wait for previously set and not passed delays before rendering a new frame.
     WaitForAllActionDelays();
 
-    const uint32_t maxICNFrame = fheroes2::AGG::GetICNCount( icn );
+    const uint32_t maxICNFrame = Assets::getImageCount( icn );
 
     AudioManager::PlaySound( m82 );
 
@@ -7069,7 +7069,7 @@ void Battle::Interface::RedrawTroopWithFrameAnimation( Unit & unit, const int ic
 
         if ( Game::validateAnimationDelay( Game::DelayType::BATTLE_SPELL_DELAY ) ) {
             if ( frame < maxICNFrame ) {
-                unitSpellEffectInfo.position = CalculateSpellPosition( unit, icn, fheroes2::AGG::GetICN( icn, frame ) );
+                unitSpellEffectInfo.position = CalculateSpellPosition( unit, icn, Assets::getImage( icn, frame ) );
                 unitSpellEffectInfo.icnIndex = frame;
             }
 
@@ -7471,7 +7471,7 @@ void Battle::PopupDamageInfo::_makeDamageImage()
     const bool isLeftSidePopup = ( unitRect.x + unitRect.width + w ) > _battleUIRect.width;
     const fheroes2::Rect borderRect( isLeftSidePopup ? ( x - w - unitRect.width - borderWidth ) : x, y, w, h );
 
-    const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( ICN::CELLWIN, 1 );
+    const fheroes2::Sprite & backgroundImage = Assets::getImage( ICN::CELLWIN, 1 );
 
     _damageImage = fheroes2::Stretch( backgroundImage, 0, 0, backgroundImage.width(), backgroundImage.height(), borderRect.width, borderRect.height );
     _damageImage.setPosition( borderRect.x, borderRect.y );

--- a/src/fheroes2/battle/battle_interface.cpp
+++ b/src/fheroes2/battle/battle_interface.cpp
@@ -3983,7 +3983,7 @@ void Battle::Interface::RedrawMissileAnimation( const fheroes2::Point & startPos
     }
     else {
         missile = Assets::getImage( static_cast<int>( Monster::GetMissileICN( monsterID ) ),
-                                         static_cast<uint32_t>( Bin_Info::GetMonsterInfo( monsterID ).getProjectileID( angle ) ) );
+                                    static_cast<uint32_t>( Bin_Info::GetMonsterInfo( monsterID ).getProjectileID( angle ) ) );
 
         // The projectile has to hit the target but not go through it so its end position is shifted in the direction to the shooter.
         endPosShift.x = reverse ? ( missile.width() / 2 ) : -( missile.width() / 2 );

--- a/src/fheroes2/battle/battle_interface_settings.cpp
+++ b/src/fheroes2/battle/battle_interface_settings.cpp
@@ -24,9 +24,9 @@
 #include <cstdint>
 #include <string>
 
-#include "agg_image.h"
 #include "battle_cell.h"
 #include "cursor.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -58,7 +58,7 @@ namespace
     void drawTurnOrder( const fheroes2::Rect & optionRoi, const bool isTurnOrderInsideWindow )
     {
         const auto state = Settings::Get().getBattleTurnOrderState();
-        const fheroes2::Sprite & turnOrderIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, state == BattleTurnOrderState::OFF ? 3 : 4 );
+        const fheroes2::Sprite & turnOrderIcon = Assets::getImage( ICN::CSPANEL, state == BattleTurnOrderState::OFF ? 3 : 4 );
 
         std::string description;
         switch ( state ) {
@@ -82,14 +82,14 @@ namespace
     void drawGrid( const fheroes2::Rect & optionRoi )
     {
         const bool isShowBattleGridEnabled = Settings::Get().BattleShowGrid();
-        const fheroes2::Sprite & battleGridIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowBattleGridEnabled ? 9 : 8 );
+        const fheroes2::Sprite & battleGridIcon = Assets::getImage( ICN::CSPANEL, isShowBattleGridEnabled ? 9 : 8 );
         fheroes2::drawOption( optionRoi, battleGridIcon, _( "Grid" ), isShowBattleGridEnabled ? _( "On" ) : _( "Off" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 
     void drawDamageInfo( const fheroes2::Rect & optionRoi )
     {
         const bool isShowBattleDamageInfoEnabled = Settings::Get().isBattleShowDamageInfoEnabled();
-        const fheroes2::Sprite & damageInfoIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowBattleDamageInfoEnabled ? 4 : 3 );
+        const fheroes2::Sprite & damageInfoIcon = Assets::getImage( ICN::CSPANEL, isShowBattleDamageInfoEnabled ? 4 : 3 );
         fheroes2::drawOption( optionRoi, damageInfoIcon, _( "Damage Info" ), isShowBattleDamageInfoEnabled ? _( "On" ) : _( "Off" ),
                               fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
@@ -97,7 +97,7 @@ namespace
     void drawShadowMovement( const fheroes2::Rect & optionRoi )
     {
         const bool isShowMoveShadowEnabled = Settings::Get().BattleShowMoveShadow();
-        const fheroes2::Sprite & moveShadowIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowMoveShadowEnabled ? 11 : 10 );
+        const fheroes2::Sprite & moveShadowIcon = Assets::getImage( ICN::CSPANEL, isShowMoveShadowEnabled ? 11 : 10 );
         fheroes2::drawOption( optionRoi, moveShadowIcon, _( "Shadow Movement" ), isShowMoveShadowEnabled ? _( "On" ) : _( "Off" ),
                               fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
@@ -105,7 +105,7 @@ namespace
     void drawShadowCursor( const fheroes2::Rect & optionRoi )
     {
         const bool isShowMouseShadowEnabled = Settings::Get().BattleShowMouseShadow();
-        const fheroes2::Sprite & mouseShadowIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, isShowMouseShadowEnabled ? 13 : 12 );
+        const fheroes2::Sprite & mouseShadowIcon = Assets::getImage( ICN::CSPANEL, isShowMouseShadowEnabled ? 13 : 12 );
         fheroes2::drawOption( optionRoi, mouseShadowIcon, _( "Shadow Cursor" ), isShowMouseShadowEnabled ? _( "On" ) : _( "Off" ),
                               fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
@@ -138,7 +138,7 @@ namespace
     {
         const bool isMovementAreaEnabled = Settings::Get().isBattleMovementAreaHighlightEnabled();
 
-        fheroes2::Sprite image = fheroes2::AGG::GetICN( ICN::EMPTY_OPTION_ICON_BACKGROUND, 0 );
+        fheroes2::Sprite image = Assets::getImage( ICN::EMPTY_OPTION_ICON_BACKGROUND, 0 );
 
         if ( isMovementAreaEnabled ) {
             // Render the shadow area.
@@ -147,13 +147,13 @@ namespace
         }
 
         // Draw Hydra.
-        const auto & hydraIcon = fheroes2::AGG::GetICN( ICN::MONS32, 34 );
+        const auto & hydraIcon = Assets::getImage( ICN::MONS32, 34 );
         fheroes2::Blit( hydraIcon, 0, 0, image, ( image.width() - hydraIcon.width() ) / 2, ( image.height() - hydraIcon.height() ) / 2, hydraIcon.width(),
                         hydraIcon.height() );
 
         if ( isMovementAreaEnabled ) {
             // Render a cursor.
-            const auto & cursor = fheroes2::AGG::GetICN( ICN::ADVMCO, 0 );
+            const auto & cursor = Assets::getImage( ICN::ADVMCO, 0 );
             fheroes2::Blit( cursor, 0, 0, image, ( image.width() - cursor.width() ) / 2 + 10, ( image.height() - cursor.height() ) / 2 + 15, cursor.width(),
                             cursor.height() );
         }

--- a/src/fheroes2/battle/battle_only.cpp
+++ b/src/fheroes2/battle/battle_only.cpp
@@ -31,7 +31,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army_bar.h"
 #include "army_troop.h"
 #include "battle.h"
@@ -39,6 +38,7 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "heroes_base.h"
@@ -91,7 +91,7 @@ namespace
 
     void prepareBackround( fheroes2::Image & output, const fheroes2::Point offset, const bool isEvilInterface )
     {
-        const auto & heroMeetingImage = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+        const auto & heroMeetingImage = Assets::getImage( ICN::SWAPWIN, 0 );
 
         // Render hero portrait area.
         for ( const fheroes2::Rect & area : heroPortraitArea ) {
@@ -123,7 +123,7 @@ namespace
 
     int32_t getMaxDefendingHeroAreaWidth()
     {
-        const fheroes2::Sprite & cell = fheroes2::AGG::GetICN( ICN::CELLWIN, 1 );
+        const fheroes2::Sprite & cell = Assets::getImage( ICN::CELLWIN, 1 );
         fheroes2::Text text( _( "Human" ), fheroes2::FontType::smallWhite() );
         text.fitToOneRow( defendingHeroTypeNameMaxWidth );
 
@@ -132,11 +132,11 @@ namespace
 
     void renderDefendingHeroTypeUI( const int heroType, const fheroes2::Point offset, const bool isEvilInterface, fheroes2::Image & output )
     {
-        const fheroes2::Sprite & cell = fheroes2::AGG::GetICN( ICN::CELLWIN, 1 );
+        const fheroes2::Sprite & cell = Assets::getImage( ICN::CELLWIN, 1 );
 
         fheroes2::Blit( cell, output, offset.x, offset.y );
         if ( ( heroType & CONTROL_HUMAN ) == CONTROL_HUMAN ) {
-            const fheroes2::Sprite & mark = fheroes2::AGG::GetICN( ICN::CELLWIN, 2 );
+            const fheroes2::Sprite & mark = Assets::getImage( ICN::CELLWIN, 2 );
             fheroes2::Blit( mark, output, offset.x + mark.x(), offset.y + mark.y() );
         }
 
@@ -165,7 +165,7 @@ namespace
 
         fheroes2::DrawRect( output, { offset.x, offset.y, terrainIconSize.width + 2, terrainIconSize.height + 2 }, 113 );
 
-        const auto & terrainSelectionSprite = fheroes2::AGG::GetTIL( TIL::GROUND32, imageIndex, 0 );
+        const auto & terrainSelectionSprite = Assets::getTileImage( TIL::GROUND32, imageIndex, 0 );
 
         fheroes2::Copy( terrainSelectionSprite, 0, 0, output, offset.x + 1, offset.y + 1, terrainIconSize.width, terrainIconSize.height );
         if ( terrainType == Maps::Ground::UNKNOWN ) {
@@ -356,9 +356,9 @@ bool Battle::Only::setup( const bool allowBackup, bool & resetBattleSetup )
     fheroes2::Button buttonStart( windowOffset.x + 178, windowOffset.y + buttonYOffset, buttonStartIcn, 0, 1 );
     fheroes2::Button buttonExit( windowOffset.x + 366, windowOffset.y + buttonYOffset, buttonExitIcn, 0, 1 );
 
-    fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonResetIcn, 0 ), display, buttonReset.area().getPosition(), shadowOffset );
-    fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonStartIcn, 0 ), display, buttonStart.area().getPosition(), shadowOffset );
-    fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonExitIcn, 0 ), display, buttonExit.area().getPosition(), shadowOffset );
+    fheroes2::addGradientShadow( Assets::getImage( buttonResetIcn, 0 ), display, buttonReset.area().getPosition(), shadowOffset );
+    fheroes2::addGradientShadow( Assets::getImage( buttonStartIcn, 0 ), display, buttonStart.area().getPosition(), shadowOffset );
+    fheroes2::addGradientShadow( Assets::getImage( buttonExitIcn, 0 ), display, buttonExit.area().getPosition(), shadowOffset );
 
     auto updateStartButton = [&buttonStart]( const Army & first, const Army & second ) {
         const bool isArmyValid = ( first.isValid() && second.isValid() );

--- a/src/fheroes2/battle/battle_troop.cpp
+++ b/src/fheroes2/battle/battle_troop.cpp
@@ -28,7 +28,6 @@
 #include <optional>
 #include <sstream>
 
-#include "agg_image.h"
 #include "army.h"
 #include "artifact.h"
 #include "artifact_info.h"
@@ -42,6 +41,7 @@
 #include "battle_tower.h"
 #include "castle.h"
 #include "color.h"
+#include "game_assets.h"
 #include "game_static.h"
 #include "heroes_base.h"
 #include "image.h"
@@ -1623,7 +1623,7 @@ fheroes2::Point Battle::Unit::GetBackPoint() const
 
 fheroes2::Point Battle::Unit::GetCenterPoint() const
 {
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( GetMonsterSprite(), GetFrame() );
+    const fheroes2::Sprite & sprite = Assets::getImage( GetMonsterSprite(), GetFrame() );
 
     const fheroes2::Rect & pos = _position.GetRect();
     const int32_t centerY = pos.y + pos.height + sprite.y() / 2 - 10;

--- a/src/fheroes2/castle/buildinginfo.cpp
+++ b/src/fheroes2/castle/buildinginfo.cpp
@@ -28,13 +28,13 @@
 #include <cassert>
 #include <utility>
 
-#include "agg_image.h"
 #include "army_troop.h"
 #include "audio_manager.h"
 #include "castle.h"
 #include "castle_building_info.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_static.h"
 #include "icn.h"
 #include "localevent.h"
@@ -238,7 +238,7 @@ BuildingInfo::BuildingInfo( const Castle & c, const BuildingType b )
 
     // fix area for captain
     if ( b == BUILD_CAPTAIN ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::getCaptainIcnId( castle.GetRace() ), ( _buildingType & BUILD_CAPTAIN ? 1 : 0 ) );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::getCaptainIcnId( castle.GetRace() ), ( _buildingType & BUILD_CAPTAIN ? 1 : 0 ) );
         area.width = sprite.width();
         area.height = sprite.height();
     }
@@ -318,29 +318,29 @@ void BuildingInfo::RedrawCaptain() const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
     if ( _status == BuildingStatus::ALREADY_BUILT ) {
-        const fheroes2::Sprite & captainSprite = fheroes2::AGG::GetICN( ICN::getCaptainIcnId( castle.GetRace() ), 1 );
-        const fheroes2::Sprite & flag = fheroes2::AGG::GetICN( ICN::getFlagIcnId( castle.GetColor() ), 0 );
+        const fheroes2::Sprite & captainSprite = Assets::getImage( ICN::getCaptainIcnId( castle.GetRace() ), 1 );
+        const fheroes2::Sprite & flag = Assets::getImage( ICN::getFlagIcnId( castle.GetColor() ), 0 );
 
         fheroes2::Blit( captainSprite, display, area.x, area.y );
         const fheroes2::Point flagOffset = GetFlagOffset( castle.GetRace() );
         fheroes2::Blit( flag, display, area.x + flagOffset.x, area.y + flagOffset.y );
     }
     else {
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::getCaptainIcnId( castle.GetRace() ), 0 ), display, area.x, area.y );
+        fheroes2::Blit( Assets::getImage( ICN::getCaptainIcnId( castle.GetRace() ), 0 ), display, area.x, area.y );
     }
 
     // indicator
     if ( _status == BuildingStatus::ALREADY_BUILT ) {
-        const fheroes2::Sprite & spriteAllow = fheroes2::AGG::GetICN( ICN::TOWNWIND, 11 );
+        const fheroes2::Sprite & spriteAllow = Assets::getImage( ICN::TOWNWIND, 11 );
         fheroes2::Blit( spriteAllow, display, area.x + 83 - 4 - spriteAllow.width(), area.y + 79 - 2 - spriteAllow.height() );
     }
     else if ( _status != BuildingStatus::ALLOW_BUILD ) {
         if ( BuildingStatus::LACK_RESOURCES == _status ) {
-            const fheroes2::Sprite & spriteMoney = fheroes2::AGG::GetICN( ICN::TOWNWIND, 13 );
+            const fheroes2::Sprite & spriteMoney = Assets::getImage( ICN::TOWNWIND, 13 );
             fheroes2::Blit( spriteMoney, display, area.x + 83 - 4 + 1 - spriteMoney.width(), area.y + 79 - 3 - spriteMoney.height() );
         }
         else {
-            const fheroes2::Sprite & spriteDeny = fheroes2::AGG::GetICN( ICN::TOWNWIND, 12 );
+            const fheroes2::Sprite & spriteDeny = Assets::getImage( ICN::TOWNWIND, 12 );
             fheroes2::Blit( spriteDeny, display, area.x + 83 - 4 + 1 - spriteDeny.width(), area.y + 79 - 2 - spriteDeny.height() );
         }
     }
@@ -356,7 +356,7 @@ void BuildingInfo::Redraw() const
     fheroes2::Display & display = fheroes2::Display::instance();
     const int index = fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) );
 
-    const fheroes2::Sprite & buildingFrame = fheroes2::AGG::GetICN( ICN::BLDGXTRA, 0 );
+    const fheroes2::Sprite & buildingFrame = Assets::getImage( ICN::BLDGXTRA, 0 );
     fheroes2::Blit( buildingFrame, display, area.x, area.y );
     if ( _status == BuildingStatus::BUILD_DISABLE || _status == BuildingStatus::SHIPYARD_NOT_ALLOWED ) {
         const fheroes2::Point offset( 6, 59 );
@@ -369,20 +369,20 @@ void BuildingInfo::Redraw() const
     // build image
     if ( BUILD_NOTHING == _buildingType ) {
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-        const fheroes2::Sprite & buildBackground = fheroes2::AGG::GetICN( isEvilInterface ? ICN::CASLXTRA_EVIL : ICN::CASLXTRA, 0 );
+        const fheroes2::Sprite & buildBackground = Assets::getImage( isEvilInterface ? ICN::CASLXTRA_EVIL : ICN::CASLXTRA, 0 );
         fheroes2::Copy( buildBackground, 0, 0, display, area.x, area.y, buildBackground.width(), buildBackground.height() );
         return;
     }
 
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::getBuildingIcnId( castle.GetRace() ), index ), display, area.x + 1, area.y + 1 );
+    fheroes2::Blit( Assets::getImage( ICN::getBuildingIcnId( castle.GetRace() ), index ), display, area.x + 1, area.y + 1 );
 
     // indicator
     if ( _status == BuildingStatus::ALREADY_BUILT ) {
-        const fheroes2::Sprite & spriteAllow = fheroes2::AGG::GetICN( ICN::TOWNWIND, 11 );
+        const fheroes2::Sprite & spriteAllow = Assets::getImage( ICN::TOWNWIND, 11 );
         fheroes2::Blit( spriteAllow, display, area.x + buildingFrame.width() - 5 - spriteAllow.width(), area.y + 58 - 2 - spriteAllow.height() );
     }
     else if ( _status == BuildingStatus::BUILD_DISABLE || _status == BuildingStatus::SHIPYARD_NOT_ALLOWED ) {
-        const fheroes2::Sprite & spriteDeny = fheroes2::AGG::GetICN( ICN::TOWNWIND, 12 );
+        const fheroes2::Sprite & spriteDeny = Assets::getImage( ICN::TOWNWIND, 12 );
         fheroes2::Sprite disabledSprite( spriteDeny );
         fheroes2::ApplyPalette( disabledSprite, PAL::GetPalette( PAL::PaletteType::GRAY ) );
         fheroes2::ApplyPalette( disabledSprite, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
@@ -390,19 +390,19 @@ void BuildingInfo::Redraw() const
     }
     else if ( _status != BuildingStatus::ALLOW_BUILD ) {
         if ( BuildingStatus::LACK_RESOURCES == _status ) {
-            const fheroes2::Sprite & spriteMoney = fheroes2::AGG::GetICN( ICN::TOWNWIND, 13 );
+            const fheroes2::Sprite & spriteMoney = Assets::getImage( ICN::TOWNWIND, 13 );
             fheroes2::Blit( spriteMoney, display, area.x + buildingFrame.width() - 5 + 1 - spriteMoney.width(), area.y + 58 - 3 - spriteMoney.height() );
         }
         else {
-            const fheroes2::Sprite & spriteDeny = fheroes2::AGG::GetICN( ICN::TOWNWIND, 12 );
+            const fheroes2::Sprite & spriteDeny = Assets::getImage( ICN::TOWNWIND, 12 );
             fheroes2::Blit( spriteDeny, display, area.x + buildingFrame.width() - 5 + 1 - spriteDeny.width(), area.y + 58 - 2 - spriteDeny.height() );
         }
 
-        const fheroes2::Sprite & textBackground = fheroes2::AGG::GetICN( ICN::CASLXTRA, 2 );
+        const fheroes2::Sprite & textBackground = Assets::getImage( ICN::CASLXTRA, 2 );
         fheroes2::Copy( textBackground, 0, 0, display, area.x, area.y + 58, textBackground.width(), textBackground.height() );
     }
     else {
-        const fheroes2::Sprite & textBackground = fheroes2::AGG::GetICN( ICN::CASLXTRA, 1 );
+        const fheroes2::Sprite & textBackground = Assets::getImage( ICN::CASLXTRA, 1 );
         fheroes2::Copy( textBackground, 0, 0, display, area.x, area.y + 58, textBackground.width(), textBackground.height() );
     }
 
@@ -473,7 +473,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
 
     Resource::BoxSprite rbs( PaymentConditions::BuyBuilding( castle.GetRace(), _buildingType ), fheroes2::boxAreaWidthPx );
 
-    const fheroes2::Sprite & buildingFrame = fheroes2::AGG::GetICN( ICN::BLDGXTRA, 0 );
+    const fheroes2::Sprite & buildingFrame = Assets::getImage( ICN::BLDGXTRA, 0 );
 
     const int32_t totalDialogHeight = elementOffset + buildingFrame.height() + elementOffset + descriptionText.height( fheroes2::boxAreaWidthPx ) + elementOffset
                                       + requirementHeight + rbs.GetArea().height;
@@ -487,7 +487,7 @@ bool BuildingInfo::DialogBuyBuilding( bool buttons ) const
     fheroes2::Blit( buildingFrame, display, pos.x, pos.y );
 
     const fheroes2::Sprite & buildingImage
-        = fheroes2::AGG::GetICN( ICN::getBuildingIcnId( castle.GetRace() ), fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) ) );
+        = Assets::getImage( ICN::getBuildingIcnId( castle.GetRace() ), fheroes2::getIndexBuildingSprite( static_cast<BuildingType>( _buildingType ) ) );
     pos.x = dialogRoi.x + ( dialogRoi.width - buildingImage.width() ) / 2;
     pos.y += 1;
     fheroes2::Blit( buildingImage, display, pos.x, pos.y );
@@ -660,11 +660,11 @@ void DwellingsBar::RedrawItem( DwellingItem & dwl, const fheroes2::Rect & pos, f
     const uint32_t dwType = castle.GetActualDwelling( dwl.dwType );
     const Monster mons{ castle.GetRace(), dwType };
 
-    const fheroes2::Sprite & mons32 = fheroes2::AGG::GetICN( ICN::MONS32, mons.GetSpriteIndex() );
+    const fheroes2::Sprite & mons32 = Assets::getImage( ICN::MONS32, mons.GetSpriteIndex() );
     fheroes2::Blit( mons32, dstsf, pos.x + ( pos.width - mons32.width() ) / 2, pos.y + ( pos.height - 3 - mons32.height() ) );
 
     if ( !castle.isBuild( dwType ) ) {
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CSLMARKER, 0 ), dstsf, pos.x + pos.width - 10, pos.y + 4 );
+        fheroes2::Blit( Assets::getImage( ICN::CSLMARKER, 0 ), dstsf, pos.x + pos.width - 10, pos.y + 4 );
 
         return;
     }

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/castle/captain.cpp
+++ b/src/fheroes2/castle/captain.cpp
@@ -25,10 +25,10 @@
 
 #include <cassert>
 
-#include "agg_image.h"
 #include "artifact.h"
 #include "artifact_info.h"
 #include "castle.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "interface_icons.h"
 #include "luck.h"
@@ -206,8 +206,8 @@ fheroes2::Sprite Captain::GetPortrait( const PortraitType type ) const
             return {};
         }
 
-        fheroes2::Sprite portrait = fheroes2::AGG::GetICN( portraitIcnId, 0 );
-        const fheroes2::Image & flag = fheroes2::AGG::GetICN( ICN::getFlagIcnId( GetColor() ), 0 );
+        fheroes2::Sprite portrait = Assets::getImage( portraitIcnId, 0 );
+        const fheroes2::Image & flag = Assets::getImage( ICN::getFlagIcnId( GetColor() ), 0 );
 
         const fheroes2::Point & offset = GetFlagOffset( GetRace() );
         fheroes2::Blit( flag, portrait, offset.x, offset.y );
@@ -217,17 +217,17 @@ fheroes2::Sprite Captain::GetPortrait( const PortraitType type ) const
     case PORT_SMALL:
         switch ( GetRace() ) {
         case Race::KNGT:
-            return fheroes2::AGG::GetICN( ICN::MINICAPT, 0 );
+            return Assets::getImage( ICN::MINICAPT, 0 );
         case Race::BARB:
-            return fheroes2::AGG::GetICN( ICN::MINICAPT, 1 );
+            return Assets::getImage( ICN::MINICAPT, 1 );
         case Race::SORC:
-            return fheroes2::AGG::GetICN( ICN::MINICAPT, 2 );
+            return Assets::getImage( ICN::MINICAPT, 2 );
         case Race::WRLK:
-            return fheroes2::AGG::GetICN( ICN::MINICAPT, 3 );
+            return Assets::getImage( ICN::MINICAPT, 3 );
         case Race::WZRD:
-            return fheroes2::AGG::GetICN( ICN::MINICAPT, 4 );
+            return Assets::getImage( ICN::MINICAPT, 4 );
         case Race::NECR:
-            return fheroes2::AGG::GetICN( ICN::MINICAPT, 5 );
+            return Assets::getImage( ICN::MINICAPT, 5 );
         default:
             break;
         }
@@ -238,7 +238,7 @@ fheroes2::Sprite Captain::GetPortrait( const PortraitType type ) const
 
     // We shouldn't even reach this code!
     assert( 0 );
-    return fheroes2::AGG::GetICN( -1, 0 );
+    return Assets::getImage( -1, 0 );
 }
 
 void Captain::PortraitRedraw( const int32_t px, const int32_t py, const PortraitType type, fheroes2::Image & dstsf ) const
@@ -252,7 +252,7 @@ void Captain::PortraitRedraw( const int32_t px, const int32_t py, const Portrait
         return;
     }
 
-    const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, getManaIndexSprite() );
+    const fheroes2::Sprite & mana = Assets::getImage( ICN::MANA, getManaIndexSprite() );
 
     const int iconWidth = Interface::IconsBar::getItemWidth();
     const int iconHeight = Interface::IconsBar::getItemHeight();

--- a/src/fheroes2/castle/castle.cpp
+++ b/src/fheroes2/castle/castle.cpp
@@ -29,7 +29,6 @@
 #include <iterator>
 #include <sstream>
 
-#include "agg_image.h"
 #include "ai_planner.h"
 #include "army_troop.h"
 #include "artifact.h"
@@ -41,6 +40,7 @@
 #include "difficulty.h"
 #include "direction.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_io.h"
 #include "game_static.h"
 #include "ground.h"
@@ -1363,14 +1363,14 @@ void Castle::DrawImageCastle( const fheroes2::Point & pt ) const
     }
 
     for ( uint32_t i = 0; i < 5; ++i ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTWBA, index + i );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::OBJNTWBA, index + i );
         dst_pt.x = pt.x + i * 32 + sprite.x();
         dst_pt.y = pt.y + 3 * 32 + sprite.y();
         fheroes2::Blit( sprite, display, dst_pt.x, dst_pt.y );
     }
 
     for ( uint32_t i = 0; i < 5; ++i ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTWBA, index + 5 + i );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::OBJNTWBA, index + 5 + i );
         dst_pt.x = pt.x + i * 32 + sprite.x();
         dst_pt.y = pt.y + 4 * 32 + sprite.y();
         fheroes2::Blit( sprite, display, dst_pt.x, dst_pt.y );
@@ -1401,24 +1401,24 @@ void Castle::DrawImageCastle( const fheroes2::Point & pt ) const
     }
     if ( !( BUILD_CASTLE & _constructedBuildings ) )
         index += 16;
-    const fheroes2::Sprite & sprite2 = fheroes2::AGG::GetICN( ICN::OBJNTOWN, index );
+    const fheroes2::Sprite & sprite2 = Assets::getImage( ICN::OBJNTOWN, index );
     dst_pt.x = pt.x + 2 * 32 + sprite2.x();
     dst_pt.y = pt.y + sprite2.y();
     fheroes2::Blit( sprite2, display, dst_pt.x, dst_pt.y );
     for ( uint32_t ii = 0; ii < 5; ++ii ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTOWN, index + 1 + ii );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::OBJNTOWN, index + 1 + ii );
         dst_pt.x = pt.x + ii * 32 + sprite.x();
         dst_pt.y = pt.y + 32 + sprite.y();
         fheroes2::Blit( sprite, display, dst_pt.x, dst_pt.y );
     }
     for ( uint32_t ii = 0; ii < 5; ++ii ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTOWN, index + 6 + ii );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::OBJNTOWN, index + 6 + ii );
         dst_pt.x = pt.x + ii * 32 + sprite.x();
         dst_pt.y = pt.y + 2 * 32 + sprite.y();
         fheroes2::Blit( sprite, display, dst_pt.x, dst_pt.y );
     }
     for ( uint32_t ii = 0; ii < 5; ++ii ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::OBJNTOWN, index + 11 + ii );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::OBJNTOWN, index + 11 + ii );
         dst_pt.x = pt.x + ii * 32 + sprite.x();
         dst_pt.y = pt.y + 3 * 32 + sprite.y();
         fheroes2::Blit( sprite, display, dst_pt.x, dst_pt.y );

--- a/src/fheroes2/castle/castle_building.cpp
+++ b/src/fheroes2/castle/castle_building.cpp
@@ -26,9 +26,9 @@
 #include <cstdint>
 #include <vector>
 
-#include "agg_image.h"
 #include "castle.h" // IWYU pragma: associated
 #include "castle_building_info.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "icn.h"
 #include "image.h"
@@ -66,7 +66,7 @@ namespace
 
     fheroes2::Rect CastleGetMaxArea( const Castle & castle, const fheroes2::Point & top )
     {
-        const fheroes2::Sprite & townbkg = fheroes2::AGG::GetICN( getTownIcnId( castle.GetRace() ), 0 );
+        const fheroes2::Sprite & townbkg = Assets::getImage( getTownIcnId( castle.GetRace() ), 0 );
 
         return { top.x, top.y, townbkg.width(), townbkg.height() };
     }
@@ -305,8 +305,8 @@ namespace
                 }
             }
             else if ( castleRace == Race::KNGT && !isBuildingFullyBuilt( castle, BUILD_CASTLE, buildingCurrentlyUnderConstruction ) ) {
-                const fheroes2::Sprite & rightFarm = fheroes2::AGG::GetICN( ICN::KNIGHT_CASTLE_RIGHT_FARM, 0 );
-                const fheroes2::Sprite & leftFarm = fheroes2::AGG::GetICN( ICN::KNIGHT_CASTLE_LEFT_FARM, 0 );
+                const fheroes2::Sprite & rightFarm = Assets::getImage( ICN::KNIGHT_CASTLE_RIGHT_FARM, 0 );
+                const fheroes2::Sprite & leftFarm = Assets::getImage( ICN::KNIGHT_CASTLE_LEFT_FARM, 0 );
                 fheroes2::drawCastleDialogBuilding( ICN::KNIGHT_CASTLE_LEFT_FARM, 0, castle, { offset.x + rightFarm.x() - leftFarm.width(), offset.y + rightFarm.y() },
                                                     roi, alpha );
             }
@@ -314,8 +314,8 @@ namespace
         else if ( building == BUILD_CAPTAIN ) {
             if ( castleRace == Race::BARB ) {
                 if ( !isBuildingFullyBuilt( castle, BUILD_CASTLE, buildingCurrentlyUnderConstruction ) ) {
-                    const fheroes2::Sprite & rightCaptainQuarters = fheroes2::AGG::GetICN( ICN::TWNBCAPT, 0 );
-                    const fheroes2::Sprite & leftCaptainQuarters = fheroes2::AGG::GetICN( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0 );
+                    const fheroes2::Sprite & rightCaptainQuarters = Assets::getImage( ICN::TWNBCAPT, 0 );
+                    const fheroes2::Sprite & leftCaptainQuarters = Assets::getImage( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0 );
                     fheroes2::drawCastleDialogBuilding( ICN::BARBARIAN_CASTLE_CAPTAIN_QUARTERS_LEFT_SIDE, 0, castle,
                                                         { offset.x + rightCaptainQuarters.x() - leftCaptainQuarters.width(), offset.y + rightCaptainQuarters.y() }, roi,
                                                         alpha );
@@ -334,13 +334,13 @@ namespace
 
         const int castleRace = castle.GetRace();
 
-        const fheroes2::Sprite & townbkg = fheroes2::AGG::GetICN( getTownIcnId( castleRace ), 0 );
+        const fheroes2::Sprite & townbkg = Assets::getImage( getTownIcnId( castleRace ), 0 );
         const fheroes2::Rect max( offset.x, offset.y, townbkg.width(), townbkg.height() );
         fheroes2::Copy( townbkg, 0, 0, display, offset.x, offset.y, max.width, max.height );
 
         if ( castleRace == Race::BARB ) {
             // Render the river animation for the Barbarian castle.
-            const fheroes2::Sprite & sprite0 = fheroes2::AGG::GetICN( ICN::TWNBEXT1, 1 + animationIndex % 5 );
+            const fheroes2::Sprite & sprite0 = Assets::getImage( ICN::TWNBEXT1, 1 + animationIndex % 5 );
             fheroes2::Blit( sprite0, display, offset.x + sprite0.x(), offset.y + sprite0.y() );
         }
 

--- a/src/fheroes2/castle/castle_dialog.cpp
+++ b/src/fheroes2/castle/castle_dialog.cpp
@@ -28,7 +28,6 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_bar.h"
 #include "army_troop.h"
@@ -41,6 +40,7 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
@@ -133,14 +133,14 @@ namespace
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 0 ), display, pt.x, pt.y + 256 );
+        fheroes2::Blit( Assets::getImage( ICN::STRIP, 0 ), display, pt.x, pt.y + 256 );
 
         if ( castle.isBuild( BUILD_CAPTAIN ) ) {
             const fheroes2::Sprite & captainImage = castle.GetCaptain().GetPortrait( PORT_BIG );
             fheroes2::Copy( captainImage, 0, 0, display, pt.x + 5, pt.y + 262, captainImage.width(), captainImage.height() );
         }
         else {
-            const fheroes2::Sprite & crestImage = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( castle.GetColor() ) );
+            const fheroes2::Sprite & crestImage = Assets::getImage( ICN::CREST, Color::GetIndex( castle.GetColor() ) );
             fheroes2::Copy( crestImage, 0, 0, display, pt.x + 5, pt.y + 262, crestImage.width(), crestImage.height() );
         }
 
@@ -148,8 +148,8 @@ namespace
             hero->PortraitRedraw( pt.x + 5, pt.y + 361, PORT_BIG, display );
         }
         else {
-            const fheroes2::Sprite & heroImage = fheroes2::AGG::GetICN( ICN::STRIP, 3 );
-            const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( ICN::STRIP, 11 );
+            const fheroes2::Sprite & heroImage = Assets::getImage( ICN::STRIP, 3 );
+            const fheroes2::Sprite & backgroundImage = Assets::getImage( ICN::STRIP, 11 );
             fheroes2::Copy( heroImage, 0, 0, display, pt.x + 5, pt.y + 361, heroImage.width(), heroImage.height() );
             fheroes2::Copy( backgroundImage, 0, 0, display, pt.x + 112, pt.y + 361, backgroundImage.width(), backgroundImage.height() );
         }
@@ -205,7 +205,7 @@ namespace
             image.reset();
         }
 
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::STRIP, 0 ), 0, 100, image, 0, 0, 552, 107 );
+        fheroes2::Blit( Assets::getImage( ICN::STRIP, 0 ), 0, 100, image, 0, 0, 552, 107 );
         const fheroes2::Sprite & port = hero->GetPortrait( PORT_BIG );
         fheroes2::Copy( port, 0, 0, image, 5, 5, port.width(), port.height() );
 
@@ -334,7 +334,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     statusBarPosition.x += buttonPrevCastle.area().width;
 
     // Status bar at the bottom of dialog.
-    const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::SMALLBAR, 0 );
+    const fheroes2::Sprite & bar = Assets::getImage( ICN::SMALLBAR, 0 );
     fheroes2::Copy( bar, 0, 0, display, statusBarPosition.x, statusBarPosition.y, bar.width(), bar.height() );
 
     StatusBar statusBar;
@@ -347,7 +347,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
     buttonNextCastle.subscribe( &timedButtonNextCastle );
 
     // Position of the captain/crest and hero portrait to the left of army bars.
-    const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( GetColor() ) );
+    const fheroes2::Sprite & crest = Assets::getImage( ICN::CREST, Color::GetIndex( GetColor() ) );
     const fheroes2::Rect rectSign1( dialogRoi.x + 5, dialogRoi.y + 262, crest.width(), crest.height() );
     const fheroes2::Rect rectSign2( rectSign1.x, dialogRoi.y + 361, 100, 92 );
 
@@ -835,7 +835,7 @@ Castle::CastleDialogReturnValue Castle::OpenDialog( const bool openConstructionW
         }
         else if ( fadeBuilding.getBuilding() == BUILD_CAPTAIN ) {
             // Fade-in the captain image while fading-in his quarters.
-            const fheroes2::Sprite & crestImage = fheroes2::AGG::GetICN( ICN::CREST, Color::GetIndex( GetColor() ) );
+            const fheroes2::Sprite & crestImage = Assets::getImage( ICN::CREST, Color::GetIndex( GetColor() ) );
             fheroes2::Copy( crestImage, 0, 0, display, rectSign1.x, rectSign1.y, crestImage.width(), crestImage.height() );
             const fheroes2::Sprite & captainImage = GetCaptain().GetPortrait( PORT_BIG );
             fheroes2::AlphaBlit( captainImage, display, rectSign1.x, rectSign1.y, fadeBuilding.getAlpha() );

--- a/src/fheroes2/castle/castle_mageguild.cpp
+++ b/src/fheroes2/castle/castle_mageguild.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/castle/castle_mageguild.cpp
+++ b/src/fheroes2/castle/castle_mageguild.cpp
@@ -25,10 +25,10 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "castle.h" // IWYU pragma: associated
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "icn.h"
@@ -69,7 +69,7 @@ Castle::MageGuildDialogResult Castle::_openMageGuild( const Heroes * hero ) cons
 
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
-    fheroes2::Blit( fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 ), display, dialogOffset.x, dialogOffset.y );
+    fheroes2::Blit( Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 ), display, dialogOffset.x, dialogOffset.y );
 
     // Create Previous Castle button.
     fheroes2::Button buttonPrevCastle( bottomUIOffset.x, bottomUIOffset.y, ICN::SMALLBAR, 1, 2 );
@@ -77,16 +77,16 @@ Castle::MageGuildDialogResult Castle::_openMageGuild( const Heroes * hero ) cons
     buttonPrevCastle.subscribe( &timedButtonPrevCastle );
 
     // Exit button.
-    const int32_t exitWidth = fheroes2::AGG::GetICN( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
+    const int32_t exitWidth = Assets::getImage( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
     fheroes2::Button buttonExit( bottomUIOffset.x + fheroes2::Display::DEFAULT_WIDTH - exitWidth, bottomUIOffset.y, ICN::BUTTON_GUILDWELL_EXIT, 0, 1 );
 
     // Create Next Castle button.
-    fheroes2::Button buttonNextCastle( buttonExit.area().x - fheroes2::AGG::GetICN( ICN::SMALLBAR, 3 ).width(), bottomUIOffset.y, ICN::SMALLBAR, 3, 4 );
+    fheroes2::Button buttonNextCastle( buttonExit.area().x - Assets::getImage( ICN::SMALLBAR, 3 ).width(), bottomUIOffset.y, ICN::SMALLBAR, 3, 4 );
     fheroes2::TimedEventValidator timedButtonNextCastle( [&buttonNextCastle]() { return buttonNextCastle.isPressed(); } );
     buttonNextCastle.subscribe( &timedButtonNextCastle );
 
     // Create the status bar UI element.
-    const fheroes2::Sprite & bottomBar = fheroes2::AGG::GetICN( ICN::SMALLBAR, 0 );
+    const fheroes2::Sprite & bottomBar = Assets::getImage( ICN::SMALLBAR, 0 );
     const int32_t barHeight = bottomBar.height();
     const fheroes2::Point bottonBarOffset{ buttonPrevCastle.area().x + buttonPrevCastle.area().width, bottomUIOffset.y };
     const int32_t bottomBarWidth{ fheroes2::Display::DEFAULT_WIDTH - exitWidth - buttonNextCastle.area().width - buttonPrevCastle.area().width };

--- a/src/fheroes2/castle/castle_town.cpp
+++ b/src/fheroes2/castle/castle_town.cpp
@@ -27,7 +27,6 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "army.h"
 #include "artifact.h"
 #include "buildinginfo.h"
@@ -35,6 +34,7 @@
 #include "castle.h" // IWYU pragma: associated
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "heroes_base.h"
@@ -76,7 +76,7 @@ int Castle::DialogBuyHero( const Heroes * hero ) const
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     const int32_t spacer = 10;
-    const fheroes2::Sprite & portrait_frame = fheroes2::AGG::GetICN( ICN::SURRENDR, 4 );
+    const fheroes2::Sprite & portrait_frame = Assets::getImage( ICN::SURRENDR, 4 );
 
     const fheroes2::Text recruitHeroText( _( "Recruit Hero" ), fheroes2::FontType::normalYellow() );
 
@@ -192,7 +192,7 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
     const Settings & conf = Settings::Get();
     const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
-    fheroes2::Blit( fheroes2::AGG::GetICN( isEvilInterface ? ICN::CASLWIND_EVIL : ICN::CASLWIND, 0 ), display, dst_pt.x, dst_pt.y );
+    fheroes2::Blit( Assets::getImage( isEvilInterface ? ICN::CASLWIND_EVIL : ICN::CASLWIND, 0 ), display, dst_pt.x, dst_pt.y );
 
     // hide captain options
     if ( !( _constructedBuildings & BUILD_CAPTAIN ) ) {
@@ -202,7 +202,7 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
         dst_pt.x += cur_pt.x;
         dst_pt.y += cur_pt.y;
 
-        const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+        const fheroes2::Sprite & backgroundImage = Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
         fheroes2::Copy( backgroundImage, rect.x, rect.y, display, dst_pt.x, dst_pt.y, rect.width, rect.height );
     }
 
@@ -337,8 +337,8 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
     buildingCaptain.Redraw();
 
     // combat format
-    const fheroes2::Sprite & spriteSpreadArmyFormat = fheroes2::AGG::GetICN( ICN::HSICONS, 9 );
-    const fheroes2::Sprite & spriteGroupedArmyFormat = fheroes2::AGG::GetICN( ICN::HSICONS, 10 );
+    const fheroes2::Sprite & spriteSpreadArmyFormat = Assets::getImage( ICN::HSICONS, 9 );
+    const fheroes2::Sprite & spriteGroupedArmyFormat = Assets::getImage( ICN::HSICONS, 10 );
     const fheroes2::Rect rectSpreadArmyFormat( cur_pt.x + 550, cur_pt.y + 220, spriteSpreadArmyFormat.width(), spriteSpreadArmyFormat.height() );
     const fheroes2::Rect rectGroupedArmyFormat( cur_pt.x + 585, cur_pt.y + 220, spriteGroupedArmyFormat.width(), spriteGroupedArmyFormat.height() );
     const std::string descriptionSpreadArmyFormat(
@@ -350,7 +350,7 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
     const fheroes2::Rect armyFormatRenderRect( pointSpreadArmyFormat, { rectGroupedArmyFormat.x + rectGroupedArmyFormat.width - pointSpreadArmyFormat.x + 1,
                                                                         rectGroupedArmyFormat.y + rectGroupedArmyFormat.height - pointSpreadArmyFormat.y + 1 } );
 
-    fheroes2::MovableSprite cursorFormat( fheroes2::AGG::GetICN( ICN::HSICONS, 11 ) );
+    fheroes2::MovableSprite cursorFormat( Assets::getImage( ICN::HSICONS, 11 ) );
 
     if ( isBuild( BUILD_CAPTAIN ) ) {
         const int32_t skillValueOffsetX = 90;
@@ -416,13 +416,13 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
         hero1->PortraitRedraw( dst_pt.x, dst_pt.y, PORT_BIG, display );
     }
     else {
-        const fheroes2::Sprite & noHeroBackgound = fheroes2::AGG::GetICN( ICN::STRIP, 3 );
+        const fheroes2::Sprite & noHeroBackgound = Assets::getImage( ICN::STRIP, 3 );
         fheroes2::Copy( noHeroBackgound, 0, 0, display, rectHero1.x, rectHero1.y, rectHero1.width, rectHero1.height );
     }
 
     // indicator
     if ( !allow_buy_hero1 ) {
-        const fheroes2::Sprite & spriteDeny = fheroes2::AGG::GetICN( ICN::TOWNWIND, 12 );
+        const fheroes2::Sprite & spriteDeny = Assets::getImage( ICN::TOWNWIND, 12 );
         fheroes2::Blit( spriteDeny, display, dst_pt.x + 102 - 4 + 1 - spriteDeny.width(), dst_pt.y + 93 - 2 - spriteDeny.height() );
     }
 
@@ -434,13 +434,13 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
         hero2->PortraitRedraw( dst_pt.x, dst_pt.y, PORT_BIG, display );
     }
     else {
-        const fheroes2::Sprite & noHeroBackgound = fheroes2::AGG::GetICN( ICN::STRIP, 3 );
+        const fheroes2::Sprite & noHeroBackgound = Assets::getImage( ICN::STRIP, 3 );
         fheroes2::Copy( noHeroBackgound, 0, 0, display, rectHero2.x, rectHero2.y, rectHero2.width, rectHero2.height );
     }
 
     // indicator
     if ( !allow_buy_hero2 ) {
-        const fheroes2::Sprite & spriteDeny = fheroes2::AGG::GetICN( ICN::TOWNWIND, 12 );
+        const fheroes2::Sprite & spriteDeny = Assets::getImage( ICN::TOWNWIND, 12 );
         fheroes2::Blit( spriteDeny, display, dst_pt.x + 102 - 4 + 1 - spriteDeny.width(), dst_pt.y + 93 - 2 - spriteDeny.height() );
     }
 
@@ -450,7 +450,7 @@ Castle::ConstructionDialogResult Castle::_openConstructionDialog( uint32_t & dwe
     buttonPrevCastle.subscribe( &timedButtonPrevCastle );
 
     // bottom small bar
-    const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::SMALLBAR, 0 );
+    const fheroes2::Sprite & bar = Assets::getImage( ICN::SMALLBAR, 0 );
     const int32_t statusBarWidth = bar.width();
     dst_pt.x = cur_pt.x + buttonPrevCastle.area().width;
     fheroes2::Copy( bar, 0, 0, display, dst_pt.x, dst_pt.y, statusBarWidth, bar.height() );

--- a/src/fheroes2/castle/castle_well.cpp
+++ b/src/fheroes2/castle/castle_well.cpp
@@ -30,13 +30,13 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_troop.h"
 #include "battle_cell.h"
 #include "castle.h" // IWYU pragma: associated
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
@@ -219,7 +219,7 @@ void Castle::_openWell()
     fheroes2::Button buttonMax( roi.x, buttonOffsetY, ICN::BUTTON_WELL_MAX, 0, 1 );
 
     // EXIT button.
-    fheroes2::Button buttonExit( roi.x + roi.width - fheroes2::AGG::GetICN( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width(), buttonOffsetY, ICN::BUTTON_GUILDWELL_EXIT, 0, 1 );
+    fheroes2::Button buttonExit( roi.x + roi.width - Assets::getImage( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width(), buttonOffsetY, ICN::BUTTON_GUILDWELL_EXIT, 0, 1 );
 
     const std::array<fheroes2::Rect, maxNumOfDwellings> rectMonster
         = { fheroes2::Rect( roi.x + 20, roi.y + 18, 288, 124 ),   fheroes2::Rect( roi.x + 20, roi.y + 168, 288, 124 ),
@@ -349,7 +349,7 @@ void Castle::_wellRedrawAvailableMonsters( const uint32_t dwellingType, const bo
 
     if ( restoreBackground ) {
         // Restore background under "Available: <number>" text.
-        const fheroes2::Sprite & wellBackground = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::WELLBKG_EVIL : ICN::WELLBKG, 0 );
+        const fheroes2::Sprite & wellBackground = Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::WELLBKG_EVIL : ICN::WELLBKG, 0 );
 
         fheroes2::Copy( wellBackground, offset.x, offset.y, background, offset.x, offset.y, 137, fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) );
     }
@@ -376,7 +376,7 @@ void Castle::_wellRedrawAvailableMonsters( const uint32_t dwellingType, const bo
 
 void Castle::_wellRedrawBackground( fheroes2::Image & background ) const
 {
-    const fheroes2::Sprite & wellBackground = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::WELLBKG_EVIL : ICN::WELLBKG, 0 );
+    const fheroes2::Sprite & wellBackground = Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::WELLBKG_EVIL : ICN::WELLBKG, 0 );
     const int32_t backgroundWidth = wellBackground.width();
 
     fheroes2::Copy( wellBackground, 0, 0, background, 0, 0, backgroundWidth, bottomBarOffsetY );
@@ -384,10 +384,10 @@ void Castle::_wellRedrawBackground( fheroes2::Image & background ) const
     // TODO: Make Well bottom bar and buttons for Evil interface.
 
     // The original ICN::WELLBKG image has incorrect bottom message bar with no yellow outline. Also the original graphics did not have MAX button.
-    const fheroes2::Sprite & bottomBar = fheroes2::AGG::GetICN( ICN::SMALLBAR, 0 );
+    const fheroes2::Sprite & bottomBar = Assets::getImage( ICN::SMALLBAR, 0 );
     const int32_t barHeight = bottomBar.height();
-    const int32_t exitWidth = fheroes2::AGG::GetICN( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
-    const int32_t buttonMaxWidth = fheroes2::AGG::GetICN( ICN::BUTTON_WELL_MAX, 0 ).width();
+    const int32_t exitWidth = Assets::getImage( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
+    const int32_t buttonMaxWidth = Assets::getImage( ICN::BUTTON_WELL_MAX, 0 ).width();
     // ICN::SMALLBAR image's first column contains all black pixels. This should not be drawn.
     fheroes2::Copy( bottomBar, 1, 0, background, buttonMaxWidth, bottomBarOffsetY, backgroundWidth / 2 - buttonMaxWidth, barHeight );
     fheroes2::Copy( bottomBar, bottomBar.width() - backgroundWidth / 2 + exitWidth - 1, 0, background, backgroundWidth / 2, bottomBarOffsetY,
@@ -443,7 +443,7 @@ void Castle::_wellRedrawBackground( fheroes2::Image & background ) const
 
         // Dwelling building image.
         fheroes2::Point renderPoint( offset.x + 21, offset.y + 35 );
-        const fheroes2::Sprite & dwellingImage = fheroes2::AGG::GetICN( ICN::getBuildingIcnId( _race ), icnIndex );
+        const fheroes2::Sprite & dwellingImage = Assets::getImage( ICN::getBuildingIcnId( _race ), icnIndex );
         fheroes2::Copy( dwellingImage, 0, 0, background, renderPoint.x, renderPoint.y, dwellingImage.width(), dwellingImage.height() );
 
         // Dwelling name.
@@ -585,7 +585,7 @@ void Castle::_wellRedrawMonsterAnimation( const fheroes2::Rect & roi, std::array
         // monster
         const bool flipMonsterSprite = ( monsterId > 2 );
 
-        const fheroes2::Sprite & smonster = fheroes2::AGG::GetICN( monsterAnimInfo[monsterId].icnFile(), monsterAnimInfo[monsterId].frameId() );
+        const fheroes2::Sprite & smonster = Assets::getImage( monsterAnimInfo[monsterId].icnFile(), monsterAnimInfo[monsterId].frameId() );
         if ( flipMonsterSprite ) {
             outPos.x += 193 - ( smonster.x() + smonster.width() ) + ( monster.isWide() ? Battle::Cell::widthPx / 2 : 0 ) + monsterAnimInfo[monsterId].offset();
         }

--- a/src/fheroes2/dialog/dialog_arena.cpp
+++ b/src/fheroes2/dialog/dialog_arena.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_arena.cpp
+++ b/src/fheroes2/dialog/dialog_arena.cpp
@@ -24,9 +24,9 @@
 #include <cstdint>
 #include <string>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -46,9 +46,9 @@ namespace
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::XPRIMARY, 0 ), display, rect1.x, rect1.y );
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::XPRIMARY, 1 ), display, rect2.x, rect2.y );
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::XPRIMARY, 2 ), display, rect3.x, rect3.y );
+        fheroes2::Blit( Assets::getImage( ICN::XPRIMARY, 0 ), display, rect1.x, rect1.y );
+        fheroes2::Blit( Assets::getImage( ICN::XPRIMARY, 1 ), display, rect2.x, rect2.y );
+        fheroes2::Blit( Assets::getImage( ICN::XPRIMARY, 2 ), display, rect3.x, rect3.y );
     }
 
     void InfoSkillSelect( int skill, const fheroes2::Rect & rect1, const fheroes2::Rect & rect2, const fheroes2::Rect & rect3 )
@@ -57,13 +57,13 @@ namespace
 
         switch ( skill ) {
         case Skill::Primary::ATTACK:
-            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::XPRIMARY, 4 ), display, rect1.x, rect1.y );
+            fheroes2::Blit( Assets::getImage( ICN::XPRIMARY, 4 ), display, rect1.x, rect1.y );
             break;
         case Skill::Primary::DEFENSE:
-            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::XPRIMARY, 5 ), display, rect2.x, rect2.y );
+            fheroes2::Blit( Assets::getImage( ICN::XPRIMARY, 5 ), display, rect2.x, rect2.y );
             break;
         case Skill::Primary::POWER:
-            fheroes2::Blit( fheroes2::AGG::GetICN( ICN::XPRIMARY, 6 ), display, rect3.x, rect3.y );
+            fheroes2::Blit( Assets::getImage( ICN::XPRIMARY, 6 ), display, rect3.x, rect3.y );
             break;
         default:
             break;
@@ -112,7 +112,7 @@ int Dialog::SelectSkillFromArena()
     fheroes2::Text textbox(
         _( "You enter the arena and face a pack of vicious lions. You handily defeat them, to the wild cheers of the crowd. Impressed by your skill, the aged trainer of gladiators agrees to train you in a skill of your choice." ),
         fheroes2::FontType::normalWhite() );
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::XPRIMARY, 0 );
+    const fheroes2::Sprite & sprite = Assets::getImage( ICN::XPRIMARY, 0 );
     const int spacer = 10;
 
     const Dialog::FrameBox box( title.height( fheroes2::boxAreaWidthPx ) + textbox.height( fheroes2::boxAreaWidthPx ) + 2 * spacer + sprite.height() + 15, true );
@@ -156,8 +156,8 @@ int Dialog::SelectSkillFromArena()
     text.draw( dst_pt.x, dst_pt.y + 2, skillTextWidth, display );
 
     // buttons
-    dst_pt.x = box_rt.x + ( box_rt.width - fheroes2::AGG::GetICN( system, 1 ).width() ) / 2;
-    dst_pt.y = box_rt.y + box_rt.height - fheroes2::AGG::GetICN( system, 1 ).height();
+    dst_pt.x = box_rt.x + ( box_rt.width - Assets::getImage( system, 1 ).width() ) / 2;
+    dst_pt.y = box_rt.y + box_rt.height - Assets::getImage( system, 1 ).height();
     fheroes2::Button buttonOk( dst_pt.x, dst_pt.y, system, 1, 2 );
 
     LocalEvent & le = LocalEvent::Get();

--- a/src/fheroes2/dialog/dialog_armyinfo.cpp
+++ b/src/fheroes2/dialog/dialog_armyinfo.cpp
@@ -31,12 +31,12 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army_troop.h"
 #include "battle.h"
 #include "battle_cell.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "icn.h"
@@ -288,40 +288,40 @@ namespace
     {
         switch ( mod ) {
         case Battle::SP_BLOODLUST:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 9 );
+            return Assets::getImage( ICN::SPELLINL, 9 );
         case Battle::SP_BLESS:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 3 );
+            return Assets::getImage( ICN::SPELLINL, 3 );
         case Battle::SP_HASTE:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 0 );
+            return Assets::getImage( ICN::SPELLINL, 0 );
         case Battle::SP_SHIELD:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 10 );
+            return Assets::getImage( ICN::SPELLINL, 10 );
         case Battle::SP_STONESKIN:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 13 );
+            return Assets::getImage( ICN::SPELLINL, 13 );
         case Battle::SP_DRAGONSLAYER:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 8 );
+            return Assets::getImage( ICN::SPELLINL, 8 );
         case Battle::SP_STEELSKIN:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 14 );
+            return Assets::getImage( ICN::SPELLINL, 14 );
         case Battle::SP_ANTIMAGIC:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 12 );
+            return Assets::getImage( ICN::SPELLINL, 12 );
         case Battle::SP_CURSE:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 4 );
+            return Assets::getImage( ICN::SPELLINL, 4 );
         case Battle::SP_SLOW:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 1 );
+            return Assets::getImage( ICN::SPELLINL, 1 );
         case Battle::SP_BERSERKER:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 5 );
+            return Assets::getImage( ICN::SPELLINL, 5 );
         case Battle::SP_HYPNOTIZE:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 7 );
+            return Assets::getImage( ICN::SPELLINL, 7 );
         case Battle::SP_BLIND:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 2 );
+            return Assets::getImage( ICN::SPELLINL, 2 );
         case Battle::SP_PARALYZE:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 6 );
+            return Assets::getImage( ICN::SPELLINL, 6 );
         case Battle::SP_STONE:
-            return fheroes2::AGG::GetICN( ICN::SPELLINL, 11 );
+            return Assets::getImage( ICN::SPELLINL, 11 );
         default:
             break;
         }
 
-        return fheroes2::AGG::GetICN( ICN::UNKNOWN, 0 );
+        return Assets::getImage( ICN::UNKNOWN, 0 );
     }
 
     std::vector<std::pair<fheroes2::Rect, Spell>> DrawBattleStats( const fheroes2::Point & dst, const Troop & b )
@@ -484,7 +484,7 @@ namespace
     void DrawMonster( fheroes2::RandomMonsterAnimation & monsterAnimation, const Troop & troop, const fheroes2::Point & offset, bool isReflected, bool isAnimated,
                       const fheroes2::Rect & roi )
     {
-        const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( monsterAnimation.icnFile(), monsterAnimation.frameId() );
+        const fheroes2::Sprite & monsterSprite = Assets::getImage( monsterAnimation.icnFile(), monsterAnimation.frameId() );
         fheroes2::Point monsterPos( offset.x, offset.y + monsterSprite.y() );
         if ( isReflected )
             monsterPos.x -= monsterSprite.x() - ( troop.isWide() ? Battle::Cell::widthPx / 2 : 0 ) - monsterAnimation.offset() + monsterSprite.width();
@@ -525,8 +525,8 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
     const int viewarmy = isEvilInterface ? ICN::VIEWARME : ICN::VIEWARMY;
-    const fheroes2::Sprite & sprite_dialog = fheroes2::AGG::GetICN( viewarmy, 0 );
-    const fheroes2::Sprite & spriteDialogShadow = fheroes2::AGG::GetICN( viewarmy, 7 );
+    const fheroes2::Sprite & sprite_dialog = Assets::getImage( viewarmy, 0 );
+    const fheroes2::Sprite & spriteDialogShadow = Assets::getImage( viewarmy, 7 );
 
     // setup cursor
     const CursorRestorer cursorRestorer( ( flags & BUTTONS ) != 0, Cursor::POINTER );
@@ -594,16 +594,16 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
     std::unique_ptr<fheroes2::Button> buttonDismiss;
 
     const int exitButtonIcnID = isEvilInterface ? ICN::BUTTON_SMALL_EXIT_EVIL : ICN::BUTTON_SMALL_EXIT_GOOD;
-    const int32_t exitWidth = fheroes2::AGG::GetICN( exitButtonIcnID, 0 ).width();
+    const int32_t exitWidth = Assets::getImage( exitButtonIcnID, 0 ).width();
     const int32_t interfaceAdjustment = isEvilInterface ? 0 : 18;
     fheroes2::Button buttonExit( pos_rt.x + sprite_dialog.width() - 58 - exitWidth + interfaceAdjustment, pos_rt.y + 221, exitButtonIcnID, 0, 1 );
-    fheroes2::addGradientShadow( fheroes2::AGG::GetICN( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
+    fheroes2::addGradientShadow( Assets::getImage( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
 
     if ( flags & UPGRADE ) {
         const int upgradeButtonIcnID = isEvilInterface ? ICN::BUTTON_SMALL_UPGRADE_EVIL : ICN::BUTTON_SMALL_UPGRADE_GOOD;
         const fheroes2::Point upgradeButtonPosition{ pos_rt.x + 280, pos_rt.y + 192 };
         buttonUpgrade = std::make_unique<fheroes2::Button>( upgradeButtonPosition.x, upgradeButtonPosition.y, upgradeButtonIcnID, 0, 1 );
-        fheroes2::addGradientShadow( fheroes2::AGG::GetICN( upgradeButtonIcnID, 0 ), display, upgradeButtonPosition, { -5, 5 } );
+        fheroes2::addGradientShadow( Assets::getImage( upgradeButtonIcnID, 0 ), display, upgradeButtonPosition, { -5, 5 } );
 
         buttonUpgrade->draw();
     }
@@ -612,7 +612,7 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
         const int dismissButtonIcnID = isEvilInterface ? ICN::BUTTON_SMALL_DISMISS_EVIL : ICN::BUTTON_SMALL_DISMISS_GOOD;
         const fheroes2::Point dismissButtonPosition{ pos_rt.x + 280, pos_rt.y + 221 };
         buttonDismiss = std::make_unique<fheroes2::Button>( dismissButtonPosition.x, dismissButtonPosition.y, dismissButtonIcnID, 0, 1 );
-        fheroes2::addGradientShadow( fheroes2::AGG::GetICN( dismissButtonIcnID, 0 ), display, dismissButtonPosition, { -5, 5 } );
+        fheroes2::addGradientShadow( Assets::getImage( dismissButtonIcnID, 0 ), display, dismissButtonPosition, { -5, 5 } );
 
         buttonDismiss->draw();
     }
@@ -699,17 +699,17 @@ int Dialog::ArmyInfo( const Troop & troop, int flags, bool isReflected, const in
             DrawMonster( monsterAnimation, troop, monsterOffset, isReflected, true, dialogRoi );
             // TODO: Remove these extra shadow drawings once the dialog has been reworked and proper restorers are in place.
             if ( buttonUpgrade ) {
-                fheroes2::addGradientShadow( fheroes2::AGG::GetICN( ICN::BUTTON_SMALL_UPGRADE_GOOD, 0 ), display, { pos_rt.x + 280, pos_rt.y + 192 }, { -5, 5 } );
+                fheroes2::addGradientShadow( Assets::getImage( ICN::BUTTON_SMALL_UPGRADE_GOOD, 0 ), display, { pos_rt.x + 280, pos_rt.y + 192 }, { -5, 5 } );
                 buttonUpgrade->draw();
             }
 
             if ( buttonDismiss ) {
-                fheroes2::addGradientShadow( fheroes2::AGG::GetICN( ICN::BUTTON_SMALL_DISMISS_GOOD, 0 ), display, { pos_rt.x + 280, pos_rt.y + 221 }, { -5, 5 } );
+                fheroes2::addGradientShadow( Assets::getImage( ICN::BUTTON_SMALL_DISMISS_GOOD, 0 ), display, { pos_rt.x + 280, pos_rt.y + 221 }, { -5, 5 } );
                 buttonDismiss->draw();
             }
 
             if ( buttonExit.isEnabled() ) {
-                fheroes2::addGradientShadow( fheroes2::AGG::GetICN( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
+                fheroes2::addGradientShadow( Assets::getImage( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
                 buttonExit.draw();
             }
 
@@ -760,7 +760,7 @@ int Dialog::ArmyJoinWithCost( const Troop & troop, const uint32_t join, const ui
 
     fheroes2::Text textbox( message, fheroes2::FontType::normalWhite() );
     const int buttons = Dialog::YES | Dialog::NO;
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::RESOURCE, 6 );
+    const fheroes2::Sprite & sprite = Assets::getImage( ICN::RESOURCE, 6 );
     int posy = 0;
 
     message = _( "(Rate: %{percent})" );

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2025                                             *
+ *   Copyright (C) 2022 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/dialog/dialog_audio.cpp
+++ b/src/fheroes2/dialog/dialog_audio.cpp
@@ -25,11 +25,11 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "cursor.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -53,7 +53,7 @@ namespace
 
         // Music volume.
         const bool isMusicOn = ( Audio::isValid() && conf.MusicVolume() > 0 );
-        const fheroes2::Sprite & musicVolumeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isMusicOn ? 1 : 0 );
+        const fheroes2::Sprite & musicVolumeIcon = Assets::getImage( ICN::SPANEL, isMusicOn ? 1 : 0 );
         std::string value;
         if ( isMusicOn ) {
             value = std::to_string( conf.MusicVolume() );
@@ -66,7 +66,7 @@ namespace
 
         // Sound volume.
         const bool isAudioOn = ( Audio::isValid() && conf.SoundVolume() > 0 );
-        const fheroes2::Sprite & soundVolumeOption = fheroes2::AGG::GetICN( ICN::SPANEL, isAudioOn ? 3 : 2 );
+        const fheroes2::Sprite & soundVolumeOption = Assets::getImage( ICN::SPANEL, isAudioOn ? 3 : 2 );
         if ( isAudioOn ) {
             value = std::to_string( conf.SoundVolume() );
         }
@@ -78,7 +78,7 @@ namespace
 
         // Music Type.
         const MusicSource musicType = conf.MusicType();
-        const fheroes2::Sprite & musicTypeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, musicType == MUSIC_EXTERNAL ? 11 : 10 );
+        const fheroes2::Sprite & musicTypeIcon = Assets::getImage( ICN::SPANEL, musicType == MUSIC_EXTERNAL ? 11 : 10 );
         if ( musicType == MUSIC_MIDI_ORIGINAL ) {
             value = _( "MIDI" );
         }
@@ -93,7 +93,7 @@ namespace
 
         // 3D Audio.
         const bool is3DAudioEnabled = conf.is3DAudioEnabled();
-        const fheroes2::Sprite & interfaceStateIcon = is3DAudioEnabled ? fheroes2::AGG::GetICN( ICN::SPANEL, 11 ) : fheroes2::AGG::GetICN( ICN::SPANEL, 10 );
+        const fheroes2::Sprite & interfaceStateIcon = is3DAudioEnabled ? Assets::getImage( ICN::SPANEL, 11 ) : Assets::getImage( ICN::SPANEL, 10 );
         if ( is3DAudioEnabled ) {
             value = _( "On" );
         }
@@ -126,7 +126,7 @@ namespace Dialog
 
         fheroes2::ImageRestorer emptyDialogRestorer( display, windowRoi.x, windowRoi.y, windowRoi.width, windowRoi.height );
 
-        const fheroes2::Sprite & optionSprite = fheroes2::AGG::GetICN( ICN::SPANEL, 0 );
+        const fheroes2::Sprite & optionSprite = Assets::getImage( ICN::SPANEL, 0 );
         const fheroes2::Point optionOffset( windowRoi.x + 53, windowRoi.y + 31 );
         const fheroes2::Point optionStep( 118, 110 );
 

--- a/src/fheroes2/dialog/dialog_box.cpp
+++ b/src/fheroes2/dialog/dialog_box.cpp
@@ -25,8 +25,8 @@
 #include <cstdint>
 #include <memory>
 
-#include "agg_image.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "screen.h"
@@ -41,13 +41,13 @@ namespace
 
     int32_t topHeight( const bool isEvilInterface )
     {
-        const fheroes2::Sprite & image = fheroes2::AGG::GetICN( isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD, 0 );
+        const fheroes2::Sprite & image = Assets::getImage( isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD, 0 );
         return image.height();
     }
 
     int32_t bottomHeight( const bool isEvilInterface )
     {
-        const fheroes2::Sprite & image = fheroes2::AGG::GetICN( isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD, 2 );
+        const fheroes2::Sprite & image = Assets::getImage( isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD, 2 );
         return image.height();
     }
 
@@ -55,9 +55,9 @@ namespace
     {
         const int icnId = isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD;
 
-        const fheroes2::Sprite & image4 = fheroes2::AGG::GetICN( icnId, 4 );
-        const fheroes2::Sprite & image5 = fheroes2::AGG::GetICN( icnId, 5 );
-        const fheroes2::Sprite & image6 = fheroes2::AGG::GetICN( icnId, 6 );
+        const fheroes2::Sprite & image4 = Assets::getImage( icnId, 4 );
+        const fheroes2::Sprite & image5 = Assets::getImage( icnId, 5 );
+        const fheroes2::Sprite & image6 = Assets::getImage( icnId, 6 );
 
         int32_t widthLeft = image4.width();
         widthLeft = std::max( widthLeft, image5.width() );
@@ -70,9 +70,9 @@ namespace
     {
         const int icnId = isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD;
 
-        const fheroes2::Sprite & image0 = fheroes2::AGG::GetICN( icnId, 0 );
-        const fheroes2::Sprite & image1 = fheroes2::AGG::GetICN( icnId, 1 );
-        const fheroes2::Sprite & image2 = fheroes2::AGG::GetICN( icnId, 2 );
+        const fheroes2::Sprite & image0 = Assets::getImage( icnId, 0 );
+        const fheroes2::Sprite & image1 = Assets::getImage( icnId, 1 );
+        const fheroes2::Sprite & image2 = Assets::getImage( icnId, 2 );
 
         int32_t widthRight = image0.width();
         widthRight = std::max( widthRight, image1.width() );
@@ -139,8 +139,8 @@ void Dialog::ResizableFrameBox::redraw()
 
     const int32_t overallLeftWidth = leftWidth( isEvilInterface );
 
-    const fheroes2::Sprite & rightTop = fheroes2::AGG::GetICN( buybuild, 0 );
-    const fheroes2::Sprite & leftTop = fheroes2::AGG::GetICN( buybuild, 4 );
+    const fheroes2::Sprite & rightTop = Assets::getImage( buybuild, 0 );
+    const fheroes2::Sprite & leftTop = Assets::getImage( buybuild, 4 );
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
@@ -154,10 +154,10 @@ void Dialog::ResizableFrameBox::redraw()
     for ( uint32_t i = 0; i < _middleFragmentCount; ++i ) {
         const int32_t chunkHeight = middleLeftHeight >= activeAreaHeight ? activeAreaHeight : middleLeftHeight;
 
-        const fheroes2::Sprite & leftMiddle = fheroes2::AGG::GetICN( buybuild, 5 );
+        const fheroes2::Sprite & leftMiddle = Assets::getImage( buybuild, 5 );
         fheroes2::Blit( leftMiddle, 0, 10, display, _position.x + overallLeftWidth - leftMiddle.width(), _position.y, leftMiddle.width(), chunkHeight );
 
-        const fheroes2::Sprite & rightMiddle = fheroes2::AGG::GetICN( buybuild, 1 );
+        const fheroes2::Sprite & rightMiddle = Assets::getImage( buybuild, 1 );
         fheroes2::Blit( rightMiddle, 0, 10, display, _position.x + overallLeftWidth, _position.y, rightMiddle.width(), chunkHeight );
 
         middleLeftHeight -= chunkHeight;
@@ -166,8 +166,8 @@ void Dialog::ResizableFrameBox::redraw()
 
     _position.y = posBeforeMiddle + _middleFragmentHeight;
 
-    const fheroes2::Sprite & rightBottom = fheroes2::AGG::GetICN( buybuild, 2 );
-    const fheroes2::Sprite & leftBottom = fheroes2::AGG::GetICN( buybuild, 6 );
+    const fheroes2::Sprite & rightBottom = Assets::getImage( buybuild, 2 );
+    const fheroes2::Sprite & leftBottom = Assets::getImage( buybuild, 6 );
 
     fheroes2::Blit( leftBottom, display, _position.x + overallLeftWidth - leftBottom.width(), _position.y );
     fheroes2::Blit( rightBottom, display, _position.x + overallLeftWidth, _position.y );

--- a/src/fheroes2/dialog/dialog_buyboat.cpp
+++ b/src/fheroes2/dialog/dialog_buyboat.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_buyboat.cpp
+++ b/src/fheroes2/dialog/dialog_buyboat.cpp
@@ -21,9 +21,9 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -44,7 +44,7 @@ int Dialog::BuyBoat( bool enable )
 
     Resource::BoxSprite rbs( PaymentConditions::BuyBoat(), fheroes2::boxAreaWidthPx );
 
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BOATWIND, 0 );
+    const fheroes2::Sprite & sprite = Assets::getImage( ICN::BOATWIND, 0 );
     fheroes2::Text text{ _( "Build a new ship:" ), fheroes2::FontType::normalWhite() };
     const int spacer = 10;
 

--- a/src/fheroes2/dialog/dialog_chest.cpp
+++ b/src/fheroes2/dialog/dialog_chest.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_chest.cpp
+++ b/src/fheroes2/dialog/dialog_chest.cpp
@@ -24,9 +24,9 @@
 #include <cstdint>
 #include <string>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "icn.h"
@@ -49,8 +49,8 @@ bool Dialog::SelectGoldOrExp( const std::string & header, const std::string & me
     // setup cursor
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const fheroes2::Sprite & sprite_gold = fheroes2::AGG::GetICN( ICN::RESOURCE, 6 );
-    const fheroes2::Sprite & sprite_expr = fheroes2::AGG::GetICN( ICN::EXPMRL, 4 );
+    const fheroes2::Sprite & sprite_gold = Assets::getImage( ICN::RESOURCE, 6 );
+    const fheroes2::Sprite & sprite_expr = Assets::getImage( ICN::EXPMRL, 4 );
 
     fheroes2::Text headerText( header, fheroes2::FontType::normalYellow() );
     fheroes2::Text messageText( message, fheroes2::FontType::normalWhite() );
@@ -67,7 +67,7 @@ bool Dialog::SelectGoldOrExp( const std::string & header, const std::string & me
     const int buttonYesIcnID = isEvilInterface ? ICN::BUTTON_SMALL_YES_EVIL : ICN::BUTTON_SMALL_YES_GOOD;
     const int buttonNoIcnID = isEvilInterface ? ICN::BUTTON_SMALL_NO_EVIL : ICN::BUTTON_SMALL_NO_GOOD;
 
-    const fheroes2::Sprite & buttonYesSprite = fheroes2::AGG::GetICN( buttonYesIcnID, 0 );
+    const fheroes2::Sprite & buttonYesSprite = Assets::getImage( buttonYesIcnID, 0 );
 
     const int32_t buttonsYPosition = box.GetArea().y + box.GetArea().height - buttonYesSprite.height();
     const int32_t buttonYesXPosition = box.GetArea().x + box.GetArea().width / 2 - buttonYesSprite.width() - 20;
@@ -100,7 +100,7 @@ bool Dialog::SelectGoldOrExp( const std::string & header, const std::string & me
     text.draw( pos.x + sprite_gold.width() / 2 - text.width() / 2, pos.y + 4, display );
 
     // sprite2
-    pos.x = buttonNoXPosition + ( ( fheroes2::AGG::GetICN( buttonNoIcnID, 0 ).width() - sprite_expr.width() ) / 2 );
+    pos.x = buttonNoXPosition + ( ( Assets::getImage( buttonNoIcnID, 0 ).width() - sprite_expr.width() ) / 2 );
     fheroes2::Blit( sprite_expr, display, pos.x, pos.y - sprite_expr.height() );
     // text
     text.set( std::to_string( expr ) + " (" + _( "Need: " ) + std::to_string( Heroes::GetExperienceFromLevel( hero.GetLevel() ) - hero.GetExperience() ) + ")",

--- a/src/fheroes2/dialog/dialog_frameborder.cpp
+++ b/src/fheroes2/dialog/dialog_frameborder.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2024                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_frameborder.cpp
+++ b/src/fheroes2/dialog/dialog_frameborder.cpp
@@ -23,8 +23,8 @@
 
 #include <cstdint>
 
-#include "agg_image.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "math_base.h"
@@ -64,7 +64,7 @@ void Dialog::FrameBorder::SetPosition( int32_t posx, int32_t posy, int32_t encw,
 
 void Dialog::FrameBorder::RenderRegular( const fheroes2::Rect & dstrt )
 {
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
+    const fheroes2::Sprite & sprite = Assets::getImage( ( Settings::Get().isEvilInterfaceEnabled() ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
     const fheroes2::Image renderedImage = fheroes2::Stretch( sprite, fheroes2::shadowWidthPx, 0, sprite.width() - fheroes2::shadowWidthPx,
                                                              sprite.height() - fheroes2::shadowWidthPx, dstrt.width, dstrt.height );
     fheroes2::Blit( renderedImage, fheroes2::Display::instance(), dstrt.x, dstrt.y );

--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -25,10 +25,10 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
 #include "difficulty.h"
+#include "game_assets.h"
 #include "game.h"
 #include "game_hotkeys.h"
 #include "game_over.h"
@@ -90,7 +90,7 @@ void Dialog::GameInfo()
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
     const bool isEvilInterface = conf.isEvilInterfaceEnabled();
-    const fheroes2::Sprite & window = fheroes2::AGG::GetICN( isEvilInterface ? ICN::SCENIBKG_EVIL : ICN::SCENIBKG, 0 );
+    const fheroes2::Sprite & window = Assets::getImage( isEvilInterface ? ICN::SCENIBKG_EVIL : ICN::SCENIBKG, 0 );
 
     const fheroes2::Point dialogOffset( ( display.width() - window.width() - DIALOG_SHADOW_OFFSET_X ) / 2, ( display.height() - window.height() ) / 2 );
     const fheroes2::Point shadowOffset( dialogOffset.x + DIALOG_SHADOW_OFFSET_X, dialogOffset.y + DIALOG_SHADOW_OFFSET_Y / 2 );
@@ -99,7 +99,7 @@ void Dialog::GameInfo()
 
     fheroes2::Blit( window, display, dialogOffset.x, shadowOffset.y );
 
-    const int32_t buttonAboutWidth = fheroes2::AGG::GetICN( ICN::BUTTON_MAP_ABOUT_GOOD, 0 ).width();
+    const int32_t buttonAboutWidth = Assets::getImage( ICN::BUTTON_MAP_ABOUT_GOOD, 0 ).width();
 
     fheroes2::Button buttonAbout( dialogOffset.x + 401 - buttonAboutWidth, dialogOffset.y + 36, isEvilInterface ? ICN::BUTTON_MAP_ABOUT_EVIL : ICN::BUTTON_MAP_ABOUT_GOOD,
                                   0, 1 );
@@ -196,7 +196,7 @@ void Dialog::GameInfo()
     conditionsText->draw( shadowOffset.x + CONDITION_DESCRIPTION_OFFSET, shadowOffset.y + 398, CONDITION_DESCRIPTION_WIDTH, display );
 
     const int buttonOkIcnId = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
-    fheroes2::Button buttonOk( shadowOffset.x + OK_BUTTON_OFFSET - fheroes2::AGG::GetICN( buttonOkIcnId, 0 ).width() / 2, shadowOffset.y + 426, buttonOkIcnId, 0, 1 );
+    fheroes2::Button buttonOk( shadowOffset.x + OK_BUTTON_OFFSET - Assets::getImage( buttonOkIcnId, 0 ).width() / 2, shadowOffset.y + 426, buttonOkIcnId, 0, 1 );
 
     buttonOk.draw();
 

--- a/src/fheroes2/dialog/dialog_gameinfo.cpp
+++ b/src/fheroes2/dialog/dialog_gameinfo.cpp
@@ -28,8 +28,8 @@
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
 #include "difficulty.h"
-#include "game_assets.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_over.h"
 #include "icn.h"

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2011 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -273,8 +273,8 @@ int Dialog::MakeGiftResource( Kingdom & kingdom )
                                                         Assets::getImage( okIcnId, 1 ), display ),
                         Dialog::OK );
     btnGroup.addButton( fheroes2::makeButtonWithShadow( box.x + box.width - border - buttonCancelSprite.width(),
-                                                        box.y + box.height - border - buttonCancelSprite.height(), buttonCancelSprite,
-                                                        Assets::getImage( cancelIcnId, 1 ), display ),
+                                                        box.y + box.height - border - buttonCancelSprite.height(), buttonCancelSprite, Assets::getImage( cancelIcnId, 1 ),
+                                                        display ),
                         Dialog::CANCEL );
     btnGroup.button( 0 ).disable();
 

--- a/src/fheroes2/dialog/dialog_giftresources.cpp
+++ b/src/fheroes2/dialog/dialog_giftresources.cpp
@@ -29,10 +29,10 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "kingdom.h"
@@ -89,7 +89,7 @@ namespace
             const fheroes2::Rect box( ( display.width() - giftDialogSize.width ) / 2, ( display.height() - giftDialogSize.height ) / 2, giftDialogSize.width,
                                       giftDialogSize.height );
 
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 43 );
+            const fheroes2::Sprite & sprite = Assets::getImage( ICN::CELLWIN, 43 );
             const int32_t colorCount = static_cast<int32_t>( colors.size() ); // safe to cast as the number of players <= 8.
             const int32_t playerContainerWidth = colorCount * sprite.width() + ( colorCount - 1 ) * recipientSpacing;
             const int32_t startX = box.x + ( giftDialogSize.width - playerContainerWidth ) / 2;
@@ -111,9 +111,9 @@ namespace
             for ( PlayerColorsVector::const_iterator it = colors.begin(); it != colors.end(); ++it ) {
                 const fheroes2::Rect & pos = positions[std::distance( colors.begin(), it )];
 
-                fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CELLWIN, 43 + Color::GetIndex( *it ) ), display, pos.x, pos.y );
+                fheroes2::Blit( Assets::getImage( ICN::CELLWIN, 43 + Color::GetIndex( *it ) ), display, pos.x, pos.y );
                 if ( recipients & *it ) {
-                    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::CELLWIN, 2 ), display, pos.x + 2, pos.y + 2 );
+                    fheroes2::Blit( Assets::getImage( ICN::CELLWIN, 2 ), display, pos.x + 2, pos.y + 2 );
                 }
             }
         }
@@ -148,7 +148,7 @@ namespace
             : resource( funds )
         {
             positions.reserve( 7 );
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
+            const fheroes2::Sprite & sprite = Assets::getImage( ICN::TRADPOST, 7 );
 
             positions.emplace_back( posx, posy, sprite.width(), sprite.height() );
             positions.emplace_back( posx + 40, posy, sprite.width(), sprite.height() );
@@ -163,7 +163,7 @@ namespace
         {
             fheroes2::Display & display = fheroes2::Display::instance();
             const fheroes2::Text text( std::to_string( count ), fheroes2::FontType::smallWhite() );
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 + Resource::getIconIcnIndex( type ) );
+            const fheroes2::Sprite & sprite = Assets::getImage( ICN::TRADPOST, 7 + Resource::getIconIcnIndex( type ) );
             fheroes2::Blit( sprite, display, posx, posy );
             text.draw( posx + ( sprite.width() - text.width() ) / 2, posy + sprite.height() - 10, display );
         }
@@ -242,7 +242,7 @@ int Dialog::MakeGiftResource( Kingdom & kingdom )
     Funds funds1( kingdom.GetFunds() );
     Funds funds2;
 
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::TRADPOST, 7 );
+    const fheroes2::Sprite & sprite = Assets::getImage( ICN::TRADPOST, 7 );
     const int32_t posX = box.x + ( giftDialogSize.width - ( sprite.width() + 240 ) ) / 2;
 
     const fheroes2::FontType normalWhite = fheroes2::FontType::normalWhite();
@@ -264,17 +264,17 @@ int Dialog::MakeGiftResource( Kingdom & kingdom )
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
     const int okIcnId = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
     const int cancelIcnId = isEvilInterface ? ICN::BUTTON_SMALL_CANCEL_EVIL : ICN::BUTTON_SMALL_CANCEL_GOOD;
-    const fheroes2::Sprite & buttonOkSprite = fheroes2::AGG::GetICN( okIcnId, 0 );
-    const fheroes2::Sprite & buttonCancelSprite = fheroes2::AGG::GetICN( cancelIcnId, 0 );
+    const fheroes2::Sprite & buttonOkSprite = Assets::getImage( okIcnId, 0 );
+    const fheroes2::Sprite & buttonCancelSprite = Assets::getImage( cancelIcnId, 0 );
 
     const int32_t border = 10;
     fheroes2::ButtonGroup btnGroup;
     btnGroup.addButton( fheroes2::makeButtonWithShadow( box.x + border, box.y + box.height - border - buttonOkSprite.height(), buttonOkSprite,
-                                                        fheroes2::AGG::GetICN( okIcnId, 1 ), display ),
+                                                        Assets::getImage( okIcnId, 1 ), display ),
                         Dialog::OK );
     btnGroup.addButton( fheroes2::makeButtonWithShadow( box.x + box.width - border - buttonCancelSprite.width(),
                                                         box.y + box.height - border - buttonCancelSprite.height(), buttonCancelSprite,
-                                                        fheroes2::AGG::GetICN( cancelIcnId, 1 ), display ),
+                                                        Assets::getImage( cancelIcnId, 1 ), display ),
                         Dialog::CANCEL );
     btnGroup.button( 0 ).disable();
 

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2025                                             *
+ *   Copyright (C) 2022 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -24,9 +24,9 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog_resolution.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -79,13 +79,13 @@ namespace
             resolutionName = std::to_string( display.width() ) + 'x' + std::to_string( display.height() );
         }
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::RESOLUTION_ICON, 0 ), _( "Resolution" ), std::move( resolutionName ),
+        fheroes2::drawOption( optionRoi, Assets::getImage( ICN::RESOLUTION_ICON, 0 ), _( "Resolution" ), std::move( resolutionName ),
                               fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 
     void drawMode( const fheroes2::Rect & optionRoi )
     {
-        const fheroes2::Sprite & originalIcon = fheroes2::AGG::GetICN( ICN::SPANEL, Settings::Get().isEvilInterfaceEnabled() ? 17 : 16 );
+        const fheroes2::Sprite & originalIcon = Assets::getImage( ICN::SPANEL, Settings::Get().isEvilInterfaceEnabled() ? 17 : 16 );
 
         if ( fheroes2::engine().isFullScreen() ) {
             fheroes2::Sprite icon = originalIcon;
@@ -102,7 +102,7 @@ namespace
     {
         const bool isVSyncEnabled = Settings::Get().isVSyncEnabled();
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "On" ) : _( "Off" ),
+        fheroes2::drawOption( optionRoi, Assets::getImage( ICN::SPANEL, isVSyncEnabled ? 18 : 19 ), _( "V-Sync" ), isVSyncEnabled ? _( "On" ) : _( "Off" ),
                               fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
     }
 
@@ -110,7 +110,7 @@ namespace
     {
         const bool isSystemInfoDisplayed = Settings::Get().isSystemInfoEnabled();
 
-        fheroes2::Sprite image = fheroes2::AGG::GetICN( ICN::EMPTY_OPTION_ICON_BACKGROUND, 0 );
+        fheroes2::Sprite image = Assets::getImage( ICN::EMPTY_OPTION_ICON_BACKGROUND, 0 );
         fheroes2::Text info;
         if ( isSystemInfoDisplayed ) {
             info.set( _( "FPS" ), fheroes2::FontType( fheroes2::FontSize::NORMAL, fheroes2::FontColor::YELLOW ) );
@@ -126,11 +126,11 @@ namespace
     void drawScreenScalingTypeOptions( const fheroes2::Rect & optionRoi, const bool isScreenScalingTypeNearest )
     {
         if ( isScreenScalingTypeNearest ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::GAME_OPTION_ICON, 3 ), _( "Screen Scaling Type" ), _( "Nearest" ),
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::GAME_OPTION_ICON, 3 ), _( "Screen Scaling Type" ), _( "Nearest" ),
                                   fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::GAME_OPTION_ICON, 2 ), _( "Screen Scaling Type" ), _( "Linear" ),
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::GAME_OPTION_ICON, 2 ), _( "Screen Scaling Type" ), _( "Linear" ),
                                   fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
     }

--- a/src/fheroes2/dialog/dialog_hotkeys.cpp
+++ b/src/fheroes2/dialog/dialog_hotkeys.cpp
@@ -28,9 +28,9 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -277,7 +277,7 @@ namespace fheroes2
         listbox.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, listRoi.y + 1 } );
         listbox.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, listRoi.y + listRoi.height - 15 } );
         listbox.setScrollBarArea( { scrollbarOffsetX + 2, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        listbox.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        listbox.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         listbox.SetAreaMaxItems( ( listRoi.height - 7 ) / fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) );
 
         std::vector<std::pair<Game::HotKeyEvent, Game::HotKeyCategory>> hotKeyEvents = Game::getAllHotKeyEvents();

--- a/src/fheroes2/dialog/dialog_interface_settings.cpp
+++ b/src/fheroes2/dialog/dialog_interface_settings.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2025                                             *
+ *   Copyright (C) 2023 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/dialog/dialog_interface_settings.cpp
+++ b/src/fheroes2/dialog/dialog_interface_settings.cpp
@@ -23,8 +23,8 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "cursor.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -67,7 +67,7 @@ namespace
         const bool isHiddenInterface = conf.isHideInterfaceEnabled();
         const bool isEvilInterface = conf.isEvilInterfaceEnabled();
         const fheroes2::Sprite & interfaceStateIcon
-            = isHiddenInterface ? fheroes2::AGG::GetICN( ICN::ESPANEL, 4 ) : fheroes2::AGG::GetICN( ICN::SPANEL, isEvilInterface ? 17 : 16 );
+            = isHiddenInterface ? Assets::getImage( ICN::ESPANEL, 4 ) : Assets::getImage( ICN::SPANEL, isEvilInterface ? 17 : 16 );
 
         std::string value;
         if ( isHiddenInterface ) {
@@ -84,7 +84,7 @@ namespace
     {
         const bool isArmyEstimationNumeric = Settings ::Get().isArmyEstimationViewNumeric();
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::ARMY_ESTIMATION_ICON, isArmyEstimationNumeric ? 1 : 0 ), _( "Army Estimation" ),
+        fheroes2::drawOption( optionRoi, Assets::getImage( ICN::ARMY_ESTIMATION_ICON, isArmyEstimationNumeric ? 1 : 0 ), _( "Army Estimation" ),
                               isArmyEstimationNumeric ? _( "Numeric" ) : _( "Canonical" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
 

--- a/src/fheroes2/dialog/dialog_language_selection.cpp
+++ b/src/fheroes2/dialog/dialog_language_selection.cpp
@@ -29,9 +29,9 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_language.h"
 #include "icn.h"
@@ -256,7 +256,7 @@ namespace
         listBox.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, listRoi.y + 1 } );
         listBox.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, listRoi.y + listRoi.height - 15 } );
         listBox.setScrollBarArea( { scrollbarOffsetX + 2, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        listBox.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        listBox.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         listBox.SetAreaMaxItems( ( listRoi.height - 7 ) / fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) );
         std::vector<fheroes2::SupportedLanguage> temp = languages;
         listBox.SetListContent( temp );

--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_levelup.cpp
+++ b/src/fheroes2/dialog/dialog_levelup.cpp
@@ -25,9 +25,9 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "icn.h"
@@ -106,7 +106,7 @@ namespace
         const int buttonLearnIcnID = isEvilInterface ? ICN::BUTTON_SMALL_LEARN_EVIL : ICN::BUTTON_SMALL_LEARN_GOOD;
 
         const fheroes2::Rect & dialogRoi = dialogFrame.GetArea();
-        const fheroes2::Sprite & buttonLearnImage = fheroes2::AGG::GetICN( buttonLearnIcnID, 0 );
+        const fheroes2::Sprite & buttonLearnImage = Assets::getImage( buttonLearnIcnID, 0 );
 
         fheroes2::Point offset;
         offset.x = dialogRoi.x + dialogRoi.width / 2 - buttonLearnImage.width() - 20;
@@ -142,7 +142,7 @@ namespace
 
         const int icnHeroes = isEvilInterface ? ICN::EVIL_ARMY_BUTTON : ICN::GOOD_ARMY_BUTTON;
         fheroes2::ButtonSprite buttonHero
-            = fheroes2::makeButtonWithBackground( offset.x, offset.y, fheroes2::AGG::GetICN( icnHeroes, 0 ), fheroes2::AGG::GetICN( icnHeroes, 1 ), display );
+            = fheroes2::makeButtonWithBackground( offset.x, offset.y, Assets::getImage( icnHeroes, 0 ), Assets::getImage( icnHeroes, 1 ), display );
 
         const fheroes2::Text text{ std::to_string( hero.GetSecondarySkills().Count() ) + "/" + std::to_string( Heroes::maxNumOfSecSkills ),
                                    fheroes2::FontType::normalWhite() };

--- a/src/fheroes2/dialog/dialog_marketplace.cpp
+++ b/src/fheroes2/dialog/dialog_marketplace.cpp
@@ -29,9 +29,9 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -98,15 +98,15 @@ namespace
             buttonLeft.setICNInfo( tradpostIcnId, 3, 4 );
             buttonRight.setICNInfo( tradpostIcnId, 5, 6 );
 
-            const fheroes2::Sprite & spriteGift = fheroes2::AGG::GetICN( giftButtonIcnID, 0 );
-            const fheroes2::Sprite & spriteTrade = fheroes2::AGG::GetICN( tradeButtonIcnID, 0 );
+            const fheroes2::Sprite & spriteGift = Assets::getImage( giftButtonIcnID, 0 );
+            const fheroes2::Sprite & spriteTrade = Assets::getImage( tradeButtonIcnID, 0 );
 
             buttonGift.setPosition( pos_rt.x - 68 + ( pos_rt.width - spriteGift.width() ) / 2, pos_rt.y + pos_rt.height - spriteGift.height() );
             buttonTrade.setPosition( pos_rt.x + ( pos_rt.width - spriteTrade.width() ) / 2, pos_rt.y + 150 );
             buttonLeft.setPosition( pos_rt.x + 11, pos_rt.y + 129 );
             buttonRight.setPosition( pos_rt.x + 220, pos_rt.y + 129 );
-            _scrollbar.setImage( fheroes2::AGG::GetICN( tradpostIcnId, 2 ) );
-            _scrollbar.setArea( { pos_rt.x + ( pos_rt.width - fheroes2::AGG::GetICN( tradpostIcnId, 1 ).width() ) / 2 + 22, pos_rt.y + 131, 187, 11 } );
+            _scrollbar.setImage( Assets::getImage( tradpostIcnId, 2 ) );
+            _scrollbar.setArea( { pos_rt.x + ( pos_rt.width - Assets::getImage( tradpostIcnId, 1 ).width() ) / 2 + 22, pos_rt.y + 131, 187, 11 } );
             _scrollbar.hide();
 
             const fheroes2::Text text( _( "Please inspect our fine wares. If you feel like offering a trade, click on the items you wish to trade with and for." ),
@@ -179,13 +179,13 @@ namespace
         else {
             back.restore();
 
-            const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( tradpostIcnId, 1 );
+            const fheroes2::Sprite & bar = Assets::getImage( tradpostIcnId, 1 );
             fheroes2::Point dst_pt( pos_rt.x + ( pos_rt.width - bar.width() ) / 2 - 2, pos_rt.y + 128 );
             fheroes2::Blit( bar, display, dst_pt.x, dst_pt.y );
 
             const uint32_t maximumValue = ( Resource::GOLD == resourceTo ) ? max_sell : max_buy;
 
-            const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( tradpostIcnId, 2 );
+            const fheroes2::Sprite & originalSlider = Assets::getImage( tradpostIcnId, 2 );
             fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, true, 187, 1, static_cast<int32_t>( maximumValue + 1 ),
                                                                                  { 0, 0, 2, originalSlider.height() }, { 2, 0, 8, originalSlider.height() } );
             _scrollbar.setImage( std::move( scrollbarSlider ) );
@@ -209,15 +209,15 @@ namespace
             const fheroes2::Text displayMessage( std::move( message ), fheroes2::FontType::normalWhite() );
             displayMessage.draw( pos_rt.x, pos_rt.y + 32, pos_rt.width, display );
 
-            const fheroes2::Sprite & sprite_from = fheroes2::AGG::GetICN( ICN::RESOURCE, Resource::getIconIcnIndex( resourceFrom ) );
+            const fheroes2::Sprite & sprite_from = Assets::getImage( ICN::RESOURCE, Resource::getIconIcnIndex( resourceFrom ) );
             dst_pt.x = pos_rt.x + ( pos_rt.width - sprite_from.width() + 1 ) / 2 - 70;
             dst_pt.y = pos_rt.y + 115 - sprite_from.height();
             fheroes2::Blit( sprite_from, display, dst_pt.x, dst_pt.y );
-            const fheroes2::Sprite & sprite_to = fheroes2::AGG::GetICN( ICN::RESOURCE, Resource::getIconIcnIndex( resourceTo ) );
+            const fheroes2::Sprite & sprite_to = Assets::getImage( ICN::RESOURCE, Resource::getIconIcnIndex( resourceTo ) );
             dst_pt.x = pos_rt.x + ( pos_rt.width - sprite_to.width() + 1 ) / 2 + 70;
             dst_pt.y = pos_rt.y + 115 - sprite_to.height();
             fheroes2::Blit( sprite_to, display, dst_pt.x, dst_pt.y );
-            const fheroes2::Sprite & sprite_fromto = fheroes2::AGG::GetICN( tradpostIcnId, 0 );
+            const fheroes2::Sprite & sprite_fromto = Assets::getImage( tradpostIcnId, 0 );
             dst_pt.x = pos_rt.x + ( pos_rt.width - sprite_fromto.width() ) / 2;
             dst_pt.y = pos_rt.y + 90;
             fheroes2::Blit( sprite_fromto, display, dst_pt.x, dst_pt.y );
@@ -294,19 +294,19 @@ namespace
         const int tradpost = Settings::Get().isEvilInterfaceEnabled() ? ICN::TRADPOSE : ICN::TRADPOST;
 
         // wood
-        RedrawResourceSprite( fheroes2::AGG::GetICN( tradpost, 7 ), pt.x, pt.y, rs.wood );
+        RedrawResourceSprite( Assets::getImage( tradpost, 7 ), pt.x, pt.y, rs.wood );
         // mercury
-        RedrawResourceSprite( fheroes2::AGG::GetICN( tradpost, 8 ), pt.x + 37, pt.y, rs.mercury );
+        RedrawResourceSprite( Assets::getImage( tradpost, 8 ), pt.x + 37, pt.y, rs.mercury );
         // ore
-        RedrawResourceSprite( fheroes2::AGG::GetICN( tradpost, 9 ), pt.x + 74, pt.y, rs.ore );
+        RedrawResourceSprite( Assets::getImage( tradpost, 9 ), pt.x + 74, pt.y, rs.ore );
         // sulfur
-        RedrawResourceSprite( fheroes2::AGG::GetICN( tradpost, 10 ), pt.x, pt.y + 37, rs.sulfur );
+        RedrawResourceSprite( Assets::getImage( tradpost, 10 ), pt.x, pt.y + 37, rs.sulfur );
         // crystal
-        RedrawResourceSprite( fheroes2::AGG::GetICN( tradpost, 11 ), pt.x + 37, pt.y + 37, rs.crystal );
+        RedrawResourceSprite( Assets::getImage( tradpost, 11 ), pt.x + 37, pt.y + 37, rs.crystal );
         // gems
-        RedrawResourceSprite( fheroes2::AGG::GetICN( tradpost, 12 ), pt.x + 74, pt.y + 37, rs.gems );
+        RedrawResourceSprite( Assets::getImage( tradpost, 12 ), pt.x + 74, pt.y + 37, rs.gems );
         // gold
-        RedrawResourceSprite( fheroes2::AGG::GetICN( tradpost, 13 ), pt.x + 37, pt.y + 74, rs.gold );
+        RedrawResourceSprite( Assets::getImage( tradpost, 13 ), pt.x + 37, pt.y + 74, rs.gold );
     }
 
     void RedrawResourceSprite2( const fheroes2::Image & sf, int32_t px, int32_t py, bool show, const Kingdom & kingdom, int from, int res, bool trading )
@@ -325,19 +325,19 @@ namespace
         const int tradpost = Settings::Get().isEvilInterfaceEnabled() ? ICN::TRADPOSE : ICN::TRADPOST;
 
         // wood
-        RedrawResourceSprite2( fheroes2::AGG::GetICN( tradpost, 7 ), pt.x, pt.y, showcost, kingdom, from_resource, Resource::WOOD, tradingPost );
+        RedrawResourceSprite2( Assets::getImage( tradpost, 7 ), pt.x, pt.y, showcost, kingdom, from_resource, Resource::WOOD, tradingPost );
         // mercury
-        RedrawResourceSprite2( fheroes2::AGG::GetICN( tradpost, 8 ), pt.x + 37, pt.y, showcost, kingdom, from_resource, Resource::MERCURY, tradingPost );
+        RedrawResourceSprite2( Assets::getImage( tradpost, 8 ), pt.x + 37, pt.y, showcost, kingdom, from_resource, Resource::MERCURY, tradingPost );
         // ore
-        RedrawResourceSprite2( fheroes2::AGG::GetICN( tradpost, 9 ), pt.x + 74, pt.y, showcost, kingdom, from_resource, Resource::ORE, tradingPost );
+        RedrawResourceSprite2( Assets::getImage( tradpost, 9 ), pt.x + 74, pt.y, showcost, kingdom, from_resource, Resource::ORE, tradingPost );
         // sulfur
-        RedrawResourceSprite2( fheroes2::AGG::GetICN( tradpost, 10 ), pt.x, pt.y + 37, showcost, kingdom, from_resource, Resource::SULFUR, tradingPost );
+        RedrawResourceSprite2( Assets::getImage( tradpost, 10 ), pt.x, pt.y + 37, showcost, kingdom, from_resource, Resource::SULFUR, tradingPost );
         // crystal
-        RedrawResourceSprite2( fheroes2::AGG::GetICN( tradpost, 11 ), pt.x + 37, pt.y + 37, showcost, kingdom, from_resource, Resource::CRYSTAL, tradingPost );
+        RedrawResourceSprite2( Assets::getImage( tradpost, 11 ), pt.x + 37, pt.y + 37, showcost, kingdom, from_resource, Resource::CRYSTAL, tradingPost );
         // gems
-        RedrawResourceSprite2( fheroes2::AGG::GetICN( tradpost, 12 ), pt.x + 74, pt.y + 37, showcost, kingdom, from_resource, Resource::GEMS, tradingPost );
+        RedrawResourceSprite2( Assets::getImage( tradpost, 12 ), pt.x + 74, pt.y + 37, showcost, kingdom, from_resource, Resource::GEMS, tradingPost );
         // gold
-        RedrawResourceSprite2( fheroes2::AGG::GetICN( tradpost, 13 ), pt.x + 37, pt.y + 74, showcost, kingdom, from_resource, Resource::GOLD, tradingPost );
+        RedrawResourceSprite2( Assets::getImage( tradpost, 13 ), pt.x + 37, pt.y + 74, showcost, kingdom, from_resource, Resource::GOLD, tradingPost );
     }
 }
 
@@ -378,7 +378,7 @@ void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
     rectsFrom.emplace_back( pt1.x + 74, pt1.y + 37, 34, 34 ); // gems
     rectsFrom.emplace_back( pt1.x + 37, pt1.y + 74, 34, 34 ); // gold
 
-    fheroes2::MovableSprite cursorFrom( fheroes2::AGG::GetICN( tradpost, 14 ) );
+    fheroes2::MovableSprite cursorFrom( Assets::getImage( tradpost, 14 ) );
     text.set( _( "Your Resources" ), fheroes2::FontType::smallWhite() );
     dst_pt.x = pt1.x + ( 108 - text.width() ) / 2;
     dst_pt.y = pt1.y - 15;
@@ -397,7 +397,7 @@ void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
     rectsTo.emplace_back( pt2.x + 74, pt2.y + 37, 34, 34 ); // gems
     rectsTo.emplace_back( pt2.x + 37, pt2.y + 74, 34, 34 ); // gold
 
-    fheroes2::MovableSprite cursorTo( fheroes2::AGG::GetICN( tradpost, 14 ) );
+    fheroes2::MovableSprite cursorTo( Assets::getImage( tradpost, 14 ) );
     text.set( _( "Available Trades" ), fheroes2::FontType::smallWhite() );
     dst_pt.x = pt2.x + ( 108 - text.width() ) / 2;
     dst_pt.y = pt2.y - 15;
@@ -426,7 +426,7 @@ void Dialog::Marketplace( Kingdom & kingdom, bool fromTradingPost )
 
     // button exit
     const int exitButtonIcnID = isEvilInterface ? ICN::UNIFORM_EVIL_EXIT_BUTTON : ICN::UNIFORM_GOOD_EXIT_BUTTON;
-    const fheroes2::Sprite & spriteExit = fheroes2::AGG::GetICN( exitButtonIcnID, 0 );
+    const fheroes2::Sprite & spriteExit = Assets::getImage( exitButtonIcnID, 0 );
 
     dst_pt.x = pos_rt.x + 68 + ( pos_rt.width - spriteExit.width() ) / 2;
     dst_pt.y = pos_rt.y + pos_rt.height - spriteExit.height();

--- a/src/fheroes2/dialog/dialog_quickinfo.cpp
+++ b/src/fheroes2/dialog/dialog_quickinfo.cpp
@@ -29,7 +29,6 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_troop.h"
 #include "artifact_ultimate.h"
@@ -39,6 +38,7 @@
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
 #include "game.h"
+#include "game_assets.h"
 #include "game_interface.h"
 #include "ground.h"
 #include "heroes.h"
@@ -602,7 +602,7 @@ namespace
         RadarUpdater radarUpdater( showOnRadar, castle.GetCenter(), areaToRestore );
 
         // image box
-        const fheroes2::Sprite & box = fheroes2::AGG::GetICN( ICN::QWIKTOWN, 0 );
+        const fheroes2::Sprite & box = Assets::getImage( ICN::QWIKTOWN, 0 );
 
         LocalEvent & le = LocalEvent::Get();
         fheroes2::Rect cur_rt = makeRectQuickInfo( le, box, position );
@@ -622,7 +622,7 @@ namespace
 
         // castle icon
         const Settings & conf = Settings::Get();
-        const fheroes2::Sprite & castleIcon = fheroes2::AGG::GetICN( conf.isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, 23 );
+        const fheroes2::Sprite & castleIcon = Assets::getImage( conf.isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, 23 );
 
         dst_pt.x = cur_rt.x + ( cur_rt.width - castleIcon.width() ) / 2;
         dst_pt.y += 10;
@@ -634,10 +634,10 @@ namespace
 
         const fheroes2::Point flagOffset( 5, 4 );
 
-        const fheroes2::Sprite & l_flag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex );
+        const fheroes2::Sprite & l_flag = Assets::getImage( ICN::FLAG32, flagIcnIndex );
         fheroes2::Blit( l_flag, display, dst_pt.x - flagOffset.x - l_flag.width(), dst_pt.y + flagOffset.y );
 
-        const fheroes2::Sprite & r_flag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex + 1 );
+        const fheroes2::Sprite & r_flag = Assets::getImage( ICN::FLAG32, flagIcnIndex + 1 );
         fheroes2::Blit( r_flag, display, dst_pt.x + flagOffset.x + castleIcon.width(), dst_pt.y + flagOffset.y );
 
         const PlayerColor currentColor = conf.CurrentColor();
@@ -699,7 +699,7 @@ namespace
         RadarUpdater radarUpdater( showOnRadar, hero.GetCenter(), areaToRestore );
 
         // image box
-        const fheroes2::Sprite & box = fheroes2::AGG::GetICN( ICN::QWIKHERO, 0 );
+        const fheroes2::Sprite & box = Assets::getImage( ICN::QWIKHERO, 0 );
 
         LocalEvent & le = LocalEvent::Get();
         fheroes2::Rect cur_rt = makeRectQuickInfo( le, box, position );
@@ -750,7 +750,7 @@ namespace
         dst_pt.y = cur_rt.y + 2;
         text.draw( dst_pt.x, dst_pt.y, display );
 
-        const fheroes2::Sprite & heroPortraitFrame = fheroes2::AGG::GetICN( conf.isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, 22 );
+        const fheroes2::Sprite & heroPortraitFrame = Assets::getImage( conf.isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, 22 );
 
         // mini port heroes
         const fheroes2::Sprite & port = isActiveHero ? activeHero->GetPortrait( PORT_SMALL ) : activeCaptain->GetPortrait( PORT_SMALL );
@@ -762,7 +762,7 @@ namespace
         // luck
         if ( isFullInfo ) {
             const int32_t luck = hero.GetLuck();
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINILKMR, ( 0 > luck ? 0 : ( 0 < luck ? 1 : 2 ) ) );
+            const fheroes2::Sprite & sprite = Assets::getImage( ICN::MINILKMR, ( 0 > luck ? 0 : ( 0 < luck ? 1 : 2 ) ) );
             uint32_t count = ( 0 == luck ? 1 : std::abs( luck ) );
             dst_pt.x = cur_rt.x + 120;
             dst_pt.y = cur_rt.y + ( count == 1 ? 20 : 13 );
@@ -785,7 +785,7 @@ namespace
                 spriteInx = 4;
             }
 
-            fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::MINILKMR, spriteInx );
+            fheroes2::Sprite sprite = Assets::getImage( ICN::MINILKMR, spriteInx );
             if ( hero.GetArmy().AllTroopsAreUndead() ) {
                 fheroes2::ApplyPalette( sprite, PAL::GetPalette( PAL::PaletteType::GRAY ) );
                 fheroes2::ApplyPalette( sprite, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
@@ -807,11 +807,11 @@ namespace
             // Use castle flags to show hero's color flags.
             const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( hero.GetColor() );
 
-            const fheroes2::Sprite & l_flag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex );
+            const fheroes2::Sprite & l_flag = Assets::getImage( ICN::FLAG32, flagIcnIndex );
             dst_pt.x = cur_rt.x + ( cur_rt.width - 40 ) / 2 - l_flag.width();
             fheroes2::Blit( l_flag, display, dst_pt.x, dst_pt.y );
 
-            const fheroes2::Sprite & r_flag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex + 1 );
+            const fheroes2::Sprite & r_flag = Assets::getImage( ICN::FLAG32, flagIcnIndex + 1 );
             dst_pt.x = cur_rt.x + ( cur_rt.width + 40 ) / 2;
             fheroes2::Blit( r_flag, display, dst_pt.x, dst_pt.y );
         }

--- a/src/fheroes2/dialog/dialog_random_map_generator.cpp
+++ b/src/fheroes2/dialog/dialog_random_map_generator.cpp
@@ -25,8 +25,8 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -94,12 +94,12 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
     if ( isDefaultScreenSize ) {
-        const Sprite & backgroundImage = AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+        const Sprite & backgroundImage = Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
         Copy( backgroundImage, 0, 0, display, activeArea );
     }
 
     // Dialog title.
-    const Sprite & titleBox = AGG::GetICN( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
+    const Sprite & titleBox = Assets::getImage( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
     const Rect titleBoxRoi( activeArea.x + ( activeArea.width - titleBox.width() ) / 2, activeArea.y + 10, titleBox.width(), titleBox.height() );
     const Rect titleTextRoi( titleBoxRoi.x + 6, titleBoxRoi.y + 5, titleBoxRoi.width - 12, titleBoxRoi.height - 11 );
 
@@ -131,7 +131,7 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
 
     // Dropdown with map layout selection.
     const int dropListIcn = isEvilInterface ? ICN::DROPLISL_EVIL : ICN::DROPLISL;
-    const Sprite & itemBackground = AGG::GetICN( dropListIcn, 0 );
+    const Sprite & itemBackground = Assets::getImage( dropListIcn, 0 );
     const int32_t layoutBackgroundWidth = 200;
     const int32_t layoutBackgroundHeight = itemBackground.height();
 
@@ -143,8 +143,8 @@ bool fheroes2::randomMapGeneratorDialog( Maps::Random_Generator::Configuration &
     ApplyPalette( display, inputPositionX + 6, positionY - 5, display, inputPositionX + 6, positionY - 5, layoutBackgroundWidth, layoutBackgroundHeight,
                   PAL::GetPalette( PAL::PaletteType::DARKENING ) );
 
-    const Sprite & dropListButtonSprite = AGG::GetICN( dropListIcn, 1 );
-    const Sprite & dropListButtonPressedSprite = AGG::GetICN( dropListIcn, 2 );
+    const Sprite & dropListButtonSprite = Assets::getImage( dropListIcn, 1 );
+    const Sprite & dropListButtonPressedSprite = Assets::getImage( dropListIcn, 2 );
 
     ButtonSprite layoutDroplistButton( inputPositionX + layoutBackgroundWidth + 6, positionY - 5, dropListButtonSprite, dropListButtonPressedSprite );
     // TODO: remove the next line when the dropdown is operational.

--- a/src/fheroes2/dialog/dialog_recruit.cpp
+++ b/src/fheroes2/dialog/dialog_recruit.cpp
@@ -30,11 +30,11 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army_troop.h"
 #include "bin_info.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -61,15 +61,15 @@ namespace
 {
     void drawButtonShadow( fheroes2::Image & output, const int buttonIcn, const uint32_t icnIndex, const fheroes2::Point & offset )
     {
-        const fheroes2::Sprite & buttonSprite = fheroes2::AGG::GetICN( buttonIcn, icnIndex );
+        const fheroes2::Sprite & buttonSprite = Assets::getImage( buttonIcn, icnIndex );
 
         fheroes2::addGradientShadow( buttonSprite, output, offset, { -5, 5 } );
     }
 
     void drawCostPerTroopFrame( fheroes2::Image & output, const fheroes2::Point & offset )
     {
-        const fheroes2::Sprite & originalBackground = fheroes2::AGG::GetICN( ICN::RECRBKG, 0 );
-        const fheroes2::Sprite & recruitWindowTitle = fheroes2::AGG::GetICN( ICN::BLDGXTRA, 0 );
+        const fheroes2::Sprite & originalBackground = Assets::getImage( ICN::RECRBKG, 0 );
+        const fheroes2::Sprite & recruitWindowTitle = Assets::getImage( ICN::BLDGXTRA, 0 );
 
         fheroes2::Sprite recruitWindow( 132, 67 );
         // Reset the transparent layer.
@@ -141,7 +141,7 @@ namespace
         // In recruit dialog (where the total sum is also shown) the resource info is shifted by 10 pixels to the right.
         const int32_t offsetX = showTotalSum ? 10 : 0;
 
-        const fheroes2::Sprite & sres = fheroes2::AGG::GetICN( ICN::RESOURCE, Resource::getIconIcnIndex( resourceIcnIndex ) );
+        const fheroes2::Sprite & sres = Assets::getImage( ICN::RESOURCE, Resource::getIconIcnIndex( resourceIcnIndex ) );
         fheroes2::Blit( sres, fheroes2::Display::instance(), pos.x + px1 + offsetX, pos.y + py1 );
 
         const fheroes2::Text text( std::to_string( value ), fheroes2::FontType::smallWhite() );
@@ -170,7 +170,7 @@ namespace
         const Bin_Info::MonsterAnimInfo & monsterInfo = Bin_Info::GetMonsterInfo( monsterId );
         assert( !monsterInfo.animationFrames[Bin_Info::MonsterAnimInfo::STATIC].empty() );
 
-        const fheroes2::Sprite & smon = fheroes2::AGG::GetICN( monster.GetMonsterSprite(), monsterInfo.animationFrames[Bin_Info::MonsterAnimInfo::STATIC][0] );
+        const fheroes2::Sprite & smon = Assets::getImage( monster.GetMonsterSprite(), monsterInfo.animationFrames[Bin_Info::MonsterAnimInfo::STATIC][0] );
         dst_pt.x = pos.x + 64 + smon.x() - ( monster.isWide() ? 22 : 0 );
         const int32_t monsterExtraOffsetY = std::max<int32_t>( 0, smon.height() - 96 );
         dst_pt.y = pos.y + 119 - smon.height() + monsterExtraOffsetY;
@@ -279,7 +279,7 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
 
     const fheroes2::Rect windowActiveArea( window.activeArea() );
 
-    const fheroes2::Sprite & originalBackground = fheroes2::AGG::GetICN( ICN::RECRBKG, 0 );
+    const fheroes2::Sprite & originalBackground = Assets::getImage( ICN::RECRBKG, 0 );
 
     // Render the recruit count background from original recruit dialog ICN.
     fheroes2::Sprite background( 68, 19 );
@@ -309,13 +309,13 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
     drawButtonShadow( display, buttonId, 0, dst_pt );
 
     buttonId = isEvilInterface ? ICN::BUTTON_SMALL_CANCEL_EVIL : ICN::BUTTON_SMALL_CANCEL_GOOD;
-    const int32_t buttonCancelWidth = fheroes2::AGG ::GetICN( buttonId, 0 ).width();
+    const int32_t buttonCancelWidth = Assets::getImage( buttonId, 0 ).width();
     dst_pt.x = dialogOffset.x + windowSize.width - backgroundMargin - buttonCancelWidth;
     fheroes2::Button buttonCancel( dst_pt.x, dst_pt.y, buttonId, 0, 1 );
     drawButtonShadow( display, buttonId, 0, dst_pt );
 
     buttonId = isEvilInterface ? ICN::BUTTON_SMALL_MAX_EVIL : ICN::BUTTON_SMALL_MAX_GOOD;
-    const int32_t buttonMaxWidth = fheroes2::AGG ::GetICN( buttonId, 0 ).width();
+    const int32_t buttonMaxWidth = Assets::getImage( buttonId, 0 ).width();
     dst_pt.x = dialogOffset.x + 253 - buttonMaxWidth / 2;
     dst_pt.y = dialogOffset.y + 140;
 
@@ -347,16 +347,16 @@ Troop Dialog::RecruitMonster( const Monster & monster0, const uint32_t available
     const bool showDowngradedMonsterSwitchButtons = allowDowngradedMonster && ( monster0.GetDowngrade() != monster0 );
 
     if ( showDowngradedMonsterSwitchButtons ) {
-        const fheroes2::Sprite & leftButtonSprite = fheroes2::AGG::GetICN( ICN::MONSTER_SWITCH_LEFT_ARROW, 0 );
-        monsterSwitchLeft.setSprite( leftButtonSprite, fheroes2::AGG::GetICN( ICN::MONSTER_SWITCH_LEFT_ARROW, 1 ) );
+        const fheroes2::Sprite & leftButtonSprite = Assets::getImage( ICN::MONSTER_SWITCH_LEFT_ARROW, 0 );
+        monsterSwitchLeft.setSprite( leftButtonSprite, Assets::getImage( ICN::MONSTER_SWITCH_LEFT_ARROW, 1 ) );
 
         dst_pt.x = dialogOffset.x + 6;
         dst_pt.y = dialogOffset.y + 64;
         monsterSwitchLeft.setPosition( dst_pt.x, dst_pt.y );
         fheroes2::addGradientShadow( leftButtonSprite, display, dst_pt, { -5, 5 } );
 
-        const fheroes2::Sprite & rightButtonSprite = fheroes2::AGG::GetICN( ICN::MONSTER_SWITCH_RIGHT_ARROW, 0 );
-        monsterSwitchRight.setSprite( rightButtonSprite, fheroes2::AGG::GetICN( ICN::MONSTER_SWITCH_RIGHT_ARROW, 1 ) );
+        const fheroes2::Sprite & rightButtonSprite = Assets::getImage( ICN::MONSTER_SWITCH_RIGHT_ARROW, 0 );
+        monsterSwitchRight.setSprite( rightButtonSprite, Assets::getImage( ICN::MONSTER_SWITCH_RIGHT_ARROW, 1 ) );
         dst_pt.x = dialogOffset.x + 105;
         monsterSwitchRight.setPosition( dst_pt.x, dst_pt.y );
         fheroes2::addGradientShadow( rightButtonSprite, display, dst_pt, { -5, 5 } );

--- a/src/fheroes2/dialog/dialog_resolution.cpp
+++ b/src/fheroes2/dialog/dialog_resolution.cpp
@@ -28,10 +28,10 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "embedded_image.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -236,7 +236,7 @@ namespace
         listBox.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, listRoi.y + 1 } );
         listBox.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, listRoi.y + listRoi.height - 15 } );
         listBox.setScrollBarArea( { scrollbarOffsetX + 2, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        listBox.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        listBox.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         listBox.SetAreaMaxItems( ( listRoi.height - 7 ) / fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) );
         listBox.SetListContent( resolutions );
         listBox.updateScrollBarImage();

--- a/src/fheroes2/dialog/dialog_selectcount.cpp
+++ b/src/fheroes2/dialog/dialog_selectcount.cpp
@@ -29,9 +29,9 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_delays.h"
 #include "icn.h"
 #include "image.h"
@@ -242,7 +242,7 @@ bool Dialog::inputString( const fheroes2::TextBase & title, const fheroes2::Text
     const int32_t titleHeight = hasTitle ? title.height( fheroes2::boxAreaWidthPx ) + 10 : 0;
     const int32_t keyBoardButtonExtraHeight = 20;
 
-    const fheroes2::Sprite & inputArea = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::BUYBUILD : ICN::BUYBUILE ), 3 );
+    const fheroes2::Sprite & inputArea = Assets::getImage( ( isEvilInterface ? ICN::BUYBUILD : ICN::BUYBUILE ), 3 );
 
     const int32_t inputAreaWidth = isMultiLine ? 226 : inputArea.width();
     const int32_t inputAreaHeight = isMultiLine ? 265 : inputArea.height();
@@ -285,18 +285,18 @@ bool Dialog::inputString( const fheroes2::TextBase & title, const fheroes2::Text
     const int okayButtonICNID = isEvilInterface ? ICN::UNIFORM_EVIL_OKAY_BUTTON : ICN::UNIFORM_GOOD_OKAY_BUTTON;
 
     dst_pt.x = frameBoxArea.x;
-    dst_pt.y = frameBoxArea.y + frameBoxArea.height - fheroes2::AGG::GetICN( okayButtonICNID, 0 ).height();
+    dst_pt.y = frameBoxArea.y + frameBoxArea.height - Assets::getImage( okayButtonICNID, 0 ).height();
     fheroes2::Button buttonOk( dst_pt.x, dst_pt.y, okayButtonICNID, 0, 1 );
 
     const int cancelButtonIcnID = isEvilInterface ? ICN::UNIFORM_EVIL_CANCEL_BUTTON : ICN::UNIFORM_GOOD_CANCEL_BUTTON;
-    const fheroes2::Sprite & cancelButtonIcn = fheroes2::AGG::GetICN( cancelButtonIcnID, 0 );
+    const fheroes2::Sprite & cancelButtonIcn = Assets::getImage( cancelButtonIcnID, 0 );
 
     dst_pt.x = frameBoxArea.x + frameBoxArea.width - cancelButtonIcn.width();
     dst_pt.y = frameBoxArea.y + frameBoxArea.height - cancelButtonIcn.height();
     fheroes2::Button buttonCancel( dst_pt.x, dst_pt.y, cancelButtonIcnID, 0, 1 );
 
     const int buttonVirtualKBIcnID = isEvilInterface ? ICN::BUTTON_VIRTUAL_KEYBOARD_EVIL : ICN::BUTTON_VIRTUAL_KEYBOARD_GOOD;
-    const fheroes2::Sprite & buttonVirtualKBIcn = fheroes2::AGG::GetICN( buttonVirtualKBIcnID, 0 );
+    const fheroes2::Sprite & buttonVirtualKBIcn = Assets::getImage( buttonVirtualKBIcnID, 0 );
 
     dst_pt.x = frameBoxArea.x + ( frameBoxArea.width - buttonVirtualKBIcn.width() ) / 2;
     dst_pt.y -= 30;
@@ -508,7 +508,7 @@ int Dialog::ArmySplitTroop( const int32_t freeSlots, const int32_t redistributeM
         const int deltaXStart = ( freeSlots - 2 ) * -5;
 
         for ( int32_t i = 0; i < freeSlots - 1; ++i ) {
-            sprites[i] = fheroes2::AGG::GetICN( ICN::REQUESTS, spriteIconIdx );
+            sprites[i] = Assets::getImage( ICN::REQUESTS, spriteIconIdx );
             ++spriteIconIdx;
 
             const int spriteWidth = sprites[i].width();

--- a/src/fheroes2/dialog/dialog_selectfile.cpp
+++ b/src/fheroes2/dialog/dialog_selectfile.cpp
@@ -34,10 +34,10 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
 #include "dir.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_io.h"
 #include "icn.h"
@@ -393,7 +393,7 @@ namespace
         listbox.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, listRoi.y + 1 } );
         listbox.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, listRoi.y + listRoi.height - 15 } );
         listbox.setScrollBarArea( { scrollbarOffsetX + 2, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        listbox.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        listbox.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         listbox.SetAreaMaxItems( ( listRoi.height - 7 ) / fheroes2::getFontHeight( fheroes2::FontSize::NORMAL ) );
         listbox.SetListContent( lists );
         listbox.updateScrollBarImage();
@@ -451,14 +451,14 @@ namespace
 
         // Draw radio buttons for toggling between sorting methods.
         const int sortMarkIcnID = isEvilInterface ? ICN::CELLWIN_EVIL : ICN::CELLWIN;
-        const fheroes2::Sprite & markBackground = fheroes2::AGG::GetICN( sortMarkIcnID, 4 );
+        const fheroes2::Sprite & markBackground = Assets::getImage( sortMarkIcnID, 4 );
 
         const fheroes2::Rect markBackgroundNameRoi( nameHeaderRoi.x + 5, nameHeaderRoi.y + 6, markBackground.width(), markBackground.height() );
         const fheroes2::Rect markBackgroundDateRoi( dateTimeOffsetX + 5, nameHeaderRoi.y + 6, markBackground.width(), markBackground.height() );
         fheroes2::Blit( markBackground, display, markBackgroundNameRoi );
         fheroes2::Blit( markBackground, display, markBackgroundDateRoi );
 
-        const fheroes2::Sprite & mark = fheroes2::AGG::GetICN( sortMarkIcnID, 5 );
+        const fheroes2::Sprite & mark = Assets::getImage( sortMarkIcnID, 5 );
 
         if ( fileSortingMethod == SaveFileSortingMethod::FILENAME ) {
             fheroes2::Blit( mark, display, { markBackgroundNameRoi.x + 3, markBackgroundNameRoi.y + 3, mark.width(), mark.height() } );

--- a/src/fheroes2/dialog/dialog_selectitems.cpp
+++ b/src/fheroes2/dialog/dialog_selectitems.cpp
@@ -32,12 +32,12 @@
 #include <numeric>
 #include <utility>
 
-#include "agg_image.h"
 #include "army_troop.h"
 #include "castle.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_string.h"
 #include "ground.h"
@@ -71,7 +71,7 @@ namespace
 
     fheroes2::Sprite renderMonsterOnBackground( const fheroes2::Sprite & monsterSprite )
     {
-        const fheroes2::Sprite & backgroundOriginal = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+        const fheroes2::Sprite & backgroundOriginal = Assets::getImage( ICN::SWAPWIN, 0 );
         fheroes2::Sprite image = fheroes2::Crop( backgroundOriginal, 36, 267, 43, 43 );
         image.setPosition( 0, 0 );
 
@@ -161,7 +161,7 @@ namespace
         virtual fheroes2::Sprite getImage( const int index )
         {
             const Monster mons( index );
-            const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( ICN::MONS32, mons.GetSpriteIndex() );
+            const fheroes2::Sprite & monsterSprite = Assets::getImage( ICN::MONS32, mons.GetSpriteIndex() );
             return renderMonsterOnBackground( monsterSprite );
         }
     };
@@ -231,7 +231,7 @@ namespace
         fheroes2::Sprite getImage( const int index ) override
         {
             const Monster mons( index );
-            const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( ICN::MONS32, mons.GetSpriteIndex() );
+            const fheroes2::Sprite & monsterSprite = Assets::getImage( ICN::MONS32, mons.GetSpriteIndex() );
             fheroes2::Sprite image = renderMonsterOnBackground( monsterSprite );
 
             if ( _selected.count( index ) == 0 ) {
@@ -267,7 +267,7 @@ namespace
         virtual fheroes2::Sprite getImage( const int index )
         {
             const Artifact art( index );
-            return fheroes2::AGG::GetICN( ICN::ARTFX, art.IndexSprite32() );
+            return Assets::getImage( ICN::ARTFX, art.IndexSprite32() );
         }
 
     private:
@@ -339,7 +339,7 @@ namespace
         fheroes2::Sprite getImage( const int index ) override
         {
             const Artifact art( index );
-            fheroes2::Sprite image = fheroes2::AGG::GetICN( ICN::ARTFX, art.IndexSprite32() );
+            fheroes2::Sprite image = Assets::getImage( ICN::ARTFX, art.IndexSprite32() );
 
             if ( _selected.count( index ) == 0 ) {
                 fheroes2::ApplyPalette( image, PAL::GetPalette( PAL::PaletteType::GRAY ) );
@@ -390,7 +390,7 @@ namespace
         void RedrawItem( const int32_t & index, int32_t dstx, int32_t dsty, bool current ) override
         {
             const Spell spell( index );
-            const fheroes2::Sprite & spellSprite = fheroes2::AGG::GetICN( ICN::SPELLS, spell.IndexSprite() );
+            const fheroes2::Sprite & spellSprite = Assets::getImage( ICN::SPELLS, spell.IndexSprite() );
 
             renderItem( spellSprite, spell.GetName(), { dstx, dsty }, 75 / 2, 80, _offsetY / 2, current );
         }
@@ -428,7 +428,7 @@ namespace
         void RedrawItem( const int32_t & index, int32_t dstx, int32_t dsty, bool current ) override
         {
             const Skill::Secondary skill( getSkillFromListIndex( index ), getLevelFromListIndex( index ) );
-            const fheroes2::Sprite & skillSprite = fheroes2::AGG::GetICN( ICN::MINISS, skill.GetIndexSprite2() );
+            const fheroes2::Sprite & skillSprite = Assets::getImage( ICN::MINISS, skill.GetIndexSprite2() );
 
             renderItem( skillSprite, skill.GetName(), { dstx, dsty }, 45 / 2, 50, _offsetY / 2, current );
         }
@@ -461,7 +461,7 @@ namespace
 
             assert( castle != nullptr );
 
-            fheroes2::Sprite castleIcon( fheroes2::AGG::GetICN( _townFrameIcnId, 23 ) );
+            fheroes2::Sprite castleIcon( Assets::getImage( _townFrameIcnId, 23 ) );
             fheroes2::drawCastleIcon( *castle, castleIcon, { 4, 4 } );
 
             renderItem( castleIcon, castle->GetName(), { dstx, dsty }, 35, 75, itemsOffsetY / 2, current );
@@ -817,11 +817,11 @@ namespace
             fheroes2::Blit( mineSprite, display, dstx + fheroes2::tileWidthPx * 5 + 5 - mineSprite.width(), dsty + 1 );
 
             // Mine type selection mark background.
-            const fheroes2::Sprite & markBackground = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::CELLWIN_EVIL : ICN::CELLWIN, 4 );
+            const fheroes2::Sprite & markBackground = Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::CELLWIN_EVIL : ICN::CELLWIN, 4 );
             fheroes2::Blit( markBackground, display, dstx + 10, dsty + 24 );
 
             if ( current ) {
-                const fheroes2::Sprite & mark = fheroes2::AGG::GetICN( ICN::CELLWIN, 5 );
+                const fheroes2::Sprite & mark = Assets::getImage( ICN::CELLWIN, 5 );
                 fheroes2::Blit( mark, display, dstx + 13, dsty + 27 );
             }
         }
@@ -937,7 +937,7 @@ namespace Dialog
         SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX + 1, listRoi.y + 1 } );
         SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX + 1, listRoi.y + listRoi.height - 15 } );
         setScrollBarArea( { scrollbarOffsetX + 3, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
 
         // Render dialog buttons.
         _window->renderOkayCancelButtons( _buttonOk, _buttonCancel );
@@ -1288,15 +1288,15 @@ int Dialog::selectHeroType( const int heroType )
     const int32_t stepX = 70;
     const int32_t raceOffsetY = 80;
     fheroes2::Point pos( area.x + 20, area.y + 30 );
-    const fheroes2::Sprite & colorSpriteBorderSelected = fheroes2::AGG::GetICN( ICN::BRCREST, 6 );
-    const fheroes2::Sprite & raceShadow = fheroes2::AGG::GetICN( ICN::NGEXTRA, 61 );
+    const fheroes2::Sprite & colorSpriteBorderSelected = Assets::getImage( ICN::BRCREST, 6 );
+    const fheroes2::Sprite & raceShadow = Assets::getImage( ICN::NGEXTRA, 61 );
     fheroes2::Sprite colorSpriteBorder( colorSpriteBorderSelected );
 
     const std::vector<uint8_t> darkGrayPalette = PAL::CombinePalettes( PAL::GetPalette( PAL::PaletteType::GRAY ), PAL::GetPalette( PAL::PaletteType::DARKENING ) );
     fheroes2::ApplyPalette( colorSpriteBorder, darkGrayPalette );
 
     // Make race selection borders.
-    const fheroes2::Sprite & randomRaceSprite = fheroes2::AGG::GetICN( ICN::NGEXTRA, 58 );
+    const fheroes2::Sprite & randomRaceSprite = Assets::getImage( ICN::NGEXTRA, 58 );
     const int32_t raceBorderWidth = randomRaceSprite.width();
     const int32_t raceBorderHeight = randomRaceSprite.height();
     fheroes2::Image raceSpriteBorder( raceBorderWidth, raceBorderHeight );
@@ -1326,7 +1326,7 @@ int Dialog::selectHeroType( const int heroType )
 
     pos.x += stepX;
     for ( uint32_t i = 0; i < 6; ++i ) {
-        const fheroes2::Sprite & colorSprite = fheroes2::AGG::GetICN( ICN::BRCREST, i );
+        const fheroes2::Sprite & colorSprite = Assets::getImage( ICN::BRCREST, i );
 
         fheroes2::addGradientShadow( colorSpriteBorder, display, { pos.x - stepX / 2, pos.y }, { -5, 5 } );
         colorRect[i] = { pos.x - stepX / 2, pos.y, colorSpriteBorder.width(), colorSpriteBorder.height() };
@@ -1334,7 +1334,7 @@ int Dialog::selectHeroType( const int heroType )
         text.set( Color::String( Color::IndexToColor( static_cast<int>( i ) ) ), fheroes2::FontType::smallWhite() );
         text.draw( colorRect[i].x + ( colorRect[i].width - text.width() ) / 2, colorRect[i].y + colorRect[i].height + 4, display );
 
-        const fheroes2::Sprite & raceSprite = fheroes2::AGG::GetICN( ICN::NGEXTRA, 51U + i );
+        const fheroes2::Sprite & raceSprite = Assets::getImage( ICN::NGEXTRA, 51U + i );
         raceRect[i] = { pos.x - 2, pos.y + raceOffsetY, raceBorderWidth, raceBorderHeight };
         fheroes2::Copy( raceSprite, 4, 4, display, raceRect[i].x + 4, raceRect[i].y + 4, raceImageWidth, raceImageHeight );
         fheroes2::Blit( raceShadow, display, pos.x - 5, pos.y + raceOffsetY + 2 );
@@ -1516,15 +1516,15 @@ void Dialog::selectTownType( int32_t & type, int32_t & color )
     const int32_t stepX = 70;
     const int32_t raceOffsetY = 80;
     fheroes2::Point pos( area.x + 20, area.y + 30 );
-    const fheroes2::Sprite & colorSpriteBorderSelected = fheroes2::AGG::GetICN( ICN::BRCREST, 6 );
-    const fheroes2::Sprite & raceShadow = fheroes2::AGG::GetICN( ICN::NGEXTRA, 61 );
+    const fheroes2::Sprite & colorSpriteBorderSelected = Assets::getImage( ICN::BRCREST, 6 );
+    const fheroes2::Sprite & raceShadow = Assets::getImage( ICN::NGEXTRA, 61 );
     fheroes2::Sprite colorSpriteBorder( colorSpriteBorderSelected );
 
     const std::vector<uint8_t> darkGrayPalette = PAL::CombinePalettes( PAL::GetPalette( PAL::PaletteType::GRAY ), PAL::GetPalette( PAL::PaletteType::DARKENING ) );
     fheroes2::ApplyPalette( colorSpriteBorder, darkGrayPalette );
 
     // Make race selection borders.
-    const fheroes2::Sprite & randomRaceSprite = fheroes2::AGG::GetICN( ICN::NGEXTRA, 58 );
+    const fheroes2::Sprite & randomRaceSprite = Assets::getImage( ICN::NGEXTRA, 58 );
     const int32_t raceBorderWidth = randomRaceSprite.width();
     const int32_t raceBorderHeight = randomRaceSprite.height();
     fheroes2::Image raceSpriteBorder( raceBorderWidth, raceBorderHeight );
@@ -1546,7 +1546,7 @@ void Dialog::selectTownType( int32_t & type, int32_t & color )
 
     // Neutral color.
     fheroes2::addGradientShadow( colorSpriteBorder, display, pos, { -5, 5 } );
-    const fheroes2::Sprite & neutralColorSprite = fheroes2::AGG::GetICN( ICN::BRCREST, 7 );
+    const fheroes2::Sprite & neutralColorSprite = Assets::getImage( ICN::BRCREST, 7 );
     fheroes2::Rect & neutralColorRect = colorRect.back();
     neutralColorRect = { pos.x, pos.y, colorSpriteBorder.width(), colorSpriteBorder.height() };
     fheroes2::Copy( neutralColorSprite, 0, 0, display, neutralColorRect.x + 4, neutralColorRect.y + 4, neutralColorSprite.width(), neutralColorSprite.height() );
@@ -1563,7 +1563,7 @@ void Dialog::selectTownType( int32_t & type, int32_t & color )
 
     pos.x += stepX;
     for ( uint32_t i = 0; i < 6; ++i ) {
-        const fheroes2::Sprite & colorSprite = fheroes2::AGG::GetICN( ICN::BRCREST, i );
+        const fheroes2::Sprite & colorSprite = Assets::getImage( ICN::BRCREST, i );
 
         fheroes2::addGradientShadow( colorSpriteBorder, display, pos, { -5, 5 } );
         colorRect[i] = { pos.x, pos.y, colorSpriteBorder.width(), colorSpriteBorder.height() };
@@ -1571,7 +1571,7 @@ void Dialog::selectTownType( int32_t & type, int32_t & color )
         text.set( Color::String( Color::IndexToColor( static_cast<int>( i ) ) ), fheroes2::FontType::smallWhite() );
         text.draw( colorRect[i].x + ( colorRect[i].width - text.width() ) / 2, colorRect[i].y + colorRect[i].height + 4, display );
 
-        const fheroes2::Sprite & raceSprite = fheroes2::AGG::GetICN( ICN::NGEXTRA, 51U + i );
+        const fheroes2::Sprite & raceSprite = Assets::getImage( ICN::NGEXTRA, 51U + i );
         raceRect[i] = { pos.x - 2, pos.y + raceOffsetY, raceBorderWidth, raceBorderHeight };
         fheroes2::Copy( raceSprite, 4, 4, display, raceRect[i].x + 4, raceRect[i].y + 4, raceImageWidth, raceImageHeight );
         fheroes2::Blit( raceShadow, display, pos.x - 5, pos.y + raceOffsetY + 2 );
@@ -1795,7 +1795,7 @@ int32_t Dialog::selectMineType( const int32_t type )
     std::array<fheroes2::Rect, resourceCount> resourceRoi;
 
     // Resource type selection mark background.
-    const fheroes2::Sprite & markBackground = fheroes2::AGG::GetICN( isEvilInterface ? ICN::CELLWIN_EVIL : ICN::CELLWIN, 4 );
+    const fheroes2::Sprite & markBackground = Assets::getImage( isEvilInterface ? ICN::CELLWIN_EVIL : ICN::CELLWIN, 4 );
 
     // Resource icons.
     const int32_t iconOffsetX = 35;
@@ -1814,7 +1814,7 @@ int32_t Dialog::selectMineType( const int32_t type )
     }
 
     // Render ghosts to select Abandoned mine type.
-    const fheroes2::Sprite & ghostImage = fheroes2::AGG::GetICN( ICN::MONS32, 59 );
+    const fheroes2::Sprite & ghostImage = Assets::getImage( ICN::MONS32, 59 );
     const int32_t ghostsOnIcon = 4;
     const int32_t ghostsIconOverlap = 12;
     const int32_t ghostsStepX = ghostImage.width() - ghostsIconOverlap;
@@ -1827,7 +1827,7 @@ int32_t Dialog::selectMineType( const int32_t type )
     fheroes2::Blit( markBackground, display, resourceRoi[7].x + 2, resourceRoi[7].y + ( resourceRoi[7].height - markBackground.height() ) / 2 );
 
     // Resource type selection mark.
-    const fheroes2::Sprite & mark = fheroes2::AGG::GetICN( ICN::CELLWIN, 5 );
+    const fheroes2::Sprite & mark = Assets::getImage( ICN::CELLWIN, 5 );
     uint32_t selectedResourceType = 0;
 
     const std::vector<Maps::ObjectInfo> & allObjectInfo = Maps::getObjectsByGroup( Maps::ObjectGroup::ADVENTURE_MINES );
@@ -1948,7 +1948,7 @@ int32_t Dialog::selectMineType( const int32_t type )
 
         listbox.SetListContent( objectInfo );
         // We need to reset the initial slider image to be able to reduce the current slider height.
-        listbox.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        listbox.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         listbox.updateScrollBarImage();
 
         if ( keepSelection ) {
@@ -2123,7 +2123,7 @@ PlayerColor Dialog::selectPlayerColor( const PlayerColor color, const uint8_t av
 
     // Render color selection sprites.
     fheroes2::Point pos( area.x + 20 + ( area.width - colorsWidth ) / 2, area.y + 40 );
-    const fheroes2::Sprite & colorSpriteBorderSelected = fheroes2::AGG::GetICN( ICN::BRCREST, 6 );
+    const fheroes2::Sprite & colorSpriteBorderSelected = Assets::getImage( ICN::BRCREST, 6 );
     fheroes2::Sprite colorSpriteBorder( colorSpriteBorderSelected );
 
     const std::vector<uint8_t> darkGrayPalette = PAL::CombinePalettes( PAL::GetPalette( PAL::PaletteType::GRAY ), PAL::GetPalette( PAL::PaletteType::DARKENING ) );
@@ -2133,7 +2133,7 @@ PlayerColor Dialog::selectPlayerColor( const PlayerColor color, const uint8_t av
 
     // Neutral color.
     fheroes2::addGradientShadow( colorSpriteBorder, display, pos, { -5, 5 } );
-    const fheroes2::Sprite & neutralColorSprite = fheroes2::AGG::GetICN( ICN::BRCREST, 7 );
+    const fheroes2::Sprite & neutralColorSprite = Assets::getImage( ICN::BRCREST, 7 );
     fheroes2::Rect & neutralColorRect = colorRect.back();
     neutralColorRect = { pos.x, pos.y, colorSpriteBorder.width(), colorSpriteBorder.height() };
     fheroes2::Copy( neutralColorSprite, 0, 0, display, neutralColorRect.x + 4, neutralColorRect.y + 4, neutralColorSprite.width(), neutralColorSprite.height() );
@@ -2148,7 +2148,7 @@ PlayerColor Dialog::selectPlayerColor( const PlayerColor color, const uint8_t av
             continue;
         }
 
-        const fheroes2::Sprite & colorSprite = fheroes2::AGG::GetICN( ICN::BRCREST, i );
+        const fheroes2::Sprite & colorSprite = Assets::getImage( ICN::BRCREST, i );
 
         fheroes2::addGradientShadow( colorSpriteBorder, display, pos, { -5, 5 } );
         colorRect[i] = { pos.x, pos.y, colorSpriteBorder.width(), colorSpriteBorder.height() };

--- a/src/fheroes2/dialog/dialog_selectscenario.cpp
+++ b/src/fheroes2/dialog/dialog_selectscenario.cpp
@@ -32,10 +32,10 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "difficulty.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -294,7 +294,7 @@ void ScenarioListBox::RedrawItem( const Maps::FileInfo & info, int32_t /*dstx*/,
 void ScenarioListBox::RedrawBackground( const fheroes2::Point & dst )
 {
     fheroes2::Display & display = fheroes2::Display::instance();
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::REQSBKG, 0 ), display, dst.x, dst.y );
+    fheroes2::Blit( Assets::getImage( ICN::REQSBKG, 0 ), display, dst.x, dst.y );
 
     if ( isSelected() ) {
         _renderSelectedScenarioInfo( display, dst );
@@ -361,7 +361,7 @@ void ScenarioListBox::_renderMapName( const Maps::FileInfo & info, bool selected
 
 void ScenarioListBox::SelectMapSize( MapsFileInfoList & mapsList, const int selectedSize_ )
 {
-    const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( ICN::ESCROLL, 3 );
+    const fheroes2::Sprite & originalSlider = Assets::getImage( ICN::ESCROLL, 3 );
     fheroes2::Image updatedScrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, 140, 9, static_cast<int32_t>( mapsList.size() ),
                                                                                 { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
     setScrollBarImage( std::move( updatedScrollbarSlider ) );
@@ -414,44 +414,44 @@ void ScenarioListBox::_renderMapIcon( const uint16_t size, fheroes2::Display & d
         fheroes2::Blit( icon, display, coordX, coordY );
     }
     else {
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::REQUESTS, mapIconIndex ), display, coordX, coordY );
+        fheroes2::Blit( Assets::getImage( ICN::REQUESTS, mapIconIndex ), display, coordX, coordY );
     }
 }
 
 const fheroes2::Sprite & ScenarioListBox::_getPlayersCountIcon( const PlayerColorsSet colors )
 {
     const uint32_t iconIndex = 19 + Color::Count( colors );
-    return fheroes2::AGG::GetICN( ICN::REQUESTS, iconIndex );
+    return Assets::getImage( ICN::REQUESTS, iconIndex );
 }
 
 const fheroes2::Sprite & ScenarioListBox::_getMapTypeIcon( const GameVersion version )
 {
     switch ( version ) {
     case GameVersion::SUCCESSION_WARS:
-        return fheroes2::AGG::GetICN( ICN::MAP_TYPE_ICON, 0 );
+        return Assets::getImage( ICN::MAP_TYPE_ICON, 0 );
     case GameVersion::PRICE_OF_LOYALTY:
-        return fheroes2::AGG::GetICN( ICN::MAP_TYPE_ICON, 1 );
+        return Assets::getImage( ICN::MAP_TYPE_ICON, 1 );
     case GameVersion::RESURRECTION:
-        return fheroes2::AGG::GetICN( ICN::MAP_TYPE_ICON, 2 );
+        return Assets::getImage( ICN::MAP_TYPE_ICON, 2 );
     default:
         // Did you add a new game version? Add the corresponding logic above!
         assert( 0 );
         break;
     }
 
-    return fheroes2::AGG::GetICN( ICN::UNKNOWN, 0 );
+    return Assets::getImage( ICN::UNKNOWN, 0 );
 }
 
 const fheroes2::Sprite & ScenarioListBox::_getWinConditionsIcon( const uint8_t condition )
 {
     uint32_t iconIndex = 30 + condition;
-    return fheroes2::AGG::GetICN( ICN::REQUESTS, iconIndex );
+    return Assets::getImage( ICN::REQUESTS, iconIndex );
 }
 
 const fheroes2::Sprite & ScenarioListBox::_getLossConditionsIcon( const uint8_t condition )
 {
     uint32_t iconIndex = 36 + condition;
-    return fheroes2::AGG::GetICN( ICN::REQUESTS, iconIndex );
+    return Assets::getImage( ICN::REQUESTS, iconIndex );
 }
 
 void ScenarioListBox::ActionListDoubleClick( Maps::FileInfo & /* unused */ )
@@ -514,12 +514,12 @@ const Maps::FileInfo * Dialog::SelectScenario( MapsFileInfoList & all, const boo
     }
 
     fheroes2::Display & display = fheroes2::Display::instance();
-    const fheroes2::Sprite & panel = fheroes2::AGG::GetICN( ICN::REQSBKG, 0 );
+    const fheroes2::Sprite & panel = Assets::getImage( ICN::REQSBKG, 0 );
     const fheroes2::Rect rt( ( display.width() - panel.width() ) / 2, ( display.height() - panel.height() ) / 2, panel.width(), panel.height() );
 
     const fheroes2::ImageRestorer background( display, rt.x - fheroes2::shadowWidthPx, rt.y, rt.width + fheroes2::shadowWidthPx, rt.height + fheroes2::shadowWidthPx );
 
-    const fheroes2::Sprite & shadow = fheroes2::AGG::GetICN( ICN::REQSBKG, 1 );
+    const fheroes2::Sprite & shadow = Assets::getImage( ICN::REQSBKG, 1 );
     fheroes2::Blit( shadow, display, rt.x - fheroes2::shadowWidthPx, rt.y + fheroes2::shadowWidthPx );
 
     const fheroes2::Rect countPlayers( rt.x + SCENARIO_LIST_COUNT_PLAYERS_OFFSET_X, rt.y + SCENARIO_LIST_ROW_OFFSET_Y, ICON_SIZE, SCENARIO_LIST_COLUMN_HEIGHT );

--- a/src/fheroes2/dialog/dialog_system_options.cpp
+++ b/src/fheroes2/dialog/dialog_system_options.cpp
@@ -27,7 +27,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_audio.h"
@@ -35,6 +34,7 @@
 #include "dialog_hotkeys.h"
 #include "dialog_interface_settings.h"
 #include "dialog_language_selection.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
@@ -99,7 +99,7 @@ namespace
             heroSpeedIconId = 4;
         }
 
-        const fheroes2::Sprite & heroSpeedIcon = fheroes2::AGG::GetICN( ICN::SPANEL, heroSpeedIconId );
+        const fheroes2::Sprite & heroSpeedIcon = Assets::getImage( ICN::SPANEL, heroSpeedIconId );
         std::string value;
         if ( heroSpeed == 10 ) {
             value = _( "Jump" );
@@ -123,7 +123,7 @@ namespace
             aiSpeedIconId = 4;
         }
 
-        const fheroes2::Sprite & aiSpeedIcon = fheroes2::AGG::GetICN( ICN::SPANEL, aiSpeedIconId );
+        const fheroes2::Sprite & aiSpeedIcon = Assets::getImage( ICN::SPANEL, aiSpeedIconId );
 
         std::string value;
         if ( aiSpeed == 0 ) {
@@ -142,7 +142,7 @@ namespace
     void drawInterfaceSettings( const fheroes2::Rect & optionRoi )
     {
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-        const fheroes2::Sprite & interfaceThemeIcon = fheroes2::AGG::GetICN( ICN::SPANEL, isEvilInterface ? 17 : 16 );
+        const fheroes2::Sprite & interfaceThemeIcon = Assets::getImage( ICN::SPANEL, isEvilInterface ? 17 : 16 );
 
         fheroes2::drawOption( optionRoi, interfaceThemeIcon, _( "Interface" ), _( "Settings" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
     }
@@ -154,11 +154,11 @@ namespace
             const bool spellcast = conf.BattleAutoSpellcast();
             std::string value = spellcast ? _( "Auto Resolve" ) : _( "Auto, No Spells" );
 
-            const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::CSPANEL, spellcast ? 7 : 6 );
+            const fheroes2::Sprite & autoBattleIcon = Assets::getImage( ICN::CSPANEL, spellcast ? 7 : 6 );
             fheroes2::drawOption( optionRoi, autoBattleIcon, _( "Battles" ), std::move( value ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
         else {
-            const fheroes2::Sprite & autoBattleIcon = fheroes2::AGG::GetICN( ICN::SPANEL, 18 );
+            const fheroes2::Sprite & autoBattleIcon = Assets::getImage( ICN::SPANEL, 18 );
             fheroes2::drawOption( optionRoi, autoBattleIcon, _( "Battles" ), _( "combatMode|Manual" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
     }

--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/dialog/dialog_thievesguild.cpp
+++ b/src/fheroes2/dialog/dialog_thievesguild.cpp
@@ -31,12 +31,12 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "castle.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h" // IWYU pragma: associated
 #include "game.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "heroes_base.h"
@@ -119,7 +119,7 @@ namespace
             return;
         }
 
-        const int32_t sptireWidth = fheroes2::AGG::GetICN( ICN::TOWNWIND, 22 ).width();
+        const int32_t sptireWidth = Assets::getImage( ICN::TOWNWIND, 22 ).width();
         const int32_t offsetY = pos.y - 4;
 
         for ( size_t i = 0; i < flagGroups; ++i ) {
@@ -128,7 +128,7 @@ namespace
             int32_t offsetX = pos.x + static_cast<int32_t>( i ) * step - ( static_cast<int32_t>( colors.size() ) * sptireWidth ) / 2 + 3;
 
             for ( const PlayerColor color : colors ) {
-                const fheroes2::Sprite & flag = fheroes2::AGG::GetICN( ICN::TOWNWIND, 22 + Color::GetIndex( color ) );
+                const fheroes2::Sprite & flag = Assets::getImage( ICN::TOWNWIND, 22 + Color::GetIndex( color ) );
                 fheroes2::Blit( flag, output, offsetX, offsetY );
                 offsetX += sptireWidth;
             }
@@ -173,7 +173,7 @@ namespace
                 continue;
             }
 
-            const fheroes2::Sprite & window = fheroes2::AGG::GetICN( frameIcnID, 22 );
+            const fheroes2::Sprite & window = Assets::getImage( frameIcnID, 22 );
             fheroes2::Blit( window, output, offsetX - window.width() / 2, pos.y - 4 );
 
             const fheroes2::Sprite & icon = hero->GetPortrait( PORT_SMALL );
@@ -207,7 +207,7 @@ namespace
         for ( const PlayerColor color : colors ) {
             const Monster monster = world.GetKingdom( color ).GetStrongestMonster();
             if ( monster.isValid() ) {
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MONS32, monster.GetSpriteIndex() );
+                const fheroes2::Sprite & sprite = Assets::getImage( ICN::MONS32, monster.GetSpriteIndex() );
                 fheroes2::Blit( sprite, output, offsetX - sprite.width() / 2, pos.y - sprite.height() / 2 );
             }
 
@@ -273,7 +273,7 @@ void Dialog::ThievesGuild( const bool oracle )
 
     const bool isEvilInterfaceTown = Settings::Get().isEvilInterfaceEnabled();
 
-    const fheroes2::Sprite & backgroundSprite = fheroes2::AGG::GetICN( isEvilInterfaceTown ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+    const fheroes2::Sprite & backgroundSprite = Assets::getImage( isEvilInterfaceTown ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
     fheroes2::Copy( backgroundSprite, 0, 0, display, dialogRoi.x, dialogRoi.y, backgroundSprite.width(), backgroundSprite.height() );
 
     const uint32_t thievesGuildCount = oracle ? 0xFF : world.GetKingdom( Settings::Get().CurrentColor() ).GetCountBuilding( BUILD_THIEVESGUILD );
@@ -295,10 +295,10 @@ void Dialog::ThievesGuild( const bool oracle )
     }
 
     // Status bar.
-    const int32_t exitWidth = fheroes2::AGG::GetICN( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
+    const int32_t exitWidth = Assets::getImage( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
     const int32_t bottomBarOffsetY = 461;
 
-    const fheroes2::Sprite & bottomBar = fheroes2::AGG::GetICN( ICN::SMALLBAR, 0 );
+    const fheroes2::Sprite & bottomBar = Assets::getImage( ICN::SMALLBAR, 0 );
     const int32_t barHeight = bottomBar.height();
     offset.y = dialogRoi.y + bottomBarOffsetY;
 

--- a/src/fheroes2/editor/editor_castle_details_window.cpp
+++ b/src/fheroes2/editor/editor_castle_details_window.cpp
@@ -34,7 +34,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_bar.h"
 #include "buildinginfo.h"
@@ -46,6 +45,7 @@
 #include "dialog_selectitems.h"
 #include "editor_spell_selection.h"
 #include "editor_ui_helper.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -205,8 +205,8 @@ namespace
 
             const int buildingIcnId = ICN::getBuildingIcnId( _race );
             const fheroes2::Sprite & buildingImage = ( buildingIcnId == ICN::UNKNOWN )
-                                                         ? fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::CASLXTRA_EVIL : ICN::CASLXTRA, 0 )
-                                                         : fheroes2::AGG::GetICN( buildingIcnId, index );
+                                                         ? Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::CASLXTRA_EVIL : ICN::CASLXTRA, 0 )
+                                                         : Assets::getImage( buildingIcnId, index );
 
             const fheroes2::Rect buildingImageRoi( _area.x + 1, _area.y + 1, 135, 57 );
 
@@ -225,7 +225,7 @@ namespace
             for ( int32_t i = 0; i < maxUpgrades; ++i ) {
                 if ( _restrictedId != -1 && i >= _restrictedId ) {
                     // Render the restricted sign: gray cross.
-                    fheroes2::Sprite denySign( fheroes2::AGG::GetICN( ICN::TOWNWIND, 12 ) );
+                    fheroes2::Sprite denySign( Assets::getImage( ICN::TOWNWIND, 12 ) );
                     fheroes2::ApplyPalette( denySign, PAL::CombinePalettes( PAL::GetPalette( PAL::PaletteType::GRAY ), PAL::GetPalette( PAL::PaletteType::DARKENING ) ) );
 
                     fheroes2::Blit( denySign, display, _area.x + _area.width - ( maxUpgrades - i ) * 20 - denySign.width() / 2, _area.y + 48 - denySign.height() / 2 );
@@ -234,21 +234,21 @@ namespace
 
                 const int icnId = ( i > _builtId ) ? ICN::CELLWIN : ICN::TOWNWIND;
                 const uint32_t icnIndex = ( i > _builtId ) ? 5 : 11;
-                const fheroes2::Sprite & mark = fheroes2::AGG::GetICN( icnId, icnIndex );
+                const fheroes2::Sprite & mark = Assets::getImage( icnId, icnIndex );
                 fheroes2::Blit( mark, display, _area.x + _area.width - ( maxUpgrades - i ) * 20 - mark.width() / 2, _area.y + 48 - mark.height() / 2 );
             }
 
             if ( _builtId > -1 ) {
-                const fheroes2::Sprite & textBackground = fheroes2::AGG::GetICN( ICN::BLDGXTRA, 0 );
+                const fheroes2::Sprite & textBackground = Assets::getImage( ICN::BLDGXTRA, 0 );
                 fheroes2::Copy( textBackground, 0, 58, display, _area.x, _area.y + 58, _area.width, textBackground.height() );
             }
             else if ( _restrictedId != 0 ) {
-                const fheroes2::Sprite & textBackground = fheroes2::AGG::GetICN( ICN::CASLXTRA, 1 );
+                const fheroes2::Sprite & textBackground = Assets::getImage( ICN::CASLXTRA, 1 );
                 fheroes2::Copy( textBackground, 0, 0, display, _area.x, _area.y + 58, _area.width, textBackground.height() );
             }
 
             if ( _restrictedId > -1 ) {
-                fheroes2::Sprite textBackground( fheroes2::AGG::GetICN( ICN::CASLXTRA, 2 ) );
+                fheroes2::Sprite textBackground( Assets::getImage( ICN::CASLXTRA, 2 ) );
                 fheroes2::ApplyPalette( textBackground, 6, 1, textBackground, 6, 1, 125, 12,
                                         PAL::CombinePalettes( PAL::GetPalette( PAL::PaletteType::GRAY ), PAL::GetPalette( PAL::PaletteType::DARKENING ) ) );
 
@@ -324,8 +324,8 @@ namespace
         fheroes2::ImageRestorer backgroundRestorer( display, dialogRoi.x, dialogRoi.y, dialogRoi.width, dialogRoi.height );
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
-        const fheroes2::Sprite & backgroundSprite = fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK ), 0 );
-        const fheroes2::Sprite & statusBarSprite = fheroes2::AGG::GetICN( ICN::CASLBAR, 0 );
+        const fheroes2::Sprite & backgroundSprite = Assets::getImage( ( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK ), 0 );
+        const fheroes2::Sprite & statusBarSprite = Assets::getImage( ICN::CASLBAR, 0 );
         const int32_t statusBarHeight = statusBarSprite.height();
 
         fheroes2::Copy( backgroundSprite, 0, 0, display, dialogRoi.x, dialogRoi.y, dialogRoi.width, dialogRoi.height - statusBarHeight );
@@ -367,7 +367,7 @@ namespace
         buttonOkay.draw();
 
         // EXIT button.
-        const int32_t buttonExitWidth = fheroes2::AGG::GetICN( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
+        const int32_t buttonExitWidth = Assets::getImage( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
         fheroes2::Button buttonExit( statusBarOffset.x + dialogRoi.width - buttonExitWidth, statusBarOffset.y, ICN::BUTTON_GUILDWELL_EXIT, 0, 1 );
         buttonExit.draw();
 
@@ -390,7 +390,7 @@ namespace
 
         // The original status bar image is much longer.
         // Since we are adding 2 buttons on each side we have to copy only left and right parts of the bar.
-        const int32_t buttonOkayWidth = fheroes2::AGG::GetICN( ICN::BUTTON_OKAY_TOWN, 0 ).width();
+        const int32_t buttonOkayWidth = Assets::getImage( ICN::BUTTON_OKAY_TOWN, 0 ).width();
         const int32_t statusBarWidth = dialogRoi.width - buttonExitWidth - buttonOkayWidth;
         fheroes2::Copy( statusBarSprite, 0, 0, display, statusBarOffset.x + buttonOkayWidth, statusBarOffset.y, statusBarWidth / 2, statusBarHeight );
         const int32_t statusBarSecondPart = statusBarWidth - statusBarWidth / 2;
@@ -622,7 +622,7 @@ namespace Editor
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
-        const fheroes2::Sprite & constructionBackground = fheroes2::AGG::GetICN( isEvilInterface ? ICN::CASLWIND_EVIL : ICN::CASLWIND, 0 );
+        const fheroes2::Sprite & constructionBackground = Assets::getImage( isEvilInterface ? ICN::CASLWIND_EVIL : ICN::CASLWIND, 0 );
         const int32_t backgroundHeight = constructionBackground.height();
 
         // Use the left part of town construction dialog.
@@ -630,14 +630,14 @@ namespace Editor
         const int32_t rightPartWidth = dialogRoi.width - rightPartOffsetX;
         fheroes2::Blit( constructionBackground, 0, 0, display, dialogRoi.x, dialogRoi.y, rightPartOffsetX, backgroundHeight );
         // Use the right part of standard background dialog.
-        fheroes2::Copy( fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 ), rightPartOffsetX, 0, display, dialogRoi.x + rightPartOffsetX,
+        fheroes2::Copy( Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 ), rightPartOffsetX, 0, display, dialogRoi.x + rightPartOffsetX,
                         dialogRoi.y, rightPartWidth, backgroundHeight );
         // Add horizontal separators.
         fheroes2::Copy( constructionBackground, rightPartOffsetX, 251, display, dialogRoi.x + rightPartOffsetX, dialogRoi.y + 226, rightPartWidth, 4 );
         fheroes2::Copy( constructionBackground, rightPartOffsetX, 251, display, dialogRoi.x + rightPartOffsetX, dialogRoi.y + 306, rightPartWidth, 4 );
 
         // Castle name background.
-        const fheroes2::Sprite & statusBarSprite = fheroes2::AGG::GetICN( ICN::CASLBAR, 0 );
+        const fheroes2::Sprite & statusBarSprite = Assets::getImage( ICN::CASLBAR, 0 );
         const int32_t statusBarHeight = statusBarSprite.height();
         const fheroes2::Rect nameArea( dialogRoi.x + rightPartOffsetX, dialogRoi.y + 1, rightPartWidth, statusBarHeight - 2 );
         fheroes2::Copy( statusBarSprite, 17, 0, display, nameArea.x, dialogRoi.y, nameArea.width, statusBarHeight );
@@ -762,7 +762,7 @@ namespace Editor
         // Captain building.
         dstPt.x = dialogRoi.x + rightPartOffsetX + 33;
         dstPt.y = dialogRoi.y + 232;
-        const fheroes2::Sprite & buildingFrame = fheroes2::AGG::GetICN( ICN::BLDGXTRA, 0 );
+        const fheroes2::Sprite & buildingFrame = Assets::getImage( ICN::BLDGXTRA, 0 );
         fheroes2::Blit( buildingFrame, display, dstPt.x, dstPt.y );
         buildings.back().setPosition( dstPt.x, dstPt.y );
         buildings.back().redraw( defaultBuildingsSign.isHidden() );
@@ -784,13 +784,13 @@ namespace Editor
         buttonOkay.draw();
 
         // EXIT button.
-        const int32_t buttonExitWidth = fheroes2::AGG::GetICN( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
+        const int32_t buttonExitWidth = Assets::getImage( ICN::BUTTON_GUILDWELL_EXIT, 0 ).width();
         fheroes2::Button buttonExit( statusBarOffset.x + dialogRoi.width - buttonExitWidth, statusBarOffset.y, ICN::BUTTON_GUILDWELL_EXIT, 0, 1 );
         buttonExit.draw();
 
         // The original status bar image is much longer.
         // Since we are adding 2 buttons on each side we have to copy only left and right parts of the bar.
-        const int32_t buttonOkayWidth = fheroes2::AGG::GetICN( ICN::BUTTON_OKAY_TOWN, 0 ).width();
+        const int32_t buttonOkayWidth = Assets::getImage( ICN::BUTTON_OKAY_TOWN, 0 ).width();
         const int32_t statusBarWidth = dialogRoi.width - buttonExitWidth - buttonOkayWidth;
         fheroes2::Copy( statusBarSprite, 0, 0, display, statusBarOffset.x + buttonOkayWidth, statusBarOffset.y, statusBarWidth / 2, statusBarHeight );
         const int32_t statusBarSecondPart = statusBarWidth - statusBarWidth / 2;

--- a/src/fheroes2/editor/editor_daily_events_window.cpp
+++ b/src/fheroes2/editor/editor_daily_events_window.cpp
@@ -28,10 +28,10 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "editor_daily_event_spec_window.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -194,7 +194,7 @@ namespace Editor
         eventList.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, eventsRoi.y + 1 } );
         eventList.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, eventsRoi.y + eventsRoi.height - 15 } );
         eventList.setScrollBarArea( { scrollbarOffsetX + 2, eventsRoi.y + topPartHeight, 10, eventsRoi.height - 2 * topPartHeight } );
-        eventList.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        eventList.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         eventList.SetAreaMaxItems( 10 );
         eventList.SetListContent( dailyEvents );
         eventList.updateScrollBarImage();
@@ -203,7 +203,7 @@ namespace Editor
 
         const int minibuttonIcnId = isEvilInterface ? ICN::CELLWIN_EVIL : ICN::CELLWIN;
 
-        const fheroes2::Sprite & buttonImage = fheroes2::AGG::GetICN( minibuttonIcnId, 13 );
+        const fheroes2::Sprite & buttonImage = Assets::getImage( minibuttonIcnId, 13 );
         const int32_t buttonWidth = buttonImage.width();
         const int32_t buttonOffset = ( eventsArea.width - 3 * buttonWidth ) / 2 + buttonWidth;
 

--- a/src/fheroes2/editor/editor_event_details_window.cpp
+++ b/src/fheroes2/editor/editor_event_details_window.cpp
@@ -29,12 +29,12 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "artifact.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
 #include "editor_ui_helper.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "icn.h"
@@ -86,7 +86,7 @@ namespace Editor
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
         if ( isDefaultScreenSize ) {
-            const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+            const fheroes2::Sprite & backgroundImage = Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
             fheroes2::Copy( backgroundImage, 0, 0, display, dialogRoi );
         }
 
@@ -137,7 +137,7 @@ namespace Editor
 
         const int minibuttonIcnId = isEvilInterface ? ICN::CELLWIN_EVIL : ICN::CELLWIN;
 
-        const fheroes2::Sprite & buttonImage = fheroes2::AGG::GetICN( minibuttonIcnId, 17 );
+        const fheroes2::Sprite & buttonImage = Assets::getImage( minibuttonIcnId, 17 );
         const int32_t buttonWidth = buttonImage.width();
 
         fheroes2::Button buttonDeleteArtifact( artifactRoi.x + ( artifactRoi.width - buttonWidth ) / 2, artifactRoi.y + artifactRoi.height + 5, minibuttonIcnId, 17, 18 );
@@ -391,7 +391,7 @@ namespace Editor
                 eventMetadata.artifact = 0;
                 eventMetadata.artifactMetadata = 0;
 
-                const fheroes2::Sprite & artifactImage = fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( eventMetadata.artifact ).IndexSprite64() );
+                const fheroes2::Sprite & artifactImage = Assets::getImage( ICN::ARTIFACT, Artifact( eventMetadata.artifact ).IndexSprite64() );
                 fheroes2::Copy( artifactImage, 0, 0, display, artifactRoi.x + 6, artifactRoi.y + 6, artifactImage.width(), artifactImage.height() );
 
                 display.render( artifactRoi );

--- a/src/fheroes2/editor/editor_interface_panel.cpp
+++ b/src/fheroes2/editor/editor_interface_panel.cpp
@@ -27,13 +27,13 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
 #include "editor_interface.h"
 #include "editor_options.h"
+#include "game_assets.h"
 #include "ground.h"
 #include "icn.h"
 #include "image.h"
@@ -117,7 +117,7 @@ namespace
 
     void drawInstrumentName( fheroes2::Image & output, const fheroes2::Point & pos, std::string text )
     {
-        const fheroes2::Sprite & originalPanel = fheroes2::AGG::GetICN( ICN::EDITPANL, 0 );
+        const fheroes2::Sprite & originalPanel = Assets::getImage( ICN::EDITPANL, 0 );
 
         const int32_t nameBackgroundOffsetX{ 7 };
         const int32_t nameBackgroundOffsetY{ 104 };
@@ -137,7 +137,7 @@ namespace
 
     void drawObjectTypeSelectionRect( fheroes2::Image & output, const fheroes2::Point & pos )
     {
-        const fheroes2::Sprite & selection = fheroes2::AGG::GetICN( ICN::TERRAINS, 9 );
+        const fheroes2::Sprite & selection = Assets::getImage( ICN::TERRAINS, 9 );
         fheroes2::Blit( selection, 0, 0, output, pos.x - 2, pos.y - 2, selection.width(), selection.height() );
     }
 
@@ -330,7 +330,7 @@ namespace Interface
         const fheroes2::Display & display = fheroes2::Display::instance();
         const int32_t instrumentPanelWidth = display.width() - displayX - fheroes2::borderWidthPx;
         const int32_t bottomBorderOffset = ( display.height() > fheroes2::Display::DEFAULT_HEIGHT + fheroes2::borderWidthPx ) ? fheroes2::borderWidthPx : 0;
-        const int32_t instrumentPanelHeight = display.height() - displayY - fheroes2::AGG::GetICN( ICN::EDITBTNS, 0 ).height() * 5 - bottomBorderOffset;
+        const int32_t instrumentPanelHeight = display.height() - displayY - Assets::getImage( ICN::EDITBTNS, 0 ).height() * 5 - bottomBorderOffset;
 
         _instrumentPanelBackground = makeInstrumentPanelBackground( instrumentPanelWidth, instrumentPanelHeight );
 
@@ -495,7 +495,7 @@ namespace Interface
 
         if ( _selectedInstrument == Instrument::TERRAIN ) {
             // We use terrain images from the original terrain instrument panel sprite.
-            const fheroes2::Sprite & originalPanel = fheroes2::AGG::GetICN( ICN::EDITPANL, 0 );
+            const fheroes2::Sprite & originalPanel = Assets::getImage( ICN::EDITPANL, 0 );
             for ( size_t i = 0; i < TerrainBrush::TERRAIN_COUNT; ++i ) {
                 const int32_t originalOffsetX = 30 + static_cast<int32_t>( i % 3 ) * 29;
                 const int32_t originalOffsetY = 11 + static_cast<int32_t>( i / 3 ) * 29;
@@ -513,7 +513,7 @@ namespace Interface
         else if ( _selectedInstrument == Instrument::LANDSCAPE_OBJECTS ) {
             // Landscape objects buttons.
             for ( uint32_t i = 0; i < LandscapeObjectBrush::LANDSCAPE_COUNT; ++i ) {
-                fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, i + 6 ), 0, 0, display, _landscapeObjectButtonsRect[i] );
+                fheroes2::Copy( Assets::getImage( ICN::EDITPANL, i + 6 ), 0, 0, display, _landscapeObjectButtonsRect[i] );
             }
 
             updateObjectTypeSelection( _selectedLandscapeObject, _landscapeObjectButtonsRect, _getLandscapeObjectTypeName,
@@ -522,7 +522,7 @@ namespace Interface
         else if ( _selectedInstrument == Instrument::DETAIL ) {
             // Detail mode types.
             for ( uint32_t i = 0; i < DetailBrushType::DETAIL_MODE_COUNT; ++i ) {
-                fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, i + 18 ), 0, 0, display, _detailModeButtonsRect[i] );
+                fheroes2::Copy( Assets::getImage( ICN::EDITPANL, i + 18 ), 0, 0, display, _detailModeButtonsRect[i] );
             }
 
             updateObjectTypeSelection( static_cast<int8_t>( _selectedDetailBrushType ), _detailModeButtonsRect, _getDetailModeTypeName,
@@ -530,18 +530,18 @@ namespace Interface
         }
         else if ( _selectedInstrument == Instrument::ADVENTURE_OBJECTS ) {
             // Adventure objects buttons.
-            const fheroes2::Sprite & originalPanel = fheroes2::AGG::GetICN( ICN::EDITPANL, 1 );
+            const fheroes2::Sprite & originalPanel = Assets::getImage( ICN::EDITPANL, 1 );
             const int32_t originalArtifactsImageOffsetX{ 15 };
             const int32_t originalTreasuresImageOffsetX{ 102 };
             const int32_t originalImagesOffsetY{ 96 };
 
             fheroes2::Copy( originalPanel, originalArtifactsImageOffsetX, originalImagesOffsetY, display, _adventureObjectButtonsRect[AdventureObjectBrush::ARTIFACTS] );
             for ( uint32_t i = AdventureObjectBrush::DWELLINGS; i < AdventureObjectBrush::TREASURES; ++i ) {
-                fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, i + 10 ), 0, 0, display, _adventureObjectButtonsRect[i] );
+                fheroes2::Copy( Assets::getImage( ICN::EDITPANL, i + 10 ), 0, 0, display, _adventureObjectButtonsRect[i] );
             }
             fheroes2::Copy( originalPanel, originalTreasuresImageOffsetX, originalImagesOffsetY, display, _adventureObjectButtonsRect[AdventureObjectBrush::TREASURES] );
             for ( uint32_t i = AdventureObjectBrush::WATER_ADVENTURE; i < AdventureObjectBrush::ADVENTURE_COUNT; ++i ) {
-                fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, i + 9 ), 0, 0, display, _adventureObjectButtonsRect[i] );
+                fheroes2::Copy( Assets::getImage( ICN::EDITPANL, i + 9 ), 0, 0, display, _adventureObjectButtonsRect[i] );
             }
 
             updateObjectTypeSelection( _selectedAdventureObject, _adventureObjectButtonsRect, _getAdventureObjectTypeName,
@@ -549,7 +549,7 @@ namespace Interface
         }
         else if ( _selectedInstrument == Instrument::KINGDOM_OBJECTS ) {
             // Kingdom objects buttons.
-            const fheroes2::Sprite & originalPanel = fheroes2::AGG::GetICN( ICN::EDITPANL, 1 );
+            const fheroes2::Sprite & originalPanel = Assets::getImage( ICN::EDITPANL, 1 );
             const int32_t originalHeroesImageOffsetX{ 102 };
             const int32_t originalTownsImageOffsetX{ 44 };
             const int32_t originalImagesOffsetY{ 68 };
@@ -594,7 +594,7 @@ namespace Interface
             instrumentName.draw( _rectInstrumentPanel.x + ( _rectInstrumentPanel.width - instrumentName.width() ) / 2, _rectInstrumentPanel.y + 8, display );
 
             // Object type to erase buttons.
-            const fheroes2::Sprite & originalPanel = fheroes2::AGG::GetICN( ICN::EDITPANL, 1 );
+            const fheroes2::Sprite & originalPanel = Assets::getImage( ICN::EDITPANL, 1 );
             const int32_t originalTownsImageOffsetX{ 44 };
             const int32_t originalMonstersImageOffsetX{ 73 };
             const int32_t originalHeroesTreasuresImageOffsetX{ 102 };
@@ -602,15 +602,15 @@ namespace Interface
             const int32_t originalArtifactsTreasresOffsetY{ 96 };
 
             // Mountains icon.
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, 6 ), 0, 0, display, _eraseButtonsRect[0] );
+            fheroes2::Copy( Assets::getImage( ICN::EDITPANL, 6 ), 0, 0, display, _eraseButtonsRect[0] );
             // Rocks icon.
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, 7 ), 0, 0, display, _eraseButtonsRect[1] );
+            fheroes2::Copy( Assets::getImage( ICN::EDITPANL, 7 ), 0, 0, display, _eraseButtonsRect[1] );
             // Trees icon.
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, 8 ), 0, 0, display, _eraseButtonsRect[2] );
+            fheroes2::Copy( Assets::getImage( ICN::EDITPANL, 8 ), 0, 0, display, _eraseButtonsRect[2] );
             // Landscape objects icon.
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, 10 ), 0, 0, display, _eraseButtonsRect[3] );
+            fheroes2::Copy( Assets::getImage( ICN::EDITPANL, 10 ), 0, 0, display, _eraseButtonsRect[3] );
             // Adventure non pickable objects icon.
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, 13 ), 0, 0, display, _eraseButtonsRect[4] );
+            fheroes2::Copy( Assets::getImage( ICN::EDITPANL, 13 ), 0, 0, display, _eraseButtonsRect[4] );
             // Castle objects icon.
             fheroes2::Copy( originalPanel, originalTownsImageOffsetX, originalTownsMonstersHeroesOffsetY, display, _eraseButtonsRect[5] );
             // Adventure pickable objects icon.
@@ -620,12 +620,12 @@ namespace Interface
             // Hero objects icon.
             fheroes2::Copy( originalPanel, originalHeroesTreasuresImageOffsetX, originalTownsMonstersHeroesOffsetY, display, _eraseButtonsRect[8] );
             // Road objects icon.
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, 16 ), 0, 0, display, _eraseButtonsRect[9] );
+            fheroes2::Copy( Assets::getImage( ICN::EDITPANL, 16 ), 0, 0, display, _eraseButtonsRect[9] );
             // Stream objects icon.
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::EDITPANL, 17 ), 0, 0, display, _eraseButtonsRect[10] );
+            fheroes2::Copy( Assets::getImage( ICN::EDITPANL, 17 ), 0, 0, display, _eraseButtonsRect[10] );
 
             // Object type to erase selection marks.
-            const fheroes2::Sprite & selectionMark = fheroes2::AGG::GetICN( ICN::TOWNWIND, 11 );
+            const fheroes2::Sprite & selectionMark = Assets::getImage( ICN::TOWNWIND, 11 );
             for ( size_t i = 0; i < _eraseButtonsRect.size(); ++i ) {
                 if ( _eraseButtonObjectTypes[i] & _eraseTypes ) {
                     fheroes2::Blit( selectionMark, 0, 0, display, _eraseButtonsRect[i].x + 10, _eraseButtonsRect[i].y + 11, selectionMark.width(),
@@ -992,7 +992,7 @@ namespace Interface
         case Maps::ObjectGroup::KINGDOM_HEROES:
             _interface.setCursorUpdater( [type]( const int32_t /*tileIndex*/ ) {
                 // TODO: render ICN::MINIHERO from the existing hero images.
-                const fheroes2::Sprite & image = fheroes2::AGG::GetICN( ICN::MINIHERO, type );
+                const fheroes2::Sprite & image = Assets::getImage( ICN::MINIHERO, type );
 
                 // Mini-hero images contain a pole with a flag.
                 // This causes a situation that a selected tile does not properly correspond to current position of the cursor.

--- a/src/fheroes2/editor/editor_language_window.cpp
+++ b/src/fheroes2/editor/editor_language_window.cpp
@@ -30,10 +30,10 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_language_selection.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -166,7 +166,7 @@ namespace Editor
         languageList.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, rumorsRoi.y + 1 } );
         languageList.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, rumorsRoi.y + rumorsRoi.height - 15 } );
         languageList.setScrollBarArea( { scrollbarOffsetX + 2, rumorsRoi.y + topPartHeight, 10, rumorsRoi.height - 2 * topPartHeight } );
-        languageList.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        languageList.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         languageList.SetAreaMaxItems( 10 );
 
         std::vector<fheroes2::SupportedLanguage> languages;
@@ -185,7 +185,7 @@ namespace Editor
 
         const int minibuttonIcnId = isEvilInterface ? ICN::CELLWIN_EVIL : ICN::CELLWIN;
 
-        const fheroes2::Sprite & buttonImage = fheroes2::AGG::GetICN( minibuttonIcnId, 13 );
+        const fheroes2::Sprite & buttonImage = Assets::getImage( minibuttonIcnId, 13 );
         const int32_t buttonWidth = buttonImage.width();
 
         fheroes2::Button buttonAdd( rumorsRoi.x, rumorsRoi.y + rumorsRoi.height + 5, minibuttonIcnId, 13, 14 );

--- a/src/fheroes2/editor/editor_map_specs_window.cpp
+++ b/src/fheroes2/editor/editor_map_specs_window.cpp
@@ -33,7 +33,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "artifact.h"
 #include "castle.h"
 #include "color.h"
@@ -45,6 +44,7 @@
 #include "editor_language_window.h"
 #include "editor_rumor_window.h"
 #include "editor_ui_helper.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_language.h"
 #include "game_over.h"
@@ -113,9 +113,9 @@ namespace
         // To render hero icons we use castle flags and frame.
         const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( color );
 
-        const fheroes2::Sprite & castleLeftFlag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex );
-        const fheroes2::Sprite & castleFrame = fheroes2::AGG::GetICN( townIcnId, 22 );
-        const fheroes2::Sprite & castleRightFlag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex + 1 );
+        const fheroes2::Sprite & castleLeftFlag = Assets::getImage( ICN::FLAG32, flagIcnIndex );
+        const fheroes2::Sprite & castleFrame = Assets::getImage( townIcnId, 22 );
+        const fheroes2::Sprite & castleRightFlag = Assets::getImage( ICN::FLAG32, flagIcnIndex + 1 );
 
         fheroes2::Sprite castleIcon( castleFrame.width() + castleLeftFlag.width() + castleRightFlag.width() + 4, castleFrame.height() );
         castleIcon.reset();
@@ -125,7 +125,7 @@ namespace
         fheroes2::Blit( castleRightFlag, 0, 0, castleIcon, castleFrame.width() + castleLeftFlag.width() + 4, 5, castleRightFlag.width(), castleRightFlag.height() );
 
         if ( heroPortait > 0 ) {
-            const fheroes2::Sprite & heroPortrait = fheroes2::AGG::GetICN( ICN::MINIPORT, heroPortait - 1 );
+            const fheroes2::Sprite & heroPortrait = Assets::getImage( ICN::MINIPORT, heroPortait - 1 );
             fheroes2::Copy( heroPortrait, 0, 0, castleIcon, castleLeftFlag.width() + 6, 4, heroPortrait.width(), heroPortrait.height() );
         }
         else {
@@ -160,7 +160,7 @@ namespace
                 break;
             }
 
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::NGEXTRA, portraitIndex ), 17, 10, castleIcon, castleLeftFlag.width() + 6, 4, 30, 22 );
+            fheroes2::Copy( Assets::getImage( ICN::NGEXTRA, portraitIndex ), 17, 10, castleIcon, castleLeftFlag.width() + 6, 4, 30, 22 );
         }
 
         return castleIcon;
@@ -170,9 +170,9 @@ namespace
     {
         const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( color );
 
-        const fheroes2::Sprite & castleLeftFlag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex );
-        const fheroes2::Sprite & castleFrame = fheroes2::AGG::GetICN( townIcnId, 23 );
-        const fheroes2::Sprite & castleRightFlag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex + 1 );
+        const fheroes2::Sprite & castleLeftFlag = Assets::getImage( ICN::FLAG32, flagIcnIndex );
+        const fheroes2::Sprite & castleFrame = Assets::getImage( townIcnId, 23 );
+        const fheroes2::Sprite & castleRightFlag = Assets::getImage( ICN::FLAG32, flagIcnIndex + 1 );
 
         fheroes2::Sprite castleIcon( castleFrame.width() + castleLeftFlag.width() + castleRightFlag.width() + 4, castleFrame.height() );
         castleIcon.reset();
@@ -183,7 +183,7 @@ namespace
 
         const uint32_t icnIndex = fheroes2::getCastleIcnIndex( race, !isTown );
 
-        const fheroes2::Sprite & castleImage = fheroes2::AGG::GetICN( townIcnId, icnIndex );
+        const fheroes2::Sprite & castleImage = Assets::getImage( townIcnId, icnIndex );
         fheroes2::Copy( castleImage, 0, 0, castleIcon, castleLeftFlag.width() + 6, 4, castleImage.width(), castleImage.height() );
 
         return castleIcon;
@@ -241,7 +241,7 @@ namespace
 
     fheroes2::Rect renderConditionsHeroIconAndName( const HeroInfo & heroInfo, const int32_t mapWidth, const fheroes2::Rect & roi, fheroes2::Image & output )
     {
-        const fheroes2::Sprite & heroFrame = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+        const fheroes2::Sprite & heroFrame = Assets::getImage( ICN::SWAPWIN, 0 );
 
         const int32_t heroFrameWidth = 111;
         const int32_t heroFrameHeight = 105;
@@ -252,8 +252,8 @@ namespace
 
         // To render hero icons we use castle flags and frame.
         const uint32_t flagIcnIndex = fheroes2::getCastleLeftFlagIcnIndex( heroInfo.color );
-        const fheroes2::Sprite & castleLeftFlag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex );
-        const fheroes2::Sprite & castleRightFlag = fheroes2::AGG::GetICN( ICN::FLAG32, flagIcnIndex + 1 );
+        const fheroes2::Sprite & castleLeftFlag = Assets::getImage( ICN::FLAG32, flagIcnIndex );
+        const fheroes2::Sprite & castleRightFlag = Assets::getImage( ICN::FLAG32, flagIcnIndex + 1 );
         Blit( castleLeftFlag, 0, 0, output, selectConditionRoi.x - 21, selectConditionRoi.y + 45, castleLeftFlag.width(), castleLeftFlag.height() );
         Blit( castleRightFlag, 0, 0, output, selectConditionRoi.x + selectConditionRoi.width + 2, selectConditionRoi.y + 45, castleRightFlag.width(),
               castleRightFlag.height() );
@@ -263,7 +263,7 @@ namespace
         assert( heroMetadata != nullptr );
 
         if ( heroMetadata->customPortrait > 0 ) {
-            const fheroes2::Sprite & heroPortrait = fheroes2::AGG::GetICN( ICN::getHeroPortraitIcnId( heroMetadata->customPortrait ), 0 );
+            const fheroes2::Sprite & heroPortrait = Assets::getImage( ICN::getHeroPortraitIcnId( heroMetadata->customPortrait ), 0 );
 
             fheroes2::Copy( heroPortrait, 0, 0, output, selectConditionRoi.x + 5, selectConditionRoi.y + 6, heroPortrait.width(), heroPortrait.height() );
         }
@@ -607,7 +607,7 @@ namespace
 
     void redrawVictoryCondition( const uint8_t condition, const fheroes2::Rect & roi, const bool yellowFont, fheroes2::Image & output )
     {
-        const fheroes2::Sprite & winIcon = fheroes2::AGG::GetICN( ICN::REQUESTS, getVictoryIcnIndex( condition ) );
+        const fheroes2::Sprite & winIcon = Assets::getImage( ICN::REQUESTS, getVictoryIcnIndex( condition ) );
         fheroes2::Copy( winIcon, 0, 0, output, roi.x + 1, roi.y, winIcon.width(), winIcon.height() );
         const fheroes2::Text winText( getVictoryConditionText( condition ), yellowFont ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );
         winText.drawInRoi( roi.x + 20, roi.y + 2, output, roi );
@@ -615,7 +615,7 @@ namespace
 
     void redrawLossCondition( const uint8_t condition, const fheroes2::Rect & roi, const bool yellowFont, fheroes2::Image & output )
     {
-        const fheroes2::Sprite & icon = fheroes2::AGG::GetICN( ICN::REQUESTS, getLossIcnIndex( condition ) );
+        const fheroes2::Sprite & icon = Assets::getImage( ICN::REQUESTS, getLossIcnIndex( condition ) );
         fheroes2::Copy( icon, 0, 0, output, roi.x + 1, roi.y, icon.width(), icon.height() );
         const fheroes2::Text winText( getLossConditionText( condition ), yellowFont ? fheroes2::FontType::normalYellow() : fheroes2::FontType::normalWhite() );
         winText.drawInRoi( roi.x + 20, roi.y + 2, output, roi );
@@ -640,7 +640,7 @@ namespace
 
             fheroes2::Display & display = fheroes2::Display::instance();
 
-            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( dropBoxIcn, 0 );
+            const fheroes2::Sprite & image = Assets::getImage( dropBoxIcn, 0 );
 
             const int32_t topPartHeight = image.height() - 2;
             const int32_t listWidth = image.width();
@@ -1102,7 +1102,7 @@ namespace
                 if ( renderEverything ) {
                     const fheroes2::Rect roi{ _restorer.rect() };
 
-                    const fheroes2::Sprite & artifactFrame = fheroes2::AGG::GetICN( ICN::RESOURCE, 7 );
+                    const fheroes2::Sprite & artifactFrame = Assets::getImage( ICN::RESOURCE, 7 );
                     _selectConditionRoi = { roi.x + ( roi.width - artifactFrame.width() ) / 2, roi.y + 4, artifactFrame.width(), artifactFrame.height() };
 
                     fheroes2::Blit( artifactFrame, output, _selectConditionRoi.x, _selectConditionRoi.y );
@@ -1115,7 +1115,7 @@ namespace
                                                                            roi.y + _selectConditionRoi.height + 10, _isEvilInterface, roi.width - 5 );
                 }
 
-                const fheroes2::Sprite & artifactImage = fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( static_cast<int>( _victoryArtifactId ) ).IndexSprite64() );
+                const fheroes2::Sprite & artifactImage = Assets::getImage( ICN::ARTIFACT, Artifact( static_cast<int>( _victoryArtifactId ) ).IndexSprite64() );
 
                 fheroes2::Copy( artifactImage, 0, 0, output, _selectConditionRoi.x + 6, _selectConditionRoi.y + 6, artifactImage.width(), artifactImage.height() );
 
@@ -2051,7 +2051,7 @@ namespace Editor
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
         if ( isDefaultScreenSize ) {
-            const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+            const fheroes2::Sprite & backgroundImage = Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
             fheroes2::Copy( backgroundImage, 0, 0, display, activeArea );
         }
 
@@ -2060,7 +2060,7 @@ namespace Editor
         }
 
         // Map name.
-        const fheroes2::Sprite & scenarioBox = fheroes2::AGG::GetICN( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
+        const fheroes2::Sprite & scenarioBox = Assets::getImage( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
         const fheroes2::Rect scenarioBoxRoi( activeArea.x + ( activeArea.width - scenarioBox.width() ) / 2, activeArea.y + 10, scenarioBox.width(),
                                              scenarioBox.height() );
         const fheroes2::Rect mapNameRoi( scenarioBoxRoi.x + 6, scenarioBoxRoi.y + 5, scenarioBoxRoi.width - 12, scenarioBoxRoi.height - 11 );
@@ -2080,7 +2080,7 @@ namespace Editor
         std::vector<fheroes2::Rect> playerRects( availablePlayersCount );
         const PlayerColorsVector availableColors( mapFormat.availablePlayerColors );
 
-        const fheroes2::Sprite & playerIconShadow = fheroes2::AGG::GetICN( ICN::NGEXTRA, 61 );
+        const fheroes2::Sprite & playerIconShadow = Assets::getImage( ICN::NGEXTRA, 61 );
         for ( int32_t i = 0; i < availablePlayersCount; ++i ) {
             playerRects[i].x = offsetX + i * playerStepX;
             playerRects[i].y = offsetY;
@@ -2089,7 +2089,7 @@ namespace Editor
 
             const uint32_t icnIndex = Color::GetIndex( availableColors[i] ) + getPlayerIcnIndex( mapFormat, availableColors[i] );
 
-            const fheroes2::Sprite & playerIcon = fheroes2::AGG::GetICN( ICN::NGEXTRA, icnIndex );
+            const fheroes2::Sprite & playerIcon = Assets::getImage( ICN::NGEXTRA, icnIndex );
             playerRects[i].width = playerIcon.width();
             playerRects[i].height = playerIcon.height();
             fheroes2::Copy( playerIcon, 0, 0, display, playerRects[i].x, playerRects[i].y, playerRects[i].width, playerRects[i].height );
@@ -2105,7 +2105,7 @@ namespace Editor
         std::array<fheroes2::Rect, 4> difficultyRects;
         offsetY += 23;
 
-        const fheroes2::Sprite & difficultyCursorSprite = fheroes2::AGG::GetICN( ICN::NGEXTRA, 62 );
+        const fheroes2::Sprite & difficultyCursorSprite = Assets::getImage( ICN::NGEXTRA, 62 );
         const int32_t difficultyIconSideLength = difficultyCursorSprite.width();
         const int difficultyIcnIndex = isEvilInterface ? 1 : 0;
 
@@ -2115,7 +2115,7 @@ namespace Editor
             difficultyRects[i].width = difficultyIconSideLength;
             difficultyRects[i].height = difficultyIconSideLength;
 
-            const fheroes2::Sprite & icon = fheroes2::AGG::GetICN( ICN::DIFFICULTY_ICON_EASY + i, difficultyIcnIndex );
+            const fheroes2::Sprite & icon = Assets::getImage( ICN::DIFFICULTY_ICON_EASY + i, difficultyIcnIndex );
             fheroes2::Copy( icon, 0, 0, display, difficultyRects[i] );
             fheroes2::addGradientShadow( icon, display, { difficultyRects[i].x, difficultyRects[i].y }, { -5, 5 } );
 
@@ -2157,7 +2157,7 @@ namespace Editor
         offsetY += 20;
 
         const int dropListIcn = isEvilInterface ? ICN::DROPLISL_EVIL : ICN::DROPLISL;
-        const fheroes2::Sprite & itemBackground = fheroes2::AGG::GetICN( dropListIcn, 0 );
+        const fheroes2::Sprite & itemBackground = Assets::getImage( dropListIcn, 0 );
         const int32_t itemBackgroundWidth = itemBackground.width();
         const int32_t itemBackgroundHeight = itemBackground.height();
         const int32_t itemBackgroundOffsetX = activeArea.width / 4 - itemBackgroundWidth / 2 - 11;
@@ -2168,8 +2168,8 @@ namespace Editor
 
         redrawVictoryCondition( mapFormat.victoryConditionType, victoryTextRoi, false, display );
 
-        const fheroes2::Sprite & dropListButtonSprite = fheroes2::AGG::GetICN( dropListIcn, 1 );
-        const fheroes2::Sprite & dropListButtonPressedSprite = fheroes2::AGG::GetICN( dropListIcn, 2 );
+        const fheroes2::Sprite & dropListButtonSprite = Assets::getImage( dropListIcn, 1 );
+        const fheroes2::Sprite & dropListButtonPressedSprite = Assets::getImage( dropListIcn, 2 );
 
         fheroes2::ButtonSprite victoryDroplistButton( offsetX + itemBackgroundWidth, offsetY, dropListButtonSprite, dropListButtonPressedSprite );
         const fheroes2::Rect victoryDroplistButtonRoi( fheroes2::getBoundaryRect( victoryDroplistButton.area(), victoryTextRoi ) );
@@ -2458,7 +2458,7 @@ namespace Editor
 
                     // Update player icon.
                     const uint32_t icnIndex = Color::GetIndex( availableColors[i] ) + getPlayerIcnIndex( mapFormat, availableColors[i] );
-                    const fheroes2::Sprite & playerIcon = fheroes2::AGG::GetICN( ICN::NGEXTRA, icnIndex );
+                    const fheroes2::Sprite & playerIcon = Assets::getImage( ICN::NGEXTRA, icnIndex );
                     fheroes2::Copy( playerIcon, 0, 0, display, playerRects[i].x, playerRects[i].y, playerRects[i].width, playerRects[i].height );
 
                     renderRoi = fheroes2::getBoundaryRect( renderRoi, playerRects[i] );

--- a/src/fheroes2/editor/editor_options.cpp
+++ b/src/fheroes2/editor/editor_options.cpp
@@ -26,7 +26,6 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_audio.h"
@@ -34,6 +33,7 @@
 #include "dialog_hotkeys.h"
 #include "dialog_language_selection.h"
 #include "editor_interface.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_language.h"
 #include "icn.h"
@@ -93,20 +93,20 @@ namespace
     void drawAnimationOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isEditorAnimationEnabled() ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::ESPANEL, 1 ), _( "Animation" ), _( "On" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::ESPANEL, 1 ), _( "Animation" ), _( "On" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::ESPANEL, 0 ), _( "Animation" ), _( "Off" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::ESPANEL, 0 ), _( "Animation" ), _( "Off" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
     }
 
     void drawPassabilityOptions( const fheroes2::Rect & optionRoi )
     {
         if ( Settings::Get().isEditorPassabilityEnabled() ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::ESPANEL, 5 ), _( "Passability" ), _( "Show" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::ESPANEL, 5 ), _( "Passability" ), _( "Show" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::ESPANEL, 4 ), _( "Passability" ), _( "Hide" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::ESPANEL, 4 ), _( "Passability" ), _( "Hide" ), fheroes2::UiOptionTextWidth::THREE_ELEMENTS_ROW );
         }
     }
 

--- a/src/fheroes2/editor/editor_rumor_window.cpp
+++ b/src/fheroes2/editor/editor_rumor_window.cpp
@@ -28,9 +28,9 @@
 #include <optional>
 #include <utility>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -173,7 +173,7 @@ namespace Editor
         rumorList.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, rumorsRoi.y + 1 } );
         rumorList.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, rumorsRoi.y + rumorsRoi.height - 15 } );
         rumorList.setScrollBarArea( { scrollbarOffsetX + 2, rumorsRoi.y + topPartHeight, 10, rumorsRoi.height - 2 * topPartHeight } );
-        rumorList.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        rumorList.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         rumorList.SetAreaMaxItems( 10 );
         rumorList.SetListContent( rumors );
         rumorList.updateScrollBarImage();
@@ -182,7 +182,7 @@ namespace Editor
 
         const int minibuttonIcnId = isEvilInterface ? ICN::CELLWIN_EVIL : ICN::CELLWIN;
 
-        const fheroes2::Sprite & buttonImage = fheroes2::AGG::GetICN( minibuttonIcnId, 13 );
+        const fheroes2::Sprite & buttonImage = Assets::getImage( minibuttonIcnId, 13 );
         const int32_t buttonWidth = buttonImage.width();
         const int32_t buttonOffset = ( rumorArea.width - 3 * buttonWidth ) / 2 + buttonWidth;
 

--- a/src/fheroes2/editor/editor_save_map_window.cpp
+++ b/src/fheroes2/editor/editor_save_map_window.cpp
@@ -32,10 +32,10 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_language.h"
 #include "game_string.h"
@@ -142,11 +142,11 @@ namespace
         fileNameText.draw( posX + 44, posY + 2, display );
 
         const uint32_t racesCountIcnIndex = static_cast<uint32_t>( Color::Count( info.kingdomColors ) + 19 );
-        const fheroes2::Sprite & racesCount = fheroes2::AGG::GetICN( ICN::REQUESTS, racesCountIcnIndex );
+        const fheroes2::Sprite & racesCount = Assets::getImage( ICN::REQUESTS, racesCountIcnIndex );
         fheroes2::Copy( racesCount, 0, 0, display, posX + 6, posY, racesCount.width(), racesCount.height() );
 
         const uint32_t mapSizeIcnIndex = static_cast<uint32_t>( info.width / Maps::SMALL + 25 );
-        const fheroes2::Sprite & mapSize = fheroes2::AGG::GetICN( ICN::REQUESTS, mapSizeIcnIndex );
+        const fheroes2::Sprite & mapSize = Assets::getImage( ICN::REQUESTS, mapSizeIcnIndex );
         fheroes2::Copy( mapSize, 0, 0, display, posX + 25, posY, mapSize.width(), mapSize.height() );
     }
 
@@ -256,7 +256,7 @@ namespace Editor
         listbox.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, listRoi.y + 1 } );
         listbox.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, listRoi.y + listRoi.height - 15 } );
         listbox.setScrollBarArea( { scrollbarOffsetX + 2, listRoi.y + topPartHeight, 10, listRoi.height - 2 * topPartHeight } );
-        listbox.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        listbox.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         listbox.SetAreaMaxItems( listItems );
         listbox.SetListContent( lists );
         listbox.updateScrollBarImage();

--- a/src/fheroes2/editor/editor_secondary_skill_selection.cpp
+++ b/src/fheroes2/editor/editor_secondary_skill_selection.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_secondary_skill_selection.cpp
+++ b/src/fheroes2/editor/editor_secondary_skill_selection.cpp
@@ -26,9 +26,9 @@
 #include <initializer_list>
 #include <utility>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_static.h"
 #include "heroes.h"
@@ -77,7 +77,7 @@ namespace
             // Calculate all areas where we are going to render skills.
             _skillRoi.reserve( _skills.size() );
 
-            const fheroes2::Sprite & frameImage = fheroes2::AGG::GetICN( ICN::SECSKILL, 15 );
+            const fheroes2::Sprite & frameImage = Assets::getImage( ICN::SECSKILL, 15 );
 
             const int32_t lastRowColumns = static_cast<int32_t>( _skills.size() % _skillsPerRow );
             const int32_t lastRowOffsetX = ( lastRowColumns > 0 ) ? ( static_cast<int32_t>( _skillsPerRow ) - lastRowColumns ) * skillItemWidth / 2 : 0;
@@ -99,7 +99,7 @@ namespace
 
         void draw( fheroes2::Image & output )
         {
-            const fheroes2::Sprite & frameImage = fheroes2::AGG::GetICN( ICN::SECSKILL, 15 );
+            const fheroes2::Sprite & frameImage = Assets::getImage( ICN::SECSKILL, 15 );
 
             fheroes2::Sprite inactiveFrameImage( frameImage );
             fheroes2::ApplyPalette( inactiveFrameImage, PAL::GetPalette( PAL::PaletteType::GRAY ) );
@@ -107,7 +107,7 @@ namespace
             for ( size_t i = 0; i < _skills.size(); ++i ) {
                 const Skill::Secondary & skill = _skills[i].first;
 
-                const fheroes2::Sprite & skillImage = fheroes2::AGG::GetICN( ICN::SECSKILL, skill.GetIndexSprite1() );
+                const fheroes2::Sprite & skillImage = Assets::getImage( ICN::SECSKILL, skill.GetIndexSprite1() );
                 const fheroes2::Point skillImagePos( _skillRoi[i].x + 3, _skillRoi[i].y + 3 );
 
                 fheroes2::Copy( skillImage, 0, 0, output, skillImagePos.x, skillImagePos.y, skillImage.width(), skillImage.height() );
@@ -138,8 +138,8 @@ namespace
             if ( _skills[_skillToRedraw].second ) {
                 const Skill::Secondary & skill = _skills[_skillToRedraw].first;
 
-                const fheroes2::Sprite & frameImage = fheroes2::AGG::GetICN( ICN::SECSKILL, 15 );
-                const fheroes2::Sprite & skillImage = fheroes2::AGG::GetICN( ICN::SECSKILL, skill.GetIndexSprite1() );
+                const fheroes2::Sprite & frameImage = Assets::getImage( ICN::SECSKILL, 15 );
+                const fheroes2::Sprite & skillImage = Assets::getImage( ICN::SECSKILL, skill.GetIndexSprite1() );
                 const int32_t skillImageOffsetX = roi.x + 3;
 
                 fheroes2::Blit( frameImage, output, roi.x, roi.y );
@@ -241,7 +241,7 @@ namespace Editor
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
         if ( isDefaultScreenSize ) {
-            const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+            const fheroes2::Sprite & backgroundImage = Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
             fheroes2::Copy( backgroundImage, 0, 0, display, activeArea );
         }
 

--- a/src/fheroes2/editor/editor_spell_selection.cpp
+++ b/src/fheroes2/editor/editor_spell_selection.cpp
@@ -26,9 +26,9 @@
 #include <initializer_list>
 #include <utility>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -78,7 +78,7 @@ namespace
             // Calculate all areas where we are going to render spells.
             _spellRoi.reserve( _spells.size() );
 
-            const fheroes2::Sprite & scrollImage = fheroes2::AGG::GetICN( ICN::TOWNWIND, 0 );
+            const fheroes2::Sprite & scrollImage = Assets::getImage( ICN::TOWNWIND, 0 );
 
             const int32_t lastRowColumns = static_cast<int32_t>( _spells.size() % _spellsPerRow );
             const int32_t lastRowOffsetX = ( lastRowColumns > 0 ) ? ( static_cast<int32_t>( _spellsPerRow ) - lastRowColumns ) * spellItemWidth / 2 : 0;
@@ -100,7 +100,7 @@ namespace
 
         void draw( fheroes2::Image & output )
         {
-            const fheroes2::Sprite & scrollImage = fheroes2::AGG::GetICN( ICN::TOWNWIND, 0 );
+            const fheroes2::Sprite & scrollImage = Assets::getImage( ICN::TOWNWIND, 0 );
 
             fheroes2::Sprite inactiveScrollImage( scrollImage );
             fheroes2::ApplyPalette( inactiveScrollImage, PAL::GetPalette( PAL::PaletteType::GRAY ) );
@@ -114,7 +114,7 @@ namespace
                     fheroes2::Blit( scrollImage, output, _spellRoi[i].x, _spellRoi[i].y );
                 }
 
-                const fheroes2::Sprite & spellImage = fheroes2::AGG::GetICN( ICN::SPELLS, _spells[i].first.IndexSprite() );
+                const fheroes2::Sprite & spellImage = Assets::getImage( ICN::SPELLS, _spells[i].first.IndexSprite() );
 
                 if ( !_spells[i].second ) {
                     // The spell is being inactive.
@@ -216,7 +216,7 @@ namespace Editor
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
         if ( isDefaultScreenSize ) {
-            const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+            const fheroes2::Sprite & backgroundImage = Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
             fheroes2::Copy( backgroundImage, 0, 0, display, activeArea );
         }
 

--- a/src/fheroes2/editor/editor_sphinx_window.cpp
+++ b/src/fheroes2/editor/editor_sphinx_window.cpp
@@ -31,13 +31,13 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "artifact.h"
 #include "artifact_info.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
 #include "editor_ui_helper.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "image.h"
@@ -200,7 +200,7 @@ namespace Editor
         answerList.SetScrollButtonUp( listIcnId, 0, 1, { scrollbarOffsetX, answerRoi.y + 1 } );
         answerList.SetScrollButtonDn( listIcnId, 2, 3, { scrollbarOffsetX, answerRoi.y + answerRoi.height - 15 } );
         answerList.setScrollBarArea( { scrollbarOffsetX + 2, answerRoi.y + topPartHeight, 10, answerRoi.height - 2 * topPartHeight } );
-        answerList.setScrollBarImage( fheroes2::AGG::GetICN( listIcnId, 4 ) );
+        answerList.setScrollBarImage( Assets::getImage( listIcnId, 4 ) );
         answerList.SetAreaMaxItems( 10 );
         answerList.SetListContent( metadata.answers );
         answerList.updateScrollBarImage();
@@ -209,7 +209,7 @@ namespace Editor
 
         const int minibuttonIcnId = isEvilInterface ? ICN::CELLWIN_EVIL : ICN::CELLWIN;
 
-        const fheroes2::Sprite & buttonImage = fheroes2::AGG::GetICN( minibuttonIcnId, 13 );
+        const fheroes2::Sprite & buttonImage = Assets::getImage( minibuttonIcnId, 13 );
         const int32_t buttonWidth = buttonImage.width();
         const int32_t buttonOffset = ( answerArea.width - 3 * buttonWidth ) / 2 + buttonWidth;
 
@@ -227,14 +227,14 @@ namespace Editor
         text.set( _( "Reward:" ), fheroes2::FontType::normalWhite() );
         text.draw( windowArea.x + ( windowArea.width - text.width() ) / 2, offsetY, display );
 
-        const fheroes2::Sprite & artifactFrame = fheroes2::AGG::GetICN( ICN::RESOURCE, 7 );
+        const fheroes2::Sprite & artifactFrame = Assets::getImage( ICN::RESOURCE, 7 );
         const fheroes2::Rect artifactRoi{ riddleRoi.x + ( riddleRoi.width - artifactFrame.width() ) / 2, offsetY + text.height(), artifactFrame.width(),
                                           artifactFrame.height() };
 
         fheroes2::Blit( artifactFrame, display, artifactRoi.x, artifactRoi.y );
 
         auto redrawArtifactImage = [&display, &artifactRoi]( const int32_t artifactId ) {
-            const fheroes2::Sprite & artifactImage = fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( artifactId ).IndexSprite64() );
+            const fheroes2::Sprite & artifactImage = Assets::getImage( ICN::ARTIFACT, Artifact( artifactId ).IndexSprite64() );
             fheroes2::Copy( artifactImage, 0, 0, display, artifactRoi.x + 6, artifactRoi.y + 6, artifactImage.width(), artifactImage.height() );
         };
 
@@ -405,7 +405,7 @@ namespace Editor
                 metadata.artifact = 0;
                 metadata.artifactMetadata = 0;
 
-                const fheroes2::Sprite & artifactImage = fheroes2::AGG::GetICN( ICN::ARTIFACT, Artifact( metadata.artifact ).IndexSprite64() );
+                const fheroes2::Sprite & artifactImage = Assets::getImage( ICN::ARTIFACT, Artifact( metadata.artifact ).IndexSprite64() );
                 fheroes2::Copy( artifactImage, 0, 0, display, artifactRoi.x + 6, artifactRoi.y + 6, artifactImage.width(), artifactImage.height() );
 
                 display.render( artifactRoi );

--- a/src/fheroes2/editor/editor_ui_helper.cpp
+++ b/src/fheroes2/editor/editor_ui_helper.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2024 - 2025                                             *
+ *   Copyright (C) 2024 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/editor/editor_ui_helper.cpp
+++ b/src/fheroes2/editor/editor_ui_helper.cpp
@@ -23,7 +23,7 @@
 #include <cassert>
 #include <utility>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "resource.h"
@@ -37,10 +37,10 @@ namespace Editor
 {
     Checkbox::Checkbox( const int32_t x, const int32_t y, const PlayerColor boxColor, const bool checked, fheroes2::Image & output )
         : _color( boxColor )
-        , _checkmark( fheroes2::AGG::GetICN( ICN::CELLWIN, 2 ) )
+        , _checkmark( Assets::getImage( ICN::CELLWIN, 2 ) )
     {
         const int32_t icnIndex = ( _color == PlayerColor::NONE ) ? 1 : Color::GetIndex( _color ) + 43;
-        const fheroes2::Sprite & playerIcon = fheroes2::AGG::GetICN( ICN::CELLWIN, icnIndex );
+        const fheroes2::Sprite & playerIcon = Assets::getImage( ICN::CELLWIN, icnIndex );
 
         _area = { x, y, playerIcon.width(), playerIcon.height() };
 
@@ -81,7 +81,7 @@ namespace Editor
     {
         assert( maxWidth > 0 );
 
-        const fheroes2::Sprite & checkboxBackground = fheroes2::AGG::GetICN( isEvil ? ICN::CELLWIN_EVIL : ICN::CELLWIN, 1 );
+        const fheroes2::Sprite & checkboxBackground = Assets::getImage( isEvil ? ICN::CELLWIN_EVIL : ICN::CELLWIN, 1 );
         fheroes2::Copy( checkboxBackground, 0, 0, output, posX, posY, checkboxBackground.width(), checkboxBackground.height() );
 
         fheroes2::addGradientShadow( checkboxBackground, output, { posX, posY }, { -4, 4 } );
@@ -92,7 +92,7 @@ namespace Editor
         checkboxText.fitToOneRow( maxWidth - textOffsetX );
         checkboxText.draw( posX + textOffsetX, posY + 4, output );
 
-        checkSprite = fheroes2::AGG::GetICN( ICN::CELLWIN, 2 );
+        checkSprite = Assets::getImage( ICN::CELLWIN, 2 );
         checkSprite.setPosition( posX + 2, posY + 2 );
 
         return { posX, posY, textOffsetX + checkboxText.width(), checkboxBackground.height() };
@@ -119,13 +119,13 @@ namespace Editor
 
         const std::array<int32_t, 2> offsetY = { roi.y + offsetFromEdge + maxHeight, roi.y + offsetFromEdge + 2 * maxHeight + fontHeight + 2 };
 
-        const fheroes2::Sprite & woodImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 0 );
-        const fheroes2::Sprite & mercuryImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 1 );
-        const fheroes2::Sprite & oreImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 2 );
-        const fheroes2::Sprite & sulfurImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 3 );
-        const fheroes2::Sprite & crystalImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 4 );
-        const fheroes2::Sprite & gemsImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 5 );
-        const fheroes2::Sprite & goldImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 6 );
+        const fheroes2::Sprite & woodImage = Assets::getImage( ICN::RESOURCE, 0 );
+        const fheroes2::Sprite & mercuryImage = Assets::getImage( ICN::RESOURCE, 1 );
+        const fheroes2::Sprite & oreImage = Assets::getImage( ICN::RESOURCE, 2 );
+        const fheroes2::Sprite & sulfurImage = Assets::getImage( ICN::RESOURCE, 3 );
+        const fheroes2::Sprite & crystalImage = Assets::getImage( ICN::RESOURCE, 4 );
+        const fheroes2::Sprite & gemsImage = Assets::getImage( ICN::RESOURCE, 5 );
+        const fheroes2::Sprite & goldImage = Assets::getImage( ICN::RESOURCE, 6 );
 
         resourceRoi[0] = { firstColumnOffset + ( maxWidth - woodImage.width() ) / 2, offsetY[0] - woodImage.height(), woodImage.width(), woodImage.height() };
         resourceRoi[1] = { secondColumnOffset + ( maxWidth - sulfurImage.width() ) / 2, offsetY[0] - sulfurImage.height(), sulfurImage.width(), sulfurImage.height() };

--- a/src/fheroes2/game/fheroes2.cpp
+++ b/src/fheroes2/game/fheroes2.cpp
@@ -57,7 +57,6 @@
 #endif
 
 #include "agg.h"
-#include "agg_image.h"
 #include "audio_manager.h"
 #include "core.h"
 #include "cursor.h"
@@ -65,6 +64,7 @@
 #include "embedded_image.h"
 #include "exception.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_logo.h"
 #include "game_video.h"
 #include "game_video_type.h"
@@ -241,7 +241,7 @@ namespace
                 _h2dInitializer.reset( new fheroes2::h2d::H2DInitializer );
 
                 // Verify that the font is present and it is not corrupted.
-                fheroes2::AGG::GetICN( ICN::FONT, 0 );
+                Assets::getImage( ICN::FONT, 0 );
             }
             catch ( ... ) {
                 displayMissingResourceWindow();

--- a/src/fheroes2/game/game_assets.cpp
+++ b/src/fheroes2/game/game_assets.cpp
@@ -18,7 +18,7 @@
  *   59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.             *
  ***************************************************************************/
 
-#include "agg_image.h"
+#include "game_assets.h"
 
 #include <algorithm>
 #include <array>
@@ -386,8 +386,8 @@ namespace
                 return;
             }
 
-            fheroes2::AGG::GetICN( ICN::FONT, 0 );
-            fheroes2::AGG::GetICN( ICN::SMALFONT, 0 );
+            Assets::getImage( ICN::FONT, 0 );
+            Assets::getImage( ICN::SMALFONT, 0 );
             // Do not automatically load resources for button fonts as
             // they are not stored in the original game resources.
 
@@ -520,8 +520,8 @@ namespace
     // NOTE: Do not call this with an evil style button's ICN ID.
     void convertToEvilButtonBackground( fheroes2::Sprite & released, fheroes2::Sprite & pressed, const int goodButtonIcnId, const uint32_t index )
     {
-        released = fheroes2::AGG::GetICN( goodButtonIcnId, index );
-        pressed = fheroes2::AGG::GetICN( goodButtonIcnId, index + 1 );
+        released = Assets::getImage( goodButtonIcnId, index );
+        pressed = Assets::getImage( goodButtonIcnId, index + 1 );
 
         const std::vector<uint8_t> & goodToEvilPalette = PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_BUTTON );
         fheroes2::ApplyPalette( released, goodToEvilPalette );
@@ -724,7 +724,7 @@ namespace
     {
         assert( icnId != originalIcnId );
 
-        fheroes2::AGG::GetICN( originalIcnId, 0 ); // always avoid calling `readIcnFromAgg()` directly
+        Assets::getImage( originalIcnId, 0 ); // always avoid calling `readIcnFromAgg()` directly
 
         _icnVsSprite[icnId] = _icnVsSprite[originalIcnId];
         const std::vector<uint8_t> & palette = PAL::GetPalette( paletteType );
@@ -740,8 +740,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::NGEXTRA, 64 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::NGEXTRA, 65 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::NGEXTRA, 64 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::NGEXTRA, 65 );
                 break;
             }
 
@@ -762,8 +762,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::REQUESTS, 9 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::REQUESTS, 10 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::REQUESTS, 9 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::REQUESTS, 10 );
                 break;
             }
 
@@ -776,8 +776,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::REQUESTS, 11 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::REQUESTS, 12 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::REQUESTS, 11 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::REQUESTS, 12 );
                 break;
             }
 
@@ -790,8 +790,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::REQUESTS, 13 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::REQUESTS, 14 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::REQUESTS, 13 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::REQUESTS, 14 );
                 break;
             }
 
@@ -804,8 +804,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::REQUESTS, 15 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::REQUESTS, 16 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::REQUESTS, 15 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::REQUESTS, 16 );
                 break;
             }
 
@@ -818,8 +818,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::REQUESTS, 17 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::REQUESTS, 18 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::REQUESTS, 17 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::REQUESTS, 18 );
                 break;
             }
 
@@ -892,8 +892,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::WELLXTRA, 0 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::WELLXTRA, 1 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::WELLXTRA, 0 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::WELLXTRA, 1 );
                 break;
             }
 
@@ -907,8 +907,8 @@ namespace
             buttonStates.resize( 2 );
 
             if ( useOriginalResources() ) {
-                buttonStates[0] = fheroes2::AGG::GetICN( ICN::TREASURY, 1 );
-                buttonStates[1] = fheroes2::AGG::GetICN( ICN::TREASURY, 2 );
+                buttonStates[0] = Assets::getImage( ICN::TREASURY, 1 );
+                buttonStates[1] = Assets::getImage( ICN::TREASURY, 2 );
                 break;
             }
 
@@ -933,8 +933,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 const int originalButtonICN = isEvilInterface ? ICN::LGNDXTRE : ICN::LGNDXTRA;
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( originalButtonICN, 4 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( originalButtonICN, 5 );
+                _icnVsSprite[id][0] = Assets::getImage( originalButtonICN, 4 );
+                _icnVsSprite[id][1] = Assets::getImage( originalButtonICN, 5 );
                 break;
             }
 
@@ -951,8 +951,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 const int originalIcnId = isEvilInterface ? ICN::LGNDXTRE : ICN::LGNDXTRA;
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( originalIcnId, 2 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( originalIcnId, 3 );
+                _icnVsSprite[id][0] = Assets::getImage( originalIcnId, 2 );
+                _icnVsSprite[id][1] = Assets::getImage( originalIcnId, 3 );
                 break;
             }
 
@@ -966,8 +966,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::OVERVIEW, 4 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::OVERVIEW, 5 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::OVERVIEW, 4 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::OVERVIEW, 5 );
                 break;
             }
 
@@ -980,8 +980,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::OVERVIEW, 0 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::OVERVIEW, 1 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::OVERVIEW, 0 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::OVERVIEW, 1 );
                 break;
             }
 
@@ -994,8 +994,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::OVERVIEW, 2 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::OVERVIEW, 3 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::OVERVIEW, 2 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::OVERVIEW, 3 );
                 break;
             }
 
@@ -1011,8 +1011,8 @@ namespace
             const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_CANCEL_EVIL );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 8 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 9 );
+                _icnVsSprite[id][0] = Assets::getImage( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 8 );
+                _icnVsSprite[id][1] = Assets::getImage( isEvilInterface ? ICN::CPANELE : ICN::CPANEL, 9 );
 
                 // To properly generate shadows and Blit the button we need to make transparent pixels in its released state the same as in the pressed state.
                 copyTransformLayer( _icnVsSprite[id][0], _icnVsSprite[id][1] );
@@ -1033,8 +1033,8 @@ namespace
             const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_OKAY_EVIL );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 1 );
+                _icnVsSprite[id][0] = Assets::getImage( isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 0 );
+                _icnVsSprite[id][1] = Assets::getImage( isEvilInterface ? ICN::SPANBTNE : ICN::SPANBTN, 1 );
 
                 // To properly generate shadows and Blit the button we need to make transparent pixels in its released state the same as in the pressed state.
                 copyTransformLayer( _icnVsSprite[id][0], _icnVsSprite[id][1] );
@@ -1052,8 +1052,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::SURRENDR, 0 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::SURRENDR, 1 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::SURRENDR, 0 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::SURRENDR, 1 );
 
                 // Fix incorrect font color.
                 ReplaceColorId( _icnVsSprite[id][0], 28, 56 );
@@ -1073,8 +1073,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::SURRENDR, 2 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::SURRENDR, 3 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::SURRENDR, 2 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::SURRENDR, 3 );
 
                 // Fix incorrect font color.
                 ReplaceColorId( _icnVsSprite[id][0], 28, 56 );
@@ -1099,8 +1099,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 const int baseIcnID = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( baseIcnID, 9 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( baseIcnID, 10 );
+                _icnVsSprite[id][0] = Assets::getImage( baseIcnID, 9 );
+                _icnVsSprite[id][1] = Assets::getImage( baseIcnID, 10 );
                 break;
             }
 
@@ -1117,8 +1117,8 @@ namespace
             const bool isEvilInterface = ( id == ICN::BUTTON_SMALL_TRADE_EVIL );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST, 15 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST, 16 );
+                _icnVsSprite[id][0] = Assets::getImage( isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST, 15 );
+                _icnVsSprite[id][1] = Assets::getImage( isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST, 16 );
                 break;
             }
 
@@ -1135,8 +1135,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 const int baseIcnID = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( baseIcnID, 5 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( baseIcnID, 6 );
+                _icnVsSprite[id][0] = Assets::getImage( baseIcnID, 5 );
+                _icnVsSprite[id][1] = Assets::getImage( baseIcnID, 6 );
                 break;
             }
 
@@ -1153,8 +1153,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 const int baseIcnID = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( baseIcnID, 7 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( baseIcnID, 8 );
+                _icnVsSprite[id][0] = Assets::getImage( baseIcnID, 7 );
+                _icnVsSprite[id][1] = Assets::getImage( baseIcnID, 8 );
                 break;
             }
 
@@ -1188,8 +1188,8 @@ namespace
                 else {
                     buttonIcnIndex = 5;
                 }
-                const fheroes2::Sprite & originalReleased = fheroes2::AGG::GetICN( buttonIcnID, buttonIcnIndex );
-                const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( buttonIcnID, buttonIcnIndex + 1 );
+                const fheroes2::Sprite & originalReleased = Assets::getImage( buttonIcnID, buttonIcnIndex );
+                const fheroes2::Sprite & originalPressed = Assets::getImage( buttonIcnID, buttonIcnIndex + 1 );
                 const int32_t originalWidth = originalReleased.width();
                 const int32_t originalHeight = originalReleased.height();
                 released.resize( originalWidth - 2, originalHeight - 1 );
@@ -1235,8 +1235,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::NON_UNIFORM_GOOD_RESTART_BUTTON, 0 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::NON_UNIFORM_GOOD_RESTART_BUTTON, 1 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::NON_UNIFORM_GOOD_RESTART_BUTTON, 0 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::NON_UNIFORM_GOOD_RESTART_BUTTON, 1 );
                 break;
             }
 
@@ -1250,8 +1250,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 // The original assets ICN contains button with shadow. We crop only the button.
-                _icnVsSprite[id][0] = fheroes2::Crop( fheroes2::AGG::GetICN( ICN::RECRUIT, 4 ), 5, 0, 60, 25 );
-                _icnVsSprite[id][1] = fheroes2::Crop( fheroes2::AGG::GetICN( ICN::RECRUIT, 5 ), 5, 0, 60, 25 );
+                _icnVsSprite[id][0] = fheroes2::Crop( Assets::getImage( ICN::RECRUIT, 4 ), 5, 0, 60, 25 );
+                _icnVsSprite[id][1] = fheroes2::Crop( Assets::getImage( ICN::RECRUIT, 5 ), 5, 0, 60, 25 );
                 _icnVsSprite[id][0].setPosition( 0, 0 );
                 _icnVsSprite[id][1].setPosition( 0, 0 );
 
@@ -1274,7 +1274,7 @@ namespace
             const bool isEvilInterface = id == ICN::BUTTON_SMALL_MIN_EVIL;
 
             const char * text = fheroes2::getSupportedText( gettext_noop( "MIN" ), fheroes2::FontType::buttonReleasedWhite() );
-            fheroes2::makeButtonSprites( _icnVsSprite[id][0], _icnVsSprite[id][1], text, { fheroes2::AGG::GetICN( ICN::BUTTON_SMALL_MAX_GOOD, 0 ).width() - 10, 25 },
+            fheroes2::makeButtonSprites( _icnVsSprite[id][0], _icnVsSprite[id][1], text, { Assets::getImage( ICN::BUTTON_SMALL_MAX_GOOD, 0 ).width() - 10, 25 },
                                          isEvilInterface, isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK );
 
             break;
@@ -1287,8 +1287,8 @@ namespace
             fheroes2::Sprite & pressed = _icnVsSprite[id][1];
             const bool maxButton = id == ICN::UNIFORM_GOOD_MAX_BUTTON;
             const int buttonIcnID = maxButton ? ICN::BUTTON_SMALL_MAX_GOOD : ICN::BUTTON_SMALL_MIN_GOOD;
-            released = fheroes2::AGG::GetICN( buttonIcnID, 0 );
-            pressed = fheroes2::AGG::GetICN( buttonIcnID, 1 );
+            released = Assets::getImage( buttonIcnID, 0 );
+            pressed = Assets::getImage( buttonIcnID, 1 );
             // Clean the borders of the pressed state.
             FillTransform( pressed, 4, 0, pressed.width() - 3, 1, 1 );
             FillTransform( pressed, pressed.width() - 3, 1, 2, 1, 1 );
@@ -1306,8 +1306,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 const int baseIcnId = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( baseIcnId, 1 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( baseIcnId, 2 );
+                _icnVsSprite[id][0] = Assets::getImage( baseIcnId, 1 );
+                _icnVsSprite[id][1] = Assets::getImage( baseIcnId, 2 );
                 break;
             }
 
@@ -1324,8 +1324,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 const int baseIcnId = isEvilInterface ? ICN::SYSTEME : ICN::SYSTEM;
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( baseIcnId, 3 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( baseIcnId, 4 );
+                _icnVsSprite[id][0] = Assets::getImage( baseIcnId, 3 );
+                _icnVsSprite[id][1] = Assets::getImage( baseIcnId, 4 );
                 break;
             }
 
@@ -1343,8 +1343,8 @@ namespace
             const int baseIcnId = isEvilInterface ? ICN::TRADPOSE : ICN::TRADPOST;
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( baseIcnId, 17 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( baseIcnId, 18 );
+                _icnVsSprite[id][0] = Assets::getImage( baseIcnId, 17 );
+                _icnVsSprite[id][1] = Assets::getImage( baseIcnId, 18 );
                 break;
             }
 
@@ -1360,12 +1360,12 @@ namespace
             if ( useOriginalResources() ) {
                 // The original DISMISS button has a broken transform layer and thinner pressed state than released state,
                 // so we use our empty vertical button as a template
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::EMPTY_VERTICAL_GOOD_BUTTON, 0 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::EMPTY_VERTICAL_GOOD_BUTTON, 1 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::EMPTY_VERTICAL_GOOD_BUTTON, 0 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::EMPTY_VERTICAL_GOOD_BUTTON, 1 );
 
                 // Copy the DISMISS text back from the original button
-                const fheroes2::Sprite & originalReleased = fheroes2::AGG::GetICN( ICN::HSBTNS, 0 );
-                const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( ICN::HSBTNS, 1 );
+                const fheroes2::Sprite & originalReleased = Assets::getImage( ICN::HSBTNS, 0 );
+                const fheroes2::Sprite & originalPressed = Assets::getImage( ICN::HSBTNS, 1 );
 
                 Copy( originalReleased, 9, 2, _icnVsSprite[id][0], 5, 2, 21, 112 );
                 Copy( originalPressed, 9, 5, _icnVsSprite[id][1], 4, 5, 19, 111 );
@@ -1391,12 +1391,12 @@ namespace
             if ( useOriginalResources() ) {
                 // The original EXIT button has a broken transform layer and we need to remove the shadows,
                 // so we use our empty vertical button as a template
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::EMPTY_VERTICAL_GOOD_BUTTON, 0 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::EMPTY_VERTICAL_GOOD_BUTTON, 1 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::EMPTY_VERTICAL_GOOD_BUTTON, 0 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::EMPTY_VERTICAL_GOOD_BUTTON, 1 );
 
                 // Copy the EXIT text back from the original button
-                const fheroes2::Sprite & originalReleased = fheroes2::AGG::GetICN( ICN::HSBTNS, 2 );
-                const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( ICN::HSBTNS, 3 );
+                const fheroes2::Sprite & originalReleased = Assets::getImage( ICN::HSBTNS, 2 );
+                const fheroes2::Sprite & originalPressed = Assets::getImage( ICN::HSBTNS, 3 );
 
                 Copy( originalReleased, 4, 2, _icnVsSprite[id][0], 5, 2, 21, 112 );
                 Copy( originalPressed, 3, 5, _icnVsSprite[id][1], 4, 5, 19, 111 );
@@ -1434,13 +1434,13 @@ namespace
             }
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( originalID, originalICNIndex );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( originalID, originalICNIndex + 1 );
+                _icnVsSprite[id][0] = Assets::getImage( originalID, originalICNIndex );
+                _icnVsSprite[id][1] = Assets::getImage( originalID, originalICNIndex + 1 );
                 break;
             }
 
             for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
-                const fheroes2::Sprite & originalButton = fheroes2::AGG::GetICN( originalID, originalICNIndex + static_cast<uint32_t>( i ) );
+                const fheroes2::Sprite & originalButton = Assets::getImage( originalID, originalICNIndex + static_cast<uint32_t>( i ) );
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
 
                 out = originalButton;
@@ -1539,7 +1539,7 @@ namespace
             // Did you add new buttons?
             assert( goodButtonIcnID != ICN::UNKNOWN );
 
-            _icnVsSprite[id].resize( fheroes2::AGG::GetICNCount( goodButtonIcnID ) );
+            _icnVsSprite[id].resize( Assets::getImageCount( goodButtonIcnID ) );
             const size_t icnSize = _icnVsSprite[id].size();
             for ( size_t i = 0; i < ( icnSize / 2 ); ++i ) {
                 convertToEvilButtonBackground( _icnVsSprite[id][i * 2], _icnVsSprite[id][i * 2 + 1], goodButtonIcnID, static_cast<uint32_t>( i * 2 ) );
@@ -1589,7 +1589,7 @@ namespace
             if ( useOriginalResources() ) {
                 // Since we are using original resources we don't need to do anything. Just copy existing images.
                 for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
-                    _icnVsSprite[id][i] = fheroes2::AGG::GetICN( originalIcnID, static_cast<uint32_t>( i ) );
+                    _icnVsSprite[id][i] = Assets::getImage( originalIcnID, static_cast<uint32_t>( i ) );
                 }
                 break;
             }
@@ -1616,7 +1616,7 @@ namespace
                                                                       fheroes2::Rect{ 21, 17, 59, 25 },
                                                                       fheroes2::Rect{ 20, 18, 59, 25 } };
             for ( size_t i = 0; i < imageRoi.size(); ++i ) {
-                const auto & originalImage = fheroes2::AGG::GetICN( originalIcnID, static_cast<uint32_t>( i ) );
+                const auto & originalImage = Assets::getImage( originalIcnID, static_cast<uint32_t>( i ) );
                 fheroes2::Copy( originalImage, imageRoi[i].x, imageRoi[i].y, _icnVsSprite[id][i],
                                 ( _icnVsSprite[id][i].width() - originalImage.width() ) / 2 + imageRoi[i].x, imageRoi[i].y, imageRoi[i].width, imageRoi[i].height );
             }
@@ -1631,8 +1631,8 @@ namespace
             if ( useOriginalResources() ) {
                 const int buttonIcnID = isEvilInterface ? ICN::CPANELE : ICN::CPANEL;
 
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( buttonIcnID, 6 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( buttonIcnID, 7 );
+                _icnVsSprite[id][0] = Assets::getImage( buttonIcnID, 6 );
+                _icnVsSprite[id][1] = Assets::getImage( buttonIcnID, 7 );
                 break;
             }
 
@@ -1654,8 +1654,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 for ( size_t i = 0; i < 3; ++i ) {
-                    _icnVsSprite[id][i * 2] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][i * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 + 1 ) );
+                    _icnVsSprite[id][i * 2] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][i * 2 + 1] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 + 1 ) );
                 }
                 // Add generated buttons.
                 const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
@@ -1665,22 +1665,22 @@ namespace
                 fheroes2::makeButtonSprites( _icnVsSprite[id][8], _icnVsSprite[id][9], fheroes2::getSupportedText( gettext_noop( "SETTINGS" ), buttonFontType ),
                                              buttonSize, false, ICN::STONEBAK );
                 // Add cancel button.
-                _icnVsSprite[id][10] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 6 );
-                _icnVsSprite[id][11] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 7 );
+                _icnVsSprite[id][10] = Assets::getImage( ICN::BTNNEWGM, 6 );
+                _icnVsSprite[id][11] = Assets::getImage( ICN::BTNNEWGM, 7 );
                 // Add hot seat button.
-                _icnVsSprite[id][12] = fheroes2::AGG::GetICN( ICN::BTNMP, 0 );
-                _icnVsSprite[id][13] = fheroes2::AGG::GetICN( ICN::BTNMP, 1 );
+                _icnVsSprite[id][12] = Assets::getImage( ICN::BTNMP, 0 );
+                _icnVsSprite[id][13] = Assets::getImage( ICN::BTNMP, 1 );
                 // Add player count buttons.
                 for ( size_t i = 0; i < 5; ++i ) {
-                    _icnVsSprite[id][( i + 7 ) * 2] = fheroes2::AGG::GetICN( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][( i + 7 ) * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 + 1 ) );
+                    _icnVsSprite[id][( i + 7 ) * 2] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][( i + 7 ) * 2 + 1] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 + 1 ) );
                 }
 
                 if ( isPoLPresent ) {
-                    _icnVsSprite[id][24] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 0 );
-                    _icnVsSprite[id][25] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 1 );
-                    _icnVsSprite[id][26] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 2 );
-                    _icnVsSprite[id][27] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 3 );
+                    _icnVsSprite[id][24] = Assets::getImage( ICN::X_LOADCM, 0 );
+                    _icnVsSprite[id][25] = Assets::getImage( ICN::X_LOADCM, 1 );
+                    _icnVsSprite[id][26] = Assets::getImage( ICN::X_LOADCM, 2 );
+                    _icnVsSprite[id][27] = Assets::getImage( ICN::X_LOADCM, 3 );
                 }
                 break;
             }
@@ -1710,8 +1710,8 @@ namespace
 
             if ( useOriginalResources() ) {
                 for ( size_t i = 0; i < 2; ++i ) {
-                    _icnVsSprite[id][i * 2] = fheroes2::AGG::GetICN( ICN::BTNEMAIN, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][i * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNEMAIN, static_cast<uint32_t>( i * 2 + 1 ) );
+                    _icnVsSprite[id][i * 2] = Assets::getImage( ICN::BTNEMAIN, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][i * 2 + 1] = Assets::getImage( ICN::BTNEMAIN, static_cast<uint32_t>( i * 2 + 1 ) );
                 }
                 // Add generated Main Menu button.
                 const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
@@ -1724,13 +1724,13 @@ namespace
 
                 // Add From Scratch and Random buttons.
                 for ( size_t i = 0; i < 2; ++i ) {
-                    _icnVsSprite[id][( i + 4 ) * 2] = fheroes2::AGG::GetICN( ICN::BTNENEW, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][( i + 4 ) * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNENEW, static_cast<uint32_t>( i * 2 + 1 ) );
+                    _icnVsSprite[id][( i + 4 ) * 2] = Assets::getImage( ICN::BTNENEW, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][( i + 4 ) * 2 + 1] = Assets::getImage( ICN::BTNENEW, static_cast<uint32_t>( i * 2 + 1 ) );
                 }
                 // Add map size buttons.
                 for ( size_t i = 0; i < 4; ++i ) {
-                    _icnVsSprite[id][( i + 6 ) * 2] = fheroes2::AGG::GetICN( ICN::BTNESIZE, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][( i + 6 ) * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNESIZE, static_cast<uint32_t>( i * 2 + 1 ) );
+                    _icnVsSprite[id][( i + 6 ) * 2] = Assets::getImage( ICN::BTNESIZE, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][( i + 6 ) * 2 + 1] = Assets::getImage( ICN::BTNESIZE, static_cast<uint32_t>( i * 2 + 1 ) );
                 }
 
                 break;
@@ -1764,7 +1764,7 @@ namespace
                 // remove embedded shadows so that we can generate shadows with our own code later
                 for ( uint32_t i = 0; i < 8; i += 2 ) {
                     // released
-                    const fheroes2::Sprite & originalReleased = fheroes2::AGG::GetICN( originalIcnId, i );
+                    const fheroes2::Sprite & originalReleased = Assets::getImage( originalIcnId, i );
 
                     fheroes2::Sprite & released = _icnVsSprite[id][i];
                     released.resize( originalReleased.width() - 6 + offsetEvilX, originalReleased.height() - 8 );
@@ -1773,7 +1773,7 @@ namespace
                     Copy( originalReleased, 6 - offsetEvilX, 0, released, 0, 0, originalReleased.width() - 1, originalReleased.height() - 8 );
 
                     // pressed
-                    const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( originalIcnId, i + 1 );
+                    const fheroes2::Sprite & originalPressed = Assets::getImage( originalIcnId, i + 1 );
 
                     fheroes2::Sprite & pressed = _icnVsSprite[id][i + 1];
                     pressed.resize( originalPressed.width(), originalPressed.height() );
@@ -1803,14 +1803,14 @@ namespace
             if ( useOriginalResources() ) {
                 for ( uint32_t i = 0; i < 8; i += 2 ) {
                     // released
-                    const fheroes2::Sprite & originalReleased = fheroes2::AGG::GetICN( baseIcnId, i );
+                    const fheroes2::Sprite & originalReleased = Assets::getImage( baseIcnId, i );
 
                     fheroes2::Sprite & released = _icnVsSprite[id][i];
                     released.resize( originalReleased.width() + 1, originalReleased.height() + 1 );
                     released.reset();
 
                     Copy( originalReleased, 0, 0, released, 1, 0, originalReleased.width(), originalReleased.height() );
-                    const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( baseIcnId, i + 1 );
+                    const fheroes2::Sprite & originalPressed = Assets::getImage( baseIcnId, i + 1 );
                     // the released state is missing the darker borders of the pressed state
                     Copy( originalPressed, 0, 0, released, 0, 1, 1, originalPressed.height() );
                     Copy( originalPressed, 0, 2, released, 0, originalPressed.height() - 1, 1, 2 );
@@ -1850,8 +1850,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             if ( useOriginalResources() ) {
-                _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::SWAPBTN, 0 );
-                _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::SWAPBTN, 1 );
+                _icnVsSprite[id][0] = Assets::getImage( ICN::SWAPBTN, 0 );
+                _icnVsSprite[id][1] = Assets::getImage( ICN::SWAPBTN, 1 );
                 // fix some wrong pixels in the original pressed state
                 setButtonCornersTransparent( _icnVsSprite[id][1] );
                 break;
@@ -1914,8 +1914,8 @@ namespace
 
             const int buttonIcnId = ICN::BUTTON_VERTICAL_DISMISS;
 
-            const fheroes2::Sprite & released = fheroes2::AGG::GetICN( buttonIcnId, 0 );
-            const fheroes2::Sprite & pressed = fheroes2::AGG::GetICN( buttonIcnId, 1 );
+            const fheroes2::Sprite & released = Assets::getImage( buttonIcnId, 0 );
+            const fheroes2::Sprite & pressed = Assets::getImage( buttonIcnId, 1 );
 
             fheroes2::Sprite & output = _icnVsSprite[id][0];
             output = released;
@@ -1998,9 +1998,9 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             fheroes2::Sprite & canonicalBackground = _icnVsSprite[id][0];
-            canonicalBackground = fheroes2::AGG::GetICN( ICN::EMPTY_OPTION_ICON_BACKGROUND, 0 );
+            canonicalBackground = Assets::getImage( ICN::EMPTY_OPTION_ICON_BACKGROUND, 0 );
 
-            const fheroes2::Sprite & creature = fheroes2::AGG::GetICN( ICN::MONS32, 34 );
+            const fheroes2::Sprite & creature = Assets::getImage( ICN::MONS32, 34 );
             const int32_t iconBackgroundSize = canonicalBackground.width();
             fheroes2::Blit( creature, 0, 0, canonicalBackground, ( iconBackgroundSize - creature.width() ) / 2, 8, creature.width(), creature.height() );
 
@@ -2034,8 +2034,8 @@ namespace
             const int buttonIcnIndex = id == ICN::BUTTON_SMALL_ACCEPT_GOOD ? 0 : 2;
             fheroes2::Sprite & released = _icnVsSprite[id][0];
             fheroes2::Sprite & pressed = _icnVsSprite[id][1];
-            released = fheroes2::AGG::GetICN( ICN::SURRENDR, buttonIcnIndex );
-            pressed = fheroes2::AGG::GetICN( ICN::SURRENDR, buttonIcnIndex + 1 );
+            released = Assets::getImage( ICN::SURRENDR, buttonIcnIndex );
+            pressed = Assets::getImage( ICN::SURRENDR, buttonIcnIndex + 1 );
             // Fill wrong transparent text pixels by using single-colored background.
             fillTransparentButtonText( released );
             return true;
@@ -2058,8 +2058,8 @@ namespace
 
             fheroes2::Sprite & released = _icnVsSprite[id][0];
             fheroes2::Sprite & pressed = _icnVsSprite[id][1];
-            released = fheroes2::AGG::GetICN( originalID, originalICNIndex );
-            pressed = fheroes2::AGG::GetICN( originalID, originalICNIndex + 1 );
+            released = Assets::getImage( originalID, originalICNIndex );
+            pressed = Assets::getImage( originalID, originalICNIndex + 1 );
             // Fill wrong transparent text pixels by using single-colored background.
             fillTransparentButtonText( released );
             return true;
@@ -2083,62 +2083,62 @@ namespace
             }
 
             for ( size_t i = 0; i < 3; ++i ) {
-                _icnVsSprite[id][i * 2] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 ) );
-                _icnVsSprite[id][i * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 + 1 ) );
+                _icnVsSprite[id][i * 2] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 ) );
+                _icnVsSprite[id][i * 2 + 1] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 + 1 ) );
             }
             // Add battle only button.
             for ( int32_t i = 0; i < 2; ++i ) {
                 fheroes2::Sprite & out = _icnVsSprite[id][6 + i];
-                out = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 6 + i );
+                out = Assets::getImage( ICN::BTNNEWGM, 6 + i );
                 // Clean the button
                 Fill( out, 27 - i, 21 + i, 77, 14, getButtonFillingColor( i == 0 ) );
                 const int32_t secondLine = 28;
                 // Add 'MODE'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNNEWGM, 4 + i ), 35 - i, 13, out, 40 - i, 13, 50, 15 );
+                Copy( Assets::getImage( ICN::BTNNEWGM, 4 + i ), 35 - i, 13, out, 40 - i, 13, 50, 15 );
                 // Clean up 'MODE'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNEMAIN, 0 + i ), 109 - i, 18, out, 89 - i, 18, 1, 10 );
+                Copy( Assets::getImage( ICN::BTNEMAIN, 0 + i ), 109 - i, 18, out, 89 - i, 18, 1, 10 );
                 // Add 'BA'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNBAUD, 2 + i ), 42 - i, 28, out, 23 - i, secondLine, 22, 15 );
+                Copy( Assets::getImage( ICN::BTNBAUD, 2 + i ), 42 - i, 28, out, 23 - i, secondLine, 22, 15 );
                 // Clean up 'BA'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNBAUD, 2 + i ), 42 - i, 31, out, 34 - i, secondLine, 1, 1 );
-                Copy( fheroes2::AGG::GetICN( ICN::BTNBAUD, 2 + i ), 39 - i, 31, out, 44 - i, secondLine + 4, 1, 2 );
+                Copy( Assets::getImage( ICN::BTNBAUD, 2 + i ), 42 - i, 31, out, 34 - i, secondLine, 1, 1 );
+                Copy( Assets::getImage( ICN::BTNBAUD, 2 + i ), 39 - i, 31, out, 44 - i, secondLine + 4, 1, 2 );
                 // Add 'T'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNDC, 2 + i ), 89 - i, 21, out, 44 - i, secondLine, 12, 15 );
+                Copy( Assets::getImage( ICN::BTNDC, 2 + i ), 89 - i, 21, out, 44 - i, secondLine, 12, 15 );
                 // Clean up 'AT'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNDC, 2 + i ), 89 - i, 18, out, 45 - i, secondLine, 1, 1 );
-                Copy( fheroes2::AGG::GetICN( ICN::BTNDC, 2 + i ), 92 - ( 5 * i ), 27 - i, out, 44 - i, secondLine + 4 + i, 1, 3 );
+                Copy( Assets::getImage( ICN::BTNDC, 2 + i ), 89 - i, 18, out, 45 - i, secondLine, 1, 1 );
+                Copy( Assets::getImage( ICN::BTNDC, 2 + i ), 92 - ( 5 * i ), 27 - i, out, 44 - i, secondLine + 4 + i, 1, 3 );
                 // Add 'AI'.
-                Copy( fheroes2::AGG::GetICN( ICN::BTNMP, 6 + i ), 51 - i, 13, out, 57 - i, secondLine, 18, 15 );
+                Copy( Assets::getImage( ICN::BTNMP, 6 + i ), 51 - i, 13, out, 57 - i, secondLine, 18, 15 );
                 // Clean up 'TA'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNBAUD, 2 + i ), 51 - i, 40, out, 55 - i, secondLine + 12, 3, 3 );
+                Copy( Assets::getImage( ICN::BTNBAUD, 2 + i ), 51 - i, 40, out, 55 - i, secondLine + 12, 3, 3 );
                 // Add 'LLE'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNEMAIN, 0 + i ), 80 - i, 13, out, 76 - i, secondLine, 31, 15 );
+                Copy( Assets::getImage( ICN::BTNEMAIN, 0 + i ), 80 - i, 13, out, 76 - i, secondLine, 31, 15 );
                 // Clean up "IL"
-                Copy( fheroes2::AGG::GetICN( ICN::BTNEMAIN, 0 + i ), 80 - i, 18, out, 76 - i, secondLine + 7, 1, 1 );
-                Copy( fheroes2::AGG::GetICN( ICN::BTNEMAIN, 0 + i ), 89 - i, 17, out, 75 - i, secondLine + 4, 2, 2 );
-                Copy( fheroes2::AGG::GetICN( ICN::BTNEMAIN, 0 + i ), 88 - i, 25, out, 74 - i, secondLine + 12, 3, 3 );
-                Copy( fheroes2::AGG::GetICN( ICN::BTNDC, 4 + i ), 23 - i, 8, out, 74 - i, secondLine + 5, 1, 10 );
-                Copy( fheroes2::AGG::GetICN( ICN::BTNMP, 6 + i ), 68 - i, 16, out, 74 - i, secondLine + 9, 1, 1 );
+                Copy( Assets::getImage( ICN::BTNEMAIN, 0 + i ), 80 - i, 18, out, 76 - i, secondLine + 7, 1, 1 );
+                Copy( Assets::getImage( ICN::BTNEMAIN, 0 + i ), 89 - i, 17, out, 75 - i, secondLine + 4, 2, 2 );
+                Copy( Assets::getImage( ICN::BTNEMAIN, 0 + i ), 88 - i, 25, out, 74 - i, secondLine + 12, 3, 3 );
+                Copy( Assets::getImage( ICN::BTNDC, 4 + i ), 23 - i, 8, out, 74 - i, secondLine + 5, 1, 10 );
+                Copy( Assets::getImage( ICN::BTNMP, 6 + i ), 68 - i, 16, out, 74 - i, secondLine + 9, 1, 1 );
             }
             // Add config button.
-            _icnVsSprite[id][8] = fheroes2::AGG::GetICN( ICN::BTNDCCFG, 4 );
-            _icnVsSprite[id][9] = fheroes2::AGG::GetICN( ICN::BTNDCCFG, 5 );
+            _icnVsSprite[id][8] = Assets::getImage( ICN::BTNDCCFG, 4 );
+            _icnVsSprite[id][9] = Assets::getImage( ICN::BTNDCCFG, 5 );
             // Add cancel button.
-            _icnVsSprite[id][10] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 6 );
-            _icnVsSprite[id][11] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 7 );
+            _icnVsSprite[id][10] = Assets::getImage( ICN::BTNNEWGM, 6 );
+            _icnVsSprite[id][11] = Assets::getImage( ICN::BTNNEWGM, 7 );
             // Add hot seat button.
-            _icnVsSprite[id][12] = fheroes2::AGG::GetICN( ICN::BTNMP, 0 );
-            _icnVsSprite[id][13] = fheroes2::AGG::GetICN( ICN::BTNMP, 1 );
+            _icnVsSprite[id][12] = Assets::getImage( ICN::BTNMP, 0 );
+            _icnVsSprite[id][13] = Assets::getImage( ICN::BTNMP, 1 );
             // Add player count buttons.
             for ( size_t i = 0; i < 5; ++i ) {
-                _icnVsSprite[id][( i + 7 ) * 2] = fheroes2::AGG::GetICN( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 ) );
-                _icnVsSprite[id][( i + 7 ) * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 + 1 ) );
+                _icnVsSprite[id][( i + 7 ) * 2] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 ) );
+                _icnVsSprite[id][( i + 7 ) * 2 + 1] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 + 1 ) );
             }
             if ( isPoLPresent ) {
-                _icnVsSprite[id][24] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 0 );
-                _icnVsSprite[id][25] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 1 );
-                _icnVsSprite[id][26] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 2 );
-                _icnVsSprite[id][27] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 3 );
+                _icnVsSprite[id][24] = Assets::getImage( ICN::X_LOADCM, 0 );
+                _icnVsSprite[id][25] = Assets::getImage( ICN::X_LOADCM, 1 );
+                _icnVsSprite[id][26] = Assets::getImage( ICN::X_LOADCM, 2 );
+                _icnVsSprite[id][27] = Assets::getImage( ICN::X_LOADCM, 3 );
             }
             return true;
         }
@@ -2146,7 +2146,7 @@ namespace
             _icnVsSprite[id].resize( 2 );
             for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
-                const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::TRADPOST, 17 + i );
+                const fheroes2::Sprite & original = Assets::getImage( ICN::TRADPOST, 17 + i );
                 // We use this Copy function to make the pressed state not single layered like the original.
                 Copy( original, out );
                 // Clean the button
@@ -2154,40 +2154,40 @@ namespace
                 const int32_t offsetY = 5;
                 // Add 'D'
                 const int32_t offsetXD = 14;
-                Copy( fheroes2::AGG::GetICN( ICN::CPANEL, 4 + i ), 48 - i, 28 + i, out, offsetXD - i, offsetY + i, 10, 15 );
+                Copy( Assets::getImage( ICN::CPANEL, 4 + i ), 48 - i, 28 + i, out, offsetXD - i, offsetY + i, 10, 15 );
                 // Clean up 'D' and restore button ornament
-                Copy( fheroes2::AGG::GetICN( ICN::CPANEL, 4 + i ), 48 - i, 36, out, offsetXD - 1 - i, offsetY + 4 + i, 1, 1 );
-                Copy( fheroes2::AGG::GetICN( ICN::CPANEL, 4 + i ), 48 - i, 35, out, offsetXD - i, offsetY + 9 + i, 1, 2 );
-                Copy( fheroes2::AGG::GetICN( ICN::CPANEL, 4 + i ), 48 - i, 35, out, offsetXD - 1 - i, offsetY + 13 + i, 1, 1 );
+                Copy( Assets::getImage( ICN::CPANEL, 4 + i ), 48 - i, 36, out, offsetXD - 1 - i, offsetY + 4 + i, 1, 1 );
+                Copy( Assets::getImage( ICN::CPANEL, 4 + i ), 48 - i, 35, out, offsetXD - i, offsetY + 9 + i, 1, 2 );
+                Copy( Assets::getImage( ICN::CPANEL, 4 + i ), 48 - i, 35, out, offsetXD - 1 - i, offsetY + 13 + i, 1, 1 );
                 Fill( out, offsetXD + 9 - i, offsetY + 13 + i, 1, 1, getButtonFillingColor( i == 0 ) );
-                Copy( fheroes2::AGG::GetICN( ICN::TRADPOST, 17 + i ), offsetXD, offsetY, out, offsetXD, offsetY, 1, 1 );
+                Copy( Assets::getImage( ICN::TRADPOST, 17 + i ), offsetXD, offsetY, out, offsetXD, offsetY, 1, 1 );
                 // Add 'O'
                 const int32_t offsetXO = 10;
-                Copy( fheroes2::AGG::GetICN( ICN::CAMPXTRG, i ), 40 - ( 7 * i ), 5 + i, out, offsetXD + offsetXO + 1 - i, offsetY + i, 13 - i, 15 );
+                Copy( Assets::getImage( ICN::CAMPXTRG, i ), 40 - ( 7 * i ), 5 + i, out, offsetXD + offsetXO + 1 - i, offsetY + i, 13 - i, 15 );
                 // Clean up 'DO'
-                Copy( fheroes2::AGG::GetICN( ICN::CPANEL, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 5, 2, 2 );
-                Copy( fheroes2::AGG::GetICN( ICN::CPANEL, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 7, 1, 1 + i );
-                Copy( fheroes2::AGG::GetICN( ICN::CPANEL, 4 + i ), 55 - i, 28 + i, out, offsetXD + 9 - i, offsetY + 2 + i, 3, 3 );
+                Copy( Assets::getImage( ICN::CPANEL, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 5, 2, 2 );
+                Copy( Assets::getImage( ICN::CPANEL, 4 + i ), 51 - i, 34, out, offsetXD + offsetXO - i, offsetY + 7, 1, 1 + i );
+                Copy( Assets::getImage( ICN::CPANEL, 4 + i ), 55 - i, 28 + i, out, offsetXD + 9 - i, offsetY + 2 + i, 3, 3 );
                 Fill( out, offsetXD + 11 - i, offsetY + i, 2, 2, getButtonFillingColor( i == 0 ) );
                 // Add 'N'
                 const int32_t offsetXN = 13;
-                Copy( fheroes2::AGG::GetICN( ICN::TRADPOST, 17 + i ), 50 - i, 5, out, offsetXD + offsetXO + offsetXN - i, offsetY, 14, 15 );
+                Copy( Assets::getImage( ICN::TRADPOST, 17 + i ), 50 - i, 5, out, offsetXD + offsetXO + offsetXN - i, offsetY, 14, 15 );
                 // Clean up 'ON'
                 Fill( out, offsetXD + offsetXO + offsetXN, offsetY, 1, 1, getButtonFillingColor( i == 0 ) );
                 Fill( out, offsetXD + offsetXO + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0 ) );
                 // Add 'N'
-                Copy( fheroes2::AGG::GetICN( ICN::TRADPOST, 17 + i ), 50 - i, 5, out, offsetXD + 10 + offsetXN + offsetXN - i, offsetY, 14, 15 );
+                Copy( Assets::getImage( ICN::TRADPOST, 17 + i ), 50 - i, 5, out, offsetXD + 10 + offsetXN + offsetXN - i, offsetY, 14, 15 );
                 // Clean up 'NN'
                 Fill( out, offsetXD + offsetXO + offsetXN + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0 ) );
                 // Add 'ER'
-                Copy( fheroes2::AGG::GetICN( ICN::CAMPXTRG, 2 + i ), 75 - ( 8 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY,
+                Copy( Assets::getImage( ICN::CAMPXTRG, 2 + i ), 75 - ( 8 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY,
                       23, 15 );
                 // Restore button ornament
-                Copy( fheroes2::AGG::GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
+                Copy( Assets::getImage( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
                       offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, 1, 1 );
-                Copy( fheroes2::AGG::GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 1, out,
+                Copy( Assets::getImage( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 1, out,
                       offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 1, 2, 3 );
-                Copy( fheroes2::AGG::GetICN( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
+                Copy( Assets::getImage( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
                       offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 21, offsetY + 4, 1, 1 );
             }
             return true;
@@ -2196,8 +2196,8 @@ namespace
             _icnVsSprite[id].resize( 2 );
             fheroes2::Sprite & released = _icnVsSprite[id][0];
             fheroes2::Sprite & pressed = _icnVsSprite[id][1];
-            const fheroes2::Sprite & originalReleased = fheroes2::AGG::GetICN( ICN::RECRUIT, 4 );
-            const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( ICN::RECRUIT, 5 );
+            const fheroes2::Sprite & originalReleased = Assets::getImage( ICN::RECRUIT, 4 );
+            const fheroes2::Sprite & originalPressed = Assets::getImage( ICN::RECRUIT, 5 );
             released = originalReleased;
             pressed = originalPressed;
             // The original assets ICN contains button with shadow. We crop only the button.
@@ -2222,16 +2222,16 @@ namespace
             _icnVsSprite[id].resize( 2 );
             for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
-                out = fheroes2::AGG::GetICN( ICN::BUTTON_SMALL_MAX_GOOD, i );
+                out = Assets::getImage( ICN::BUTTON_SMALL_MAX_GOOD, i );
                 // Clean the button and leave 'M'
                 Fill( out, 26 - 2 * i, 5 + i, 25, 15, getButtonFillingColor( i == 0 ) );
                 Fill( out, 24 - 2 * i, 17 + i, 2, 2, getButtonFillingColor( i == 0 ) );
                 // Add 'I'
-                Copy( fheroes2::AGG::GetICN( ICN::APANEL, 4 + i ), 25 - i, 19 + i, out, 27 - i, 4 + i, 7 - i, 15 );
-                Copy( fheroes2::AGG::GetICN( ICN::RECRUIT, 4 + i ), 28 - i, 7 + i, out, 31 - i, 7 + i, 3, 9 );
+                Copy( Assets::getImage( ICN::APANEL, 4 + i ), 25 - i, 19 + i, out, 27 - i, 4 + i, 7 - i, 15 );
+                Copy( Assets::getImage( ICN::RECRUIT, 4 + i ), 28 - i, 7 + i, out, 31 - i, 7 + i, 3, 9 );
                 Fill( out, 32 - i, 16 + i, 2, 3, getButtonFillingColor( i == 0 ) );
                 // Add 'N'
-                Copy( fheroes2::AGG::GetICN( ICN::TRADPOST, 17 + i ), 50 - i, 5, out, 36 - i, 5, 14, 15 );
+                Copy( Assets::getImage( ICN::TRADPOST, 17 + i ), 50 - i, 5, out, 36 - i, 5, 14, 15 );
                 Fill( out, 36 - i, 5, 1, 1, getButtonFillingColor( i == 0 ) );
                 Fill( out, 36 - i, 5 + 9, 1, 1, getButtonFillingColor( i == 0 ) );
             }
@@ -2243,8 +2243,8 @@ namespace
             const int buttonIcnIndex = id == ICN::BUTTON_SMALL_ACCEPT_GOOD ? 0 : 2;
             fheroes2::Sprite & released = _icnVsSprite[id][0];
             fheroes2::Sprite & pressed = _icnVsSprite[id][1];
-            released = fheroes2::AGG::GetICN( ICN::SURRENDR, buttonIcnIndex );
-            pressed = fheroes2::AGG::GetICN( ICN::SURRENDR, buttonIcnIndex + 1 );
+            released = Assets::getImage( ICN::SURRENDR, buttonIcnIndex );
+            pressed = Assets::getImage( ICN::SURRENDR, buttonIcnIndex + 1 );
             // Fill wrong transparent text pixels by using single-colored background.
             fillTransparentButtonText( released );
             // Fix corrupted pixels.
@@ -2270,8 +2270,8 @@ namespace
 
             fheroes2::Sprite & released = _icnVsSprite[id][0];
             fheroes2::Sprite & pressed = _icnVsSprite[id][1];
-            released = fheroes2::AGG::GetICN( originalID, originalICNIndex );
-            pressed = fheroes2::AGG::GetICN( originalID, originalICNIndex + 1 );
+            released = Assets::getImage( originalID, originalICNIndex );
+            pressed = Assets::getImage( originalID, originalICNIndex + 1 );
             // Fill wrong transparent text pixels by using single-colored background.
             fillTransparentButtonText( released );
             return true;
@@ -2303,45 +2303,45 @@ namespace
             }
 
             for ( size_t i = 0; i < 3; ++i ) {
-                _icnVsSprite[id][i * 2] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 ) );
-                _icnVsSprite[id][i * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 + 1 ) );
+                _icnVsSprite[id][i * 2] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 ) );
+                _icnVsSprite[id][i * 2 + 1] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 + 1 ) );
             }
             // Add battle only button.
             for ( int32_t i = 0; i < 2; ++i ) {
                 fheroes2::Sprite & out = _icnVsSprite[id][6 + i];
-                out = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 6 + i );
+                out = Assets::getImage( ICN::BTNNEWGM, 6 + i );
                 // clean the button
                 Fill( out, 36 - i, 23 + i, 57, 11, getButtonFillingColor( i == 0 ) );
                 const int32_t offsetX = 41;
                 const int32_t offsetY = 23;
                 // Add 'BI'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNMCFG, 2 + i ), 58 - i, 29, out, offsetX - i, offsetY, 14, 11 );
+                Copy( Assets::getImage( ICN::BTNMCFG, 2 + i ), 58 - i, 29, out, offsetX - i, offsetY, 14, 11 );
                 // Add 'T'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNNEWGM, 0 + i ), 19 - i, 29, out, offsetX + 14 - i, offsetY, 9, 11 );
+                Copy( Assets::getImage( ICN::BTNNEWGM, 0 + i ), 19 - i, 29, out, offsetX + 14 - i, offsetY, 9, 11 );
                 // Add 'WA'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNEMAIN, 0 + i ), 40 - i, 23, out, offsetX + 23 - i, offsetY, 24, 11 );
+                Copy( Assets::getImage( ICN::BTNEMAIN, 0 + i ), 40 - i, 23, out, offsetX + 23 - i, offsetY, 24, 11 );
                 // Add pixel to 'W'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNEMAIN, 0 + i ), 42 - i, 23 + i, out, offsetX + 38 - i, offsetY + i, 1, 1 );
+                Copy( Assets::getImage( ICN::BTNEMAIN, 0 + i ), 42 - i, 23 + i, out, offsetX + 38 - i, offsetY + i, 1, 1 );
             }
             // Add config button.
-            _icnVsSprite[id][8] = fheroes2::AGG::GetICN( ICN::BTNDCCFG, 4 );
-            _icnVsSprite[id][9] = fheroes2::AGG::GetICN( ICN::BTNDCCFG, 5 );
+            _icnVsSprite[id][8] = Assets::getImage( ICN::BTNDCCFG, 4 );
+            _icnVsSprite[id][9] = Assets::getImage( ICN::BTNDCCFG, 5 );
             // Add cancel button.
-            _icnVsSprite[id][10] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 6 );
-            _icnVsSprite[id][11] = fheroes2::AGG::GetICN( ICN::BTNNEWGM, 7 );
+            _icnVsSprite[id][10] = Assets::getImage( ICN::BTNNEWGM, 6 );
+            _icnVsSprite[id][11] = Assets::getImage( ICN::BTNNEWGM, 7 );
             // Add hot seat button.
-            _icnVsSprite[id][12] = fheroes2::AGG::GetICN( ICN::BTNMP, 0 );
-            _icnVsSprite[id][13] = fheroes2::AGG::GetICN( ICN::BTNMP, 1 );
+            _icnVsSprite[id][12] = Assets::getImage( ICN::BTNMP, 0 );
+            _icnVsSprite[id][13] = Assets::getImage( ICN::BTNMP, 1 );
             // Add player count buttons.
             for ( size_t i = 0; i < 5; ++i ) {
-                _icnVsSprite[id][( i + 7 ) * 2] = fheroes2::AGG::GetICN( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 ) );
-                _icnVsSprite[id][( i + 7 ) * 2 + 1] = fheroes2::AGG::GetICN( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 + 1 ) );
+                _icnVsSprite[id][( i + 7 ) * 2] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 ) );
+                _icnVsSprite[id][( i + 7 ) * 2 + 1] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 + 1 ) );
             }
             if ( isPoLPresent ) {
-                _icnVsSprite[id][24] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 0 );
-                _icnVsSprite[id][25] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 1 );
-                _icnVsSprite[id][26] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 2 );
-                _icnVsSprite[id][27] = fheroes2::AGG::GetICN( ICN::X_LOADCM, 3 );
+                _icnVsSprite[id][24] = Assets::getImage( ICN::X_LOADCM, 0 );
+                _icnVsSprite[id][25] = Assets::getImage( ICN::X_LOADCM, 1 );
+                _icnVsSprite[id][26] = Assets::getImage( ICN::X_LOADCM, 2 );
+                _icnVsSprite[id][27] = Assets::getImage( ICN::X_LOADCM, 3 );
             }
             return true;
         }
@@ -2349,16 +2349,16 @@ namespace
             _icnVsSprite[id].resize( 2 );
             for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
-                const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::BUTTON_SMALL_MAX_GOOD, i );
+                const fheroes2::Sprite & original = Assets::getImage( ICN::BUTTON_SMALL_MAX_GOOD, i );
                 out = original;
                 // Wipe the button
                 Fill( out, 9 - 2 * i, 7 + i, 46 + i, 10, getButtonFillingColor( i == 0 ) );
                 // 'M'
                 Copy( original, 9 - i, 7 + i, out, 13 - i, 7 + i, 14, 10 );
                 // 'I'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNMCFG, 4 + i ), 53 - i, 23 + i, out, 28 - i, 7 + i, 5, 10 );
+                Copy( Assets::getImage( ICN::BTNMCFG, 4 + i ), 53 - i, 23 + i, out, 28 - i, 7 + i, 5, 10 );
                 // 'N'
-                Copy( fheroes2::AGG::GetICN( ICN::BTNMCFG, 0 + i ), 83 - i, 29 + i, out, 34 - i, 7 + i, 11, 10 );
+                Copy( Assets::getImage( ICN::BTNMCFG, 0 + i ), 83 - i, 29 + i, out, 34 - i, 7 + i, 11, 10 );
                 // '.'
                 Copy( original, 52 - i, 14 + i, out, 47 - i, 14 + i, 3, 3 );
                 fheroes2::Fill( out, 44 - i, 8 + i, 1, 9, getButtonFillingColor( i == 0 ) );
@@ -2416,7 +2416,7 @@ namespace
     {
         assert( fontId != originalFontId );
 
-        fheroes2::AGG::GetICN( originalFontId, 0 );
+        Assets::getImage( originalFontId, 0 );
         const std::vector<fheroes2::Sprite> & original = _icnVsSprite[originalFontId];
 
         _icnVsSprite[fontId].resize( original.size() );
@@ -2629,7 +2629,7 @@ namespace
 
             // Mass Dispel icon.
             {
-                const auto & spellAnimation = fheroes2::AGG::GetICN( ICN::MAGIC07, 2 );
+                const auto & spellAnimation = Assets::getImage( ICN::MAGIC07, 2 );
                 _icnVsSprite[id][73] = fheroes2::Crop( spellAnimation, 28, 27, 39, 36 );
 
                 fheroes2::Sprite contour;
@@ -2642,7 +2642,7 @@ namespace
         case ICN::CSLMARKER:
             _icnVsSprite[id].resize( 3 );
             for ( uint32_t i = 0; i < 3; ++i ) {
-                _icnVsSprite[id][i] = fheroes2::AGG::GetICN( ICN::LOCATORS, 24 );
+                _icnVsSprite[id][i] = Assets::getImage( ICN::LOCATORS, 24 );
                 if ( i == 1 ) {
                     ReplaceColorId( _icnVsSprite[id][i], 0x0A, 0xD6 );
                 }
@@ -2661,7 +2661,7 @@ namespace
             break;
         case ICN::MONH0028: // phoenix
             if ( _icnVsSprite[id].size() == 1 ) {
-                const fheroes2::Sprite & correctFrame = fheroes2::AGG::GetICN( ICN::PHOENIX, 32 );
+                const fheroes2::Sprite & correctFrame = Assets::getImage( ICN::PHOENIX, 32 );
                 Copy( correctFrame, 60, 73, _icnVsSprite[id][0], 58, 70, 14, 13 );
             }
             break;
@@ -2905,7 +2905,7 @@ namespace
             fheroes2::Sprite & cornerSprite = _icnVsSprite[id][0];
             const int32_t cornerSideLength = 43;
             cornerSprite.resize( cornerSideLength * 2, cornerSideLength * 2 );
-            const fheroes2::Sprite & originalGoodDialog = fheroes2::AGG::GetICN( ICN::WINLOSE, 0 );
+            const fheroes2::Sprite & originalGoodDialog = Assets::getImage( ICN::WINLOSE, 0 );
             Copy( originalGoodDialog, 0, 0, cornerSprite, 0, 0, cornerSideLength, cornerSideLength );
             Copy( originalGoodDialog, originalGoodDialog.width() - cornerSideLength, 0, cornerSprite, cornerSideLength, 0, cornerSideLength, cornerSideLength );
             Copy( originalGoodDialog, 0, originalGoodDialog.height() - cornerSideLength, cornerSprite, 0, cornerSideLength, cornerSideLength, cornerSideLength );
@@ -2986,7 +2986,7 @@ namespace
         case ICN::MONSTER_SWITCH_LEFT_ARROW:
             _icnVsSprite[id].resize( 2 );
             for ( uint32_t i = 0; i < 2; ++i ) {
-                const fheroes2::Sprite & source = fheroes2::AGG::GetICN( ICN::RECRUIT, i );
+                const fheroes2::Sprite & source = Assets::getImage( ICN::RECRUIT, i );
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
                 out.resize( source.height(), source.width() );
                 Transpose( source, out );
@@ -2997,7 +2997,7 @@ namespace
         case ICN::MONSTER_SWITCH_RIGHT_ARROW:
             _icnVsSprite[id].resize( 2 );
             for ( uint32_t i = 0; i < 2; ++i ) {
-                const fheroes2::Sprite & source = fheroes2::AGG::GetICN( ICN::RECRUIT, i + 2 );
+                const fheroes2::Sprite & source = Assets::getImage( ICN::RECRUIT, i + 2 );
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
                 out.resize( source.height(), source.width() );
                 Transpose( source, out );
@@ -3023,17 +3023,17 @@ namespace
             break;
         case ICN::NON_UNIFORM_GOOD_RESTART_BUTTON:
             _icnVsSprite[id].resize( 2 );
-            _icnVsSprite[id][0] = Crop( fheroes2::AGG::GetICN( ICN::CAMPXTRG, 2 ), 6, 0, 108, 25 );
+            _icnVsSprite[id][0] = Crop( Assets::getImage( ICN::CAMPXTRG, 2 ), 6, 0, 108, 25 );
             _icnVsSprite[id][0].setPosition( 0, 0 );
 
-            _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::CAMPXTRG, 3 );
+            _icnVsSprite[id][1] = Assets::getImage( ICN::CAMPXTRG, 3 );
             _icnVsSprite[id][1].setPosition( 0, 0 );
 
             // fix transparent corners
             copyTransformLayer( _icnVsSprite[id][1], _icnVsSprite[id][0] );
             break;
         case ICN::WHITE_LARGE_FONT: {
-            fheroes2::AGG::GetICN( ICN::FONT, 0 );
+            Assets::getImage( ICN::FONT, 0 );
             const std::vector<fheroes2::Sprite> & original = _icnVsSprite[ICN::FONT];
             _icnVsSprite[id].resize( original.size() );
             for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
@@ -3048,7 +3048,7 @@ namespace
         case ICN::SWAP_ARROW_LEFT_TO_RIGHT:
         case ICN::SWAP_ARROW_RIGHT_TO_LEFT: {
             // Since the original game does not have such resources we could generate it from hero meeting sprite.
-            const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+            const fheroes2::Sprite & original = Assets::getImage( ICN::SWAPWIN, 0 );
             std::array<fheroes2::Image, 4> input;
 
             const int32_t width = 45;
@@ -3087,7 +3087,7 @@ namespace
             break;
         }
         case ICN::SWAP_ARROWS_CIRCULAR: {
-            const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::SWAP_ARROW_LEFT_TO_RIGHT, 0 );
+            const fheroes2::Sprite & original = Assets::getImage( ICN::SWAP_ARROW_LEFT_TO_RIGHT, 0 );
 
             const int32_t width = 47;
             const int32_t height = 42;
@@ -3211,8 +3211,8 @@ namespace
                 _icnVsSprite[id].resize( 45 );
 
                 // First make clean button sprites (pressed and released).
-                fheroes2::Sprite released = fheroes2::AGG::GetICN( ICN::EDITBTNS, 4 );
-                fheroes2::Sprite pressed = fheroes2::AGG::GetICN( ICN::EDITBTNS, 5 );
+                fheroes2::Sprite released = Assets::getImage( ICN::EDITBTNS, 4 );
+                fheroes2::Sprite pressed = Assets::getImage( ICN::EDITBTNS, 5 );
                 // Clean the image from the button.
                 Fill( released, 16, 6, 18, 24, 41U );
                 Fill( pressed, 16, 7, 17, 23, 46U );
@@ -3226,14 +3226,14 @@ namespace
 
                 // Adventure objects button.
                 if ( AGG::isPoLResourceFilePresent() ) {
-                    drawImageOnButton( fheroes2::AGG::GetICN( ICN::X_LOC1, 0 ), 39, 29, _icnVsSprite[id][35], _icnVsSprite[id][36] );
+                    drawImageOnButton( Assets::getImage( ICN::X_LOC1, 0 ), 39, 29, _icnVsSprite[id][35], _icnVsSprite[id][36] );
                 }
 
                 // Kingdom objects button.
-                drawImageOnButton( fheroes2::AGG::GetICN( ICN::OBJNARTI, 13 ), 39, 29, _icnVsSprite[id][37], _icnVsSprite[id][38] );
+                drawImageOnButton( Assets::getImage( ICN::OBJNARTI, 13 ), 39, 29, _icnVsSprite[id][37], _icnVsSprite[id][38] );
 
                 // Monsters objects button.
-                drawImageOnButton( fheroes2::AGG::GetICN( ICN::MONS32, 11 ), 39, 29, _icnVsSprite[id][39], _icnVsSprite[id][40] );
+                drawImageOnButton( Assets::getImage( ICN::MONS32, 11 ), 39, 29, _icnVsSprite[id][39], _icnVsSprite[id][40] );
 
                 // Undo and Redo buttons.
                 fheroes2::Image undoImage( 19, 13 );
@@ -3313,13 +3313,13 @@ namespace
                 }
 
                 // Make Mountains objects button.
-                Blit( fheroes2::AGG::GetICN( ICN::MTNCRCK, 3 ), 4, 0, _icnVsSprite[id][6], 1, 1, 24, 24 );
+                Blit( Assets::getImage( ICN::MTNCRCK, 3 ), 4, 0, _icnVsSprite[id][6], 1, 1, 24, 24 );
 
                 // Make Rocks objects button.
-                Blit( fheroes2::AGG::GetICN( ICN::OBJNGRAS, 41 ), 1, 0, _icnVsSprite[id][7], 1, 9, 23, 12 );
+                Blit( Assets::getImage( ICN::OBJNGRAS, 41 ), 1, 0, _icnVsSprite[id][7], 1, 9, 23, 12 );
 
                 // Make Trees object button. Also used as erase terrain objects button image.
-                Copy( fheroes2::AGG::GetICN( ICN::EDITBTNS, 2 ), 13, 4, _icnVsSprite[id][8], 1, 1, 24, 24 );
+                Copy( Assets::getImage( ICN::EDITBTNS, 2 ), 13, 4, _icnVsSprite[id][8], 1, 1, 24, 24 );
 
                 // Replace image contour colors with the background color.
                 std::vector<uint8_t> indexes( 256 );
@@ -3335,38 +3335,38 @@ namespace
                 ApplyPalette( _icnVsSprite[id][8], indexes );
 
                 // Make Landscape Water objects button.
-                Blit( fheroes2::AGG::GetICN( ICN::OBJNWAT2, 0 ), 0, 3, _icnVsSprite[id][9], 5, 1, 13, 3 );
-                Blit( fheroes2::AGG::GetICN( ICN::OBJNWAT2, 2 ), 5, 0, _icnVsSprite[id][9], 1, 4, 24, 21 );
+                Blit( Assets::getImage( ICN::OBJNWAT2, 0 ), 0, 3, _icnVsSprite[id][9], 5, 1, 13, 3 );
+                Blit( Assets::getImage( ICN::OBJNWAT2, 2 ), 5, 0, _icnVsSprite[id][9], 1, 4, 24, 21 );
 
                 // Make Landscape Miscellaneous objects button.
-                Blit( fheroes2::AGG::GetICN( ICN::OBJNDIRT, 73 ), 8, 0, _icnVsSprite[id][10], 1, 1, 24, 24 );
+                Blit( Assets::getImage( ICN::OBJNDIRT, 73 ), 8, 0, _icnVsSprite[id][10], 1, 1, 24, 24 );
 
                 // Make Dwellings button image.
-                Blit( fheroes2::AGG::GetICN( ICN::OBJNMULT, 114 ), 7, 0, _icnVsSprite[id][11], 1, 1, 24, 24 );
+                Blit( Assets::getImage( ICN::OBJNMULT, 114 ), 7, 0, _icnVsSprite[id][11], 1, 1, 24, 24 );
 
                 // Make Mines button image.
-                Blit( fheroes2::AGG::GetICN( ICN::MTNMULT, 82 ), 8, 4, _icnVsSprite[id][12], 1, 1, 24, 24 );
+                Blit( Assets::getImage( ICN::MTNMULT, 82 ), 8, 4, _icnVsSprite[id][12], 1, 1, 24, 24 );
 
                 // Make Power-ups button image.
-                Blit( fheroes2::AGG::GetICN( ICN::OBJNMULT, 72 ), 0, 6, _icnVsSprite[id][13], 1, 1, 24, 24 );
+                Blit( Assets::getImage( ICN::OBJNMULT, 72 ), 0, 6, _icnVsSprite[id][13], 1, 1, 24, 24 );
 
                 // Make Adventure Water objects button.
-                Blit( fheroes2::AGG::GetICN( ICN::OBJNWATR, 24 ), 3, 0, _icnVsSprite[id][14], 1, 1, 24, 24 );
+                Blit( Assets::getImage( ICN::OBJNWATR, 24 ), 3, 0, _icnVsSprite[id][14], 1, 1, 24, 24 );
 
                 // Make Adventure Miscellaneous objects button.
-                Blit( fheroes2::AGG::GetICN( ICN::OBJNMUL2, 198 ), 2, 0, _icnVsSprite[id][15], 1, 1, 24, 24 );
+                Blit( Assets::getImage( ICN::OBJNMUL2, 198 ), 2, 0, _icnVsSprite[id][15], 1, 1, 24, 24 );
 
                 // Make erase Roads button image.
-                Blit( fheroes2::AGG::GetICN( ICN::ROAD, 2 ), 0, 0, _icnVsSprite[id][16], 1, 8, 24, 5 );
-                Blit( fheroes2::AGG::GetICN( ICN::ROAD, 1 ), 1, 0, _icnVsSprite[id][16], 1, 13, 24, 5 );
+                Blit( Assets::getImage( ICN::ROAD, 2 ), 0, 0, _icnVsSprite[id][16], 1, 8, 24, 5 );
+                Blit( Assets::getImage( ICN::ROAD, 1 ), 1, 0, _icnVsSprite[id][16], 1, 13, 24, 5 );
 
                 // Make erase Streams button image.
-                Blit( fheroes2::AGG::GetICN( ICN::STREAM, 2 ), 0, 0, _icnVsSprite[id][17], 1, 8, 24, 11 );
+                Blit( Assets::getImage( ICN::STREAM, 2 ), 0, 0, _icnVsSprite[id][17], 1, 8, 24, 11 );
 
                 // Make Detail mode images.
-                Blit( fheroes2::AGG::GetICN( ICN::CMSECO, 5 ), 0, 0, _icnVsSprite[id][18], 8, 4, 11, 18 );
-                Blit( fheroes2::AGG::GetICN( ICN::CMSECO, 2 ), 0, 0, _icnVsSprite[id][19], 3, 1, 21, 24 );
-                Blit( fheroes2::AGG::GetICN( ICN::ADVMCO, 8 ), 0, 0, _icnVsSprite[id][20], 6, 3, 15, 20 );
+                Blit( Assets::getImage( ICN::CMSECO, 5 ), 0, 0, _icnVsSprite[id][18], 8, 4, 11, 18 );
+                Blit( Assets::getImage( ICN::CMSECO, 2 ), 0, 0, _icnVsSprite[id][19], 3, 1, 21, 24 );
+                Blit( Assets::getImage( ICN::ADVMCO, 8 ), 0, 0, _icnVsSprite[id][20], 6, 3, 15, 20 );
             }
             break;
         case ICN::TEXTBAR:
@@ -3695,19 +3695,19 @@ namespace
 
             const int originalCursorId = isColorCursor ? ICN::ADVMCO : ICN::MONO_CURSOR_ADVMBW;
 
-            populateCursorIcons( _icnVsSprite[id], fheroes2::AGG::GetICN( originalCursorId, 4 ), digits,
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 4 ), digits,
                                  isColorCursor ? fheroes2::Point( -2, 1 ) : fheroes2::Point( -4, -6 ) );
-            populateCursorIcons( _icnVsSprite[id], fheroes2::AGG::GetICN( originalCursorId, 5 ), digits,
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 5 ), digits,
                                  isColorCursor ? fheroes2::Point( 1, 1 ) : fheroes2::Point( -6, -6 ) );
-            populateCursorIcons( _icnVsSprite[id], fheroes2::AGG::GetICN( originalCursorId, 6 ), digits,
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 6 ), digits,
                                  isColorCursor ? fheroes2::Point( 0, 1 ) : fheroes2::Point( -8, -7 ) );
-            populateCursorIcons( _icnVsSprite[id], fheroes2::AGG::GetICN( originalCursorId, 7 ), digits,
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 7 ), digits,
                                  isColorCursor ? fheroes2::Point( -2, 1 ) : fheroes2::Point( -15, -8 ) );
-            populateCursorIcons( _icnVsSprite[id], fheroes2::AGG::GetICN( originalCursorId, 8 ), digits,
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 8 ), digits,
                                  isColorCursor ? fheroes2::Point( 1, 1 ) : fheroes2::Point( -16, -11 ) );
-            populateCursorIcons( _icnVsSprite[id], fheroes2::AGG::GetICN( originalCursorId, 9 ), digits,
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 9 ), digits,
                                  isColorCursor ? fheroes2::Point( -6, 1 ) : fheroes2::Point( -8, -1 ) );
-            populateCursorIcons( _icnVsSprite[id], fheroes2::AGG::GetICN( originalCursorId, 28 ), digits,
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 28 ), digits,
                                  isColorCursor ? fheroes2::Point( 0, 1 ) : fheroes2::Point( -8, -7 ) );
 
             break;
@@ -3715,7 +3715,7 @@ namespace
         case ICN::KNIGHT_CASTLE_RIGHT_FARM: {
             _icnVsSprite[id].resize( 1 );
             fheroes2::Sprite & output = _icnVsSprite[id][0];
-            output = fheroes2::AGG::GetICN( ICN::TWNKWEL2, 0 );
+            output = Assets::getImage( ICN::TWNKWEL2, 0 );
 
             ApplyPalette( output, 28, 21, output, 28, 21, 39, 1, 8 );
             ApplyPalette( output, 0, 22, output, 0, 22, 69, 1, 8 );
@@ -3739,7 +3739,7 @@ namespace
         case ICN::NECROMANCER_CASTLE_STANDALONE_CAPTAIN_QUARTERS: {
             _icnVsSprite[id].resize( 1 );
             fheroes2::Sprite & output = _icnVsSprite[id][0];
-            const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::TWNNCAPT, 0 );
+            const fheroes2::Sprite & original = Assets::getImage( ICN::TWNNCAPT, 0 );
 
             output = Crop( original, 21, 0, original.width() - 21, original.height() );
             output.setPosition( original.x() + 21, original.y() );
@@ -3748,7 +3748,7 @@ namespace
                 SetTransformPixel( output, 0, y, 1 );
             }
 
-            const fheroes2::Sprite & castle = fheroes2::AGG::GetICN( ICN::TWNNCSTL, 0 );
+            const fheroes2::Sprite & castle = Assets::getImage( ICN::TWNNCSTL, 0 );
             Copy( castle, 402, 123, output, 1, 56, 2, 11 );
 
             break;
@@ -3756,7 +3756,7 @@ namespace
         case ICN::NECROMANCER_CASTLE_CAPTAIN_QUARTERS_BRIDGE: {
             _icnVsSprite[id].resize( 1 );
             fheroes2::Sprite & output = _icnVsSprite[id][0];
-            const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::TWNNCAPT, 0 );
+            const fheroes2::Sprite & original = Assets::getImage( ICN::TWNNCAPT, 0 );
 
             output = Crop( original, 0, 0, 23, original.height() );
             output.setPosition( original.x(), original.y() );
@@ -3781,9 +3781,9 @@ namespace
                 icon.fill( 0 );
             }
 
-            const fheroes2::Sprite & successionWarsIcon = fheroes2::AGG::GetICN( ICN::ARTFX, 6 );
-            const fheroes2::Sprite & priceOfLoyaltyIcon = fheroes2::AGG::GetICN( ICN::ARTFX, 90 );
-            const fheroes2::Sprite & resurrectionIcon = fheroes2::AGG::GetICN( ICN::ARTFX, 101 );
+            const fheroes2::Sprite & successionWarsIcon = Assets::getImage( ICN::ARTFX, 6 );
+            const fheroes2::Sprite & priceOfLoyaltyIcon = Assets::getImage( ICN::ARTFX, 90 );
+            const fheroes2::Sprite & resurrectionIcon = Assets::getImage( ICN::ARTFX, 101 );
 
             if ( !successionWarsIcon.empty() ) {
                 Resize( successionWarsIcon, 0, 0, successionWarsIcon.width(), successionWarsIcon.height(), _icnVsSprite[id][0], 1, 1, 15, 15 );
@@ -3837,8 +3837,8 @@ namespace
             loadICN( ICN::ADVBTNS );
 
             const int releasedIndex = ( id == ICN::GOOD_ARMY_BUTTON ) ? 0 : 4;
-            Copy( fheroes2::AGG::GetICN( ICN::ADVBTNS, releasedIndex ), _icnVsSprite[id][0] );
-            Copy( fheroes2::AGG::GetICN( ICN::ADVBTNS, releasedIndex + 1 ), _icnVsSprite[id][1] );
+            Copy( Assets::getImage( ICN::ADVBTNS, releasedIndex ), _icnVsSprite[id][0] );
+            Copy( Assets::getImage( ICN::ADVBTNS, releasedIndex + 1 ), _icnVsSprite[id][1] );
 
             // Make all black pixels transparent.
             addTransparency( _icnVsSprite[id][0], 36 );
@@ -3854,8 +3854,8 @@ namespace
             loadICN( ICN::ADVEBTNS );
 
             const int releasedIndex = ( id == ICN::EVIL_ARMY_BUTTON ) ? 0 : 4;
-            Copy( fheroes2::AGG::GetICN( ICN::ADVEBTNS, releasedIndex ), _icnVsSprite[id][0] );
-            Copy( fheroes2::AGG::GetICN( ICN::ADVEBTNS, releasedIndex + 1 ), _icnVsSprite[id][1] );
+            Copy( Assets::getImage( ICN::ADVEBTNS, releasedIndex ), _icnVsSprite[id][0] );
+            Copy( Assets::getImage( ICN::ADVEBTNS, releasedIndex + 1 ), _icnVsSprite[id][1] );
 
             // Make all black pixels transparent.
             addTransparency( _icnVsSprite[id][0], 36 );
@@ -3898,7 +3898,7 @@ namespace
                     addTransparency( pressed, 25 ); // remove too dark background
 
                     // take background from the empty system button
-                    _icnVsSprite[id][i] = fheroes2::AGG::GetICN( ICN::SYSTEME, 12 );
+                    _icnVsSprite[id][i] = Assets::getImage( ICN::SYSTEME, 12 );
 
                     // put back dark-gray pixels in the middle of the button
                     Fill( _icnVsSprite[id][i], 5, 5, 86, 17, 25 );
@@ -3974,7 +3974,7 @@ namespace
         case ICN::DIFFICULTY_ICON_IMPOSSIBLE: {
             const int originalIcnId = ICN::NGHSBKG;
 
-            const fheroes2::Sprite & originalBackground = fheroes2::AGG::GetICN( originalIcnId, 0 );
+            const fheroes2::Sprite & originalBackground = Assets::getImage( originalIcnId, 0 );
 
             if ( !originalBackground.empty() ) {
                 _icnVsSprite[id].resize( 2 );
@@ -4020,7 +4020,7 @@ namespace
         case ICN::METALLIC_BORDERED_TEXTBOX_GOOD: {
             const int originalIcnId = ICN::NGHSBKG;
 
-            const fheroes2::Sprite & originalBackground = fheroes2::AGG::GetICN( originalIcnId, 0 );
+            const fheroes2::Sprite & originalBackground = Assets::getImage( originalIcnId, 0 );
 
             if ( !originalBackground.empty() ) {
                 _icnVsSprite[id].resize( 1 );
@@ -4041,7 +4041,7 @@ namespace
             break;
         }
         case ICN::METALLIC_BORDERED_TEXTBOX_EVIL: {
-            const fheroes2::Sprite & originalEvilBackground = fheroes2::AGG::GetICN( ICN::CAMPBKGE, 0 );
+            const fheroes2::Sprite & originalEvilBackground = Assets::getImage( ICN::CAMPBKGE, 0 );
 
             if ( !originalEvilBackground.empty() ) {
                 _icnVsSprite[id].resize( 1 );
@@ -4062,7 +4062,7 @@ namespace
                       10 );
 
                 // Copy red central part.
-                const fheroes2::Sprite goodBox = fheroes2::AGG::GetICN( ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
+                const fheroes2::Sprite goodBox = Assets::getImage( ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
                 Copy( goodBox, 6, 5, _icnVsSprite[id][0], 6, 5, 359, 19 );
             }
 
@@ -4123,7 +4123,7 @@ namespace
                 const int emptyButtonId = isGoodButton ? ICN::EMPTY_INTERFACE_BUTTON_GOOD : ICN::EMPTY_INTERFACE_BUTTON_EVIL;
 
                 // Get the action cursor and prepare it for button. We make it a little smaller.
-                const fheroes2::Sprite & originalActionCursor = fheroes2::AGG::GetICN( ICN::ADVMCO, 9 );
+                const fheroes2::Sprite & originalActionCursor = Assets::getImage( ICN::ADVMCO, 9 );
                 const int32_t actionCursorWidth = originalActionCursor.width() - 1;
                 const int32_t actionCursorHeight = originalActionCursor.height() - 3;
                 fheroes2::Image buttonImage( actionCursorWidth, actionCursorHeight );
@@ -4167,7 +4167,7 @@ namespace
                 updateShadow( buttonImage, { -1, 1 }, 6, true );
                 updateShadow( buttonImage, { 2, -2 }, 4, true );
 
-                const fheroes2::Sprite & emptyButtonPressed = fheroes2::AGG::GetICN( emptyButtonId, 1 );
+                const fheroes2::Sprite & emptyButtonPressed = Assets::getImage( emptyButtonId, 1 );
                 if ( emptyButtonPressed.singleLayer() ) {
                     _icnVsSprite[id][17]._disableTransformLayer();
                     _icnVsSprite[id][19]._disableTransformLayer();
@@ -4186,7 +4186,7 @@ namespace
                 }
                 ReplaceColorId( buttonImage, mainPressedColor, mainReleasedColor );
 
-                const fheroes2::Sprite & emptyButtonReleased = fheroes2::AGG::GetICN( emptyButtonId, 0 );
+                const fheroes2::Sprite & emptyButtonReleased = Assets::getImage( emptyButtonId, 0 );
                 if ( emptyButtonPressed.singleLayer() ) {
                     _icnVsSprite[id][16]._disableTransformLayer();
                     _icnVsSprite[id][18]._disableTransformLayer();
@@ -4305,7 +4305,7 @@ namespace
             if ( _icnVsSprite[id].size() > 82 ) {
                 // Make a sprite for EDITOR_ANY_ULTIMATE_ARTIFACT used only in Editor for the special victory condition.
                 // A temporary solution is below.
-                const fheroes2::Sprite & originalImage = fheroes2::AGG::GetICN( ICN::ARTIFACT, 83 );
+                const fheroes2::Sprite & originalImage = Assets::getImage( ICN::ARTIFACT, 83 );
                 SubpixelResize( originalImage, _icnVsSprite[id][82] );
             }
             if ( _icnVsSprite[id].size() > 63 ) {
@@ -4368,7 +4368,7 @@ namespace
 
                 // Magic Book main sprite. We use sprite from the info dialog to make the map sprite.
                 fheroes2::Sprite body( 21, 32 );
-                Copy( fheroes2::AGG::GetICN( ICN::ARTFX, 81 ), 6, 0, body, 0, 0, 21, 32 );
+                Copy( Assets::getImage( ICN::ARTFX, 81 ), 6, 0, body, 0, 0, 21, 32 );
                 FillTransform( body, 0, 0, 12, 1, 1U );
                 FillTransform( body, 15, 0, 6, 1, 1U );
                 FillTransform( body, 0, 1, 9, 1, 1U );
@@ -4493,7 +4493,7 @@ namespace
             break;
         case ICN::SCENIBKG:
             if ( !_icnVsSprite[id].empty() && _icnVsSprite[id][0].width() == 436 && _icnVsSprite[id][0].height() == 476 ) {
-                const fheroes2::Sprite & helper = fheroes2::AGG::GetICN( ICN::CSPANBKE, 1 );
+                const fheroes2::Sprite & helper = Assets::getImage( ICN::CSPANBKE, 1 );
                 if ( !helper.empty() ) {
                     fheroes2::Sprite & original = _icnVsSprite[id][0];
                     fheroes2::Sprite temp( original.width(), original.height() + 12 );
@@ -4507,7 +4507,7 @@ namespace
             break;
         case ICN::CSTLCAPS:
             if ( !_icnVsSprite[id].empty() && _icnVsSprite[id][0].width() == 84 && _icnVsSprite[id][0].height() == 81 ) {
-                const fheroes2::Sprite & castle = fheroes2::AGG::GetICN( ICN::TWNSCSTL, 0 );
+                const fheroes2::Sprite & castle = Assets::getImage( ICN::TWNSCSTL, 0 );
                 if ( !castle.empty() ) {
                     Blit( castle, 206, 106, _icnVsSprite[id][0], 2, 2, 33, 67 );
                 }
@@ -4546,7 +4546,7 @@ namespace
             // Fill button backgrounds. This bug was present in the original game too.
             Fill( background, 540, 361, 99, 83, 57 );
             Fill( background, 540, 454, 99, 24, 57 );
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::OVERBACK, 0 ), 540, 444, background, 540, 402, 99, 5 );
+            fheroes2::Copy( Assets::getImage( ICN::OVERBACK, 0 ), 540, 444, background, 540, 402, 99, 5 );
             break;
         }
         case ICN::ESPANBKG_EVIL: {
@@ -4555,17 +4555,17 @@ namespace
             const fheroes2::Rect roi{ 28, 28, 265, 206 };
 
             fheroes2::Sprite & output = _icnVsSprite[id][0];
-            _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::CSPANBKE, 0 );
-            Copy( fheroes2::AGG::GetICN( ICN::ESPANBKG, 0 ), roi.x, roi.y, output, roi.x, roi.y, roi.width, roi.height );
+            _icnVsSprite[id][0] = Assets::getImage( ICN::CSPANBKE, 0 );
+            Copy( Assets::getImage( ICN::ESPANBKG, 0 ), roi.x, roi.y, output, roi.x, roi.y, roi.width, roi.height );
 
             convertToEvilInterface( output, roi );
 
-            _icnVsSprite[id][1] = fheroes2::AGG::GetICN( ICN::ESPANBKG, 1 );
+            _icnVsSprite[id][1] = Assets::getImage( ICN::ESPANBKG, 1 );
 
             break;
         }
         case ICN::STONEBAK_EVIL: {
-            fheroes2::AGG::GetICN( ICN::STONEBAK, 0 );
+            Assets::getImage( ICN::STONEBAK, 0 );
             _icnVsSprite[id] = _icnVsSprite[ICN::STONEBAK];
             if ( !_icnVsSprite[id].empty() ) {
                 const fheroes2::Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() );
@@ -4576,7 +4576,7 @@ namespace
         }
         case ICN::STONEBAK_SMALL_POL: {
             _icnVsSprite[id].resize( 1 );
-            const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::X_CMPBKG, 0 );
+            const fheroes2::Sprite & original = Assets::getImage( ICN::X_CMPBKG, 0 );
             if ( !original.empty() ) {
                 _icnVsSprite[id][0] = Crop( original, original.width() - 272, original.height() - 52, 244, 28 );
             }
@@ -4584,7 +4584,7 @@ namespace
         }
         case ICN::REDBAK_SMALL_VERTICAL: {
             _icnVsSprite[id].resize( 1 );
-            const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::HEROBKG, 0 );
+            const fheroes2::Sprite & original = Assets::getImage( ICN::HEROBKG, 0 );
             if ( !original.empty() ) {
                 _icnVsSprite[id][0] = Crop( original, 0, 0, 37, 230 );
             }
@@ -4610,7 +4610,7 @@ namespace
         case ICN::UNIFORMBAK_EVIL: {
             _icnVsSprite[id].resize( 1 );
             const bool isEvilInterface = ( id == ICN::UNIFORMBAK_EVIL );
-            const fheroes2::Sprite & original = fheroes2::AGG::GetICN( isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD, 1 );
+            const fheroes2::Sprite & original = Assets::getImage( isEvilInterface ? ICN::BUYBUILE : ICN::BUYBUILD, 1 );
             if ( !original.empty() ) {
                 _icnVsSprite[id][0].resize( 246, 45 );
                 _icnVsSprite[id][0].reset();
@@ -4621,7 +4621,7 @@ namespace
             break;
         }
         case ICN::WELLBKG_EVIL: {
-            fheroes2::AGG::GetICN( ICN::WELLBKG, 0 );
+            Assets::getImage( ICN::WELLBKG, 0 );
             _icnVsSprite[id] = _icnVsSprite[ICN::WELLBKG];
             if ( !_icnVsSprite[id].empty() ) {
                 const fheroes2::Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() - 19 );
@@ -4631,7 +4631,7 @@ namespace
             break;
         }
         case ICN::CASLWIND_EVIL: {
-            fheroes2::AGG::GetICN( ICN::CASLWIND, 0 );
+            Assets::getImage( ICN::CASLWIND, 0 );
             _icnVsSprite[id] = _icnVsSprite[ICN::CASLWIND];
             if ( !_icnVsSprite[id].empty() ) {
                 const fheroes2::Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() );
@@ -4641,7 +4641,7 @@ namespace
             break;
         }
         case ICN::CASLXTRA_EVIL: {
-            fheroes2::AGG::GetICN( ICN::CASLXTRA, 0 );
+            Assets::getImage( ICN::CASLXTRA, 0 );
             _icnVsSprite[id] = _icnVsSprite[ICN::CASLXTRA];
             if ( !_icnVsSprite[id].empty() ) {
                 const fheroes2::Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() );
@@ -4652,7 +4652,7 @@ namespace
         }
         case ICN::STRIP_BACKGROUND_EVIL: {
             _icnVsSprite[id].resize( 1 );
-            _icnVsSprite[id][0] = fheroes2::AGG::GetICN( ICN::STRIP, 11 );
+            _icnVsSprite[id][0] = Assets::getImage( ICN::STRIP, 11 );
 
             const fheroes2::Rect roi( 0, 0, _icnVsSprite[id][0].width(), _icnVsSprite[id][0].height() - 7 );
             convertToEvilInterface( _icnVsSprite[id][0], roi );
@@ -4845,7 +4845,7 @@ namespace
 
             Fill( released, 8, 7, 1, 1, getButtonFillingColor( true, isGoodInterface ) );
 
-            const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( originalId, 12 );
+            const fheroes2::Sprite & originalPressed = Assets::getImage( originalId, 12 );
 
             if ( originalPressed.width() > 2 && originalPressed.height() > 2 ) {
                 pressed.resize( originalPressed.width(), originalPressed.height() );
@@ -4882,8 +4882,8 @@ namespace
 
             _icnVsSprite[id].resize( 2 );
             // Move dark border to new released state from original pressed state button
-            const fheroes2::Sprite & originalReleased = fheroes2::AGG::GetICN( originalID, 4 );
-            const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( originalID, 5 );
+            const fheroes2::Sprite & originalReleased = Assets::getImage( originalID, 4 );
+            const fheroes2::Sprite & originalPressed = Assets::getImage( originalID, 5 );
             if ( originalReleased.width() != 94 && originalPressed.width() != 94 && originalReleased.height() < 5 && originalPressed.height() < 5 ) {
                 break;
             }
@@ -4930,7 +4930,7 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                const fheroes2::Sprite & original = fheroes2::AGG::GetICN( originalID, 0 + i );
+                const fheroes2::Sprite & original = Assets::getImage( originalID, 0 + i );
 
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
                 // The empty button needs to shortened by 1 px so that when it is divided by 3 in resizeButton() in ui_tools.h it will give an integer result.
@@ -4960,8 +4960,8 @@ namespace
             }
 
             _icnVsSprite[id].resize( 2 );
-            const fheroes2::Sprite & originalReleased = fheroes2::AGG::GetICN( originalId, 2 );
-            const fheroes2::Sprite & originalPressed = fheroes2::AGG::GetICN( originalId, 3 );
+            const fheroes2::Sprite & originalReleased = Assets::getImage( originalId, 2 );
+            const fheroes2::Sprite & originalPressed = Assets::getImage( originalId, 3 );
 
             fheroes2::Sprite & released = _icnVsSprite[id][0];
             fheroes2::Sprite & pressed = _icnVsSprite[id][1];
@@ -4998,7 +4998,7 @@ namespace
                 copyTransformLayer( exitCommonMask, pressed );
 
                 // Restore dark-brown lines on the left and bottom borders of the button backgrounds.
-                const fheroes2::Sprite & originalDismiss = fheroes2::AGG::GetICN( ICN::HSBTNS, 0 );
+                const fheroes2::Sprite & originalDismiss = Assets::getImage( ICN::HSBTNS, 0 );
 
                 Copy( originalReleased, 0, 4, released, 1, 4, 1, originalReleased.height() - 4 );
                 Copy( originalDismiss, 6, originalDismiss.height() - 7, released, 2, originalReleased.height() - 1, 22, 1 );
@@ -5029,7 +5029,7 @@ namespace
             _icnVsSprite[id].resize( 2 );
 
             for ( int32_t i = 0; i < static_cast<int32_t>( _icnVsSprite[id].size() ); ++i ) {
-                const fheroes2::Sprite & original = fheroes2::AGG::GetICN( originalId, 64 + i );
+                const fheroes2::Sprite & original = Assets::getImage( originalId, 64 + i );
 
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
                 // the empty button needs to widened by 1 px so that when it is divided by 3 in resizeButton() in ui_tools.h it will
@@ -5086,7 +5086,7 @@ namespace
 
             // An extra image for the neutral color (for Editor).
             if ( _icnVsSprite[id].size() == 7 ) {
-                fheroes2::Sprite neutralShield( fheroes2::AGG::GetICN( ICN::SPELLS, 15 ) );
+                fheroes2::Sprite neutralShield( Assets::getImage( ICN::SPELLS, 15 ) );
                 if ( neutralShield.width() < 2 || neutralShield.height() < 2 ) {
                     // We can not make a new image if there is no original shield image.
                     break;
@@ -5157,7 +5157,7 @@ namespace
             fheroes2::Sprite & background = _icnVsSprite[id][0];
             background._disableTransformLayer();
             background.resize( 65, 65 );
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::ESPANBKG, 0 ), 69, 47, background, 0, 0, 65, 65 );
+            fheroes2::Copy( Assets::getImage( ICN::ESPANBKG, 0 ), 69, 47, background, 0, 0, 65, 65 );
 
             break;
         }
@@ -5165,7 +5165,7 @@ namespace
             _icnVsSprite[id].resize( 4 );
 
             // TODO: Cut the icons from the embedded background in resurrection.h2d and use the empty background ICN to make the icons instead.
-            const fheroes2::Sprite & background = fheroes2::AGG::GetICN( ICN::EMPTY_OPTION_ICON_BACKGROUND, 0 );
+            const fheroes2::Sprite & background = Assets::getImage( ICN::EMPTY_OPTION_ICON_BACKGROUND, 0 );
 
             fheroes2::h2d::readImage( "hotkeys_icon.image", _icnVsSprite[id][0] );
             _icnVsSprite[id][0]._disableTransformLayer();
@@ -5180,7 +5180,7 @@ namespace
 
             fheroes2::Copy( background, linearScaling );
 
-            fheroes2::Sprite creature = fheroes2::AGG::GetICN( ICN::MONS32, 38 );
+            fheroes2::Sprite creature = Assets::getImage( ICN::MONS32, 38 );
             // Remove shadows
             setTransformLayerTransparent( creature );
             fheroes2::Sprite linearCreature( creature.width() * 2, creature.height() * 2 );
@@ -5498,7 +5498,7 @@ namespace
                 auto & original = _icnVsSprite[id][0];
 
                 // The original puzzle image has a rendered button. We should remove it.
-                const auto & streamsImage = fheroes2::AGG::GetICN( ICN::EDITPANL, 3 );
+                const auto & streamsImage = Assets::getImage( ICN::EDITPANL, 3 );
                 fheroes2::Sprite croppedImage = fheroes2::Crop( streamsImage, 0, streamsImage.height() - 48, streamsImage.width(), 48 );
                 if ( id == ICN::EVIWPUZL ) {
                     fheroes2::ApplyPalette( croppedImage, PAL::GetPalette( PAL::PaletteType::GOOD_TO_EVIL_INTERFACE ) );
@@ -5781,9 +5781,9 @@ namespace
     }
 }
 
-namespace fheroes2::AGG
+namespace Assets
 {
-    const Sprite & GetICN( int icnId, uint32_t index )
+    const fheroes2::Sprite & getImage( int icnId, uint32_t index )
     {
         if ( !IsValidICNId( icnId ) ) {
             return errorImage;
@@ -5800,7 +5800,7 @@ namespace fheroes2::AGG
         return _icnVsSprite[icnId][index];
     }
 
-    uint32_t GetICNCount( int icnId )
+    uint32_t getImageCount( int icnId )
     {
         if ( !IsValidICNId( icnId ) ) {
             return 0;
@@ -5809,7 +5809,7 @@ namespace fheroes2::AGG
         return static_cast<uint32_t>( GetMaximumICNIndex( icnId ) );
     }
 
-    const Image & GetTIL( int tilId, uint32_t index, uint32_t shapeId )
+    const fheroes2::Image & getTileImage( int tilId, uint32_t index, uint32_t shapeId )
     {
         if ( shapeId > 3 ) {
             return errorImage;
@@ -5827,10 +5827,10 @@ namespace fheroes2::AGG
         return _tilVsImage[tilId][shapeId][index];
     }
 
-    void updateLanguageDependentResources( const SupportedLanguage language, const bool loadOriginalAlphabet )
+    void updateLanguageDependentResources( const fheroes2::SupportedLanguage language, const bool loadOriginalAlphabet )
     {
         static bool areOriginalResourcesInUse = false;
-        static CodePage currentCodePage{ CodePage::NONE };
+        static fheroes2::CodePage currentCodePage{ fheroes2::CodePage::NONE };
 
         if ( loadOriginalAlphabet ) {
             if ( alphabetPreserver.isPreserved() ) {
@@ -5848,7 +5848,7 @@ namespace fheroes2::AGG
             }
         }
         else {
-            if ( !areOriginalResourcesInUse && currentCodePage == getCodePage( language ) ) {
+            if ( !areOriginalResourcesInUse && currentCodePage == fheroes2::getCodePage( language ) ) {
                 // We are trying to load resources for the same code page. We don't need to redo the same work again.
                 return;
             }
@@ -5857,17 +5857,17 @@ namespace fheroes2::AGG
             // Restore original letters when changing language to avoid changes to them being carried over.
             alphabetPreserver.restore();
 
-            generateAlphabet( language, _icnVsSprite );
+            fheroes2::generateAlphabet( language, _icnVsSprite );
         }
 
-        generateButtonAlphabet( language, _icnVsSprite );
+        fheroes2::generateButtonAlphabet( language, _icnVsSprite );
 
         // Clear language dependent resources.
         for ( const int id : languageDependentIcnId ) {
             _icnVsSprite[id].clear();
         }
 
-        currentCodePage = getCodePage( language );
+        currentCodePage = fheroes2::getCodePage( language );
         areOriginalResourcesInUse = loadOriginalAlphabet;
     }
 }

--- a/src/fheroes2/game/game_assets.cpp
+++ b/src/fheroes2/game/game_assets.cpp
@@ -2180,8 +2180,8 @@ namespace
                 // Clean up 'NN'
                 Fill( out, offsetXD + offsetXO + offsetXN + offsetXN - i, offsetY + 9, 1, 1, getButtonFillingColor( i == 0 ) );
                 // Add 'ER'
-                Copy( Assets::getImage( ICN::CAMPXTRG, 2 + i ), 75 - ( 8 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY,
-                      23, 15 );
+                Copy( Assets::getImage( ICN::CAMPXTRG, 2 + i ), 75 - ( 8 * i ), 5, out, offsetXD + offsetXO + offsetXN + offsetXN + offsetXN - ( 2 * i ), offsetY, 23,
+                      15 );
                 // Restore button ornament
                 Copy( Assets::getImage( ICN::TRADPOST, 17 + i ), offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, out,
                       offsetXD + offsetXO + offsetXN + offsetXN + offsetXN + 20, offsetY, 1, 1 );
@@ -3697,10 +3697,8 @@ namespace
 
             populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 4 ), digits,
                                  isColorCursor ? fheroes2::Point( -2, 1 ) : fheroes2::Point( -4, -6 ) );
-            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 5 ), digits,
-                                 isColorCursor ? fheroes2::Point( 1, 1 ) : fheroes2::Point( -6, -6 ) );
-            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 6 ), digits,
-                                 isColorCursor ? fheroes2::Point( 0, 1 ) : fheroes2::Point( -8, -7 ) );
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 5 ), digits, isColorCursor ? fheroes2::Point( 1, 1 ) : fheroes2::Point( -6, -6 ) );
+            populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 6 ), digits, isColorCursor ? fheroes2::Point( 0, 1 ) : fheroes2::Point( -8, -7 ) );
             populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 7 ), digits,
                                  isColorCursor ? fheroes2::Point( -2, 1 ) : fheroes2::Point( -15, -8 ) );
             populateCursorIcons( _icnVsSprite[id], Assets::getImage( originalCursorId, 8 ), digits,

--- a/src/fheroes2/game/game_assets.h
+++ b/src/fheroes2/game/game_assets.h
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2025                                             *
+ *   Copyright (C) 2021 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_assets.h
+++ b/src/fheroes2/game/game_assets.h
@@ -28,16 +28,16 @@ namespace fheroes2
     class Sprite;
 
     enum class SupportedLanguage : uint8_t;
+}
 
-    namespace AGG
-    {
-        const Sprite & GetICN( int icnId, uint32_t index );
-        uint32_t GetICNCount( int icnId );
+namespace Assets
+{
+    const fheroes2::Sprite & getImage( int icnId, uint32_t index );
+    uint32_t getImageCount( int icnId );
 
-        // shapeId could be 0, 1, 2 or 3 only
-        const Image & GetTIL( int tilId, uint32_t index, uint32_t shapeId );
+    // shapeId could be 0, 1, 2 or 3 only
+    const fheroes2::Image & getTileImage( int tilId, uint32_t index, uint32_t shapeId );
 
-        // This function must be called only at the time of setting up a new language.
-        void updateLanguageDependentResources( const SupportedLanguage language, const bool loadOriginalAlphabet );
-    }
+    // This function must be called only at the time of setting up a new language.
+    void updateLanguageDependentResources( const fheroes2::SupportedLanguage language, const bool loadOriginalAlphabet );
 }

--- a/src/fheroes2/game/game_auto_playtest.cpp
+++ b/src/fheroes2/game/game_auto_playtest.cpp
@@ -26,13 +26,13 @@
 #include <memory>
 #include <string>
 
-#include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "icn.h"
@@ -153,7 +153,7 @@ namespace
         const Settings & conf = Settings::Get();
         const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
-        const fheroes2::Sprite & titleBox = fheroes2::AGG::GetICN( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
+        const fheroes2::Sprite & titleBox = Assets::getImage( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
         const fheroes2::Rect titleBoxRoi{ activeArea.x + ( activeArea.width - titleBox.width() ) / 2, activeArea.y + 10, titleBox.width(), titleBox.height() };
         const fheroes2::Rect titleTextRoi{ titleBoxRoi.x + 6, titleBoxRoi.y + 5, titleBoxRoi.width - 12, titleBoxRoi.height - 11 };
 
@@ -176,7 +176,7 @@ namespace
 
         const PlayerColorsVector availableColors{ playerColorSet };
 
-        const fheroes2::Sprite & playerIconShadow = fheroes2::AGG::GetICN( ICN::NGEXTRA, 61 );
+        const fheroes2::Sprite & playerIconShadow = Assets::getImage( ICN::NGEXTRA, 61 );
         for ( int32_t i = 0; i < playerCount; ++i ) {
             playerRects[i].x = offsetX + i * playerStepX;
             playerRects[i].y = offsetY;
@@ -185,7 +185,7 @@ namespace
 
             const uint32_t icnIndex = Color::GetIndex( availableColors[i] ) + 3;
 
-            const fheroes2::Sprite & playerIcon = fheroes2::AGG::GetICN( ICN::NGEXTRA, icnIndex );
+            const fheroes2::Sprite & playerIcon = Assets::getImage( ICN::NGEXTRA, icnIndex );
             playerRects[i].width = playerIcon.width();
             playerRects[i].height = playerIcon.height();
             fheroes2::Copy( playerIcon, 0, 0, display, playerRects[i].x, playerRects[i].y, playerRects[i].width, playerRects[i].height );
@@ -331,11 +331,11 @@ namespace
 
     fheroes2::Rect renderCheckbox( const int32_t offsetX, const int32_t offsetY, const bool isEnabled, fheroes2::Image & output, const bool isEvilInterface )
     {
-        const fheroes2::Sprite & cell = fheroes2::AGG::GetICN( ICN::CELLWIN, 1 );
+        const fheroes2::Sprite & cell = Assets::getImage( ICN::CELLWIN, 1 );
 
         fheroes2::Blit( cell, output, offsetX, offsetY );
         if ( isEnabled ) {
-            const fheroes2::Sprite & mark = fheroes2::AGG::GetICN( ICN::CELLWIN, 2 );
+            const fheroes2::Sprite & mark = Assets::getImage( ICN::CELLWIN, 2 );
             fheroes2::Blit( mark, output, offsetX + mark.x(), offsetY + mark.y() );
         }
 
@@ -360,7 +360,7 @@ namespace fheroes2
         const Settings & conf = Settings::Get();
         const bool isEvilInterface = conf.isEvilInterfaceEnabled();
 
-        const Sprite & titleBox = AGG::GetICN( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
+        const Sprite & titleBox = Assets::getImage( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
         const Rect titleBoxRoi( activeArea.x + ( activeArea.width - titleBox.width() ) / 2, activeArea.y + 10, titleBox.width(), titleBox.height() );
         const Rect titleTextRoi( titleBoxRoi.x + 6, titleBoxRoi.y + 5, titleBoxRoi.width - 12, titleBoxRoi.height - 11 );
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2025                                             *
+ *   Copyright (C) 2020 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -1342,8 +1342,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
     const int32_t spaceBetweenViewIntroAndCancel = cancelPlacement - endOfViewIntroPlacement;
     const int32_t difficultyButtonWidth = Assets::getImage( buttonIconID, 8 ).width();
     const uint32_t okayRestartIndex = allowToRestart ? 2 : 4;
-    const int32_t middleButtonsMargin
-        = ( spaceBetweenViewIntroAndCancel - difficultyButtonWidth - ( Assets::getImage( buttonIconID, okayRestartIndex ).width() ) ) / 3;
+    const int32_t middleButtonsMargin = ( spaceBetweenViewIntroAndCancel - difficultyButtonWidth - ( Assets::getImage( buttonIconID, okayRestartIndex ).width() ) ) / 3;
     const int32_t difficultyPlacement = endOfViewIntroPlacement + middleButtonsMargin;
     const int32_t okRestartPlacement = difficultyPlacement + difficultyButtonWidth + middleButtonsMargin;
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -30,7 +30,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_troop.h"
 #include "artifact.h"
@@ -44,6 +43,7 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_credits.h"
 #include "game_hotkeys.h"
 #include "game_io.h"
@@ -178,7 +178,7 @@ namespace
 
     void DrawCampaignScenarioIcon( const int icnId, const uint32_t iconIdx, const fheroes2::Point & offset, const int posX, const int posY )
     {
-        const fheroes2::Sprite & icon = fheroes2::AGG::GetICN( icnId, iconIdx );
+        const fheroes2::Sprite & icon = Assets::getImage( icnId, iconIdx );
         fheroes2::Blit( icon, fheroes2::Display::instance(), offset.x + posX, offset.y + posY );
     }
 
@@ -228,8 +228,8 @@ namespace
 
         // available scenario (one of which should be selected)
         if ( std::find( availableMaps.begin(), availableMaps.end(), scenarioInfo ) != availableMaps.end() ) {
-            const fheroes2::Sprite & availableIcon = fheroes2::AGG::GetICN( iconsId, iconStatusOffset + SCENARIO_ICON_AVAILABLE );
-            const fheroes2::Sprite & selectedIcon = fheroes2::AGG::GetICN( iconsId, selectedIconIdx );
+            const fheroes2::Sprite & availableIcon = Assets::getImage( iconsId, iconStatusOffset + SCENARIO_ICON_AVAILABLE );
+            const fheroes2::Sprite & selectedIcon = Assets::getImage( iconsId, selectedIconIdx );
             buttonGroup.createButton( trackOffset.x + offset.x, trackOffset.y + offset.y, availableIcon, selectedIcon, buttonId );
         }
         // cleared scenario
@@ -339,7 +339,7 @@ namespace
             return;
         }
 
-        const fheroes2::Sprite & track = fheroes2::AGG::GetICN( campaignTrack, 0 );
+        const fheroes2::Sprite & track = Assets::getImage( campaignTrack, 0 );
         const fheroes2::Point trackOffset( top.x + track.x(), top.y + track.y() );
         fheroes2::Blit( track, fheroes2::Display::instance(), trackOffset.x, trackOffset.y );
 
@@ -869,7 +869,7 @@ namespace
             return;
         }
 
-        const fheroes2::Sprite & header = fheroes2::AGG::GetICN( ICN::X_CMPEXT, campaignNameHeader );
+        const fheroes2::Sprite & header = Assets::getImage( ICN::X_CMPEXT, campaignNameHeader );
         fheroes2::Blit( header, output, offset.x + 24, offset.y + 25 );
     }
 
@@ -918,14 +918,14 @@ namespace
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
         const int buttonIcnId = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
-        const fheroes2::Sprite & buttonSprite = fheroes2::AGG::GetICN( buttonIcnId, 0 );
+        const fheroes2::Sprite & buttonSprite = Assets::getImage( buttonIcnId, 0 );
 
         fheroes2::Display & display = fheroes2::Display::instance();
 
         const fheroes2::Rect buttonMaxRoi( windowRoi.x + 5, windowRoi.y, windowRoi.width - 10, windowRoi.height - 5 );
         fheroes2::ButtonSprite buttonOk = fheroes2::makeButtonWithShadow( buttonMaxRoi.x + ( buttonMaxRoi.width - buttonSprite.width() ) / 2,
                                                                           buttonMaxRoi.y + buttonMaxRoi.height - buttonSprite.height(),
-                                                                          fheroes2::AGG::GetICN( buttonIcnId, 0 ), fheroes2::AGG::GetICN( buttonIcnId, 1 ), display );
+                                                                          Assets::getImage( buttonIcnId, 0 ), Assets::getImage( buttonIcnId, 1 ), display );
 
         buttonOk.draw();
 
@@ -946,7 +946,7 @@ namespace
         const std::array<fheroes2::Point, 3> copyToOffset{ fheroes2::Point{ pawnIconOffsetX, windowRoi.y + 40 }, fheroes2::Point{ horseIconOffsetX, windowRoi.y + 40 },
                                                            fheroes2::Point{ rookIconOffsetX, windowRoi.y + 40 } };
 
-        const fheroes2::Sprite & chessIcon = fheroes2::AGG::GetICN( ICN::NGHSBKG, 0 );
+        const fheroes2::Sprite & chessIcon = Assets::getImage( ICN::NGHSBKG, 0 );
 
         for ( size_t i = 0; i < copyToOffset.size(); ++i ) {
             fheroes2::Copy( chessIcon, copyFromArea[i].x, copyFromArea[i].y, display, copyToOffset[i].x, copyToOffset[i].y, copyFromArea[i].width,
@@ -962,7 +962,7 @@ namespace
             }
         }
 
-        const fheroes2::Sprite & selectionImage = fheroes2::AGG::GetICN( ICN::NGEXTRA, 62 );
+        const fheroes2::Sprite & selectionImage = Assets::getImage( ICN::NGEXTRA, 62 );
 
         fheroes2::MovableSprite selection( selectionImage );
 
@@ -1139,7 +1139,7 @@ bool Game::isSuccessionWarsCampaignPresent()
 bool Game::isPriceOfLoyaltyCampaignPresent()
 {
     // We need to check game resources as well.
-    if ( fheroes2::AGG::GetICN( ICN::X_LOADCM, 0 ).empty() || fheroes2::AGG::GetICN( ICN::X_IVY, 0 ).empty() ) {
+    if ( Assets::getImage( ICN::X_LOADCM, 0 ).empty() || Assets::getImage( ICN::X_IVY, 0 ).empty() ) {
         return false;
     }
 
@@ -1324,7 +1324,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
         break;
     }
 
-    const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( backgroundIconID, 0 );
+    const fheroes2::Sprite & backgroundImage = Assets::getImage( backgroundIconID, 0 );
     const int32_t backgroundImageWidth = backgroundImage.width();
     const fheroes2::Point top( ( display.width() - backgroundImageWidth ) / 2, ( display.height() - backgroundImage.height() ) / 2 );
 
@@ -1337,13 +1337,13 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
     // for the 3 interbutton spaces. The OKAY and RESTART buttons never appear together
     const int32_t backgroundMargin = 30;
     const int32_t viewIntroPlacement = top.x + backgroundMargin;
-    const int32_t endOfViewIntroPlacement = viewIntroPlacement + fheroes2::AGG::GetICN( buttonIconID, 0 ).width();
-    const int32_t cancelPlacement = top.x + backgroundImageWidth - backgroundMargin - fheroes2::AGG::GetICN( buttonIconID, 6 ).width();
+    const int32_t endOfViewIntroPlacement = viewIntroPlacement + Assets::getImage( buttonIconID, 0 ).width();
+    const int32_t cancelPlacement = top.x + backgroundImageWidth - backgroundMargin - Assets::getImage( buttonIconID, 6 ).width();
     const int32_t spaceBetweenViewIntroAndCancel = cancelPlacement - endOfViewIntroPlacement;
-    const int32_t difficultyButtonWidth = fheroes2::AGG::GetICN( buttonIconID, 8 ).width();
+    const int32_t difficultyButtonWidth = Assets::getImage( buttonIconID, 8 ).width();
     const uint32_t okayRestartIndex = allowToRestart ? 2 : 4;
     const int32_t middleButtonsMargin
-        = ( spaceBetweenViewIntroAndCancel - difficultyButtonWidth - ( fheroes2::AGG::GetICN( buttonIconID, okayRestartIndex ).width() ) ) / 3;
+        = ( spaceBetweenViewIntroAndCancel - difficultyButtonWidth - ( Assets::getImage( buttonIconID, okayRestartIndex ).width() ) ) / 3;
     const int32_t difficultyPlacement = endOfViewIntroPlacement + middleButtonsMargin;
     const int32_t okRestartPlacement = difficultyPlacement + difficultyButtonWidth + middleButtonsMargin;
 
@@ -1355,10 +1355,10 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
     fheroes2::Button buttonCancel( cancelPlacement, buttonOffsetY, buttonIconID, 6, 7 );
     fheroes2::Button buttonDifficulty( difficultyPlacement, buttonOffsetY, buttonIconID, 8, 9 );
 
-    fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonIconID, 0 ), display, { viewIntroPlacement, buttonOffsetY }, { -5, 5 } );
-    fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonIconID, okayRestartIndex ), display, { okRestartPlacement, buttonOffsetY }, { -5, 5 } );
-    fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonIconID, 6 ), display, { cancelPlacement, buttonOffsetY }, { -5, 5 } );
-    fheroes2::addGradientShadow( fheroes2::AGG::GetICN( buttonIconID, 8 ), display, { difficultyPlacement, buttonOffsetY }, { -5, 5 } );
+    fheroes2::addGradientShadow( Assets::getImage( buttonIconID, 0 ), display, { viewIntroPlacement, buttonOffsetY }, { -5, 5 } );
+    fheroes2::addGradientShadow( Assets::getImage( buttonIconID, okayRestartIndex ), display, { okRestartPlacement, buttonOffsetY }, { -5, 5 } );
+    fheroes2::addGradientShadow( Assets::getImage( buttonIconID, 6 ), display, { cancelPlacement, buttonOffsetY }, { -5, 5 } );
+    fheroes2::addGradientShadow( Assets::getImage( buttonIconID, 8 ), display, { difficultyPlacement, buttonOffsetY }, { -5, 5 } );
 
     // create scenario bonus choice buttons
     fheroes2::ButtonGroup buttonChoices;
@@ -1370,7 +1370,7 @@ fheroes2::GameMode Game::SelectCampaignScenario( const fheroes2::GameMode prevMo
     const fheroes2::Point optionButtonOffset( 590, 199 );
     const int32_t optionButtonStep = 22;
 
-    const fheroes2::Sprite & pressedButton = fheroes2::AGG::GetICN( ICN::CAMPXTRG, 8 );
+    const fheroes2::Sprite & pressedButton = Assets::getImage( ICN::CAMPXTRG, 8 );
     fheroes2::Sprite releaseButton( pressedButton.width(), pressedButton.height(), pressedButton.x(), pressedButton.y() );
     fheroes2::Copy( backgroundImage, optionButtonOffset.x + pressedButton.x(), optionButtonOffset.y + pressedButton.y(), releaseButton, 0, 0, releaseButton.width(),
                     releaseButton.height() );

--- a/src/fheroes2/game/game_credits.cpp
+++ b/src/fheroes2/game/game_credits.cpp
@@ -28,10 +28,10 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "cursor.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "icn.h"
 #include "image.h"
@@ -152,7 +152,7 @@ namespace
 
     fheroes2::Sprite generateHeader()
     {
-        const fheroes2::Sprite & background = fheroes2::AGG::GetICN( ICN::CBKGLAVA, 0 );
+        const fheroes2::Sprite & background = Assets::getImage( ICN::CBKGLAVA, 0 );
         assert( background.height() < fheroes2::Display::DEFAULT_HEIGHT );
 
         fheroes2::Sprite output;
@@ -181,7 +181,7 @@ namespace
 
     fheroes2::Sprite generateResurrectionCreditsFirstPage()
     {
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::CBKGLAVA, 0 );
+        fheroes2::Sprite output = Assets::getImage( ICN::CBKGLAVA, 0 );
         output._disableTransformLayer();
 
         const int32_t columnStep = 210;
@@ -194,7 +194,7 @@ namespace
         offsetY += renderText( output, offsetX, offsetY, textWidth, _( "Project Coordination and Core Development" ), "Ihar Hubchyk" );
         offsetY += 10;
 
-        const fheroes2::Sprite & blackDragon = fheroes2::AGG::GetICN( ICN::DRAGBLAK, 5 );
+        const fheroes2::Sprite & blackDragon = Assets::getImage( ICN::DRAGBLAK, 5 );
         fheroes2::Blit( blackDragon, output, ( columnStep - blackDragon.width() ) / 2, offsetY );
         offsetY += blackDragon.height() + 50;
 
@@ -203,7 +203,7 @@ namespace
         offsetY += renderText( output, offsetX, offsetY, textWidth, _( "Development" ), "Sergei Ivanov" );
         offsetY += 10;
 
-        const fheroes2::Sprite & minotaur = fheroes2::AGG::GetICN( ICN::MINOTAUR, 14 );
+        const fheroes2::Sprite & minotaur = Assets::getImage( ICN::MINOTAUR, 14 );
         fheroes2::Blit( minotaur, output, ( columnStep - minotaur.width() ) / 2, offsetY );
         offsetY += minotaur.height();
 
@@ -220,7 +220,7 @@ namespace
         websiteInto.draw( websiteOffsetX, offsetY, output );
         website.draw( websiteOffsetX + websiteIntoWidth, offsetY, output );
 
-        const fheroes2::Sprite & missile = fheroes2::AGG::GetICN( ICN::ARCH_MSL, 4 );
+        const fheroes2::Sprite & missile = Assets::getImage( ICN::ARCH_MSL, 4 );
         fheroes2::Blit( missile, output, websiteOffsetX - 10 - missile.width(), offsetY + websiteHeight / 2 - missile.height() / 2 );
         fheroes2::Blit( missile, output, websiteOffsetX + websiteIntoWidth + websiteWidth + 10, offsetY + websiteHeight / 2 - missile.height() / 2, true );
 
@@ -230,7 +230,7 @@ namespace
         offsetY += renderText( output, offsetX, offsetY, textWidth, _( "QA and Support" ), "Igor Tsivilko" );
         offsetY += 10;
 
-        const fheroes2::Sprite & cyclop = fheroes2::AGG::GetICN( ICN::CYCLOPS, 38 );
+        const fheroes2::Sprite & cyclop = Assets::getImage( ICN::CYCLOPS, 38 );
         fheroes2::Blit( cyclop, output, offsetX + ( columnStep - cyclop.width() ) / 2, offsetY );
 
         offsetY = secondAuthorLayerY;
@@ -238,7 +238,7 @@ namespace
         offsetY += renderText( output, offsetX, offsetY, textWidth, _( "Development" ), "Ivan Shibanov" );
         offsetY += 10;
 
-        const fheroes2::Sprite & crusader = fheroes2::AGG::GetICN( ICN::PALADIN2, 23 );
+        const fheroes2::Sprite & crusader = Assets::getImage( ICN::PALADIN2, 23 );
         fheroes2::Blit( crusader, output, offsetX + ( columnStep - crusader.width() ) / 2, offsetY );
 
         offsetY = textInitialOffsetY;
@@ -247,7 +247,7 @@ namespace
         offsetY += renderText( output, offsetX, offsetY, textWidth, _( "Development" ), "Oleg Derevenetz" );
         offsetY += 10;
 
-        const fheroes2::Sprite & mage = fheroes2::AGG::GetICN( ICN::MAGE1, 24 );
+        const fheroes2::Sprite & mage = Assets::getImage( ICN::MAGE1, 24 );
         fheroes2::Blit( mage, output, offsetX + ( columnStep - mage.width() ) / 2, offsetY );
 
         offsetY = secondAuthorLayerY;
@@ -255,10 +255,10 @@ namespace
         offsetY += renderText( output, offsetX, offsetY, textWidth, _( "Dev and Support" ), "Zense" );
         offsetY += 10;
 
-        const fheroes2::Sprite & phoenix = fheroes2::AGG::GetICN( ICN::PHOENIX, 4 );
+        const fheroes2::Sprite & phoenix = Assets::getImage( ICN::PHOENIX, 4 );
         fheroes2::Blit( phoenix, output, offsetX + ( columnStep - phoenix.width() ) / 2, offsetY - 10 );
 
-        const fheroes2::Sprite & goblin = fheroes2::AGG::GetICN( ICN::GOBLIN, 27 );
+        const fheroes2::Sprite & goblin = Assets::getImage( ICN::GOBLIN, 27 );
         fheroes2::Blit( goblin, output, output.width() - goblin.width() * 2, output.height() - goblin.height() - 10, true );
 
         return output;
@@ -266,7 +266,7 @@ namespace
 
     fheroes2::Sprite generateResurrectionCreditsSecondPage()
     {
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::CBKGLAVA, 0 );
+        fheroes2::Sprite output = Assets::getImage( ICN::CBKGLAVA, 0 );
         output._disableTransformLayer();
 
         const int32_t columnStep = 210;
@@ -345,7 +345,7 @@ namespace
         name.set( _( "and all the people who have helped make the project possible!" ), fheroes2::FontType::normalWhite() );
         name.draw( output.width() / 2 - name.width() / 2, offsetY, output );
 
-        const fheroes2::Sprite & hydra = fheroes2::AGG::GetICN( ICN::HYDRA, 11 );
+        const fheroes2::Sprite & hydra = Assets::getImage( ICN::HYDRA, 11 );
 
         offsetY = output.height() - hydra.height() - 40;
 
@@ -356,7 +356,7 @@ namespace
 
     fheroes2::Sprite generateResurrectionCreditsThirdPage()
     {
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::CBKGSWMP, 0 );
+        fheroes2::Sprite output = Assets::getImage( ICN::CBKGSWMP, 0 );
         output._disableTransformLayer();
 
         const int32_t textInitialOffsetX = output.width() / 2;
@@ -369,7 +369,7 @@ namespace
         offsetY += renderText( output, offsetX, offsetY, textWidth, _( "Support us at" ), _( "local-donation-platform|https://www.patreon.com/fheroes2" ) );
         offsetY += 30;
 
-        const fheroes2::Sprite & wizard = fheroes2::AGG::GetICN( ICN::CMBTCAPZ, 4 );
+        const fheroes2::Sprite & wizard = Assets::getImage( ICN::CMBTCAPZ, 4 );
         fheroes2::Blit( wizard, output, ( textInitialOffsetX - wizard.width() ) / 2, offsetY );
         offsetY += wizard.height() + 20;
 
@@ -377,7 +377,7 @@ namespace
             += renderText( output, offsetX, offsetY, textWidth - 10, _( "Connect with us at" ), _( "local-social-network|https://www.facebook.com/groups/fheroes2" ) );
         offsetY += 20;
 
-        const fheroes2::Sprite & vampireLord = fheroes2::AGG::GetICN( ICN::VAMPIRE2, 22 );
+        const fheroes2::Sprite & vampireLord = Assets::getImage( ICN::VAMPIRE2, 22 );
         fheroes2::Blit( vampireLord, output, ( textInitialOffsetX - vampireLord.width() ) / 2, offsetY );
 
         offsetY = textInitialOffsetY;
@@ -386,7 +386,7 @@ namespace
         offsetY += renderText( output, offsetX, offsetY, textWidth - 10, _( "Need help with the game?" ), "https://discord.com/servers/fheroes2-733093692860137523" );
         offsetY += 10;
 
-        fheroes2::Sprite labyrinth = fheroes2::AGG::GetICN( ICN::TWNWUP_3, 0 );
+        fheroes2::Sprite labyrinth = Assets::getImage( ICN::TWNWUP_3, 0 );
         fheroes2::ApplyPalette( labyrinth, 2 );
         fheroes2::Blit( labyrinth, output, textInitialOffsetX + ( textInitialOffsetX - labyrinth.width() ) / 2, offsetY );
 
@@ -400,7 +400,7 @@ namespace
         name.set( "Andrey Afletdinov\nhttps://sourceforge.net/\nprojects/fheroes2/", fheroes2::FontType::smallWhite() );
         name.draw( offsetX, offsetY, textWidth - 10, output );
 
-        fheroes2::Sprite creature = fheroes2::AGG::GetICN( ICN::MAGE2, 4 );
+        fheroes2::Sprite creature = Assets::getImage( ICN::MAGE2, 4 );
         transformToBlack( creature );
 
         const int32_t creatureOffsetY = output.height() - 95;
@@ -413,7 +413,7 @@ namespace
 
     fheroes2::Sprite generateSuccessionWarsCreditsFirstPage()
     {
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::CBKGWATR, 0 );
+        fheroes2::Sprite output = Assets::getImage( ICN::CBKGWATR, 0 );
         fheroes2::ApplyPalette( output, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
         output._disableTransformLayer();
 
@@ -476,7 +476,7 @@ namespace
 
     fheroes2::Sprite generateSuccessionWarsCreditsSecondPage()
     {
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::CBKGWATR, 0 );
+        fheroes2::Sprite output = Assets::getImage( ICN::CBKGWATR, 0 );
         fheroes2::ApplyPalette( output, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
         output._disableTransformLayer();
 
@@ -536,7 +536,7 @@ namespace
 
     fheroes2::Sprite generatePriceOfLoyaltyCreditsFirstPage()
     {
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::CBKGGRAV, 0 );
+        fheroes2::Sprite output = Assets::getImage( ICN::CBKGGRAV, 0 );
         fheroes2::ApplyPalette( output, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
         output._disableTransformLayer();
 
@@ -587,7 +587,7 @@ namespace
 
     fheroes2::Sprite generatePriceOfLoyaltyCreditsSecondPage()
     {
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::CBKGGRAV, 0 );
+        fheroes2::Sprite output = Assets::getImage( ICN::CBKGGRAV, 0 );
         fheroes2::ApplyPalette( output, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
         output._disableTransformLayer();
 
@@ -647,7 +647,7 @@ namespace
 
     fheroes2::Sprite generatePriceOfLoyaltyCreditsThirdPage()
     {
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::CBKGGRAV, 0 );
+        fheroes2::Sprite output = Assets::getImage( ICN::CBKGGRAV, 0 );
         fheroes2::ApplyPalette( output, PAL::GetPalette( PAL::PaletteType::DARKENING ) );
         output._disableTransformLayer();
 
@@ -701,7 +701,7 @@ void Game::ShowCredits( const bool keepMainMenuBorders )
 {
     // Credits are shown in the place of Main Menu background which is correctly resized.
     // We get the Main Menu background ROI to use it for credits ROI and leave borders unchanged.
-    const fheroes2::Sprite & mainMenuBackground = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
+    const fheroes2::Sprite & mainMenuBackground = Assets::getImage( ICN::HEROES, 0 );
     const fheroes2::Rect creditsRoi( mainMenuBackground.x(), mainMenuBackground.y(), mainMenuBackground.width(), mainMenuBackground.height() );
 
     // Hide mouse cursor.

--- a/src/fheroes2/game/game_highscores.cpp
+++ b/src/fheroes2/game/game_highscores.cpp
@@ -31,12 +31,12 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "campaign_savedata.h"
 #include "campaign_scenariodata.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "game_io.h"
@@ -112,8 +112,8 @@ namespace
 
         // Animation frames: 0 - static part, 1-6 - animation, 7 and 8 - attacking sprite. We analyze and render here only 0-6 frames.
         for ( uint32_t i = 0; i < 7; ++i ) {
-            const fheroes2::Sprite & topMonsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, animationIndex.front() + i );
-            const fheroes2::Sprite & bottomMonsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, animationIndex.back() + i );
+            const fheroes2::Sprite & topMonsterSprite = Assets::getImage( ICN::MINIMON, animationIndex.front() + i );
+            const fheroes2::Sprite & bottomMonsterSprite = Assets::getImage( ICN::MINIMON, animationIndex.back() + i );
 
             // We search for the most top sprite offset of the top monster sprite, the most bottom offset of the bottom monster.
             int32_t offset = topMonsterSprite.y();
@@ -128,7 +128,7 @@ namespace
             }
 
             for ( const uint32_t index : animationIndex ) {
-                const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, index + i );
+                const fheroes2::Sprite & monsterSprite = Assets::getImage( ICN::MINIMON, index + i );
 
                 offset = monsterSprite.x();
                 if ( offset < roi.x ) {
@@ -168,7 +168,7 @@ namespace
             const uint32_t monsterAnimationId
                 = monsterAnimationSequence[( position.x + offsetY + data.dayCount + monsterAnimationFrameId ) % monsterAnimationSequence.size()];
             const uint32_t secondaryMonsterAnimationIndex = getMonster( data.rating ).GetSpriteIndex() * 9 + 1 + monsterAnimationId;
-            const fheroes2::Sprite & secondaryMonsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, secondaryMonsterAnimationIndex );
+            const fheroes2::Sprite & secondaryMonsterSprite = Assets::getImage( ICN::MINIMON, secondaryMonsterAnimationIndex );
             fheroes2::Blit( secondaryMonsterSprite, display, secondaryMonsterSprite.x() + position.x + monsterOffsetX,
                             secondaryMonsterSprite.y() + offsetY + monsterOffsetY );
 
@@ -194,9 +194,9 @@ namespace
         fheroes2::Display & display = fheroes2::Display::instance();
 
         // Draw background.
-        const fheroes2::Sprite & background = fheroes2::AGG::GetICN( ICN::HSBKG, 0 );
+        const fheroes2::Sprite & background = Assets::getImage( ICN::HSBKG, 0 );
         fheroes2::Copy( background, 0, 0, display, position.x, position.y, background.width(), background.height() );
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::HISCORE, titleImageIndex ), display, position.x + 50, position.y + 31 );
+        fheroes2::Blit( Assets::getImage( ICN::HISCORE, titleImageIndex ), display, position.x + 50, position.y + 31 );
 
         fheroes2::Text text( "", fheroes2::FontType::normalWhite() );
 
@@ -226,7 +226,7 @@ namespace
             // Render static part of monster animation.
             const Monster monster = getMonster( data.rating );
             const uint32_t baseMonsterAnimationIndex = monster.GetSpriteIndex() * 9;
-            const fheroes2::Sprite & baseMonsterSprite = fheroes2::AGG::GetICN( ICN::MINIMON, baseMonsterAnimationIndex );
+            const fheroes2::Sprite & baseMonsterSprite = Assets::getImage( ICN::MINIMON, baseMonsterAnimationIndex );
             fheroes2::Blit( baseMonsterSprite, display, baseMonsterSprite.x() + position.x + 554, baseMonsterSprite.y() + offsetY + 91 );
 
             offsetY += highScoreEntryStepY;
@@ -343,7 +343,7 @@ namespace
 
         const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-        const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::HSBKG, 0 );
+        const fheroes2::Sprite & back = Assets::getImage( ICN::HSBKG, 0 );
 
         const fheroes2::Point top{ ( display.width() - back.width() ) / 2, ( display.height() - back.height() ) / 2 };
 

--- a/src/fheroes2/game/game_interface.cpp
+++ b/src/fheroes2/game/game_interface.cpp
@@ -26,10 +26,10 @@
 #include <algorithm>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_auto_playtest.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
@@ -195,7 +195,7 @@ int32_t Interface::AdventureMap::GetDimensionDoorDestination( const int32_t from
             Dialog::FrameBorder::RenderRegular( radarRect );
         }
 
-        fheroes2::Blit( fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::EVIWDDOR : ICN::VIEWDDOR ), 0 ), display, radarArea.x, radarArea.y );
+        fheroes2::Blit( Assets::getImage( ( isEvilInterface ? ICN::EVIWDDOR : ICN::VIEWDDOR ), 0 ), display, radarArea.x, radarArea.y );
 
         buttonExit.draw();
     };

--- a/src/fheroes2/game/game_mainmenu.cpp
+++ b/src/fheroes2/game/game_mainmenu.cpp
@@ -31,7 +31,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "cursor.h"
@@ -41,6 +40,7 @@
 #include "dialog_resolution.h"
 #include "editor_mainmenu.h"
 #include "game.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_exit.h"
 #include "game_hotkeys.h"
@@ -266,10 +266,10 @@ fheroes2::GameMode Game::MainMenu( const bool isFirstGameRun )
     fheroes2::Button buttonEditor( 0, 0, ICN::BTNSHNGL, EDITOR_DEFAULT, EDITOR_DEFAULT + 2 );
     fheroes2::Button buttonQuit( 0, 0, ICN::BTNSHNGL, QUIT_DEFAULT, QUIT_DEFAULT + 2 );
 
-    const fheroes2::Sprite & lantern10 = fheroes2::AGG::GetICN( ICN::SHNGANIM, 0 );
+    const fheroes2::Sprite & lantern10 = Assets::getImage( ICN::SHNGANIM, 0 );
     fheroes2::Blit( lantern10, display, lantern10.x(), lantern10.y() );
 
-    const fheroes2::Sprite & lantern11 = fheroes2::AGG::GetICN( ICN::SHNGANIM, ICN::getAnimatedIcnIndex( ICN::SHNGANIM, 0, 0 ) );
+    const fheroes2::Sprite & lantern11 = Assets::getImage( ICN::SHNGANIM, ICN::getAnimatedIcnIndex( ICN::SHNGANIM, 0, 0 ) );
     fheroes2::Blit( lantern11, display, lantern11.x(), lantern11.y() );
 
     buttonNewGame.draw();
@@ -305,11 +305,11 @@ fheroes2::GameMode Game::MainMenu( const bool isFirstGameRun )
     }
 
     for ( size_t i = 0; le.hasMouseMoved() && i < buttons.size(); ++i ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BTNSHNGL, buttons[i].frame );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::BTNSHNGL, buttons[i].frame );
         fheroes2::Blit( sprite, display, sprite.x(), sprite.y() );
     }
 
-    fheroes2::Sprite highlightDoor = fheroes2::AGG::GetICN( ICN::SHNGANIM, 18 );
+    fheroes2::Sprite highlightDoor = Assets::getImage( ICN::SHNGANIM, 18 );
     fheroes2::ApplyPalette( highlightDoor, 8 );
 
     while ( true ) {
@@ -340,7 +340,7 @@ fheroes2::GameMode Game::MainMenu( const bool isFirstGameRun )
                 if ( !redrawScreen ) {
                     redrawScreen = true;
                 }
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::BTNSHNGL, frame );
+                const fheroes2::Sprite & sprite = Assets::getImage( ICN::BTNSHNGL, frame );
                 fheroes2::Blit( sprite, display, sprite.x(), sprite.y() );
             }
         }
@@ -406,7 +406,7 @@ fheroes2::GameMode Game::MainMenu( const bool isFirstGameRun )
         }
 
         if ( validateAnimationDelay( DelayType::MAIN_MENU_DELAY ) ) {
-            const fheroes2::Sprite & lantern12 = fheroes2::AGG::GetICN( ICN::SHNGANIM, ICN::getAnimatedIcnIndex( ICN::SHNGANIM, 0, lantern_frame ) );
+            const fheroes2::Sprite & lantern12 = Assets::getImage( ICN::SHNGANIM, ICN::getAnimatedIcnIndex( ICN::SHNGANIM, 0, lantern_frame ) );
             ++lantern_frame;
             fheroes2::Blit( lantern12, display, lantern12.x(), lantern12.y() );
             if ( le.isMouseCursorPosInArea( settingsArea ) ) {

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2025                                             *
+ *   Copyright (C) 2021 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/game/game_mainmenu_ui.cpp
+++ b/src/fheroes2/game/game_mainmenu_ui.cpp
@@ -24,8 +24,8 @@
 #include <cassert>
 #include <cstdint>
 
-#include "agg_image.h"
 #include "game.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "math_base.h"
@@ -37,7 +37,7 @@ namespace
 {
     void drawSprite( fheroes2::Image & output, const int icnId, const uint32_t index )
     {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icnId, index );
+        const fheroes2::Sprite & sprite = Assets::getImage( icnId, index );
         fheroes2::Blit( sprite, 0, 0, output, sprite.x(), sprite.y(), sprite.width(), sprite.height() );
     }
 
@@ -50,7 +50,7 @@ namespace
 
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
-        const fheroes2::Sprite & background = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
+        const fheroes2::Sprite & background = Assets::getImage( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK, 0 );
 
         const int32_t stepX = ( roi.width + background.width() ) / background.width();
         const int32_t stepY = ( roi.height + background.height() ) / background.height();
@@ -93,7 +93,7 @@ namespace fheroes2
     {
         Display & display = Display::instance();
 
-        const Sprite & mainMenuBackground = AGG::GetICN( ICN::HEROES, 0 );
+        const Sprite & mainMenuBackground = Assets::getImage( ICN::HEROES, 0 );
         Copy( mainMenuBackground, 0, 0, display, mainMenuBackground.x(), mainMenuBackground.y(), mainMenuBackground.width(), mainMenuBackground.height() );
 
         drawSprite( display, ICN::BTNSHNGL, 1 );
@@ -109,7 +109,7 @@ namespace fheroes2
     {
         Display & display = Display::instance();
 
-        const Sprite & background = AGG::GetICN( ICN::EDITOR, 0 );
+        const Sprite & background = Assets::getImage( ICN::EDITOR, 0 );
         Copy( background, 0, 0, display, background.x(), background.y(), background.width(), background.height() );
 
         fillScreenBorders( display, { background.x(), background.y(), background.width(), background.height() } );

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/game/game_newgame.cpp
+++ b/src/fheroes2/game/game_newgame.cpp
@@ -33,7 +33,6 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "campaign_savedata.h"
@@ -41,6 +40,7 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_game_settings.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "game_io.h"
@@ -315,10 +315,10 @@ fheroes2::GameMode Game::NewPriceOfLoyaltyCampaign()
     fheroes2::Display & display = fheroes2::Display::instance();
     const fheroes2::Point roiOffset( ( display.width() - display.DEFAULT_WIDTH ) / 2, ( display.height() - display.DEFAULT_HEIGHT ) / 2 );
 
-    const fheroes2::Sprite & background = fheroes2::AGG::GetICN( ICN::X_IVY, 1 );
+    const fheroes2::Sprite & background = Assets::getImage( ICN::X_IVY, 1 );
     fheroes2::Blit( background, 0, 0, display, roiOffset.x, roiOffset.y, background.width(), background.height() );
 
-    const fheroes2::Sprite & campaignChoice = fheroes2::AGG::GetICN( ICN::X_IVY, 0 );
+    const fheroes2::Sprite & campaignChoice = Assets::getImage( ICN::X_IVY, 0 );
     fheroes2::Blit( campaignChoice, 0, 0, display, roiOffset.x + campaignChoice.x(), roiOffset.y + campaignChoice.y(), campaignChoice.width(), campaignChoice.height() );
 
     display.render();

--- a/src/fheroes2/game/game_scenarioinfo.cpp
+++ b/src/fheroes2/game/game_scenarioinfo.cpp
@@ -30,7 +30,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "cursor.h"
@@ -38,6 +37,7 @@
 #include "dialog_selectscenario.h"
 #include "difficulty.h"
 #include "game.h" // IWYU pragma: associated
+#include "game_assets.h"
 #include "game_exit.h"
 #include "game_hotkeys.h"
 #include "game_mainmenu_ui.h"
@@ -192,14 +192,14 @@ namespace
         const fheroes2::Point pointOpponentInfo( roi.x + 8, roi.y + 181 );
         const fheroes2::Point pointClassInfo( roi.x + 8, roi.y + 265 );
 
-        const fheroes2::Sprite & scenarioBox = fheroes2::AGG::GetICN( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
+        const fheroes2::Sprite & scenarioBox = Assets::getImage( isEvilInterface ? ICN::METALLIC_BORDERED_TEXTBOX_EVIL : ICN::METALLIC_BORDERED_TEXTBOX_GOOD, 0 );
 
         const fheroes2::Rect scenarioBoxRoi( roi.x + ( roi.width - scenarioBox.width() ) / 2, roi.y + 24, scenarioBox.width(), scenarioBox.height() );
 
         fheroes2::Copy( scenarioBox, 0, 0, display, scenarioBoxRoi );
         fheroes2::addGradientShadow( scenarioBox, display, scenarioBoxRoi.getPosition(), { -5, 5 } );
 
-        const fheroes2::Sprite & difficultyCursor = fheroes2::AGG::GetICN( ICN::NGEXTRA, 62 );
+        const fheroes2::Sprite & difficultyCursor = Assets::getImage( ICN::NGEXTRA, 62 );
 
         const int32_t difficultyCursorWidth = difficultyCursor.width();
         const int32_t difficultyCursorHeight = difficultyCursor.height();
@@ -214,7 +214,7 @@ namespace
         coordDifficulty.emplace_back( roi.x + 238, roi.y + 78, difficultyCursorWidth, difficultyCursorHeight );
         coordDifficulty.emplace_back( roi.x + 315, roi.y + 78, difficultyCursorWidth, difficultyCursorHeight );
 
-        const int32_t buttonSelectWidth = fheroes2::AGG::GetICN( ICN::BUTTON_MAP_SELECT_GOOD, 0 ).width();
+        const int32_t buttonSelectWidth = Assets::getImage( ICN::BUTTON_MAP_SELECT_GOOD, 0 ).width();
 
         fheroes2::Button buttonSelectMaps( scenarioBoxRoi.x + scenarioBoxRoi.width - 6 - buttonSelectWidth, scenarioBoxRoi.y + 5,
                                            isEvilInterface ? ICN::BUTTON_MAP_SELECT_EVIL : ICN::BUTTON_MAP_SELECT_GOOD, 0, 1 );
@@ -268,7 +268,7 @@ namespace
 
         // Draw difficulty icons.
         for ( int i = 0; i < 5; ++i ) {
-            const fheroes2::Sprite & icon = fheroes2::AGG::GetICN( ICN::DIFFICULTY_ICON_EASY + i, icnIndex );
+            const fheroes2::Sprite & icon = Assets::getImage( ICN::DIFFICULTY_ICON_EASY + i, icnIndex );
             fheroes2::Copy( icon, 0, 0, display, coordDifficulty[i] );
             fheroes2::addGradientShadow( icon, display, { coordDifficulty[i].x, coordDifficulty[i].y }, { -5, 5 } );
         }

--- a/src/fheroes2/game/game_startgame.cpp
+++ b/src/fheroes2/game/game_startgame.cpp
@@ -34,7 +34,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "ai_planner.h"
 #include "army.h"
 #include "audio.h"
@@ -45,6 +44,7 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "direction.h"
+#include "game_assets.h"
 #include "game_auto_playtest.h"
 #include "game_delays.h"
 #include "game_exit.h"
@@ -253,27 +253,27 @@ void Game::DialogPlayers( const PlayerColor color, std::string title, std::strin
     const Player * player = Players::Get( color );
     StringReplace( message, "%{color}", ( player ? player->GetName() : Color::String( color ) ) );
 
-    const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::BRCREST, 6 );
+    const fheroes2::Sprite & border = Assets::getImage( ICN::BRCREST, 6 );
     fheroes2::Sprite sign = border;
 
     switch ( color ) {
     case PlayerColor::BLUE:
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::BRCREST, 0 ), sign, 4, 4 );
+        fheroes2::Blit( Assets::getImage( ICN::BRCREST, 0 ), sign, 4, 4 );
         break;
     case PlayerColor::GREEN:
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::BRCREST, 1 ), sign, 4, 4 );
+        fheroes2::Blit( Assets::getImage( ICN::BRCREST, 1 ), sign, 4, 4 );
         break;
     case PlayerColor::RED:
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::BRCREST, 2 ), sign, 4, 4 );
+        fheroes2::Blit( Assets::getImage( ICN::BRCREST, 2 ), sign, 4, 4 );
         break;
     case PlayerColor::YELLOW:
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::BRCREST, 3 ), sign, 4, 4 );
+        fheroes2::Blit( Assets::getImage( ICN::BRCREST, 3 ), sign, 4, 4 );
         break;
     case PlayerColor::ORANGE:
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::BRCREST, 4 ), sign, 4, 4 );
+        fheroes2::Blit( Assets::getImage( ICN::BRCREST, 4 ), sign, 4, 4 );
         break;
     case PlayerColor::PURPLE:
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::BRCREST, 5 ), sign, 4, 4 );
+        fheroes2::Blit( Assets::getImage( ICN::BRCREST, 5 ), sign, 4, 4 );
         break;
     default:
         // Did you add a new color? Add the logic for it!

--- a/src/fheroes2/gui/cursor.cpp
+++ b/src/fheroes2/gui/cursor.cpp
@@ -23,7 +23,7 @@
 
 #include "cursor.h"
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -57,7 +57,7 @@ void Cursor::SetThemes( const int theme, const bool force /* = false */ )
     default:
         break;
     }
-    const fheroes2::Sprite & spr = fheroes2::AGG::GetICN( icnID, 0xFF & theme );
+    const fheroes2::Sprite & spr = Assets::getImage( icnID, 0xFF & theme );
     SetOffset( theme, { ( spr.width() - spr.x() ) / 2, ( spr.height() - spr.y() ) / 2 } );
 
     fheroes2::Cursor & cursor = fheroes2::cursor();

--- a/src/fheroes2/gui/interface_border.cpp
+++ b/src/fheroes2/gui/interface_border.cpp
@@ -25,8 +25,8 @@
 
 #include <algorithm>
 
-#include "agg_image.h"
 #include "cursor.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -118,7 +118,7 @@ void Interface::GameBorderRedraw( const bool viewWorldMode )
 
     fheroes2::Rect srcrt;
     fheroes2::Point dstpt;
-    const fheroes2::Sprite & icnadv = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
+    const fheroes2::Sprite & icnadv = Assets::getImage( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
 
     // TOP BORDER
     srcrt.x = 0;

--- a/src/fheroes2/gui/interface_cpanel.cpp
+++ b/src/fheroes2/gui/interface_cpanel.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/interface_cpanel.cpp
+++ b/src/fheroes2/gui/interface_cpanel.cpp
@@ -57,8 +57,8 @@ void Interface::ControlPanel::ResetTheme()
 {
     const int icn = Settings::Get().isEvilInterfaceEnabled() ? ICN::ADVEBTNS : ICN::ADVBTNS;
 
-    _buttons.reset(
-        new Buttons( Assets::getImage( icn, 4 ), Assets::getImage( icn, 0 ), Assets::getImage( icn, 12 ), Assets::getImage( icn, 10 ), Assets::getImage( icn, 8 ) ) );
+    _buttons = std::make_unique<Buttons>(
+        Assets::getImage( icn, 4 ), Assets::getImage( icn, 0 ), Assets::getImage( icn, 12 ), Assets::getImage( icn, 10 ), Assets::getImage( icn, 8 ) );
 }
 
 void Interface::ControlPanel::SetPos( int32_t ox, int32_t oy )

--- a/src/fheroes2/gui/interface_cpanel.cpp
+++ b/src/fheroes2/gui/interface_cpanel.cpp
@@ -57,8 +57,8 @@ void Interface::ControlPanel::ResetTheme()
 {
     const int icn = Settings::Get().isEvilInterfaceEnabled() ? ICN::ADVEBTNS : ICN::ADVBTNS;
 
-    _buttons = std::make_unique<Buttons>(
-        Assets::getImage( icn, 4 ), Assets::getImage( icn, 0 ), Assets::getImage( icn, 12 ), Assets::getImage( icn, 10 ), Assets::getImage( icn, 8 ) );
+    _buttons = std::make_unique<Buttons>( Assets::getImage( icn, 4 ), Assets::getImage( icn, 0 ), Assets::getImage( icn, 12 ), Assets::getImage( icn, 10 ),
+                                          Assets::getImage( icn, 8 ) );
 }
 
 void Interface::ControlPanel::SetPos( int32_t ox, int32_t oy )

--- a/src/fheroes2/gui/interface_cpanel.cpp
+++ b/src/fheroes2/gui/interface_cpanel.cpp
@@ -25,7 +25,7 @@
 
 #include <cassert>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "game_interface.h"
 #include "icn.h"
 #include "image.h"
@@ -57,8 +57,8 @@ void Interface::ControlPanel::ResetTheme()
 {
     const int icn = Settings::Get().isEvilInterfaceEnabled() ? ICN::ADVEBTNS : ICN::ADVBTNS;
 
-    _buttons.reset( new Buttons( fheroes2::AGG::GetICN( icn, 4 ), fheroes2::AGG::GetICN( icn, 0 ), fheroes2::AGG::GetICN( icn, 12 ), fheroes2::AGG::GetICN( icn, 10 ),
-                                 fheroes2::AGG::GetICN( icn, 8 ) ) );
+    _buttons.reset( new Buttons( Assets::getImage( icn, 4 ), Assets::getImage( icn, 0 ), Assets::getImage( icn, 12 ), Assets::getImage( icn, 10 ),
+                                 Assets::getImage( icn, 8 ) ) );
 }
 
 void Interface::ControlPanel::SetPos( int32_t ox, int32_t oy )

--- a/src/fheroes2/gui/interface_cpanel.cpp
+++ b/src/fheroes2/gui/interface_cpanel.cpp
@@ -57,8 +57,8 @@ void Interface::ControlPanel::ResetTheme()
 {
     const int icn = Settings::Get().isEvilInterfaceEnabled() ? ICN::ADVEBTNS : ICN::ADVBTNS;
 
-    _buttons.reset( new Buttons( Assets::getImage( icn, 4 ), Assets::getImage( icn, 0 ), Assets::getImage( icn, 12 ), Assets::getImage( icn, 10 ),
-                                 Assets::getImage( icn, 8 ) ) );
+    _buttons.reset(
+        new Buttons( Assets::getImage( icn, 4 ), Assets::getImage( icn, 0 ), Assets::getImage( icn, 12 ), Assets::getImage( icn, 10 ), Assets::getImage( icn, 8 ) ) );
 }
 
 void Interface::ControlPanel::SetPos( int32_t ox, int32_t oy )

--- a/src/fheroes2/gui/interface_gamearea.cpp
+++ b/src/fheroes2/gui/interface_gamearea.cpp
@@ -33,11 +33,11 @@
 #include <ostream>
 #include <type_traits>
 
-#include "agg_image.h"
 #include "castle.h"
 #include "color.h"
 #include "cursor.h"
 #include "direction.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_interface.h"
 #include "ground.h"
@@ -297,7 +297,7 @@ namespace
     {
         for ( const auto & [offset, imgInfo] : images ) {
             for ( const auto & info : imgInfo ) {
-                area.BlitOnTile( output, fheroes2::AGG::GetICN( info.icnId, info.icnIndex ), info.area, info.imageOffset.x, info.imageOffset.y, offset, info.isFlipped,
+                area.BlitOnTile( output, Assets::getImage( info.icnId, info.icnIndex ), info.area, info.imageOffset.x, info.imageOffset.y, offset, info.isFlipped,
                                  info.alphaValue );
             }
         }
@@ -747,7 +747,7 @@ void Interface::GameArea::Redraw( fheroes2::Image & dst, int flag, bool isPuzzle
                 routeSpriteIndex = Route::Path::GetIndexSprite( currentStep->GetDirection(), nextStep->GetDirection(), cost );
             }
 
-            const fheroes2::Sprite & routeSprite = fheroes2::AGG::GetICN( ( ( greenColorSteps < 0 ) ? ICN::ROUTERED : ICN::ROUTE ), routeSpriteIndex );
+            const fheroes2::Sprite & routeSprite = Assets::getImage( ( ( greenColorSteps < 0 ) ? ICN::ROUTERED : ICN::ROUTE ), routeSpriteIndex );
             BlitOnTile( dst, routeSprite, routeSprite.x() - 12, routeSprite.y() + 2, mp, false, 255 );
         }
     }
@@ -819,7 +819,7 @@ void Interface::GameArea::redrawOnlyFog( fheroes2::Image & dst ) const
                     Maps::redrawEmptyTile( dst, offset, *this );
                 }
                 else {
-                    const fheroes2::Image & sf = fheroes2::AGG::GetTIL( TIL::CLOF32, ( offset.x + offset.y ) % 4, 0 );
+                    const fheroes2::Image & sf = Assets::getTileImage( TIL::CLOF32, ( offset.x + offset.y ) % 4, 0 );
                     DrawTile( dst, sf, offset );
                 }
             }
@@ -919,7 +919,7 @@ fheroes2::Image Interface::GameArea::GenerateUltimateArtifactAreaSurface( const 
 
     gamearea.Redraw( result, LEVEL_OBJECTS, true );
 
-    const fheroes2::Sprite & marker = fheroes2::AGG::GetICN( ICN::ROUTE, 0 );
+    const fheroes2::Sprite & marker = Assets::getImage( ICN::ROUTE, 0 );
     const fheroes2::Point markerPos( gamearea.GetRelativeTilePosition( pt ) - gamearea._middlePoint() - fheroes2::Point( gamearea._windowROI.x, gamearea._windowROI.y )
                                      + fheroes2::Point( result.width() / 2, result.height() / 2 ) );
 

--- a/src/fheroes2/gui/interface_icons.cpp
+++ b/src/fheroes2/gui/interface_icons.cpp
@@ -28,10 +28,10 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "castle.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
 #include "heroes.h"
@@ -75,7 +75,7 @@ void Interface::IconsBar::redrawBackground( fheroes2::Image & output, const fher
 {
     const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
-    const fheroes2::Sprite & icnadv = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
+    const fheroes2::Sprite & icnadv = Assets::getImage( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
     fheroes2::Rect srcrt( icnadv.width() - fheroes2::radarWidthPx - fheroes2::borderWidthPx, fheroes2::radarWidthPx + 2 * fheroes2::borderWidthPx,
                           fheroes2::radarWidthPx / 2, 32 );
 
@@ -98,7 +98,7 @@ void Interface::IconsBar::redrawBackground( fheroes2::Image & output, const fher
     fheroes2::Blit( icnadv, srcrt.x, srcrt.y, output, offset.x, internalOffsetY, srcrt.width, srcrt.height );
 
     for ( int32_t i = validItemCount; i < _iconsCount; ++i ) {
-        const fheroes2::Sprite & background = fheroes2::AGG::GetICN( isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS, 1 + i % 8 );
+        const fheroes2::Sprite & background = Assets::getImage( isEvilInterface ? ICN::LOCATORE : ICN::LOCATORS, 1 + i % 8 );
         fheroes2::Copy( background, 0, 0, output, offset.x + 5, offset.y + 5 + i * ( IconsBar::getItemHeight() + 10 ), background.width(), background.height() );
     }
 }
@@ -199,7 +199,7 @@ void Interface::CastleIcons::setPos( const int32_t px, const int32_t py )
 
     VecCastles & castles = world.GetKingdom( Settings::Get().CurrentColor() ).GetCastles();
 
-    const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );
+    const fheroes2::Sprite & originalSlider = Assets::getImage( icnscroll, 4 );
     fheroes2::Image scrollbarSlider
         = fheroes2::generateScrollbarSlider( originalSlider, false, iconsCursorHeight * _iconsCount - 38, _iconsCount, static_cast<int32_t>( castles.size() ),
                                              { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
@@ -312,7 +312,7 @@ void Interface::HeroesIcons::setPos( const int32_t px, const int32_t py )
 
     VecHeroes & heroes = world.GetKingdom( Settings::Get().CurrentColor() ).GetHeroes();
 
-    const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );
+    const fheroes2::Sprite & originalSlider = Assets::getImage( icnscroll, 4 );
     fheroes2::Image scrollbarSlider
         = fheroes2::generateScrollbarSlider( originalSlider, false, iconsCursorHeight * _iconsCount - 38, _iconsCount, static_cast<int32_t>( heroes.size() ),
                                              { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
@@ -457,7 +457,7 @@ void Interface::IconsPanel::resetIcons( const HeroesCastlesIcons type )
     if ( !kingdom.isControlAI() || player->isAIAutoControlMode() ) {
         const int icnscroll = Settings::Get().isEvilInterfaceEnabled() ? ICN::SCROLLE : ICN::SCROLL;
 
-        const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( icnscroll, 4 );
+        const fheroes2::Sprite & originalSlider = Assets::getImage( icnscroll, 4 );
 
         if ( type & ICON_HEROES ) {
             fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, iconsCursorHeight * _heroesIcons.getIconsCount() - 38,

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/gui/interface_radar.cpp
+++ b/src/fheroes2/gui/interface_radar.cpp
@@ -26,9 +26,9 @@
 #include <cassert>
 #include <cstring>
 
-#include "agg_image.h"
 #include "castle.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "ground.h"
 #include "heroes.h"
 #include "icn.h"
@@ -231,7 +231,7 @@ void Interface::Radar::_redraw( const bool redrawMapObjects )
     fheroes2::Display & display = fheroes2::Display::instance();
     const fheroes2::Rect & rect = GetArea();
     if ( _hide ) {
-        fheroes2::Blit( fheroes2::AGG::GetICN( ( conf.isEvilInterfaceEnabled() ? ICN::HEROLOGE : ICN::HEROLOGO ), 0 ), display, rect.x, rect.y );
+        fheroes2::Blit( Assets::getImage( ( conf.isEvilInterfaceEnabled() ? ICN::HEROLOGE : ICN::HEROLOGO ), 0 ), display, rect.x, rect.y );
 
         // Force set radar ROI for the whole world to be prepared to fully update radar when it will be shown.
         _roi = { 0, 0, world.w(), world.h() };

--- a/src/fheroes2/gui/interface_status.cpp
+++ b/src/fheroes2/gui/interface_status.cpp
@@ -27,12 +27,12 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "army.h"
 #include "castle.h"
 #include "color.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_interface.h"
 #include "heroes.h"
@@ -111,7 +111,7 @@ void Interface::StatusPanel::_redraw() const
     }
 
     // draw info: Day and Funds and Army
-    const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( conf.isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+    const fheroes2::Sprite & ston = Assets::getImage( conf.isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
     const int32_t stonHeight = ston.height();
 
     if ( _state == StatusType::STATUS_AITURN ) {
@@ -182,7 +182,7 @@ void Interface::StatusPanel::_redraw() const
 void Interface::StatusPanel::NextState()
 {
     const int32_t areaHeight = GetArea().height;
-    const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+    const fheroes2::Sprite & ston = Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
     const int32_t stonHeight = ston.height();
 
     const bool skipDayStatus = areaHeight >= ( stonHeight * 2 + 15 ) && areaHeight < ( stonHeight * 3 + 15 );
@@ -224,7 +224,7 @@ void Interface::StatusPanel::_drawKingdomInfo( const int32_t offsetY ) const
 
     // sprite all resource
     fheroes2::Display & display = fheroes2::Display::instance();
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::RESSMALL, 0 ), display, pos.x + 6, pos.y );
+    fheroes2::Blit( Assets::getImage( ICN::RESSMALL, 0 ), display, pos.x + 6, pos.y );
 
     pos.y += 27;
 
@@ -276,7 +276,7 @@ void Interface::StatusPanel::_drawDayInfo( const int32_t offsetY ) const
     }
 
     fheroes2::Display & display = fheroes2::Display::instance();
-    fheroes2::Blit( fheroes2::AGG::GetICN( icnType, icnId ), display, pos.x, pos.y + 1 + offsetY );
+    fheroes2::Blit( Assets::getImage( icnType, icnId ), display, pos.x, pos.y + 1 + offsetY );
 
     std::string message = _( "Month: %{month} Week: %{week}" );
     StringReplace( message, "%{month}", month );
@@ -310,7 +310,7 @@ void Interface::StatusPanel::_drawResourceInfo( const int32_t offsetY ) const
     fheroes2::Text text{ std::move( message ), fheroes2::FontType::smallWhite() };
     text.draw( pos.x, pos.y + 6 + offsetY, pos.width, display );
 
-    const fheroes2::Sprite & spr = fheroes2::AGG::GetICN( ICN::RESOURCE, Resource::getIconIcnIndex( _lastResource ) );
+    const fheroes2::Sprite & spr = Assets::getImage( ICN::RESOURCE, Resource::getIconIcnIndex( _lastResource ) );
     fheroes2::Blit( spr, display, pos.x + ( pos.width - spr.width() ) / 2, pos.y + 6 + offsetY + text.height( pos.width ) );
 
     text.set( std::to_string( _lastResourceCount ), fheroes2::FontType::smallWhite() );
@@ -341,7 +341,7 @@ void Interface::StatusPanel::_drawAITurns() const
 
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    const fheroes2::Sprite & glass = fheroes2::AGG::GetICN( ICN::HOURGLAS, 0 );
+    const fheroes2::Sprite & glass = Assets::getImage( ICN::HOURGLAS, 0 );
     const fheroes2::Rect & statusRoi = GetArea();
 
     int32_t posX = statusRoi.x + ( statusRoi.width - glass.width() ) / 2;
@@ -375,7 +375,7 @@ void Interface::StatusPanel::_drawAITurns() const
         return;
     }
 
-    const fheroes2::Sprite & crest = fheroes2::AGG::GetICN( ICN::BRCREST, colorIndex );
+    const fheroes2::Sprite & crest = Assets::getImage( ICN::BRCREST, colorIndex );
 
     posX += 2;
     posY += 2;
@@ -395,17 +395,17 @@ void Interface::StatusPanel::_drawAITurns() const
         animationIndex = 21 + ( animationIndex % 10 );
     }
 
-    const fheroes2::Sprite & sandGains = fheroes2::AGG::GetICN( ICN::HOURGLAS, animationIndex );
+    const fheroes2::Sprite & sandGains = Assets::getImage( ICN::HOURGLAS, animationIndex );
     fheroes2::Blit( sandGains, display, posX - sandGains.width() - sandGains.x(), posY + sandGains.y() );
 
-    const fheroes2::Sprite & sand = fheroes2::AGG::GetICN( ICN::HOURGLAS, 1 + ( _aiTurnProgress % 10 ) );
+    const fheroes2::Sprite & sand = Assets::getImage( ICN::HOURGLAS, 1 + ( _aiTurnProgress % 10 ) );
     fheroes2::Blit( sand, display, posX - sand.width() - sand.x(), posY + sand.y() );
 }
 
 void Interface::StatusPanel::_drawBackground() const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
-    const fheroes2::Sprite & icnston = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+    const fheroes2::Sprite & icnston = Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
     const fheroes2::Rect & pos = GetArea();
 
     if ( !Settings::Get().isHideInterfaceEnabled() && display.height() - fheroes2::borderWidthPx - icnston.height() > pos.y ) {
@@ -453,7 +453,7 @@ void Interface::StatusPanel::QueueEventProcessing()
         setRedraw();
     }
     else if ( le.isMouseRightButtonPressedInArea( GetRect() ) ) {
-        const fheroes2::Sprite & ston = fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
+        const fheroes2::Sprite & ston = Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::STONBAKE : ICN::STONBACK, 0 );
         const bool isFullInfo = StatusType::STATUS_UNKNOWN != _state && pos.height >= ( ston.height() * 3 + 15 );
         if ( isFullInfo ) {
             fheroes2::showStandardTextMessage( _( "Status Window" ), _( "This window provides information on the status of your hero or kingdom, and shows the date." ),

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2020 - 2025                                             *
+ *   Copyright (C) 2020 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/player_info.cpp
+++ b/src/fheroes2/gui/player_info.cpp
@@ -27,10 +27,10 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "color.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -48,9 +48,9 @@ void Interface::PlayersInfo::UpdateInfo( Players & players, const fheroes2::Poin
 {
     clear();
 
-    const fheroes2::Sprite & playerTypeImage = fheroes2::AGG::GetICN( ICN::NGEXTRA, 3 );
-    const fheroes2::Sprite & classImage = fheroes2::AGG::GetICN( ICN::NGEXTRA, 51 );
-    const fheroes2::Sprite & handicapImage = fheroes2::AGG::GetICN( ICN::NGEXTRA, 0 );
+    const fheroes2::Sprite & playerTypeImage = Assets::getImage( ICN::NGEXTRA, 3 );
+    const fheroes2::Sprite & classImage = Assets::getImage( ICN::NGEXTRA, 51 );
+    const fheroes2::Sprite & handicapImage = Assets::getImage( ICN::NGEXTRA, 0 );
 
     const int32_t playerCount = static_cast<int32_t>( players.size() ); // safe to cast as the number of players <= 8.
 
@@ -200,8 +200,8 @@ void Interface::PlayersInfo::RedrawInfo( const bool displayInGameInfo ) const
         // wide sprite offset
         playerTypeIcnIndex += 24;
 
-        const fheroes2::Sprite & playerIconShadow = fheroes2::AGG::GetICN( ICN::NGEXTRA, 60 );
-        const fheroes2::Sprite & playerIcon = fheroes2::AGG::GetICN( ICN::NGEXTRA, playerTypeIcnIndex );
+        const fheroes2::Sprite & playerIconShadow = Assets::getImage( ICN::NGEXTRA, 60 );
+        const fheroes2::Sprite & playerIcon = Assets::getImage( ICN::NGEXTRA, playerTypeIcnIndex );
 
         fheroes2::Blit( playerIconShadow, display, info.playerTypeRoi.x - 5, info.playerTypeRoi.y + 3 );
 
@@ -224,8 +224,8 @@ void Interface::PlayersInfo::RedrawInfo( const bool displayInGameInfo ) const
         // 2. redraw class
         const bool isActivePlayer = displayInGameInfo ? info.player->isPlay() : mapInfo.AllowChangeRace( info.player->GetColor() );
 
-        const fheroes2::Sprite & classIcon = fheroes2::AGG::GetICN( ICN::NGEXTRA, Race::getRaceIcnIndex( info.player->GetRace(), isActivePlayer ) );
-        const fheroes2::Sprite & classIconShadow = fheroes2::AGG::GetICN( ICN::NGEXTRA, 61 );
+        const fheroes2::Sprite & classIcon = Assets::getImage( ICN::NGEXTRA, Race::getRaceIcnIndex( info.player->GetRace(), isActivePlayer ) );
+        const fheroes2::Sprite & classIconShadow = Assets::getImage( ICN::NGEXTRA, 61 );
 
         fheroes2::Blit( classIconShadow, display, info.classRoi.x - 5, info.classRoi.y + 3 );
         fheroes2::Blit( classIcon, display, info.classRoi.x, info.classRoi.y );
@@ -267,8 +267,8 @@ void Interface::PlayersInfo::RedrawInfo( const bool displayInGameInfo ) const
             handicapIcnIndex = 78;
         }
 
-        const fheroes2::Sprite & handicapIcon = fheroes2::AGG::GetICN( ICN::NGEXTRA, handicapIcnIndex );
-        const fheroes2::Sprite & handicapIconShadow = fheroes2::AGG::GetICN( ICN::NGEXTRA, 59 );
+        const fheroes2::Sprite & handicapIcon = Assets::getImage( ICN::NGEXTRA, handicapIcnIndex );
+        const fheroes2::Sprite & handicapIconShadow = Assets::getImage( ICN::NGEXTRA, 59 );
 
         fheroes2::Blit( handicapIconShadow, display, info.handicapRoi.x - 5, info.handicapRoi.y + 3 );
         fheroes2::Blit( handicapIcon, display, info.handicapRoi.x, info.handicapRoi.y );

--- a/src/fheroes2/gui/skill_bar.cpp
+++ b/src/fheroes2/gui/skill_bar.cpp
@@ -24,9 +24,9 @@
 #include <cassert>
 #include <utility>
 
-#include "agg_image.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
+#include "game_assets.h"
 #include "heroes.h"
 #include "icn.h"
 #include "pal.h"
@@ -46,7 +46,7 @@ namespace
         icon.resize( 34, 34 );
         icon.reset();
         fheroes2::DrawBorder( icon, fheroes2::GetColorId( 0xD0, 0xC0, 0x48 ) );
-        fheroes2::Copy( fheroes2::AGG::GetICN( ICN::HSICONS, 0 ), 26, 21, icon, 1, 1, 32, 32 );
+        fheroes2::Copy( Assets::getImage( ICN::HSICONS, 0 ), 26, 21, icon, 1, 1, 32, 32 );
         return icon;
     }
 }
@@ -62,7 +62,7 @@ PrimarySkillsBar::PrimarySkillsBar( Heroes * hero, const bool useSmallSize, cons
         setSingleItemSize( { backsf.width(), backsf.height() } );
     }
     else {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::PRIMSKIL, 0 );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::PRIMSKIL, 0 );
         setSingleItemSize( { sprite.width(), sprite.height() } );
     }
 
@@ -90,7 +90,7 @@ void PrimarySkillsBar::RedrawItem( int & skill, const fheroes2::Rect & pos, fher
     }
 
     if ( _useSmallSize ) {
-        const fheroes2::Sprite & backSprite = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+        const fheroes2::Sprite & backSprite = Assets::getImage( ICN::SWAPWIN, 0 );
         const int ww = 32;
         const fheroes2::Point dstpt( pos.x + ( pos.width - ww ) / 2, pos.y + ( pos.height - ww ) / 2 );
 
@@ -134,7 +134,7 @@ void PrimarySkillsBar::RedrawItem( int & skill, const fheroes2::Rect & pos, fher
         }
     }
     else {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::PRIMSKIL, skill - 1 );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::PRIMSKIL, skill - 1 );
         fheroes2::Copy( sprite, 0, 0, dstsf, pos.x + ( pos.width - sprite.width() ) / 2, pos.y + ( pos.height - sprite.height() ) / 2, pos.width, pos.height );
 
         fheroes2::Text text{ Skill::Primary::String( skill ), fheroes2::FontType::smallWhite() };
@@ -315,7 +315,7 @@ SecondarySkillsBar::SecondarySkillsBar( const Heroes & hero, const bool mini /* 
         setSingleItemSize( { backsf.width(), backsf.height() } );
     }
     else {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::SECSKILL, 0 );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::SECSKILL, 0 );
         setSingleItemSize( { sprite.width(), sprite.height() } );
     }
 }
@@ -328,14 +328,14 @@ void SecondarySkillsBar::RedrawBackground( const fheroes2::Rect & pos, fheroes2:
     else {
         if ( _showDefaultSkillsMessage && std::none_of( items.begin(), items.end(), []( Skill::Secondary const * skill ) { return skill->isValid(); } ) ) {
             // In editor when no skill are set it means that default skills will be applied on the game start.
-            fheroes2::ApplyPalette( fheroes2::AGG::GetICN( ICN::SECSKILL, 0 ), 0, 0, dstsf, pos.x, pos.y, pos.width, pos.height,
+            fheroes2::ApplyPalette( Assets::getImage( ICN::SECSKILL, 0 ), 0, 0, dstsf, pos.x, pos.y, pos.width, pos.height,
                                     PAL::GetPalette( PAL::PaletteType::DARKENING ) );
 
             const fheroes2::Text text( _( "Default\nskill" ), fheroes2::FontType::normalWhite() );
             text.drawInRoi( pos.x, pos.y + ( pos.height - text.height() * text.rows( pos.width ) ) / 2 + 2, pos.width, dstsf, pos );
         }
         else {
-            fheroes2::Copy( fheroes2::AGG::GetICN( ICN::SECSKILL, 0 ), 0, 0, dstsf, pos );
+            fheroes2::Copy( Assets::getImage( ICN::SECSKILL, 0 ), 0, 0, dstsf, pos );
         }
     }
 }
@@ -348,7 +348,7 @@ void SecondarySkillsBar::RedrawItem( Skill::Secondary & skill, const fheroes2::R
     }
 
     const fheroes2::Sprite & sprite
-        = use_mini_sprite ? fheroes2::AGG::GetICN( ICN::MINISS, skill.GetIndexSprite2() ) : fheroes2::AGG::GetICN( ICN::SECSKILL, skill.GetIndexSprite1() );
+        = use_mini_sprite ? Assets::getImage( ICN::MINISS, skill.GetIndexSprite2() ) : Assets::getImage( ICN::SECSKILL, skill.GetIndexSprite1() );
     fheroes2::Copy( sprite, 0, 0, dstsf, pos.x + ( pos.width - sprite.width() ) / 2, pos.y + ( pos.height - sprite.height() ) / 2, pos.width, pos.height );
 
     if ( use_mini_sprite ) {

--- a/src/fheroes2/gui/ui_button.cpp
+++ b/src/fheroes2/gui/ui_button.cpp
@@ -23,8 +23,8 @@
 #include <algorithm>
 #include <cassert>
 
-#include "agg_image.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "icn.h"
 #include "localevent.h"
@@ -450,12 +450,12 @@ namespace fheroes2
 
     const Sprite & Button::_getPressed() const
     {
-        return AGG::GetICN( _icnId, _pressedIndex );
+        return Assets::getImage( _icnId, _pressedIndex );
     }
 
     const Sprite & Button::_getReleased() const
     {
-        return AGG::GetICN( _icnId, _releasedIndex );
+        return Assets::getImage( _icnId, _releasedIndex );
     }
 
     const Sprite & ButtonSprite::_getPressed() const
@@ -490,8 +490,8 @@ namespace fheroes2
 
         switch ( buttonTypes ) {
         case Dialog::YES | Dialog::NO: {
-            const Sprite & yesButtonSprite = AGG::GetICN( buttonYesIcnID, 0 );
-            const Sprite & noButtonSprite = AGG::GetICN( buttonNoIcnID, 0 );
+            const Sprite & yesButtonSprite = Assets::getImage( buttonYesIcnID, 0 );
+            const Sprite & noButtonSprite = Assets::getImage( buttonNoIcnID, 0 );
 
             const int32_t horizontalFreeSpace = area.width - yesButtonSprite.width() - noButtonSprite.width();
             const int32_t padding = horizontalFreeSpace / 4;
@@ -508,8 +508,8 @@ namespace fheroes2
         }
 
         case Dialog::OK | Dialog::CANCEL: {
-            const Sprite & okayButtonSprite = AGG::GetICN( buttonOkayIcnID, 0 );
-            const Sprite & cancelButtonSprite = AGG::GetICN( buttonCancelIcnID, 0 );
+            const Sprite & okayButtonSprite = Assets::getImage( buttonOkayIcnID, 0 );
+            const Sprite & cancelButtonSprite = Assets::getImage( buttonCancelIcnID, 0 );
             const int32_t horizontalFreeSpace = area.width - okayButtonSprite.width() - cancelButtonSprite.width();
             const int32_t padding = horizontalFreeSpace / 4;
             assert( horizontalFreeSpace > 0 );
@@ -525,7 +525,7 @@ namespace fheroes2
         }
 
         case Dialog::OK: {
-            const Sprite & okayButtonSprite = AGG::GetICN( buttonOkayIcnID, 0 );
+            const Sprite & okayButtonSprite = Assets::getImage( buttonOkayIcnID, 0 );
 
             offset.x = area.x + ( area.width - okayButtonSprite.width() ) / 2;
             offset.y = area.y + area.height - okayButtonSprite.height();
@@ -534,7 +534,7 @@ namespace fheroes2
         }
 
         case Dialog::CANCEL: {
-            const Sprite & cancelButtonSprite = AGG::GetICN( buttonCancelIcnID, 0 );
+            const Sprite & cancelButtonSprite = Assets::getImage( buttonCancelIcnID, 0 );
 
             offset.x = area.x + ( area.width - cancelButtonSprite.width() ) / 2;
             offset.y = area.y + area.height - cancelButtonSprite.height();
@@ -563,7 +563,7 @@ namespace fheroes2
     ButtonGroup::ButtonGroup( const int icnID )
     {
         // Button ICNs contain released and pressed states so we divide by two to find the number of buttons they correspond to.
-        const int32_t buttonCount = static_cast<int32_t>( fheroes2::AGG::GetICNCount( icnID ) ) / 2;
+        const int32_t buttonCount = static_cast<int32_t>( Assets::getImageCount( icnID ) ) / 2;
         for ( int32_t i = 0; i < buttonCount; ++i ) {
             createButton( 0, 0, icnID, i * 2, i * 2 + 1, i );
         }
@@ -718,7 +718,7 @@ namespace fheroes2
     void makeTransparentBackground( const Sprite & released, Sprite & pressed, const int backgroundIcnID )
     {
         // We need to copy the background image to pressed button only where it does not overlay the image of released button.
-        const Sprite & background = AGG::GetICN( backgroundIcnID, 0 );
+        const Sprite & background = Assets::getImage( backgroundIcnID, 0 );
         // you are trying to apply transform on an image that is single-layered
         assert( !pressed.singleLayer() && !released.singleLayer() );
         const uint8_t * releasedTransform = released.transform();
@@ -824,8 +824,8 @@ namespace fheroes2
 
         const int32_t icnId = isEvilInterface ? ICN::EMPTY_EVIL_BUTTON : ICN::EMPTY_GOOD_BUTTON;
 
-        const Sprite & originalReleased = AGG::GetICN( icnId, 0 );
-        const Sprite & originalPressed = AGG::GetICN( icnId, 1 );
+        const Sprite & originalReleased = Assets::getImage( icnId, 0 );
+        const Sprite & originalPressed = Assets::getImage( icnId, 1 );
 
         released = resizeButton( originalReleased, buttonSize );
         pressed = resizeButton( originalPressed, buttonSize );
@@ -878,8 +878,8 @@ namespace fheroes2
 
         assert( buttonSize.height > 0 );
 
-        released = resizeButton( AGG::GetICN( emptyButtonIcnID, 0 ), buttonSize );
-        pressed = resizeButton( AGG::GetICN( emptyButtonIcnID, 1 ), buttonSize );
+        released = resizeButton( Assets::getImage( emptyButtonIcnID, 0 ), buttonSize );
+        pressed = resizeButton( Assets::getImage( emptyButtonIcnID, 1 ), buttonSize );
 
         if ( buttonBackgroundIcnID != ICN::UNKNOWN ) {
             makeTransparentBackground( released, pressed, buttonBackgroundIcnID );

--- a/src/fheroes2/gui/ui_campaign.cpp
+++ b/src/fheroes2/gui/ui_campaign.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022 - 2024                                             *
+ *   Copyright (C) 2022 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/ui_campaign.cpp
+++ b/src/fheroes2/gui/ui_campaign.cpp
@@ -28,13 +28,13 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army_troop.h"
 #include "artifact.h"
 #include "campaign_data.h"
 #include "campaign_savedata.h"
 #include "campaign_scenariodata.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "heroes.h"
 #include "icn.h"
 #include "image.h"
@@ -53,7 +53,7 @@ namespace
     {
         const fheroes2::Point frameOffset = { 6, 6 };
 
-        fheroes2::Sprite output = fheroes2::AGG::GetICN( ICN::STRIP, 12 );
+        fheroes2::Sprite output = Assets::getImage( ICN::STRIP, 12 );
         renderMonsterFrame( monster, output, frameOffset );
 
         if ( count > 0 ) {
@@ -108,7 +108,7 @@ namespace fheroes2
         }
         case Campaign::ScenarioBonusData::STARTING_RACE:
         case Campaign::ScenarioBonusData::STARTING_RACE_AND_ARMY: {
-            const CustomImageDialogElement raceUI( AGG::GetICN( ICN::getCaptainIcnId( bonusData._subType ), 1 ) );
+            const CustomImageDialogElement raceUI( Assets::getImage( ICN::getCaptainIcnId( bonusData._subType ), 1 ) );
 
             showStandardTextMessage( bonusData.getName(), bonusData.getDescription(), Dialog::ZERO, { &raceUI } );
             break;
@@ -200,8 +200,8 @@ namespace fheroes2
         }
         case Campaign::CampaignAwardData::TYPE_HIREABLE_HERO:
         case Campaign::CampaignAwardData::TYPE_DEFEAT_ENEMY_HERO: {
-            Sprite output = Crop( AGG::GetICN( ICN::HEROBKG, 0 ), 47, 29, 105, 98 );
-            const Sprite & heroPortrait = AGG::GetICN( ICN::getHeroPortraitIcnId( awardData._subType ), 0 );
+            Sprite output = Crop( Assets::getImage( ICN::HEROBKG, 0 ), 47, 29, 105, 98 );
+            const Sprite & heroPortrait = Assets::getImage( ICN::getHeroPortraitIcnId( awardData._subType ), 0 );
             Blit( heroPortrait, 0, 0, output, 2, 2, heroPortrait.width(), heroPortrait.height() );
 
             const CustomImageDialogElement heroUI( std::move( output ) );

--- a/src/fheroes2/gui/ui_castle.cpp
+++ b/src/fheroes2/gui/ui_castle.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2025                                             *
+ *   Copyright (C) 2021 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/ui_castle.cpp
+++ b/src/fheroes2/gui/ui_castle.cpp
@@ -25,9 +25,9 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
 #include "castle.h"
 #include "color.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "logging.h"
@@ -90,7 +90,7 @@ namespace
                 return { fheroes2::Rect( 76, 7, 3, 3 ), fheroes2::Rect( 96, 7, 3, 3 ), fheroes2::Rect( 178, 11, 3, 3 ) };
             }
 
-            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( icnId, icnIndex );
+            const fheroes2::Sprite & image = Assets::getImage( icnId, icnIndex );
             return { fheroes2::Rect( 0, 0, image.width(), image.height() ) };
         }
         case ICN::TWNKCSTL: {
@@ -98,7 +98,7 @@ namespace
                 return { fheroes2::Rect( 127, 36, 3, 3 ), fheroes2::Rect( 287, 6, 3, 3 ) };
             }
 
-            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( icnId, icnIndex );
+            const fheroes2::Sprite & image = Assets::getImage( icnId, icnIndex );
             return { fheroes2::Rect( 0, 0, image.width(), image.height() ) };
         }
         case ICN::TWNKDW_4:
@@ -113,7 +113,7 @@ namespace
                 return { fheroes2::Rect( 5, 6, 3, 3 ) };
             }
 
-            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( icnId, icnIndex );
+            const fheroes2::Sprite & image = Assets::getImage( icnId, icnIndex );
             return { fheroes2::Rect( 0, 0, image.width(), image.height() ) };
         }
         case ICN::TWNKRTUR: {
@@ -121,7 +121,7 @@ namespace
                 return { fheroes2::Rect( 55, 6, 3, 3 ) };
             }
 
-            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( icnId, icnIndex );
+            const fheroes2::Sprite & image = Assets::getImage( icnId, icnIndex );
             return { fheroes2::Rect( 0, 0, image.width(), image.height() ) };
         }
         default:
@@ -138,7 +138,7 @@ namespace
         const std::vector<fheroes2::Rect> regions = getColorEffectiveAreas( icnId, icnIndex );
         const std::vector<uint8_t> palette = getModifiedPaletteByPlayerColor( originalCastleFlagStartColorId, originalCastleFlagColorLength, colorId );
 
-        fheroes2::Sprite temp = fheroes2::AGG::GetICN( icnId, icnIndex );
+        fheroes2::Sprite temp = Assets::getImage( icnId, icnIndex );
 
         for ( const fheroes2::Rect & roi : regions ) {
             fheroes2::ApplyPalette( temp, roi.x, roi.y, temp, roi.x, roi.y, roi.width, roi.height, palette );
@@ -223,16 +223,16 @@ namespace fheroes2
     {
         const uint32_t icnIndex = getCastleIcnIndex( castle.GetRace(), castle.isCastle() );
 
-        const Sprite & castleImage = AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, icnIndex );
+        const Sprite & castleImage = Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::LOCATORE : ICN::LOCATORS, icnIndex );
         Copy( castleImage, 0, 0, output, offset.x, offset.y, castleImage.width(), castleImage.height() );
 
         // Draw castle's marker.
         switch ( Castle::GetAllBuildingStatus( castle ) ) {
         case BuildingStatus::NOT_TODAY:
-            Blit( AGG::GetICN( ICN::CSLMARKER, 0 ), output, offset.x + 40, offset.y );
+            Blit( Assets::getImage( ICN::CSLMARKER, 0 ), output, offset.x + 40, offset.y );
             break;
         case BuildingStatus::REQUIRES_BUILD:
-            Blit( AGG::GetICN( ICN::CSLMARKER, 1 ), output, offset.x + 40, offset.y );
+            Blit( Assets::getImage( ICN::CSLMARKER, 1 ), output, offset.x + 40, offset.y );
             break;
         default:
             break;
@@ -255,13 +255,13 @@ namespace fheroes2
 
         const std::array<int32_t, 4> offsetY = { 0, maxHeight + fontHeight + 2, ( maxHeight + fontHeight ) * 2 - 1, ( maxHeight + fontHeight ) * 3 + 1 };
 
-        const fheroes2::Sprite & woodImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 0 );
-        const fheroes2::Sprite & mercuryImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 1 );
-        const fheroes2::Sprite & oreImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 2 );
-        const fheroes2::Sprite & sulfurImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 3 );
-        const fheroes2::Sprite & crystalImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 4 );
-        const fheroes2::Sprite & gemsImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 5 );
-        const fheroes2::Sprite & goldImage = fheroes2::AGG::GetICN( ICN::RESOURCE, 6 );
+        const fheroes2::Sprite & woodImage = Assets::getImage( ICN::RESOURCE, 0 );
+        const fheroes2::Sprite & mercuryImage = Assets::getImage( ICN::RESOURCE, 1 );
+        const fheroes2::Sprite & oreImage = Assets::getImage( ICN::RESOURCE, 2 );
+        const fheroes2::Sprite & sulfurImage = Assets::getImage( ICN::RESOURCE, 3 );
+        const fheroes2::Sprite & crystalImage = Assets::getImage( ICN::RESOURCE, 4 );
+        const fheroes2::Sprite & gemsImage = Assets::getImage( ICN::RESOURCE, 5 );
+        const fheroes2::Sprite & goldImage = Assets::getImage( ICN::RESOURCE, 6 );
 
         fheroes2::Blit( woodImage, output, leftColumnOffset + ( maxWidth - woodImage.width() ) / 2, roi.y + offsetY[0] + maxHeight - woodImage.height() );
         fheroes2::Blit( sulfurImage, output, rightColumnOffset + ( maxWidth - sulfurImage.width() ) / 2, roi.y + offsetY[0] + maxHeight - sulfurImage.height() );
@@ -295,14 +295,14 @@ namespace fheroes2
         text.set( std::to_string( kingdomTreasures.gold ), fontType );
         text.draw( roi.x + ( roi.width - text.width() ) / 2, roi.y + offsetY[3] + goldImage.height() + 1, output );
 
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::BUTTON_EXIT_TOWN, 0 ), output, roi.x + 1, roi.y + 166 );
+        fheroes2::Blit( Assets::getImage( ICN::BUTTON_EXIT_TOWN, 0 ), output, roi.x + 1, roi.y + 166 );
 
         return roi;
     }
 
     void drawCastleName( const Castle & castle, Image & output, const Point & offset )
     {
-        const fheroes2::Sprite & background = fheroes2::AGG::GetICN( ICN::TOWNNAME, 0 );
+        const fheroes2::Sprite & background = Assets::getImage( ICN::TOWNNAME, 0 );
         fheroes2::Blit( background, fheroes2::Display::instance(), offset.x + 320 - background.width() / 2, offset.y + 248 );
 
         const fheroes2::Text text( castle.GetName(), fheroes2::FontType::smallWhite() );
@@ -313,7 +313,7 @@ namespace fheroes2
                                    const uint8_t alpha )
     {
         const fheroes2::Sprite & image
-            = isImagePlayerColorDependent( icnId ) ? getModifiedByColorImage( icnId, icnIndex, castle.GetColor() ) : AGG::GetICN( icnId, icnIndex );
+            = isImagePlayerColorDependent( icnId ) ? getModifiedByColorImage( icnId, icnIndex, castle.GetColor() ) : Assets::getImage( icnId, icnIndex );
 
         const fheroes2::Rect imageRoi{ offset.x + image.x(), offset.y + image.y(), image.width(), image.height() };
         const fheroes2::Rect overlappedRoi = renderArea ^ imageRoi;

--- a/src/fheroes2/gui/ui_dialog.cpp
+++ b/src/fheroes2/gui/ui_dialog.cpp
@@ -29,11 +29,11 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "army_troop.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "experience.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "heroes_indicator.h"
@@ -378,18 +378,18 @@ namespace fheroes2
     ArtifactDialogElement::ArtifactDialogElement( const Artifact & artifact )
         : _artifact( artifact )
     {
-        const Sprite & frame = AGG::GetICN( ICN::RESOURCE, 7 );
+        const Sprite & frame = Assets::getImage( ICN::RESOURCE, 7 );
         _area = { frame.width(), frame.height() };
     }
 
     void ArtifactDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const Sprite & frame = AGG::GetICN( ICN::RESOURCE, 7 );
+        const Sprite & frame = Assets::getImage( ICN::RESOURCE, 7 );
         Blit( frame, 0, 0, output, offset.x, offset.y, frame.width(), frame.height() );
 
         const uint32_t icnIndex = ( _artifact.GetID() == Artifact::EDITOR_ANY_ULTIMATE_ARTIFACT || _artifact.isValid() ) ? _artifact.IndexSprite64() : 0;
 
-        const Sprite & artifact = AGG::GetICN( ICN::ARTIFACT, icnIndex );
+        const Sprite & artifact = Assets::getImage( ICN::ARTIFACT, icnIndex );
         Blit( artifact, output, offset.x + 6, offset.y + 6 );
     }
 
@@ -411,7 +411,7 @@ namespace fheroes2
         , _icnIndex( Resource::getIconIcnIndex( resourceType ) )
         , _text( std::move( text ) )
     {
-        const Sprite & icn = AGG::GetICN( ICN::RESOURCE, _icnIndex );
+        const Sprite & icn = Assets::getImage( ICN::RESOURCE, _icnIndex );
 
         if ( _text.empty() ) {
             _area = { icn.width(), icn.height() };
@@ -424,7 +424,7 @@ namespace fheroes2
 
     void ResourceDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const Sprite & icn = AGG::GetICN( ICN::RESOURCE, _icnIndex );
+        const Sprite & icn = Assets::getImage( ICN::RESOURCE, _icnIndex );
 
         if ( _text.empty() ) {
             Blit( icn, 0, 0, output, offset.x, offset.y, icn.width(), icn.height() );
@@ -510,7 +510,7 @@ namespace fheroes2
 
         const Text spellNameText( std::move( spellText ), FontType::smallWhite() );
 
-        const Sprite & icn = AGG::GetICN( ICN::SPELLS, _spell.IndexSprite() );
+        const Sprite & icn = Assets::getImage( ICN::SPELLS, _spell.IndexSprite() );
         _area = { std::max( icn.width(), spellNameText.width() ), icn.height() + textOffsetFromElement + spellNameText.height() };
     }
 
@@ -523,7 +523,7 @@ namespace fheroes2
         }
 
         const Text spellNameText( std::move( spellText ), FontType::smallWhite() );
-        const Sprite & icn = AGG::GetICN( ICN::SPELLS, _spell.IndexSprite() );
+        const Sprite & icn = Assets::getImage( ICN::SPELLS, _spell.IndexSprite() );
 
         const int32_t maxWidth = std::max( icn.width(), spellNameText.width() );
 
@@ -548,13 +548,13 @@ namespace fheroes2
     LuckDialogElement::LuckDialogElement( const bool goodLuck )
         : _goodLuck( goodLuck )
     {
-        const Sprite & icn = AGG::GetICN( ICN::EXPMRL, ( _goodLuck ? 0 : 1 ) );
+        const Sprite & icn = Assets::getImage( ICN::EXPMRL, ( _goodLuck ? 0 : 1 ) );
         _area = { icn.width(), icn.height() };
     }
 
     void LuckDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const Sprite & icn = AGG::GetICN( ICN::EXPMRL, ( _goodLuck ? 0 : 1 ) );
+        const Sprite & icn = Assets::getImage( ICN::EXPMRL, ( _goodLuck ? 0 : 1 ) );
         Blit( icn, 0, 0, output, offset.x, offset.y, icn.width(), icn.height() );
     }
 
@@ -576,13 +576,13 @@ namespace fheroes2
     MoraleDialogElement::MoraleDialogElement( const bool goodMorale )
         : _goodMorale( goodMorale )
     {
-        const Sprite & icn = AGG::GetICN( ICN::EXPMRL, ( _goodMorale ? 2 : 3 ) );
+        const Sprite & icn = Assets::getImage( ICN::EXPMRL, ( _goodMorale ? 2 : 3 ) );
         _area = { icn.width(), icn.height() };
     }
 
     void MoraleDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const Sprite & icn = AGG::GetICN( ICN::EXPMRL, ( _goodMorale ? 2 : 3 ) );
+        const Sprite & icn = Assets::getImage( ICN::EXPMRL, ( _goodMorale ? 2 : 3 ) );
         Blit( icn, 0, 0, output, offset.x, offset.y, icn.width(), icn.height() );
     }
 
@@ -604,7 +604,7 @@ namespace fheroes2
     ExperienceDialogElement::ExperienceDialogElement( const int32_t experience )
         : _experience( experience )
     {
-        const Sprite & icn = AGG::GetICN( ICN::EXPMRL, 4 );
+        const Sprite & icn = Assets::getImage( ICN::EXPMRL, 4 );
         if ( experience != 0 ) {
             const Text experienceText( std::to_string( _experience ), FontType::smallWhite() );
             _area = { std::max( icn.width(), experienceText.width() ), icn.height() + textOffsetFromElement + experienceText.height() };
@@ -616,7 +616,7 @@ namespace fheroes2
 
     void ExperienceDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const Sprite & icn = AGG::GetICN( ICN::EXPMRL, 4 );
+        const Sprite & icn = Assets::getImage( ICN::EXPMRL, 4 );
 
         if ( _experience != 0 ) {
             const Text experienceText( std::to_string( _experience ), FontType::smallWhite() );
@@ -652,13 +652,13 @@ namespace fheroes2
     {
         assert( _skillType >= Skill::Primary::ATTACK && _skillType <= Skill::Primary::KNOWLEDGE );
 
-        const Sprite & background = AGG::GetICN( ICN::PRIMSKIL, 4 );
+        const Sprite & background = Assets::getImage( ICN::PRIMSKIL, 4 );
         _area = { background.width(), background.height() };
     }
 
     void PrimarySkillDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const Sprite & background = AGG::GetICN( ICN::PRIMSKIL, 4 );
+        const Sprite & background = Assets::getImage( ICN::PRIMSKIL, 4 );
         Blit( background, 0, 0, output, offset.x, offset.y, background.width(), background.height() );
 
         uint32_t icnId = 0;
@@ -682,7 +682,7 @@ namespace fheroes2
             break;
         }
 
-        const Sprite & icn = AGG::GetICN( ICN::PRIMSKIL, icnId );
+        const Sprite & icn = Assets::getImage( ICN::PRIMSKIL, icnId );
         Blit( icn, 0, 0, output, offset.x + ( background.width() - icn.width() ) / 2, offset.y + ( background.height() - icn.height() ) / 2, icn.width(), icn.height() );
 
         const Text skillName( Skill::Primary::String( _skillType ), FontType::smallWhite() );
@@ -721,7 +721,7 @@ namespace fheroes2
 
     void SmallPrimarySkillDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const Sprite & originalImage = AGG::GetICN( ICN::SWAPWIN, 0 );
+        const Sprite & originalImage = Assets::getImage( ICN::SWAPWIN, 0 );
 
         switch ( _skillType ) {
         case Skill::Primary::ATTACK:
@@ -752,24 +752,24 @@ namespace fheroes2
         : _skill( skill )
         , _hero( hero )
     {
-        const Sprite & background = AGG::GetICN( ICN::SECSKILL, 15 );
+        const Sprite & background = Assets::getImage( ICN::SECSKILL, 15 );
         _area = { background.width(), background.height() };
     }
 
     void SecondarySkillDialogElement::draw( Image & output, const Point & offset ) const
     {
-        const Sprite & background = AGG::GetICN( ICN::SECSKILL, 15 );
+        const Sprite & background = Assets::getImage( ICN::SECSKILL, 15 );
         Blit( background, 0, 0, output, offset.x, offset.y, background.width(), background.height() );
 
         if ( !_skill.isValid() ) {
-            const Sprite & icn = AGG::GetICN( ICN::SECSKILL, 0 );
+            const Sprite & icn = Assets::getImage( ICN::SECSKILL, 0 );
             const Rect icnRect( offset.x + ( background.width() - icn.width() ) / 2, offset.y + ( background.height() - icn.height() ) / 2, icn.width(), icn.height() );
             Copy( icn, 0, 0, output, icnRect );
 
             return;
         }
 
-        const Sprite & icn = AGG::GetICN( ICN::SECSKILL, _skill.GetIndexSprite1() );
+        const Sprite & icn = Assets::getImage( ICN::SECSKILL, _skill.GetIndexSprite1() );
         const Rect icnRect( offset.x + ( background.width() - icn.width() ) / 2, offset.y + ( background.height() - icn.height() ) / 2, icn.width(), icn.height() );
         Copy( icn, 0, 0, output, icnRect );
 
@@ -805,7 +805,7 @@ namespace fheroes2
         assert( !_backgroundIndices.empty() && _delay > 0 );
 
         for ( const uint32_t index : _backgroundIndices ) {
-            const Sprite & image = AGG::GetICN( _icnId, index );
+            const Sprite & image = Assets::getImage( _icnId, index );
             _area.width = std::max( _area.width, image.width() );
             _area.height = std::max( _area.height, image.height() );
 
@@ -818,7 +818,7 @@ namespace fheroes2
         if ( _currentIndex == 0 ) {
             // Since this is the first time to draw we have to draw the background.
             for ( const uint32_t index : _backgroundIndices ) {
-                const Sprite & image = AGG::GetICN( _icnId, index );
+                const Sprite & image = Assets::getImage( _icnId, index );
                 Blit( image, 0, 0, output, offset.x + ( _area.width - image.width() ) / 2, offset.y + ( _area.height - image.height() ) / 2, image.width(),
                       image.height() );
             }
@@ -827,7 +827,7 @@ namespace fheroes2
         const uint32_t animationFrameId = ICN::getAnimatedIcnIndex( _icnId, _animationIndexOffset, _currentIndex );
         ++_currentIndex;
 
-        const Sprite & animationImage = AGG::GetICN( _icnId, animationFrameId );
+        const Sprite & animationImage = Assets::getImage( _icnId, animationFrameId );
 
         Blit( animationImage, 0, 0, output, offset.x + _internalOffset.x + animationImage.x(), offset.y + _internalOffset.y + animationImage.y(), animationImage.width(),
               animationImage.height() );
@@ -876,7 +876,7 @@ namespace fheroes2
         const uint32_t animationFrameId = ICN::getAnimatedIcnIndex( _icnId, _animationIndexOffset, _currentIndex );
         ++_currentIndex;
 
-        const Sprite & animationImage = AGG::GetICN( _icnId, animationFrameId );
+        const Sprite & animationImage = Assets::getImage( _icnId, animationFrameId );
 
         Blit( animationImage, 0, 0, output, offset.x + _animationPosition.x, offset.y + _animationPosition.y, animationImage.width(), animationImage.height() );
     }
@@ -905,13 +905,13 @@ namespace fheroes2
         : _monster( monster )
     {
         assert( _monster.isValid() );
-        const Sprite & sprite = AGG::GetICN( ICN::STRIP, 12 );
+        const Sprite & sprite = Assets::getImage( ICN::STRIP, 12 );
         _area = { sprite.width(), sprite.height() };
     }
 
     void MonsterDialogElement::draw( Image & output, const Point & offset ) const
     {
-        Sprite sprite = AGG::GetICN( ICN::STRIP, 12 );
+        Sprite sprite = Assets::getImage( ICN::STRIP, 12 );
         sprite._disableTransformLayer();
         renderMonsterFrame( _monster, sprite, { 6, 6 } );
         Copy( sprite, 0, 0, output, offset.x, offset.y, sprite.width(), sprite.height() );
@@ -958,8 +958,8 @@ namespace fheroes2
 
     void ValueSelectionDialogElement::setOffset( const fheroes2::Point & offset )
     {
-        const Sprite & editBoxImage = AGG::GetICN( ICN::TOWNWIND, 4 );
-        const Sprite & arrowImage = AGG::GetICN( ICN::TOWNWIND, 5 );
+        const Sprite & editBoxImage = Assets::getImage( ICN::TOWNWIND, 4 );
+        const Sprite & arrowImage = Assets::getImage( ICN::TOWNWIND, 5 );
 
         _area = { offset.x, offset.y, editBoxImage.width() + 6 + arrowImage.width(), arrowImage.height() * 2 + 5 };
 
@@ -971,7 +971,7 @@ namespace fheroes2
 
     void ValueSelectionDialogElement::draw( Image & output ) const
     {
-        const Sprite & editBoxImage = AGG::GetICN( ICN::TOWNWIND, 4 );
+        const Sprite & editBoxImage = Assets::getImage( ICN::TOWNWIND, 4 );
         assert( _editBox.width == editBoxImage.width() && _editBox.height == editBoxImage.height() );
 
         Blit( editBoxImage, 0, 0, output, _editBox.x, _editBox.y, _editBox.width, _editBox.height );
@@ -1037,8 +1037,8 @@ namespace fheroes2
 
     Size ValueSelectionDialogElement::getArea()
     {
-        const Sprite & editBoxImage = AGG::GetICN( ICN::TOWNWIND, 4 );
-        const Sprite & arrowImage = AGG::GetICN( ICN::TOWNWIND, 5 );
+        const Sprite & editBoxImage = Assets::getImage( ICN::TOWNWIND, 4 );
+        const Sprite & arrowImage = Assets::getImage( ICN::TOWNWIND, 5 );
 
         return { editBoxImage.width() + 6 + arrowImage.width(), arrowImage.height() * 2 + 5 };
     }

--- a/src/fheroes2/gui/ui_keyboard.cpp
+++ b/src/fheroes2/gui/ui_keyboard.cpp
@@ -31,8 +31,8 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_language.h"
 #include "icn.h"
@@ -184,7 +184,7 @@ namespace
             _textInputArea.y = windowRoi.y + inputAreaOffsetFromWindowTop;
 
             // Draw the text input background.
-            const fheroes2::Sprite & initialWindow = fheroes2::AGG::GetICN( ICN::REQBKG, 0 );
+            const fheroes2::Sprite & initialWindow = Assets::getImage( ICN::REQBKG, 0 );
             fheroes2::Copy( initialWindow, 40, 286, _output, _textInputArea );
 
             if ( _isEvilInterface ) {
@@ -1050,8 +1050,8 @@ namespace
         renderButtons( buttons, windowRoi.getPosition() + offsetFromWindowBorders, display, windowWidth );
 
         const int buttonIcnId = isEvilInterface ? ICN::BUTTON_SMALL_OKAY_EVIL : ICN::BUTTON_SMALL_OKAY_GOOD;
-        const fheroes2::Sprite & okayButtonReleasedImage = fheroes2::AGG::GetICN( buttonIcnId, 0 );
-        const fheroes2::Sprite & okayButtonPressedImage = fheroes2::AGG::GetICN( buttonIcnId, 1 );
+        const fheroes2::Sprite & okayButtonReleasedImage = Assets::getImage( buttonIcnId, 0 );
+        const fheroes2::Sprite & okayButtonPressedImage = Assets::getImage( buttonIcnId, 1 );
 
         const fheroes2::Point okayButtonPosition{ windowRoi.x + ( windowRoi.width - okayButtonReleasedImage.width() ) / 2, windowRoi.y + windowRoi.height - 35 };
 

--- a/src/fheroes2/gui/ui_kingdom.cpp
+++ b/src/fheroes2/gui/ui_kingdom.cpp
@@ -26,7 +26,7 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "icn.h"
 #include "image.h"
@@ -52,13 +52,13 @@ namespace fheroes2
     {
         const uint32_t lighthouseCount = world.CountCapturedObject( MP2::OBJ_LIGHTHOUSE, kingdom.GetColor() );
 
-        const Sprite & shadowTop = AGG::GetICN( ICN::OBJNMUL2, 60 );
-        const Sprite & shadowMiddle = AGG::GetICN( ICN::OBJNMUL2, 71 );
-        const Sprite & shadowBottom = AGG::GetICN( ICN::OBJNMUL2, 72 );
-        const Sprite & lighthouseTop = AGG::GetICN( ICN::OBJNMUL2, 59 );
-        const Sprite & lighthouseMiddle = AGG::GetICN( ICN::OBJNMUL2, 61 );
-        const Sprite & lighthouseBottom = AGG::GetICN( ICN::OBJNMUL2, 73 );
-        const Sprite & lighthouseLight = AGG::GetICN( ICN::OBJNMUL2, 62 );
+        const Sprite & shadowTop = Assets::getImage( ICN::OBJNMUL2, 60 );
+        const Sprite & shadowMiddle = Assets::getImage( ICN::OBJNMUL2, 71 );
+        const Sprite & shadowBottom = Assets::getImage( ICN::OBJNMUL2, 72 );
+        const Sprite & lighthouseTop = Assets::getImage( ICN::OBJNMUL2, 59 );
+        const Sprite & lighthouseMiddle = Assets::getImage( ICN::OBJNMUL2, 61 );
+        const Sprite & lighthouseBottom = Assets::getImage( ICN::OBJNMUL2, 73 );
+        const Sprite & lighthouseLight = Assets::getImage( ICN::OBJNMUL2, 62 );
 
         const int32_t topOffset = fheroes2::tileWidthPx - lighthouseTop.height();
 

--- a/src/fheroes2/gui/ui_language.cpp
+++ b/src/fheroes2/gui/ui_language.cpp
@@ -30,7 +30,7 @@
 #include <utility>
 
 #include "agg.h"
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "settings.h"
 #include "tools.h"
@@ -297,7 +297,7 @@ namespace fheroes2
         // In the engine we use CP1252 for these characters.
         if ( ( language == SupportedLanguage::English ) && ( resourceLanguage == SupportedLanguage::French ) ) {
             // Force generate CP1252 alphabet when English language is selected for French assets.
-            AGG::updateLanguageDependentResources( SupportedLanguage::French, false );
+            Assets::updateLanguageDependentResources( SupportedLanguage::French, false );
         }
         else {
             // To generate CP1252 alphabet for French assets we must assume that these assets are not original.
@@ -306,7 +306,7 @@ namespace fheroes2
                 = ( language == SupportedLanguage::English )
                   || ( language == resourceLanguage && resourceLanguage != SupportedLanguage::French && resourceLanguage != SupportedLanguage::Russian );
 
-            AGG::updateLanguageDependentResources( language, isOriginalResourceLanguage );
+            Assets::updateLanguageDependentResources( language, isOriginalResourceLanguage );
         }
     }
 

--- a/src/fheroes2/gui/ui_mage_guild.cpp
+++ b/src/fheroes2/gui/ui_mage_guild.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2025                                                    *
+ *   Copyright (C) 2025 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/ui_mage_guild.cpp
+++ b/src/fheroes2/gui/ui_mage_guild.cpp
@@ -24,8 +24,8 @@
 #include <cstddef>
 #include <string>
 
-#include "agg_image.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -68,7 +68,7 @@ namespace fheroes2
         }
 
         assert( guildLevel >= 1 && guildLevel <= 5 );
-        const Sprite & sprite = AGG::GetICN( guildIcn, guildLevel - 1 );
+        const Sprite & sprite = Assets::getImage( guildIcn, guildLevel - 1 );
 
         const Rect area = GetActiveROI( sprite );
 
@@ -96,8 +96,8 @@ namespace fheroes2
     {
         _coords.clear();
 
-        const Sprite & spellScrollOpened = AGG::GetICN( ICN::TOWNWIND, 0 );
-        const Sprite & spellScroll = AGG::GetICN( ICN::TOWNWIND, 1 );
+        const Sprite & spellScrollOpened = Assets::getImage( ICN::TOWNWIND, 0 );
+        const Sprite & spellScroll = Assets::getImage( ICN::TOWNWIND, 1 );
 
         for ( size_t i = 0; i < _spells.size(); ++i ) {
             const Spell & spell = _spells[i];
@@ -118,8 +118,8 @@ namespace fheroes2
             return;
         }
 
-        const Sprite & spellScrollOpened = AGG::GetICN( ICN::TOWNWIND, 0 );
-        const Sprite & spellScroll = AGG::GetICN( ICN::TOWNWIND, 1 );
+        const Sprite & spellScrollOpened = Assets::getImage( ICN::TOWNWIND, 0 );
+        const Sprite & spellScroll = Assets::getImage( ICN::TOWNWIND, 1 );
 
         for ( size_t i = 0; i < _spells.size(); ++i ) {
             const Spell & spell = _spells[i];
@@ -133,7 +133,7 @@ namespace fheroes2
                 // Draw scroll with a spell over it.
                 Blit( spellScrollOpened, output, dst.x, dst.y );
 
-                const Sprite & icon = AGG::GetICN( ICN::SPELLS, spell.IndexSprite() );
+                const Sprite & icon = Assets::getImage( ICN::SPELLS, spell.IndexSprite() );
                 Blit( icon, output, dst.x + 3 + ( dst.width - icon.width() ) / 2, dst.y + 31 - icon.height() / 2 );
 
                 const Text text( spell.GetName(), FontType::smallWhite() );
@@ -153,15 +153,15 @@ namespace fheroes2
 
         if ( spell == Spell::NONE ) {
             // Draw folded scroll when there is no spell.
-            const Sprite & spellScroll = AGG::GetICN( ICN::TOWNWIND, 1 );
+            const Sprite & spellScroll = Assets::getImage( ICN::TOWNWIND, 1 );
             Blit( spellScroll, output, dst.x, dst.y );
         }
         else {
             // Draw scroll with a spell over it.
-            const Sprite & spellScrollOpened = AGG::GetICN( ICN::TOWNWIND, 0 );
+            const Sprite & spellScrollOpened = Assets::getImage( ICN::TOWNWIND, 0 );
             Blit( spellScrollOpened, output, dst.x, dst.y );
 
-            const Sprite & icon = AGG::GetICN( ICN::SPELLS, spell.IndexSprite() );
+            const Sprite & icon = Assets::getImage( ICN::SPELLS, spell.IndexSprite() );
             Blit( icon, output, dst.x + 3 + ( dst.width - icon.width() ) / 2, dst.y + 31 - icon.height() / 2 );
 
             const Text text( spell.GetName(), FontType::smallWhite() );

--- a/src/fheroes2/gui/ui_map_interface.cpp
+++ b/src/fheroes2/gui/ui_map_interface.cpp
@@ -25,8 +25,8 @@
 #include <cstdint>
 #include <utility>
 
-#include "agg_image.h"
 #include "cursor.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -57,7 +57,7 @@ namespace Interface
     {
         const CursorRestorer cursorRestorer( false );
 
-        const fheroes2::Sprite & windowImage = fheroes2::AGG::GetICN( ICN::QWIKINFO, 0 );
+        const fheroes2::Sprite & windowImage = Assets::getImage( ICN::QWIKINFO, 0 );
 
         LocalEvent & le = LocalEvent::Get();
         const fheroes2::Rect windowRoi = Interface::getPopupWindowPosition( le.getMouseCursorPos(), interfaceArea, { windowImage.width(), windowImage.height() } );

--- a/src/fheroes2/gui/ui_map_object.cpp
+++ b/src/fheroes2/gui/ui_map_object.cpp
@@ -31,7 +31,7 @@
 #include <cstdint>
 #include <vector>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "ground.h"
 #include "map_object_info.h"
 #include "maps_tiles.h"
@@ -47,12 +47,12 @@ namespace
     {
         const int icnId = MP2::getIcnIdFromObjectIcnType( objectPart.icnType );
 
-        const fheroes2::Sprite & imagePart = fheroes2::AGG::GetICN( icnId, objectPart.icnIndex );
+        const fheroes2::Sprite & imagePart = Assets::getImage( icnId, objectPart.icnIndex );
         Blit( imagePart, 0, 0, image, ( objectPart.tileOffset.x - minOffset.x ) * tileSize + imagePart.x(),
               ( objectPart.tileOffset.y - minOffset.y ) * tileSize + imagePart.y(), imagePart.width(), imagePart.height() );
 
         if ( objectPart.animationFrames > 0 ) {
-            const fheroes2::Sprite & animationFrame = fheroes2::AGG::GetICN( icnId, objectPart.icnIndex + 1 );
+            const fheroes2::Sprite & animationFrame = Assets::getImage( icnId, objectPart.icnIndex + 1 );
             Blit( animationFrame, 0, 0, image, ( objectPart.tileOffset.x - minOffset.x ) * tileSize + animationFrame.x(),
                   ( objectPart.tileOffset.y - minOffset.y ) * tileSize + animationFrame.y(), animationFrame.width(), animationFrame.height() );
         }
@@ -175,7 +175,7 @@ namespace fheroes2
                 renderObjectPart( image, objectPart, { 0, 0 } );
             }
             else {
-                image = AGG::GetICN( MP2::getIcnIdFromObjectIcnType( objectPart.icnType ), objectPart.icnIndex );
+                image = Assets::getImage( MP2::getIcnIdFromObjectIcnType( objectPart.icnType ), objectPart.icnIndex );
             }
 
             // If it is a one tile image make sure that the offset is in the middle of the image.

--- a/src/fheroes2/gui/ui_monster.cpp
+++ b/src/fheroes2/gui/ui_monster.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2022                                                    *
+ *   Copyright (C) 2022 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/gui/ui_monster.cpp
+++ b/src/fheroes2/gui/ui_monster.cpp
@@ -20,7 +20,7 @@
 
 #include "ui_monster.h"
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "monster.h"
@@ -32,29 +32,29 @@ namespace fheroes2
     {
         switch ( monster.GetRace() ) {
         case Race::KNGT:
-            Blit( AGG::GetICN( ICN::STRIP, 4 ), output, offset.x, offset.y );
+            Blit( Assets::getImage( ICN::STRIP, 4 ), output, offset.x, offset.y );
             break;
         case Race::BARB:
-            Blit( AGG::GetICN( ICN::STRIP, 5 ), output, offset.x, offset.y );
+            Blit( Assets::getImage( ICN::STRIP, 5 ), output, offset.x, offset.y );
             break;
         case Race::SORC:
-            Blit( AGG::GetICN( ICN::STRIP, 6 ), output, offset.x, offset.y );
+            Blit( Assets::getImage( ICN::STRIP, 6 ), output, offset.x, offset.y );
             break;
         case Race::WRLK:
-            Blit( AGG::GetICN( ICN::STRIP, 7 ), output, offset.x, offset.y );
+            Blit( Assets::getImage( ICN::STRIP, 7 ), output, offset.x, offset.y );
             break;
         case Race::WZRD:
-            Blit( AGG::GetICN( ICN::STRIP, 8 ), output, offset.x, offset.y );
+            Blit( Assets::getImage( ICN::STRIP, 8 ), output, offset.x, offset.y );
             break;
         case Race::NECR:
-            Blit( AGG::GetICN( ICN::STRIP, 9 ), output, offset.x, offset.y );
+            Blit( Assets::getImage( ICN::STRIP, 9 ), output, offset.x, offset.y );
             break;
         default:
-            Blit( AGG::GetICN( ICN::STRIP, 10 ), output, offset.x, offset.y );
+            Blit( Assets::getImage( ICN::STRIP, 10 ), output, offset.x, offset.y );
             break;
         }
 
-        const fheroes2::Sprite & monsterImage = fheroes2::AGG::GetICN( monster.ICNMonh(), 0 );
+        const fheroes2::Sprite & monsterImage = Assets::getImage( monster.ICNMonh(), 0 );
         fheroes2::Blit( monsterImage, output, offset.x + monsterImage.x(), offset.y + monsterImage.y() );
     }
 }

--- a/src/fheroes2/gui/ui_option_item.cpp
+++ b/src/fheroes2/gui/ui_option_item.cpp
@@ -24,7 +24,7 @@
 #include <cstdint>
 #include <utility>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "screen.h"
@@ -94,7 +94,7 @@ namespace fheroes2
 
         assert( scrollSpeedIconIcn != ICN::UNKNOWN );
 
-        const fheroes2::Sprite & scrollSpeedIcon = fheroes2::AGG::GetICN( scrollSpeedIconIcn, scrollSpeedIconId );
+        const fheroes2::Sprite & scrollSpeedIcon = Assets::getImage( scrollSpeedIconIcn, scrollSpeedIconId );
         fheroes2::drawOption( optionRoi, scrollSpeedIcon, _( "Scroll Speed" ), std::move( scrollSpeedName ), fheroes2::UiOptionTextWidth::TWO_ELEMENTS_ROW );
     }
 
@@ -119,32 +119,32 @@ namespace fheroes2
             break;
         }
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, icnInx ), _( "Interface Type" ), std::move( value ), textMaxWidth );
+        fheroes2::drawOption( optionRoi, Assets::getImage( ICN::SPANEL, icnInx ), _( "Interface Type" ), std::move( value ), textMaxWidth );
     }
 
     void drawCursorType( const fheroes2::Rect & optionRoi, const bool isMonochromeCursor, const int32_t textMaxWidth )
     {
         if ( isMonochromeCursor ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ), textMaxWidth );
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::SPANEL, 20 ), _( "Mouse Cursor" ), _( "Black & White" ), textMaxWidth );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ), textMaxWidth );
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::SPANEL, 21 ), _( "Mouse Cursor" ), _( "Color" ), textMaxWidth );
         }
     }
 
     void drawHotKeyOptions( const fheroes2::Rect & optionRoi, const int32_t textMaxWidth )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::GAME_OPTION_ICON, 0 ), _( "Hot Keys" ), _( "Configure" ), textMaxWidth );
+        fheroes2::drawOption( optionRoi, Assets::getImage( ICN::GAME_OPTION_ICON, 0 ), _( "Hot Keys" ), _( "Configure" ), textMaxWidth );
     }
 
     void drawAudioOptions( const fheroes2::Rect & optionRoi, const int32_t textMaxWidth )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ), textMaxWidth );
+        fheroes2::drawOption( optionRoi, Assets::getImage( ICN::SPANEL, 1 ), _( "Audio" ), _( "Settings" ), textMaxWidth );
     }
 
     void drawGraphics( const fheroes2::Rect & optionRoi, const int32_t textMaxWidth )
     {
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::GAME_OPTION_ICON, 1 ), _( "Graphics" ), _( "Settings" ), textMaxWidth );
+        fheroes2::drawOption( optionRoi, Assets::getImage( ICN::GAME_OPTION_ICON, 1 ), _( "Graphics" ), _( "Settings" ), textMaxWidth );
     }
 
     void drawLanguage( const fheroes2::Rect & optionRoi, const std::string & languageAbbreviation, const int32_t textMaxWidth )
@@ -152,16 +152,16 @@ namespace fheroes2
         const fheroes2::SupportedLanguage currentLanguage = fheroes2::getLanguageFromAbbreviation( languageAbbreviation );
         const fheroes2::LanguageSwitcher languageSwitcher( currentLanguage );
 
-        fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 18 ), _( "Language" ), fheroes2::getLanguageName( currentLanguage ), textMaxWidth );
+        fheroes2::drawOption( optionRoi, Assets::getImage( ICN::SPANEL, 18 ), _( "Language" ), fheroes2::getLanguageName( currentLanguage ), textMaxWidth );
     }
 
     void drawTextSupportModeOptions( const fheroes2::Rect & optionRoi, const bool isEnabled, const int32_t textMaxWidth )
     {
         if ( isEnabled ) {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ), textMaxWidth );
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::CSPANEL, 4 ), _( "Text Support" ), _( "On" ), textMaxWidth );
         }
         else {
-            fheroes2::drawOption( optionRoi, fheroes2::AGG::GetICN( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ), textMaxWidth );
+            fheroes2::drawOption( optionRoi, Assets::getImage( ICN::SPANEL, 9 ), _( "Text Support" ), _( "Off" ), textMaxWidth );
         }
     }
 }

--- a/src/fheroes2/gui/ui_slider.cpp
+++ b/src/fheroes2/gui/ui_slider.cpp
@@ -25,7 +25,7 @@
 #include <functional>
 #include <utility>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -44,7 +44,7 @@ namespace fheroes2
 
         Display & display = Display::instance();
         const int tradpostIcnId = Settings::Get().isEvilInterfaceEnabled() ? ICN::TRADPOSE : ICN::TRADPOST;
-        const Sprite & bar = AGG::GetICN( tradpostIcnId, 1 );
+        const Sprite & bar = Assets::getImage( tradpostIcnId, 1 );
         // The original slider is 230 pixels wide with the active slider area of 187.
         constexpr int32_t buttonWidth{ 15 };
 
@@ -65,7 +65,7 @@ namespace fheroes2
         _buttonRight.subscribe( &_timedButtonRight );
         _buttonRight.draw( display );
 
-        const Sprite & originalSlider = AGG::GetICN( tradpostIcnId, 2 );
+        const Sprite & originalSlider = Assets::getImage( tradpostIcnId, 2 );
         Image scrollbarSlider = generateScrollbarSlider( originalSlider, true, width, 1, static_cast<int32_t>( maxIndex - minIndex + 1 ),
                                                          { 0, 0, 2, originalSlider.height() }, { 2, 0, 8, originalSlider.height() } );
         _scrollbar.setImage( std::move( scrollbarSlider ) );

--- a/src/fheroes2/gui/ui_text.cpp
+++ b/src/fheroes2/gui/ui_text.cpp
@@ -28,7 +28,7 @@
 #include <memory>
 #include <numeric>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "ui_language.h"
 
@@ -62,11 +62,11 @@ namespace
         case fheroes2::FontSize::SMALL:
             switch ( fontType.color ) {
             case fheroes2::FontColor::WHITE:
-                return fheroes2::AGG::GetICN( ICN::SMALFONT, character );
+                return Assets::getImage( ICN::SMALFONT, character );
             case fheroes2::FontColor::GRAY:
-                return fheroes2::AGG::GetICN( ICN::GRAY_SMALL_FONT, character );
+                return Assets::getImage( ICN::GRAY_SMALL_FONT, character );
             case fheroes2::FontColor::YELLOW:
-                return fheroes2::AGG::GetICN( ICN::YELLOW_SMALLFONT, character );
+                return Assets::getImage( ICN::YELLOW_SMALLFONT, character );
             default:
                 // Did you add a new font color? Add the corresponding logic for it!
                 assert( 0 );
@@ -76,15 +76,15 @@ namespace
         case fheroes2::FontSize::NORMAL:
             switch ( fontType.color ) {
             case fheroes2::FontColor::WHITE:
-                return fheroes2::AGG::GetICN( ICN::FONT, character );
+                return Assets::getImage( ICN::FONT, character );
             case fheroes2::FontColor::GRAY:
-                return fheroes2::AGG::GetICN( ICN::GRAY_FONT, character );
+                return Assets::getImage( ICN::GRAY_FONT, character );
             case fheroes2::FontColor::YELLOW:
-                return fheroes2::AGG::GetICN( ICN::YELLOW_FONT, character );
+                return Assets::getImage( ICN::YELLOW_FONT, character );
             case fheroes2::FontColor::GOLDEN_GRADIENT:
-                return fheroes2::AGG::GetICN( ICN::GOLDEN_GRADIENT_FONT, character );
+                return Assets::getImage( ICN::GOLDEN_GRADIENT_FONT, character );
             case fheroes2::FontColor::SILVER_GRADIENT:
-                return fheroes2::AGG::GetICN( ICN::SILVER_GRADIENT_FONT, character );
+                return Assets::getImage( ICN::SILVER_GRADIENT_FONT, character );
             default:
                 // Did you add a new font color? Add the corresponding logic for it!
                 assert( 0 );
@@ -94,11 +94,11 @@ namespace
         case fheroes2::FontSize::LARGE:
             switch ( fontType.color ) {
             case fheroes2::FontColor::WHITE:
-                return fheroes2::AGG::GetICN( ICN::WHITE_LARGE_FONT, character );
+                return Assets::getImage( ICN::WHITE_LARGE_FONT, character );
             case fheroes2::FontColor::GOLDEN_GRADIENT:
-                return fheroes2::AGG::GetICN( ICN::GOLDEN_GRADIENT_LARGE_FONT, character );
+                return Assets::getImage( ICN::GOLDEN_GRADIENT_LARGE_FONT, character );
             case fheroes2::FontColor::SILVER_GRADIENT:
-                return fheroes2::AGG::GetICN( ICN::SILVER_GRADIENT_LARGE_FONT, character );
+                return Assets::getImage( ICN::SILVER_GRADIENT_LARGE_FONT, character );
             default:
                 // Did you add a new font color? Add the corresponding logic for it!
                 assert( 0 );
@@ -108,9 +108,9 @@ namespace
         case fheroes2::FontSize::BUTTON_RELEASED:
             switch ( fontType.color ) {
             case fheroes2::FontColor::WHITE:
-                return fheroes2::AGG::GetICN( ICN::BUTTON_GOOD_FONT_RELEASED, character );
+                return Assets::getImage( ICN::BUTTON_GOOD_FONT_RELEASED, character );
             case fheroes2::FontColor::GRAY:
-                return fheroes2::AGG::GetICN( ICN::BUTTON_EVIL_FONT_RELEASED, character );
+                return Assets::getImage( ICN::BUTTON_EVIL_FONT_RELEASED, character );
             default:
                 // Did you add a new font color? Add the corresponding logic for it!
                 assert( 0 );
@@ -120,9 +120,9 @@ namespace
         case fheroes2::FontSize::BUTTON_PRESSED:
             switch ( fontType.color ) {
             case fheroes2::FontColor::WHITE:
-                return fheroes2::AGG::GetICN( ICN::BUTTON_GOOD_FONT_PRESSED, character );
+                return Assets::getImage( ICN::BUTTON_GOOD_FONT_PRESSED, character );
             case fheroes2::FontColor::GRAY:
-                return fheroes2::AGG::GetICN( ICN::BUTTON_EVIL_FONT_PRESSED, character );
+                return Assets::getImage( ICN::BUTTON_EVIL_FONT_PRESSED, character );
             default:
                 // Did you add a new font color? Add the corresponding logic for it!
                 assert( 0 );
@@ -144,13 +144,13 @@ namespace
     {
         switch ( fontSize ) {
         case fheroes2::FontSize::SMALL:
-            return fheroes2::AGG::GetICNCount( ICN::SMALFONT );
+            return Assets::getImageCount( ICN::SMALFONT );
         case fheroes2::FontSize::NORMAL:
         case fheroes2::FontSize::LARGE:
-            return fheroes2::AGG::GetICNCount( ICN::FONT );
+            return Assets::getImageCount( ICN::FONT );
         case fheroes2::FontSize::BUTTON_RELEASED:
         case fheroes2::FontSize::BUTTON_PRESSED:
-            return fheroes2::AGG::GetICNCount( ICN::BUTTON_GOOD_FONT_RELEASED );
+            return Assets::getImageCount( ICN::BUTTON_GOOD_FONT_RELEASED );
         default:
             // Did you add a new font size? Please add implementation.
             assert( 0 );

--- a/src/fheroes2/gui/ui_tool.cpp
+++ b/src/fheroes2/gui/ui_tool.cpp
@@ -30,8 +30,8 @@
 #include <string>
 #include <type_traits>
 
-#include "agg_image.h"
 #include "cursor.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "icn.h"
 #include "image_palette.h"
@@ -807,8 +807,8 @@ namespace fheroes2
         fheroes2::Image racePortrait( portPos.width, portPos.height );
 
         auto preparePortrait = [&racePortrait, &portPos]( const int icnId, const int bkgIndex, const bool applyRandomPalette ) {
-            fheroes2::SubpixelResize( fheroes2::AGG::GetICN( ICN::STRIP, bkgIndex ), racePortrait );
-            const fheroes2::Sprite & heroSprite = fheroes2::AGG::GetICN( icnId, 1 );
+            fheroes2::SubpixelResize( Assets::getImage( ICN::STRIP, bkgIndex ), racePortrait );
+            const fheroes2::Sprite & heroSprite = Assets::getImage( icnId, 1 );
             if ( applyRandomPalette ) {
                 fheroes2::Sprite tmp = heroSprite;
                 fheroes2::ApplyPalette( tmp, PAL::GetPalette( PAL::PaletteType::PURPLE ) );

--- a/src/fheroes2/gui/ui_window.cpp
+++ b/src/fheroes2/gui/ui_window.cpp
@@ -24,7 +24,7 @@
 #include <cassert>
 #include <cstddef>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "settings.h"
 #include "ui_button.h"
@@ -87,7 +87,7 @@ namespace
         }
         fheroes2::Point placement;
         if ( isSingleColumn ) {
-            const fheroes2::Sprite & mainMenuBackground = fheroes2::AGG::GetICN( ICN::HEROES, 0 );
+            const fheroes2::Sprite & mainMenuBackground = Assets::getImage( ICN::HEROES, 0 );
             const int32_t panelXPos = output.width() - mainMenuBackground.x() - ( dialogWidth + fheroes2::borderWidthPx ) - 8;
             const int32_t panelYPos = mainMenuBackground.y() + fheroes2::borderWidthPx + 8;
             placement.x = panelXPos;
@@ -147,8 +147,8 @@ namespace fheroes2
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
 
         // Notice: ICN::SURDRBKE and ICN::SURDRBKG has 16 (equals to borderWidthPx) pixels shadow from the left and the bottom sides.
-        const Sprite & horizontalSprite = AGG::GetICN( ( isEvilInterface ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
-        const Sprite & verticalSprite = AGG::GetICN( ( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE ), 0 );
+        const Sprite & horizontalSprite = Assets::getImage( ( isEvilInterface ? ICN::SURDRBKE : ICN::SURDRBKG ), 0 );
+        const Sprite & verticalSprite = Assets::getImage( ( isEvilInterface ? ICN::WINLOSEE : ICN::WINLOSE ), 0 );
 
         // Offset from window edges to background copy area and also the size of corners to render.
         const int32_t cornerSize = _hasBackground ? backgroundOffset : borderSize;
@@ -371,11 +371,11 @@ namespace fheroes2
         gem.reset();
         const bool isEvilInterface = Settings::Get().isEvilInterfaceEnabled();
         if ( !isEvilInterface ) {
-            const fheroes2::Sprite & gemDialog = fheroes2::AGG::GetICN( ICN::REDBACK, 0 );
+            const fheroes2::Sprite & gemDialog = Assets::getImage( ICN::REDBACK, 0 );
             Copy( gemDialog, 20, 2, gem, 0, 0, gemSideLength, gemSideLength );
         }
         else {
-            const fheroes2::Sprite & corners = fheroes2::AGG::GetICN( ICN::EVIL_DIALOG_PLAIN_CORNERS, 0 );
+            const fheroes2::Sprite & corners = Assets::getImage( ICN::EVIL_DIALOG_PLAIN_CORNERS, 0 );
             const int32_t cornerSideLength = 43;
             Copy( corners, 0, 0, _output, _windowArea.x, _windowArea.y, cornerSideLength, cornerSideLength );
             Copy( corners, cornerSideLength, 0, _output, _windowArea.x + _windowArea.width - cornerSideLength, _windowArea.y, cornerSideLength, cornerSideLength );
@@ -383,7 +383,7 @@ namespace fheroes2
             Copy( corners, cornerSideLength, cornerSideLength, _output, _windowArea.x + _windowArea.width - cornerSideLength,
                   _windowArea.y + _windowArea.height - cornerSideLength, cornerSideLength, cornerSideLength );
 
-            const fheroes2::Sprite & gemDialog = fheroes2::AGG::GetICN( ICN::WINLOSEE, 0 );
+            const fheroes2::Sprite & gemDialog = Assets::getImage( ICN::WINLOSEE, 0 );
             Copy( gemDialog, 32, 2, gem, 0, 0, gemSideLength, gemSideLength );
             FillTransform( gem, 0, 0, 1, 1, 1 );
             FillTransform( gem, gemSideLength - 1, 0, 1, 1, 1 );
@@ -399,7 +399,7 @@ namespace fheroes2
 
     void StandardWindow::renderScrollbarBackground( const Rect & roi, const bool isEvilInterface )
     {
-        const Sprite & scrollBar = AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
+        const Sprite & scrollBar = Assets::getImage( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
 
         const int32_t topPartHeight = 19;
         const int32_t scrollBarWidth = 16;
@@ -433,7 +433,7 @@ namespace fheroes2
     void StandardWindow::renderButton( Button & button, const int icnId, const uint32_t releasedIndex, const uint32_t pressedIndex, const Point & offset,
                                        const Padding padding )
     {
-        const Sprite & buttonSprite = AGG::GetICN( icnId, 0 );
+        const Sprite & buttonSprite = Assets::getImage( icnId, 0 );
 
         const Point pos = _getRenderPos( offset, { buttonSprite.width(), buttonSprite.height() }, padding );
 
@@ -592,7 +592,7 @@ namespace fheroes2
 
     void StandardWindow::renderBackgroundImage( Image & output, const Rect & roi, const int32_t borderOffset, const bool isEvilInterface )
     {
-        const Sprite & backgroundSprite = AGG::GetICN( ( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK ), 0 );
+        const Sprite & backgroundSprite = Assets::getImage( ( isEvilInterface ? ICN::STONEBAK_EVIL : ICN::STONEBAK ), 0 );
         const int32_t backgroundSpriteWidth{ backgroundSprite.width() };
         const int32_t backgroundSpriteHeight{ backgroundSprite.height() };
 

--- a/src/fheroes2/heroes/heroes.cpp
+++ b/src/fheroes2/heroes/heroes.cpp
@@ -32,7 +32,6 @@
 #include <sstream>
 #include <utility>
 
-#include "agg_image.h"
 #include "ai_planner.h"
 #include "army_troop.h"
 #include "artifact.h"
@@ -44,6 +43,7 @@
 #include "difficulty.h"
 #include "direction.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_auto_playtest.h"
 #include "game_io.h"
 #include "game_static.h"
@@ -2058,7 +2058,7 @@ const fheroes2::Sprite & Heroes::GetPortrait( const int heroId, const int portra
     if ( isValidId( heroId ) )
         switch ( portraitType ) {
         case PORT_BIG:
-            return fheroes2::AGG::GetICN( ICN::getHeroPortraitIcnId( heroId ), 0 );
+            return Assets::getImage( ICN::getHeroPortraitIcnId( heroId ), 0 );
         case PORT_MEDIUM: {
             // Original ICN::PORTMEDI sprites are badly rendered. Instead of them we're getting high quality ICN:PORT00xx file and resize it to a smaller image.
             // TODO: find a better way to store these images, ideally in agg_image.cpp file.
@@ -2068,7 +2068,7 @@ const fheroes2::Sprite & Heroes::GetPortrait( const int heroId, const int portra
                 return iter->second;
             }
 
-            const fheroes2::Sprite & original = fheroes2::AGG::GetICN( ICN::getHeroPortraitIcnId( heroId ), 0 );
+            const fheroes2::Sprite & original = Assets::getImage( ICN::getHeroPortraitIcnId( heroId ), 0 );
             fheroes2::Sprite output( 50, 47 );
             fheroes2::Resize( original, output );
 
@@ -2076,16 +2076,16 @@ const fheroes2::Sprite & Heroes::GetPortrait( const int heroId, const int portra
         }
         case PORT_SMALL:
             if ( heroId == Heroes::DEBUG_HERO ) {
-                return fheroes2::AGG::GetICN( ICN::MINIPORT, BRAX - 1 );
+                return Assets::getImage( ICN::MINIPORT, BRAX - 1 );
             }
 
             // Since hero IDs start from 1 we have to deduct 1 from the ID.
-            return fheroes2::AGG::GetICN( ICN::MINIPORT, heroId - 1 );
+            return Assets::getImage( ICN::MINIPORT, heroId - 1 );
         default:
             break;
         }
 
-    return fheroes2::AGG::GetICN( ICN::UNKNOWN, 0 );
+    return Assets::getImage( ICN::UNKNOWN, 0 );
 }
 
 void Heroes::PortraitRedraw( const int32_t px, const int32_t py, const PortraitType type, fheroes2::Image & dstsf ) const
@@ -2104,9 +2104,9 @@ void Heroes::PortraitRedraw( const int32_t px, const int32_t py, const PortraitT
             mp.x = port.width() - 10;
         }
         else if ( PORT_SMALL == type ) {
-            const fheroes2::Sprite & background = fheroes2::AGG::GetICN( ICN::PORTXTRA, 0 );
-            const fheroes2::Sprite & mobility = fheroes2::AGG::GetICN( ICN::MOBILITY, GetMobilityIndexSprite() );
-            const fheroes2::Sprite & mana = fheroes2::AGG::GetICN( ICN::MANA, getManaIndexSprite() );
+            const fheroes2::Sprite & background = Assets::getImage( ICN::PORTXTRA, 0 );
+            const fheroes2::Sprite & mobility = Assets::getImage( ICN::MOBILITY, GetMobilityIndexSprite() );
+            const fheroes2::Sprite & mana = Assets::getImage( ICN::MANA, getManaIndexSprite() );
 
             const int barw = 7;
 
@@ -2132,7 +2132,7 @@ void Heroes::PortraitRedraw( const int32_t px, const int32_t py, const PortraitT
     }
 
     if ( Modes( Heroes::SLEEPER ) ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MISC4, 14 );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::MISC4, 14 );
         fheroes2::Image sleeperBG( sprite.width() - 4, sprite.height() - 4 );
         sleeperBG.fill( 0 );
 

--- a/src/fheroes2/heroes/heroes_action.cpp
+++ b/src/fheroes2/heroes/heroes_action.cpp
@@ -35,7 +35,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "ai_hero_action.h"
 #include "army.h"
 #include "army_troop.h"
@@ -47,6 +46,7 @@
 #include "color.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_auto_playtest.h"
 #include "game_delays.h"
 #include "game_interface.h"
@@ -2708,7 +2708,7 @@ namespace
             // composite sprite
             int32_t offsetX = 0;
             int32_t offsetY = 0;
-            const fheroes2::Sprite & border = fheroes2::AGG::GetICN( ICN::STRIP, 12 );
+            const fheroes2::Sprite & border = Assets::getImage( ICN::STRIP, 12 );
 
             const int32_t monsterCount = static_cast<int32_t>( mons.size() ); // safe to do as the count is no more than 3
 

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -368,9 +368,9 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
     if ( !isEditor && !readonly && !disableDismiss ) {
         const fheroes2::Sprite & dismissReleased = Assets::getImage( ICN::BUTTON_VERTICAL_DISMISS, 0 );
-        buttonDismiss = std::make_unique<fheroes2::ButtonSprite>( dst_pt.x, dst_pt.y - dismissReleased.height() / 2, dismissReleased,
-                                                                  Assets::getImage( ICN::BUTTON_VERTICAL_DISMISS, 1 ),
-                                                                  Assets::getImage( ICN::DISMISS_HERO_DISABLED_BUTTON, 0 ) );
+        buttonDismiss
+            = std::make_unique<fheroes2::ButtonSprite>( dst_pt.x, dst_pt.y - dismissReleased.height() / 2, dismissReleased,
+                                                        Assets::getImage( ICN::BUTTON_VERTICAL_DISMISS, 1 ), Assets::getImage( ICN::DISMISS_HERO_DISABLED_BUTTON, 0 ) );
 
         if ( inCastle() || readonly || disableDismiss || Modes( NOTDISMISS ) ) {
             buttonDismiss->disable();

--- a/src/fheroes2/heroes/heroes_dialog.cpp
+++ b/src/fheroes2/heroes/heroes_dialog.cpp
@@ -30,7 +30,6 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_bar.h"
 #include "artifact.h"
@@ -38,6 +37,7 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
 #include "heroes.h" // IWYU pragma: associated
@@ -110,9 +110,9 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         fheroes2::fadeOutDisplay( dialogRoi, !isDefaultScreenSize );
     }
 
-    const fheroes2::Sprite & backgroundImage = fheroes2::AGG::GetICN( ICN::HEROBKG, 0 );
+    const fheroes2::Sprite & backgroundImage = Assets::getImage( ICN::HEROBKG, 0 );
     fheroes2::Blit( backgroundImage, display, dialogRoi.x, dialogRoi.y );
-    fheroes2::Blit( fheroes2::AGG::GetICN( Settings::Get().isEvilInterfaceEnabled() ? ICN::HEROEXTE : ICN::HEROEXTG, 0 ), display, dialogRoi.x, dialogRoi.y );
+    fheroes2::Blit( Assets::getImage( Settings::Get().isEvilInterfaceEnabled() ? ICN::HEROEXTE : ICN::HEROEXTG, 0 ), display, dialogRoi.x, dialogRoi.y );
 
     // Hero portrait.
     const fheroes2::Rect portPos( dialogRoi.x + 49, dialogRoi.y + 31, 101, 93 );
@@ -217,18 +217,18 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     // Army format spread icon.
     dst_pt.x = dialogRoi.x + 516;
     dst_pt.y = dialogRoi.y + 63;
-    const fheroes2::Sprite & sprite1 = fheroes2::AGG::GetICN( ICN::HSICONS, 9 );
+    const fheroes2::Sprite & sprite1 = Assets::getImage( ICN::HSICONS, 9 );
     const fheroes2::Rect rectSpreadArmyFormat( dst_pt.x, dst_pt.y, sprite1.width(), sprite1.height() );
     const fheroes2::Point army1_pt( dst_pt.x - 1, dst_pt.y - 1 );
 
     // Army format grouped icon.
     dst_pt.x = dialogRoi.x + 552;
-    const fheroes2::Sprite & sprite2 = fheroes2::AGG::GetICN( ICN::HSICONS, 10 );
+    const fheroes2::Sprite & sprite2 = Assets::getImage( ICN::HSICONS, 10 );
     const fheroes2::Rect rectGroupedArmyFormat( dst_pt.x, dst_pt.y, sprite2.width(), sprite2.height() );
     const fheroes2::Point army2_pt( dst_pt.x - 1, dst_pt.y - 1 );
 
     // Army format cursor.
-    fheroes2::MovableSprite cursorFormat( fheroes2::AGG::GetICN( ICN::HSICONS, 11 ) );
+    fheroes2::MovableSprite cursorFormat( Assets::getImage( ICN::HSICONS, 11 ) );
     const fheroes2::Point cursorFormatPos = _army.isSpreadFormation() ? army1_pt : army2_pt;
 
     // Do not show Army format in Editor.
@@ -268,14 +268,14 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     fheroes2::Rect raceRect;
 
     auto redrawRace = [&raceRect, &crestRect, &display]( const int race ) {
-        const fheroes2::Sprite & raceSprite = fheroes2::AGG::GetICN( ICN::NGEXTRA, Race::getRaceIcnIndex( race, true ) );
+        const fheroes2::Sprite & raceSprite = Assets::getImage( ICN::NGEXTRA, Race::getRaceIcnIndex( race, true ) );
         fheroes2::Copy( raceSprite, 0, 0, display, raceRect );
 
         // Update race text background.
         const int32_t offsetY = raceRect.y - crestRect.y + raceRect.height + 9;
         const int32_t posY = crestRect.y + offsetY;
         const int32_t sizeY = crestRect.height - offsetY;
-        fheroes2::ApplyPalette( fheroes2::AGG::GetICN( ICN::STRIP, 3 ), 0, offsetY, display, crestRect.x, posY, crestRect.width, sizeY,
+        fheroes2::ApplyPalette( Assets::getImage( ICN::STRIP, 3 ), 0, offsetY, display, crestRect.x, posY, crestRect.width, sizeY,
                                 PAL::GetPalette( PAL::PaletteType::DARKENING ) );
         const fheroes2::Text raceText( Race::String( race ), fheroes2::FontType::smallWhite() );
         raceText.drawInRoi( crestRect.x, posY, crestRect.width, display, { crestRect.x, posY, crestRect.width, sizeY } );
@@ -283,19 +283,19 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
     if ( isEditor && Modes( JAIL ) ) {
         assert( GetColor() == PlayerColor::NONE );
-        fheroes2::ApplyPalette( fheroes2::AGG::GetICN( ICN::STRIP, 3 ), 0, 0, display, crestRect.x, crestRect.y, crestRect.width, crestRect.height,
+        fheroes2::ApplyPalette( Assets::getImage( ICN::STRIP, 3 ), 0, 0, display, crestRect.x, crestRect.y, crestRect.width, crestRect.height,
                                 PAL::GetPalette( PAL::PaletteType::DARKENING ) );
 
         const fheroes2::Text raceText( _( "Hero class:" ), fheroes2::FontType::normalWhite() );
         raceText.drawInRoi( crestRect.x, crestRect.y + 6, crestRect.width, display, crestRect );
 
-        const fheroes2::Sprite & raceSprite = fheroes2::AGG::GetICN( ICN::NGEXTRA, Race::getRaceIcnIndex( _race, true ) );
+        const fheroes2::Sprite & raceSprite = Assets::getImage( ICN::NGEXTRA, Race::getRaceIcnIndex( _race, true ) );
         raceRect.width = raceSprite.width();
         raceRect.height = raceSprite.height();
         raceRect.x = crestRect.x + ( crestRect.width - raceRect.width ) / 2;
         raceRect.y = crestRect.y + ( crestRect.height - raceRect.height ) / 2;
 
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::NGEXTRA, 61U ), display, raceRect.x - 5, raceRect.y + 3 );
+        fheroes2::Blit( Assets::getImage( ICN::NGEXTRA, 61U ), display, raceRect.x - 5, raceRect.y + 3 );
 
         redrawRace( _race );
     }
@@ -304,7 +304,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
         const PlayerColor color = GetColor();
         const uint32_t icnIndex = Color::GetIndex( color == PlayerColor::NONE ? Settings::Get().CurrentColor() : color );
 
-        fheroes2::Copy( fheroes2::AGG::GetICN( ICN::CREST, icnIndex ), 0, 0, display, crestRect );
+        fheroes2::Copy( Assets::getImage( ICN::CREST, icnIndex ), 0, 0, display, crestRect );
     }
 
     // Hero's army.
@@ -329,7 +329,7 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     // Status bar.
     dst_pt.x = dialogRoi.x + 22;
     dst_pt.y = dialogRoi.y + 460;
-    const fheroes2::Sprite & bar = fheroes2::AGG::GetICN( ICN::HSBTNS, 8 );
+    const fheroes2::Sprite & bar = Assets::getImage( ICN::HSBTNS, 8 );
     fheroes2::Copy( bar, 0, 0, display, dst_pt.x, dst_pt.y, bar.width(), bar.height() );
 
     StatusBar statusBar;
@@ -367,10 +367,10 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     std::unique_ptr<fheroes2::ButtonSprite> buttonDismiss;
 
     if ( !isEditor && !readonly && !disableDismiss ) {
-        const fheroes2::Sprite & dismissReleased = fheroes2::AGG::GetICN( ICN::BUTTON_VERTICAL_DISMISS, 0 );
+        const fheroes2::Sprite & dismissReleased = Assets::getImage( ICN::BUTTON_VERTICAL_DISMISS, 0 );
         buttonDismiss = std::make_unique<fheroes2::ButtonSprite>( dst_pt.x, dst_pt.y - dismissReleased.height() / 2, dismissReleased,
-                                                                  fheroes2::AGG::GetICN( ICN::BUTTON_VERTICAL_DISMISS, 1 ),
-                                                                  fheroes2::AGG::GetICN( ICN::DISMISS_HERO_DISABLED_BUTTON, 0 ) );
+                                                                  Assets::getImage( ICN::BUTTON_VERTICAL_DISMISS, 1 ),
+                                                                  Assets::getImage( ICN::DISMISS_HERO_DISABLED_BUTTON, 0 ) );
 
         if ( inCastle() || readonly || disableDismiss || Modes( NOTDISMISS ) ) {
             buttonDismiss->disable();
@@ -385,9 +385,9 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
     std::unique_ptr<fheroes2::ButtonSprite> buttonPatrol;
 
     if ( isEditor ) {
-        const fheroes2::Sprite & patrolReleased = fheroes2::AGG::GetICN( ICN::BUTTON_VERTICAL_PATROL, 0 );
+        const fheroes2::Sprite & patrolReleased = Assets::getImage( ICN::BUTTON_VERTICAL_PATROL, 0 );
         buttonPatrol = std::make_unique<fheroes2::ButtonSprite>( dst_pt.x, dst_pt.y - patrolReleased.height() / 2, patrolReleased,
-                                                                 fheroes2::AGG::GetICN( ICN::BUTTON_VERTICAL_PATROL, 1 ) );
+                                                                 Assets::getImage( ICN::BUTTON_VERTICAL_PATROL, 1 ) );
 
         fheroes2::addGradientShadow( patrolReleased, display, { dialogRoi.x + 9, dst_pt.y - patrolReleased.height() / 2 }, { -3, 5 } );
 
@@ -400,8 +400,8 @@ int Heroes::OpenDialog( const bool readonly, const bool fade, const bool disable
 
     // Exit button.
     dst_pt.x = dialogRoi.x + 602;
-    const fheroes2::Sprite & exitReleased = fheroes2::AGG::GetICN( ICN::BUTTON_VERTICAL_EXIT, 0 );
-    fheroes2::ButtonSprite buttonExit( dst_pt.x, dst_pt.y - exitReleased.height() / 2, exitReleased, fheroes2::AGG::GetICN( ICN::BUTTON_VERTICAL_EXIT, 1 ) );
+    const fheroes2::Sprite & exitReleased = Assets::getImage( ICN::BUTTON_VERTICAL_EXIT, 0 );
+    fheroes2::ButtonSprite buttonExit( dst_pt.x, dst_pt.y - exitReleased.height() / 2, exitReleased, Assets::getImage( ICN::BUTTON_VERTICAL_EXIT, 1 ) );
 
     LocalEvent & le = LocalEvent::Get();
 

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_indicator.cpp
+++ b/src/fheroes2/heroes/heroes_indicator.cpp
@@ -28,9 +28,9 @@
 #include <cstdlib>
 #include <utility>
 
-#include "agg_image.h"
 #include "army.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "heroes.h"
 #include "icn.h"
 #include "image.h"
@@ -93,7 +93,7 @@ void LuckIndicator::Redraw()
     _description.append( _( "Current Luck Modifiers:" ) );
     _description.append( "\n\n" );
 
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::HSICONS, ( 0 > _luck ? 3 : ( 0 < _luck ? 2 : 6 ) ) );
+    const fheroes2::Sprite & sprite = Assets::getImage( ICN::HSICONS, ( 0 > _luck ? 3 : ( 0 < _luck ? 2 : 6 ) ) );
     const int32_t inter = 6;
     int32_t count = ( 0 == _luck ? 1 : std::abs( _luck ) );
     int32_t cx = _area.x + ( _area.width - ( sprite.width() + inter * ( count - 1 ) ) ) / 2;
@@ -154,7 +154,7 @@ void MoraleIndicator::Redraw()
         spriteInx = 4;
     }
 
-    fheroes2::Sprite sprite = fheroes2::AGG::GetICN( ICN::HSICONS, spriteInx );
+    fheroes2::Sprite sprite = Assets::getImage( ICN::HSICONS, spriteInx );
     if ( _hero->GetArmy().AllTroopsAreUndead() ) {
         _description.append( "\n\n" );
         _description.append( _( "Entire army is undead, so morale does not apply." ) );
@@ -208,7 +208,7 @@ void ExperienceIndicator::Redraw() const
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    const fheroes2::Sprite & experienceImage = fheroes2::AGG::GetICN( ICN::HSICONS, 1 );
+    const fheroes2::Sprite & experienceImage = Assets::getImage( ICN::HSICONS, 1 );
     fheroes2::Blit( experienceImage, display, _area.x, _area.y );
 
     const fheroes2::Rect renderRoi{ _area.x + 1, _area.y + 24, 33, 9 };
@@ -282,7 +282,7 @@ void SpellPointsIndicator::Redraw()
 {
     fheroes2::Display & display = fheroes2::Display::instance();
 
-    const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::HSICONS, 8 );
+    const fheroes2::Sprite & sprite = Assets::getImage( ICN::HSICONS, 8 );
 
     const fheroes2::Rect renderRoi{ _area.x + 1, _area.y + 22, 33, 9 };
 

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/heroes/heroes_meeting.cpp
+++ b/src/fheroes2/heroes/heroes_meeting.cpp
@@ -30,7 +30,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army.h"
 #include "army_bar.h"
 #include "army_troop.h"
@@ -39,6 +38,7 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h" // IWYU pragma: associated
 #include "heroes_base.h"
@@ -63,8 +63,8 @@ namespace
 {
     fheroes2::ButtonSprite createMoveButton( const int32_t icnId, const int32_t offsetX, const int32_t offsetY, const fheroes2::Image & display )
     {
-        const fheroes2::Sprite & originalReleasedImage = fheroes2::AGG::GetICN( icnId, 0 );
-        const fheroes2::Sprite & originalPressedImage = fheroes2::AGG::GetICN( icnId, 1 );
+        const fheroes2::Sprite & originalReleasedImage = Assets::getImage( icnId, 0 );
+        const fheroes2::Sprite & originalPressedImage = Assets::getImage( icnId, 1 );
 
         const int32_t minX = std::min( originalReleasedImage.x(), originalPressedImage.x() );
         const int32_t minY = std::min( originalReleasedImage.y(), originalPressedImage.y() );
@@ -175,7 +175,7 @@ public:
 
         const fheroes2::Text text( std::to_string( troop.GetCount() ), fheroes2::FontType::smallWhite() );
 
-        const fheroes2::Sprite & mons32 = fheroes2::AGG::GetICN( ICN::MONS32, troop.GetSpriteIndex() );
+        const fheroes2::Sprite & mons32 = Assets::getImage( ICN::MONS32, troop.GetSpriteIndex() );
         fheroes2::Rect srcrt( 0, 0, mons32.width(), mons32.height() );
 
         if ( mons32.width() > roi.width ) {
@@ -237,7 +237,7 @@ public:
         if ( !arifact.isValid() )
             return;
 
-        const fheroes2::Sprite & artifactSprite = fheroes2::AGG::GetICN( ICN::ARTFX, arifact.IndexSprite32() );
+        const fheroes2::Sprite & artifactSprite = Assets::getImage( ICN::ARTFX, arifact.IndexSprite32() );
         fheroes2::Blit( artifactSprite, image, roi.x + 1, roi.y + 1 );
 
         if ( isSelected ) {
@@ -289,7 +289,7 @@ public:
         if ( !skill.isValid() )
             return;
 
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::MINISS, skill.GetIndexSprite2() );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::MINISS, skill.GetIndexSprite2() );
         fheroes2::Blit( sprite, image, roi.x + ( roi.width - sprite.width() ) / 2, roi.y + ( roi.height - sprite.height() ) / 2 );
 
         const fheroes2::Text text( std::to_string( skill.Level() ), fheroes2::FontType::smallWhite() );
@@ -308,7 +308,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     // Game Area event processor will change it to the appropriate one after this dialog is closed.
     Cursor::Get().SetThemes( Cursor::POINTER );
 
-    const fheroes2::Sprite & backSprite = fheroes2::AGG::GetICN( ICN::SWAPWIN, 0 );
+    const fheroes2::Sprite & backSprite = Assets::getImage( ICN::SWAPWIN, 0 );
     const fheroes2::Point cur_pt( ( display.width() - backSprite.width() ) / 2, ( display.height() - backSprite.height() ) / 2 );
     fheroes2::ImageRestorer restorer( display, cur_pt.x, cur_pt.y, backSprite.width(), backSprite.height() );
 
@@ -421,7 +421,7 @@ void Heroes::MeetingDialog( Heroes & otherHero )
     secskill_bar2.setRenderingOffset( { cur_pt.x + 353, cur_pt.y + 199 } );
     secskill_bar2.Redraw( display );
 
-    const fheroes2::Sprite & moveButtonBackground = fheroes2::AGG::GetICN( ICN::STONEBAK, 0 );
+    const fheroes2::Sprite & moveButtonBackground = Assets::getImage( ICN::STONEBAK, 0 );
     fheroes2::Blit( moveButtonBackground, 292, 270, display, cur_pt.x + 292, cur_pt.y + 270, 48, 44 );
 
     // The original resources do not have such animated buttons so we have to create those.

--- a/src/fheroes2/kingdom/kingdom_overview.cpp
+++ b/src/fheroes2/kingdom/kingdom_overview.cpp
@@ -30,7 +30,6 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
 #include "army_bar.h"
 #include "artifact.h"
 #include "buildinginfo.h"
@@ -39,6 +38,7 @@
 #include "cursor.h"
 #include "dialog.h"
 #include "game.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
 #include "heroes.h"
@@ -95,12 +95,12 @@ namespace
     void redrawCommonBackground( const fheroes2::Point & dst, const int visibleItems, fheroes2::Image & output )
     {
         // Scrollbar background.
-        const fheroes2::Sprite & scrollbar = fheroes2::AGG::GetICN( ICN::OVERVIEW, 13 );
+        const fheroes2::Sprite & scrollbar = Assets::getImage( ICN::OVERVIEW, 13 );
         fheroes2::Copy( scrollbar, 0, 0, output, dst.x + scrollbarOffset + 1, dst.y + 17, scrollbar.width(), scrollbar.height() );
 
         // Items background.
-        const fheroes2::Sprite & itemsBack = fheroes2::AGG::GetICN( ICN::OVERVIEW, 8 );
-        const fheroes2::Sprite & overback = fheroes2::AGG::GetICN( ICN::OVERBACK, 0 );
+        const fheroes2::Sprite & itemsBack = Assets::getImage( ICN::OVERVIEW, 8 );
+        const fheroes2::Sprite & overback = Assets::getImage( ICN::OVERBACK, 0 );
         const int32_t itemsBackWidth = itemsBack.width();
         const int32_t itemsBackHeight = itemsBack.height();
         const int32_t offsetX = dst.x + 30;
@@ -217,14 +217,14 @@ namespace
         : Interface::ListBox<HeroRow>( offset )
         , _windowArea( windowArea )
     {
-        const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::OVERVIEW, 13 );
+        const fheroes2::Sprite & back = Assets::getImage( ICN::OVERVIEW, 13 );
         const int32_t backHeight = back.height();
 
         SetTopLeft( offset );
         const int32_t offsetX = offset.x + scrollbarOffset;
         setScrollBarArea( { offsetX + 2, offset.y + 18, back.width(), backHeight - 2 } );
 
-        const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( ICN::SCROLL, 4 );
+        const fheroes2::Sprite & originalSlider = Assets::getImage( ICN::SCROLL, 4 );
         fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, backHeight - 2, 4, static_cast<int32_t>( heroes.size() ),
                                                                              { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
 
@@ -253,8 +253,8 @@ namespace
         const size_t contentSize = content.size();
 
         if ( heroes.size() != contentSize ) {
-            const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::OVERVIEW, 13 );
-            const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( ICN::SCROLL, 4 );
+            const fheroes2::Sprite & back = Assets::getImage( ICN::OVERVIEW, 13 );
+            const fheroes2::Sprite & originalSlider = Assets::getImage( ICN::SCROLL, 4 );
             fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, back.height() - 2, 4, static_cast<int32_t>( heroes.size() ),
                                                                                  { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
             setScrollBarImage( std::move( scrollbarSlider ) );
@@ -332,7 +332,7 @@ namespace
         }
 
         fheroes2::Display & display = fheroes2::Display::instance();
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::OVERVIEW, 10 ), display, dstx, dsty );
+        fheroes2::Blit( Assets::getImage( ICN::OVERVIEW, 10 ), display, dstx, dsty );
 
         // base info
         Interface::redrawHeroesIcon( *row.hero, dstx + 5, dsty + 4 );
@@ -376,7 +376,7 @@ namespace
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        const fheroes2::Sprite & header = fheroes2::AGG::GetICN( ICN::OVERVIEW, 6 );
+        const fheroes2::Sprite & header = Assets::getImage( ICN::OVERVIEW, 6 );
         fheroes2::Copy( header, 0, 0, display, dst.x + 30, dst.y, header.width(), header.height() );
 
         const int32_t offsetY = dst.y + 3;
@@ -499,14 +499,14 @@ namespace
         : Interface::ListBox<CstlRow>( offset )
         , _windowArea( windowArea )
     {
-        const fheroes2::Sprite & back = fheroes2::AGG::GetICN( ICN::OVERVIEW, 13 );
+        const fheroes2::Sprite & back = Assets::getImage( ICN::OVERVIEW, 13 );
         const int32_t backHeight = back.height();
 
         SetTopLeft( offset );
         const int32_t offsetX = offset.x + scrollbarOffset;
         setScrollBarArea( { offsetX + 2, offset.y + 18, back.width(), backHeight - 2 } );
 
-        const fheroes2::Sprite & originalSlider = fheroes2::AGG::GetICN( ICN::SCROLL, 4 );
+        const fheroes2::Sprite & originalSlider = Assets::getImage( ICN::SCROLL, 4 );
         fheroes2::Image scrollbarSlider = fheroes2::generateScrollbarSlider( originalSlider, false, back.height() - 2, 4, static_cast<int32_t>( castles.size() ),
                                                                              { 0, 0, originalSlider.width(), 8 }, { 0, 7, originalSlider.width(), 8 } );
 
@@ -618,7 +618,7 @@ namespace
 
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::OVERVIEW, 11 ), display, dstx, dsty );
+        fheroes2::Blit( Assets::getImage( ICN::OVERVIEW, 11 ), display, dstx, dsty );
 
         // base info
         Interface::redrawCastleIcon( *row.castle, dstx + 17, dsty + 19 );
@@ -667,7 +667,7 @@ namespace
     {
         fheroes2::Display & display = fheroes2::Display::instance();
 
-        const fheroes2::Sprite & header = fheroes2::AGG::GetICN( ICN::OVERVIEW, 7 );
+        const fheroes2::Sprite & header = Assets::getImage( ICN::OVERVIEW, 7 );
         fheroes2::Copy( header, 0, 0, display, dst.x + 30, dst.y, header.width(), header.height() );
 
         const int32_t offsetY = dst.y + 3;
@@ -718,7 +718,7 @@ namespace
         int32_t offsetY = pt.y + 450;
 
         fheroes2::Display & display = fheroes2::Display::instance();
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::OVERBACK, 0 ), 4, 422, display, pt.x + 4, pt.y + 422, 530, 56 );
+        fheroes2::Blit( Assets::getImage( ICN::OVERBACK, 0 ), 4, 422, display, pt.x + 4, pt.y + 422, 530, 56 );
 
         fheroes2::Text text( std::to_string( funds.wood ), fheroes2::FontType::smallWhite() );
         text.draw( pt.x + 56 - text.width() / 2, offsetY, display );
@@ -755,7 +755,7 @@ namespace
         text.set( std::to_string( lighthouseCount ), fheroes2::FontType::smallWhite() );
         text.draw( pt.x + 105, offsetY, display );
 
-        const fheroes2::Sprite & lighthouse = fheroes2::AGG::GetICN( ICN::OVERVIEW, 14 );
+        const fheroes2::Sprite & lighthouse = Assets::getImage( ICN::OVERVIEW, 14 );
         fheroes2::Blit( lighthouse, 0, 0, display, pt.x + 100 - lighthouse.width(), pt.y + 459, lighthouse.width(), lighthouse.height() );
     }
 }
@@ -780,7 +780,7 @@ void Kingdom::openOverviewDialog()
     const fheroes2::Point cur_pt( background.activeArea().x, background.activeArea().y );
     fheroes2::Point dst_pt( cur_pt );
 
-    fheroes2::Blit( fheroes2::AGG::GetICN( ICN::OVERBACK, 0 ), display, dst_pt.x, dst_pt.y );
+    fheroes2::Blit( Assets::getImage( ICN::OVERBACK, 0 ), display, dst_pt.x, dst_pt.y );
 
     RedrawIncomeInfo( cur_pt, *this );
     RedrawFundsInfo( cur_pt, *this );
@@ -802,7 +802,7 @@ void Kingdom::openOverviewDialog()
     const fheroes2::Rect rectIncome( cur_pt.x + 1, cur_pt.y + 360, 535, 60 );
     const fheroes2::Rect rectGoldPerDay( cur_pt.x + 124, cur_pt.y + 459, 289, 16 );
 
-    const fheroes2::Sprite & lighthouse = fheroes2::AGG::GetICN( ICN::OVERVIEW, 14 );
+    const fheroes2::Sprite & lighthouse = Assets::getImage( ICN::OVERVIEW, 14 );
     const fheroes2::Rect rectLighthouse( cur_pt.x + 100 - lighthouse.width(), cur_pt.y + 459, lighthouse.width() + 10, lighthouse.height() );
 
     Interface::ListBasic * listStats = nullptr;

--- a/src/fheroes2/kingdom/puzzle.cpp
+++ b/src/fheroes2/kingdom/puzzle.cpp
@@ -30,12 +30,12 @@
 #include <string>
 #include <vector>
 
-#include "agg_image.h"
 #include "artifact_ultimate.h"
 #include "audio.h"
 #include "audio_manager.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_delays.h"
 #include "game_hotkeys.h"
 #include "game_interface.h"
@@ -96,7 +96,7 @@ namespace
         }
 
         for ( size_t i = 0; i < pzl.size(); ++i ) {
-            const fheroes2::Sprite & piece = fheroes2::AGG::GetICN( ICN::PUZZLE, static_cast<uint32_t>( i ) );
+            const fheroes2::Sprite & piece = Assets::getImage( ICN::PUZZLE, static_cast<uint32_t>( i ) );
 
             fheroes2::Blit( piece, display, dstx + piece.x() - fheroes2::borderWidthPx, dsty + piece.y() - fheroes2::borderWidthPx );
         }
@@ -136,7 +136,7 @@ namespace
                 fheroes2::Copy( sf, 0, 0, display, dstx, dsty, sf.width(), sf.height() );
 
                 for ( size_t i = 0; i < pzl.size(); ++i ) {
-                    const fheroes2::Sprite & piece = fheroes2::AGG::GetICN( ICN::PUZZLE, static_cast<uint32_t>( i ) );
+                    const fheroes2::Sprite & piece = Assets::getImage( ICN::PUZZLE, static_cast<uint32_t>( i ) );
 
                     uint8_t pieceAlpha = 255;
                     if ( pzl.test( i ) )
@@ -178,13 +178,13 @@ namespace
 
         fheroes2::fadeOutDisplay( back.rect(), false );
 
-        fheroes2::Copy( fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::EVIWPUZL : ICN::VIEWPUZL ), 0 ), 0, 0, display, radarArea );
+        fheroes2::Copy( Assets::getImage( ( isEvilInterface ? ICN::EVIWPUZL : ICN::VIEWPUZL ), 0 ), 0, 0, display, radarArea );
         display.updateNextRenderRoi( radarArea );
 
         const int exitButtonIcnID = ( isEvilInterface ? ICN::BUTTON_SMALL_EXIT_EVIL : ICN::BUTTON_SMALL_EXIT_GOOD );
         fheroes2::Button buttonExit( radarArea.x + 32, radarArea.y + radarArea.height - 37, exitButtonIcnID, 0, 1 );
         buttonExit.setPosition( radarArea.x + ( radarArea.width - buttonExit.area().width ) / 2, buttonExit.area().y );
-        fheroes2::addGradientShadow( fheroes2::AGG::GetICN( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
+        fheroes2::addGradientShadow( Assets::getImage( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
 
         buttonExit.draw();
 
@@ -255,7 +255,7 @@ namespace
         const int exitButtonIcnID = ( isEvilInterface ? ICN::BUTTON_SMALL_EXIT_EVIL : ICN::BUTTON_SMALL_EXIT_GOOD );
         fheroes2::Button buttonExit( radarArea.x + 32, radarArea.y + radarArea.height - 37, exitButtonIcnID, 0, 1 );
         buttonExit.setPosition( radarArea.x + ( radarArea.width - buttonExit.area().width ) / 2, buttonExit.area().y );
-        fheroes2::addGradientShadow( fheroes2::AGG::GetICN( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
+        fheroes2::addGradientShadow( Assets::getImage( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
 
         const fheroes2::Rect & radarRect = radar.GetRect();
 
@@ -264,11 +264,11 @@ namespace
                 Dialog::FrameBorder::RenderRegular( radarRect );
             }
 
-            fheroes2::Copy( fheroes2::AGG::GetICN( ( isEvilInterface ? ICN::EVIWPUZL : ICN::VIEWPUZL ), 0 ), 0, 0, display, radarArea );
+            fheroes2::Copy( Assets::getImage( ( isEvilInterface ? ICN::EVIWPUZL : ICN::VIEWPUZL ), 0 ), 0, 0, display, radarArea );
             display.updateNextRenderRoi( radarArea );
 
             buttonExit.draw();
-            fheroes2::addGradientShadow( fheroes2::AGG::GetICN( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
+            fheroes2::addGradientShadow( Assets::getImage( exitButtonIcnID, 0 ), display, buttonExit.area().getPosition(), { -5, 5 } );
 
             return radarRect;
         };

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2021 - 2025                                             *
+ *   Copyright (C) 2021 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/kingdom/view_world.cpp
+++ b/src/fheroes2/kingdom/view_world.cpp
@@ -28,11 +28,11 @@
 #include <cstring>
 #include <utility>
 
-#include "agg_image.h"
 #include "castle.h"
 #include "color.h"
 #include "cursor.h"
 #include "dialog.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes.h"
 #include "icn.h"
@@ -334,7 +334,7 @@ namespace
 
                 const int32_t icnFlagsBase = icnPerZoomLevelFlags[zoomLevelId];
                 const uint32_t flagIndex = ( icnFlagsBase == ICN::FLAG32 ) ? ( 2 * icnIndex + 1 ) : icnIndex;
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icnFlagsBase, flagIndex );
+                const fheroes2::Sprite & sprite = Assets::getImage( icnFlagsBase, flagIndex );
 
                 const int32_t dstx = posX * tileSize + ( tileSize - sprite.width() ) / 2;
                 const int32_t dsty = posY * tileSize + ( tileSize - sprite.height() ) / 2 + 1;
@@ -352,7 +352,7 @@ namespace
                 const int32_t dstx = posX * tileSize + tileSize / 2;
                 const int32_t dsty = posY * tileSize + tileSize / 2;
 
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icnPerZoomLevel[zoomLevelId], icnIndex );
+                const fheroes2::Sprite & sprite = Assets::getImage( icnPerZoomLevel[zoomLevelId], icnIndex );
                 fheroes2::Blit( sprite, cache.cachedImages[zoomLevelId], dstx - sprite.width() / 2, dsty - sprite.height() / 2 );
             }
         };
@@ -371,9 +371,9 @@ namespace
                 const int32_t dstx = posX * tileSize + tileSize / 2;
                 const int32_t dsty = posY * tileSize + tileSize / 2;
 
-                const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icnPerZoomLevel[zoomLevelId], icnIndex );
+                const fheroes2::Sprite & sprite = Assets::getImage( icnPerZoomLevel[zoomLevelId], icnIndex );
                 fheroes2::Blit( sprite, cache.cachedImages[zoomLevelId], dstx - sprite.width() / 2, dsty - sprite.height() / 2 );
-                const fheroes2::Sprite & letter = fheroes2::AGG::GetICN( icnLetterPerZoomLevel[zoomLevelId], letterIndex );
+                const fheroes2::Sprite & letter = Assets::getImage( icnLetterPerZoomLevel[zoomLevelId], letterIndex );
                 fheroes2::Blit( letter, cache.cachedImages[zoomLevelId], dstx - letter.width() / 2, dsty - letter.height() / 2 );
             }
         };
@@ -488,7 +488,7 @@ namespace
         dstY += cutHeight;
 
         if ( display.height() > fheroes2::Display::DEFAULT_HEIGHT ) {
-            const fheroes2::Sprite & icnston = fheroes2::AGG::GetICN( isEvilInterface ? ICN::STONBAKE : ICN::STONBACK, 0 );
+            const fheroes2::Sprite & icnston = Assets::getImage( isEvilInterface ? ICN::STONBAKE : ICN::STONBACK, 0 );
             const int32_t startY = 11;
             const int32_t copyHeight = 46;
             const int32_t repeatHeight = display.height() - fheroes2::borderWidthPx - dstY - ( viewWorldSprite.height() - cutHeight );
@@ -656,7 +656,7 @@ void ViewWorld::ViewWorldWindow( const PlayerColor color, const ViewWorldMode mo
     }
     else if ( display.height() == fheroes2::Display::DEFAULT_HEIGHT ) {
         // Fix borders for Editor if screen height is 480 pixels.
-        const fheroes2::Sprite & borderSprite = fheroes2::AGG::GetICN( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
+        const fheroes2::Sprite & borderSprite = Assets::getImage( isEvilInterface ? ICN::ADVBORDE : ICN::ADVBORD, 0 );
 
         const int32_t offsetX = 480;
         const int32_t stepY = 304;
@@ -680,7 +680,7 @@ void ViewWorld::ViewWorldWindow( const PlayerColor color, const ViewWorldMode mo
     radar.RedrawForViewWorld( currentROI, mode, true );
 
     // "View world" sprite
-    const fheroes2::Sprite & viewWorldSprite = fheroes2::AGG::GetICN( GetSpriteResource( mode, isEvilInterface ), 0 );
+    const fheroes2::Sprite & viewWorldSprite = Assets::getImage( GetSpriteResource( mode, isEvilInterface ), 0 );
     drawViewWorldSprite( viewWorldSprite, display, isEvilInterface );
 
     // Zoom button

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2023 - 2025                                             *
+ *   Copyright (C) 2023 - 2026                                             *
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *
  *   it under the terms of the GNU General Public License as published by  *

--- a/src/fheroes2/maps/maps_tiles_render.cpp
+++ b/src/fheroes2/maps/maps_tiles_render.cpp
@@ -30,10 +30,10 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "color.h"
 #include "direction.h"
 #include "game.h"
+#include "game_assets.h"
 #include "heroes.h"
 #include "icn.h"
 #include "image.h"
@@ -108,7 +108,7 @@ namespace
 
         const uint8_t alphaValue = area.getObjectAlphaValue( part._uid );
 
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( icn, part.icnIndex );
+        const fheroes2::Sprite & sprite = Assets::getImage( icn, part.icnIndex );
 
         // Ideally we need to check that the image is within a tile area. However, flags are among those for which this rule doesn't apply.
         if ( icn == ICN::FLAG32 ) {
@@ -130,7 +130,7 @@ namespace
         }
 
         const uint32_t secondaryFrameIndex = part.icnIndex + ( Game::getAdventureMapAnimationIndex() % objectInfo->animationFrames ) + 1;
-        const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( icn, secondaryFrameIndex );
+        const fheroes2::Sprite & animationSprite = Assets::getImage( icn, secondaryFrameIndex );
 
         // If this assertion blows up we are trying to render an image bigger than a tile. Render this object properly as heroes or monsters!
         assert( animationSprite.x() >= 0 && animationSprite.width() + animationSprite.x() <= fheroes2::tileWidthPx && animationSprite.y() >= 0
@@ -152,7 +152,7 @@ namespace
 
         const uint8_t mainObjectAlphaValue = area.getObjectAlphaValue( part._uid );
 
-        const fheroes2::Sprite & mainObjectSprite = fheroes2::AGG::GetICN( mainObjectIcn, part.icnIndex );
+        const fheroes2::Sprite & mainObjectSprite = Assets::getImage( mainObjectIcn, part.icnIndex );
 
         // If this assertion blows up we are trying to render an image bigger than a tile. Render this object properly as heroes or monsters!
         assert( mainObjectSprite.x() >= 0 && mainObjectSprite.width() + mainObjectSprite.x() <= fheroes2::tileWidthPx && mainObjectSprite.y() >= 0
@@ -176,7 +176,7 @@ namespace
             secondaryFrameIndex = part.icnIndex + objectInfo->animationFrames + 1;
         }
 
-        const fheroes2::Sprite & animationSprite = fheroes2::AGG::GetICN( mainObjectIcn, secondaryFrameIndex );
+        const fheroes2::Sprite & animationSprite = Assets::getImage( mainObjectIcn, secondaryFrameIndex );
 
         // If this assertion blows up we are trying to render an image bigger than a tile. Render this object properly as heroes or monsters!
         assert( animationSprite.x() >= 0 && animationSprite.width() + animationSprite.x() <= fheroes2::tileWidthPx && animationSprite.y() >= 0
@@ -635,19 +635,19 @@ namespace Maps
     void redrawEmptyTile( fheroes2::Image & dst, const fheroes2::Point & mp, const Interface::GameArea & area )
     {
         if ( mp.y == -1 && mp.x >= 0 && mp.x < world.w() ) { // top first row
-            area.DrawTile( dst, fheroes2::AGG::GetTIL( TIL::STON, 20 + ( mp.x % 4 ), 0 ), mp );
+            area.DrawTile( dst, Assets::getTileImage( TIL::STON, 20 + ( mp.x % 4 ), 0 ), mp );
         }
         else if ( mp.x == world.w() && mp.y >= 0 && mp.y < world.h() ) { // right first row
-            area.DrawTile( dst, fheroes2::AGG::GetTIL( TIL::STON, 24 + ( mp.y % 4 ), 0 ), mp );
+            area.DrawTile( dst, Assets::getTileImage( TIL::STON, 24 + ( mp.y % 4 ), 0 ), mp );
         }
         else if ( mp.y == world.h() && mp.x >= 0 && mp.x < world.w() ) { // bottom first row
-            area.DrawTile( dst, fheroes2::AGG::GetTIL( TIL::STON, 28 + ( mp.x % 4 ), 0 ), mp );
+            area.DrawTile( dst, Assets::getTileImage( TIL::STON, 28 + ( mp.x % 4 ), 0 ), mp );
         }
         else if ( mp.x == -1 && mp.y >= 0 && mp.y < world.h() ) { // left first row
-            area.DrawTile( dst, fheroes2::AGG::GetTIL( TIL::STON, 32 + ( mp.y % 4 ), 0 ), mp );
+            area.DrawTile( dst, Assets::getTileImage( TIL::STON, 32 + ( mp.y % 4 ), 0 ), mp );
         }
         else {
-            area.DrawTile( dst, fheroes2::AGG::GetTIL( TIL::STON, ( std::abs( mp.y ) % 4 ) * 4 + std::abs( mp.x ) % 4, 0 ), mp );
+            area.DrawTile( dst, Assets::getTileImage( TIL::STON, ( std::abs( mp.y ) % 4 ) * 4 + std::abs( mp.x ) % 4, 0 ), mp );
         }
     }
 
@@ -656,7 +656,7 @@ namespace Maps
         // This sprite is bigger than tileWidthPx but rendering is correct for heroes and boats.
         // TODO: consider adding this sprite as a part of an object part.
 
-        const fheroes2::Sprite & image = fheroes2::AGG::GetICN( ICN::OBJNHAUN, Game::getAdventureMapAnimationIndex() % 15 );
+        const fheroes2::Sprite & image = Assets::getImage( ICN::OBJNHAUN, Game::getAdventureMapAnimationIndex() % 15 );
 
         // We should not render ghosts over the map top border if the tile near this border is not revealed.
         if ( !isEditor && ( pos.y == 1 ) && ( image.y() < -32 ) && ( world.getTile( pos.x, pos.y - 1 ).getFogDirection() & Direction::TOP ) == Direction::TOP ) {
@@ -679,7 +679,7 @@ namespace Maps
 
         // We should not render flags over the map top border if the tile near this border is not revealed.
         if ( ( pos.y == 0 ) && ( part.icnType == MP2::OBJ_ICN_TYPE_FLAG32 ) && ( tile.getFogDirection() & Direction::TOP ) == Direction::TOP ) {
-            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( MP2::getIcnIdFromObjectIcnType( part.icnType ), part.icnIndex );
+            const fheroes2::Sprite & image = Assets::getImage( MP2::getIcnIdFromObjectIcnType( part.icnType ), part.icnIndex );
 
             if ( image.y() < 0 ) {
                 const fheroes2::Rect roi( 0, -image.y(), image.width(), image.height() + image.y() );
@@ -707,7 +707,7 @@ namespace Maps
         // And another array to store revert flag.
 
         if ( DIRECTION_ALL == fogDirection ) {
-            const fheroes2::Image & sf = fheroes2::AGG::GetTIL( TIL::CLOF32, ( mp.x + mp.y ) % 4, 0 );
+            const fheroes2::Image & sf = Assets::getTileImage( TIL::CLOF32, ( mp.x + mp.y ) % 4, 0 );
             area.DrawTile( dst, sf, mp );
         }
         else {
@@ -909,12 +909,12 @@ namespace Maps
             else {
                 // unknown
                 DEBUG_LOG( DBG_GAME, DBG_WARN, "Invalid direction for fog: " << Direction::String( fogDirection ) << ". Tile index: " << tile.GetIndex() )
-                const fheroes2::Image & sf = fheroes2::AGG::GetTIL( TIL::CLOF32, ( mp.x + mp.y ) % 4, 0 );
+                const fheroes2::Image & sf = Assets::getTileImage( TIL::CLOF32, ( mp.x + mp.y ) % 4, 0 );
                 area.DrawTile( dst, sf, mp );
                 return;
             }
 
-            const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::CLOP32, index );
+            const fheroes2::Sprite & sprite = Assets::getImage( ICN::CLOP32, index );
             area.BlitOnTile( dst, sprite, ( revert ? fheroes2::tileWidthPx - sprite.x() - sprite.width() : sprite.x() ), sprite.y(), mp, revert, 255 );
         }
     }
@@ -1013,7 +1013,7 @@ namespace Maps
         const std::pair<uint32_t, uint32_t> spriteIndices = GetMonsterSpriteIndices( tile, monster.GetSpriteIndex(), isEditorMode );
 
         const int icnId{ ICN::MINI_MONSTER_IMAGE };
-        const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( icnId, spriteIndices.first );
+        const fheroes2::Sprite & monsterSprite = Assets::getImage( icnId, spriteIndices.first );
         const fheroes2::Point monsterSpriteOffset( monsterSprite.x() + monsterImageOffset.x, monsterSprite.y() + monsterImageOffset.y );
 
         std::vector<fheroes2::Point> outputSquareInfo;
@@ -1032,7 +1032,7 @@ namespace Maps
         outputImageInfo.clear();
 
         if ( spriteIndices.second > 0 ) {
-            const fheroes2::Sprite & secondaryMonsterSprite = fheroes2::AGG::GetICN( icnId, spriteIndices.second );
+            const fheroes2::Sprite & secondaryMonsterSprite = Assets::getImage( icnId, spriteIndices.second );
             const fheroes2::Point secondaryMonsterSpriteOffset( secondaryMonsterSprite.x() + monsterImageOffset.x, secondaryMonsterSprite.y() + monsterImageOffset.y );
 
             fheroes2::DivideImageBySquares( secondaryMonsterSpriteOffset, secondaryMonsterSprite, fheroes2::tileWidthPx, outputSquareInfo, outputImageInfo );
@@ -1056,7 +1056,7 @@ namespace Maps
         const std::pair<uint32_t, uint32_t> spriteIndices = GetMonsterSpriteIndices( tile, monster.GetSpriteIndex(), isEditorMode );
 
         const int icnId{ ICN::MINI_MONSTER_SHADOW };
-        const fheroes2::Sprite & monsterSprite = fheroes2::AGG::GetICN( icnId, spriteIndices.first );
+        const fheroes2::Sprite & monsterSprite = Assets::getImage( icnId, spriteIndices.first );
         const fheroes2::Point monsterSpriteOffset( monsterSprite.x() + monsterImageOffset.x, monsterSprite.y() + monsterImageOffset.y );
 
         std::vector<fheroes2::Point> outputSquareInfo;
@@ -1075,7 +1075,7 @@ namespace Maps
         outputImageInfo.clear();
 
         if ( spriteIndices.second > 0 ) {
-            const fheroes2::Sprite & secondaryMonsterSprite = fheroes2::AGG::GetICN( icnId, spriteIndices.second );
+            const fheroes2::Sprite & secondaryMonsterSprite = Assets::getImage( icnId, spriteIndices.second );
             const fheroes2::Point secondaryMonsterSpriteOffset( secondaryMonsterSprite.x() + monsterImageOffset.x, secondaryMonsterSprite.y() + monsterImageOffset.y );
 
             fheroes2::DivideImageBySquares( secondaryMonsterSpriteOffset, secondaryMonsterSprite, fheroes2::tileWidthPx, outputSquareInfo, outputImageInfo );
@@ -1102,7 +1102,7 @@ namespace Maps
 
         const int icnId{ ICN::BOAT32 };
         const uint32_t icnIndex = spriteIndex % 128;
-        const fheroes2::Sprite & boatSprite = fheroes2::AGG::GetICN( icnId, icnIndex );
+        const fheroes2::Sprite & boatSprite = Assets::getImage( icnId, icnIndex );
 
         const fheroes2::Point boatSpriteOffset( ( isReflected ? ( fheroes2::tileWidthPx + 1 - boatSprite.x() - boatSprite.width() ) : boatSprite.x() ),
                                                 boatSprite.y() + fheroes2::tileWidthPx - 11 );
@@ -1131,7 +1131,7 @@ namespace Maps
 
         const int icnId{ ICN::BOATSHAD };
         const uint32_t icnIndex = spriteIndex % 128;
-        const fheroes2::Sprite & boatShadowSprite = fheroes2::AGG::GetICN( icnId, icnIndex );
+        const fheroes2::Sprite & boatShadowSprite = Assets::getImage( icnId, icnIndex );
         const fheroes2::Point boatShadowSpriteOffset( boatShadowSprite.x(), fheroes2::tileWidthPx + boatShadowSprite.y() - 11 );
 
         // Shadows cannot be flipped so flip flag is always false.
@@ -1167,7 +1167,7 @@ namespace Maps
 
             const int icnId{ ICN::OBJNXTRA };
             const uint32_t icnIndex = spellID - Spell::SETEGUARDIAN;
-            const fheroes2::Sprite & image = fheroes2::AGG::GetICN( icnId, icnIndex );
+            const fheroes2::Sprite & image = Assets::getImage( icnId, icnIndex );
 
             std::vector<fheroes2::Point> outputSquareInfo;
             std::vector<std::pair<fheroes2::Point, fheroes2::Rect>> outputImageInfo;
@@ -1213,7 +1213,7 @@ namespace Maps
         uint32_t icnIndex{ 0 };
         getHeroSpriteInfo( hero, hero.GetSpriteIndex(), false, icnId, icnIndex );
 
-        const fheroes2::Sprite & spriteHero = fheroes2::AGG::GetICN( icnId, icnIndex );
+        const fheroes2::Sprite & spriteHero = Assets::getImage( icnId, icnIndex );
         const fheroes2::Point heroSpriteOffset( offset.x + ( reflect ? ( fheroes2::tileWidthPx + 1 - spriteHero.x() - spriteHero.width() ) : spriteHero.x() ),
                                                 offset.y + spriteHero.y() + fheroes2::tileWidthPx );
 
@@ -1234,7 +1234,7 @@ namespace Maps
         fheroes2::Point flagOffset;
         getFlagSpriteInfo( hero, flagFrameID, false, flagOffset, icnId, icnIndex );
 
-        const fheroes2::Sprite & spriteFlag = fheroes2::AGG::GetICN( icnId, icnIndex );
+        const fheroes2::Sprite & spriteFlag = Assets::getImage( icnId, icnIndex );
         const fheroes2::Point flagSpriteOffset( offset.x
                                                     + ( reflect ? ( fheroes2::tileWidthPx - spriteFlag.x() - flagOffset.x - spriteFlag.width() )
                                                                 : spriteFlag.x() + flagOffset.x ),
@@ -1254,7 +1254,7 @@ namespace Maps
         if ( hero.isShipMaster() && hero.isMoveEnabled() && hero.isInDeepOcean() ) {
             // TODO: draw froth for all boats in deep water, not only for a moving boat.
             getFrothSpriteInfo( hero, hero.GetSpriteIndex(), icnId, icnIndex );
-            const fheroes2::Sprite & spriteFroth = fheroes2::AGG::GetICN( icnId, icnIndex );
+            const fheroes2::Sprite & spriteFroth = Assets::getImage( icnId, icnIndex );
             const fheroes2::Point frothSpriteOffset( offset.x + ( reflect ? fheroes2::tileWidthPx - spriteFroth.x() - spriteFroth.width() : spriteFroth.x() ),
                                                      offset.y + spriteFroth.y() + fheroes2::tileWidthPx );
 
@@ -1284,7 +1284,7 @@ namespace Maps
         uint32_t icnIndex{ 0 };
         getShadowSpriteInfo( hero, hero.GetSpriteIndex(), icnId, icnIndex );
 
-        const fheroes2::Sprite & spriteShadow = fheroes2::AGG::GetICN( icnId, icnIndex );
+        const fheroes2::Sprite & spriteShadow = Assets::getImage( icnId, icnIndex );
         const fheroes2::Point shadowSpriteOffset( offset.x + spriteShadow.x(), offset.y + spriteShadow.y() + fheroes2::tileWidthPx );
 
         std::vector<fheroes2::Point> outputSquareInfo;
@@ -1308,7 +1308,7 @@ namespace Maps
         const uint32_t icnIndex = tile.getMainObjectPart().icnIndex;
         const int icnId{ ICN::MINIHERO };
 
-        const fheroes2::Sprite & boatSprite = fheroes2::AGG::GetICN( icnId, icnIndex );
+        const fheroes2::Sprite & boatSprite = Assets::getImage( icnId, icnIndex );
 
         const fheroes2::Point boatSpriteOffset{ 0, 32 - 50 };
 
@@ -1328,6 +1328,6 @@ namespace Maps
 
     const fheroes2::Image & getTileSurface( const Tile & tile )
     {
-        return fheroes2::AGG::GetTIL( TIL::GROUND32, tile.getTerrainImageIndex(), ( tile.getTerrainFlags() & 0x3 ) );
+        return Assets::getTileImage( TIL::GROUND32, tile.getTerrainImageIndex(), ( tile.getTerrainFlags() & 0x3 ) );
     }
 }

--- a/src/fheroes2/resource/artifact.cpp
+++ b/src/fheroes2/resource/artifact.cpp
@@ -35,9 +35,9 @@
 #include <string>
 #include <utility>
 
-#include "agg_image.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
+#include "game_assets.h"
 #include "heroes.h"
 #include "icn.h"
 #include "logging.h"
@@ -1110,7 +1110,7 @@ ArtifactsBar::ArtifactsBar( Heroes * hero, const bool mini, const bool ro, const
     , _statusBar( bar )
 {
     if ( use_mini_sprite ) {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::HSICONS, 0 );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::HSICONS, 0 );
         const fheroes2::Rect rt( 26, 21, 32, 32 );
 
         backsf.resize( rt.width + 2, rt.height + 2 );
@@ -1126,7 +1126,7 @@ ArtifactsBar::ArtifactsBar( Heroes * hero, const bool mini, const bool ro, const
         fheroes2::DrawBorder( spcursor, 214 );
     }
     else {
-        const fheroes2::Sprite & sprite = fheroes2::AGG::GetICN( ICN::ARTIFACT, 0 );
+        const fheroes2::Sprite & sprite = Assets::getImage( ICN::ARTIFACT, 0 );
         setSingleItemSize( { sprite.width(), sprite.height() } );
 
         spcursor.resize( 70, 70 );
@@ -1154,19 +1154,19 @@ void ArtifactsBar::RedrawBackground( const fheroes2::Rect & pos, fheroes2::Image
     if ( use_mini_sprite )
         fheroes2::Blit( backsf, dstsf, pos.x, pos.y );
     else
-        fheroes2::Blit( fheroes2::AGG::GetICN( ICN::ARTIFACT, 0 ), dstsf, pos.x, pos.y );
+        fheroes2::Blit( Assets::getImage( ICN::ARTIFACT, 0 ), dstsf, pos.x, pos.y );
 }
 
 void ArtifactsBar::RedrawItem( Artifact & art, const fheroes2::Rect & pos, bool selected, fheroes2::Image & dstsf )
 {
     if ( art.isValid() ) {
         if ( use_mini_sprite ) {
-            const fheroes2::Sprite & artifactSprite = fheroes2::AGG::GetICN( ICN::ARTFX, art.IndexSprite32() );
+            const fheroes2::Sprite & artifactSprite = Assets::getImage( ICN::ARTFX, art.IndexSprite32() );
             fheroes2::Fill( dstsf, pos.x + 1, pos.y + 1, artifactSprite.width(), artifactSprite.height(), 0 );
             fheroes2::Blit( artifactSprite, dstsf, pos.x + 1, pos.y + 1 );
         }
         else {
-            const fheroes2::Sprite & artifactSprite = fheroes2::AGG::GetICN( ICN::ARTIFACT, art.IndexSprite64() );
+            const fheroes2::Sprite & artifactSprite = Assets::getImage( ICN::ARTIFACT, art.IndexSprite64() );
             fheroes2::Fill( dstsf, pos.x, pos.y, artifactSprite.width(), artifactSprite.height(), 0 );
             fheroes2::Blit( artifactSprite, dstsf, pos.x, pos.y );
         }

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -1,6 +1,6 @@
 /***************************************************************************
  *   fheroes2: https://github.com/ihhub/fheroes2                           *
- *   Copyright (C) 2019 - 2025                                             *
+ *   Copyright (C) 2019 - 2026                                             *
  *                                                                         *
  *   Free Heroes2 Engine: http://sourceforge.net/projects/fheroes2         *
  *   Copyright (C) 2009 by Andrey Afletdinov <fheroes2@gmail.com>          *

--- a/src/fheroes2/resource/resource.cpp
+++ b/src/fheroes2/resource/resource.cpp
@@ -31,7 +31,7 @@
 #include <utility>
 #include <vector>
 
-#include "agg_image.h"
+#include "game_assets.h"
 #include "icn.h"
 #include "image.h"
 #include "logging.h"
@@ -613,9 +613,9 @@ void Resource::BoxSprite::Redraw() const
 
     while ( valueVsSprite.size() - id > 2 ) {
         const uint32_t width_ = width / 3;
-        const fheroes2::Sprite & res1 = fheroes2::AGG::GetICN( ICN::RESOURCE, valueVsSprite[id].second );
-        const fheroes2::Sprite & res2 = fheroes2::AGG::GetICN( ICN::RESOURCE, valueVsSprite[id + 1].second );
-        const fheroes2::Sprite & res3 = fheroes2::AGG::GetICN( ICN::RESOURCE, valueVsSprite[id + 2].second );
+        const fheroes2::Sprite & res1 = Assets::getImage( ICN::RESOURCE, valueVsSprite[id].second );
+        const fheroes2::Sprite & res2 = Assets::getImage( ICN::RESOURCE, valueVsSprite[id + 1].second );
+        const fheroes2::Sprite & res3 = Assets::getImage( ICN::RESOURCE, valueVsSprite[id + 2].second );
 
         RedrawResourceSprite( res1, { x, y }, 0, width_, offsetY, valueVsSprite[id].first );
         RedrawResourceSprite( res2, { x, y }, 1, width_, offsetY, valueVsSprite[id + 1].first );
@@ -628,8 +628,8 @@ void Resource::BoxSprite::Redraw() const
     const bool isManyResources = valueVsSprite.size() > 2;
 
     if ( valueVsSprite.size() - id == 2 ) {
-        const fheroes2::Sprite & res1 = fheroes2::AGG::GetICN( ICN::RESOURCE, valueVsSprite[id].second );
-        const fheroes2::Sprite & res2 = fheroes2::AGG::GetICN( ICN::RESOURCE, valueVsSprite[id + 1].second );
+        const fheroes2::Sprite & res1 = Assets::getImage( ICN::RESOURCE, valueVsSprite[id].second );
+        const fheroes2::Sprite & res2 = Assets::getImage( ICN::RESOURCE, valueVsSprite[id + 1].second );
 
         const uint32_t width_ = isManyResources ? width / 3 : width / 2;
         const int32_t offsetX = isManyResources ? width_ / 2 : 0;
@@ -638,7 +638,7 @@ void Resource::BoxSprite::Redraw() const
         RedrawResourceSprite( res2, { x + offsetX, y }, 1, width_, offsetY, valueVsSprite[id + 1].first );
     }
     else if ( valueVsSprite.size() - id == 1 ) {
-        const fheroes2::Sprite & res1 = fheroes2::AGG::GetICN( ICN::RESOURCE, valueVsSprite[id].second );
+        const fheroes2::Sprite & res1 = Assets::getImage( ICN::RESOURCE, valueVsSprite[id].second );
 
         const int32_t width_ = isManyResources ? width / 3 : width;
 

--- a/src/fheroes2/spell/spell_book.cpp
+++ b/src/fheroes2/spell/spell_book.cpp
@@ -30,10 +30,10 @@
 #include <set>
 #include <vector>
 
-#include "agg_image.h"
 #include "cursor.h"
 #include "dialog.h"
 #include "dialog_selectitems.h"
+#include "game_assets.h"
 #include "game_hotkeys.h"
 #include "heroes_base.h"
 #include "icn.h"
@@ -60,11 +60,11 @@ namespace
 
     fheroes2::Size getSpellBookSize( const SpellBook::Filter displayableSpells )
     {
-        const fheroes2::Sprite & bookPage = fheroes2::AGG::GetICN( ICN::BOOK, 0 );
-        const fheroes2::Sprite & bookmark_info = fheroes2::AGG::GetICN( ICN::BOOK, 6 );
-        const fheroes2::Sprite & bookmark_advn = fheroes2::AGG::GetICN( ICN::BOOK, 3 );
-        const fheroes2::Sprite & bookmark_cmbt = fheroes2::AGG::GetICN( ICN::BOOK, 4 );
-        const fheroes2::Sprite & bookmark_clos = fheroes2::AGG::GetICN( ICN::BOOK, 5 );
+        const fheroes2::Sprite & bookPage = Assets::getImage( ICN::BOOK, 0 );
+        const fheroes2::Sprite & bookmark_info = Assets::getImage( ICN::BOOK, 6 );
+        const fheroes2::Sprite & bookmark_advn = Assets::getImage( ICN::BOOK, 3 );
+        const fheroes2::Sprite & bookmark_cmbt = Assets::getImage( ICN::BOOK, 4 );
+        const fheroes2::Sprite & bookmark_clos = Assets::getImage( ICN::BOOK, 5 );
 
         const bool isAdventureTabPresent = displayableSpells != SpellBook::Filter::CMBT;
         const bool isCombatTabPresent = displayableSpells != SpellBook::Filter::ADVN;
@@ -103,7 +103,7 @@ namespace
             // If casting spells is prohibited in principle, it makes no sense to check whether this hero can cast them and highlight them in gray if not
             const bool isAvailable = !canCastSpell || hero.CanCastSpell( spell );
 
-            const fheroes2::Sprite & icon = fheroes2::AGG::GetICN( ICN::SPELLS, spell.IndexSprite() );
+            const fheroes2::Sprite & icon = Assets::getImage( ICN::SPELLS, spell.IndexSprite() );
             const int32_t vertOffset = std::min<int32_t>( 6, 49 - icon.height() );
             fheroes2::Rect rect( px + ox - ( icon.width() + icon.width() % 2 ) / 2, py + oy - icon.height() - vertOffset + 2, icon.width(), icon.height() + 10 );
             fheroes2::Blit( icon, output, rect.x, rect.y );
@@ -148,12 +148,12 @@ namespace
         fheroes2::Sprite output( spellBookSize.width, spellBookSize.height );
         output.reset();
 
-        const fheroes2::Sprite & bookPage = fheroes2::AGG::GetICN( ICN::BOOK, 0 );
+        const fheroes2::Sprite & bookPage = Assets::getImage( ICN::BOOK, 0 );
 
         // Left page.
         fheroes2::Blit( bookPage, 0, 0, output, 0, 0, bookPage.width(), bookPage.height(), true );
         if ( index == 0 ) {
-            const fheroes2::Sprite & straightCorner = fheroes2::AGG::GetICN( ICN::BOOK, 7 );
+            const fheroes2::Sprite & straightCorner = Assets::getImage( ICN::BOOK, 7 );
             fheroes2::Blit( straightCorner, 0, 0, output, bookPage.width() - straightCorner.x() - straightCorner.width(), straightCorner.y(), straightCorner.width(),
                             straightCorner.height(), true );
         }
@@ -161,23 +161,23 @@ namespace
         // Right page.
         fheroes2::Blit( bookPage, 0, 0, output, bookPage.width(), 0, bookPage.width(), bookPage.height() );
         if ( spells.size() <= ( index + ( spellsPerPage * 2 ) ) ) {
-            const fheroes2::Sprite & straightCorner = fheroes2::AGG::GetICN( ICN::BOOK, 7 );
+            const fheroes2::Sprite & straightCorner = Assets::getImage( ICN::BOOK, 7 );
             fheroes2::Blit( straightCorner, 0, 0, output, bookPage.width() + straightCorner.x(), straightCorner.y(), straightCorner.width(), straightCorner.height() );
         }
 
-        const fheroes2::Sprite & bookmarkSpellPoints = fheroes2::AGG::GetICN( ICN::BOOK, 6 );
+        const fheroes2::Sprite & bookmarkSpellPoints = Assets::getImage( ICN::BOOK, 6 );
         fheroes2::Blit( bookmarkSpellPoints, output, bookmarkInfoOffset.x, bookmarkInfoOffset.y );
 
         if ( displayableSpells != SpellBook::Filter::CMBT ) {
-            const fheroes2::Sprite & bookmarkAdvantureSpells = fheroes2::AGG::GetICN( ICN::BOOK, 3 );
+            const fheroes2::Sprite & bookmarkAdvantureSpells = Assets::getImage( ICN::BOOK, 3 );
             fheroes2::Blit( bookmarkAdvantureSpells, output, bookmarkAdvOffset.x, bookmarkAdvOffset.y );
         }
         if ( displayableSpells != SpellBook::Filter::ADVN ) {
-            const fheroes2::Sprite & bookmarkCombatSpells = fheroes2::AGG::GetICN( ICN::BOOK, 4 );
+            const fheroes2::Sprite & bookmarkCombatSpells = Assets::getImage( ICN::BOOK, 4 );
             fheroes2::Blit( bookmarkCombatSpells, output, bookmarkCombatoOffset.x, bookmarkCombatoOffset.y );
         }
 
-        const fheroes2::Sprite & bookmarkClose = fheroes2::AGG::GetICN( ICN::BOOK, 5 );
+        const fheroes2::Sprite & bookmarkClose = Assets::getImage( ICN::BOOK, 5 );
         fheroes2::Blit( bookmarkClose, output, bookmarkCloseOffset.x, bookmarkCloseOffset.y );
 
         SpellBookRedrawManaPoints( bookmarkInfoOffset, spellPoints, output );
@@ -222,12 +222,12 @@ Spell SpellBook::Open( const HeroBase & hero, const Filter displayableSpells, co
 
     const CursorRestorer cursorRestorer( true, Cursor::POINTER );
 
-    const fheroes2::Sprite & bookPage = fheroes2::AGG::GetICN( ICN::BOOK, 0 );
+    const fheroes2::Sprite & bookPage = Assets::getImage( ICN::BOOK, 0 );
 
-    const fheroes2::Sprite & bookmark_info = fheroes2::AGG::GetICN( ICN::BOOK, 6 );
-    const fheroes2::Sprite & bookmark_advn = fheroes2::AGG::GetICN( ICN::BOOK, 3 );
-    const fheroes2::Sprite & bookmark_cmbt = fheroes2::AGG::GetICN( ICN::BOOK, 4 );
-    const fheroes2::Sprite & bookmark_clos = fheroes2::AGG::GetICN( ICN::BOOK, 5 );
+    const fheroes2::Sprite & bookmark_info = Assets::getImage( ICN::BOOK, 6 );
+    const fheroes2::Sprite & bookmark_advn = Assets::getImage( ICN::BOOK, 3 );
+    const fheroes2::Sprite & bookmark_cmbt = Assets::getImage( ICN::BOOK, 4 );
+    const fheroes2::Sprite & bookmark_clos = Assets::getImage( ICN::BOOK, 5 );
 
     const fheroes2::Size spellBookSize = getSpellBookSize( displayableSpells );
 
@@ -413,9 +413,9 @@ void SpellBook::Edit( const HeroBase & hero )
     size_t firstSpellOnPageIndex = 0;
     SpellStorage displayedSpells = SetFilter( Filter::ALL, &hero );
 
-    const fheroes2::Sprite & bookmark_clos = fheroes2::AGG::GetICN( ICN::BOOK, 5 );
+    const fheroes2::Sprite & bookmark_clos = Assets::getImage( ICN::BOOK, 5 );
 
-    const fheroes2::Sprite & bookPage = fheroes2::AGG::GetICN( ICN::BOOK, 0 );
+    const fheroes2::Sprite & bookPage = Assets::getImage( ICN::BOOK, 0 );
 
     const fheroes2::Size spellBookSize = getSpellBookSize( Filter::ALL );
 


### PR DESCRIPTION
To have a clear name of the namespace as agg_image.cpp doesn't contain only resources from AGG files and also to unify the code.

Having `fheroes2` namespace everywhere has become too much.