### PR TITLE
Make the Campaign Difficulty Names More Accurate

### DIFF
--- a/src/fheroes2/campaign/campaign_savedata.cpp
+++ b/src/fheroes2/campaign/campaign_savedata.cpp
@@ -104,8 +104,8 @@ namespace Campaign
         _carryOverTroops.clear();
         _currentScenarioInfoId = { -1, -1 };
         _currentScenarioBonusId = -1;
-        _difficulty = CampaignDifficulty::Normal;
-        _minDifficulty = CampaignDifficulty::Normal;
+        _difficulty = CampaignDifficulty::Default;
+        _minDifficulty = CampaignDifficulty::Default;
     }
 
     void CampaignSaveData::setCarryOverTroops( const Troops & troops )
@@ -126,12 +126,12 @@ namespace Campaign
     uint32_t CampaignSaveData::getCampaignDifficultyPercent() const
     {
         switch ( _minDifficulty ) {
-        case CampaignDifficulty::Easy:
+        case CampaignDifficulty::Decreased:
             return 125;
-        case CampaignDifficulty::Normal:
+        case CampaignDifficulty::Default:
             // Original campaign difficulty.
             return 100;
-        case CampaignDifficulty::Hard:
+        case CampaignDifficulty::Increased:
             return 75;
         default:
             // Did you add a new campaign difficulty? Add the logic above!

--- a/src/fheroes2/campaign/campaign_savedata.h
+++ b/src/fheroes2/campaign/campaign_savedata.h
@@ -40,9 +40,9 @@ namespace Campaign
 
     enum CampaignDifficulty : int32_t
     {
-        Easy = -1,
-        Normal = 0,
-        Hard = 1
+        Decreased = -1,
+        Default = 0,
+        Increased = 1
     };
 
     class CampaignSaveData
@@ -144,8 +144,8 @@ namespace Campaign
         ScenarioInfoId _currentScenarioInfoId;
         int32_t _currentScenarioBonusId{ -1 };
 
-        int32_t _difficulty{ CampaignDifficulty::Normal };
-        int32_t _minDifficulty{ CampaignDifficulty::Normal };
+        int32_t _difficulty{ CampaignDifficulty::Default };
+        int32_t _minDifficulty{ CampaignDifficulty::Default };
     };
 
     // Call this function only when playing campaign scenario.

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -896,13 +896,13 @@ namespace
     std::string getCampaignDifficultyText( const int32_t difficulty )
     {
         switch ( difficulty ) {
-        case Campaign::CampaignDifficulty::Easy:
-            return { _( "Easy" ) };
-        case Campaign::CampaignDifficulty::Normal:
+        case Campaign::CampaignDifficulty::Decreased:
+            return { _( "Decreased" ) };
+        case Campaign::CampaignDifficulty::Default:
             // Original campaign difficulty.
-            return { _( "Normal" ) };
-        case Campaign::CampaignDifficulty::Hard:
-            return { _( "Hard" ) };
+            return { _( "Default" ) };
+        case Campaign::CampaignDifficulty::Increased:
+            return { _( "Increased" ) };
         default:
             // Did you add a new campaign difficulty? Add the logic above!
             assert( 0 );
@@ -966,9 +966,9 @@ namespace
 
         fheroes2::MovableSprite selection( selectionImage );
 
-        const char * easyDescription = _( "Choose this difficulty to experience the game's story with less challenge. The AI will be weaker than at Normal difficulty." );
-        const char * normalDescription = _( "Choose this difficulty to experience the campaign as per the original design." );
-        const char * hardDescription = _( "Choose this difficulty if you want more challenge. The AI will be stronger than at Normal difficulty." );
+        const char * decreasedDifficultyDescription = _( "Choose this difficulty to experience the game's story with decreased challenge. The AI will be weaker than at the default difficulty." );
+        const char * defaultDifficultyDescription = _( "Choose this difficulty to experience the campaign as close to the original design as possible with the fheroes2 AI." );
+        const char * increasedDifficultyDescription = _( "Choose this difficulty if you want more of a challenge. The AI will be stronger than at the default difficulty." );
 
         const std::array<fheroes2::Rect, 3> difficultyArea{ fheroes2::Rect( copyToOffset[0].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
                                                             fheroes2::Rect( copyToOffset[1].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
@@ -976,16 +976,16 @@ namespace
 
         const char * currentDescription = nullptr;
         switch ( currentDifficulty ) {
-        case Campaign::CampaignDifficulty::Easy:
-            currentDescription = easyDescription;
+        case Campaign::CampaignDifficulty::Decreased:
+            currentDescription = decreasedDifficultyDescription;
             selection.setPosition( difficultyArea[0].x, difficultyArea[0].y );
             break;
-        case Campaign::CampaignDifficulty::Normal:
-            currentDescription = normalDescription;
+        case Campaign::CampaignDifficulty::Default:
+            currentDescription = defaultDifficultyDescription;
             selection.setPosition( difficultyArea[1].x, difficultyArea[1].y );
             break;
-        case Campaign::CampaignDifficulty::Hard:
-            currentDescription = hardDescription;
+        case Campaign::CampaignDifficulty::Increased:
+            currentDescription = increasedDifficultyDescription;
             selection.setPosition( difficultyArea[2].x, difficultyArea[2].y );
             break;
         default:
@@ -1002,9 +1002,9 @@ namespace
         description.setUniformVerticalAlignment( false );
         description.draw( textOffset.x, textOffset.y, textWidth, display );
 
-        const fheroes2::Text easyName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Easy ), fheroes2::FontType::normalWhite() );
-        const fheroes2::Text normalName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Normal ), fheroes2::FontType::normalWhite() );
-        const fheroes2::Text hardName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Hard ), fheroes2::FontType::normalWhite() );
+        const fheroes2::Text easyName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Decreased ), fheroes2::FontType::normalWhite() );
+        const fheroes2::Text normalName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Default ), fheroes2::FontType::normalWhite() );
+        const fheroes2::Text hardName( getCampaignDifficultyText( Campaign::CampaignDifficulty::Increased ), fheroes2::FontType::normalWhite() );
 
         easyName.draw( difficultyArea[0].x + ( difficultyArea[0].width - easyName.width() ) / 2, difficultyArea[0].y + difficultyArea[0].height + 5, display );
         normalName.draw( difficultyArea[1].x + ( difficultyArea[1].width - normalName.width() ) / 2, difficultyArea[1].y + difficultyArea[1].height + 5, display );
@@ -1027,34 +1027,34 @@ namespace
                 updateInfo = true;
             }
             else if ( le.isMouseRightButtonPressedInArea( difficultyArea[0] ) ) {
-                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Easy ), easyDescription, Dialog::ZERO );
+                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Decreased ), decreasedDifficultyDescription, Dialog::ZERO );
                 updateInfo = true;
             }
             else if ( le.isMouseRightButtonPressedInArea( difficultyArea[1] ) ) {
-                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Normal ), normalDescription, Dialog::ZERO );
+                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Default ), defaultDifficultyDescription, Dialog::ZERO );
                 updateInfo = true;
             }
             else if ( le.isMouseRightButtonPressedInArea( difficultyArea[2] ) ) {
-                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Hard ), hardDescription, Dialog::ZERO );
+                fheroes2::showStandardTextMessage( getCampaignDifficultyText( Campaign::CampaignDifficulty::Increased ), increasedDifficultyDescription, Dialog::ZERO );
                 updateInfo = true;
             }
 
             if ( le.MouseClickLeft( difficultyArea[0] ) ) {
-                currentDescription = easyDescription;
+                currentDescription = decreasedDifficultyDescription;
                 selection.setPosition( difficultyArea[0].x, difficultyArea[0].y );
-                currentDifficulty = Campaign::CampaignDifficulty::Easy;
+                currentDifficulty = Campaign::CampaignDifficulty::Decreased;
                 updateInfo = true;
             }
             else if ( le.MouseClickLeft( difficultyArea[1] ) ) {
-                currentDescription = normalDescription;
+                currentDescription = defaultDifficultyDescription;
                 selection.setPosition( difficultyArea[1].x, difficultyArea[1].y );
-                currentDifficulty = Campaign::CampaignDifficulty::Normal;
+                currentDifficulty = Campaign::CampaignDifficulty::Default;
                 updateInfo = true;
             }
             else if ( le.MouseClickLeft( difficultyArea[2] ) ) {
-                currentDescription = hardDescription;
+                currentDescription = increasedDifficultyDescription;
                 selection.setPosition( difficultyArea[2].x, difficultyArea[2].y );
-                currentDifficulty = Campaign::CampaignDifficulty::Hard;
+                currentDifficulty = Campaign::CampaignDifficulty::Increased;
                 updateInfo = true;
             }
 

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -897,12 +897,12 @@ namespace
     {
         switch ( difficulty ) {
         case Campaign::CampaignDifficulty::Decreased:
-            return { _( "Decreased" ) };
+            return { _( "campaignDifficulty|Decreased" ) };
         case Campaign::CampaignDifficulty::Default:
             // Original campaign difficulty.
-            return { _( "Default" ) };
+            return { _( "campaignDifficulty|Default" ) };
         case Campaign::CampaignDifficulty::Increased:
-            return { _( "Increased" ) };
+            return { _( "campaignDifficulty|Increased" ) };
         default:
             // Did you add a new campaign difficulty? Add the logic above!
             assert( 0 );

--- a/src/fheroes2/game/game_campaign.cpp
+++ b/src/fheroes2/game/game_campaign.cpp
@@ -966,9 +966,12 @@ namespace
 
         fheroes2::MovableSprite selection( selectionImage );
 
-        const char * decreasedDifficultyDescription = _( "Choose this difficulty to experience the game's story with decreased challenge. The AI will be weaker than at the default difficulty." );
-        const char * defaultDifficultyDescription = _( "Choose this difficulty to experience the campaign as close to the original design as possible with the fheroes2 AI." );
-        const char * increasedDifficultyDescription = _( "Choose this difficulty if you want more of a challenge. The AI will be stronger than at the default difficulty." );
+        const char * decreasedDifficultyDescription
+            = _( "Choose this difficulty to experience the game's story with decreased challenge. The AI will be weaker than at the default difficulty." );
+        const char * defaultDifficultyDescription
+            = _( "Choose this difficulty to experience the campaign as close to the original design as possible with the fheroes2 AI." );
+        const char * increasedDifficultyDescription
+            = _( "Choose this difficulty if you want more of a challenge. The AI will be stronger than at the default difficulty." );
 
         const std::array<fheroes2::Rect, 3> difficultyArea{ fheroes2::Rect( copyToOffset[0].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),
                                                             fheroes2::Rect( copyToOffset[1].x + 1, windowRoi.y + 37, selectionImage.width(), selectionImage.height() ),


### PR DESCRIPTION
After countless discussions about the campaigns being too hard, this will (hopefully) create less confusion from players who expect the difficulty to be the same challenge as a regular scenario on Easy difficulty.


<img width="407" height="344" alt="image" src="https://github.com/user-attachments/assets/a0cb9316-92a5-4e36-bfd4-99981a1a630d" />
