### PR TITLE
Use "unit" (отряд) for target-buffing spells in Russian translation

### DIFF
--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -12228,7 +12228,7 @@ msgstr "Телепорт"
 
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
-msgstr "Телепортирует выбранный отряд в любую свободную точку на поле."
+msgstr "Телепортирует выбранный отряд в любую свободную точку на поле боя."
 
 msgid "Cure"
 msgstr "Лечение"

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -12228,7 +12228,7 @@ msgstr "Телепорт"
 
 msgid ""
 "Teleports the creature you select to any open position on the battlefield."
-msgstr "Телепортирует выбранное существо в любую свободную точку на поле."
+msgstr "Телепортирует выбранный отряд в любую свободную точку на поле."
 
 msgid "Cure"
 msgstr "Лечение"
@@ -12475,7 +12475,7 @@ msgid "Dragon Slayer"
 msgstr "Убийца драконов"
 
 msgid "Greatly increases a unit's attack skill vs. Dragons."
-msgstr "Увеличивает атаку выбранного существа в схватке с драконами на 5."
+msgstr "Увеличивает атаку выбранного отряда в схватке с драконами на 5."
 
 msgid "Blood Lust"
 msgstr "Жажда крови"
@@ -12519,8 +12519,8 @@ msgid ""
 "Halves damage received from ranged attacks for all of your units. Does not "
 "affect damage received from Turrets or Ballistae."
 msgstr ""
-"Принимает на себя половину урона стрелковых атак врага, направленных на всех "
-"Ваших существ. Не влияет на урон от замковых башен или баллисты."
+"Принимает на себя половину урона стрелковых атак врага, направленных на все "
+"Ваши отряды. Не влияет на урон от замковых башен или баллисты."
 
 msgid "Summon Earth Elemental"
 msgstr "Земной элементаль"

--- a/files/lang/ru.po
+++ b/files/lang/ru.po
@@ -12255,7 +12255,7 @@ msgstr "Оживление"
 
 msgid "Resurrects creatures from a damaged or dead unit until end of combat."
 msgstr ""
-"До конца боя оживляет воинов в отряде, которому был нанесён урон или который "
+"До конца боя оживляет существ в отряде, которому был нанесён урон или который "
 "был уничтожен."
 
 msgid "Resurrect True"
@@ -12263,7 +12263,7 @@ msgstr "Воскрешение"
 
 msgid "Resurrects creatures from a damaged or dead unit permanently."
 msgstr ""
-"Навсегда оживляет воинов в отряде, которому был нанесён урон или который был "
+"Навсегда оживляет существ в отряде, которому был нанесён урон или который был "
 "уничтожен."
 
 msgid "Haste"
@@ -12409,7 +12409,7 @@ msgid ""
 "A rain of rocks strikes an area of the battlefield, damaging all nearby "
 "creatures."
 msgstr ""
-"Призывает дождь из камней, наносящий урон всем существам, находящимся в поле "
+"Призывает дождь из камней, наносящий урон всем отрядам, находящимся в поле "
 "действия заклинания."
 
 msgid "Meteor Shower"


### PR DESCRIPTION
## Purpose

Brings three target-buffing Russian spell descriptions in line with the standard wording used across the rest of the battle spells ("отряд" / unit) instead of "существо" (creature).

This follows the request from the review thread on the Russian translation PR:
https://github.com/ihhub/fheroes2/pull/10998#discussion_r3948944914

## Why Meteor Shower (Камнепад) is NOT changed

Meteor Shower is an area-of-effect damage spell. Its source text reads "...damaging all nearby creatures" (plural "creatures"), unlike the target-buffing spells that use a single "unit/selected creatures". It already matches the established translation of the same AOE damage group — Death Ripple and Death Wave use "всем живым существам". Changing only Meteor Shower would break consistency within that group, so it is intentionally left out of this PR.
