### PR TITLE
Minor change to the application description attribute

### DIFF
--- a/src/resources/fheroes2.rc
+++ b/src/resources/fheroes2.rc
@@ -46,7 +46,7 @@ BEGIN
         BEGIN
             VALUE "Comments",         "Visit us at https://ihhub.github.io/fheroes2\0"
             VALUE "CompanyName",      "fheroes2 Resurrection team\0"
-            VALUE "FileDescription",  "Free implementation of the Heroes of Might and Magic II game engine\0"
+            VALUE "FileDescription",  "Free implementation of the Heroes of M&M II game engine\0"
             VALUE "FileVersion",      FH2_VERSION_STR
             VALUE "InternalName",     "fheroes2\0"
             VALUE "LegalCopyright",   "\251 2026 fheroes2 Resurrection team <fhomm2@gmail.com>. All rights for the original HoMM II game belong to Ubisoft\0"


### PR DESCRIPTION
Avoid using the might & magic trademark in the application description.  This also makes the entry in task manager shorter and less likely to be truncated:

<img width="264" height="40" alt="image" src="https://github.com/user-attachments/assets/850b3258-57d7-4e0d-bf2e-1c4670d7fbfc" />
