### PR TITLE
Fix untranslated and fuzzy strings in the Russian translation

### DIFF
--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -4264,7 +4264,7 @@ msgid "Failed to save the map."
 msgstr "Не удалось сохранить карту."
 
 msgid "The selected object has been moved to the top layer."
-msgstr ""
+msgstr "Выбранный объект перемещён на верхний слой."
 
 msgid "Unsaved Changes"
 msgstr "Несохранённые изменения"
@@ -5386,22 +5386,18 @@ msgstr ""
 msgid "and more..."
 msgstr "и т.д."
 
-#, fuzzy
 msgid "campaignDifficulty|Decreased"
-msgstr "Сложность кампании"
+msgstr "Пониженная"
 
-#, fuzzy
 msgid "campaignDifficulty|Default"
-msgstr "Сложность кампании"
+msgstr "Обычная"
 
-#, fuzzy
 msgid "campaignDifficulty|Increased"
-msgstr "Сложность кампании"
+msgstr "Повышенная"
 
 msgid "Campaign Difficulty"
 msgstr "Сложность кампании"
 
-#, fuzzy
 msgid ""
 "Choose this difficulty to experience the game's story with decreased "
 "challenge. The AI will be weaker than at the default difficulty."
@@ -5409,7 +5405,6 @@ msgstr ""
 "Выберите данный уровень сложности, если Вы предпочитаете сюжет, а не сложные "
 "сражения. ИИ слабее, чем обычно."
 
-#, fuzzy
 msgid ""
 "Choose this difficulty to experience the campaign as close to the original "
 "design as possible with the fheroes2 AI."
@@ -5417,7 +5412,6 @@ msgstr ""
 "Выберите данный уровень сложности, чтобы насладиться кампанией, как она "
 "первоначально задумывалась."
 
-#, fuzzy
 msgid ""
 "Choose this difficulty if you want more of a challenge. The AI will be "
 "stronger than at the default difficulty."
@@ -12484,6 +12478,8 @@ msgid ""
 "Increases a unit's attack skill by 3. The effect lasts for 3 rounds of "
 "combat, regardless of spell power."
 msgstr ""
+"Увеличивает навык атаки выбранного существа на 3. Действие длится 3 раунда "
+"боя, независимо от силы магии."
 
 msgid "Animate Dead"
 msgstr "Поднять нежить"


### PR DESCRIPTION
Complete the Russian translation to 100% by:
- translating the 2 remaining untranslated strings;
- correcting and confirming translation of the 6 fuzzy campaign-difficulty entries.

Verified with `msgfmt --statistics`: 3242 translated messages, 0 fuzzy, 0 untranslated.