### PR TITLE
Allow to check out fork pull request code from a workflow for Clang-Tidy comments

### DIFF
--- a/.github/workflows/clang_tidy_comments.yml
+++ b/.github/workflows/clang_tidy_comments.yml
@@ -63,6 +63,7 @@ jobs:
         repository: ${{ env.PR_HEAD_REPO }}
         ref: ${{ env.PR_HEAD_SHA }}
         persist-credentials: false
+        allow-unsafe-pr-checkout: true
     - name: Redownload analysis results
       uses: actions/github-script@v9
       with:


### PR DESCRIPTION
Close #10915
This PR allows to "unsafe" check out fork pull request code from a workflow for Clang-Tidy comments like it was earlier before https://github.com/ihhub/fheroes2/pull/10873

The breaking change:
> <h2>v7.0.0</h2>
> <li>block checking out fork pr for pull_request_target and workflow_run by <a href="https://github.com/aiqiaoy"><code>@​aiqiaoy</code></a> in <a href="https://redirect.github.com/actions/checkout/pull/2454">actions/checkout#2454</a></li>