### PR TITLE
Make all buttons in the Main Menu and Editor Menu to be engine-generated for German game resources

### DIFF
--- a/src/fheroes2/game/game_assets.cpp
+++ b/src/fheroes2/game/game_assets.cpp
@@ -1652,38 +1652,6 @@ namespace
                 _icnVsSprite[id].resize( 24 );
             }
 
-            if ( useOriginalResources() ) {
-                for ( size_t i = 0; i < 3; ++i ) {
-                    _icnVsSprite[id][i * 2] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][i * 2 + 1] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 + 1 ) );
-                }
-                // Add generated buttons.
-                const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
-                const fheroes2::Size buttonSize{ _icnVsSprite[id][0].width() - 10, _icnVsSprite[id][0].height() };
-                fheroes2::makeButtonSprites( _icnVsSprite[id][6], _icnVsSprite[id][7], fheroes2::getSupportedText( gettext_noop( "BATTLE\nONLY" ), buttonFontType ),
-                                             buttonSize, false, ICN::STONEBAK );
-                fheroes2::makeButtonSprites( _icnVsSprite[id][8], _icnVsSprite[id][9], fheroes2::getSupportedText( gettext_noop( "SETTINGS" ), buttonFontType ),
-                                             buttonSize, false, ICN::STONEBAK );
-                // Add cancel button.
-                _icnVsSprite[id][10] = Assets::getImage( ICN::BTNNEWGM, 6 );
-                _icnVsSprite[id][11] = Assets::getImage( ICN::BTNNEWGM, 7 );
-                // Add hot seat button.
-                _icnVsSprite[id][12] = Assets::getImage( ICN::BTNMP, 0 );
-                _icnVsSprite[id][13] = Assets::getImage( ICN::BTNMP, 1 );
-                // Add player count buttons.
-                for ( size_t i = 0; i < 5; ++i ) {
-                    _icnVsSprite[id][( i + 7 ) * 2] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][( i + 7 ) * 2 + 1] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 + 1 ) );
-                }
-
-                if ( isPoLPresent ) {
-                    _icnVsSprite[id][24] = Assets::getImage( ICN::X_LOADCM, 0 );
-                    _icnVsSprite[id][25] = Assets::getImage( ICN::X_LOADCM, 1 );
-                    _icnVsSprite[id][26] = Assets::getImage( ICN::X_LOADCM, 2 );
-                    _icnVsSprite[id][27] = Assets::getImage( ICN::X_LOADCM, 3 );
-                }
-                break;
-            }
             const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
             std::vector<const char *> texts = { fheroes2::getSupportedText( gettext_noop( "STANDARD\nGAME" ), buttonFontType ),
                                                 fheroes2::getSupportedText( gettext_noop( "CAMPAIGN\nGAME" ), buttonFontType ),
@@ -1708,33 +1676,6 @@ namespace
         case ICN::BUTTONS_EDITOR_MENU_GOOD: {
             _icnVsSprite[id].resize( 20 );
 
-            if ( useOriginalResources() ) {
-                for ( size_t i = 0; i < 2; ++i ) {
-                    _icnVsSprite[id][i * 2] = Assets::getImage( ICN::BTNEMAIN, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][i * 2 + 1] = Assets::getImage( ICN::BTNEMAIN, static_cast<uint32_t>( i * 2 + 1 ) );
-                }
-                // Add generated Main Menu button.
-                const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
-                const fheroes2::Size buttonSize{ _icnVsSprite[id][0].width() - 10, _icnVsSprite[id][0].height() };
-                fheroes2::makeButtonSprites( _icnVsSprite[id][4], _icnVsSprite[id][5], fheroes2::getSupportedText( gettext_noop( "MAIN\nMENU" ), buttonFontType ),
-                                             buttonSize, false, ICN::STONEBAK );
-                // Add generated Back button.
-                fheroes2::makeButtonSprites( _icnVsSprite[id][6], _icnVsSprite[id][7],
-                                             fheroes2::getSupportedText( gettext_noop( "editorMainMenu|BACK" ), buttonFontType ), buttonSize, false, ICN::STONEBAK );
-
-                // Add From Scratch and Random buttons.
-                for ( size_t i = 0; i < 2; ++i ) {
-                    _icnVsSprite[id][( i + 4 ) * 2] = Assets::getImage( ICN::BTNENEW, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][( i + 4 ) * 2 + 1] = Assets::getImage( ICN::BTNENEW, static_cast<uint32_t>( i * 2 + 1 ) );
-                }
-                // Add map size buttons.
-                for ( size_t i = 0; i < 4; ++i ) {
-                    _icnVsSprite[id][( i + 6 ) * 2] = Assets::getImage( ICN::BTNESIZE, static_cast<uint32_t>( i * 2 ) );
-                    _icnVsSprite[id][( i + 6 ) * 2 + 1] = Assets::getImage( ICN::BTNESIZE, static_cast<uint32_t>( i * 2 + 1 ) );
-                }
-
-                break;
-            }
             const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
             const std::vector<const char *> texts = { fheroes2::getSupportedText( gettext_noop( "NEW\nMAP" ), buttonFontType ),
                                                       fheroes2::getSupportedText( gettext_noop( "LOAD\nMAP" ), buttonFontType ),

--- a/src/fheroes2/game/game_assets.cpp
+++ b/src/fheroes2/game/game_assets.cpp
@@ -1668,6 +1668,7 @@ namespace
             if ( isPoLPresent ) {
                 texts.emplace_back( fheroes2::getSupportedText( gettext_noop( "ORIGINAL\nCAMPAIGN" ), buttonFontType ) );
                 texts.emplace_back( fheroes2::getSupportedText( gettext_noop( "EXPANSION\nCAMPAIGN" ), buttonFontType ) );
+                texts.emplace_back( fheroes2::getSupportedText( gettext_noop( "RESURRECTION\nCAMPAIGN" ), buttonFontType ) );
             }
 
             fheroes2::makeSymmetricBackgroundSprites( _icnVsSprite[id], texts, false, 117 );

--- a/src/fheroes2/game/game_assets.cpp
+++ b/src/fheroes2/game/game_assets.cpp
@@ -1652,6 +1652,40 @@ namespace
                 _icnVsSprite[id].resize( 24 );
             }
 
+            // German game resources are completed off with the engine's generated buttons.
+            if ( useOriginalResources() && ( fheroes2::getResourceLanguage() != fheroes2::SupportedLanguage::German ) ) {
+                for ( size_t i = 0; i < 3; ++i ) {
+                    _icnVsSprite[id][i * 2] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][i * 2 + 1] = Assets::getImage( ICN::BTNNEWGM, static_cast<uint32_t>( i * 2 + 1 ) );
+                }
+                // Add generated buttons.
+                const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
+                const fheroes2::Size buttonSize{ _icnVsSprite[id][0].width() - 10, _icnVsSprite[id][0].height() };
+                fheroes2::makeButtonSprites( _icnVsSprite[id][6], _icnVsSprite[id][7], fheroes2::getSupportedText( gettext_noop( "BATTLE\nONLY" ), buttonFontType ),
+                                             buttonSize, false, ICN::STONEBAK );
+                fheroes2::makeButtonSprites( _icnVsSprite[id][8], _icnVsSprite[id][9], fheroes2::getSupportedText( gettext_noop( "SETTINGS" ), buttonFontType ),
+                                             buttonSize, false, ICN::STONEBAK );
+                // Add cancel button.
+                _icnVsSprite[id][10] = Assets::getImage( ICN::BTNNEWGM, 6 );
+                _icnVsSprite[id][11] = Assets::getImage( ICN::BTNNEWGM, 7 );
+                // Add hot seat button.
+                _icnVsSprite[id][12] = Assets::getImage( ICN::BTNMP, 0 );
+                _icnVsSprite[id][13] = Assets::getImage( ICN::BTNMP, 1 );
+                // Add player count buttons.
+                for ( size_t i = 0; i < 5; ++i ) {
+                    _icnVsSprite[id][( i + 7 ) * 2] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][( i + 7 ) * 2 + 1] = Assets::getImage( ICN::BTNHOTST, static_cast<uint32_t>( i * 2 + 1 ) );
+                }
+
+                if ( isPoLPresent ) {
+                    _icnVsSprite[id][24] = Assets::getImage( ICN::X_LOADCM, 0 );
+                    _icnVsSprite[id][25] = Assets::getImage( ICN::X_LOADCM, 1 );
+                    _icnVsSprite[id][26] = Assets::getImage( ICN::X_LOADCM, 2 );
+                    _icnVsSprite[id][27] = Assets::getImage( ICN::X_LOADCM, 3 );
+                }
+                break;
+            }
+
             const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
             std::vector<const char *> texts = { fheroes2::getSupportedText( gettext_noop( "STANDARD\nGAME" ), buttonFontType ),
                                                 fheroes2::getSupportedText( gettext_noop( "CAMPAIGN\nGAME" ), buttonFontType ),
@@ -1676,6 +1710,35 @@ namespace
         }
         case ICN::BUTTONS_EDITOR_MENU_GOOD: {
             _icnVsSprite[id].resize( 20 );
+
+            // German game resources are completed off with the engine's generated buttons.
+            if ( useOriginalResources() && ( fheroes2::getResourceLanguage() != fheroes2::SupportedLanguage::German ) ) {
+                for ( size_t i = 0; i < 2; ++i ) {
+                    _icnVsSprite[id][i * 2] = Assets::getImage( ICN::BTNEMAIN, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][i * 2 + 1] = Assets::getImage( ICN::BTNEMAIN, static_cast<uint32_t>( i * 2 + 1 ) );
+                }
+                // Add generated Main Menu button.
+                const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
+                const fheroes2::Size buttonSize{ _icnVsSprite[id][0].width() - 10, _icnVsSprite[id][0].height() };
+                fheroes2::makeButtonSprites( _icnVsSprite[id][4], _icnVsSprite[id][5], fheroes2::getSupportedText( gettext_noop( "MAIN\nMENU" ), buttonFontType ),
+                                             buttonSize, false, ICN::STONEBAK );
+                // Add generated Back button.
+                fheroes2::makeButtonSprites( _icnVsSprite[id][6], _icnVsSprite[id][7],
+                                             fheroes2::getSupportedText( gettext_noop( "editorMainMenu|BACK" ), buttonFontType ), buttonSize, false, ICN::STONEBAK );
+
+                // Add From Scratch and Random buttons.
+                for ( size_t i = 0; i < 2; ++i ) {
+                    _icnVsSprite[id][( i + 4 ) * 2] = Assets::getImage( ICN::BTNENEW, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][( i + 4 ) * 2 + 1] = Assets::getImage( ICN::BTNENEW, static_cast<uint32_t>( i * 2 + 1 ) );
+                }
+                // Add map size buttons.
+                for ( size_t i = 0; i < 4; ++i ) {
+                    _icnVsSprite[id][( i + 6 ) * 2] = Assets::getImage( ICN::BTNESIZE, static_cast<uint32_t>( i * 2 ) );
+                    _icnVsSprite[id][( i + 6 ) * 2 + 1] = Assets::getImage( ICN::BTNESIZE, static_cast<uint32_t>( i * 2 + 1 ) );
+                }
+
+                break;
+            }
 
             const fheroes2::FontType buttonFontType = fheroes2::FontType::buttonReleasedWhite();
             const std::vector<const char *> texts = { fheroes2::getSupportedText( gettext_noop( "NEW\nMAP" ), buttonFontType ),


### PR DESCRIPTION
To avoid a mix of different button styles.

Before:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/f9d68c0e-f5eb-4281-9579-02dab6c01ee7" />
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/06b8fb92-b795-4e4f-8be1-5469a020e3cc" />
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/44d2ca99-c520-4853-9c0a-10168b569bab" />

After:
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/b10c62b8-3f25-4eaf-a976-4e73e12d6099" />
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/442fe99a-5e86-43e2-bba8-cb5b9befbc74" />
<img width="640" height="480" alt="image" src="https://github.com/user-attachments/assets/5bfdbc43-e6a7-492c-88b7-8d0c0fd855a7" />
