### PR TITLE
Fix macOS x86_64 compilation

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -103,7 +103,7 @@ jobs:
             FHEROES2_WITH_TSAN: ON
         - name: macOS SDL2
           on: [ 'pull_request', 'push' ]
-          os: macos-14
+          os: macos-26-intel
           arch: x86_64
           dependencies: sdl2 sdl2_mixer sdl2_image
           env:
@@ -165,11 +165,6 @@ jobs:
     - name: Install dependencies (macOS)
       if: ${{ contains( matrix.on, github.event_name ) && startsWith( matrix.os, 'macos-' ) }}
       run: |
-        if [[ "${{ matrix.arch }}" == x86_64 ]]; then
-            arch -x86_64 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
-            # Homebrew uses /opt/homebrew for Apple Silicon packages and /usr/local for x86_64 packages
-            export PATH=/usr/local/bin:$PATH
-        fi
         brew install ${{ matrix.dependencies }}
       env:
         # Do not update outdated dependencies of installed packages
@@ -182,10 +177,6 @@ jobs:
     - name: Build (MacOS)
       if: ${{ contains( matrix.on, github.event_name ) && startsWith( matrix.os, 'macos-' ) }}
       run: |
-        if [[ "${{ matrix.arch }}" == x86_64 ]]; then
-            # Homebrew uses /opt/homebrew for Apple Silicon packages and /usr/local for x86_64 packages
-            export PATH=/usr/local/bin:$PATH
-        fi
         make -j "$(sysctl -n hw.logicalcpu)"
       env: ${{ matrix.env }}
     - name: Create packages


### PR DESCRIPTION
The macOS 14 runner has been deprecated and homebrew dropped support. Fortunately, they added a macOS 26-Intel runner.

It is probably worth discussing if x86_64 macos is worth supporting, although the runners seem to be going to be available for a while.

See
https://github.com/actions/runner-images/pull/13634

and here it seems like the original plan was August 2027 so we will probably have at least an extra year :)

https://github.com/actions/runner-images/issues/13045
