### PR TITLE
Use in-engine image scaling type according to the scaling type option

### DIFF
--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -195,7 +195,7 @@ namespace fheroes2
     {
         drawMainMenuScreen();
 
-        fheroes2::Display & display = fheroes2::Display::instance();
+        Display & display = Display::instance();
 
         // First we need to render the whole screen to update the rendered background image when this dialog is called from the menu.
         display.updateNextRenderRoi( { 0, 0, display.width(), display.height() } );
@@ -221,15 +221,14 @@ namespace fheroes2
 
                     conf.setGameLanguage( getLanguageAbbreviation( SupportedLanguage::English ) );
 
-                    fheroes2::showStandardTextMessage( "Attention", "Your version of Heroes of Might and Magic II does not support any other languages than English.",
-                                                       Dialog::OK );
+                    showStandardTextMessage( "Attention", "Your version of Heroes of Might and Magic II does not support any other languages than English.", Dialog::OK );
                 }
 
                 windowType = SelectedWindow::UpdateSettings;
                 break;
             }
             case SelectedWindow::Graphics:
-                saveConfiguration |= fheroes2::openGraphicsSettingsDialog( []() { drawMainMenuScreen(); } );
+                saveConfiguration |= openGraphicsSettingsDialog( drawMainMenuScreen);
                 windowType = SelectedWindow::Configuration;
                 break;
             case SelectedWindow::AudioSettings:
@@ -237,7 +236,7 @@ namespace fheroes2
                 windowType = SelectedWindow::Configuration;
                 break;
             case SelectedWindow::HotKeys:
-                fheroes2::openHotkeysDialog();
+                openHotkeysDialog();
                 windowType = SelectedWindow::Configuration;
                 break;
             case SelectedWindow::CursorType:

--- a/src/fheroes2/dialog/dialog_game_settings.cpp
+++ b/src/fheroes2/dialog/dialog_game_settings.cpp
@@ -228,7 +228,7 @@ namespace fheroes2
                 break;
             }
             case SelectedWindow::Graphics:
-                saveConfiguration |= openGraphicsSettingsDialog( drawMainMenuScreen);
+                saveConfiguration |= openGraphicsSettingsDialog( drawMainMenuScreen );
                 windowType = SelectedWindow::Configuration;
                 break;
             case SelectedWindow::AudioSettings:

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -28,6 +28,7 @@
 #include "dialog_resolution.h"
 #include "game_assets.h"
 #include "game_hotkeys.h"
+#include "game_mainmenu_ui.h"
 #include "icn.h"
 #include "image.h"
 #include "localevent.h"
@@ -251,8 +252,10 @@ namespace fheroes2
             case SelectedWindow::Resolution:
                 if ( Dialog::SelectResolution() ) {
                     saveConfiguration = true;
+
+                    Assets::resetScaledBackgroundImages();
+                    updateUI();
                 }
-                updateUI();
                 windowType = SelectedWindow::Configuration;
                 break;
             case SelectedWindow::Mode:
@@ -265,7 +268,13 @@ namespace fheroes2
                 saveConfiguration = true;
                 windowType = SelectedWindow::Configuration;
 
-                fheroes2::Display::instance().resetRenderer();
+                Assets::resetScaledImages();
+                Display::instance().resetRenderer();
+
+                // We upgrade the scaled background image.
+                if ( const auto * fn = updateUI.target<void ( * )()>(); fn != nullptr && *fn == &drawMainMenuScreen ) {
+                    updateUI();
+                }
                 break;
             case SelectedWindow::VSync:
                 conf.setVSync( !conf.isVSyncEnabled() );

--- a/src/fheroes2/dialog/dialog_graphics_settings.cpp
+++ b/src/fheroes2/dialog/dialog_graphics_settings.cpp
@@ -268,7 +268,7 @@ namespace fheroes2
                 saveConfiguration = true;
                 windowType = SelectedWindow::Configuration;
 
-                Assets::resetScaledImages();
+                Assets::resetAllScaledImages();
                 Display::instance().resetRenderer();
 
                 // We upgrade the scaled background image.

--- a/src/fheroes2/game/game_assets.cpp
+++ b/src/fheroes2/game/game_assets.cpp
@@ -60,13 +60,13 @@
 
 namespace
 {
-    const std::array<const char *, TIL::LASTTIL> tilFileName = { "UNKNOWN", "CLOF32.TIL", "GROUND32.TIL", "STON.TIL" };
+    constexpr std::array<const char *, TIL::LASTTIL> tilFileName = { "UNKNOWN", "CLOF32.TIL", "GROUND32.TIL", "STON.TIL" };
 
     std::vector<std::vector<fheroes2::Sprite>> _icnVsSprite( ICN::LASTICN );
     std::array<std::vector<std::vector<fheroes2::Image>>, TIL::LASTTIL> _tilVsImage;
     const fheroes2::Sprite errorImage;
 
-    const uint32_t headerSize = 6;
+    constexpr uint32_t headerSize = 6;
 
     std::map<int, std::vector<fheroes2::Sprite>> _icnVsScaledSprite;
 
@@ -181,9 +181,27 @@ namespace
                                                 ICN::BUTTON_TOGGLE_ALL_OFF_EVIL,
                                                 ICN::ARMY_ESTIMATION_ICON };
 
+    // Images that are scaled to the screen size (Main Menu and Editor backgrounds).
+    const std::set<int> scalableBackgroundIcnId{ ICN::EDITOR, ICN::HEROES, ICN::BTNSHNGL, ICN::SHNGANIM };
+
+    // Images that are scaled by Resize() or SubpixelResize() function.
+    const std::set<int> scalableIcnId{ ICN::WHITE_LARGE_FONT };
+
     bool isLanguageDependentIcnId( const int id )
     {
         return languageDependentIcnId.count( id ) > 0;
+    }
+
+    // We have few ICNs which we need to scale to the screen size, like Main Menu and Editor backgrounds.
+    bool isScaledToScreenBackgroundImage( const int icnId )
+    {
+        return scalableBackgroundIcnId.count( icnId ) > 0;
+    }
+
+    // Returns true if the image was scaled by Resize() or SubpixelResize() function.
+    bool isScaledImage( const size_t icnId )
+    {
+        return scalableIcnId.count( icnId ) > 0;
     }
 
     bool useOriginalResources()
@@ -3042,7 +3060,7 @@ namespace
                 const fheroes2::Sprite & in = original[i];
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
                 out.resize( in.width() * 2, in.height() * 2 );
-                if (isNearestScalingType) {
+                if ( isNearestScalingType ) {
                     Resize( in, out );
                 }
                 else {
@@ -5726,31 +5744,6 @@ namespace
         return tilImages[0].size();
     }
 
-    // We have few ICNs which we need to scale like some related to main screen
-    bool isScaledToScreenBackgroundImage( const int id )
-    {
-        switch ( id ) {
-        case ICN::EDITOR:
-        case ICN::HEROES:
-        case ICN::BTNSHNGL:
-        case ICN::SHNGANIM:
-            return true;
-        default:
-            return false;
-        }
-    }
-
-    // Returns true if the image was scaled by Resize of SubpixelResize function.
-    bool isScaledImage( const size_t icnId )
-    {
-        switch ( icnId ) {
-        case ICN::WHITE_LARGE_FONT:
-            return true;
-        default:
-            return false;
-        }
-    }
-
     const fheroes2::Sprite & GetScaledICN( const int icnId, const uint32_t index )
     {
         const fheroes2::Sprite & originalIcn = _icnVsSprite[icnId][index];
@@ -5766,7 +5759,8 @@ namespace
 
         fheroes2::Sprite & resizedIcn = _icnVsScaledSprite[icnId][index];
 
-        if (!resizedIcn.empty()) {
+        // The image is already resized.
+        if ( !resizedIcn.empty() ) {
             return resizedIcn;
         }
 
@@ -5784,23 +5778,15 @@ namespace
         const int32_t offsetY = static_cast<int32_t>( std::lround( display.height() - fheroes2::Display::DEFAULT_HEIGHT * scaleFactor ) ) / 2;
         assert( offsetX >= 0 && offsetY >= 0 );
 
-        // Resize only if needed
-        if ( resizedIcn.height() != resizedHeight || resizedIcn.width() != resizedWidth ) {
-            resizedIcn.resize( resizedWidth, resizedHeight );
-            resizedIcn.setPosition( static_cast<int32_t>( std::lround( originalIcn.x() * scaleFactor ) ) + offsetX,
-                                    static_cast<int32_t>( std::lround( originalIcn.y() * scaleFactor ) ) + offsetY );
+        resizedIcn.resize( resizedWidth, resizedHeight );
+        resizedIcn.setPosition( static_cast<int32_t>( std::lround( originalIcn.x() * scaleFactor ) ) + offsetX,
+                                static_cast<int32_t>( std::lround( originalIcn.y() * scaleFactor ) ) + offsetY );
 
-            if (Settings::Get().isScreenScalingTypeNearest()) {
-                Resize( originalIcn, resizedIcn );
-            }
-            else {
-                SubpixelResize( originalIcn, resizedIcn );
-            }
+        if ( Settings::Get().isScreenScalingTypeNearest() ) {
+            Resize( originalIcn, resizedIcn );
         }
         else {
-            // No need to resize, but we have to update the offset.
-            resizedIcn.setPosition( static_cast<int32_t>( std::lround( originalIcn.x() * scaleFactor ) ) + offsetX,
-                                    static_cast<int32_t>( std::lround( originalIcn.y() * scaleFactor ) ) + offsetY );
+            SubpixelResize( originalIcn, resizedIcn );
         }
 
         return resizedIcn;
@@ -5897,24 +5883,19 @@ namespace Assets
         areOriginalResourcesInUse = loadOriginalAlphabet;
     }
 
-    void resetScaledImages()
+    void resetAllScaledImages()
     {
-        for (size_t i = ICN::UNKNOWN + 1; i < _icnVsSprite.size(); ++i) {
-            if (isScaledImage( i )) {
-                _icnVsSprite[i].clear();
-            }
-            if (isScaledToScreenBackgroundImage( i )) {
-                _icnVsScaledSprite[i].clear();
-            }
+        for ( const int icnId : scalableIcnId ) {
+            _icnVsSprite[icnId].clear();
         }
+
+        resetScaledBackgroundImages();
     }
 
     void resetScaledBackgroundImages()
     {
-        for (size_t i = ICN::UNKNOWN + 1; i < _icnVsSprite.size(); ++i) {
-            if (isScaledToScreenBackgroundImage( i )) {
-                _icnVsScaledSprite[i].clear();
-            }
+        for ( const int icnId : scalableBackgroundIcnId ) {
+            _icnVsScaledSprite[icnId].clear();
         }
     }
 }

--- a/src/fheroes2/game/game_assets.cpp
+++ b/src/fheroes2/game/game_assets.cpp
@@ -48,6 +48,7 @@
 #include "rand.h"
 #include "screen.h"
 #include "serialize.h"
+#include "settings.h"
 #include "til.h"
 #include "tools.h"
 #include "translations.h"
@@ -3036,11 +3037,17 @@ namespace
             Assets::getImage( ICN::FONT, 0 );
             const std::vector<fheroes2::Sprite> & original = _icnVsSprite[ICN::FONT];
             _icnVsSprite[id].resize( original.size() );
+            const bool isNearestScalingType = Settings::Get().isScreenScalingTypeNearest();
             for ( size_t i = 0; i < _icnVsSprite[id].size(); ++i ) {
                 const fheroes2::Sprite & in = original[i];
                 fheroes2::Sprite & out = _icnVsSprite[id][i];
                 out.resize( in.width() * 2, in.height() * 2 );
-                SubpixelResize( in, out );
+                if (isNearestScalingType) {
+                    Resize( in, out );
+                }
+                else {
+                    SubpixelResize( in, out );
+                }
                 out.setPosition( in.x() * 2, in.y() * 2 );
             }
             break;
@@ -5664,7 +5671,7 @@ namespace
         }
     }
 
-    size_t GetMaximumICNIndex( int id )
+    size_t GetMaximumICNIndex( const int id )
     {
         loadICN( id );
 
@@ -5720,13 +5727,24 @@ namespace
     }
 
     // We have few ICNs which we need to scale like some related to main screen
-    bool IsScalableICN( const int id )
+    bool isScaledToScreenBackgroundImage( const int id )
     {
         switch ( id ) {
         case ICN::EDITOR:
         case ICN::HEROES:
         case ICN::BTNSHNGL:
         case ICN::SHNGANIM:
+            return true;
+        default:
+            return false;
+        }
+    }
+
+    // Returns true if the image was scaled by Resize of SubpixelResize function.
+    bool isScaledImage( const size_t icnId )
+    {
+        switch ( icnId ) {
+        case ICN::WHITE_LARGE_FONT:
             return true;
         default:
             return false;
@@ -5748,6 +5766,10 @@ namespace
 
         fheroes2::Sprite & resizedIcn = _icnVsScaledSprite[icnId][index];
 
+        if (!resizedIcn.empty()) {
+            return resizedIcn;
+        }
+
         if ( originalIcn.singleLayer() && !resizedIcn.singleLayer() ) {
             resizedIcn._disableTransformLayer();
         }
@@ -5767,10 +5789,16 @@ namespace
             resizedIcn.resize( resizedWidth, resizedHeight );
             resizedIcn.setPosition( static_cast<int32_t>( std::lround( originalIcn.x() * scaleFactor ) ) + offsetX,
                                     static_cast<int32_t>( std::lround( originalIcn.y() * scaleFactor ) ) + offsetY );
-            Resize( originalIcn, resizedIcn );
+
+            if (Settings::Get().isScreenScalingTypeNearest()) {
+                Resize( originalIcn, resizedIcn );
+            }
+            else {
+                SubpixelResize( originalIcn, resizedIcn );
+            }
         }
         else {
-            // No need to resize but we have to update the offset.
+            // No need to resize, but we have to update the offset.
             resizedIcn.setPosition( static_cast<int32_t>( std::lround( originalIcn.x() * scaleFactor ) ) + offsetX,
                                     static_cast<int32_t>( std::lround( originalIcn.y() * scaleFactor ) ) + offsetY );
         }
@@ -5781,7 +5809,7 @@ namespace
 
 namespace Assets
 {
-    const fheroes2::Sprite & getImage( int icnId, uint32_t index )
+    const fheroes2::Sprite & getImage( const int icnId, const uint32_t index )
     {
         if ( !IsValidICNId( icnId ) ) {
             return errorImage;
@@ -5791,14 +5819,14 @@ namespace Assets
             return errorImage;
         }
 
-        if ( IsScalableICN( icnId ) ) {
+        if ( isScaledToScreenBackgroundImage( icnId ) ) {
             return GetScaledICN( icnId, index );
         }
 
         return _icnVsSprite[icnId][index];
     }
 
-    uint32_t getImageCount( int icnId )
+    uint32_t getImageCount( const int icnId )
     {
         if ( !IsValidICNId( icnId ) ) {
             return 0;
@@ -5807,7 +5835,7 @@ namespace Assets
         return static_cast<uint32_t>( GetMaximumICNIndex( icnId ) );
     }
 
-    const fheroes2::Image & getTileImage( int tilId, uint32_t index, uint32_t shapeId )
+    const fheroes2::Image & getTileImage( const int tilId, const uint32_t index, const uint32_t shapeId )
     {
         if ( shapeId > 3 ) {
             return errorImage;
@@ -5867,5 +5895,26 @@ namespace Assets
 
         currentCodePage = fheroes2::getCodePage( language );
         areOriginalResourcesInUse = loadOriginalAlphabet;
+    }
+
+    void resetScaledImages()
+    {
+        for (size_t i = ICN::UNKNOWN + 1; i < _icnVsSprite.size(); ++i) {
+            if (isScaledImage( i )) {
+                _icnVsSprite[i].clear();
+            }
+            if (isScaledToScreenBackgroundImage( i )) {
+                _icnVsScaledSprite[i].clear();
+            }
+        }
+    }
+
+    void resetScaledBackgroundImages()
+    {
+        for (size_t i = ICN::UNKNOWN + 1; i < _icnVsSprite.size(); ++i) {
+            if (isScaledToScreenBackgroundImage( i )) {
+                _icnVsScaledSprite[i].clear();
+            }
+        }
     }
 }

--- a/src/fheroes2/game/game_assets.cpp
+++ b/src/fheroes2/game/game_assets.cpp
@@ -198,12 +198,6 @@ namespace
         return scalableBackgroundIcnId.count( icnId ) > 0;
     }
 
-    // Returns true if the image was scaled by Resize() or SubpixelResize() function.
-    bool isScaledImage( const size_t icnId )
-    {
-        return scalableIcnId.count( icnId ) > 0;
-    }
-
     bool useOriginalResources()
     {
         const fheroes2::SupportedLanguage currentLanguage = fheroes2::getCurrentLanguage();

--- a/src/fheroes2/game/game_assets.h
+++ b/src/fheroes2/game/game_assets.h
@@ -41,6 +41,6 @@ namespace Assets
     // This function must be called only at the time of setting up a new language.
     void updateLanguageDependentResources( const fheroes2::SupportedLanguage language, const bool loadOriginalAlphabet );
 
-    void resetScaledImages();
+    void resetAllScaledImages();
     void resetScaledBackgroundImages();
 }

--- a/src/fheroes2/game/game_assets.h
+++ b/src/fheroes2/game/game_assets.h
@@ -32,12 +32,15 @@ namespace fheroes2
 
 namespace Assets
 {
-    const fheroes2::Sprite & getImage( int icnId, uint32_t index );
-    uint32_t getImageCount( int icnId );
+    const fheroes2::Sprite & getImage( const int icnId, const uint32_t index );
+    uint32_t getImageCount( const int icnId );
 
     // shapeId could be 0, 1, 2 or 3 only
-    const fheroes2::Image & getTileImage( int tilId, uint32_t index, uint32_t shapeId );
+    const fheroes2::Image & getTileImage( const int tilId, const uint32_t index, const uint32_t shapeId );
 
     // This function must be called only at the time of setting up a new language.
     void updateLanguageDependentResources( const fheroes2::SupportedLanguage language, const bool loadOriginalAlphabet );
+
+    void resetScaledImages();
+    void resetScaledBackgroundImages();
 }


### PR DESCRIPTION
Relates to https://github.com/ihhub/fheroes2/pull/10885

This PR makes the engine to scale Large Font, Main Menu background and Editor Menu background according to selected Screen Scaling Type option:
<img src="https://github.com/user-attachments/assets/9a082dcd-4227-419a-a5ed-01d715514849" /> <img src="https://github.com/user-attachments/assets/9d3037f8-8036-40df-94fb-d977f17439c7" />
<img src="https://github.com/user-attachments/assets/ca59bed7-2a5a-456c-a6e3-ae436206df65" />

<->
<img src="https://github.com/user-attachments/assets/91c94e96-fcc0-4d3f-985e-4fd69d57e58d" /> <img width="372" src="https://github.com/user-attachments/assets/e37c64fb-80eb-4c75-bc3d-720c84d0ae46" />
<img src="https://github.com/user-attachments/assets/4b4ebd7a-9ddb-4f76-96ae-dddaf89d6dbb" />

It also makes the `GetScaledICN()` function to calculate the sprite position only once (on image first load or resolution change).